### PR TITLE
Workers will now retry (but not re-resolve) on some ExecuteFetch failures

### DIFF
--- a/go/vt/tabletmanager/tmclient/rpc_client_api.go
+++ b/go/vt/tabletmanager/tmclient/rpc_client_api.go
@@ -174,6 +174,13 @@ type TabletManagerClient interface {
 
 	// Restore restores a database snapshot
 	Restore(ctx context.Context, tablet *topo.TabletInfo, sa *actionnode.RestoreArgs) (<-chan *logutil.LoggerEvent, ErrFunc, error)
+
+	//
+	// RPC related methods
+	//
+
+	// IsTimeoutError checks if an error was caused by an RPC layer timeout vs an application-specific one
+	IsTimeoutError(err error) bool
 }
 
 type TabletManagerClientFactory func() TabletManagerClient


### PR DESCRIPTION
@enisoc @alainjobart 

First pass at retrying for errors.  Wanted to get your thoughts on this approach - still need to add re-resolving, but I think it should be straight-forward with this approach.

Existing tests pass, but nothing is explicitly testing tablets temporarily going away. I'd like to add something to our test suite along those lines (maybe vtctl Pause/Resume commands, or maybe just easy ways for disabling and enabling queryservice).