### PR TITLE
Simplify MarkDown and retry behavior

### DIFF
--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -20,7 +20,7 @@ var (
 	cell        = flag.String("cell", "test_nj", "cell to use")
 	schemaFile  = flag.String("vschema_file", "", "JSON schema file")
 	retryDelay  = flag.Duration("retry-delay", 200*time.Millisecond, "retry delay")
-	retryCount  = flag.Int("retry-count", 3, "retry count")
+	retryCount  = flag.Int("retry-count", 10, "retry count")
 	timeout     = flag.Duration("timeout", 5*time.Second, "connection and call timeout")
 	maxInFlight = flag.Int("max-in-flight", 0, "maximum number of calls to allow simultaneously")
 )

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -20,7 +20,7 @@ var (
 	cell        = flag.String("cell", "test_nj", "cell to use")
 	schemaFile  = flag.String("vschema_file", "", "JSON schema file")
 	retryDelay  = flag.Duration("retry-delay", 200*time.Millisecond, "retry delay")
-	retryCount  = flag.Int("retry-count", 10, "retry count")
+	retryCount  = flag.Int("retry-count", 3, "retry count")
 	timeout     = flag.Duration("timeout", 5*time.Second, "connection and call timeout")
 	maxInFlight = flag.Int("max-in-flight", 0, "maximum number of calls to allow simultaneously")
 )

--- a/go/vt/vtgate/balancer.go
+++ b/go/vt/vtgate/balancer.go
@@ -5,10 +5,8 @@
 package vtgate
 
 import (
-	"flag"
 	"fmt"
 	"math/rand"
-	"sort"
 	"sync"
 	"time"
 
@@ -16,20 +14,17 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 )
 
-var resetDownConnDelay = flag.Duration("reset-down-conn-delay", 10*time.Minute, "delay to reset a marked down tabletconn")
-
 type GetEndPointsFunc func() (*topo.EndPoints, error)
 
 // Balancer is a simple round-robin load balancer.
 // It allows you to temporarily mark down nodes that
 // are non-functional.
 type Balancer struct {
-	mu                 sync.Mutex
-	addressNodes       []*addressStatus
-	index              int
-	getEndPoints       GetEndPointsFunc
-	retryDelay         time.Duration
-	resetDownConnDelay time.Duration
+	mu           sync.Mutex
+	addressNodes []*addressStatus
+	index        int
+	getEndPoints GetEndPointsFunc
+	retryDelay   time.Duration
 }
 
 type addressStatus struct {
@@ -47,7 +42,6 @@ func NewBalancer(getEndPoints GetEndPointsFunc, retryDelay time.Duration) *Balan
 	blc := new(Balancer)
 	blc.getEndPoints = getEndPoints
 	blc.retryDelay = retryDelay
-	blc.resetDownConnDelay = *resetDownConnDelay
 	return blc
 }
 
@@ -60,27 +54,15 @@ func (blc *Balancer) Get() (endPoint topo.EndPoint, err error) {
 	blc.mu.Lock()
 	defer blc.mu.Unlock()
 
-	// Clear timeRetry if it has been a long time
-	for _, addrNode := range blc.addressNodes {
-		if time.Now().Sub(addrNode.timeRetry) > blc.resetDownConnDelay {
-			addrNode.timeRetry = time.Time{}
-		}
-	}
-
-	// Get the latest endpoints
+	// Get the latest non-markdown endpoints
 	err = blc.refresh()
 	if err != nil {
 		return topo.EndPoint{}, err
 	}
 
-	// Return the first endpoint, sleep if we need to
+	// Shuffle and return the first endpoint
+	shuffle(blc.addressNodes, len(blc.addressNodes))
 	addrNode := blc.addressNodes[0]
-	if addrNode.timeRetry.After(time.Now()) {
-		// Allow mark downs to happen while sleeping
-		blc.mu.Unlock()
-		time.Sleep(addrNode.timeRetry.Sub(time.Now()))
-		blc.mu.Lock()
-	}
 	return addrNode.endPoint, nil
 }
 
@@ -123,13 +105,23 @@ func (blc *Balancer) refresh() error {
 		}
 		i++
 	}
+
+	// Remove nodes that are still under mark down.
+	// Reset timeRetry for nodes that are past the retryDelay.
+	for i, addrNode := range blc.addressNodes {
+		if !addrNode.timeRetry.IsZero() {
+			if addrNode.timeRetry.After(time.Now()) {
+				blc.addressNodes = delAddrNode(blc.addressNodes, i)
+			} else {
+				addrNode.timeRetry = time.Time{}
+			}
+		}
+	}
+
 	if len(blc.addressNodes) == 0 {
 		return fmt.Errorf("no available addresses")
 	}
-	// Sort endpoints by timeRetry (from ZERO to largest)
-	sort.Sort(AddressList(blc.addressNodes))
-	// Randomize endpoints with ZERO timeRetry
-	shuffle(blc.addressNodes, findFirstAddrNodeNonZeroTimeRetry(blc.addressNodes))
+
 	return nil
 }
 
@@ -145,15 +137,6 @@ func (al AddressList) Swap(i, j int) {
 
 func (al AddressList) Less(i, j int) bool {
 	return al[i].timeRetry.Before(al[j].timeRetry)
-}
-
-func findFirstAddrNodeNonZeroTimeRetry(addressNodes []*addressStatus) (index int) {
-	for i, addrNode := range addressNodes {
-		if !addrNode.timeRetry.IsZero() {
-			return i
-		}
-	}
-	return len(addressNodes)
 }
 
 func findAddrNode(addressNodes []*addressStatus, uid uint32) (index int) {

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -180,6 +180,7 @@ func (sdc *ShardConn) withRetry(ctx context.Context, action func(conn tabletconn
 	for i := 0; i < sdc.retryCount+1; i++ {
 		conn, endPoint, err, retry = sdc.getConn(ctx)
 		if err != nil {
+			// No sleep while retrying on connection error.
 			if retry {
 				continue
 			}
@@ -204,7 +205,9 @@ func (sdc *ShardConn) withRetry(ctx context.Context, action func(conn tabletconn
 			}
 			tmr.Stop()
 		}
+		// sleep for retryDelay and retry.
 		if sdc.canRetry(err, transactionID, conn) {
+			time.Sleep(sdc.retryDelay)
 			continue
 		}
 		return sdc.WrapError(err, endPoint, inTransaction)


### PR DESCRIPTION
@guoliang100 @alainjobart @sougou 

WIP, still fixing tests, but wanted to get early feedback on main fix.
balancer -
- removed sleep from balancer.Get
- refresh removes nodes that were MarkDown and resets the timeRetry.
- removed resetDownConnDelay - doesn't have any precedent and was complicating things.
shard_conn 
- moved the sleep to retry loop for retyable execute failures
- no sleep on connect failures to retain parity with vtclient.