### PR TITLE
Add proxy prefix to /debug/vars in JS update func.

### DIFF
--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -160,8 +160,17 @@ isStacked: true,
 
 function update() {
   var varzData;
+
+  // If we're accessing status through a proxy that requires a URL prefix,
+  // add the prefix to the vars URL.
+  var vars_url = '/debug/vars';
+  var pos = window.location.pathname.lastIndexOf('/debug/status');
+  if (pos > 0) {
+    vars_url = window.location.pathname.substring(0, pos) + vars_url;
+  }
+
   var up = function() {
-  $.getJSON('/debug/vars', function(d) {
+  $.getJSON(vars_url, function(d) {
     for (var i = 0; i < updateCallbacks.length; i++) {
       updateCallbacks[i](d, new Date());
     }

--- a/go/vt/tabletserver/status.go
+++ b/go/vt/tabletserver/status.go
@@ -33,9 +33,16 @@ function drawQPSChart() {
     }
   };
 
+  // If we're accessing status through a proxy that requires a URL prefix,
+  // add the prefix to the vars URL.
+  var vars_url = '/debug/vars';
+  var pos = window.location.pathname.lastIndexOf('/debug/status');
+  if (pos > 0) {
+    vars_url = window.location.pathname.substring(0, pos) + vars_url;
+  }
 
   var redraw = function() {
-    $.getJSON("/debug/vars", function(input_data) {
+    $.getJSON(vars_url, function(input_data) {
       var now = new Date();
       var qps = input_data.QPS;
       var planTypes = Object.keys(qps);


### PR DESCRIPTION
e.g. if we're accessing the status page at:

http://my.proxy/vttablet-123/debug/status

then the JS on that page needs to request vars from:

/vttablet-123/debug/vars

instead of just /debug/vars.