### PR TITLE
Add note about setting proxy for bootstrap.

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -38,6 +38,10 @@ If the mysql_config command from libmariadbclient-dev is not on the PATH,
 you'll need to *export VT_MYSQL_ROOT=/path/to/mariadb* before running bootstrap.sh,
 where mysql_config is found at /path/to/mariadb/**bin**/mysql_config.
 
+Also note that the bootstrap script needs to download some dependencies,
+so if your machine requires a proxy to access the internet, you'll need to
+set the usual environment variables (e.g. http_proxy, https_proxy, no_proxy).
+
 ``` sh
 cd $WORKSPACE
 sudo apt-get install make automake libtool memcached python-dev python-mysqldb libssl-dev g++ mercurial git pkg-config bison curl unzip


### PR DESCRIPTION
Users may not expect that bootstrap.sh goes out and fetches things from
the internet. If internet access requires a proxy, they won't know that
they need to set up the proxy environment variables before running
bootstrap.

We can't tell them exactly how to set up their proxy, but they should
know how to do that if it's required. We just need to make them aware
that bootstrap requires internet access.

Fixes #473