### PR TITLE
Display health-checking interval and thresholds on vttablet status page.

### DIFF
--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -75,7 +75,7 @@ var (
 	// healthTemplate is just about the tablet health
 	healthTemplate = `
 <div style="font-size: x-large">Current status: <span style="padding-left: 0.5em; padding-right: 0.5em; padding-bottom: 0.5ex; padding-top: 0.5ex;" class="{{.CurrentClass}}">{{.CurrentHTML}}</span></div>
-<p>Polling health information from {{github_com_youtube_vitess_health_html_name}}.</p>
+<p>Polling health information from {{github_com_youtube_vitess_health_html_name}}. ({{.Config}})</p>
 <h2>History</h2>
 <table>
   <tr>
@@ -146,6 +146,7 @@ No binlog player is running.
 
 type healthStatus struct {
 	Records []interface{}
+	Config  template.HTML
 }
 
 func (hs *healthStatus) CurrentClass() string {
@@ -182,7 +183,10 @@ func addStatusParts(qsc tabletserver.QueryServiceControl) {
 			"github_com_youtube_vitess_health_html_name": healthHTMLName,
 		})
 		servenv.AddStatusPart("Health", healthTemplate, func() interface{} {
-			return &healthStatus{Records: agent.History.Records()}
+			return &healthStatus{
+				Records: agent.History.Records(),
+				Config:  tabletmanager.ConfigHTML(),
+			}
 		})
 	}
 	qsc.AddStatusPart()

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -84,6 +84,13 @@ func (r *HealthRecord) IsDuplicate(other interface{}) bool {
 	return (unhealthy && unhealthyOther) || (!unhealthy && !unhealthyOther)
 }
 
+// ConfigHTML returns a formatted summary of health checking config values.
+func ConfigHTML() template.HTML {
+	return template.HTML(fmt.Sprintf(
+		"healthCheckInterval: %v; degradedThreshold: %v; unhealthyThreshold: %v",
+		healthCheckInterval, degradedThreshold, unhealthyThreshold))
+}
+
 // IsRunningHealthCheck indicates if the agent is configured to run healthchecks.
 func (agent *ActionAgent) IsRunningHealthCheck() bool {
 	return *targetTabletType != ""


### PR DESCRIPTION
Looks like this,

Current status: healthy
Polling health information from MySQLReplicationLag. (healthCheckInterval: 2s; degradedThreshold: 5s; unhealthyThreshold: 2h0m0s)

(taken from a run of test/tabletmanager.py)