### PR TITLE
Resolve CNAME in Python ZkTopoServer to match Go's net.LookupCNAME().

### DIFF
--- a/go/netutil/netutil.go
+++ b/go/netutil/netutil.go
@@ -90,7 +90,7 @@ func SplitHostPort(addr string) (string, int, error) {
 		host = addr[:i]
 		port = addr[i+1:]
 	}
-	p, err := strconv.ParseInt(port, 10, 16)
+	p, err := strconv.ParseUint(port, 10, 16)
 	if err != nil {
 		return "", 0, fmt.Errorf("SplitHostPort: can't parse port %q: %v", port, err)
 	}

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -71,9 +71,10 @@ func TestSplitHostPort(t *testing.T) {
 		port int
 	}
 	table := map[string]addr{
-		"host-name:132": addr{host: "host-name", port: 132},
-		"[::1]:321":     addr{host: "::1", port: 321},
-		"::1:432":       addr{host: "::1", port: 432},
+		"host-name:132":  addr{host: "host-name", port: 132},
+		"hostname:65535": addr{host: "hostname", port: 65535},
+		"[::1]:321":      addr{host: "::1", port: 321},
+		"::1:432":        addr{host: "::1", port: 432},
 	}
 	for input, want := range table {
 		gotHost, gotPort, err := SplitHostPort(input)

--- a/go/netutil/netutil_test.go
+++ b/go/netutil/netutil_test.go
@@ -73,6 +73,7 @@ func TestSplitHostPort(t *testing.T) {
 	table := map[string]addr{
 		"host-name:132": addr{host: "host-name", port: 132},
 		"[::1]:321":     addr{host: "::1", port: 321},
+		"::1:432":       addr{host: "::1", port: 432},
 	}
 	for input, want := range table {
 		gotHost, gotPort, err := SplitHostPort(input)
@@ -81,6 +82,20 @@ func TestSplitHostPort(t *testing.T) {
 		}
 		if gotHost != want.host || gotPort != want.port {
 			t.Errorf("SplitHostPort(%#v) = (%v, %v), want (%v, %v)", input, gotHost, gotPort, want.host, want.port)
+		}
+	}
+}
+
+func TestSplitHostPortFail(t *testing.T) {
+	// These cases should all fail to parse.
+	inputs := []string{
+		"host-name",
+		"host-name:123abc",
+	}
+	for _, input := range inputs {
+		_, _, err := SplitHostPort(input)
+		if err == nil {
+			t.Errorf("expected error from SplitHostPort(%q), but got none", input)
 		}
 	}
 }

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path"
 	"strconv"
@@ -22,6 +21,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -381,7 +381,7 @@ func (mysqld *Mysqld) FindSlaves() ([]string, error) {
 	addrs := make([]string, 0, 32)
 	for _, row := range qr.Rows {
 		if row[colCommand].String() == binlogDumpCommand {
-			host, _, err := net.SplitHostPort(row[colClientAddr].String())
+			host, _, err := netutil.SplitHostPort(row[colClientAddr].String())
 			if err != nil {
 				return nil, fmt.Errorf("FindSlaves: malformed addr %v", err)
 			}

--- a/test/topo_flavor/zookeeper.py
+++ b/test/topo_flavor/zookeeper.py
@@ -6,7 +6,6 @@
 
 import logging
 import os
-import socket
 import json
 
 import server
@@ -24,9 +23,10 @@ class ZkTopoServer(server.TopoServer):
       return
 
     from environment import reserve_ports
+    import utils
 
     self.zk_port_base = reserve_ports(3)
-    self.hostname = socket.getaddrinfo(socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
+    self.hostname = utils.hostname
     self.zk_ports = ':'.join(str(self.zk_port_base + i) for i in range(3))
     self.zk_client_port = self.zk_port_base + 2
     self.ports_assigned = True

--- a/test/topo_flavor/zookeeper.py
+++ b/test/topo_flavor/zookeeper.py
@@ -26,7 +26,7 @@ class ZkTopoServer(server.TopoServer):
     from environment import reserve_ports
 
     self.zk_port_base = reserve_ports(3)
-    self.hostname = socket.getfqdn()
+    self.hostname = socket.getaddrinfo(socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
     self.zk_ports = ':'.join(str(self.zk_port_base + i) for i in range(3))
     self.zk_client_port = self.zk_port_base + 2
     self.ports_assigned = True

--- a/test/utils.py
+++ b/test/utils.py
@@ -25,7 +25,7 @@ from topo_flavor.server import set_topo_server_flavor
 
 options = None
 devnull = open('/dev/null', 'w')
-hostname = socket.getfqdn()
+hostname = socket.getaddrinfo(socket.getfqdn(), None, 0, 0, 0, socket.AI_CANONNAME)[0][3]
 
 class TestError(Exception):
   pass


### PR DESCRIPTION
@alainjobart @henryanand 

If your /etc/hosts file contains something like this:

127.0.0.1 localhost localhost.localdomain.

Then both Python and Go will resolve the FQDN as localhost.localdomain.
However, in Go we additionally call net.LookupCNAME(), which converts
localhost.localdomain back to just localhost, since it comes first in
the /etc/hosts line. In Python, we need to also do the equivalent CNAME
lookup, or else we won't match the hostname that Vitess sees.