### PR TITLE
Add test to verify that vtgate allows ongoing query to finish when vttablet restarts.

### DIFF
--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -324,6 +324,7 @@ func TestScatterConnClose(t *testing.T) {
 	stc := NewScatterConn(new(sandboxTopo), "", "aa", 1*time.Millisecond, 3, 2*time.Millisecond, 1*time.Millisecond)
 	stc.Execute(context.Background(), "query1", nil, "TestScatterConnClose", []string{"0"}, "", nil)
 	stc.Close()
+	time.Sleep(1)
 	if sbc.CloseCount != 1 {
 		t.Errorf("want 1, got %d", sbc.CloseCount)
 	}

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -173,7 +173,7 @@ func (sdc *ShardConn) Close() {
 	if sdc.conn == nil {
 		return
 	}
-	sdc.conn.Close()
+	go sdc.conn.Close()
 	sdc.conn = nil
 }
 
@@ -341,7 +341,7 @@ func (sdc *ShardConn) markDown(conn tabletconn.TabletConn, reason string) {
 	}
 	sdc.balancer.MarkDown(conn.EndPoint().Uid, reason)
 
-	sdc.conn.Close()
+	go sdc.conn.Close()
 	sdc.conn = nil
 }
 


### PR DESCRIPTION
Make the Close() call in another go routine.

@sougou @alainjobart @shrutip 