### PR TITLE
Force a known locale when generating build time.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS = "\
 	-X github.com/youtube/vitess/go/vt/servenv.buildHost   '$$(hostname)'\
 	-X github.com/youtube/vitess/go/vt/servenv.buildUser   '$$(whoami)'\
 	-X github.com/youtube/vitess/go/vt/servenv.buildGitRev '$$(git rev-parse HEAD)'\
-	-X github.com/youtube/vitess/go/vt/servenv.buildTime   '$$(date)'\
+	-X github.com/youtube/vitess/go/vt/servenv.buildTime   '$$(LC_ALL=C date)'\
 "
 
 build:


### PR DESCRIPTION
Adding LC_ALL=C forces the "default" locale, so the user's own setting
won't prevent us from parsing the output of the 'date' command.