### PR TITLE
Extend FakeMysqlDaemon to respect the  parameters "tables", "excludeTabl...

### DIFF
--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -101,12 +101,32 @@ func (fmd *FakeMysqlDaemon) SlaveStatus() (*proto.ReplicationStatus, error) {
 	return fmd.CurrentSlaveStatus, nil
 }
 
+// ExcludeTables copies the current schema, excluding tables specified by name.
+func ExcludeTables(sd *proto.SchemaDefinition, excludeTables []string) *proto.SchemaDefinition {
+	copy := *sd
+	filteredTables := make(proto.TableDefinitions, 0, len(sd.TableDefinitions))
+	for _, table := range sd.TableDefinitions {
+		excluded := false
+		for _, excludedTableName := range excludeTables {
+			if table.Name == excludedTableName {
+				excluded = true
+				break
+			}
+		}
+		if !excluded {
+			filteredTables = append(filteredTables, table)
+		}
+	}
+	copy.TableDefinitions = filteredTables
+	return &copy
+}
+
 // GetSchema is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) GetSchema(dbName string, tables, excludeTables []string, includeViews bool) (*proto.SchemaDefinition, error) {
 	if fmd.Schema == nil {
 		return nil, fmt.Errorf("no schema defined")
 	}
-	return fmd.Schema, nil
+	return fmd.Schema.FilterTables(tables, excludeTables, includeViews)
 }
 
 // GetDbConnection is part of the MysqlDaemon interface

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -101,26 +101,6 @@ func (fmd *FakeMysqlDaemon) SlaveStatus() (*proto.ReplicationStatus, error) {
 	return fmd.CurrentSlaveStatus, nil
 }
 
-// ExcludeTables copies the current schema, excluding tables specified by name.
-func ExcludeTables(sd *proto.SchemaDefinition, excludeTables []string) *proto.SchemaDefinition {
-	copy := *sd
-	filteredTables := make(proto.TableDefinitions, 0, len(sd.TableDefinitions))
-	for _, table := range sd.TableDefinitions {
-		excluded := false
-		for _, excludedTableName := range excludeTables {
-			if table.Name == excludedTableName {
-				excluded = true
-				break
-			}
-		}
-		if !excluded {
-			filteredTables = append(filteredTables, table)
-		}
-	}
-	copy.TableDefinitions = filteredTables
-	return &copy
-}
-
 // GetSchema is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) GetSchema(dbName string, tables, excludeTables []string, includeViews bool) (*proto.SchemaDefinition, error) {
 	if fmd.Schema == nil {


### PR DESCRIPTION
...es" and "includeViews".

Moved existing code out into a new member function SchemaDefinition.FilterTables(...).

Updated Mysqld.GetSchema(...) to get all tables from MySQL first and then filter the tables. Breaking up this work into two phases adds another iteration of the TableDefinitions list and another copy of it.

@aaijazi 