### PR TITLE
jeffjiang: export opmap for other implementation of dynamic query rules

### DIFF
--- a/go/vt/tabletserver/query_rules.go
+++ b/go/vt/tabletserver/query_rules.go
@@ -693,7 +693,7 @@ func MapStrOperator(strop string) (op Operator, err error) {
 	if op, ok := opmap[strop]; ok {
 		return op, nil
 	}
-	return QR_NOOP, NewTabletError(ErrFail, "Cannot map string %s to a valid Operator", strop)
+	return QR_NOOP, NewTabletError(ErrFail, "invalid Operator %s", strop)
 }
 
 func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) {
@@ -824,7 +824,6 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 	}
 	op, err = MapStrOperator(strop)
 	if err != nil {
-		err = NewTabletError(ErrFail, "invalid Operator %s", strop)
 		return
 	}
 	if op == QR_NOOP {

--- a/go/vt/tabletserver/query_rules.go
+++ b/go/vt/tabletserver/query_rules.go
@@ -689,6 +689,13 @@ func getstring(val interface{}) (sv string, status int) {
 //-----------------------------------------------
 // Support functions for JSON
 
+func MapStrOperator(strop string) (op Operator, err error) {
+	if op, ok := opmap[strop]; ok {
+		return op, nil
+	}
+	return QR_NOOP, NewTabletError(ErrFail, "Cannot map string %s to a valid Operator", strop)
+}
+
 func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) {
 	qr = NewQueryRule("", "", QR_FAIL)
 	for k, v := range ruleInfo {
@@ -815,8 +822,8 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 		err = NewTabletError(ErrFail, "want string for Operator")
 		return
 	}
-	op, ok = opmap[strop]
-	if !ok {
+	op, err = MapStrOperator(strop)
+	if err != nil {
 		err = NewTabletError(ErrFail, "invalid Operator %s", strop)
 		return
 	}


### PR DESCRIPTION
@sougou This is yet another small follow up to #265 , I made a small helper to export opmap in query_rules.go so that other implementation of dynamic query rules may be able to use this map for deserializing their query rule encodings (such as protobuf)