### PR TITLE
Fix MySQL force close for real this time.

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -343,16 +343,13 @@ func (conn *Connection) SendCommand(command uint32, data []byte) error {
 	return nil
 }
 
-// ForceClose closes a MySQL connection forcibly at the socket level, instead of
-// gracefully through mysql_close(). This is necessary when a thread is blocked
-// in a call to ReadPacket(), and another thread wants to cancel the read. We
-// can't use mysql_close() because it isn't safe to use while another thread is
-// blocked in an I/O call on that MySQL connection.
-//
-// After calling ForceClose, you must wait until the MySQL I/O call that was
-// blocked has returned, before calling Close to finish freeing resources.
-func (conn *Connection) ForceClose() {
-	C.vt_force_close(&conn.c)
+// Shutdown invokes the low-level shutdown call on the socket associated with
+// a MySQL connection to stop ongoing communication. This is necessary when a
+// thread is blocked in a MySQL I/O call, such as  ReadPacket(), and another
+// thread wants to cancel the operation. We can't use mysql_close() because it
+// isn't thread-safe.
+func (conn *Connection) Shutdown() {
+	C.vt_shutdown(&conn.c)
 }
 
 // GetCharset returns the current numerical values of the per-session character

--- a/go/mysql/vtmysql.c
+++ b/go/mysql/vtmysql.c
@@ -39,7 +39,6 @@ int vt_connect(
 
   mysql_thread_init();
   conn->mysql = mysql_init(0);
-  conn->force_closed = 0;
   c = mysql_real_connect(conn->mysql, host, user, passwd, db, port, unix_socket, client_flag);
   if(!c) {
     return 1;
@@ -50,16 +49,6 @@ int vt_connect(
 void vt_close(VT_CONN *conn) {
   if (conn->mysql) {
     mysql_thread_init();
-
-    // If the socket was force-closed by vt_force_close, we should tell
-    // mysql_close() not to try using it to send a QUIT command.
-    // We also need to free the vio resources since we were the ones who
-    // called vio_close.
-    if (conn->force_closed) {
-      vio_delete(conn->mysql->net.vio);
-      conn->mysql->net.vio = 0;
-    }
-
     mysql_close(conn->mysql);
     conn->mysql = 0;
   }
@@ -172,18 +161,10 @@ unsigned long vt_cli_safe_read(VT_CONN *conn) {
   return len == packet_error ? 0 : len;
 }
 
-void vt_force_close(VT_CONN *conn) {
+void vt_shutdown(VT_CONN *conn) {
   mysql_thread_init();
 
-  // Close the underlying socket of a MYSQL connection object.
-  if (conn->mysql->net.vio) {
-    vio_close(conn->mysql->net.vio);
-
-    // Ideally, we would call vio_delete here and set mysql->net.vio to 0
-    // to signal that the socket is closed. However, we can't safely do
-    // that until the thread that's blocked in a read call returns.
-    // So we mark that it needs to be done, and do it in vt_close before
-    // calling mysql_close.
-    conn->force_closed = 1;
-  }
+  // Shut down the underlying socket of a MYSQL connection object.
+  if (conn->mysql->net.vio)
+    vio_socket_shutdown(conn->mysql->net.vio, 2 /* SHUT_RDWR */);
 }

--- a/go/mysql/vtmysql.h
+++ b/go/mysql/vtmysql.h
@@ -16,7 +16,6 @@ typedef struct vt_conn {
   unsigned int num_fields;
   MYSQL_FIELD  *fields;
   MYSQL_RES    *result;
-  unsigned int force_closed;
 } VT_CONN;
 
 // vt_connect: Create a connection. You must call vt_close even if vt_connect fails.
@@ -64,6 +63,6 @@ my_bool vt_simple_command(
 // or 0 if there was an error.
 unsigned long vt_cli_safe_read(VT_CONN *conn);
 
-// vt_force_close: Kill a MySQL connection at the socket level, to unblock
+// vt_shutdown: Kill a MySQL connection at the socket level, to unblock
 // a thread that is waiting on a read call.
-void vt_force_close(VT_CONN *conn);
+void vt_shutdown(VT_CONN *conn);

--- a/go/mysql/vtmysql_internals.h
+++ b/go/mysql/vtmysql_internals.h
@@ -15,8 +15,7 @@
 
 // These low-level vio functions are not declared
 // anywhere in the libmysqlclient headers.
-int vio_close(Vio*);
-void vio_delete(Vio*);
+int vio_socket_shutdown(Vio *vio, int how);
 
 // cli_safe_read is declared in sql_common.h.
 unsigned long cli_safe_read(MYSQL *mysql);

--- a/go/vt/mysqlctl/slave_connection.go
+++ b/go/vt/mysqlctl/slave_connection.go
@@ -127,8 +127,8 @@ func (sc *SlaveConnection) StartBinlogDump(startPos proto.ReplicationPosition) (
 // The ID for the slave connection is recycled back into the pool.
 func (sc *SlaveConnection) Close() {
 	if sc.Connection != nil {
-		log.Infof("force-closing slave socket to unblock reads")
-		sc.Connection.ForceClose()
+		log.Infof("shutting down slave socket to unblock reads")
+		sc.Connection.Shutdown()
 
 		log.Infof("waiting for slave dump thread to end")
 		sc.svm.Stop()
@@ -142,7 +142,7 @@ func (sc *SlaveConnection) Close() {
 
 // makeBinlogDumpCommand builds a buffer containing the data for a MySQL
 // COM_BINLOG_DUMP command.
-func makeBinlogDumpCommand(pos uint32, flags uint16, server_id uint32, filename string) []byte {
+func makeBinlogDumpCommand(pos uint32, flags uint16, serverID uint32, filename string) []byte {
 	var buf bytes.Buffer
 	buf.Grow(4 + 2 + 4 + len(filename))
 
@@ -151,7 +151,7 @@ func makeBinlogDumpCommand(pos uint32, flags uint16, server_id uint32, filename 
 	// binlog_flags (2 bytes)
 	binary.Write(&buf, binary.LittleEndian, flags)
 	// server_id of slave (4 bytes)
-	binary.Write(&buf, binary.LittleEndian, server_id)
+	binary.Write(&buf, binary.LittleEndian, serverID)
 	// binlog_filename (string with no terminator and no length)
 	buf.WriteString(filename)
 


### PR DESCRIPTION
@sougou 

Closing the socket was too harsh, because that makes the socket handle
invalid for any calls, even checking its status. Instead, we should only
call shutdown on the socket.