### PR TITLE
query service: low level reconnect logic

### DIFF
--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -33,6 +33,7 @@ type PoolConnection interface {
 	Close()
 	IsClosed() bool
 	Recycle()
+	Reconnect() error
 }
 
 // CreateConnectionFunc is the factory method to create new connections

--- a/go/vt/tabletserver/tablet_error.go
+++ b/go/vt/tabletserver/tablet_error.go
@@ -73,6 +73,18 @@ func NewTabletErrorSql(errorType int, err error) *TabletError {
 	}
 }
 
+func IsConnErr(err error) bool {
+	terr, ok := err.(*TabletError)
+	if !ok {
+		return false
+	}
+	// 2013 means that someone sniped the query.
+	if terr.SqlError == 2013 {
+		return false
+	}
+	return terr.SqlError >= 2000 && terr.SqlError <= 2018
+}
+
 func (te *TabletError) Error() string {
 	format := "error: %s"
 	switch te.ErrorType {

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -5,6 +5,7 @@
 package tabletserver
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -232,6 +233,10 @@ func (txc *TxConnection) Recycle() {
 	} else {
 		txc.pool.activePool.Put(txc.TransactionID)
 	}
+}
+
+func (txc *TxConnection) Reconnect() error {
+	return errors.New("Reconnect not allowed for TxConnection")
 }
 
 func (txc *TxConnection) RecordQuery(query string) {

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -166,6 +166,10 @@ func (fpc *FakePoolConnection) IsClosed() bool {
 func (fpc *FakePoolConnection) Recycle() {
 }
 
+func (fpc *FakePoolConnection) Reconnect() error {
+	return nil
+}
+
 // on the source rdonly guy, should only have one query to find min & max
 func SourceRdonlyFactory(t *testing.T) func() (dbconnpool.PoolConnection, error) {
 	return func() (dbconnpool.PoolConnection, error) {

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -86,6 +86,10 @@ func (fpc *FakePoolConnection) IsClosed() bool {
 func (fpc *FakePoolConnection) Recycle() {
 }
 
+func (fpc *FakePoolConnection) Reconnect() error {
+	return nil
+}
+
 // on the destinations
 func DestinationsFactory(t *testing.T) func() (dbconnpool.PoolConnection, error) {
 	var queryIndex int64 = -1

--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -630,3 +630,24 @@ class TestNocache(framework.TestCase):
     cu.execute("select * from vtocc_acl_all_user_read_only where key1=1", {})
     cu.fetchall()
     cu.close()
+
+  # This is a super-slow test. Uncomment and test if you change
+  # the server-side reconnect logic.
+  #def test_server_reconnect(self):
+  #  self.env.execute("set vt_pool_size=1")
+  #  self.env.execute("select * from vtocc_test limit :l", {"l": 1})
+  #  self.env.tablet.shutdown_mysql()
+  #  time.sleep(5)
+  #  self.env.tablet.start_mysql()
+  #  time.sleep(5)
+  #  self.env.execute("select * from vtocc_test limit :l", {"l": 1})
+  #  self.env.conn.begin()
+  #  self.env.tablet.shutdown_mysql()
+  #  time.sleep(5)
+  #  self.env.tablet.start_mysql()
+  #  time.sleep(5)
+  #  with self.assertRaises(dbexceptions.DatabaseError):
+  #    self.env.execute("select * from vtocc_test limit :l", {"l": 1})
+  #  with self.assertRaises(dbexceptions.DatabaseError):
+  #    self.env.conn.rollback()
+  #  self.env.execute("set vt_pool_size=16")


### PR DESCRIPTION
@alainjobart @enisoc 
If MySQL is restarted underneath query service, all connections
become invalid. This ends up returning one error per connection
until everything heals.
This CL changes the low-level exec to do a transparent reconnect
and retry if such an error was detected. But this is done only
if you're not in a transaction.
The test for this is hairy and slow. Probably flaky also. So,
I've commented it out after making sure it passes.