### PR TITLE
workers will now re-resolve if a write fails on the destination master

### DIFF
--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -10,6 +10,8 @@ package worker
 
 import (
 	"html/template"
+
+	"github.com/youtube/vitess/go/vt/topo"
 )
 
 // Worker is the base interface for all long running workers.
@@ -40,4 +42,7 @@ type Resolver interface {
 	// ResolveDestinationMasters forces the worker to (re)resolve the topology and update
 	// the destination masters that it knows about.
 	ResolveDestinationMasters() error
+
+	// GetDestinationMaster returns the most recently resolved destination master for a particular shard.
+	GetDestinationMaster(shardName string) (*topo.TabletInfo, error)
 }

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -10,6 +10,7 @@ package worker
 
 import (
 	"html/template"
+	"time"
 
 	"github.com/youtube/vitess/go/vt/topo"
 )
@@ -46,3 +47,7 @@ type Resolver interface {
 	// GetDestinationMaster returns the most recently resolved destination master for a particular shard.
 	GetDestinationMaster(shardName string) (*topo.TabletInfo, error)
 }
+
+// Resolvers should attempt to keep the previous topo resolution cached for at
+// least this long.
+const resolveTTL = 15 * time.Second


### PR DESCRIPTION
@alainjobart 

Unfortunately, I think this may significantly slow down write throughput, since there's a mutex bottleneck. Don't have a good way to benchmark though. A mutex per shard should be easy to implement, but we would still have destinationWriterCount goroutines fighting for each shard lock... Maybe we should use some VtGate topo resolving code, so that we cache the topo and only reread it every n seconds?

Thoughts?