### PR TITLE
Using a MariaDB GTID in this test.

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -85,6 +85,7 @@ case "$MYSQL_FLAVOR" in
     ;;
   "MariaDB")
     export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $VT_MYSQL_ROOT/lib)
+    export CGO_CFLAGS="$CGO_CFLAGS -I$VT_MYSQL_ROOT/include"
     ;;
   *)
     echo "Unsupported MYSQL_FLAVOR $MYSQL_FLAVOR"

--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -476,9 +476,10 @@ func agentRPCTestExecuteFetch(ctx context.Context, t *testing.T, client tmclient
 
 var testReplicationStatus = &myproto.ReplicationStatus{
 	Position: myproto.ReplicationPosition{
-		GTIDSet: myproto.GoogleGTID{
-			ServerID: 345,
-			GroupID:  789,
+		GTIDSet: myproto.MariadbGTID{
+			Domain:   1,
+			Server:   345,
+			Sequence: 789,
 		},
 	},
 	SlaveIORunning:      true,


### PR DESCRIPTION
@enisoc 

I tried to also do binlog_streamer_test.go but I failed. I don't know which test cases are needed for MariaDB (apart from the obvious MariaDB ones). So I can't remove the google gtid code. Anthony, I think you're going to have to do that part. Maybe while you add support for MySQL 5.6, as there might be similarities?