### PR TITLE
add test and some minor changes to vtgateconn

### DIFF
--- a/go/vt/vtgate/vtgateconn/vtgateconn_test.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn_test.go
@@ -1,0 +1,48 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vtgateconn
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestRegisterDialer(t *testing.T) {
+	dialerFunc := func(context.Context, string, time.Duration) (VTGateConn, error) {
+		return nil, nil
+	}
+	RegisterDialer("test1", dialerFunc)
+	RegisterDialer("test1", dialerFunc)
+}
+
+func TestGetDialerWithProtocol(t *testing.T) {
+	var protocol = "test2"
+	var dialerFunc = GetDialerWithProtocol(protocol)
+	if dialerFunc != nil {
+		t.Fatalf("protocol: %s is not registered, should return nil", protocol)
+	}
+	RegisterDialer(protocol, func(context.Context, string, time.Duration) (VTGateConn, error) {
+		return nil, nil
+	})
+	dialerFunc = GetDialerWithProtocol(protocol)
+	if dialerFunc == nil {
+		t.Fatalf("dialerFunc has been registered, should not get nil")
+	}
+}
+
+func TestServerError(t *testing.T) {
+	serverError := &ServerError{Code: 12, Err: "error"}
+	if serverError.Error() == "" {
+		t.Fatalf("server error is not empty, should not return empty error")
+	}
+}
+
+func TestOperationalError(t *testing.T) {
+	if OperationalError("error").Error() == "" {
+		t.Fatal("operational error is not mepty, should not return empty error")
+	}
+}


### PR DESCRIPTION
1. add unit test
2. change RegisterDialer behavior, it will do nothing when one tries
   to register an existing protocol instead of throwing a fatal error
3. add GetDialerWithProtocol function so that caller could use speficied
   DialerFunc instead of relying on command line flag: vtgateProtocol to
   choose a protocol.
4. both GetDialer and GetDialerWithProtocol will return nil DialerFunc
   if protocol is not found in the dialers map. This allows one to write
   unit test for GetDialerWithProtocol and won't make a big change on
   error handling since dereferencing nil is almost same as throwing
   a fatal error (both will crash an app)

@sougou 