### PR TITLE
Travis: Skip coveralls and new relic for pull requests from forks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,9 @@ unit_test_race:
 unit_test_goveralls:
 	go list -f '{{if len .TestGoFiles}}go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}{{end}}' ./go/... | xargs -i sh -c {}
 	gover ./go/
-	goveralls -coverprofile=gover.coverprofile -repotoken $$COVERALLS_TOKEN
+	if ! [ -z "$$COVERALLS_TOKEN" ]; then \
+		goveralls -coverprofile=gover.coverprofile -repotoken $$COVERALLS_TOKEN; \
+	fi
 
 queryservice_test:
 	echo $$(date): Running test/queryservice_test.py...

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ unit_test_race:
 unit_test_goveralls:
 	go list -f '{{if len .TestGoFiles}}go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}{{end}}' ./go/... | xargs -i sh -c {}
 	gover ./go/
+	# Travis doesn't set the token for forked pull requests, so skip
+	# upload if COVERALLS_TOKEN is unset.
 	if ! [ -z "$$COVERALLS_TOKEN" ]; then \
 		goveralls -coverprofile=gover.coverprofile -repotoken $$COVERALLS_TOKEN; \
 	fi

--- a/travis/dependencies.sh
+++ b/travis/dependencies.sh
@@ -13,6 +13,8 @@ wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
 sudo apt-get update
 
 # Install New relic to monitor perf metrics
+# Travis will not set license key for forked pull
+# requests, so skip the install.
 if ! [ -z "$$NEWRELIC_LICENSE_KEY" ]; then
   sudo apt-get install newrelic-sysmond
   sudo nrsysmond-config --set license_key=$NEWRELIC_LICENSE_KEY

--- a/travis/dependencies.sh
+++ b/travis/dependencies.sh
@@ -13,9 +13,11 @@ wget -O- https://download.newrelic.com/548C16BF.gpg | sudo apt-key add -
 sudo apt-get update
 
 # Install New relic to monitor perf metrics
-sudo apt-get install newrelic-sysmond
-sudo nrsysmond-config --set license_key=$NEWRELIC_LICENSE_KEY
-sudo /etc/init.d/newrelic-sysmond start
+if ! [ -z "$$NEWRELIC_LICENSE_KEY" ]; then
+  sudo apt-get install newrelic-sysmond
+  sudo nrsysmond-config --set license_key=$NEWRELIC_LICENSE_KEY
+  sudo /etc/init.d/newrelic-sysmond start
+fi
 
 # Remove pre-installed mysql
 sudo apt-get purge mysql* mariadb*

--- a/travis/dependencies.sh
+++ b/travis/dependencies.sh
@@ -15,7 +15,7 @@ sudo apt-get update
 # Install New relic to monitor perf metrics
 # Travis will not set license key for forked pull
 # requests, so skip the install.
-if ! [ -z "$$NEWRELIC_LICENSE_KEY" ]; then
+if ! [ -z "$NEWRELIC_LICENSE_KEY" ]; then
   sudo apt-get install newrelic-sysmond
   sudo nrsysmond-config --set license_key=$NEWRELIC_LICENSE_KEY
   sudo /etc/init.d/newrelic-sysmond start


### PR DESCRIPTION
Forks aren't allowed to use the secret tokens set in Travis, so skip the dependencies that uses these tokens.