### PR TITLE
replace doc link script should use site.url

### DIFF
--- a/replace_doc_link.py
+++ b/replace_doc_link.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         if filename in filename_dict:
             ans.append(line[pos:m.start()])
             ans.append('[' + title + ']')
-            ans.append('(' + filename_dict[filename] + ')')
+            ans.append('( {{ site.url }}/' + filename_dict[filename] + ')')
             pos = m.end()
     ans.append(line[pos:])
     print ''.join(ans)


### PR DESCRIPTION
site.url is the variable defined in vitess.io/_config.yml which
specifies the site url. The replace_doc_link should put the abs
link (by concatenating site.url) instead of writing relative link.
Relative link causes problem for some link, e.g. GettingStarted link
in page youtube.github.io/vitess/doc/TestingOnARamDisk