### PR TITLE
More useful error in counting_listener_test.

### DIFF
--- a/go/proc/counting_listener_test.go
+++ b/go/proc/counting_listener_test.go
@@ -19,8 +19,9 @@ func TestPublished(t *testing.T) {
 	}
 	go http.Serve(l, nil)
 
+	url := fmt.Sprintf("http://%s/debug/vars", l.Addr().String())
 	for i := 1; i <= 3; i++ {
-		resp, err := http.Get(fmt.Sprintf("http://%s/debug/vars", l.Addr().String()))
+		resp, err := http.Get(url)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -32,7 +33,7 @@ func TestPublished(t *testing.T) {
 		vars := make(map[string]interface{})
 		err = json.Unmarshal(val, &vars)
 		if err != nil {
-			t.Error(err)
+			t.Fatalf("%s response is not valid JSON. error: %v, response: %q", url, err, val)
 		}
 		if vars["ConnCount"].(float64) != 1 {
 			t.Errorf("want 1, got %v", vars["connection-count"])


### PR DESCRIPTION
We received the following error report:

https://groups.google.com/forum/#!topic/vitess/fUXULkZlZzs
```
--- FAIL: TestPublished (0.10s)
	counting_listener_test.go:35: invalid character '<' looking for beginning of value
panic: interface conversion: interface is nil, not float64 [recovered]
	panic: interface conversion: interface is nil, not float64
...
```

For future diagnosis, it would be nice if we printed more info.