### PR TITLE
Use a background context per vtworker, and have all contexts derive from there.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,16 @@ ci_skip_integration_test_files = \
 	resharding.py \
 	update_stream.py
 
+# Run the following tests after making worker changes
+worker_integration_test_files = \
+	binlog.py \
+	resharding.py \
+	resharding_bytes.py \
+	vertical_split.py \
+	vertical_split_vtgate.py \
+	initial_sharding.py \
+	initial_sharding_bytes.py
+
 .ONESHELL:
 SHELL = /bin/bash
 
@@ -138,6 +148,10 @@ large_integration_test:
 
 ci_skip_integration_test:
 	$(call run_integration_tests, $(ci_skip_integration_test_files))
+
+worker_test:
+	go test ./go/vt/worker/
+	$(call run_integration_tests, $(worker_integration_test_files))
 
 integration_test: small_integration_test medium_integration_test large_integration_test ci_skip_integration_test
 

--- a/go/vt/wrangler/cleaner.go
+++ b/go/vt/wrangler/cleaner.go
@@ -54,6 +54,7 @@ type cleanUpHelper struct {
 // If an action on a target fails, it will not run the next action on
 // the same target.
 // We return the aggregate errors for all cleanups.
+// CleanUp uses its own context, with a timeout of 5 minutes, so that clean up action will run even if the original context times out.
 // TODO(alainjobart) Actions should run concurrently on a per target
 // basis. They are then serialized on each target.
 func (cleaner *Cleaner) CleanUp(wr *Wrangler) error {


### PR DESCRIPTION
@alainjobart 

I spent a few hours poking around the abort channel / interrupts, so I can probably fix that pretty quickly now. But I thought it was better to punt on that and get out the stuff that would block resharding work.