### PR TITLE
Deflake proc_test by adding a sleep

### DIFF
--- a/go/proc/counting_listener_test.go
+++ b/go/proc/counting_listener_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestPublished(t *testing.T) {
@@ -30,6 +31,7 @@ func TestPublished(t *testing.T) {
 			t.Fatal(err)
 		}
 		http.DefaultTransport.(*http.Transport).CloseIdleConnections()
+		time.Sleep(100 * time.Millisecond)
 		vars := make(map[string]interface{})
 		err = json.Unmarshal(val, &vars)
 		if err != nil {


### PR DESCRIPTION
@alainjobart 

Just tested this w/ and w/o the sleep with 1000s of iterations.
With the sleep: ~1/1000 failures.
Without the sleep: ~140/1000 failures.
This won't completely fix the problem but is a temporary solution.