### PR TITLE
Only register one topo explorer, for the topo flavor that's in use.

### DIFF
--- a/go/cmd/vtctld/plugin_etcdtopo.go
+++ b/go/cmd/vtctld/plugin_etcdtopo.go
@@ -7,17 +7,16 @@ package main
 // This plugin imports etcdtopo to register the etcd implementation of TopoServer.
 
 import (
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/etcdtopo"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 )
 
 func init() {
-	ts := topo.GetServerByName("etcd")
-	if ts == nil {
-		log.Warning("etcd explorer disabled: no etcdtopo.Server")
-		return
-	}
-
-	HandleExplorer("etcd", "/etcd/", "etcd.html", etcdtopo.NewExplorer(ts.(*etcdtopo.Server)))
+	// Wait until flags are parsed, so we can check which topo server is in use.
+	servenv.OnRun(func() {
+		if etcdServer, ok := topo.GetServer().(*etcdtopo.Server); ok {
+			HandleExplorer("etcd", "/etcd/", "etcd.html", etcdtopo.NewExplorer(etcdServer))
+		}
+	})
 }

--- a/go/cmd/vtctld/plugin_zktopo.go
+++ b/go/cmd/vtctld/plugin_zktopo.go
@@ -15,23 +15,21 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/cmd/vtctld/proto"
 	"github.com/youtube/vitess/go/netutil"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"github.com/youtube/vitess/go/zk"
 )
 
 func init() {
-	// handles /zk paths
-	ts := topo.GetServerByName("zookeeper")
-	if ts == nil {
-		log.Error("zookeeper explorer disabled: no zktopo.Server")
-		return
-	}
-
-	HandleExplorer("zk", "/zk/", "zk.html", NewZkExplorer(ts.(*zktopo.Server).GetZConn()))
+	// Wait until flags are parsed, so we can check which topo server is in use.
+	servenv.OnRun(func() {
+		if zkServer, ok := topo.GetServer().(*zktopo.Server); ok {
+			HandleExplorer("zk", "/zk/", "zk.html", NewZkExplorer(zkServer.GetZConn()))
+		}
+	})
 }
 
 // ZkExplorer implements Explorer


### PR DESCRIPTION
@sougou 

This should prevent the broken links in vtctld that are for the wrong topo flavor.