### PR TITLE
Allow fast external reparent to be called concurrently.

### DIFF
--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -64,6 +64,9 @@ type ActionAgent struct {
 	// batchCtx is given to the agent by its creator, and should be used for
 	// any background tasks spawned by the agent.
 	batchCtx context.Context
+	// finalizeReparentCtx represents the background finalize step of a
+	// TabletExternallyReparented call.
+	finalizeReparentCtx context.Context
 
 	// This is the History of the health checks, public so status
 	// pages can display it


### PR DESCRIPTION
@alainjobart 

TabletExternallyReparented takes the agent action mutex, so only one
instance can run at a time. However, it launches a background task so
that the work can complete regardless of whether the incoming context is
canceled by the caller. If TER gets called again while the first
background task is still running, we should wait for it to either
succeed or time out before checking if we should try again.