### PR TITLE
Make the mysql failure checks more explicit.

### DIFF
--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -842,6 +842,7 @@ class TestFailures(unittest.TestCase):
           "select 1 from vt_insert_test", {},
           KEYSPACE_NAME, 'replica',
           keyranges=[self.keyrange])
+      self.fail("DatabaseError should have been raised")
     except Exception, e:
       self.assertIsInstance(e, dbexceptions.DatabaseError)
       self.assertNotIsInstance(e, dbexceptions.IntegrityError)

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -837,11 +837,17 @@ class TestFailures(unittest.TestCase):
     except Exception, e:
       self.fail("Connection to vtgate failed with error %s" % str(e))
     utils.wait_procs([self.replica_tablet.shutdown_mysql(),])
-    with self.assertRaises(dbexceptions.DatabaseError):
+    try:
       vtgate_conn._execute(
           "select 1 from vt_insert_test", {},
           KEYSPACE_NAME, 'replica',
           keyranges=[self.keyrange])
+    except Exception, e:
+      self.assertIsInstance(e, dbexceptions.DatabaseError)
+      self.assertNotIsInstance(e, dbexceptions.IntegrityError)
+      self.assertNotIsInstance(e, dbexceptions.OperationalError)
+      self.assertNotIsInstance(e, dbexceptions.TimeoutError)
+
     utils.wait_procs([self.replica_tablet.start_mysql(),])
     self.replica_tablet.kill_vttablet()
     self.replica_tablet.start_vttablet()


### PR DESCRIPTION
@guoliang100 @alainjobart 
DatabaseError is a parent class of other exceptions. This is to check that we aren't accidentally throwing
IntegrityError etc.