### PR TITLE
Return errors instead of log.Fatal in commands.

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -157,6 +158,7 @@ var commands = []command{
 }
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 
 	flag.Usage = func() {
@@ -190,7 +192,8 @@ func main() {
 
 	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, flags)
 	if err != nil {
-		log.Fatalf("%v", err)
+		log.Errorf("%v", err)
+		exit.Return(1)
 	}
 	mysqld := mysqlctl.NewMysqld("Dba", mycnf, &dbcfgs.Dba, &dbcfgs.Repl)
 	defer mysqld.Close()
@@ -209,5 +212,6 @@ func main() {
 			return
 		}
 	}
-	log.Fatalf("invalid action: %v", action)
+	log.Errorf("invalid action: %v", action)
+	exit.Return(1)
 }

--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -27,108 +27,115 @@ var (
 	tabletAddr string
 )
 
-func initCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func initCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	waitTime := subFlags.Duration("wait_time", mysqlctl.MysqlWaitTime, "how long to wait for startup")
 	bootstrapArchive := subFlags.String("bootstrap_archive", "mysql-db-dir.tbz", "name of bootstrap archive within vitess/data/bootstrap directory")
 	skipSchema := subFlags.Bool("skip_schema", false, "don't apply initial schema")
 	subFlags.Parse(args)
 
 	if err := mysqld.Init(*waitTime, *bootstrapArchive, *skipSchema); err != nil {
-		log.Fatalf("failed init mysql: %v", err)
+		return fmt.Errorf("failed init mysql: %v", err)
 	}
+	return nil
 }
 
-func restoreCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func restoreCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	dontWaitForSlaveStart := subFlags.Bool("dont_wait_for_slave_start", false, "won't wait for replication to start (useful when restoring from master server)")
 	fetchConcurrency := subFlags.Int("fetch_concurrency", 3, "how many files to fetch simultaneously")
 	fetchRetryCount := subFlags.Int("fetch_retry_count", 3, "how many times to retry a failed transfer")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("Command restore requires <snapshot manifest file>")
+		return fmt.Errorf("Command restore requires <snapshot manifest file>")
 	}
 
 	rs, err := mysqlctl.ReadSnapshotManifest(subFlags.Arg(0))
-	if err == nil {
-		err = mysqld.RestoreFromSnapshot(logutil.NewConsoleLogger(), rs, *fetchConcurrency, *fetchRetryCount, *dontWaitForSlaveStart, nil)
-	}
 	if err != nil {
-		log.Fatalf("restore failed: %v", err)
+		return fmt.Errorf("restore failed: ReadSnapshotManifest: %v", err)
 	}
+	err = mysqld.RestoreFromSnapshot(logutil.NewConsoleLogger(), rs, *fetchConcurrency, *fetchRetryCount, *dontWaitForSlaveStart, nil)
+	if err != nil {
+		return fmt.Errorf("restore failed: RestoreFromSnapshot: %v", err)
+	}
+	return nil
 }
 
-func shutdownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func shutdownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	waitTime := subFlags.Duration("wait_time", mysqlctl.MysqlWaitTime, "how long to wait for shutdown")
 	subFlags.Parse(args)
 
-	if mysqlErr := mysqld.Shutdown(true, *waitTime); mysqlErr != nil {
-		log.Fatalf("failed shutdown mysql: %v", mysqlErr)
+	if err := mysqld.Shutdown(true, *waitTime); err != nil {
+		return fmt.Errorf("failed shutdown mysql: %v", err)
 	}
+	return nil
 }
 
-func snapshotCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func snapshotCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 4, "how many compression jobs to run simultaneously")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("Command snapshot requires <db name>")
+		return fmt.Errorf("Command snapshot requires <db name>")
 	}
 
 	filename, _, _, err := mysqld.CreateSnapshot(logutil.NewConsoleLogger(), subFlags.Arg(0), tabletAddr, false, *concurrency, false, nil)
 	if err != nil {
-		log.Fatalf("snapshot failed: %v", err)
-	} else {
-		log.Infof("manifest location: %v", filename)
+		return fmt.Errorf("snapshot failed: %v", err)
 	}
+	log.Infof("manifest location: %v", filename)
+	return nil
 }
 
-func snapshotSourceStartCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func snapshotSourceStartCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	concurrency := subFlags.Int("concurrency", 4, "how many checksum jobs to run simultaneously")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("Command snapshotsourcestart requires <db name>")
+		return fmt.Errorf("Command snapshotsourcestart requires <db name>")
 	}
 
 	filename, slaveStartRequired, readOnly, err := mysqld.CreateSnapshot(logutil.NewConsoleLogger(), subFlags.Arg(0), tabletAddr, false, *concurrency, true, nil)
 	if err != nil {
-		log.Fatalf("snapshot failed: %v", err)
-	} else {
-		log.Infof("manifest location: %v", filename)
-		log.Infof("slave start required: %v", slaveStartRequired)
-		log.Infof("read only: %v", readOnly)
+		return fmt.Errorf("snapshot failed: %v", err)
 	}
+	log.Infof("manifest location: %v", filename)
+	log.Infof("slave start required: %v", slaveStartRequired)
+	log.Infof("read only: %v", readOnly)
+	return nil
 }
 
-func snapshotSourceEndCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func snapshotSourceEndCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	slaveStartRequired := subFlags.Bool("slave_start", false, "will restart replication")
 	readWrite := subFlags.Bool("read_write", false, "will make the server read-write")
 	subFlags.Parse(args)
 
 	err := mysqld.SnapshotSourceEnd(*slaveStartRequired, !(*readWrite), true, map[string]string{})
 	if err != nil {
-		log.Fatalf("snapshotsourceend failed: %v", err)
+		return fmt.Errorf("snapshotsourceend failed: %v", err)
 	}
+	return nil
 }
 
-func startCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func startCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	waitTime := subFlags.Duration("wait_time", mysqlctl.MysqlWaitTime, "how long to wait for startup")
 	subFlags.Parse(args)
 
 	if err := mysqld.Start(*waitTime); err != nil {
-		log.Fatalf("failed start mysql: %v", err)
+		return fmt.Errorf("failed start mysql: %v", err)
 	}
+	return nil
 }
 
-func teardownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) {
+func teardownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
 	force := subFlags.Bool("force", false, "will remove the root directory even if mysqld shutdown fails")
 	subFlags.Parse(args)
 
 	if err := mysqld.Teardown(*force); err != nil {
-		log.Fatalf("failed teardown mysql (forced? %v): %v", *force, err)
+		return fmt.Errorf("failed teardown mysql (forced? %v): %v", *force, err)
 	}
+	return nil
 }
 
 type command struct {
 	name   string
-	method func(*mysqlctl.Mysqld, *flag.FlagSet, []string)
+	method func(*mysqlctl.Mysqld, *flag.FlagSet, []string) error
 	params string
 	help   string
 }
@@ -208,7 +215,10 @@ func main() {
 				subFlags.PrintDefaults()
 			}
 
-			cmd.method(mysqld, subFlags, flag.Args()[1:])
+			if err := cmd.method(mysqld, subFlags, flag.Args()[1:]); err != nil {
+				log.Error(err)
+				exit.Return(1)
+			}
 			return
 		}
 	}

--- a/go/cmd/query_analyzer/query_analyzer.go
+++ b/go/cmd/query_analyzer/query_analyzer.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 )
 
@@ -31,26 +32,30 @@ var (
 	queries   = make(map[string]int)
 )
 
-type Stat struct {
+type stat struct {
 	Query string
 	Count int
 }
 
-type Stats []Stat
+type stats []stat
 
-func (a Stats) Len() int           { return len(a) }
-func (a Stats) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a Stats) Less(i, j int) bool { return a[i].Count > a[j].Count }
+func (a stats) Len() int           { return len(a) }
+func (a stats) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a stats) Less(i, j int) bool { return a[i].Count > a[j].Count }
 
 func main() {
+	defer exit.Recover()
 	flag.Parse()
 	for _, filename := range flag.Args() {
 		fmt.Printf("processing: %s\n", filename)
-		processFile(filename)
+		if err := processFile(filename); err != nil {
+			log.Errorf("processFile error: %v", err)
+			exit.Return(1)
+		}
 	}
-	var stats = make(Stats, 0, 128)
+	var stats = make(stats, 0, 128)
 	for k, v := range queries {
-		stats = append(stats, Stat{Query: k, Count: v})
+		stats = append(stats, stat{Query: k, Count: v})
 	}
 	sort.Sort(stats)
 	for _, s := range stats {
@@ -58,10 +63,10 @@ func main() {
 	}
 }
 
-func processFile(filename string) {
+func processFile(filename string) error {
 	f, err := os.Open(filename)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	r := bufio.NewReader(f)
 	for {
@@ -70,10 +75,11 @@ func processFile(filename string) {
 			if err == io.EOF {
 				break
 			}
-			log.Fatal(err)
+			return err
 		}
 		analyze(line)
 	}
+	return nil
 }
 
 func analyze(line []byte) {
@@ -89,12 +95,12 @@ func analyze(line []byte) {
 		return
 	}
 	bindIndex = 0
-	buf := sqlparser.NewTrackedBuffer(FormatWithBind)
+	buf := sqlparser.NewTrackedBuffer(formatWithBind)
 	buf.Myprintf("%v", ast)
 	addQuery(buf.ParsedQuery().Query)
 }
 
-func FormatWithBind(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
+func formatWithBind(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
 	switch node := node.(type) {
 	case sqlparser.StrVal, sqlparser.NumVal:
 		buf.WriteArg(fmt.Sprintf(":v%d", bindIndex))

--- a/go/cmd/topo2topo/topo2topo.go
+++ b/go/cmd/topo2topo/topo2topo.go
@@ -37,7 +37,8 @@ func main() {
 	}
 
 	if *fromTopo == "" || *toTopo == "" {
-		log.Fatalf("Need both from and to topo")
+		log.Errorf("Need both from and to topo")
+		exit.Return(1)
 	}
 
 	fromTS := topo.GetServerByName(*fromTopo)

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtgate"
@@ -36,6 +37,8 @@ func init() {
 }
 
 func main() {
+	defer exit.Recover()
+
 	flag.Parse()
 	servenv.Init()
 
@@ -47,7 +50,8 @@ func main() {
 	if *schemaFile != "" {
 		var err error
 		if schema, err = planbuilder.LoadFile(*schemaFile); err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			exit.Return(1)
 		}
 		log.Infof("v3 is enabled: loaded schema from file: %v", *schemaFile)
 	} else {

--- a/go/cmd/vtjanitor/vtjanitor.go
+++ b/go/cmd/vtjanitor/vtjanitor.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/flagutil"
 	"github.com/youtube/vitess/go/vt/janitor"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -44,6 +45,8 @@ func init() {
 }
 
 func main() {
+	defer exit.Recover()
+
 	flag.Parse()
 	servenv.Init()
 
@@ -51,11 +54,13 @@ func main() {
 
 	scheduler, err := janitor.New(*keyspace, *shard, ts, wrangler.New(logutil.NewConsoleLogger(), ts, *lockTimeout), *sleepTime)
 	if err != nil {
-		log.Fatalf("janitor.New: %v", err)
+		log.Errorf("janitor.New: %v", err)
+		exit.Return(1)
 	}
 
 	if len(activeModules)+len(dryRunModules) < 1 {
-		log.Fatal("no modules to run specified")
+		log.Error("no modules to run specified")
+		exit.Return(1)
 	}
 
 	scheduler.Enable(activeModules)

--- a/go/cmd/vtocc/vtocc.go
+++ b/go/cmd/vtocc/vtocc.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
@@ -33,19 +34,23 @@ func init() {
 }
 
 func main() {
+	defer exit.Recover()
+
 	flags := dbconfigs.AppConfig | dbconfigs.DbaConfig |
 		dbconfigs.FilteredConfig | dbconfigs.ReplConfig
 	dbconfigs.RegisterFlags(flags)
 	flag.Parse()
 	if len(flag.Args()) > 0 {
 		flag.Usage()
-		log.Fatalf("vtocc doesn't take any positional arguments")
+		log.Errorf("vtocc doesn't take any positional arguments")
+		exit.Return(1)
 	}
 	servenv.Init()
 
 	dbConfigs, err := dbconfigs.Init("", flags)
 	if err != nil {
-		log.Fatalf("Cannot initialize App dbconfig: %v", err)
+		log.Errorf("Cannot initialize App dbconfig: %v", err)
+		exit.Return(1)
 	}
 	if *enableRowcache {
 		dbConfigs.App.EnableRowcache = true

--- a/go/cmd/vtocc/vtocc.go
+++ b/go/cmd/vtocc/vtocc.go
@@ -7,6 +7,7 @@ package main
 import (
 	"encoding/json"
 	"flag"
+	"fmt"
 	"io/ioutil"
 
 	log "github.com/golang/glog"
@@ -61,7 +62,10 @@ func main() {
 	mycnf := &mysqlctl.Mycnf{BinLogPath: *binlogPath}
 	mysqld := mysqlctl.NewMysqld("Dba", mycnf, &dbConfigs.Dba, &dbConfigs.Repl)
 
-	unmarshalFile(*overridesFile, &schemaOverrides)
+	if err := unmarshalFile(*overridesFile, &schemaOverrides); err != nil {
+		log.Error(err)
+		exit.Return(1)
+	}
 	data, _ := json.MarshalIndent(schemaOverrides, "", "  ")
 	log.Infof("schemaOverrides: %s\n", data)
 
@@ -83,14 +87,15 @@ func main() {
 	servenv.RunDefault()
 }
 
-func unmarshalFile(name string, val interface{}) {
+func unmarshalFile(name string, val interface{}) error {
 	if name != "" {
 		data, err := ioutil.ReadFile(name)
 		if err != nil {
-			log.Fatalf("could not read %v: %v", val, err)
+			return fmt.Errorf("unmarshalFile: could not read %v: %v", val, err)
 		}
 		if err = json.Unmarshal(data, val); err != nil {
-			log.Fatalf("could not read %s: %v", val, err)
+			return fmt.Errorf("unmarshalFile: could not read %s: %v", val, err)
 		}
 	}
+	return nil
 }

--- a/go/cmd/vtprimecache/main.go
+++ b/go/cmd/vtprimecache/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/primecache"
@@ -23,6 +24,7 @@ var (
 )
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 
 	flags := dbconfigs.AppConfig | dbconfigs.DbaConfig
@@ -31,7 +33,8 @@ func main() {
 
 	dbcfgs, err := dbconfigs.Init(*mysqlSocketFile, flags)
 	if err != nil {
-		log.Fatalf("Failed to init dbconfigs: %v", err)
+		log.Errorf("Failed to init dbconfigs: %v", err)
+		exit.Return(1)
 	}
 
 	pc := primecache.NewPrimeCache(dbcfgs, *relayLogsPath)

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"strings"
 
 	log "github.com/golang/glog"
@@ -43,20 +44,20 @@ func init() {
 
 // tabletParamToTabletAlias takes either an old style ZK tablet path or a
 // new style tablet alias as a string, and returns a TabletAlias.
-func tabletParamToTabletAlias(param string) topo.TabletAlias {
+func tabletParamToTabletAlias(param string) (topo.TabletAlias, error) {
 	if param[0] == '/' {
 		// old zookeeper path, convert to new-style string tablet alias
 		zkPathParts := strings.Split(param, "/")
 		if len(zkPathParts) != 6 || zkPathParts[0] != "" || zkPathParts[1] != "zk" || zkPathParts[3] != "vt" || zkPathParts[4] != "tablets" {
-			log.Fatalf("Invalid tablet path: %v", param)
+			return topo.TabletAlias{}, fmt.Errorf("invalid tablet path: %v", param)
 		}
 		param = zkPathParts[2] + "-" + zkPathParts[5]
 	}
 	result, err := topo.ParseTabletAliasString(param)
 	if err != nil {
-		log.Fatalf("Invalid tablet alias %v: %v", param, err)
+		return topo.TabletAlias{}, fmt.Errorf("invalid tablet alias %v: %v", param, err)
 	}
-	return result
+	return result, nil
 }
 
 func main() {
@@ -79,7 +80,11 @@ func main() {
 		log.Errorf("tabletPath required")
 		exit.Return(1)
 	}
-	tabletAlias := tabletParamToTabletAlias(*tabletPath)
+	tabletAlias, err := tabletParamToTabletAlias(*tabletPath)
+	if err != nil {
+		log.Error(err)
+		exit.Return(1)
+	}
 
 	mycnf, err := mysqlctl.NewMycnfFromFlags(tabletAlias.Uid)
 	if err != nil {

--- a/go/cmd/vtworker/interactive.go
+++ b/go/cmd/vtworker/interactive.go
@@ -45,10 +45,11 @@ func httpError(w http.ResponseWriter, format string, err error) {
 	http.Error(w, fmt.Sprintf(format, err), http.StatusInternalServerError)
 }
 
-func loadTemplate(name, contents string) *template.Template {
+func mustParseTemplate(name, contents string) *template.Template {
 	t, err := template.New(name).Parse(contents)
 	if err != nil {
-		log.Fatalf("Cannot parse %v template: %v", name, err)
+		// An invalid template here is a programming error.
+		panic(fmt.Sprintf("cannot parse %v template: %v", name, err))
 	}
 	return t
 }
@@ -60,8 +61,8 @@ func executeTemplate(w http.ResponseWriter, t *template.Template, data interface
 }
 
 func initInteractiveMode() {
-	indexTemplate := loadTemplate("index", indexHTML)
-	subIndexTemplate := loadTemplate("subIndex", subIndexHTML)
+	indexTemplate := mustParseTemplate("index", indexHTML)
+	subIndexTemplate := mustParseTemplate("subIndex", subIndexHTML)
 
 	// toplevel menu
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/go/cmd/vtworker/split_diff.go
+++ b/go/cmd/vtworker/split_diff.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"sync"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/worker"
@@ -35,15 +34,18 @@ const splitDiffHTML = `
 </body>
 `
 
-var splitDiffTemplate = loadTemplate("splitDiff", splitDiffHTML)
+var splitDiffTemplate = mustParseTemplate("splitDiff", splitDiffHTML)
 
-func commandSplitDiff(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) worker.Worker {
+func commandSplitDiff(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (worker.Worker, error) {
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("command SplitDiff requires <keyspace/shard|zk shard path>")
+		return nil, fmt.Errorf("command SplitDiff requires <keyspace/shard|zk shard path>")
 	}
-	keyspace, shard := shardParamToKeyspaceShard(subFlags.Arg(0))
-	return worker.NewSplitDiffWorker(wr, *cell, keyspace, shard)
+	keyspace, shard, err := shardParamToKeyspaceShard(subFlags.Arg(0))
+	if err != nil {
+		return nil, err
+	}
+	return worker.NewSplitDiffWorker(wr, *cell, keyspace, shard), nil
 }
 
 // shardsWithSources returns all the shards that have SourceShards set

--- a/go/cmd/vtworker/status.go
+++ b/go/cmd/vtworker/status.go
@@ -56,7 +56,7 @@ const workerStatusHTML = `
 
 func initStatusHandling() {
 	// code to serve /status
-	workerTemplate := loadTemplate("worker", workerStatusHTML)
+	workerTemplate := mustParseTemplate("worker", workerStatusHTML)
 	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		currentWorkerMutex.Lock()
 		wrk := currentWorker

--- a/go/cmd/vtworker/vertical_split_clone.go
+++ b/go/cmd/vtworker/vertical_split_clone.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/worker"
@@ -82,10 +81,10 @@ const verticalSplitCloneHTML2 = `
   </body>
 `
 
-var verticalSplitCloneTemplate = loadTemplate("verticalSplitClone", verticalSplitCloneHTML)
-var verticalSplitCloneTemplate2 = loadTemplate("verticalSplitClone2", verticalSplitCloneHTML2)
+var verticalSplitCloneTemplate = mustParseTemplate("verticalSplitClone", verticalSplitCloneHTML)
+var verticalSplitCloneTemplate2 = mustParseTemplate("verticalSplitClone2", verticalSplitCloneHTML2)
 
-func commandVerticalSplitClone(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) worker.Worker {
+func commandVerticalSplitClone(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (worker.Worker, error) {
 	tables := subFlags.String("tables", "", "comma separated list of tables to replicate (used for vertical split)")
 	strategy := subFlags.String("strategy", "", "which strategy to use for restore, use 'mysqlctl multirestore -strategy=-help' for more info")
 	sourceReaderCount := subFlags.Int("source_reader_count", defaultSourceReaderCount, "number of concurrent streaming queries to use on the source")
@@ -94,19 +93,22 @@ func commandVerticalSplitClone(wr *wrangler.Wrangler, subFlags *flag.FlagSet, ar
 	destinationWriterCount := subFlags.Int("destination_writer_count", defaultDestinationWriterCount, "number of concurrent RPCs to execute on the destination")
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("command VerticalSplitClone requires <destination keyspace/shard>")
+		return nil, fmt.Errorf("command VerticalSplitClone requires <destination keyspace/shard>")
 	}
 
-	keyspace, shard := shardParamToKeyspaceShard(subFlags.Arg(0))
+	keyspace, shard, err := shardParamToKeyspaceShard(subFlags.Arg(0))
+	if err != nil {
+		return nil, err
+	}
 	var tableArray []string
 	if *tables != "" {
 		tableArray = strings.Split(*tables, ",")
 	}
 	worker, err := worker.NewVerticalSplitCloneWorker(wr, *cell, keyspace, shard, tableArray, *strategy, *sourceReaderCount, *destinationPackCount, uint64(*minTableSizeForSplit), *destinationWriterCount)
 	if err != nil {
-		log.Fatalf("cannot create worker: %v", err)
+		return nil, fmt.Errorf("cannot create worker: %v", err)
 	}
-	return worker
+	return worker, nil
 }
 
 // keyspacesWithServedFrom returns all the keyspaces that have ServedFrom set

--- a/go/cmd/vtworker/vertical_split_diff.go
+++ b/go/cmd/vtworker/vertical_split_diff.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"sync"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/worker"
@@ -35,15 +34,18 @@ const verticalSplitDiffHTML = `
 </body>
 `
 
-var verticalSplitDiffTemplate = loadTemplate("verticalSplitDiff", verticalSplitDiffHTML)
+var verticalSplitDiffTemplate = mustParseTemplate("verticalSplitDiff", verticalSplitDiffHTML)
 
-func commandVerticalSplitDiff(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) worker.Worker {
+func commandVerticalSplitDiff(wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (worker.Worker, error) {
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatalf("command VerticalSplitDiff requires <keyspace/shard|zk shard path>")
+		return nil, fmt.Errorf("command VerticalSplitDiff requires <keyspace/shard|zk shard path>")
 	}
-	keyspace, shard := shardParamToKeyspaceShard(subFlags.Arg(0))
-	return worker.NewVerticalSplitDiffWorker(wr, *cell, keyspace, shard)
+	keyspace, shard, err := shardParamToKeyspaceShard(subFlags.Arg(0))
+	if err != nil {
+		return nil, err
+	}
+	return worker.NewVerticalSplitDiffWorker(wr, *cell, keyspace, shard), nil
 }
 
 // shardsWithTablesSources returns all the shards that have SourceShards set

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -91,6 +92,8 @@ func setAndStartWorker(wrk worker.Worker) (chan struct{}, error) {
 }
 
 func main() {
+	defer exit.Recover()
+
 	flag.Parse()
 	args := flag.Args()
 
@@ -100,16 +103,19 @@ func main() {
 	ts := topo.GetServer()
 	defer topo.CloseServers()
 
-	// the logger will be replaced when we start a job
-	// FIXME(aaijazi) the signal handler is wrong
+	// The logger will be replaced when we start a job.
+	// FIXME(aaijazi): The signal handler is wrong.
 	_, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	wr = wrangler.New(logutil.NewConsoleLogger(), ts, 30*time.Second)
 	if len(args) == 0 {
-		// interactive mode, initialize the web UI to chose a command
+		// In interactive mode, initialize the web UI to choose a command.
 		initInteractiveMode()
 	} else {
-		// single command mode, just runs it
-		runCommand(args)
+		// In single command mode, just run it.
+		if err := runCommand(args); err != nil {
+			log.Error(err)
+			exit.Return(1)
+		}
 	}
 	installSignalHandlers(cancel)
 	initStatusHandling()

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/terminal"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/zk"
@@ -119,6 +120,7 @@ var (
 )
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage of %v:\n", os.Args[0])
@@ -129,14 +131,15 @@ func main() {
 	args := flag.Args()
 	if len(args) == 0 {
 		flag.Usage()
-		os.Exit(1)
+		exit.Return(1)
 	}
 
 	if *zkAddrs != "" {
 		var err error
 		zconn, _, err = zk.DialZkTimeout(*zkAddrs, 5*time.Second, 10*time.Second)
 		if err != nil {
-			log.Fatalf("zk connect failed: %v", err.Error())
+			log.Errorf("zk connect failed: %v", err.Error())
+			exit.Return(1)
 		}
 	}
 

--- a/go/cmd/zk/zkcmd.go
+++ b/go/cmd/zk/zkcmd.go
@@ -89,7 +89,7 @@ const (
 	timeFmtMicro = "2006-01-02 15:04:05.000000"
 )
 
-type cmdFunc func(subFlags *flag.FlagSet, args []string)
+type cmdFunc func(subFlags *flag.FlagSet, args []string) error
 
 var cmdMap map[string]cmdFunc
 var zconn zk.Conn
@@ -147,7 +147,10 @@ func main() {
 	args = args[1:]
 	if cmd, ok := cmdMap[cmdName]; ok {
 		subFlags := flag.NewFlagSet(cmdName, flag.ExitOnError)
-		cmd(subFlags, args)
+		if err := cmd(subFlags, args); err != nil {
+			log.Error(err)
+			exit.Return(1)
+		}
 	}
 }
 
@@ -162,7 +165,7 @@ func isZkFile(path string) bool {
 	return strings.HasPrefix(path, "/zk")
 }
 
-func cmdWait(subFlags *flag.FlagSet, args []string) {
+func cmdWait(subFlags *flag.FlagSet, args []string) error {
 	var (
 		exitIfExists = subFlags.Bool("e", false, "exit if the path already exists")
 	)
@@ -170,7 +173,7 @@ func cmdWait(subFlags *flag.FlagSet, args []string) {
 	subFlags.Parse(args)
 
 	if subFlags.NArg() != 1 {
-		log.Fatalf("wait: can only wait for one path")
+		return fmt.Errorf("wait: can only wait for one path")
 	}
 	zkPath := subFlags.Arg(0)
 	isDir := zkPath[len(zkPath)-1] == '/'
@@ -187,19 +190,19 @@ func cmdWait(subFlags *flag.FlagSet, args []string) {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
 			_, wait, err = zconn.ExistsW(zkPath)
 		} else {
-			log.Fatalf("wait: error %v: %v", zkPath, err)
+			return fmt.Errorf("wait: error %v: %v", zkPath, err)
 		}
 	} else {
 		if *exitIfExists {
-			fmt.Printf("already exists: %v\n", zkPath)
-			return
+			return fmt.Errorf("already exists: %v\n", zkPath)
 		}
 	}
 	event := <-wait
 	fmt.Printf("event: %v\n", event)
+	return nil
 }
 
-func cmdQlock(subFlags *flag.FlagSet, args []string) {
+func cmdQlock(subFlags *flag.FlagSet, args []string) error {
 	var (
 		lockWaitTimeout = subFlags.Duration("lock-wait-timeout", 0, "wait for a lock for the specified duration")
 	)
@@ -213,13 +216,14 @@ func cmdQlock(subFlags *flag.FlagSet, args []string) {
 		close(interrupted)
 	}()
 	if err := zk.ObtainQueueLock(zconn, zkPath, *lockWaitTimeout, interrupted); err != nil {
-		log.Fatalf("qlock: error %v: %v", zkPath, err)
+		return fmt.Errorf("qlock: error %v: %v", zkPath, err)
 	}
 	fmt.Printf("qlock: locked %v\n", zkPath)
+	return nil
 }
 
 // Create an ephemeral node an just wait.
-func cmdElock(subFlags *flag.FlagSet, args []string) {
+func cmdElock(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	zkPath := fixZkPath(subFlags.Arg(0))
 	// Speed up case where we die nicely, otherwise you have to wait for
@@ -230,23 +234,23 @@ func cmdElock(subFlags *flag.FlagSet, args []string) {
 	for {
 		_, err := zconn.Create(zkPath, "", zookeeper.EPHEMERAL, zookeeper.WorldACL(zookeeper.PERM_ALL))
 		if err != nil {
-			log.Fatalf("elock: error %v: %v", zkPath, err)
+			return fmt.Errorf("elock: error %v: %v", zkPath, err)
 		}
 
 	watchLoop:
 		for {
 			_, _, watch, err := zconn.GetW(zkPath)
 			if err != nil {
-				log.Fatalf("elock: error %v: %v", zkPath, err)
+				return fmt.Errorf("elock: error %v: %v", zkPath, err)
 			}
 			select {
 			case <-sigRecv:
 				zconn.Delete(zkPath, -1)
-				return
+				return nil
 			case event := <-watch:
 				log.Infof("elock: event %v: %v", zkPath, event)
 				if !event.Ok() {
-					//log.Fatalf("elock: error %v: %v", zkPath, event)
+					//return fmt.Errorf("elock: error %v: %v", zkPath, event)
 					break watchLoop
 				}
 			}
@@ -255,7 +259,7 @@ func cmdElock(subFlags *flag.FlagSet, args []string) {
 }
 
 // Watch for changes to the node.
-func cmdWatch(subFlags *flag.FlagSet, args []string) {
+func cmdWatch(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	// Speed up case where we die nicely, otherwise you have to wait for
 	// the server to notice the client's demise.
@@ -267,7 +271,7 @@ func cmdWatch(subFlags *flag.FlagSet, args []string) {
 		zkPath := fixZkPath(arg)
 		_, _, watch, err := zconn.GetW(zkPath)
 		if err != nil {
-			log.Fatalf("watch error: %v", err)
+			return fmt.Errorf("watch error: %v", err)
 		}
 		go func() {
 			eventChan <- <-watch
@@ -277,13 +281,13 @@ func cmdWatch(subFlags *flag.FlagSet, args []string) {
 	for {
 		select {
 		case <-sigRecv:
-			return
+			return nil
 		case event := <-eventChan:
 			log.Infof("watch: event %v: %v", event.Path, event)
 			if event.Type == zookeeper.EVENT_CHANGED {
 				data, stat, watch, err := zconn.GetW(event.Path)
 				if err != nil {
-					log.Fatalf("ERROR: failed to watch %v", err)
+					return fmt.Errorf("ERROR: failed to watch %v", err)
 				}
 				log.Infof("watch: %v %v\n", event.Path, stat)
 				println(data)
@@ -291,14 +295,14 @@ func cmdWatch(subFlags *flag.FlagSet, args []string) {
 					eventChan <- <-watch
 				}()
 			} else if event.State == zookeeper.STATE_CLOSED {
-				return
+				return nil
 			} else if event.Type == zookeeper.EVENT_DELETED {
 				log.Infof("watch: %v deleted\n", event.Path)
 			} else {
 				// Most likely a session event - try t
 				_, _, watch, err := zconn.GetW(event.Path)
 				if err != nil {
-					log.Fatalf("ERROR: failed to watch %v", err)
+					return fmt.Errorf("ERROR: failed to watch %v", err)
 				}
 				go func() {
 					eventChan <- <-watch
@@ -308,7 +312,7 @@ func cmdWatch(subFlags *flag.FlagSet, args []string) {
 	}
 }
 
-func cmdLs(subFlags *flag.FlagSet, args []string) {
+func cmdLs(subFlags *flag.FlagSet, args []string) error {
 	var (
 		longListing      = subFlags.Bool("l", false, "long listing")
 		directoryListing = subFlags.Bool("d", false, "list directory instead of contents")
@@ -317,17 +321,17 @@ func cmdLs(subFlags *flag.FlagSet, args []string) {
 	)
 	subFlags.Parse(args)
 	if subFlags.NArg() == 0 {
-		log.Fatal("ls: no path specified")
+		return fmt.Errorf("ls: no path specified")
 	}
 	// FIXME(szopa): shadowing?
 	resolved, err := zk.ResolveWildcards(zconn, subFlags.Args())
 	if err != nil {
-		log.Fatalf("ls: invalid wildcards: %v", err)
+		return fmt.Errorf("ls: invalid wildcards: %v", err)
 	}
 	if len(resolved) == 0 {
 		// the wildcards didn't result in anything, we're
 		// done.
-		return
+		return nil
 	}
 
 	hasError := false
@@ -404,8 +408,9 @@ func cmdLs(subFlags *flag.FlagSet, args []string) {
 		}
 	}
 	if hasError {
-		os.Exit(1)
+		return fmt.Errorf("ls: some paths had errors")
 	}
+	return nil
 }
 
 func fmtPath(stat zk.Stat, zkPath string, showFullPath bool, longListing bool) {
@@ -439,7 +444,7 @@ func fmtPath(stat zk.Stat, zkPath string, showFullPath bool, longListing bool) {
 	}
 }
 
-func cmdTouch(subFlags *flag.FlagSet, args []string) {
+func cmdTouch(subFlags *flag.FlagSet, args []string) error {
 	var (
 		createParents = subFlags.Bool("p", false, "create parents")
 		touchOnly     = subFlags.Bool("c", false, "touch only - don't create")
@@ -447,12 +452,12 @@ func cmdTouch(subFlags *flag.FlagSet, args []string) {
 
 	subFlags.Parse(args)
 	if subFlags.NArg() != 1 {
-		log.Fatal("touch: need to specify exactly one path")
+		return fmt.Errorf("touch: need to specify exactly one path")
 	}
 
 	zkPath := fixZkPath(subFlags.Arg(0))
 	if !isZkFile(zkPath) {
-		log.Fatalf("touch: not a /zk file %v", zkPath)
+		return fmt.Errorf("touch: not a /zk file %v", zkPath)
 	}
 
 	var (
@@ -467,14 +472,14 @@ func cmdTouch(subFlags *flag.FlagSet, args []string) {
 	case zookeeper.IsError(err, zookeeper.ZNONODE):
 		create = true
 	default:
-		log.Fatalf("touch: cannot access %v: %v", zkPath, err)
+		return fmt.Errorf("touch: cannot access %v: %v", zkPath, err)
 	}
 
 	switch {
 	case !create:
 		_, err = zconn.Set(zkPath, data, version)
 	case *touchOnly:
-		log.Fatalf("touch: no such path %v", zkPath)
+		return fmt.Errorf("touch: no such path %v", zkPath)
 	case *createParents:
 		_, err = zk.CreateRecursive(zconn, zkPath, data, 0, zookeeper.WorldACL(zookeeper.PERM_ALL))
 	default:
@@ -482,11 +487,12 @@ func cmdTouch(subFlags *flag.FlagSet, args []string) {
 	}
 
 	if err != nil {
-		log.Fatalf("touch: cannot modify %v: %v", zkPath, err)
+		return fmt.Errorf("touch: cannot modify %v: %v", zkPath, err)
 	}
+	return nil
 }
 
-func cmdRm(subFlags *flag.FlagSet, args []string) {
+func cmdRm(subFlags *flag.FlagSet, args []string) error {
 	var (
 		force             = subFlags.Bool("f", false, "no warning on nonexistent node")
 		recursiveDelete   = subFlags.Bool("r", false, "recursive delete")
@@ -497,25 +503,25 @@ func cmdRm(subFlags *flag.FlagSet, args []string) {
 	*recursiveDelete = *recursiveDelete || *forceAndRecursive
 
 	if subFlags.NArg() == 0 {
-		log.Fatal("rm: no path specified")
+		return fmt.Errorf("rm: no path specified")
 	}
 
 	if *recursiveDelete {
 		for _, arg := range subFlags.Args() {
 			zkPath := fixZkPath(arg)
 			if strings.Count(zkPath, "/") < 4 {
-				log.Fatalf("rm: overly general path: %v", zkPath)
+				return fmt.Errorf("rm: overly general path: %v", zkPath)
 			}
 		}
 	}
 
 	resolved, err := zk.ResolveWildcards(zconn, subFlags.Args())
 	if err != nil {
-		log.Fatalf("rm: invalid wildcards: %v", err)
+		return fmt.Errorf("rm: invalid wildcards: %v", err)
 	}
 	if len(resolved) == 0 {
 		// the wildcards didn't result in anything, we're done
-		return
+		return nil
 	}
 
 	hasError := false
@@ -535,26 +541,27 @@ func cmdRm(subFlags *flag.FlagSet, args []string) {
 	if hasError {
 		// to be consistent with the command line 'rm -f', return
 		// 0 if using 'zk rm -f' and the file doesn't exist.
-		os.Exit(1)
+		return fmt.Errorf("rm: some paths had errors")
 	}
+	return nil
 }
 
-func cmdCat(subFlags *flag.FlagSet, args []string) {
+func cmdCat(subFlags *flag.FlagSet, args []string) error {
 	var (
 		longListing = subFlags.Bool("l", false, "long listing")
 		force       = subFlags.Bool("f", false, "no warning on nonexistent node")
 	)
 	subFlags.Parse(args)
 	if subFlags.NArg() == 0 {
-		log.Fatal("cat: no path specified")
+		return fmt.Errorf("cat: no path specified")
 	}
 	resolved, err := zk.ResolveWildcards(zconn, subFlags.Args())
 	if err != nil {
-		log.Fatalf("cat: invalid wildcards: %v", err)
+		return fmt.Errorf("cat: invalid wildcards: %v", err)
 	}
 	if len(resolved) == 0 {
 		// the wildcards didn't result in anything, we're done
-		return
+		return nil
 	}
 
 	hasError := false
@@ -577,17 +584,18 @@ func cmdCat(subFlags *flag.FlagSet, args []string) {
 		}
 	}
 	if hasError {
-		os.Exit(1)
+		return fmt.Errorf("cat: some paths had errors")
 	}
+	return nil
 }
 
-func cmdEdit(subFlags *flag.FlagSet, args []string) {
+func cmdEdit(subFlags *flag.FlagSet, args []string) error {
 	var (
 		force = subFlags.Bool("f", false, "no warning on nonexistent node")
 	)
 	subFlags.Parse(args)
 	if subFlags.NArg() == 0 {
-		log.Fatal("edit: no path specified")
+		return fmt.Errorf("edit: no path specified")
 	}
 	arg := subFlags.Arg(0)
 	zkPath := fixZkPath(arg)
@@ -596,7 +604,7 @@ func cmdEdit(subFlags *flag.FlagSet, args []string) {
 		if !*force || !zookeeper.IsError(err, zookeeper.ZNONODE) {
 			log.Warningf("edit: cannot access %v: %v", zkPath, err)
 		}
-		os.Exit(1)
+		return fmt.Errorf("edit: cannot access %v: %v", zkPath, err)
 	}
 
 	name := path.Base(zkPath)
@@ -607,8 +615,7 @@ func cmdEdit(subFlags *flag.FlagSet, args []string) {
 		f.Close()
 	}
 	if err != nil {
-		log.Warningf("edit: cannot write file %v", err)
-		os.Exit(1)
+		return fmt.Errorf("edit: cannot write file %v", err)
 	}
 
 	cmd := exec.Command(os.Getenv("EDITOR"), tmpPath)
@@ -618,13 +625,13 @@ func cmdEdit(subFlags *flag.FlagSet, args []string) {
 	err = cmd.Run()
 	if err != nil {
 		os.Remove(tmpPath)
-		log.Fatalf("edit: cannot start $EDITOR: %v", err)
+		return fmt.Errorf("edit: cannot start $EDITOR: %v", err)
 	}
 
 	fileData, err := ioutil.ReadFile(tmpPath)
 	if err != nil {
 		os.Remove(tmpPath)
-		log.Fatalf("edit: cannot read file %v", err)
+		return fmt.Errorf("edit: cannot read file %v", err)
 	}
 
 	if string(fileData) != data {
@@ -632,29 +639,30 @@ func cmdEdit(subFlags *flag.FlagSet, args []string) {
 		_, err = zconn.Set(zkPath, string(fileData), stat.Version())
 		if err != nil {
 			os.Remove(tmpPath)
-			log.Fatalf("edit: cannot write zk file %v", err)
+			return fmt.Errorf("edit: cannot write zk file %v", err)
 		}
 	}
 	os.Remove(tmpPath)
+	return nil
 }
 
-func cmdStat(subFlags *flag.FlagSet, args []string) {
+func cmdStat(subFlags *flag.FlagSet, args []string) error {
 	var (
 		force = subFlags.Bool("f", false, "no warning on nonexistent node")
 	)
 	subFlags.Parse(args)
 
 	if subFlags.NArg() == 0 {
-		log.Fatal("stat: no path specified")
+		return fmt.Errorf("stat: no path specified")
 	}
 
 	resolved, err := zk.ResolveWildcards(zconn, subFlags.Args())
 	if err != nil {
-		log.Fatalf("stat: invalid wildcards: %v", err)
+		return fmt.Errorf("stat: invalid wildcards: %v", err)
 	}
 	if len(resolved) == 0 {
 		// the wildcards didn't result in anything, we're done
-		return
+		return nil
 	}
 
 	hasError := false
@@ -684,8 +692,9 @@ func cmdStat(subFlags *flag.FlagSet, args []string) {
 		}
 	}
 	if hasError {
-		os.Exit(1)
+		return fmt.Errorf("stat: some paths had errors")
 	}
+	return nil
 }
 
 var charPermMap map[string]uint32
@@ -718,21 +727,21 @@ func fmtAcl(acl zookeeper.ACL) string {
 	return s
 }
 
-func cmdChmod(subFlags *flag.FlagSet, args []string) {
+func cmdChmod(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	if subFlags.NArg() < 2 {
-		log.Fatal("chmod: no permission specified")
+		return fmt.Errorf("chmod: no permission specified")
 	}
 	mode := subFlags.Arg(0)
 	if mode[0] != 'n' {
-		log.Fatal("chmod: invalid mode")
+		return fmt.Errorf("chmod: invalid mode")
 	}
 
 	addPerms := false
 	if mode[1] == '+' {
 		addPerms = true
 	} else if mode[1] != '-' {
-		log.Fatal("chmod: invalid mode")
+		return fmt.Errorf("chmod: invalid mode")
 	}
 
 	var permMask uint32
@@ -742,11 +751,11 @@ func cmdChmod(subFlags *flag.FlagSet, args []string) {
 
 	resolved, err := zk.ResolveWildcards(zconn, subFlags.Args()[1:])
 	if err != nil {
-		log.Fatalf("chmod: invalid wildcards: %v", err)
+		return fmt.Errorf("chmod: invalid wildcards: %v", err)
 	}
 	if len(resolved) == 0 {
 		// the wildcards didn't result in anything, we're done
-		return
+		return nil
 	}
 
 	hasError := false
@@ -771,19 +780,20 @@ func cmdChmod(subFlags *flag.FlagSet, args []string) {
 		}
 	}
 	if hasError {
-		os.Exit(1)
+		return fmt.Errorf("chmod: some paths had errors")
 	}
+	return nil
 }
 
-func cmdCp(subFlags *flag.FlagSet, args []string) {
+func cmdCp(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	switch {
 	case subFlags.NArg() < 2:
-		log.Fatalf("cp: need to specify source and destination paths")
+		return fmt.Errorf("cp: need to specify source and destination paths")
 	case subFlags.NArg() == 2:
-		fileCp(args[0], args[1])
+		return fileCp(args[0], args[1])
 	default:
-		multiFileCp(args)
+		return multiFileCp(args)
 	}
 }
 
@@ -791,17 +801,16 @@ func getPathData(filePath string) (string, error) {
 	if isZkFile(filePath) {
 		data, _, err := zconn.Get(filePath)
 		return data, err
-	} else {
-		var err error
-		file, err := os.Open(filePath)
-		if err == nil {
-			data, err := ioutil.ReadAll(file)
-			if err == nil {
-				return string(data), err
-			}
-		}
-		return "", err
 	}
+	var err error
+	file, err := os.Open(filePath)
+	if err == nil {
+		data, err := ioutil.ReadAll(file)
+		if err == nil {
+			return string(data), err
+		}
+	}
+	return "", err
 }
 
 func setPathData(filePath, data string) error {
@@ -811,23 +820,22 @@ func setPathData(filePath, data string) error {
 			_, err = zk.CreateRecursive(zconn, filePath, data, 0, zookeeper.WorldACL(zookeeper.PERM_ALL))
 		}
 		return err
-	} else {
-		return ioutil.WriteFile(filePath, []byte(data), 0666)
 	}
+	return ioutil.WriteFile(filePath, []byte(data), 0666)
 }
 
-func fileCp(srcPath, dstPath string) {
+func fileCp(srcPath, dstPath string) error {
 	dstIsDir := dstPath[len(dstPath)-1] == '/'
 	srcPath = fixZkPath(srcPath)
 	dstPath = fixZkPath(dstPath)
 
 	if !isZkFile(srcPath) && !isZkFile(dstPath) {
-		log.Fatal("cp: neither src nor dst is a /zk file: exitting")
+		return fmt.Errorf("cp: neither src nor dst is a /zk file: exitting")
 	}
 
 	data, err := getPathData(srcPath)
 	if err != nil {
-		log.Fatalf("cp: cannot read %v: %v", srcPath, err)
+		return fmt.Errorf("cp: cannot read %v: %v", srcPath, err)
 	}
 
 	// If we are copying to a local directory - say '.', make the filename
@@ -836,7 +844,7 @@ func fileCp(srcPath, dstPath string) {
 		fileInfo, err := os.Stat(dstPath)
 		if err != nil {
 			if err.(*os.PathError).Err != syscall.ENOENT {
-				log.Fatalf("cp: cannot stat %v: %v", dstPath, err)
+				return fmt.Errorf("cp: cannot stat %v: %v", dstPath, err)
 			}
 		} else if fileInfo.IsDir() {
 			dstPath = path.Join(dstPath, path.Base(srcPath))
@@ -847,11 +855,12 @@ func fileCp(srcPath, dstPath string) {
 		dstPath = path.Join(dstPath, path.Base(srcPath))
 	}
 	if err := setPathData(dstPath, data); err != nil {
-		log.Fatalf("cp: cannot write %v: %v", dstPath, err)
+		return fmt.Errorf("cp: cannot write %v: %v", dstPath, err)
 	}
+	return nil
 }
 
-func multiFileCp(args []string) {
+func multiFileCp(args []string) error {
 	dstPath := args[len(args)-1]
 	if dstPath[len(dstPath)-1] != '/' {
 		// In multifile context, dstPath must be a directory.
@@ -859,8 +868,11 @@ func multiFileCp(args []string) {
 	}
 
 	for _, srcPath := range args[:len(args)-1] {
-		fileCp(srcPath, dstPath)
+		if err := fileCp(srcPath, dstPath); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 type zkItem struct {
@@ -872,21 +884,21 @@ type zkItem struct {
 
 // Store a zk tree in a zip archive. This won't be immediately useful to
 // zip tools since even "directories" can contain data.
-func cmdZip(subFlags *flag.FlagSet, args []string) {
+func cmdZip(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	if subFlags.NArg() < 2 {
-		log.Fatalf("zip: need to specify source and destination paths")
+		return fmt.Errorf("zip: need to specify source and destination paths")
 	}
 
 	dstPath := subFlags.Arg(subFlags.NArg() - 1)
 	paths := subFlags.Args()[:len(args)-1]
 	if !strings.HasSuffix(dstPath, ".zip") {
-		log.Fatalf("zip: need to specify destination .zip path: %v", dstPath)
+		return fmt.Errorf("zip: need to specify destination .zip path: %v", dstPath)
 	}
 
 	zipFile, err := os.Create(dstPath)
 	if err != nil {
-		log.Fatalf("zip: error %v", err)
+		return fmt.Errorf("zip: error %v", err)
 	}
 
 	wg := sync.WaitGroup{}
@@ -895,7 +907,7 @@ func cmdZip(subFlags *flag.FlagSet, args []string) {
 		zkPath := fixZkPath(arg)
 		children, err := zk.ChildrenRecursive(zconn, zkPath)
 		if err != nil {
-			log.Fatalf("zip: error %v", err)
+			return fmt.Errorf("zip: error %v", err)
 		}
 		for _, child := range children {
 			toAdd := path.Join(zkPath, child)
@@ -916,7 +928,7 @@ func cmdZip(subFlags *flag.FlagSet, args []string) {
 	for item := range items {
 		path, data, stat, err := item.path, item.data, item.stat, item.err
 		if err != nil {
-			log.Fatalf("zip: get failed: %v", err)
+			return fmt.Errorf("zip: get failed: %v", err)
 		}
 		// Skip ephemerals - not sure why you would archive them.
 		if stat.EphemeralOwner() > 0 {
@@ -926,46 +938,47 @@ func cmdZip(subFlags *flag.FlagSet, args []string) {
 		fi.SetModTime(stat.MTime())
 		f, err := zipWriter.CreateHeader(fi)
 		if err != nil {
-			log.Fatalf("zip: create failed: %v", err)
+			return fmt.Errorf("zip: create failed: %v", err)
 		}
 		_, err = f.Write([]byte(data))
 		if err != nil {
-			log.Fatalf("zip: create failed: %v", err)
+			return fmt.Errorf("zip: create failed: %v", err)
 		}
 	}
 	err = zipWriter.Close()
 	if err != nil {
-		log.Fatalf("zip: close failed: %v", err)
+		return fmt.Errorf("zip: close failed: %v", err)
 	}
 	zipFile.Close()
+	return nil
 }
 
-func cmdUnzip(subFlags *flag.FlagSet, args []string) {
+func cmdUnzip(subFlags *flag.FlagSet, args []string) error {
 	subFlags.Parse(args)
 	if subFlags.NArg() != 2 {
-		log.Fatalf("zip: need to specify source and destination paths")
+		return fmt.Errorf("zip: need to specify source and destination paths")
 	}
 
 	srcPath, dstPath := subFlags.Arg(0), subFlags.Arg(1)
 
 	if !strings.HasSuffix(srcPath, ".zip") {
-		log.Fatalf("zip: need to specify src .zip path: %v", srcPath)
+		return fmt.Errorf("zip: need to specify src .zip path: %v", srcPath)
 	}
 
 	zipReader, err := zip.OpenReader(srcPath)
 	if err != nil {
-		log.Fatalf("zip: error %v", err)
+		return fmt.Errorf("zip: error %v", err)
 	}
 	defer zipReader.Close()
 
 	for _, zf := range zipReader.File {
 		rc, err := zf.Open()
 		if err != nil {
-			log.Fatalf("unzip: error %v", err)
+			return fmt.Errorf("unzip: error %v", err)
 		}
 		data, err := ioutil.ReadAll(rc)
 		if err != nil {
-			log.Fatalf("unzip: failed reading archive: %v", err)
+			return fmt.Errorf("unzip: failed reading archive: %v", err)
 		}
 		zkPath := zf.Name
 		if dstPath != "/" {
@@ -973,12 +986,13 @@ func cmdUnzip(subFlags *flag.FlagSet, args []string) {
 		}
 		_, err = zk.CreateRecursive(zconn, zkPath, string(data), 0, zookeeper.WorldACL(zookeeper.PERM_ALL))
 		if err != nil && !zookeeper.IsError(err, zookeeper.ZNODEEXISTS) {
-			log.Fatalf("unzip: zk create failed: %v", err)
+			return fmt.Errorf("unzip: zk create failed: %v", err)
 		}
 		_, err = zconn.Set(zkPath, string(data), -1)
 		if err != nil {
-			log.Fatalf("unzip: zk set failed: %v", err)
+			return fmt.Errorf("unzip: zk set failed: %v", err)
 		}
 		rc.Close()
 	}
+	return nil
 }

--- a/go/cmd/zkclient2/zkclient2.go
+++ b/go/cmd/zkclient2/zkclient2.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
 	"github.com/youtube/vitess/go/sync2"
@@ -141,19 +142,21 @@ func qps(cell string, keyspaces []string) {
 }
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 
 	flag.Parse()
 	args := flag.Args()
 	if len(args) == 0 {
 		flag.Usage()
-		os.Exit(1)
+		exit.Return(1)
 	}
 
 	if *cpuProfile != "" {
 		f, err := os.Create(*cpuProfile)
 		if err != nil {
-			log.Fatal(err)
+			log.Error(err)
+			exit.Return(1)
 		}
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
@@ -164,7 +167,8 @@ func main() {
 		if len(args) == 1 {
 			getSrvKeyspaceNames(rpcClient, args[0], true)
 		} else {
-			log.Fatalf("getSrvKeyspaceNames only takes one argument")
+			log.Errorf("getSrvKeyspaceNames only takes one argument")
+			exit.Return(1)
 		}
 
 	} else if *mode == "getSrvKeyspace" {
@@ -172,7 +176,8 @@ func main() {
 		if len(args) == 2 {
 			getSrvKeyspace(rpcClient, args[0], args[1], true)
 		} else {
-			log.Fatalf("getSrvKeyspace only takes two arguments")
+			log.Errorf("getSrvKeyspace only takes two arguments")
+			exit.Return(1)
 		}
 
 	} else if *mode == "getEndPoints" {
@@ -180,7 +185,8 @@ func main() {
 		if len(args) == 4 {
 			getEndPoints(rpcClient, args[0], args[1], args[2], args[3], true)
 		} else {
-			log.Fatalf("getEndPoints only takes four arguments")
+			log.Errorf("getEndPoints only takes four arguments")
+			exit.Return(1)
 		}
 
 	} else if *mode == "qps" {
@@ -188,6 +194,7 @@ func main() {
 
 	} else {
 		flag.Usage()
-		log.Fatalf("Invalid mode: %v", *mode)
+		log.Errorf("Invalid mode: %v", *mode)
+		exit.Return(1)
 	}
 }

--- a/go/cmd/zkctl/zkctl.go
+++ b/go/cmd/zkctl/zkctl.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/zk/zkctl"
 )
@@ -53,6 +54,7 @@ func confirm(prompt string) bool {
 }
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 
 	flag.Parse()
@@ -60,7 +62,7 @@ func main() {
 
 	if len(args) == 0 {
 		flag.Usage()
-		os.Exit(1)
+		exit.Return(1)
 	}
 
 	zkConfig := zkctl.MakeZkConfigFromString(*zkCfg, uint32(*myId))
@@ -78,9 +80,11 @@ func main() {
 	case "teardown":
 		err = zkd.Teardown()
 	default:
-		log.Fatalf("invalid action: %v", action)
+		log.Errorf("invalid action: %v", action)
+		exit.Return(1)
 	}
 	if err != nil {
-		log.Fatalf("failed %v: %v", action, err)
+		log.Errorf("failed %v: %v", action, err)
+		exit.Return(1)
 	}
 }

--- a/go/cmd/zkns2pdns/pdns.go
+++ b/go/cmd/zkns2pdns/pdns.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -334,6 +335,7 @@ func (pd *pdns) Serve(r io.Reader, w io.Writer) {
 }
 
 func main() {
+	defer exit.Recover()
 	defer logutil.Flush()
 
 	zknsDomain := flag.String("zkns-domain", "", "The naming hierarchy portion to serve")
@@ -345,7 +347,8 @@ func main() {
 		go func() {
 			err := http.ListenAndServe(*bindAddr, nil)
 			if err != nil {
-				log.Fatalf("ListenAndServe: %s", err)
+				log.Errorf("ListenAndServe: %s", err)
+				exit.Return(1)
 			}
 		}()
 	}


### PR DESCRIPTION
Lots of places in go/cmd were using log.Fatal as a shortcut for "print and exit".

That caused the following problems:
- It prints a stack trace, which is useless when coming from main().
- The trace obscures the actual error message, which is confusing for users.
- It skips deferred functions, like flushing of logs.
- Functions that call Fatal() can't be reused for other purposes.
- It's not Go-y. Functions should return errors to indicate failure, and the caller can decide whether it wants to abort whatever it was doing as well.