### PR TITLE
Unzip is needed when compile protobuf

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -40,7 +40,7 @@ where mysql_config is found at /path/to/mariadb/**bin**/mysql_config.
 
 ``` sh
 cd $WORKSPACE
-sudo apt-get install make automake libtool memcached python-dev python-mysqldb libssl-dev g++ mercurial git pkg-config bison curl
+sudo apt-get install make automake libtool memcached python-dev python-mysqldb libssl-dev g++ mercurial git pkg-config bison curl unzip
 git clone https://github.com/youtube/vitess.git src/github.com/youtube/vitess
 cd src/github.com/youtube/vitess
 export MYSQL_FLAVOR=MariaDB


### PR DESCRIPTION
Unzip is needed when compile protobuf


the build error log 
```
make[1]: Leaving directory `/vagrant/src/github.com/youtube/vitess/third_party/zookeeper/zookeeper-3.3.5/src/c'
--2015-03-12 04:08:58--  https://github.com/google/protobuf/archive/v3.0.0-alpha-1.zip
Resolving github.com (github.com)... 192.30.252.131
Connecting to github.com (github.com)|192.30.252.131|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/google/protobuf/zip/v3.0.0-alpha-1 [following]
--2015-03-12 04:09:15--  https://codeload.github.com/google/protobuf/zip/v3.0.0-alpha-1
Resolving codeload.github.com (codeload.github.com)... 192.30.252.147
Connecting to codeload.github.com (codeload.github.com)|192.30.252.147|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/zip]
Saving to: ‘v3.0.0-alpha-1.zip’

    [                                        <=>                                                       ] 2,286,099    332KB/s   in 11s    

2015-03-12 04:09:39 (212 KB/s) - ‘v3.0.0-alpha-1.zip’ saved [2286099]

./bootstrap.sh: line 59: unzip: command not found
protobuf build failed

```