### PR TITLE
add ExecuteShard in vtgateconn

### DIFF
--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -47,7 +47,8 @@ type DialerFunc func(ctx context.Context, address string, timeout time.Duration)
 type VTGateConn interface {
 	// Execute executes a non-streaming query on vtgate.
 	Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
-
+	// ExecuteShard executes a non-streaming query for multiple shards on vtgate
+	ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
 	// ExecuteBatch executes a group of queries.
 	ExecuteBatch(ctx context.Context, queries []tproto.BoundQuery, tabletType topo.TabletType) (*tproto.QueryResultList, error)
 


### PR DESCRIPTION
1. Add ExecuteShard in go/vt/vtgate/vtgateconn/vtgateconn.go and an implementation
   in go/vt/vtgate/gorpcvtgateconn/conn.go
2. Fix go/vt/vtgate/gorpcvtgateconn/conn_test.go so that it reads vtgate
   port from test/java_vtgate_test_helper.py output instead of a hard coded
   number.