### PR TITLE
Support SSD flag.  Remove hardcoded region in cluster-down.sh.

### DIFF
--- a/examples/kubernetes/cluster-down.sh
+++ b/examples/kubernetes/cluster-down.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 
 # Tears down the container engine cluster, removes rules/pools
+GKE_ZONE=${GKE_ZONE:-'us-central1-b'}
 GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-'example'}
+GKE_NUM_NODES=${GKE_NUM_NODES:-3}
+GKE_SSD_SIZE_GB=${GKE_SSD_SIZE_GB:-0}
+
+# Get the region from the zone (everything up to last dash)
+gke_region=`echo $GKE_ZONE | sed "s/-[^-]*$//"`
+
 gcloud preview container clusters delete $GKE_CLUSTER_NAME
-gcloud compute forwarding-rules delete vtctld -q --region=us-central1
-gcloud compute forwarding-rules delete vtgate -q --region=us-central1
+
+if [ $GKE_SSD_SIZE_GB -gt 0 ]
+then
+  for i in `seq 1 $GKE_NUM_NODES`; do
+    gcutil deletedisk -f $GKE_CLUSTER_NAME-vt-ssd-$i
+  done
+fi
+
+gcloud compute forwarding-rules delete vtctld -q --region=$gke_region
+gcloud compute forwarding-rules delete vtgate -q --region=$gke_region
 gcloud compute firewall-rules delete vtctld -q
 gcloud compute firewall-rules delete vtgate -q
-gcloud compute target-pools delete vtctld -q --region=us-central1
-gcloud compute target-pools delete vtgate -q --region=us-central1
+gcloud compute target-pools delete vtctld -q --region=$gke_region
+gcloud compute target-pools delete vtgate -q --region=$gke_region


### PR DESCRIPTION
Also start vt* pods in parallel in cluster-up.sh.  Note that although SSDs will be attached to nodes, there is nothing yet forcing vttablets onto the SSDs.  This, along with preventing multiple vttablets from finding their way onto the same node, is still a work in progress.

@enisoc @henryanand 