### PR TITLE
Deflaked TestUpdateStream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ small_integration_test_files = \
 	sharded.py \
 	secure.py \
 	binlog.py \
-	clone.py
+	clone.py \
+	update_stream.py
 
 medium_integration_test_files = \
 	tabletmanager.py \
@@ -106,8 +107,7 @@ large_integration_test_files = \
 # in the continous integration test suites
 ci_skip_integration_test_files = \
 	resharding_bytes.py \
-	resharding.py \
-	update_stream.py
+	resharding.py
 
 # Run the following tests after making worker changes
 worker_integration_test_files = \

--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -276,8 +276,16 @@ class TestUpdateStream(unittest.TestCase):
   # from master and replica for the same writes. Also tests
   # transactions are retrieved properly.
   def test_stream_parity(self):
-    master_start_position = _get_master_current_position()
-    replica_start_position = _get_repl_current_position()
+    timeout = 30#s
+    while True:
+      master_start_position = _get_master_current_position()
+      replica_start_position = _get_repl_current_position()
+      if master_start_position == replica_start_position:
+        break
+      timeout = utils.wait_step(
+        "%s == %s" % (master_start_position, replica_start_position),
+        timeout
+      )
     logging.debug('run_test_stream_parity starting @ %s',
                   master_start_position)
     master_txn_count = 0

--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -173,7 +173,7 @@ class TestUpdateStream(unittest.TestCase):
     self._exec_vt_txn(self._populate_vt_insert_test)
     self._exec_vt_txn(['delete from vt_insert_test'])
     utils.run_vtctl(['ChangeSlaveType', replica_tablet.tablet_alias, 'spare'])
-    #  time.sleep(20)
+    utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'spare')
     replica_conn = self._get_replica_stream_conn()
     logging.debug('dialing replica update stream service')
     replica_conn.dial()
@@ -202,9 +202,9 @@ class TestUpdateStream(unittest.TestCase):
     logging.debug('_test_service_enabled starting @ %s', start_position)
     utils.run_vtctl(['ChangeSlaveType', replica_tablet.tablet_alias, 'replica'])
     logging.debug('sleeping a bit for the replica action to complete')
-    time.sleep(10)
+    utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'replica', 30)
     thd = threading.Thread(target=self.perform_writes, name='write_thd',
-                           args=(400,))
+                           args=(100,))
     thd.daemon = True
     thd.start()
     replica_conn = self._get_replica_stream_conn()
@@ -238,13 +238,12 @@ class TestUpdateStream(unittest.TestCase):
     try:
       data = replica_conn.stream_start(start_position)
       utils.run_vtctl(['ChangeSlaveType', replica_tablet.tablet_alias, 'spare'])
-      #logging.debug("Sleeping a bit for the spare action to complete")
-      # time.sleep(20)
+      utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'spare', 30)
       while data:
         data = replica_conn.stream_next()
         if data is not None and data['Category'] == 'POS':
           txn_count += 1
-      logging.error('Test Service Switch: FAIL')
+      logging.debug('Test Service Switch: FAIL')
       return
     except dbexceptions.DatabaseError, e:
       self.assertEqual(
@@ -369,6 +368,7 @@ class TestUpdateStream(unittest.TestCase):
     self._test_service_enabled()
     # The above tests leaves the service in disabled state, hence enabling it.
     utils.run_vtctl(['ChangeSlaveType', replica_tablet.tablet_alias, 'replica'])
+    utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'replica', 30)
 
   def test_log_rotation(self):
     start_position = _get_master_current_position()

--- a/test/utils.py
+++ b/test/utils.py
@@ -320,6 +320,20 @@ def wait_for_vars(name, port, var=None):
       break
     timeout = wait_step('waiting for /debug/vars of %s' % name, timeout)
 
+def wait_for_tablet_type(tablet_alias, expected_type, timeout=10):
+  """Waits for a given tablet's SlaveType to become the expected value.
+
+  If the SlaveType does not become expected_type within timeout seconds,
+  it will raise a TestError.
+  """
+  while True:
+    if run_vtctl_json(['GetTablet', tablet_alias])['Type'] == expected_type:
+      break
+    timeout = wait_step(
+      "%s's SlaveType to be %s" % (tablet_alias, expected_type),
+      timeout
+    )
+
 # vtgate helpers, assuming it always restarts on the same port
 def vtgate_start(vtport=None, cell='test_nj', retry_delay=1, retry_count=1,
                  topo_impl=None, tablet_bson_encrypted=False, cache_ttl='1s',


### PR DESCRIPTION
Closes #136 and #137. After this, `make site_test ` should pass on spinning disks again (tested on a spinning disk, without a ramdisk).

@enisoc @henryanand