### PR TITLE
tabletserver: fix shutdown race conditions

### DIFF
--- a/go/sync2/service_manager.go
+++ b/go/sync2/service_manager.go
@@ -57,11 +57,11 @@ func (svm *ServiceManager) Go(service func(svc *ServiceContext) error) bool {
 	svm.wg.Add(1)
 	svm.err = nil
 	svm.shutdown = make(chan struct{})
-	go func() {
-		svm.err = service(&ServiceContext{ShuttingDown: svm.shutdown})
+	go func(shutdown chan struct{}) {
+		svm.err = service(&ServiceContext{ShuttingDown: shutdown})
 		svm.state.Set(SERVICE_STOPPED)
 		svm.wg.Done()
-	}()
+	}(svm.shutdown)
 	return true
 }
 

--- a/go/sync2/service_manager_test.go
+++ b/go/sync2/service_manager_test.go
@@ -174,3 +174,14 @@ func TestServiceManagerJoinReturn(t *testing.T) {
 		t.Errorf("Join().Error() = %#v, want %#v", got, want)
 	}
 }
+
+func TestServiceManagerRace(t *testing.T) {
+	var sm ServiceManager
+	sm.Go(func(sc *ServiceContext) error {
+		if sc.ShuttingDown == nil {
+			t.Errorf("ShuttingDown: nil, want non-nil")
+		}
+		return nil
+	})
+	sm.Stop()
+}

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -116,7 +116,7 @@ func (rci *RowcacheInvalidator) run(ctx *sync2.ServiceContext) error {
 			}()
 			return evs.Stream(ctx)
 		}()
-		if err == nil {
+		if err == nil || !ctx.IsRunning() {
 			break
 		}
 		if IsConnErr(err) {


### PR DESCRIPTION
- Fix race condition in ServiceManager.
- Change rowcache invalidator to check shutdown state before
  trying to restart binlog streamer.