### PR TITLE
Migrate Kubernetes example from kubecfg to kubectl.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -10,7 +10,7 @@ to get Kubernetes up and running if you haven't already.
 
 This example was most recently tested with the
 [binary release](https://github.com/GoogleCloudPlatform/kubernetes/releases)
-of Kubernetes v0.8.2.
+of Kubernetes v0.9.1.
 
 The easiest way to run the local commands like vtctl is just to install
 [Docker](https://www.docker.com/)
@@ -21,7 +21,7 @@ by removing the docker preamble if you prefer.
 ## Starting an etcd cluster for Vitess
 
 Once you have a running Kubernetes deployment, make sure
-`kubernetes/cluster/kubecfg.sh` is in your path, and then run:
+`kubernetes/cluster/kubectl.sh` is in your path, and then run:
 
 ```
 vitess/examples/kubernetes$ ./etcd-up.sh
@@ -32,7 +32,7 @@ since they read other config files.
 
 This will create two clusters: one for the 'global' cell, and one for the
 'test' cell.
-You can check the status of the pods with `kubecfg.sh list pods` or by using the
+You can check the status of the pods with `kubectl.sh get pods` or by using the
 [Kubernetes web interface](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/ux.md).
 Note that it may take a while for each minion to download the Docker images the
 first time it needs them, during which time the pod status will be `Pending`.
@@ -40,7 +40,7 @@ first time it needs them, during which time the pod status will be `Pending`.
 In general, each `-up.sh` script in this example has a corresponding `-down.sh`
 in case you want to stop certain pieces without bringing down the whole cluster.
 For example, to tear down the etcd deployment
-(again, with `kubecfg.sh` in your path):
+(again, with `kubectl.sh` in your path):
 
 ```
 vitess/examples/kubernetes$ ./etcd-down.sh
@@ -97,10 +97,9 @@ service. For example:
 
 ```
 # get service IP
-$ kubecfg.sh list services
-Name                Labels                  Selector                                  IP                  Port
-----------          ----------              ----------                                ----------          ----------
-vtctld              name=vtctld             name=vtctld                               10.0.12.151         15000
+$ kubectl.sh get services
+NAME     LABELS        SELECTOR      IP            PORT
+vtctld   name=vtctld   name=vtctld   10.0.12.151   15000
 
 # log in to a minion
 $ gcloud compute ssh kubernetes-minion-1
@@ -124,7 +123,7 @@ for three replicas.
 vitess/examples/kubernetes$ ./vttablet-up.sh
 ```
 
-Wait for the pods to enter Running state (`kubecfg.sh list pods`).
+Wait for the pods to enter Running state (`kubectl.sh get pods`).
 Again, this may take a while if a pod was scheduled on a minion that needs to
 download the Vitess Docker image. Eventually you should see the tablets show up
 in the *DB topology* summary page of vtctld (`http://12.34.56.78:15000/dbtopo`).
@@ -146,8 +145,8 @@ For example, on GCE that would look like this:
 
 ```
 # which minion is the vttablet-101 pod on?
-$ kubecfg.sh list pods | grep vttablet-101
-vttablet-101    vitess/root,vitess/root    kubernetes-minion-2    Running
+$ kubectl.sh get pods | grep vttablet-101
+vttablet-101   [...]   kubernetes-minion-2   [...]   Running
 
 # ssh to the minion
 $ gcloud compute ssh kubernetes-minion-2

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 
 # This is an example script that tears down the etcd servers started by
-# etcd-up.sh. It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# etcd-up.sh. It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 # Delete replication controllers
 for cell in 'global' 'test'; do
-  echo "Deleting pods created by etcd replicationController for $cell cell..."
-  kubecfg.sh stop etcd-$cell
-
-  echo "Deleting etcd replicationController for $cell cell..."
-  kubecfg.sh delete replicationControllers/etcd-$cell
+  echo "Stopping etcd replicationController for $cell cell..."
+  kubectl.sh stop replicationController etcd-$cell
 
   echo "Deleting etcd service for $cell cell..."
-  kubecfg.sh delete services/etcd-$cell
+  kubectl.sh delete service etcd-$cell
 done
 

--- a/examples/kubernetes/etcd-up.sh
+++ b/examples/kubernetes/etcd-up.sh
@@ -8,7 +8,7 @@
 # service, but you can use your own. See the etcd docs for more:
 # https://github.com/coreos/etcd/blob/v0.4.6/Documentation/cluster-discovery.md
 #
-# This script assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# This script assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
@@ -21,12 +21,12 @@ for cell in 'global' 'test'; do
   echo "Creating etcd service for $cell cell..."
   cat etcd-service-template.yaml | \
     sed -e "s/{{cell}}/$cell/g" | \
-    kubecfg.sh -c - create services
+    kubectl.sh create -f -
 
   # Create the replication controller.
   echo "Creating etcd replicationController for $cell cell..."
   cat etcd-controller-template.yaml | \
     sed -e "s/{{cell}}/$cell/g" -e "s,{{discovery}},$discovery,g" | \
-    kubecfg.sh -c - create replicationControllers
+    kubectl.sh create -f -
 done
 

--- a/examples/kubernetes/guestbook-down.sh
+++ b/examples/kubernetes/guestbook-down.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
 # This is an example script that stops guestbook.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
-echo "Deleting pods created by guestbook replicationController..."
-kubecfg.sh stop guestbook
-
-echo "Deleting guestbook replicationController..."
-kubecfg.sh delete replicationControllers/guestbook
+echo "Stopping guestbook replicationController..."
+kubectl.sh stop replicationController guestbook
 
 echo "Deleting guestbook service..."
-kubecfg.sh delete services/guestbook
+kubectl.sh delete service guestbook

--- a/examples/kubernetes/guestbook-up.sh
+++ b/examples/kubernetes/guestbook-up.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This is an example script that starts a guestbook replicationController.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
 echo "Creating guestbook service..."
-kubecfg.sh -c guestbook-service.yaml create services
+kubectl.sh create -f guestbook-service.yaml
 
 echo "Creating guestbook replicationController..."
-kubecfg.sh -c guestbook-controller.yaml create replicationControllers
+kubectl.sh create -f guestbook-controller.yaml

--- a/examples/kubernetes/vtctld-down.sh
+++ b/examples/kubernetes/vtctld-down.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # This is an example script that stops vtctld.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 echo "Deleting vtctld pod..."
-kubecfg.sh delete pods/vtctld
+kubectl.sh delete pod vtctld
 
 echo "Deleting vtctld service..."
-kubecfg.sh delete services/vtctld
+kubectl.sh delete service vtctld

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This is an example script that starts vtctld.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
 echo "Creating vtctld service..."
-kubecfg.sh -c vtctld-service.yaml create services
+kubectl.sh create -f vtctld-service.yaml
 
 echo "Creating vtctld pod..."
-kubecfg.sh -c vtctld-pod.yaml create pods
+kubectl.sh create -f vtctld-pod.yaml

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
 # This is an example script that stops vtgate.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
-echo "Deleting pods created by vtgate replicationController..."
-kubecfg.sh stop vtgate
-
-echo "Deleting vtgate replicationController..."
-kubecfg.sh delete replicationControllers/vtgate
+echo "Stopping vtgate replicationController..."
+kubectl.sh stop replicationController vtgate
 
 echo "Deleting vtgate service..."
-kubecfg.sh delete services/vtgate
+kubectl.sh delete service vtgate

--- a/examples/kubernetes/vtgate-up.sh
+++ b/examples/kubernetes/vtgate-up.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # This is an example script that starts a vtgate replicationController.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
 echo "Creating vtgate service..."
-kubecfg.sh -c vtgate-service.yaml create services
+kubectl.sh create -f vtgate-service.yaml
 
 echo "Creating vtgate replicationController..."
-kubecfg.sh -c vtgate-controller.yaml create replicationControllers
+kubectl.sh create -f vtgate-controller.yaml

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is an example script that tears down the vttablet pods started by
-# vttablet-up.sh. It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# vttablet-up.sh. It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 # Delete the pods for shard-0
 cell='test'
@@ -14,5 +14,5 @@ for uid_index in 0 1 2; do
   printf -v alias '%s-%010d' $cell $uid
 
   echo "Deleting pod for tablet $alias..."
-  kubecfg.sh delete pods/vttablet-$uid
+  kubectl.sh delete pod vttablet-$uid
 done

--- a/examples/kubernetes/vttablet-up.sh
+++ b/examples/kubernetes/vttablet-up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This is an example script that creates a single shard vttablet deployment.
-# It assumes that kubernetes/cluster/kubecfg.sh is in the path.
+# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
@@ -26,8 +26,8 @@ for uid_index in 0 1 2; do
     sed_script+="s/{{$var}}/${!var}/g;"
   done
 
-  # Instantiate template and send to kubecfg.
+  # Instantiate template and send to kubectl.
   cat vttablet-pod-template.yaml | \
     sed -e "$sed_script" | \
-    kubecfg.sh -c - create pods
+    kubectl.sh create -f -
 done


### PR DESCRIPTION
This will allow the instructions to work in Container Engine, which only
supports the new kubectl (kubecfg is deprecated).