### PR TITLE
Support different custom rule implementation in custom rule test

### DIFF
--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -465,21 +465,22 @@ class TestNocache(framework.TestCase):
       self.assertContains(str(e), "error: Query disallowed")
     # Test dynamic custom rule for vttablet
     if self.env.env == "vttablet":
-      # Make a change to the rule
-      self.env.change_customrules()
-      time.sleep(3)
-      try:
-        self.env.execute("select * from vtocc_test where intval=:asdfg", bv)
-      except dbexceptions.DatabaseError as e:
-        self.fail("Bindvar asdfg should be allowed after a change of custom rule, Err=" + str(e))
-      # Restore the rule
-      self.env.restore_customrules()
-      time.sleep(3)
-      try:
-        self.env.execute("select * from vtocc_test where intval=:asdfg", bv)
-        self.fail("Bindvar asdfg should not be allowed by custom rule")
-      except dbexceptions.DatabaseError as e:
-        self.assertContains(str(e), "error: Query disallowed")
+      if environment.topo_server().flavor() == 'zookeeper':
+        # Make a change to the rule
+        self.env.change_customrules()
+        time.sleep(3)
+        try:
+          self.env.execute("select * from vtocc_test where intval=:asdfg", bv)
+        except dbexceptions.DatabaseError as e:
+          self.fail("Bindvar asdfg should be allowed after a change of custom rule, Err=" + str(e))
+        # Restore the rule
+        self.env.restore_customrules()
+        time.sleep(3)
+        try:
+          self.env.execute("select * from vtocc_test where intval=:asdfg", bv)
+          self.fail("Bindvar asdfg should not be allowed by custom rule")
+        except dbexceptions.DatabaseError as e:
+          self.assertContains(str(e), "error: Query disallowed")
 
   def test_health(self):
     self.assertEqual(self.env.health(), "ok")

--- a/test/queryservice_tests/stream_tests.py
+++ b/test/queryservice_tests/stream_tests.py
@@ -7,6 +7,7 @@ import urllib
 from vtdb import cursor
 from vtdb import dbexceptions
 
+import environment
 import framework
 
 class TestStream(framework.TestCase):
@@ -38,22 +39,23 @@ class TestStream(framework.TestCase):
       self.assertContains(str(e), "error: Query disallowed")
     # Test dynamic custom rule for vttablet
     if self.env.env == "vttablet":
-      # Make a change to the rule
-      self.env.change_customrules()
-      time.sleep(3)
-      try:
-        self.env.execute("select * from vtocc_test where intval=:asdfg", bv,
+      if environment.topo_server().flavor() == 'zookeeper':
+        # Make a change to the rule
+        self.env.change_customrules()
+        time.sleep(3)
+        try:
+          self.env.execute("select * from vtocc_test where intval=:asdfg", bv,
                        cursorclass=cursor.StreamCursor)
-      except dbexceptions.DatabaseError as e:
-        self.fail("Bindvar asdfg should be allowed after a change of custom rule, Err=" + str(e))
-      self.env.restore_customrules()
-      time.sleep(3)
-      try:
-        self.env.execute("select * from vtocc_test where intval=:asdfg", bv,
+        except dbexceptions.DatabaseError as e:
+          self.fail("Bindvar asdfg should be allowed after a change of custom rule, Err=" + str(e))
+        self.env.restore_customrules()
+        time.sleep(3)
+        try:
+          self.env.execute("select * from vtocc_test where intval=:asdfg", bv,
                        cursorclass=cursor.StreamCursor)
-        self.fail("Bindvar asdfg should not be allowed by custom rule")
-      except dbexceptions.DatabaseError as e:
-        self.assertContains(str(e), "error: Query disallowed")
+          self.fail("Bindvar asdfg should not be allowed by custom rule")
+        except dbexceptions.DatabaseError as e:
+          self.assertContains(str(e), "error: Query disallowed")
 
   def test_basic_stream(self):
     self._populate_vtocc_big_table(100)


### PR DESCRIPTION
@sougou This is a follow up to pull request #265 . This patch let the custom rule test aware of what topology server is being in use so that it fixes potential issues which may be brought by mixing zookeeper dependent code into the tests