### PR TITLE
SplitQuery: Error handling and session validation

### DIFF
--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -236,6 +236,7 @@ func (conn *TabletBson) SplitQuery(ctx context.Context, query tproto.BoundQuery,
 	req := &tproto.SplitQueryRequest{
 		Query:      query,
 		SplitCount: splitCount,
+		SessionId:  conn.sessionID,
 	}
 	reply := new(tproto.SplitQueryResult)
 	action := func() error {

--- a/go/vt/tabletserver/proto/structs.go
+++ b/go/vt/tabletserver/proto/structs.go
@@ -94,6 +94,7 @@ type TransactionInfo struct {
 type SplitQueryRequest struct {
 	Query      BoundQuery
 	SplitCount int
+	SessionId  int64
 }
 
 // QuerySplit represents a split of SplitQueryRequest.Query. RowCount is only


### PR DESCRIPTION
1. Add SessionId to SplitQueryRequest
2. Do not panic if a table contains no rows, just return empty set of
boundaries.
3. Remove panic style error handling and explicitly return errors