### PR TITLE
Factor out fakeTopo from vt/vtgate to vt/topo/test/faketopo

### DIFF
--- a/go/vt/topo/test/faketopo/fixture.go
+++ b/go/vt/topo/test/faketopo/fixture.go
@@ -1,0 +1,129 @@
+package faketopo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/key"
+	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/mysqlctl"
+	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/wrangler"
+	"golang.org/x/net/context"
+)
+
+const (
+	// TestShard is the shard we use in tests
+	TestShard = "0"
+
+	// TestKeyspace is the keyspace we use in tests
+	TestKeyspace = "test_keyspace"
+)
+
+func newKeyRange(value string) key.KeyRange {
+	_, result, err := topo.ValidateShardName(value)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+type tabletPack struct {
+	*topo.Tablet
+	mysql *mysqlctl.FakeMysqlDaemon
+}
+
+// Fixture is a fixture that provides a fresh topology, to which you
+// can add tablets that react to events and have fake MySQL
+// daemons. It uses an in memory fake ZooKeeper to store its
+// data. When you are done with the fixture you have to call its
+// TearDown method.
+type Fixture struct {
+	*testing.T
+	tablets  map[int]*tabletPack
+	done     chan struct{}
+	Topo     topo.Server
+	Wrangler *wrangler.Wrangler
+}
+
+// New creates a topology fixture.
+func New(t *testing.T, logger logutil.Logger, ts topo.Server, cells []string) *Fixture {
+	wr := wrangler.New(logger, ts, tmclient.NewTabletManagerClient(), 1*time.Second)
+
+	return &Fixture{
+		T:        t,
+		Topo:     ts,
+		Wrangler: wr,
+		done:     make(chan struct{}, 1),
+		tablets:  make(map[int]*tabletPack),
+	}
+}
+
+// TearDown releases any resources used by the fixture.
+func (fix *Fixture) TearDown() {
+	close(fix.done)
+}
+
+// MakeMySQLMaster makes the (fake) MySQL used by tablet identified by
+// uid the master.
+func (fix *Fixture) MakeMySQLMaster(uid int) {
+	newMaster, ok := fix.tablets[uid]
+	if !ok {
+		fix.Fatalf("bad tablet uid: %v", uid)
+	}
+	for id, tablet := range fix.tablets {
+		if id == uid {
+			tablet.mysql.MasterAddr = ""
+		} else {
+			tablet.mysql.MasterAddr = newMaster.MysqlIPAddr()
+		}
+	}
+}
+
+// AddTablet adds a new tablet to the topology and starts its event
+// loop.
+func (fix *Fixture) AddTablet(uid int, cell string, tabletType topo.TabletType, master *topo.Tablet) *topo.Tablet {
+	tablet := &topo.Tablet{
+		Alias:    topo.TabletAlias{Cell: cell, Uid: uint32(uid)},
+		Hostname: fmt.Sprintf("%vbsr%v", cell, uid),
+		IPAddr:   fmt.Sprintf("212.244.218.%v", uid),
+		Portmap: map[string]int{
+			"vt":    3333 + 10*uid,
+			"mysql": 3334 + 10*uid,
+		},
+		Keyspace: TestKeyspace,
+		Type:     tabletType,
+		Shard:    TestShard,
+		KeyRange: newKeyRange(TestShard),
+	}
+
+	if err := fix.Wrangler.InitTablet(context.Background(), tablet, true, true, false); err != nil {
+		fix.Fatalf("CreateTablet: %v", err)
+	}
+	mysqlDaemon := &mysqlctl.FakeMysqlDaemon{}
+	if master != nil {
+		mysqlDaemon.MasterAddr = master.MysqlIPAddr()
+	}
+	mysqlDaemon.MysqlPort = 3334 + 10*uid
+
+	pack := &tabletPack{Tablet: tablet, mysql: mysqlDaemon}
+	fix.tablets[uid] = pack
+
+	return tablet
+}
+
+// GetTablet returns a fresh copy of the tablet identified by uid.
+func (fix *Fixture) GetTablet(uid int) *topo.TabletInfo {
+	tablet, ok := fix.tablets[uid]
+	if !ok {
+		panic("bad tablet uid")
+	}
+	ti, err := fix.Topo.GetTablet(tablet.Alias)
+	if err != nil {
+		fix.Fatalf("GetTablet %v: %v", tablet.Alias, err)
+	}
+	return ti
+
+}

--- a/go/vt/vtgate/srv_topo_server_test.go
+++ b/go/vt/vtgate/srv_topo_server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/topo/test/faketopo"
 	"golang.org/x/net/context"
 )
 
@@ -189,6 +190,7 @@ func TestFilterUnhealthy(t *testing.T) {
 // fakeTopo is used in testing ResilientSrvTopoServer logic.
 // returns errors for everything, except the one keyspace.
 type fakeTopo struct {
+	faketopo.FakeTopo
 	keyspace  string
 	callCount int
 }
@@ -208,77 +210,6 @@ func (ft *fakeTopo) GetSrvKeyspace(cell, keyspace string) (*topo.SrvKeyspace, er
 func (ft *fakeTopo) GetEndPoints(cell, keyspace, shard string, tabletType topo.TabletType) (*topo.EndPoints, error) {
 	return nil, fmt.Errorf("No endpoints")
 }
-func (ft *fakeTopo) Close()                                                     {}
-func (ft *fakeTopo) GetKnownCells() ([]string, error)                           { return nil, nil }
-func (ft *fakeTopo) CreateKeyspace(keyspace string, value *topo.Keyspace) error { return nil }
-func (ft *fakeTopo) UpdateKeyspace(ki *topo.KeyspaceInfo, existingVersion int64) (int64, error) {
-	return 0, nil
-}
-func (ft *fakeTopo) GetKeyspace(keyspace string) (*topo.KeyspaceInfo, error)     { return nil, nil }
-func (ft *fakeTopo) GetKeyspaces() ([]string, error)                             { return nil, nil }
-func (ft *fakeTopo) DeleteKeyspaceShards(keyspace string) error                  { return nil }
-func (ft *fakeTopo) CreateShard(keyspace, shard string, value *topo.Shard) error { return nil }
-func (ft *fakeTopo) UpdateShard(si *topo.ShardInfo, existingVersion int64) (int64, error) {
-	return 0, nil
-}
-func (ft *fakeTopo) ValidateShard(keyspace, shard string) error               { return nil }
-func (ft *fakeTopo) GetShard(keyspace, shard string) (*topo.ShardInfo, error) { return nil, nil }
-func (ft *fakeTopo) GetShardNames(keyspace string) ([]string, error)          { return nil, nil }
-func (ft *fakeTopo) DeleteShard(keyspace, shard string) error                 { return nil }
-func (ft *fakeTopo) CreateTablet(tablet *topo.Tablet) error                   { return nil }
-func (ft *fakeTopo) UpdateTablet(tablet *topo.TabletInfo, existingVersion int64) (newVersion int64, err error) {
-	return 0, nil
-}
-func (ft *fakeTopo) UpdateTabletFields(tabletAlias topo.TabletAlias, update func(*topo.Tablet) error) error {
-	return nil
-}
-func (ft *fakeTopo) DeleteTablet(alias topo.TabletAlias) error                  { return nil }
-func (ft *fakeTopo) GetTablet(alias topo.TabletAlias) (*topo.TabletInfo, error) { return nil, nil }
-func (ft *fakeTopo) GetTabletsByCell(cell string) ([]topo.TabletAlias, error)   { return nil, nil }
-func (ft *fakeTopo) UpdateShardReplicationFields(cell, keyspace, shard string, update func(*topo.ShardReplication) error) error {
-	return nil
-}
-func (ft *fakeTopo) GetShardReplication(cell, keyspace, shard string) (*topo.ShardReplicationInfo, error) {
-	return nil, nil
-}
-func (ft *fakeTopo) DeleteShardReplication(cell, keyspace, shard string) error { return nil }
-func (ft *fakeTopo) LockSrvShardForAction(ctx context.Context, cell, keyspace, shard, contents string) (string, error) {
-	return "", nil
-}
-func (ft *fakeTopo) UnlockSrvShardForAction(cell, keyspace, shard, lockPath, results string) error {
-	return nil
-}
-func (ft *fakeTopo) GetSrvTabletTypesPerShard(cell, keyspace, shard string) ([]topo.TabletType, error) {
-	return nil, nil
-}
-func (ft *fakeTopo) UpdateEndPoints(cell, keyspace, shard string, tabletType topo.TabletType, addrs *topo.EndPoints) error {
-	return nil
-}
-func (ft *fakeTopo) DeleteEndPoints(cell, keyspace, shard string, tabletType topo.TabletType) error {
-	return nil
-}
-func (ft *fakeTopo) WatchEndPoints(cell, keyspace, shard string, tabletType topo.TabletType) (notifications <-chan *topo.EndPoints, stopWatching chan<- struct{}, err error) {
-	return nil, nil, nil
-}
-func (ft *fakeTopo) UpdateSrvShard(cell, keyspace, shard string, srvShard *topo.SrvShard) error {
-	return nil
-}
-func (ft *fakeTopo) GetSrvShard(cell, keyspace, shard string) (*topo.SrvShard, error) { return nil, nil }
-func (ft *fakeTopo) DeleteSrvShard(cell, keyspace, shard string) error                { return nil }
-func (ft *fakeTopo) UpdateSrvKeyspace(cell, keyspace string, srvKeyspace *topo.SrvKeyspace) error {
-	return nil
-}
-func (ft *fakeTopo) UpdateTabletEndpoint(cell, keyspace, shard string, tabletType topo.TabletType, addr *topo.EndPoint) error {
-	return nil
-}
-func (ft *fakeTopo) LockKeyspaceForAction(ctx context.Context, keyspace, contents string) (string, error) {
-	return "", nil
-}
-func (ft *fakeTopo) UnlockKeyspaceForAction(keyspace, lockPath, results string) error { return nil }
-func (ft *fakeTopo) LockShardForAction(ctx context.Context, keyspace, shard, contents string) (string, error) {
-	return "", nil
-}
-func (ft *fakeTopo) UnlockShardForAction(keyspace, shard, lockPath, results string) error { return nil }
 
 type fakeTopoRemoteMaster struct {
 	fakeTopo


### PR DESCRIPTION
This also renames old faketopo.go to fixture.go (this doesn't display nicely in diff)