### PR TITLE
fix vtctld_test

### DIFF
--- a/go/vt/health/health.go
+++ b/go/vt/health/health.go
@@ -3,6 +3,7 @@ package health
 import (
 	"fmt"
 	"html/template"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -124,6 +125,7 @@ func (ag *Aggregator) HTMLName() template.HTML {
 	for _, rep := range ag.reporters {
 		result = append(result, string(rep.HTMLName()))
 	}
+	sort.Strings(result)
 	return template.HTML(strings.Join(result, "&nbsp; + &nbsp;"))
 }
 

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -4,6 +4,7 @@ import logging
 import os
 import unittest
 import urllib2
+import re
 
 import environment
 import tablet
@@ -211,7 +212,7 @@ class TestVtctld(unittest.TestCase):
   def test_tablet_status(self):
     # the vttablet that has a health check has a bit more, so using it
     shard_0_replica_status = shard_0_replica.get_status()
-    self.assertIn('Polling health information from MySQLReplicationLag', shard_0_replica_status)
+    self.assertIn(re.search(r'Polling health information from.+MySQLReplicationLag', shard_0_replica_status))
     self.assertIn('Alias: <a href="http://localhost:', shard_0_replica_status)
     self.assertIn('</html>', shard_0_replica_status)
 


### PR DESCRIPTION
1. make HTMLName() in go/vt/health/health.go return consistent name
2. fix test_tablet_status in vtctld_test to do a regular exprssion
   search for MySQLReplicationLag status.

@alainjobart 