### PR TITLE
tabletserver: state management cleanup

### DIFF
--- a/go/vt/tabletserver/proto/structs.go
+++ b/go/vt/tabletserver/proto/structs.go
@@ -90,6 +90,7 @@ type TransactionInfo struct {
 
 // SplitQueryRequest represents a request to split a Query into queries that
 // each return a subset of the original query.
+// TODO(anandhenry): Add SessionId to this struct.
 type SplitQueryRequest struct {
 	Query      BoundQuery
 	SplitCount int

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -354,7 +354,7 @@ func (rqsc *realQueryServiceControl) IsHealthy() error {
 		context.Background(),
 		&proto.Query{
 			Sql:       "select 1 from dual",
-			SessionId: rqsc.sqlQueryRPCService.sessionId,
+			SessionId: rqsc.sqlQueryRPCService.sessionID,
 		},
 		new(mproto.QueryResult),
 	)

--- a/go/vt/tabletserver/transaction.go
+++ b/go/vt/tabletserver/transaction.go
@@ -4,15 +4,10 @@
 
 package tabletserver
 
-import (
-	"time"
-
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // Commit commits the specified transaction.
 func Commit(ctx context.Context, logStats *SQLQueryStats, qe *QueryEngine, transactionID int64) {
-	defer queryStats.Record("COMMIT", time.Now())
 	dirtyTables, err := qe.txPool.SafeCommit(ctx, transactionID)
 	for tableName, invalidList := range dirtyTables {
 		tableInfo := qe.schemaInfo.GetTable(tableName)

--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -657,7 +657,7 @@ class TestNocache(framework.TestCase):
   #  self.env.execute("select * from vtocc_test limit :l", {"l": 1})
   #  self.env.tablet.shutdown_mysql()
   #  time.sleep(5)
-  #  with self.assertRaisesRegexp(dbexceptions.DatabaseError, '.*NOT_SERVING state.*'):
+  #  with self.assertRaisesRegexp(dbexceptions.DatabaseError, '.*state NOT_SERVING.*'):
   #    self.env.execute("select * from vtocc_test limit :l", {"l": 1})
   #  self.env.tablet.start_mysql()
   #  time.sleep(5)


### PR DESCRIPTION
The older state management code was in a confused state
with no clarity on how locks, atomic updates, and
wait groups interacted. It's all cleaned up now.
The rules are simpler, the code is more readable
and documented inline.