### PR TITLE
Make Kubernetes example run on Container Engine.

### DIFF
--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,54 +2,88 @@
 
 This directory contains an example configuration for running Vitess on
 [Kubernetes](https://github.com/GoogleCloudPlatform/kubernetes/).
-Refer to the appropriate
-[Getting Started Guide](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/docs/getting-started-guides)
-to get Kubernetes up and running if you haven't already.
 
-## Requirements
+These instructions are written for running in
+[Google Container Engine](https://cloud.google.com/container-engine/),
+but they can be adapted to run on other
+[platforms that Kubernetes supports](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/docs/getting-started-guides).
 
-This example was most recently tested with the
-[binary release](https://github.com/GoogleCloudPlatform/kubernetes/releases)
-of Kubernetes v0.9.1.
+## Prerequisites
 
-The easiest way to run the local commands like vtctl is just to install
-[Docker](https://www.docker.com/)
-on your workstation. You can also adapt the commands below to use a local
-[Vitess build](https://github.com/youtube/vitess/blob/master/doc/GettingStarted.md)
-by removing the docker preamble if you prefer.
+If you're running Kubernetes manually, instead of through Container Engine,
+make sure to use at least
+[v0.9.2](https://github.com/GoogleCloudPlatform/kubernetes/releases).
+Container Engine will use the latest available release by default.
 
-## Starting an etcd cluster for Vitess
+You'll need [Go 1.3+](http://golang.org/doc/install) in order to build the
+`vtctlclient` tool used to issue commands to Vitess:
 
-Once you have a running Kubernetes deployment, make sure
-`kubernetes/cluster/kubectl.sh` is in your path, and then run:
+### Build and install vtctlclient
+
+```
+$ go get github.com/youtube/vitess/go/cmd/vtctlclient
+```
+
+### Set the path to kubectl
+
+If you're running in Container Engine, set the `KUBECTL` environment variable
+to point to the `gcloud` command:
+
+```
+$ export KUBECTL='gcloud preview container kubectl'
+```
+
+If you're running Kubernetes manually, set the `KUBECTL` environment variable
+to point to the location of `kubectl.sh`. For example:
+
+```
+$ export KUBECTL=$HOME/kubernetes/cluster/kubectl.sh
+```
+
+### Create a Container Engine cluster
+
+Follow the steps to
+[enable the Container Engine API](https://cloud.google.com/container-engine/docs/before-you-begin).
+
+Set the [zone](https://cloud.google.com/compute/docs/zones#available) you want to use:
+
+```
+$ gcloud config set compute/zone us-central1-b
+```
+
+Then create a cluster:
+
+```
+$ gcloud preview container clusters create example --machine-type n1-standard-1 --num-nodes 3
+```
+
+## Start an etcd cluster for Vitess
+
+Once you have a running Kubernetes deployment, make sure to set `KUBECTL`
+as described above, and then run:
 
 ```
 vitess/examples/kubernetes$ ./etcd-up.sh
 ```
 
-Note that these example scripts should be run from the directory they're in,
-since they read other config files.
-
 This will create two clusters: one for the 'global' cell, and one for the
 'test' cell.
-You can check the status of the pods with `kubectl.sh get pods` or by using the
-[Kubernetes web interface](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/ux.md).
+You can check the status of the pods with `$KUBECTL get pods`.
 Note that it may take a while for each minion to download the Docker images the
 first time it needs them, during which time the pod status will be `Pending`.
 
 In general, each `-up.sh` script in this example has a corresponding `-down.sh`
 in case you want to stop certain pieces without bringing down the whole cluster.
-For example, to tear down the etcd deployment
-(again, with `kubectl.sh` in your path):
+For example, to tear down the etcd deployment:
 
 ```
 vitess/examples/kubernetes$ ./etcd-down.sh
 ```
 
-## Starting vtctld
+## Start vtctld
 
 The vtctld server provides a web interface to inspect the state of the system,
-and also accepts RPC commands to modify the system.
+and also accepts RPC commands from `vtctlclient` to modify the system.
 
 ```
 vitess/examples/kubernetes$ ./vtctld-up.sh
@@ -69,50 +103,26 @@ $ gcloud compute firewall-rules create vtctld --allow tcp:15000
 $ gcloud compute forwarding-rules list
 NAME   REGION      IP_ADDRESS    IP_PROTOCOL TARGET
 vtctld us-central1 12.34.56.78   TCP         us-central1/targetPools/vtctld
-
-# now access vtctld at http://12.34.56.78:15000/
 ```
 
-## Issuing commands with vtctlclient
+In the example above, you would then access vtctld at
+http://12.34.56.78:15000/ once the pod has entered the `Running` state.
+
+## Control vtctld with vtctlclient
 
 If you've opened port 15000 on your firewall, you can run `vtctlclient`
-locally to issue commands. Depending on your actual vtctld IP, as well as
-whether you're running via Docker, the vtctlclient command will look
-different. So from here on, we will assume you've made an alias called `kvtctl`
-with your particular parameters, such as:
+locally to issue commands. Depending on your actual vtctld IP,
+the `vtctlclient` command will look different. So from here on, we'll assume
+you've made an alias called `kvtctl` with your particular parameters, such as:
 
 ```
-$ alias kvtctl="sudo docker run -ti --rm vitess/base vtctlclient -server 12.34.56.78:15000"
+$ alias kvtctl='vtctlclient -server 12.34.56.78:15000'
 
 # check the connection to vtctld, and list available commands
 $ kvtctl
-
-# create a global keyspace record
-$ kvtctl CreateKeyspace my_keyspace
 ```
 
-If you don't want to open the port on the firewall, you can SSH into one of your
-minions and perform the above commands against the internal IP for the vtctld
-service. For example:
-
-```
-# get service IP
-$ kubectl.sh get services
-NAME     LABELS        SELECTOR      IP            PORT
-vtctld   name=vtctld   name=vtctld   10.0.12.151   15000
-
-# log in to a minion
-$ gcloud compute ssh kubernetes-minion-1
-
-# run a command
-kubernetes-minion-1:~$ sudo docker run -ti --rm vitess/base vtctlclient -server 10.0.12.151:15000 CreateKeyspace your_keyspace
-```
-
-Note that the CreateKeyspace commands above are just for testing that
-vtctlclient works. You normally would not need to do that manually,
-as vttablet will initialize the necessary entries upon startup.
-
-## Launching vttablets
+## Start vttablets
 
 We launch vttablet in a
 [pod](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/pods.md)
@@ -123,7 +133,7 @@ for three replicas.
 vitess/examples/kubernetes$ ./vttablet-up.sh
 ```
 
-Wait for the pods to enter Running state (`kubectl.sh get pods`).
+Wait for the pods to enter Running state (`$KUBECTL get pods`).
 Again, this may take a while if a pod was scheduled on a minion that needs to
 download the Vitess Docker image. Eventually you should see the tablets show up
 in the *DB topology* summary page of vtctld (`http://12.34.56.78:15000/dbtopo`).
@@ -138,30 +148,18 @@ $ kvtctl RebuildKeyspaceGraph test_keyspace
 
 Note that most vtctlclient commands produce no output on success.
 
-### Viewing logs
-
-You can inspect the output of any Kubernetes container with the `kubectl`
-command. For example, to see the logs for vttablet:
-
-```
-# show logs for container 'vttablet' within pod 'vttablet-100'
-$ kubectl.sh log vttablet-100 vttablet
-
-# show logs for container 'mysql' within pod 'vttablet-100'
-$ kubectl.sh log vttablet-100 mysql
-```
-
-### Viewing vttablet status
+### Status pages for vttablets
 
 Each vttablet serves a set of HTML status pages on its primary port.
-The vtctld interface provides links on each tablet entry, but these links are
-to internal per-pod IPs that can only be accessed from within Kubernetes.
-As a workaround, you can proxy over an SSH connection to a Kubernetes minion,
-or launch a proxy as a Kubernetes service.
+The vtctld interface provides links on each tablet entry marked *[status]*,
+but these links are to internal per-pod IPs that can only be accessed from
+within Kubernetes. As a workaround, you can proxy over an SSH connection to
+a Kubernetes minion, or launch a proxy as a Kubernetes service.
 
-The status url for each tablet is http://tablet-ip:15002/debug/status
+In the future, we plan to accomplish the proxying via the Kubernetes API
+server, without the need for additional setup.
 
-## Electing a master vttablet
+## Elect a master vttablet
 
 The vttablets have all been started as replicas, but there is no master yet.
 When we pick a master vttablet, Vitess will also take care of connecting the
@@ -185,16 +183,17 @@ test-0000000101 test_keyspace 0 replica 10.244.1.8:15002 10.244.1.8:3306 []
 test-0000000102 test_keyspace 0 replica 10.244.1.9:15002 10.244.1.9:3306 []
 ```
 
-## Creating a table
+## Create a table
 
-The vtctl tool can manage schema across all tablets in a keyspace.
+The `vtctlclient` tool can manage schema across all tablets in a keyspace.
 To create the table defined in `create_test_table.sql`:
 
 ```
+# run this from the example dir so it finds the create_test_table.sql file
 vitess/examples/kubernetes$ kvtctl ApplySchemaKeyspace -simple -sql "$(cat create_test_table.sql)" test_keyspace
 ```
 
-## Launching the vtgate pool
+## Start a vtgate pool
 
 Clients send queries to Vitess through vtgate, which routes them to the
 correct vttablet(s) behind the scenes. In Kubernetes, we define a vtgate
@@ -205,7 +204,7 @@ service that distributes connections to a pool of vtgate pods curated by a
 vitess/examples/kubernetes$ ./vtgate-up.sh
 ```
 
-## Launching the sample GuestBook app
+## Start the sample GuestBook app server
 
 The GuestBook app in this example is ported from the
 [Kubernetes GuestBook example](https://github.com/GoogleCloudPlatform/kubernetes/tree/master/examples/guestbook-go).
@@ -236,4 +235,37 @@ is working.
 
 See the
 [GuestBook source](https://github.com/youtube/vitess/tree/master/examples/kubernetes/guestbook)
-for more details.
+for more details on how the app server interacts with Vitess.
+
+## Tear down and clean up
+
+Tear down the Container Engine cluster:
+
+```
+$ gcloud preview container clusters delete example
+```
+
+Clean up other entities created for this example:
+
+```
+$ gcloud compute forwarding-rules delete vtctld
+$ gcloud compute firewall-rules delete vtctld
+$ gcloud compute target-pools delete vtctld
+```
+
+## Troubleshooting
+
+If a pod enters the `Running` state, but the server doesn't respond as expected,
+try checking the pod output with the `kubectl log` command:
+
+```
+# show logs for container 'vttablet' within pod 'vttablet-100'
+$ $KUBECTL log vttablet-100 vttablet
+
+# show logs for container 'mysql' within pod 'vttablet-100'
+$ $KUBECTL log vttablet-100 mysql
+```
+
+You can post the logs somewhere and send a link to the
+[Vitess mailing list](https://groups.google.com/forum/#!forum/vitess)
+to get more help.

--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -1,0 +1,6 @@
+# This is an include file used by the other scripts in this directory.
+
+if [ -z "$KUBECTL" ]; then
+  echo 'Please set KUBECTL env var to point to kubectl or kubectl.sh'
+  exit 1
+fi

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
 # This is an example script that tears down the etcd servers started by
-# etcd-up.sh. It assumes that kubernetes/cluster/kubectl.sh is in the path.
+# etcd-up.sh.
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 # Delete replication controllers
 for cell in 'global' 'test'; do
   echo "Stopping etcd replicationController for $cell cell..."
-  kubectl.sh stop replicationController etcd-$cell
+  $KUBECTL stop replicationController etcd-$cell
 
   echo "Deleting etcd service for $cell cell..."
-  kubectl.sh delete service etcd-$cell
+  $KUBECTL delete service etcd-$cell
 done
 

--- a/examples/kubernetes/etcd-up.sh
+++ b/examples/kubernetes/etcd-up.sh
@@ -7,10 +7,11 @@
 # existing cluster. In this example, we use an externally-run discovery
 # service, but you can use your own. See the etcd docs for more:
 # https://github.com/coreos/etcd/blob/v0.4.6/Documentation/cluster-discovery.md
-#
-# This script assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 for cell in 'global' 'test'; do
   # Generate a discovery token.
@@ -21,12 +22,12 @@ for cell in 'global' 'test'; do
   echo "Creating etcd service for $cell cell..."
   cat etcd-service-template.yaml | \
     sed -e "s/{{cell}}/$cell/g" | \
-    kubectl.sh create -f -
+    $KUBECTL create -f -
 
   # Create the replication controller.
   echo "Creating etcd replicationController for $cell cell..."
   cat etcd-controller-template.yaml | \
     sed -e "s/{{cell}}/$cell/g" -e "s,{{discovery}},$discovery,g" | \
-    kubectl.sh create -f -
+    $KUBECTL create -f -
 done
 

--- a/examples/kubernetes/guestbook-down.sh
+++ b/examples/kubernetes/guestbook-down.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # This is an example script that stops guestbook.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 echo "Stopping guestbook replicationController..."
-kubectl.sh stop replicationController guestbook
+$KUBECTL stop replicationController guestbook
 
 echo "Deleting guestbook service..."
-kubectl.sh delete service guestbook
+$KUBECTL delete service guestbook

--- a/examples/kubernetes/guestbook-up.sh
+++ b/examples/kubernetes/guestbook-up.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 # This is an example script that starts a guestbook replicationController.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
+
 echo "Creating guestbook service..."
-kubectl.sh create -f guestbook-service.yaml
+$KUBECTL create -f guestbook-service.yaml
 
 echo "Creating guestbook replicationController..."
-kubectl.sh create -f guestbook-controller.yaml
+$KUBECTL create -f guestbook-controller.yaml

--- a/examples/kubernetes/vtctld-down.sh
+++ b/examples/kubernetes/vtctld-down.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # This is an example script that stops vtctld.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 echo "Deleting vtctld pod..."
-kubectl.sh delete pod vtctld
+$KUBECTL delete pod vtctld
 
 echo "Deleting vtctld service..."
-kubectl.sh delete service vtctld
+$KUBECTL delete service vtctld

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 # This is an example script that starts vtctld.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
+
 echo "Creating vtctld service..."
-kubectl.sh create -f vtctld-service.yaml
+$KUBECTL create -f vtctld-service.yaml
 
 echo "Creating vtctld pod..."
-kubectl.sh create -f vtctld-pod.yaml
+$KUBECTL create -f vtctld-pod.yaml

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 # This is an example script that stops vtgate.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 echo "Stopping vtgate replicationController..."
-kubectl.sh stop replicationController vtgate
+$KUBECTL stop replicationController vtgate
 
 echo "Deleting vtgate service..."
-kubectl.sh delete service vtgate
+$KUBECTL delete service vtgate

--- a/examples/kubernetes/vtgate-up.sh
+++ b/examples/kubernetes/vtgate-up.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
 # This is an example script that starts a vtgate replicationController.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
 
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
+
 echo "Creating vtgate service..."
-kubectl.sh create -f vtgate-service.yaml
+$KUBECTL create -f vtgate-service.yaml
 
 echo "Creating vtgate replicationController..."
-kubectl.sh create -f vtgate-controller.yaml
+$KUBECTL create -f vtgate-controller.yaml

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # This is an example script that tears down the vttablet pods started by
-# vttablet-up.sh. It assumes that kubernetes/cluster/kubectl.sh is in the path.
+# vttablet-up.sh.
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 # Delete the pods for shard-0
 cell='test'
@@ -14,5 +17,5 @@ for uid_index in 0 1 2; do
   printf -v alias '%s-%010d' $cell $uid
 
   echo "Deleting pod for tablet $alias..."
-  kubectl.sh delete pod vttablet-$uid
+  $KUBECTL delete pod vttablet-$uid
 done

--- a/examples/kubernetes/vttablet-up.sh
+++ b/examples/kubernetes/vttablet-up.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # This is an example script that creates a single shard vttablet deployment.
-# It assumes that kubernetes/cluster/kubectl.sh is in the path.
 
 set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
 
 # Create the pods for shard-0
 cell='test'
@@ -29,5 +31,5 @@ for uid_index in 0 1 2; do
   # Instantiate template and send to kubectl.
   cat vttablet-pod-template.yaml | \
     sed -e "$sed_script" | \
-    kubectl.sh create -f -
+    $KUBECTL create -f -
 done


### PR DESCRIPTION
Previously, it ran directly on Kubernetes in Compute Engine.
Running on Container Engine eliminates the need to worry about
setting up Kubernetes itself. It's still possible to run the
Vitess example on a bare Kubernetes deployment by setting the
KUBECTL environment variable accordingly.

[ci skip]