### PR TITLE
Speeding up travis and docker, no need to get protoc as it's not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
     - MAKE_TARGET=unit_test
 before_install:
   - bash -v travis/dependencies.sh
-  - sudo bash -v travis/install_protobuf.sh
   - sudo bash -v travis/install_grpc.sh
 install:
   - bash -v bootstrap.sh --skip_root_installs

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN groupadd -r vitess && useradd -r -g vitess vitess && \
 
 # Compile and install required packages as root
 WORKDIR /vt/src/github.com/youtube/vitess
-RUN ./travis/install_protobuf.sh
 RUN ./travis/install_grpc.sh
 
 # Bootstrap Vitess

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@
 # be found in the LICENSE file.
 
 SKIP_ROOT_INSTALLS=False
-if [ "$1 " == "--skip_root_installs" ]; then
+if [ "$1" = "--skip_root_installs" ]; then
   SKIP_ROOT_INSTALLS=True
 fi
 


### PR DESCRIPTION
for building. Also properly parsing the command line flag
in bootstrap.sh.

Should reduce te nuber of times we build proto from 4x to 1x, and
grpc from 2x to 1x. Doh.

@enisoc @aaijazi 