### PR TITLE
Split main() in tests into two parts.

### DIFF
--- a/test/environment.py
+++ b/test/environment.py
@@ -128,3 +128,7 @@ def binary_argstr(name):
 # binary management for the MySQL distribution.
 def mysql_binary_path(name):
   return os.path.join(vt_mysql_root, 'bin', name)
+
+# add environment-specific command-line options
+def add_options(parser):
+  pass

--- a/test/queryservice_test.py
+++ b/test/queryservice_test.py
@@ -21,7 +21,7 @@ from protocols_flavor import set_protocols_flavor
 from topo_flavor.server import set_topo_server_flavor
 
 
-if __name__ == "__main__":
+def main():
   parser = optparse.OptionParser(usage="usage: %prog [options] [test_names]")
   parser.add_option("-m", "--memcache", action="store_true", default=False,
                     help="starts a memcache d, and tests rowcache")
@@ -33,6 +33,9 @@ if __name__ == "__main__":
   logging.getLogger().setLevel(logging.ERROR)
   utils.set_options(options)
 
+  run_tests(options, args)
+
+def run_tests(options, args):
   suite = unittest.TestSuite()
   if args:
     if args[0] == 'teardown':
@@ -72,3 +75,6 @@ if __name__ == "__main__":
     if options.keep_logs:
       print("Leaving temporary files behind (--keep-logs), please "
             "clean up before next run: " + os.environ["VTDATAROOT"])
+
+if __name__ == "__main__":
+  main()

--- a/test/utils.py
+++ b/test/utils.py
@@ -57,6 +57,7 @@ class LoggingStream(object):
     pass
 
 def add_options(parser):
+  environment.add_options(parser)
   parser.add_option('-d', '--debug', action='store_true',
                     help='utils.pause() statements will wait for user input')
   parser.add_option('-k', '--keep-logs', action='store_true',
@@ -99,6 +100,9 @@ def main(mod=None):
 
   set_options(options)
 
+  run_tests(mod, args)
+
+def run_tests(mod, args):
   try:
     suite = unittest.TestSuite()
     if not args:


### PR DESCRIPTION
So that one part can be replaced on import.