### PR TITLE
Fixes to vtgatev3 for PEP 249 compliance

### DIFF
--- a/py/vtdb/__init__.py
+++ b/py/vtdb/__init__.py
@@ -12,3 +12,5 @@ from vtdb.dbexceptions import *
 from vtdb.times import Date, Time, Timestamp, DateFromTicks, TimeFromTicks, TimestampFromTicks
 from vtdb.field_types import Binary
 from vtdb.field_types import STRING, BINARY, NUMBER, DATETIME, ROWID
+from vtdb.vtgatev3 import *
+from vtdb.cursorv3 import *

--- a/py/vtdb/dbexceptions.py
+++ b/py/vtdb/dbexceptions.py
@@ -6,6 +6,9 @@ class Error(exceptions.StandardError):
 class DatabaseError(exceptions.StandardError):
   pass
 
+class DataError(DatabaseError):
+  pass
+
 class Warning(exceptions.StandardError):
   pass
 

--- a/py/vtdb/vtgatev3.py
+++ b/py/vtdb/vtgatev3.py
@@ -318,7 +318,7 @@ def _make_row(row, conversions):
   return converted_row
 
 
-def connect(addr, timeout, **kwargs):
-  conn = VTGateConnection(addr, timeout, **kwargs)
+def connect(*pargs, **kwargs):
+  conn = VTGateConnection(*pargs, **kwargs)
   conn.dial()
   return conn


### PR DESCRIPTION
Exposed the Connection and Cursor objects from the module,
and modified the connect function appropriately. Added
the missing DataError exception.