### PR TITLE
Fix Travis build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
   - bash -v bootstrap.sh
 script:
   - source dev.env
-  - travis_retry make $MAKE_TARGET
+  - travis_retry make build $MAKE_TARGET

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ site_integration_test_files = \
 # - medium: 30 secs - 1 min
 # - large: over 1 min
 small_integration_test_files = \
-	initial_sharding_bytes.py \
 	vertical_split.py \
 	vertical_split_vtgate.py \
 	schema.py \
@@ -106,6 +105,7 @@ large_integration_test_files = \
 # The following tests are considered too flaky to be included
 # in the continous integration test suites
 ci_skip_integration_test_files = \
+	initial_sharding_bytes.py \
 	initial_sharding.py \
 	resharding_bytes.py \
 	resharding.py

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ site_integration_test_files = \
 # - medium: 30 secs - 1 min
 # - large: over 1 min
 small_integration_test_files = \
-	initial_sharding.py \
 	initial_sharding_bytes.py \
 	vertical_split.py \
 	vertical_split_vtgate.py \
@@ -107,6 +106,7 @@ large_integration_test_files = \
 # The following tests are considered too flaky to be included
 # in the continous integration test suites
 ci_skip_integration_test_files = \
+	initial_sharding.py \
 	resharding_bytes.py \
 	resharding.py
 


### PR DESCRIPTION
With a recent upgrade, Travis is taking more memory than usual, so a couple of our tests that spawn a lot of tablets are OOMing the build. 