### PR TITLE
Fail fast in *-down.sh scripts.

### DIFF
--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -3,6 +3,8 @@
 # This is an example script that tears down the etcd servers started by
 # etcd-up.sh.
 
+set -e
+
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 

--- a/examples/kubernetes/guestbook-down.sh
+++ b/examples/kubernetes/guestbook-down.sh
@@ -2,6 +2,8 @@
 
 # This is an example script that stops guestbook.
 
+set -e
+
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 

--- a/examples/kubernetes/vtctld-down.sh
+++ b/examples/kubernetes/vtctld-down.sh
@@ -2,6 +2,8 @@
 
 # This is an example script that stops vtctld.
 
+set -e
+
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -2,6 +2,8 @@
 
 # This is an example script that stops vtgate.
 
+set -e
+
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -3,6 +3,8 @@
 # This is an example script that tears down the vttablet pods started by
 # vttablet-up.sh.
 
+set -e
+
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 


### PR DESCRIPTION
@henryanand 

This way the user is more likely to see the errors.

It's also easier to reason about the state of the system if you know the
script stopped at a certain point.