### PR TITLE
tabletserver: Undo SplitQuery bug fix

### DIFF
--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -492,7 +492,9 @@ func (sq *SqlQuery) ExecuteBatch(ctx context.Context, queryList *proto.QueryList
 // SplitQuery splits a BoundQuery into smaller queries that return a subset of rows from the original query.
 func (sq *SqlQuery) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) (err error) {
 	logStats := newSqlQueryStats("SplitQuery", ctx)
-	defer handleError(&err, logStats)
+	// TODO(anandhenry): Remove ignoreError once all tests are fixed.
+	var ignoreError error
+	defer handleError(&ignoreError, logStats)
 
 	// TODO(anandhenry): Change this to use session id from req.
 	if err = sq.startRequest(0, true, false); err != nil {


### PR DESCRIPTION
@henryanand 
Some tests are failing because they're getting unexpected
errors from SplitQuery. Temporarily reverting this bug
fix until tests are fixed.