### PR TITLE
queryservice_test: Fix issue when multiple lines were read.

### DIFF
--- a/test/framework.py
+++ b/test/framework.py
@@ -67,6 +67,7 @@ class Tailer(object):
     self.pos = self.f.tell()
 
   def read(self):
+    """Returns a string which may contain multiple lines."""
     if self.flush:
       self.flush()
     else:
@@ -79,6 +80,10 @@ class Tailer(object):
     size = newpos-self.pos
     self.pos = newpos
     return self.f.read(size)
+
+  def readLines(self):
+    """Returns a list of read lines."""
+    return self.read().splitlines()
 
 # FIXME: Hijacked from go/vt/tabletserver/test.py
 # Reuse when things come together

--- a/test/queryservice_tests/cases_framework.py
+++ b/test/queryservice_tests/cases_framework.py
@@ -165,14 +165,15 @@ class Case(object):
       if self.result != result:
         failures.append("%r:\n%s !=\n%s" % (self.sql, self.result, result))
     for i in range(30):
-      line = env.querylog.tailer.read()
-      if line == '':
+      lines = env.querylog.tailer.readLines()
+      if not lines:
         time.sleep(0.1)
         continue
       break
-    case_failures = Log(line).check(self)
-    if case_failures:
-      failures.extend(case_failures)
+    for line in lines:
+      case_failures = Log(line).check(self)
+      if case_failures:
+        failures.extend(case_failures)
 
     if self.is_testing_cache:
       tdelta = self.table_stats_delta(tstart, env)


### PR DESCRIPTION
@sougou 

Added new method Tailer.readLines() and adapted flaky test to use this.

Original error was "Wrong looking line:" and "ValueError: too many values to unpack" when splitting the multi-line string on '\t'.

Here's a run where the test was flaky due to this problem: https://travis-ci.org/youtube/vitess/jobs/51146837

Example for a read multi-line string:


`.........................Wrong looking line: 'Begin\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.312714\tFeb 18 00:24:38.312927\t0.000213\t\t"begin"\t{}\t0\t""\tnone\t0.000000\t0.000000\t0\t0\t0\t0\t0\t0\t""\t\nExecute\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.313258\tFeb 18 00:24:38.314169\t0.000911\tDML_SUBQUERY\t"update vtocc_a set foo=\'efgh\' where id=1"\t{"#maxLimit":10001,"#pk":{"Columns":["eid","id"],"Rows":[[1,1]]}}\t2\t"select eid, id from vtocc_a where id = 1 limit 10001 for update; update vtocc_a set foo = \'efgh\' where (eid = 1 and id = 1) /* _stream vtocc_a (eid id ) (1 1 ); */"\tmysql\t0.000794\t0.000000\t1\t0\t0\t0\t0\t0\t""\t\nExecute\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.314551\tFeb 18 00:24:38.315009\t0.000458\tDML_SUBQUERY\t"update vtocc_a set foo=\'fghi\' where id=2"\t{"#maxLimit":10001,"#pk":{"Columns":["eid","id"],"Rows":[[1,2]]}}\t2\t"select eid, id from vtocc_a where id = 2 limit 10001 for update; update vtocc_a set foo = \'fghi\' where (eid = 1 and id = 2) /* _stream vtocc_a (eid id ) (1 2 ); */"\tmysql\t0.000383\t0.000000\t1\t0\t0\t0\t0\t0\t""\t\nCommit\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.315286\tFeb 18 00:24:38.317977\t0.002691\t\t"commit"\t{}\t0\t""\tnone\t0.000000\t0.000000\t0\t0\t0\t0\t0\t0\t""\t\nBegin\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.318464\tFeb 18 00:24:38.318605\t0.000141\t\t"begin"\t{}\t0\t""\tnone\t0.000000\t0.000000\t0\t0\t0\t0\t0\t0\t""\t\nExecute\t127.0.0.1:54719\tyoutube-dev-dedicated\tFeb 18 00:24:38.453896\tFeb 18 00:24:38.454873\t0.000978\tDML_PK\t"update vtocc_a set eid = 2 where eid = 1 and id = 1"\t{"#maxLimit":10001,"#pk":{"Columns":["eid","id"],"Rows":[[1,1]]}}\t1\t"update vtocc_a set eid = 2 where (eid = 1 and id = 1) /* _stream vtocc_a (eid id ) (1 1 ) (2 1 ); */"\tmysql\t0.000605\t0.000000\t1\t0\t0\t0\t0\t0\t""\t\n'`
