### PR TITLE
add old portmap back

### DIFF
--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -408,6 +408,7 @@ func (tablet *Tablet) EndPoint() (*EndPoint, error) {
 	entry.NamedPortMap = map[string]int{}
 
 	if port, ok := tablet.Portmap["vt"]; ok {
+		entry.NamedPortMap["_vtocc"] = port
 		entry.NamedPortMap["vt"] = port
 	}
 	if port, ok := tablet.Portmap["mysql"]; ok {


### PR DESCRIPTION
an earlier change (https://github.com/youtube/vitess/pull/327) makes all clients use new portmap name, however, we should only remove these names in topo server until all clients have been update to use only new portmap name.


@alainjobart @enisoc 