### PR TITLE
Automatically add local etcd cluster addresses to global etcd.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -8,8 +8,9 @@ to get Kubernetes up and running if you haven't already.
 
 ## Requirements
 
-This example currently assumes Kubernetes v0.7.x. We recommend downloading a
-[binary release](https://github.com/GoogleCloudPlatform/kubernetes/releases).
+This example was most recently tested with the
+[binary release](https://github.com/GoogleCloudPlatform/kubernetes/releases)
+of Kubernetes v0.8.1.
 
 The easiest way to run the local commands like vtctl is just to install
 [Docker](https://www.docker.com/)
@@ -35,30 +36,6 @@ You can check the status of the pods with *kubecfg.sh list pods* or by using the
 [Kubernetes web interface](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/ux.md).
 Note that it may take a while for each minion to download the Docker images the
 first time it needs them, during which time the pod status will be *Pending*.
-
-Once your etcd clusters are running, you need to make a record in the global
-cell to tell Vitess how to find the other etcd cells. In this case, we only
-have one cell named 'test'. Since we don't want to serve etcd on external IPs,
-you'll need to SSH into one of your minions and use internal IPs.
-
-For example, if you are running
-[Kubernetes on Google Compute Engine](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/getting-started-guides/gce.md):
-
-```
-# find the service IPs
-$ kubecfg.sh list services
-Name                Labels                  Selector                                  IP                  Port
-----------          ----------              ----------                                ----------          ----------
-etcd-test           cell=test,name=etcd     cell=test,name=etcd                       10.0.207.54         4001
-etcd-global         cell=global,name=etcd   cell=global,name=etcd                     10.0.86.120         4001
-
-# log in to a minion
-$ gcloud compute ssh kubernetes-minion-1
-
-# create a node in the global etcd that points to the 'test' cell
-kubernetes-minion-1:~$ curl -L http://10.0.86.120:4001/v2/keys/vt/cells/test -XPUT -d value=http://10.0.207.54:4001
-{"action":"set","node":{"key":"/vt/cells/test","value":"http://10.0.207.54:4001","modifiedIndex":9,"createdIndex":9}}
-```
 
 In general, each *-up.sh* script in this example has a corresponding *-down.sh*
 in case you want to stop certain pieces without bringing down the whole cluster.
@@ -93,7 +70,7 @@ $ gcloud compute forwarding-rules list
 NAME   REGION      IP_ADDRESS    IP_PROTOCOL TARGET
 vtctld us-central1 12.34.56.78   TCP         us-central1/targetPools/vtctld
 
-# now load up vtctld on http://12.34.56.78:15000/
+# now access vtctld at http://12.34.56.78:15000/
 ```
 
 ## Issuing commands with vtctlclient

--- a/examples/kubernetes/etcd-controller-template.yaml
+++ b/examples/kubernetes/etcd-controller-template.yaml
@@ -20,6 +20,14 @@ desiredState:
               - >-
                 ipaddr=$(hostname -i)
 
+                if [ "{{cell}}" != "global" ]; then
+                until curl -L
+                http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT/v2/keys/vt/cells/{{cell}}
+                -XPUT -d value=http://$ipaddr:4001; do
+                echo "[$(date)] waiting for global etcd to register cell '{{cell}}'"; sleep 1;
+                done;
+                fi
+
                 etcd -name $HOSTNAME -peer-addr $ipaddr:7001 -addr $ipaddr:4001 -discovery {{discovery}}
     labels:
       name: etcd

--- a/examples/kubernetes/etcd-controller-template.yaml
+++ b/examples/kubernetes/etcd-controller-template.yaml
@@ -20,10 +20,16 @@ desiredState:
               - >-
                 ipaddr=$(hostname -i)
 
+                global_etcd=$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+
+                cell="{{cell}}" &&
+                local_etcd_host_var="ETCD_${cell^^}_SERVICE_HOST" &&
+                local_etcd_port_var="ETCD_${cell^^}_SERVICE_PORT" &&
+                local_etcd=${!local_etcd_host_var}:${!local_etcd_port_var}
+
                 if [ "{{cell}}" != "global" ]; then
-                until curl -L
-                http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT/v2/keys/vt/cells/{{cell}}
-                -XPUT -d value=http://$ipaddr:4001; do
+                until curl -L http://$global_etcd/v2/keys/vt/cells/{{cell}}
+                -XPUT -d value=http://$local_etcd; do
                 echo "[$(date)] waiting for global etcd to register cell '{{cell}}'"; sleep 1;
                 done;
                 fi


### PR DESCRIPTION
@alainjobart 

On startup, the cell-local etcd instances will try to add or update the
cell record in global etcd. If global etcd isn't ready yet, the curl
command will fail and the startup script will wait 1 second and try
again.