### PR TITLE
Speed up TabletExternallyReparented.

### DIFF
--- a/go/trace/trace.go
+++ b/go/trace/trace.go
@@ -58,6 +58,15 @@ func NewSpanFromContext(ctx context.Context) Span {
 	return NewSpan(nil)
 }
 
+// CopySpan creates a new context from parentCtx, with only the trace span
+// copied over from spanCtx, if it has any. If not, parentCtx is returned.
+func CopySpan(parentCtx, spanCtx context.Context) context.Context {
+	if span, ok := FromContext(spanCtx); ok {
+		return NewContext(parentCtx, span)
+	}
+	return parentCtx
+}
+
 // SpanFactory is an interface for creating spans or extracting them from Contexts.
 type SpanFactory interface {
 	New(parent Span) Span

--- a/go/trace/trace_test.go
+++ b/go/trace/trace_test.go
@@ -22,4 +22,5 @@ func TestFakeSpan(t *testing.T) {
 	span.Annotate("key", "value")
 	span.Finish()
 	NewContext(ctx, span)
+	CopySpan(ctx, ctx)
 }

--- a/go/vt/etcdtopo/server_test.go
+++ b/go/vt/etcdtopo/server_test.go
@@ -39,7 +39,7 @@ func TestKeyspace(t *testing.T) {
 func TestShard(t *testing.T) {
 	ts := newTestServer(t, []string{"test"})
 	defer ts.Close()
-	test.CheckShard(t, ts)
+	test.CheckShard(context.Background(), t, ts)
 }
 
 func TestTablet(t *testing.T) {
@@ -57,7 +57,7 @@ func TestShardReplication(t *testing.T) {
 func TestServingGraph(t *testing.T) {
 	ts := newTestServer(t, []string{"test"})
 	defer ts.Close()
-	test.CheckServingGraph(t, ts)
+	test.CheckServingGraph(context.Background(), t, ts)
 }
 
 func TestKeyspaceLock(t *testing.T) {

--- a/go/vt/tabletmanager/after_action.go
+++ b/go/vt/tabletmanager/after_action.go
@@ -73,7 +73,7 @@ func (agent *ActionAgent) loadKeyspaceAndBlacklistRules(tablet *topo.Tablet, bla
 	keyrangeRules := tabletserver.NewQueryRules()
 	if tablet.KeyRange.IsPartial() {
 		log.Infof("Restricting to keyrange: %v", tablet.KeyRange)
-		dml_plans := []struct {
+		dmlPlans := []struct {
 			planID   planbuilder.PlanType
 			onAbsent bool
 		}{
@@ -83,7 +83,7 @@ func (agent *ActionAgent) loadKeyspaceAndBlacklistRules(tablet *topo.Tablet, bla
 			{planbuilder.PLAN_DML_PK, false},
 			{planbuilder.PLAN_DML_SUBQUERY, false},
 		}
-		for _, plan := range dml_plans {
+		for _, plan := range dmlPlans {
 			qr := tabletserver.NewQueryRule(
 				fmt.Sprintf("enforce keyspace_id range for %v", plan.planID),
 				fmt.Sprintf("keyspace_id_not_in_range_%v", plan.planID),
@@ -150,7 +150,7 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 	var blacklistedTables []string
 	var err error
 	if allowQuery {
-		shardInfo, err = agent.TopoServer.GetShard(newTablet.Keyspace, newTablet.Shard)
+		shardInfo, err = topo.GetShard(ctx, agent.TopoServer, newTablet.Keyspace, newTablet.Shard)
 		if err != nil {
 			log.Errorf("Cannot read shard for this tablet %v, might have inaccurate SourceShards and TabletControls: %v", newTablet.Alias, err)
 		} else {

--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -168,8 +168,9 @@ func NewActionAgent(
 
 // NewTestActionAgent creates an agent for test purposes. Only a
 // subset of features are supported now, but we'll add more over time.
-func NewTestActionAgent(ts topo.Server, tabletAlias topo.TabletAlias, port int, mysqlDaemon mysqlctl.MysqlDaemon) (agent *ActionAgent) {
+func NewTestActionAgent(batchCtx context.Context, ts topo.Server, tabletAlias topo.TabletAlias, port int, mysqlDaemon mysqlctl.MysqlDaemon) (agent *ActionAgent) {
 	agent = &ActionAgent{
+		batchCtx:           batchCtx,
 		TopoServer:         ts,
 		TabletAlias:        tabletAlias,
 		Mysqld:             nil,

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -5,10 +5,15 @@
 package tabletmanager
 
 import (
+	"flag"
 	"fmt"
+	"sync"
+	"time"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/event"
+	"github.com/youtube/vitess/go/trace"
+	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
@@ -18,14 +23,191 @@ import (
 	"golang.org/x/net/context"
 )
 
+var (
+	fastReparent = flag.Bool("fast_external_reparent", false, "Skip updating of fields in topology that aren't needed if all MySQL reparents are done by an external tool, instead of by Vitess directly.")
+
+	finalizeReparentTimeout = flag.Duration("finalize_external_reparent_timeout", 10*time.Second, "Timeout for the finalize stage of a fast external reparent reconciliation.")
+)
+
+// fastTabletExternallyReparented completely replaces TabletExternallyReparented
+// if the -fast_external_reparent flag is specified.
+func (agent *ActionAgent) fastTabletExternallyReparented(ctx context.Context, externalID string) (err error) {
+	tablet := agent.Tablet()
+
+	log.Infof("using fast TabletExternallyReparented")
+
+	// Check the global shard record.
+	si, err := topo.GetShard(ctx, agent.TopoServer, tablet.Keyspace, tablet.Shard)
+	if err != nil {
+		log.Warningf("TabletExternallyReparented: failed to read global shard record for %v/%v: %v", tablet.Keyspace, tablet.Shard, err)
+		return err
+	}
+	if si.MasterAlias == tablet.Alias {
+		// We may get called on the current master even when nothing has changed.
+		// If the global shard record is already updated, it means we successfully
+		// finished a previous reparent to this tablet.
+		return nil
+	}
+
+	// Create a reusable Reparent event with available info.
+	ev := &events.Reparent{
+		ShardInfo:  *si,
+		NewMaster:  *tablet.Tablet,
+		OldMaster:  topo.Tablet{Alias: si.MasterAlias, Type: topo.TYPE_MASTER},
+		ExternalID: externalID,
+	}
+	defer func() {
+		if err != nil {
+			event.DispatchUpdate(ev, "failed: "+err.Error())
+		}
+	}()
+	event.DispatchUpdate(ev, "starting external from tablet (fast)")
+
+	// Execute state change to master by force-updating only the local copy of the
+	// tablet record. The actual record in topo will be updated later.
+	log.Infof("TabletExternallyReparented: executing change callback for state change to MASTER")
+	oldTablet := *tablet.Tablet
+	newTablet := oldTablet
+	newTablet.Type = topo.TYPE_MASTER
+	newTablet.State = topo.STATE_READ_WRITE
+	newTablet.Health = nil
+	agent.setTablet(topo.NewTabletInfo(&newTablet, -1))
+	if err := agent.updateState(ctx, &oldTablet, "TabletExternallyReparented"); err != nil {
+		return fmt.Errorf("TabletExternallyReparented: failed to change tablet state to MASTER: %v", err)
+	}
+
+	// Directly write the new master endpoint in the serving graph.
+	// We will do a true rebuild in the background soon, but in the meantime,
+	// this will be enough for clients to re-resolve the new master.
+	event.DispatchUpdate(ev, "writing new master endpoint")
+	log.Infof("TabletExternallyReparented: writing new master endpoint to serving graph")
+	ep, err := tablet.EndPoint()
+	if err != nil {
+		return fmt.Errorf("failed to generate EndPoint for tablet %v: %v", tablet.Alias, err)
+	}
+	err = topo.UpdateEndPoints(ctx, agent.TopoServer, tablet.Alias.Cell,
+		si.Keyspace(), si.ShardName(), topo.TYPE_MASTER,
+		&topo.EndPoints{Entries: []topo.EndPoint{*ep}})
+	if err != nil {
+		return fmt.Errorf("TabletExternallyReparented: failed to update master endpoint: %v", err)
+	}
+
+	// Start the finalize stage with a background context, but connect the trace.
+	go agent.finalizeTabletExternallyReparented(
+		trace.CopySpan(agent.batchCtx, ctx), si, ev)
+
+	return nil
+}
+
+// finalizeTabletExternallyReparented performs slow, synchronized reconciliation
+// tasks that ensure topology is self-consistent, and then marks the reparent as
+// finished by updating the global shard record.
+func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context, si *topo.ShardInfo, ev *events.Reparent) (err error) {
+	ctx, cancel := context.WithTimeout(ctx, *finalizeReparentTimeout)
+	defer cancel()
+
+	defer func() {
+		if err != nil {
+			log.Warningf("finalizeTabletExternallyReparented error: %v", err)
+			event.DispatchUpdate(ev, "failed: "+err.Error())
+		}
+	}()
+
+	var wg sync.WaitGroup
+	var errs concurrency.AllErrorRecorder
+	oldMasterAlias := si.MasterAlias
+
+	// Update the tablet records for the old and new master concurrently.
+	// We don't need a lock to update them because they are the source of truth,
+	// not derived values (like the serving graph).
+	event.DispatchUpdate(ev, "updating old and new master tablet records")
+	log.Infof("finalizeTabletExternallyReparented: updating tablet records")
+	wg.Add(2)
+	go func() {
+		// Update our own record to master.
+		err := topo.UpdateTabletFields(ctx, agent.TopoServer, agent.TabletAlias,
+			func(tablet *topo.Tablet) error {
+				tablet.Type = topo.TYPE_MASTER
+				tablet.State = topo.STATE_READ_WRITE
+				tablet.Health = nil
+				return nil
+			})
+		errs.RecordError(err)
+		wg.Done()
+	}()
+	go func() {
+		// Force the old master to spare.
+		var oldMasterTablet *topo.Tablet
+		err := topo.UpdateTabletFields(ctx, agent.TopoServer, oldMasterAlias,
+			func(tablet *topo.Tablet) error {
+				tablet.Type = topo.TYPE_SPARE
+				oldMasterTablet = tablet
+				return nil
+			})
+		errs.RecordError(err)
+		wg.Done()
+		if err != nil {
+			return
+		}
+
+		// Tell the old master to refresh its state. We don't need to wait for it.
+		if oldMasterTablet != nil {
+			tmc := tmclient.NewTabletManagerClient()
+			tmc.RefreshState(ctx, topo.NewTabletInfo(oldMasterTablet, -1))
+		}
+	}()
+
+	tablet := agent.Tablet()
+
+	// Wait for the tablet records to be updated. At that point, any rebuild will
+	// see the new master, so we're ready to mark the reparent as done in the
+	// global shard record.
+	wg.Wait()
+	if errs.HasErrors() {
+		return errs.Error()
+	}
+
+	// Update the master field in the global shard record. We don't use a lock
+	// here anymore. The lock was only to ensure that the global shard record
+	// didn't get modified between the time when we read it and the time when we
+	// write it back. Now we use an update loop pattern to do that instead.
+	event.DispatchUpdate(ev, "updating global shard record")
+	log.Infof("finalizeTabletExternallyReparented: updating global shard record")
+	topo.UpdateShardFields(ctx, agent.TopoServer, tablet.Keyspace, tablet.Shard, func(shard *topo.Shard) error {
+		shard.MasterAlias = tablet.Alias
+		return nil
+	})
+
+	// Rebuild the shard serving graph in the necessary cells.
+	// If it's a cross-cell reparent, rebuild all cells (by passing nil).
+	// If it's a same-cell reparent, we only need to rebuild the master cell.
+	event.DispatchUpdate(ev, "rebuilding shard serving graph")
+	var cells []string
+	if oldMasterAlias.Cell == tablet.Alias.Cell {
+		cells = []string{tablet.Alias.Cell}
+	}
+	logger := logutil.NewConsoleLogger()
+	log.Infof("finalizeTabletExternallyReparented: rebuilding shard")
+	if _, err = topotools.RebuildShard(ctx, logger, agent.TopoServer, tablet.Keyspace, tablet.Shard, cells, agent.LockTimeout); err != nil {
+		return err
+	}
+
+	event.DispatchUpdate(ev, "finished")
+	return nil
+}
+
 // TabletExternallyReparented updates all topo records so the current
 // tablet is the new master for this shard.
 // Should be called under RPCWrapLock.
 func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, externalID string) error {
+	if *fastReparent {
+		return agent.fastTabletExternallyReparented(ctx, externalID)
+	}
+
 	tablet := agent.Tablet()
 
 	// fast quick check on the shard to see if we're not the master already
-	shardInfo, err := agent.TopoServer.GetShard(tablet.Keyspace, tablet.Shard)
+	shardInfo, err := topo.GetShard(ctx, agent.TopoServer, tablet.Keyspace, tablet.Shard)
 	if err != nil {
 		log.Warningf("TabletExternallyReparented: Cannot read the shard %v/%v: %v", tablet.Keyspace, tablet.Shard, err)
 		return err
@@ -70,13 +252,13 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 // Note both are set independently (can have both true and an error).
 func (agent *ActionAgent) tabletExternallyReparentedLocked(ctx context.Context, externalID string) (bool, error) {
 	// re-read the tablet record to be sure we have the latest version
-	tablet, err := agent.TopoServer.GetTablet(agent.TabletAlias)
+	tablet, err := topo.GetTablet(ctx, agent.TopoServer, agent.TabletAlias)
 	if err != nil {
 		return false, err
 	}
 
 	// read the shard, make sure again the master is not already good.
-	shardInfo, err := agent.TopoServer.GetShard(tablet.Keyspace, tablet.Shard)
+	shardInfo, err := topo.GetShard(ctx, agent.TopoServer, tablet.Keyspace, tablet.Shard)
 	if err != nil {
 		return false, err
 	}

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -29,6 +29,12 @@ var (
 	finalizeReparentTimeout = flag.Duration("finalize_external_reparent_timeout", 10*time.Second, "Timeout for the finalize stage of a fast external reparent reconciliation.")
 )
 
+// SetReparentFlags changes flag values. It should only be used in tests.
+func SetReparentFlags(fast bool, timeout time.Duration) {
+	*fastReparent = fast
+	*finalizeReparentTimeout = timeout
+}
+
 // fastTabletExternallyReparented completely replaces TabletExternallyReparented
 // if the -fast_external_reparent flag is specified.
 func (agent *ActionAgent) fastTabletExternallyReparented(ctx context.Context, externalID string) (err error) {

--- a/go/vt/topo/helpers/tee_topo_test.go
+++ b/go/vt/topo/helpers/tee_topo_test.go
@@ -54,7 +54,7 @@ func TestKeyspace(t *testing.T) {
 
 func TestShard(t *testing.T) {
 	ts := newFakeTeeServer(t)
-	test.CheckShard(t, ts)
+	test.CheckShard(context.Background(), t, ts)
 }
 
 func TestTablet(t *testing.T) {
@@ -64,7 +64,7 @@ func TestTablet(t *testing.T) {
 
 func TestServingGraph(t *testing.T) {
 	ts := newFakeTeeServer(t)
-	test.CheckServingGraph(t, ts)
+	test.CheckServingGraph(context.Background(), t, ts)
 }
 
 func TestShardReplication(t *testing.T) {

--- a/go/vt/topo/serving_graph.go
+++ b/go/vt/topo/serving_graph.go
@@ -1,0 +1,25 @@
+// Copyright 2014, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package topo
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/trace"
+)
+
+// UpdateEndPoints is a high level wrapper for TopoServer.UpdateEndPoints.
+// It generates trace spans.
+func UpdateEndPoints(ctx context.Context, ts Server, cell, keyspace, shard string, tabletType TabletType, addrs *EndPoints) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.UpdateEndPoints")
+	span.Annotate("cell", cell)
+	span.Annotate("keyspace", keyspace)
+	span.Annotate("shard", shard)
+	span.Annotate("tablet_type", string(tabletType))
+	defer span.Finish()
+
+	return ts.UpdateEndPoints(cell, keyspace, shard, tabletType, addrs)
+}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -561,6 +561,17 @@ func UpdateTablet(ctx context.Context, ts Server, tablet *TabletInfo) error {
 	return err
 }
 
+// UpdateTabletFields is a high level wrapper for TopoServer.UpdateTabletFields
+// that generates trace spans.
+func UpdateTabletFields(ctx context.Context, ts Server, alias TabletAlias, update func(*Tablet) error) error {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.UpdateTabletFields")
+	span.Annotate("tablet", alias.String())
+	defer span.Finish()
+
+	return ts.UpdateTabletFields(alias, update)
+}
+
 // Validate makes sure a tablet is represented correctly in the topology server.
 func Validate(ts Server, tabletAlias TabletAlias) error {
 	// read the tablet record, make sure it parses

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -531,6 +531,17 @@ func NewTabletInfo(tablet *Tablet, version int64) *TabletInfo {
 	return &TabletInfo{version: version, Tablet: tablet}
 }
 
+// GetTablet is a high level function to read tablet data.
+// It generates trace spans.
+func GetTablet(ctx context.Context, ts Server, alias TabletAlias) (*TabletInfo, error) {
+	span := trace.NewSpanFromContext(ctx)
+	span.StartClient("TopoServer.GetTablet")
+	span.Annotate("tablet", alias.String())
+	defer span.Finish()
+
+	return ts.GetTablet(alias)
+}
+
 // UpdateTablet updates the tablet data only - not associated replication paths.
 func UpdateTablet(ctx context.Context, ts Server, tablet *TabletInfo) error {
 	span := trace.NewSpanFromContext(ctx)

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/topo"
+	"golang.org/x/net/context"
 )
 
-func CheckServingGraph(t *testing.T, ts topo.Server) {
+func CheckServingGraph(ctx context.Context, t *testing.T, ts topo.Server) {
 	cell := getLocalCell(t, ts)
 
 	// test individual cell/keyspace/shard/type entries
@@ -32,7 +33,7 @@ func CheckServingGraph(t *testing.T, ts topo.Server) {
 		},
 	}
 
-	if err := ts.UpdateEndPoints(cell, "test_keyspace", "-10", topo.TYPE_MASTER, &endPoints); err != nil {
+	if err := topo.UpdateEndPoints(ctx, ts, cell, "test_keyspace", "-10", topo.TYPE_MASTER, &endPoints); err != nil {
 		t.Fatalf("UpdateEndPoints(master): %v", err)
 	}
 	if types, err := ts.GetSrvTabletTypesPerShard(cell, "test_keyspace", "-10"); err != nil || len(types) != 1 || types[0] != topo.TYPE_MASTER {
@@ -51,7 +52,7 @@ func CheckServingGraph(t *testing.T, ts topo.Server) {
 	}
 
 	// Re-add endpoints.
-	if err := ts.UpdateEndPoints(cell, "test_keyspace", "-10", topo.TYPE_MASTER, &endPoints); err != nil {
+	if err := topo.UpdateEndPoints(ctx, ts, cell, "test_keyspace", "-10", topo.TYPE_MASTER, &endPoints); err != nil {
 		t.Fatalf("UpdateEndPoints(master): %v", err)
 	}
 

--- a/go/vt/topo/test/shard.go
+++ b/go/vt/topo/test/shard.go
@@ -94,6 +94,29 @@ func CheckShard(ctx context.Context, t *testing.T, ts topo.Server) {
 		t.Errorf("UpdateShard: %v", err)
 	}
 
+	other := topo.TabletAlias{Cell: "ny", Uid: 82873}
+	_, err = topo.UpdateShardFields(ctx, ts, "test_keyspace", "b0-c0", func(shard *topo.Shard) error {
+		shard.MasterAlias = other
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateShardFields error: %v", err)
+	}
+	si, err := topo.GetShard(ctx, ts, "test_keyspace", "b0-c0")
+	if err != nil {
+		t.Fatalf("GetShard: %v", err)
+	}
+	if si.MasterAlias != other {
+		t.Fatalf("shard.MasterAlias = %v, want %v", si.MasterAlias, other)
+	}
+	_, err = topo.UpdateShardFields(ctx, ts, "test_keyspace", "b0-c0", func(shard *topo.Shard) error {
+		shard.MasterAlias = master
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateShardFields error: %v", err)
+	}
+
 	updatedShardInfo, err := topo.GetShard(ctx, ts, "test_keyspace", "b0-c0")
 	if err != nil {
 		t.Fatalf("GetShard: %v", err)

--- a/go/vt/topo/test/shard.go
+++ b/go/vt/topo/test/shard.go
@@ -25,7 +25,7 @@ func shardEqual(left, right *topo.Shard) (bool, error) {
 	return string(lj) == string(rj), nil
 }
 
-func CheckShard(t *testing.T, ts topo.Server) {
+func CheckShard(ctx context.Context, t *testing.T, ts topo.Server) {
 	if err := ts.CreateKeyspace("test_keyspace", &topo.Keyspace{}); err != nil {
 		t.Fatalf("CreateKeyspace: %v", err)
 	}
@@ -53,11 +53,11 @@ func CheckShard(t *testing.T, ts topo.Server) {
 		t.Fatalf("CreateShard: %v", err)
 	}
 
-	if _, err := ts.GetShard("test_keyspace", "666"); err != topo.ErrNoNode {
+	if _, err := topo.GetShard(ctx, ts, "test_keyspace", "666"); err != topo.ErrNoNode {
 		t.Errorf("GetShard(666): %v", err)
 	}
 
-	shardInfo, err := ts.GetShard("test_keyspace", "b0-c0")
+	shardInfo, err := topo.GetShard(ctx, ts, "test_keyspace", "b0-c0")
 	if err != nil {
 		t.Errorf("GetShard: %v", err)
 	}
@@ -90,11 +90,11 @@ func CheckShard(t *testing.T, ts topo.Server) {
 			DisableQueryService: true,
 		},
 	}
-	if err := topo.UpdateShard(context.TODO(), ts, shardInfo); err != nil {
+	if err := topo.UpdateShard(ctx, ts, shardInfo); err != nil {
 		t.Errorf("UpdateShard: %v", err)
 	}
 
-	updatedShardInfo, err := ts.GetShard("test_keyspace", "b0-c0")
+	updatedShardInfo, err := topo.GetShard(ctx, ts, "test_keyspace", "b0-c0")
 	if err != nil {
 		t.Fatalf("GetShard: %v", err)
 	}

--- a/go/vt/topo/test/tablet.go
+++ b/go/vt/topo/test/tablet.go
@@ -88,7 +88,7 @@ func CheckTablet(ctx context.Context, t *testing.T, ts topo.Server) {
 		t.Errorf("ti.State: want %v, got %v", want, ti.State)
 	}
 
-	if err := ts.UpdateTabletFields(tablet.Alias, func(t *topo.Tablet) error {
+	if err := topo.UpdateTabletFields(ctx, ts, tablet.Alias, func(t *topo.Tablet) error {
 		t.State = topo.STATE_READ_WRITE
 		return nil
 	}); err != nil {

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/gorpctmserver"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/wrangler"
+	"golang.org/x/net/context"
 )
 
 // This file contains utility methods for unit tests.
@@ -133,7 +134,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 
 	// create a test agent on that port, and re-read the record
 	// (it has new ports and IP)
-	ft.Agent = tabletmanager.NewTestActionAgent(wr.TopoServer(), ft.Tablet.Alias, port, ft.FakeMysqlDaemon)
+	ft.Agent = tabletmanager.NewTestActionAgent(context.TODO(), wr.TopoServer(), ft.Tablet.Alias, port, ft.FakeMysqlDaemon)
 	ft.Tablet = ft.Agent.Tablet().Tablet
 
 	// create the RPC server

--- a/go/vt/wrangler/testlib/reparent_external_test.go
+++ b/go/vt/wrangler/testlib/reparent_external_test.go
@@ -5,21 +5,35 @@
 package testlib
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/event"
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/tabletmanager"
 	_ "github.com/youtube/vitess/go/vt/tabletmanager/gorpctmclient"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topotools"
+	"github.com/youtube/vitess/go/vt/topotools/events"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"github.com/youtube/vitess/go/vt/zktopo"
 )
 
 func TestTabletExternallyReparented(t *testing.T) {
+	testTabletExternallyReparented(t, false /* falst */)
+}
+
+func TestTabletExternallyReparentedFast(t *testing.T) {
+	testTabletExternallyReparented(t, true /* fast */)
+}
+
+func testTabletExternallyReparented(t *testing.T, fast bool) {
+	tabletmanager.SetReparentFlags(fast, time.Minute /* finalizeTimeout */)
+
 	ctx := context.Background()
 	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, time.Minute, time.Second)
@@ -139,8 +153,12 @@ func TestTabletExternallyReparented(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTablet failed: %v", err)
 	}
-	if err := tmc.TabletExternallyReparented(wr.Context(), ti, ""); err != nil {
+	waitID := makeWaitID()
+	if err := tmc.TabletExternallyReparented(wr.Context(), ti, waitID); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+	if fast {
+		waitForExternalReparent(t, waitID)
 	}
 
 	// Now double-check the serving graph is good.
@@ -158,6 +176,16 @@ func TestTabletExternallyReparented(t *testing.T) {
 // that if mysql is restarted on the master-elect tablet and has a different
 // port, we pick it up correctly.
 func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
+	testTabletExternallyReparentedWithDifferentMysqlPort(t, false /* fast */)
+}
+
+func TestTabletExternallyReparentedWithDifferentMysqlPortFast(t *testing.T) {
+	testTabletExternallyReparentedWithDifferentMysqlPort(t, true /* fast */)
+}
+
+func testTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T, fast bool) {
+	tabletmanager.SetReparentFlags(fast, time.Minute /* finalizeTimeout */)
+
 	ts := zktopo.NewTestServer(t, []string{"cell1"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, time.Minute, time.Second)
 
@@ -206,6 +234,16 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 // TestTabletExternallyReparentedContinueOnUnexpectedMaster makes sure
 // that we ignore mysql's master if the flag is set
 func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
+	testTabletExternallyReparentedContinueOnUnexpectedMaster(t, false /* fast */)
+}
+
+func TestTabletExternallyReparentedContinueOnUnexpectedMasterFast(t *testing.T) {
+	testTabletExternallyReparentedContinueOnUnexpectedMaster(t, true /* fast */)
+}
+
+func testTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T, fast bool) {
+	tabletmanager.SetReparentFlags(fast, time.Minute /* finalizeTimeout */)
+
 	ts := zktopo.NewTestServer(t, []string{"cell1"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, time.Minute, time.Second)
 
@@ -248,17 +286,27 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 }
 
 func TestTabletExternallyReparentedFailedOldMaster(t *testing.T) {
+	testTabletExternallyReparentedFailedOldMaster(t, false /* fast */)
+}
+
+func TestTabletExternallyReparentedFailedOldMasterFast(t *testing.T) {
+	testTabletExternallyReparentedFailedOldMaster(t, true /* fast */)
+}
+
+func testTabletExternallyReparentedFailedOldMaster(t *testing.T, fast bool) {
+	tabletmanager.SetReparentFlags(fast, time.Minute /* finalizeTimeout */)
+
 	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, time.Minute, time.Second)
 
-	// Create an old master, a new master, two good slaves
+	// Create an old master, a new master, and a good slave.
 	oldMaster := NewFakeTablet(t, wr, "cell1", 0, topo.TYPE_MASTER)
 	newMaster := NewFakeTablet(t, wr, "cell1", 1, topo.TYPE_REPLICA,
 		TabletParent(oldMaster.Tablet.Alias))
 	goodSlave := NewFakeTablet(t, wr, "cell1", 2, topo.TYPE_REPLICA,
 		TabletParent(oldMaster.Tablet.Alias))
 
-	// Reparent to a replica, and pretend the old master is not responding
+	// Reparent to a replica, and pretend the old master is not responding.
 
 	// On the elected master, we will respond to
 	// TABLET_ACTION_SLAVE_WAS_PROMOTED
@@ -283,8 +331,12 @@ func TestTabletExternallyReparentedFailedOldMaster(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTablet failed: %v", err)
 	}
-	if err := tmc.TabletExternallyReparented(wr.Context(), ti, ""); err != nil {
+	waitID := makeWaitID()
+	if err := tmc.TabletExternallyReparented(wr.Context(), ti, waitID); err != nil {
 		t.Fatalf("TabletExternallyReparented(replica) failed: %v", err)
+	}
+	if fast {
+		waitForExternalReparent(t, waitID)
 	}
 
 	// Now double-check the serving graph is good.
@@ -304,5 +356,45 @@ func TestTabletExternallyReparentedFailedOldMaster(t *testing.T) {
 	}
 	if tablet.Type != topo.TYPE_SPARE {
 		t.Fatalf("old master should be spare but is: %v", tablet.Type)
+	}
+}
+
+var externalReparents = make(map[string]chan struct{})
+
+// makeWaitID generates a unique externalID that can be passed to
+// TabletExternallyReparented, and then to waitForExternalReparent.
+func makeWaitID() string {
+	id := fmt.Sprintf("wait id %v", len(externalReparents))
+	externalReparents[id] = make(chan struct{})
+	return id
+}
+
+func init() {
+	event.AddListener(func(ev *events.Reparent) {
+		if ev.Status == "finished" {
+			if c, ok := externalReparents[ev.ExternalID]; ok {
+				close(c)
+			}
+		}
+	})
+}
+
+// waitForExternalReparent waits up to a fixed duration for the external
+// reparent with the given ID to finish. The ID must have been previously
+// generated by makeWaitID().
+//
+// In fast mode, the TabletExternallyReparented RPC returns as soon as the
+// new master is visible in the serving graph. Before checking things like
+// replica endpoints and old master status, we should wait for the finalize
+// stage, which happens in the background.
+func waitForExternalReparent(t *testing.T, externalID string) {
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-externalReparents[externalID]:
+		return
+	case <-timer.C:
+		t.Fatalf("deadline exceeded waiting for finalized external reparent %q", externalID)
 	}
 }

--- a/go/vt/zktopo/zktopo_test.go
+++ b/go/vt/zktopo/zktopo_test.go
@@ -17,7 +17,7 @@ func TestKeyspace(t *testing.T) {
 func TestShard(t *testing.T) {
 	ts := NewTestServer(t, []string{"test"})
 	defer ts.Close()
-	test.CheckShard(t, ts)
+	test.CheckShard(context.Background(), t, ts)
 }
 
 func TestTablet(t *testing.T) {
@@ -35,7 +35,7 @@ func TestShardReplication(t *testing.T) {
 func TestServingGraph(t *testing.T) {
 	ts := NewTestServer(t, []string{"test"})
 	defer ts.Close()
-	test.CheckServingGraph(t, ts)
+	test.CheckServingGraph(context.Background(), t, ts)
 }
 
 func TestKeyspaceLock(t *testing.T) {

--- a/go/zk/config.go
+++ b/go/zk/config.go
@@ -69,6 +69,7 @@ func letterPrefix(str string) string {
 	return str
 }
 
+// ZkCellFromZkPath extracts the cell name from a zkPath.
 func ZkCellFromZkPath(zkPath string) (string, error) {
 	pathParts := strings.Split(zkPath, "/")
 	if len(pathParts) < 3 {
@@ -78,8 +79,8 @@ func ZkCellFromZkPath(zkPath string) (string, error) {
 		return "", fmt.Errorf("path should start with /%v: %v", MagicPrefix, zkPath)
 	}
 	cell := pathParts[2]
-	if strings.Contains(cell, "-") {
-		return "", fmt.Errorf("invalid cell name %v", cell)
+	if cell == "" || strings.Contains(cell, "-") {
+		return "", fmt.Errorf("invalid cell name %q", cell)
 	}
 	return cell, nil
 }

--- a/go/zk/config_test.go
+++ b/go/zk/config_test.go
@@ -71,3 +71,20 @@ func TestZkConfig(t *testing.T) {
 		t.Errorf("ZkKnownCells(false) failed, expected %v got %v", expectedKnownCells, knownCells)
 	}
 }
+
+func TestZkCellFromZkPathInvalid(t *testing.T) {
+	// The following paths should be rejected so the invalid cell name doesn't
+	// cause problems down the line.
+	inputs := []string{
+		"/zk",
+		"bad/zk/path",
+		"/wrongprefix/cell",
+		"/zk//emptycellname",
+		"/zk/bad-cell-name/",
+	}
+	for _, input := range inputs {
+		if _, err := ZkCellFromZkPath(input); err == nil {
+			t.Errorf("expected error for ZkCellFromZkPath(%q), got none", input)
+		}
+	}
+}

--- a/go/zk/conn_cache.go
+++ b/go/zk/conn_cache.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,7 @@ func (cc *ConnCache) setState(zcell string, conn *cachedConn, state int64) {
 }
 
 func (cc *ConnCache) ConnForPath(zkPath string) (cn Conn, err error) {
+	fmt.Fprintf(os.Stderr, "zkPath: %q\n", zkPath) // DEBUG
 	zcell, err := ZkCellFromZkPath(zkPath)
 	if err != nil {
 		return nil, &zookeeper.Error{Op: "dial", Code: zookeeper.ZSYSTEMERROR, SystemError: err, Path: zkPath}

--- a/go/zk/conn_cache.go
+++ b/go/zk/conn_cache.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -58,7 +57,6 @@ func (cc *ConnCache) setState(zcell string, conn *cachedConn, state int64) {
 }
 
 func (cc *ConnCache) ConnForPath(zkPath string) (cn Conn, err error) {
-	fmt.Fprintf(os.Stderr, "zkPath: %q\n", zkPath) // DEBUG
 	zcell, err := ZkCellFromZkPath(zkPath)
 	if err != nil {
 		return nil, &zookeeper.Error{Op: "dial", Code: zookeeper.ZSYSTEMERROR, SystemError: err, Path: zkPath}

--- a/test/reparent.py
+++ b/test/reparent.py
@@ -429,6 +429,9 @@ class TestReparent(unittest.TestCase):
   def test_reparent_from_outside_brutal(self):
     self._test_reparent_from_outside(brutal=True)
 
+  def test_reparent_from_outside_brutal_fast(self):
+    self._test_reparent_from_outside(brutal=True, fast=True)
+
   def _test_reparent_from_outside(self, brutal=False, fast=False):
     """This test will start a master and 3 slaves. Then:
     - one slave will be the new master

--- a/test/reparent.py
+++ b/test/reparent.py
@@ -423,10 +423,13 @@ class TestReparent(unittest.TestCase):
   def test_reparent_from_outside(self):
     self._test_reparent_from_outside(brutal=False)
 
+  def test_reparent_from_outside_fast(self):
+    self._test_reparent_from_outside(brutal=False, fast=True)
+
   def test_reparent_from_outside_brutal(self):
     self._test_reparent_from_outside(brutal=True)
 
-  def _test_reparent_from_outside(self, brutal=False):
+  def _test_reparent_from_outside(self, brutal=False, fast=False):
     """This test will start a master and 3 slaves. Then:
     - one slave will be the new master
     - one slave will be reparented to that new master
@@ -442,17 +445,21 @@ class TestReparent(unittest.TestCase):
     for t in [tablet_62344, tablet_62044, tablet_41983, tablet_31981]:
       t.create_db('vt_test_keyspace')
 
+    extra_args = None
+    if fast:
+      extra_args = ['-fast_external_reparent']
+
     # Start up a master mysql and vttablet
     tablet_62344.init_tablet('master', 'test_keyspace', '0', start=True,
-                             wait_for_start=False)
+                             wait_for_start=False, extra_args=extra_args)
 
     # Create a few slaves for testing reparenting.
     tablet_62044.init_tablet('replica', 'test_keyspace', '0', start=True,
-                             wait_for_start=False)
+                             wait_for_start=False, extra_args=extra_args)
     tablet_41983.init_tablet('replica', 'test_keyspace', '0', start=True,
-                             wait_for_start=False)
+                             wait_for_start=False, extra_args=extra_args)
     tablet_31981.init_tablet('replica', 'test_keyspace', '0', start=True,
-                             wait_for_start=False)
+                             wait_for_start=False, extra_args=extra_args)
 
     # wait for all tablets to start
     for t in [tablet_62344, tablet_62044, tablet_41983, tablet_31981]:
@@ -509,6 +516,7 @@ class TestReparent(unittest.TestCase):
   def _test_reparent_from_outside_check(self, brutal):
     if environment.topo_server().flavor() != 'zookeeper':
       return
+
     # make sure the shard replication graph is fine
     shard_replication = utils.run_vtctl_json(['GetShardReplication', 'test_nj',
                                               'test_keyspace/0'])


### PR DESCRIPTION
@alainjobart 

This adds an alternate implementation of TabletExternallyReparented
that reduces the client-visible downtime for a reparent by making sure
the serving graph sees the new master ASAP. The rest of topology is
then reconciled as necessary.

The new implementation is only used when the -fast_external_reparent
flag is enabled on vttablet. This flag is currently off by default.