### PR TITLE
Finish force_close before calling mysql_close.

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -348,6 +348,9 @@ func (conn *Connection) SendCommand(command uint32, data []byte) error {
 // in a call to ReadPacket(), and another thread wants to cancel the read. We
 // can't use mysql_close() because it isn't safe to use while another thread is
 // blocked in an I/O call on that MySQL connection.
+//
+// After calling ForceClose, you must wait until the MySQL I/O call that was
+// blocked has returned, before calling Close to finish freeing resources.
 func (conn *Connection) ForceClose() {
 	C.vt_force_close(&conn.c)
 }

--- a/go/mysql/vtmysql.h
+++ b/go/mysql/vtmysql.h
@@ -16,6 +16,7 @@ typedef struct vt_conn {
   unsigned int num_fields;
   MYSQL_FIELD  *fields;
   MYSQL_RES    *result;
+  unsigned int force_closed;
 } VT_CONN;
 
 // vt_connect: Create a connection. You must call vt_close even if vt_connect fails.

--- a/go/mysql/vtmysql_internals.h
+++ b/go/mysql/vtmysql_internals.h
@@ -13,8 +13,10 @@
 #define NULL ((void*)0)
 #endif
 
-// vio_close is not declared anywhere in the libmysqlclient headers.
+// These low-level vio functions are not declared
+// anywhere in the libmysqlclient headers.
 int vio_close(Vio*);
+void vio_delete(Vio*);
 
 // cli_safe_read is declared in sql_common.h.
 unsigned long cli_safe_read(MYSQL *mysql);


### PR DESCRIPTION
Trying to address crashes in CGO that happen when closing a connection
that was previously force-closed.