### PR TITLE
add vitess.io site preview script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ third_party/acolyte
 # intellij files
 *.iml
 .idea
+
+## vitess.io preview site
+preview-vitess.io/

--- a/preview-site.sh
+++ b/preview-site.sh
@@ -1,0 +1,42 @@
+#! /bin/bash 
+
+set -e 
+
+PREVIEW_DIR=preview-vitess.io
+
+rm -rf $PREVIEW_DIR
+mkdir $PREVIEW_DIR
+cp -rf vitess.io/* $PREVIEW_DIR
+
+mkdir $PREVIEW_DIR/_includes/doc
+mkdir -p $PREVIEW_DIR/_posts/doc
+
+# create ref files for each doc
+for d in doc/*.md
+do
+  name=${d:4}
+  title=${name%%.*}
+  docpath="$PREVIEW_DIR/_posts/doc/2015-01-01-${name}"
+  touch $docpath
+  echo "---" >> $docpath
+  echo "layout: doc" >> $docpath
+  echo "title: \"$title\"" >> $docpath
+  echo "categories: doc" >> $docpath
+  echo "toc: true" >> $docpath
+  echo "---" >> $docpath
+  echo "{% include $d %}" >> $docpath
+done
+
+# preserve links between docs
+for d in `ls doc/*.md` README.md
+do
+  python replace_doc_link.py doc $d > $PREVIEW_DIR/_includes/$d
+done
+
+# launch web site locally
+cd $PREVIEW_DIR
+bundle install
+bundle exec jekyll serve --config _config_dev.yml
+cd ..
+
+rm -rf $PREVIEW_DIR

--- a/vitess.io/_config_dev.yml
+++ b/vitess.io/_config_dev.yml
@@ -1,0 +1,37 @@
+# Site wide configuration
+
+title: Vitess
+description: "A set of servers and tools meant to facilitate scaling of MySQL databases for the web."
+logo: 120x120.gif
+teaser: 400x250.gif
+locale: en_US
+url: 
+project-name: Vitess
+repo: https://github.com/youtube/vitess
+
+# Jekyll configuration
+sass:
+  sass_dir: _sass
+  style: compressed
+permalink: /:categories/:title/
+highlighter: pygments
+gems:
+  - jekyll-sitemap
+
+markdown: redcarpet
+
+redcarpet:
+  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "tables", "with_toc_data"]
+
+# Site owner
+owner:
+  name: Vitess Team
+  web: https://github.com/youtube/vitess
+  email: 
+  twitter: 
+  bio: 
+  avatar: 
+  disqus-shortname:
+
+
+exclude: ["lib", "config.rb", ".sass-cache", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "*.sublime-project", "*.sublime-workspace", "Gemfile", "Gemfile.lock", "README.md", "LICENSE", "node_modules", "Gruntfile.js", "package.json"]


### PR DESCRIPTION
Developers could simply run ./preview-site.sh to preview the latest vitess.io page on their local machine (localhost:4000)

preview-site.sh: 
    1. create a temp dir called "preview-vitess.io" 
    2. copy everything from vitess.io to it
    3. copy all docs from doc dir 
    4. replace links between markdown docs
    5. launch local site using _config_dev.yml
