### PR TITLE
Add attempted proof-of-concept PHP client.

### DIFF
--- a/php/bsonrpc.php
+++ b/php/bsonrpc.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+NOTE: This module requires bson_encode() and bson_decode(),
+      which can be obtained by installing the MongoDB driver.
+      For example, on Debian/Ubuntu:
+          $ sudo apt-get install php5-mongo
+*/
+
+require_once('gorpc.php');
+
+class BsonRpcClient extends GoRpcClient {
+	const LEN_PACK_FORMAT = 'V';
+	const LEN_PACK_SIZE = 4;
+
+	protected function send_request(GoRpcRequest $req) {
+		$this->write(bson_encode($req->header));
+		$this->write(bson_encode($req->body));
+	}
+
+	protected function read_response() {
+		// Read the header.
+		$data = $this->read_n(LEN_PACK_SIZE);
+		$len = unpack(LEN_PACK_FORMAT, $data)[0];
+		$header = $data . $this->read_n($len - LEN_PACK_SIZE);
+
+		// Read the body.
+		$data = $this->read_n(LEN_PACK_SIZE);
+		$len = unpack(LEN_PACK_FORMAT, $data)[0];
+		$body = $data . $this->read_n($len - LEN_PACK_SIZE);
+
+		// Decode and return.
+		return new GoRpcResponse(bson_decode($header), bson_decode($body));
+	}
+}

--- a/php/bsonrpc.php
+++ b/php/bsonrpc.php
@@ -13,6 +13,10 @@ class BsonRpcClient extends GoRpcClient {
 	const LEN_PACK_FORMAT = 'V';
 	const LEN_PACK_SIZE = 4;
 
+	public function dial($addr) {
+		parent::dial("tcp://$addr", '/_bson_rpc_');
+	}
+
 	protected function send_request(GoRpcRequest $req) {
 		$this->write(bson_encode($req->header));
 		$this->write(bson_encode($req->body));

--- a/php/bsonrpc.php
+++ b/php/bsonrpc.php
@@ -20,14 +20,14 @@ class BsonRpcClient extends GoRpcClient {
 
 	protected function read_response() {
 		// Read the header.
-		$data = $this->read_n(LEN_PACK_SIZE);
-		$len = unpack(LEN_PACK_FORMAT, $data)[0];
-		$header = $data . $this->read_n($len - LEN_PACK_SIZE);
+		$data = $this->read_n(self::LEN_PACK_SIZE);
+		$len = unpack(self::LEN_PACK_FORMAT, $data)[0];
+		$header = $data . $this->read_n($len - self::LEN_PACK_SIZE);
 
 		// Read the body.
-		$data = $this->read_n(LEN_PACK_SIZE);
-		$len = unpack(LEN_PACK_FORMAT, $data)[0];
-		$body = $data . $this->read_n($len - LEN_PACK_SIZE);
+		$data = $this->read_n(self::LEN_PACK_SIZE);
+		$len = unpack(self::LEN_PACK_FORMAT, $data)[0];
+		$body = $data . $this->read_n($len - self::LEN_PACK_SIZE);
 
 		// Decode and return.
 		return new GoRpcResponse(bson_decode($header), bson_decode($body));

--- a/php/bsonrpc.php
+++ b/php/bsonrpc.php
@@ -19,18 +19,21 @@ class BsonRpcClient extends GoRpcClient {
 
 	protected function send_request(GoRpcRequest $req) {
 		$this->write(bson_encode($req->header));
-		$this->write(bson_encode($req->body));
+		if ($req->body === NULL)
+			$this->write(bson_encode(array()));
+		else
+			$this->write(bson_encode($req->body));
 	}
 
 	protected function read_response() {
 		// Read the header.
 		$data = $this->read_n(self::LEN_PACK_SIZE);
-		$len = unpack(self::LEN_PACK_FORMAT, $data)[0];
+		$len = unpack(self::LEN_PACK_FORMAT, $data)[1];
 		$header = $data . $this->read_n($len - self::LEN_PACK_SIZE);
 
 		// Read the body.
 		$data = $this->read_n(self::LEN_PACK_SIZE);
-		$len = unpack(self::LEN_PACK_FORMAT, $data)[0];
+		$len = unpack(self::LEN_PACK_FORMAT, $data)[1];
 		$body = $data . $this->read_n($len - self::LEN_PACK_SIZE);
 
 		// Decode and return.

--- a/php/gorpc.php
+++ b/php/gorpc.php
@@ -64,6 +64,7 @@ abstract class GoRpcClient {
 		$fp = stream_socket_client($addr, $errno, $errstr);
 		if ($fp === FALSE)
 			throw new GoRpcException("can't connect to $addr: $errstr ($errno)");
+		$this->stream = $fp;
 
 		// Initiate request for $path.
 		$this->write("CONNECT $path HTTP/1.0\n\n");
@@ -72,8 +73,6 @@ abstract class GoRpcClient {
 		$data = '';
 		while (strpos($data, "\n\n") === FALSE)
 			$data .= $this->read(1024);
-
-		$this->stream = $fp;
 	}
 
 	public function close() {
@@ -118,6 +117,7 @@ abstract class GoRpcClient {
 		$packet = fread($this->stream, $max_len);
 		if ($packet === FALSE)
 			throw new GoRpcException("can't read from stream");
+		return $packet;
 	}
 
 	protected function read_n($target_len) {
@@ -127,7 +127,6 @@ abstract class GoRpcClient {
 			$data .= $this->read($target_len - $len);
 		return $data;
 	}
-
 
 	protected function write($data) {
 		if (fwrite($this->stream, $data) === FALSE)

--- a/php/gorpc.php
+++ b/php/gorpc.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+This is a naive implementation of a Vitess-compatible Go-style RPC layer
+for PHP. It should be considered a proof-of-concept, as it has not been
+tested, since we don't use PHP ourselves. It was loosely modeled after
+the Python implementation in the Vitess tree, but without consideration
+for timeouts.
+*/
+
+class GoRpcException extends Exception {
+}
+
+class GoRpcRemoteError extends GoRpcException {
+}
+
+class GoRpcRequest {
+	public $header;
+	public $body;
+
+	public function __construct($seq, $method, $body) {
+		$this->header = array('ServiceMethod' => $method, 'Seq' => $seq);
+		$this->body = $body;
+	}
+
+	public function seq() {
+		return $this->header['Seq'];
+	}
+}
+
+class GoRpcResponse {
+	public $header;
+	public $reply;
+
+	public function __construct($header, $body) {
+		$this->header = $header;
+		$this->reply = $body;
+	}
+
+	public function error() {
+		return $this->header['Error'];
+	}
+
+	public function seq() {
+		return $this->header['Seq'];
+	}
+}
+
+abstract class GoRpcClient {
+	protected $seq = 0;
+	protected $stream = NULL;
+
+	abstract protected function send_request(GoRpcRequest $req);
+	abstract protected function read_response();
+
+	public function dial($addr, $path) {
+		// Connect to $addr.
+		$fp = stream_socket_client($addr, $errno, $errstr);
+		if ($fp === FALSE)
+			throw new GoRpcException("can't connect to $addr: $errstr ($errno)");
+
+		// Initiate request for $path.
+		$this->write("CONNECT $path HTTP/1.0\n\n");
+
+		// Read until handshake is completed.
+		$data = '';
+		while (strpos($data, "\n\n") === FALSE)
+			$data .= $this->read(1024);
+
+		$this->stream = $fp;
+	}
+
+	public function close() {
+		if ($this->stream !== NULL) {
+			fclose($this->stream);
+			$this->stream = NULL;
+		}
+	}
+
+	public function call($method, $request) {
+		$req = new GoRpcRequest($this->next_seq(), $method, $request);
+		$this->send_request($req);
+
+		$resp = $this->read_response();
+		if ($resp->error())
+			throw new GoRpcRemoteError("$method: " . $resp->error());
+		if ($resp->seq() != $req->seq())
+			throw new GoRpcException("$method: request sequence mismatch");
+
+		return $resp;
+	}
+
+	protected function read($max_len) {
+		if (feof($this->stream))
+			throw new GoRpcException("unexpected EOF while reading from stream");
+		$packet = fread($this->stream, $max_len);
+		if ($packet === FALSE)
+			throw new GoRpcException("can't read from stream");
+	}
+
+	protected function read_n($target_len) {
+		// Read exactly $target_len bytes or bust.
+		$data = '';
+		while (($len = strlen($data)) < $target_len)
+			$data .= $this->read($target_len - $len);
+		return $data;
+	}
+
+
+	protected function write($data) {
+		if (fwrite($this->stream, $data) === FALSE)
+			throw new GoRpcException("can't write to stream");
+	}
+
+	protected function next_seq() {
+		return ++$this->seq;
+	}
+}

--- a/php/test.php
+++ b/php/test.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+This is a sample for using the vtgatev3.php module.
+
+Before running this, start up a local demo cluster by running:
+    vitess$ test/demo.py
+*/
+
+require_once('vtgatev3.php');
+
+$dbh = new VTGateConnection('localhost:15009');
+
+$dbh->beginTransaction();
+$dbh->exec('INSERT INTO user (name) VALUES (:name)', array('name' => 'user 1'), 'master');
+$dbh->exec('INSERT INTO user (name) VALUES (:name)', array('name' => 'user 2'), 'master');
+$dbh->commit();
+
+$stmt = $dbh->query('SELECT * FROM user');
+print_r($stmt->fetchAll());

--- a/php/vtgatev3.php
+++ b/php/vtgatev3.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+This module contains a connection class for the VTGate V3 API over BSON RPC,
+in a vaguely PDO-like interface. This is a minimal implementation to serve
+as a proof-of-concept in PHP.
+*/
+
+require_once('bsonrpc.php');
+
+class VTGateStatement {
+	protected $res = NULL;
+	protected $i = 0;
+
+	public function __construct($res) {
+		$this->res = $res;
+	}
+
+	public function rowCount() {
+		return $this->res['RowsAffected'];
+	}
+
+	public function fetch() {
+		if ($this->i >= count($this->res['Rows']))
+			return FALSE;
+		return $this->res['Rows'][$this->i++];
+	}
+
+	public function fetchAll() {
+		return $this->res['Rows'];
+	}
+
+	public function closeCursor() {
+		$this->res = NULL;
+	}
+}
+
+class VTGateConnection {
+	protected $rpc = NULL;
+	protected $session = NULL;
+
+	public function __construct($addr) {
+		$this->rpc = new BsonRpcClient();
+		$this->rpc->dial($addr);
+	}
+
+	public function beginTransaction() {
+		$resp = $this->rpc->call('VTGate.Begin', NULL);
+		$this->session = $resp->reply;
+	}
+
+	public function commit() {
+		$session = $this->session;
+		$this->session = NULL;
+		$this->rpc->call('VTGate.Commit', $session);
+	}
+
+	public function rollBack() {
+		$session = $this->session;
+		$this->session = NULL;
+		$this->rpc->call('VTGate.Rollback', $session);
+	}
+
+	public function execute($sql, $bind_vars, $tablet_type) {
+		$req = array(
+			'Sql' => $sql,
+			'BindVariables' => $bind_vars,
+			'TabletType' => $tablet_type,
+		);
+		if ($this->session)
+			$req['Session'] = $this->session;
+
+		$resp = $this->rpc->call('VTGate.Execute', $req);
+
+		$reply = $resp->reply;
+		if (array_key_exists('Session', $reply) && $reply['Session'])
+			$this->session = $reply['Session'];
+		if (array_key_exists('Error', $reply) && $reply['Error'])
+			throw new GoRpcRemoteError('exec: ' . $reply['Error']);
+
+		return $reply['Result'];
+	}
+
+	public function exec($sql, $bind_vars, $tablet_type) {
+		$res = $this->execute($sql, $bind_vars, $tablet_type);
+		return $res['RowsAffected'];
+	}
+
+	public function query($sql, $bind_vars, $tablet_type) {
+		$res = $this->execute($sql, $bind_vars, $tablet_type);
+		return new VTGateStatement($res);
+	}
+}


### PR DESCRIPTION
@sougou 

It was a slow oncall day, so I decided to try writing a PHP client for Vitess. I don't imagine that we'll put much effort into maintaining it, but it would be nice to have as a starting point for anyone who's interested in PHP. It's not working yet, but I thought I should share it to avoid potential duplication of effort.

The BSON implementation for PHP, as recommended by bsonspec.org, is the MongoDB driver for PHP. The nice thing is that it's available for easy installation on Ubuntu (apt-get install php5-mongo). Unfortunately, it doesn't support the nonstandard extension we use for uint64. Specifically, I get this error while decoding the response from VTGate.Begin:

vitess/php$ php test.php
PHP Fatal error:  Uncaught exception 'MongoException' with message 'type 0x3f not supported: 3e 00 00 00 05 53 65 72 76 69 63 65 4d 65 74 68 6f 64 00 0c 00 00 00 00 56 54 47 61 74 65 2e 42 65 67 69 6e 3f 53 65 71 00'

Is there any way to change some of these uint64s into int64s in a backward-compatible way?