### PR TITLE
Fix "invalid heap pointer" crash when built with Go 1.4.

### DIFF
--- a/third_party/go/launchpad.net/gozk/zookeeper/helpers.c
+++ b/third_party/go/launchpad.net/gozk/zookeeper/helpers.c
@@ -86,5 +86,23 @@ void destroy_watch_data(watch_data *data) {
 watcher_fn watch_handler = _watch_handler;
 void_completion_t handle_void_completion = _handle_void_completion;
 
+zhandle_t *zookeeper_init_int(const char *host, watcher_fn fn,
+		int recv_timeout, const clientid_t *clientid, unsigned long context, int flags) {
+	return zookeeper_init(host, fn, recv_timeout, clientid, (void*)context, flags);
+}
+int zoo_wget_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx,
+		char *buffer, int* buffer_len, struct Stat *stat) {
+	return zoo_wget(zh, path, watcher, (void*)watcherCtx, buffer, buffer_len, stat);
+}
+int zoo_wget_children2_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx,
+		struct String_vector *strings, struct Stat *stat) {
+	return zoo_wget_children2(zh, path, watcher, (void*)watcherCtx, strings, stat);
+}
+int zoo_wexists_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx, struct Stat *stat) {
+	return zoo_wexists(zh, path, watcher, (void*)watcherCtx, stat);
+}
 
 // vim:ts=4:sw=4:et

--- a/third_party/go/launchpad.net/gozk/zookeeper/helpers.h
+++ b/third_party/go/launchpad.net/gozk/zookeeper/helpers.h
@@ -28,6 +28,22 @@ void destroy_watch_data(watch_data *data);
 extern watcher_fn watch_handler;
 extern void_completion_t handle_void_completion;
 
+// The precise GC in Go 1.4+ doesn't like it when we cast arbitrary
+// integers to unsafe.Pointer to pass to the void* context parameter.
+// Below are helper functions that perform the cast in C so the Go GC
+// doesn't try to interpret it as a pointer.
+
+zhandle_t *zookeeper_init_int(const char *host, watcher_fn fn,
+		int recv_timeout, const clientid_t *clientid, unsigned long context, int flags);
+int zoo_wget_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx,
+		char *buffer, int* buffer_len, struct Stat *stat);
+int zoo_wget_children2_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx,
+		struct String_vector *strings, struct Stat *stat);
+int zoo_wexists_int(zhandle_t *zh, const char *path,
+		watcher_fn watcher, unsigned long watcherCtx, struct Stat *stat);
+
 #endif
 
 // vim:ts=4:sw=4:et


### PR DESCRIPTION
@sougou 

The CGO wrapper for ZK was casting arbitrary integers to unsafe.Pointer.
For example, it would call C.something(unsafe.Pointer(1)) in order to
call "void something(void* tag)" with a tag value of (void*)1.

In Go 1.4, if a GC happens to occur while C.something() is executing, it
will find the unsafe.Pointer(1) on the stack and crash because 1 is not
a valid memory address.