### PR TITLE
add SqlDBConn interface for low level db connection

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -202,7 +203,7 @@ func main() {
 		log.Errorf("%v", err)
 		exit.Return(1)
 	}
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl, mysql.Connect)
 	defer mysqld.Close()
 
 	action := flag.Arg(0)

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
@@ -60,7 +61,7 @@ func main() {
 		log.Errorf("%v", err)
 		exit.Return(255)
 	}
-	mysqld = mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld = mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl, mysql.Connect)
 
 	// Register OnTerm handler before mysqld starts, so we get notified if mysqld
 	// dies on its own without us (or our RPC client) telling it to.

--- a/go/cmd/vtocc/vtocc.go
+++ b/go/cmd/vtocc/vtocc.go
@@ -13,6 +13,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
@@ -61,7 +62,7 @@ func main() {
 		}
 	}
 	mycnf := &mysqlctl.Mycnf{BinLogPath: *binlogPath}
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbConfigs.Dba, &dbConfigs.App.ConnectionParams, &dbConfigs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbConfigs.Dba, &dbConfigs.App.ConnectionParams, &dbConfigs.Repl, mysql.Connect)
 
 	if err := unmarshalFile(*overridesFile, &schemaOverrides); err != nil {
 		log.Error(err)
@@ -73,7 +74,7 @@ func main() {
 	if *tableAclConfig != "" {
 		tableacl.Init(*tableAclConfig)
 	}
-	qsc := tabletserver.NewQueryServiceControl()
+	qsc := tabletserver.NewQueryServiceControl(mysql.Connect)
 	tabletserver.InitQueryService(qsc)
 
 	// Query service can go into NOT_SERVING state if mysql goes down.

--- a/go/cmd/vtprimecache/main.go
+++ b/go/cmd/vtprimecache/main.go
@@ -11,6 +11,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/primecache"
@@ -37,7 +38,7 @@ func main() {
 		exit.Return(1)
 	}
 
-	pc := primecache.NewPrimeCache(dbcfgs, *relayLogsPath)
+	pc := primecache.NewPrimeCache(dbcfgs, *relayLogsPath, mysql.Connect)
 	pc.WorkerCount = *workerCount
 	pc.SleepDuration = *sleepDuration
 

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/binlog"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
@@ -84,12 +85,12 @@ func main() {
 	}
 
 	// creates and registers the query service
-	qsc := tabletserver.NewQueryServiceControl()
+	qsc := tabletserver.NewQueryServiceControl(mysql.Connect)
 	tabletserver.InitQueryService(qsc)
 	binlog.RegisterUpdateStreamService(mycnf)
 
 	// Depends on both query and updateStream.
-	agent, err = tabletmanager.NewActionAgent(qsc, context.Background(), tabletAlias, dbcfgs, mycnf, *servenv.Port, *servenv.SecurePort, *overridesFile, *lockTimeout)
+	agent, err = tabletmanager.NewActionAgent(qsc, context.Background(), tabletAlias, dbcfgs, mycnf, *servenv.Port, *servenv.SecurePort, *overridesFile, *lockTimeout, mysql.Connect)
 	if err != nil {
 		log.Error(err)
 		exit.Return(1)

--- a/go/sqldbconn/conn.go
+++ b/go/sqldbconn/conn.go
@@ -1,0 +1,51 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sqldbconn defines a interface for low level db connection
+package sqldbconn
+
+import (
+	"github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+// NewSqlDBConnFunc is a factory method that creates a SqlDBConn instance
+// given ConnectionParams
+type NewSqlDBConnFunc func(params ConnectionParams) (SqlDBConn, error)
+
+// SqlDBConn defines the behavior for the low level db connection
+type SqlDBConn interface {
+	// ExecuteFetch executes the query on the connection
+	ExecuteFetch(query string, maxrows int, wantfields bool) (*proto.QueryResult, error)
+	// ExecuteFetchMap returns a map from column names to cell data for a query
+	// that should return exactly 1 row.
+	ExecuteFetchMap(query string) (map[string]string, error)
+	// ExecuteStreamFetch starts a streaming query to db server. Use FetchNext
+	// on the Connection until it returns nil or error
+	ExecuteStreamFetch(query string) error
+	// Close closes the db connection
+	Close()
+	// IsClosed returns if the connection was ever closed
+	IsClosed() bool
+	// CloseResult finishes the result set
+	CloseResult()
+	// Shutdown invokes the low-level shutdown call on the socket associated with
+	// a connection to stop ongoing communication.
+	Shutdown()
+	// Fields returns the current fields description for the query
+	Fields() []proto.Field
+	// ID returns the connection id.
+	ID() int64
+	// FetchNext returns the next row for a query
+	FetchNext() ([]sqltypes.Value, error)
+	// ReadPacket reads a raw packet from the connection.
+	ReadPacket() ([]byte, error)
+	// SendCommand sends a raw command to the db server.
+	SendCommand(command uint32, data []byte) error
+	// GetCharset returns the current numerical values of the per-session character
+	// set variables.
+	GetCharset() (cs proto.Charset, err error)
+	// SetCharset changes the per-session character set variables.
+	SetCharset(cs proto.Charset) error
+}

--- a/go/sqldbconn/conn_params.go
+++ b/go/sqldbconn/conn_params.go
@@ -1,0 +1,25 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sqldbconn defines a interface for low level db connection
+package sqldbconn
+
+// ConnectionParams contains all the parameters to use to connect to mysql
+type ConnectionParams struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Uname      string `json:"uname"`
+	Pass       string `json:"pass"`
+	DbName     string `json:"dbname"`
+	UnixSocket string `json:"unix_socket"`
+	Charset    string `json:"charset"`
+	Flags      uint64 `json:"flags"`
+
+	// the following flags are only used for 'Change Master' command
+	// for now (along with flags |= 2048 for CLIENT_SSL)
+	SslCa     string `json:"ssl_ca"`
+	SslCaPath string `json:"ssl_ca_path"`
+	SslCert   string `json:"ssl_cert"`
+	SslKey    string `json:"ssl_key"`
+}

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/env"
 )
@@ -21,7 +22,7 @@ func TestMycnf(t *testing.T) {
 	dbaConfig := dbconfigs.DefaultDBConfigs.Dba
 	appConfig := dbconfigs.DefaultDBConfigs.App.ConnectionParams
 	replConfig := dbconfigs.DefaultDBConfigs.Repl
-	tablet0 := NewMysqld("Dba", "App", NewMycnf(0, 6802), &dbaConfig, &appConfig, &replConfig)
+	tablet0 := NewMysqld("Dba", "App", NewMycnf(0, 6802), &dbaConfig, &appConfig, &replConfig, mysql.Connect)
 	defer tablet0.Close()
 	root, err := env.VtRoot()
 	if err != nil {

--- a/go/vt/mysqlctl/mysql_flavor.go
+++ b/go/vt/mysqlctl/mysql_flavor.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -37,7 +37,7 @@ type MysqlFlavor interface {
 
 	// StartReplicationCommands returns the commands to start replicating from
 	// a given master and position as specified in a ReplicationStatus.
-	StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error)
+	StartReplicationCommands(params *sqldbconn.ConnectionParams, status *proto.ReplicationStatus) ([]string, error)
 
 	// ParseGTID parses a GTID in the canonical format of this MySQL flavor into
 	// a proto.GTID interface value.
@@ -68,7 +68,7 @@ type MysqlFlavor interface {
 	DisableBinlogPlayback(mysqld *Mysqld) error
 }
 
-var mysqlFlavors map[string]MysqlFlavor = make(map[string]MysqlFlavor)
+var mysqlFlavors = make(map[string]MysqlFlavor)
 
 // registerFlavorBuiltin adds a flavor to the map only if the name is unused.
 // The flavor implementation passed to this function will only be used if there

--- a/go/vt/mysqlctl/mysql_flavor_google.go
+++ b/go/vt/mysqlctl/mysql_flavor_google.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -128,7 +128,7 @@ func (*googleMysql51) PromoteSlaveCommands() []string {
 }
 
 // StartReplicationCommands implements MysqlFlavor.StartReplicationCommands().
-func (*googleMysql51) StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
+func (*googleMysql51) StartReplicationCommands(params *sqldbconn.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
 	// Make SET binlog_group_id command. We have to cast to the Google-specific
 	// struct to access the fields because there is no canonical printed format to
 	// represent both a group_id and server_id in Google MySQL.
@@ -191,18 +191,18 @@ func (*googleMysql51) DisableBinlogPlayback(mysqld *Mysqld) error {
 
 // makeBinlogDump2Command builds a buffer containing the data for a Google MySQL
 // COM_BINLOG_DUMP2 command.
-func makeBinlogDump2Command(flags uint16, slave_id uint32, group_id uint64, source_server_id uint32) []byte {
+func makeBinlogDump2Command(flags uint16, slaveID uint32, groupID uint64, sourceServerID uint32) []byte {
 	var buf bytes.Buffer
 	buf.Grow(2 + 4 + 8 + 4)
 
 	// binlog_flags (2 bytes)
 	binary.Write(&buf, binary.LittleEndian, flags)
 	// server_id of slave (4 bytes)
-	binary.Write(&buf, binary.LittleEndian, slave_id)
+	binary.Write(&buf, binary.LittleEndian, slaveID)
 	// group_id (8 bytes)
-	binary.Write(&buf, binary.LittleEndian, group_id)
+	binary.Write(&buf, binary.LittleEndian, groupID)
 	// server_id of the server that generated the group_id (4 bytes)
-	binary.Write(&buf, binary.LittleEndian, source_server_id)
+	binary.Write(&buf, binary.LittleEndian, sourceServerID)
 
 	return buf.Bytes()
 }
@@ -210,8 +210,8 @@ func makeBinlogDump2Command(flags uint16, slave_id uint32, group_id uint64, sour
 // SendBinlogDumpCommand implements MysqlFlavor.SendBinlogDumpCommand().
 func (flavor *googleMysql51) SendBinlogDumpCommand(mysqld *Mysqld, conn *SlaveConnection, startPos proto.ReplicationPosition) error {
 	const (
-		COM_BINLOG_DUMP2    = 0x27
-		BINLOG_USE_GROUP_ID = 0x04
+		ComBinlogDump2   = 0x27
+		BinlogUseGroupID = 0x04
 	)
 
 	gtid, ok := startPos.GTIDSet.(proto.GoogleGTID)
@@ -220,8 +220,8 @@ func (flavor *googleMysql51) SendBinlogDumpCommand(mysqld *Mysqld, conn *SlaveCo
 	}
 
 	// Build the command.
-	buf := makeBinlogDump2Command(BINLOG_USE_GROUP_ID, conn.slaveID, gtid.GroupID, gtid.ServerID)
-	return conn.SendCommand(COM_BINLOG_DUMP2, buf)
+	buf := makeBinlogDump2Command(BinlogUseGroupID, conn.slaveID, gtid.GroupID, gtid.ServerID)
+	return conn.SendCommand(ComBinlogDump2, buf)
 }
 
 // MakeBinlogEvent implements MysqlFlavor.MakeBinlogEvent().
@@ -236,6 +236,7 @@ type googleBinlogEvent struct {
 	binlogEvent
 }
 
+// NewGoogleBinlogEvent creates a BinlogEvent from given byte array
 func NewGoogleBinlogEvent(buf []byte) blproto.BinlogEvent {
 	return googleBinlogEvent{binlogEvent: binlogEvent(buf)}
 }
@@ -283,11 +284,11 @@ func (ev googleBinlogEvent) groupID() uint64 {
 
 // GTID implements BinlogEvent.GTID().
 func (ev googleBinlogEvent) GTID(f blproto.BinlogFormat) (proto.GTID, error) {
-	group_id := ev.groupID()
-	if group_id == 0 {
+	groupID := ev.groupID()
+	if groupID == 0 {
 		return nil, fmt.Errorf("invalid group_id 0")
 	}
-	return proto.GoogleGTID{ServerID: ev.ServerID(), GroupID: group_id}, nil
+	return proto.GoogleGTID{ServerID: ev.ServerID(), GroupID: groupID}, nil
 }
 
 // StripChecksum implements BinlogEvent.StripChecksum().

--- a/go/vt/mysqlctl/mysql_flavor_google_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_google_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	proto "github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -196,7 +197,7 @@ func TestGoogleBinlogEventStripChecksum(t *testing.T) {
 }
 
 func TestGoogleStartReplicationCommands(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldbconn.ConnectionParams{
 		Uname: "username",
 		Pass:  "password",
 	}
@@ -231,7 +232,7 @@ func TestGoogleStartReplicationCommands(t *testing.T) {
 }
 
 func TestGoogleStartReplicationCommandsSSL(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldbconn.ConnectionParams{
 		Uname:     "username",
 		Pass:      "password",
 		SslCa:     "ssl-ca",
@@ -239,7 +240,7 @@ func TestGoogleStartReplicationCommandsSSL(t *testing.T) {
 		SslCert:   "ssl-cert",
 		SslKey:    "ssl-key",
 	}
-	params.EnableSSL()
+	mysql.EnableSSL(params)
 	status := &proto.ReplicationStatus{
 		Position:           proto.ReplicationPosition{GTIDSet: proto.GoogleGTID{ServerID: 41983, GroupID: 12345}},
 		MasterHost:         "localhost",

--- a/go/vt/mysqlctl/mysql_flavor_mariadb.go
+++ b/go/vt/mysqlctl/mysql_flavor_mariadb.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -91,7 +91,7 @@ func (*mariaDB10) PromoteSlaveCommands() []string {
 }
 
 // StartReplicationCommands implements MysqlFlavor.StartReplicationCommands().
-func (*mariaDB10) StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
+func (*mariaDB10) StartReplicationCommands(params *sqldbconn.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
 	// Make SET gtid_slave_pos command.
 	setSlavePos := fmt.Sprintf("SET GLOBAL gtid_slave_pos = '%s'", status.Position)
 
@@ -121,7 +121,7 @@ func (*mariaDB10) ParseReplicationPosition(s string) (proto.ReplicationPosition,
 
 // SendBinlogDumpCommand implements MysqlFlavor.SendBinlogDumpCommand().
 func (*mariaDB10) SendBinlogDumpCommand(mysqld *Mysqld, conn *SlaveConnection, startPos proto.ReplicationPosition) error {
-	const COM_BINLOG_DUMP = 0x12
+	const ComBinlogDump = 0x12
 
 	// Tell the server that we understand GTIDs by setting our slave capability
 	// to MARIA_SLAVE_CAPABILITY_GTID = 4 (MariaDB >= 10.0.1).
@@ -151,7 +151,7 @@ func (*mariaDB10) SendBinlogDumpCommand(mysqld *Mysqld, conn *SlaveConnection, s
 
 	// Since we use @slave_connect_state, the file and position here are ignored.
 	buf := makeBinlogDumpCommand(0, 0, conn.slaveID, "")
-	return conn.SendCommand(COM_BINLOG_DUMP, buf)
+	return conn.SendCommand(ComBinlogDump, buf)
 }
 
 // MakeBinlogEvent implements MysqlFlavor.MakeBinlogEvent().
@@ -176,6 +176,7 @@ type mariadbBinlogEvent struct {
 	binlogEvent
 }
 
+// NewMariadbBinlogEvent creates a BinlogEvent instance from given byte array
 func NewMariadbBinlogEvent(buf []byte) blproto.BinlogEvent {
 	return mariadbBinlogEvent{binlogEvent: binlogEvent(buf)}
 }
@@ -199,11 +200,11 @@ func (ev mariadbBinlogEvent) IsGTID() bool {
 //   4         domain ID
 //   1         flags2
 func (ev mariadbBinlogEvent) IsBeginGTID(f blproto.BinlogFormat) bool {
-	const FL_STANDALONE = 1
+	const FLStandalone = 1
 
 	data := ev.Bytes()[f.HeaderLength:]
 	flags2 := data[8+4]
-	return flags2&FL_STANDALONE == 0
+	return flags2&FLStandalone == 0
 }
 
 // GTID implements BinlogEvent.GTID().
@@ -243,7 +244,7 @@ func (ev mariadbBinlogEvent) Format() (f blproto.BinlogFormat, err error) {
 // StripChecksum implements BinlogEvent.StripChecksum().
 func (ev mariadbBinlogEvent) StripChecksum(f blproto.BinlogFormat) (blproto.BinlogEvent, []byte) {
 	switch f.ChecksumAlgorithm {
-	case BINLOG_CHECKSUM_ALG_OFF, BINLOG_CHECKSUM_ALG_UNDEF:
+	case BinlogChecksumAlgOff, BinlogChecksumAlgUndef:
 		// There is no checksum.
 		return ev, nil
 	default:
@@ -257,10 +258,10 @@ func (ev mariadbBinlogEvent) StripChecksum(f blproto.BinlogFormat) (blproto.Binl
 }
 
 const (
-	// BINLOG_CHECKSUM_ALG_OFF indicates that checksums are supported but off.
-	BINLOG_CHECKSUM_ALG_OFF = 0
-	// BINLOG_CHECKSUM_ALG_UNDEF indicates that checksums are not supported.
-	BINLOG_CHECKSUM_ALG_UNDEF = 255
+	// BinlogChecksumAlgOff indicates that checksums are supported but off.
+	BinlogChecksumAlgOff = 0
+	// BinlogChecksumAlgUndef indicates that checksums are not supported.
+	BinlogChecksumAlgUndef = 255
 )
 
 func init() {

--- a/go/vt/mysqlctl/mysql_flavor_mariadb_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_mariadb_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -175,7 +176,7 @@ func TestMariadbMakeBinlogEvent(t *testing.T) {
 }
 
 func TestMariadbStartReplicationCommands(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldbconn.ConnectionParams{
 		Uname: "username",
 		Pass:  "password",
 	}
@@ -210,7 +211,7 @@ func TestMariadbStartReplicationCommands(t *testing.T) {
 }
 
 func TestMariadbStartReplicationCommandsSSL(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldbconn.ConnectionParams{
 		Uname:     "username",
 		Pass:      "password",
 		SslCa:     "ssl-ca",
@@ -218,7 +219,7 @@ func TestMariadbStartReplicationCommandsSSL(t *testing.T) {
 		SslCert:   "ssl-cert",
 		SslKey:    "ssl-key",
 	}
-	params.EnableSSL()
+	mysql.EnableSSL(params)
 	status := &proto.ReplicationStatus{
 		Position:           proto.ReplicationPosition{GTIDSet: proto.MariadbGTID{Domain: 1, Server: 41983, Sequence: 12345}},
 		MasterHost:         "localhost",

--- a/go/vt/mysqlctl/mysql_flavor_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldbconn"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -33,7 +33,7 @@ func (fakeMysqlFlavor) MasterPosition(mysqld *Mysqld) (proto.ReplicationPosition
 	return proto.ReplicationPosition{}, nil
 }
 func (fakeMysqlFlavor) SlaveStatus(mysqld *Mysqld) (*proto.ReplicationStatus, error) { return nil, nil }
-func (fakeMysqlFlavor) StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
+func (fakeMysqlFlavor) StartReplicationCommands(params *sqldbconn.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
 	return nil, nil
 }
 func (fakeMysqlFlavor) EnableBinlogPlayback(mysqld *Mysqld) error  { return nil }

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/netutil"
+	"github.com/youtube/vitess/go/sqldbconn"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -30,6 +31,7 @@ import (
 )
 
 const (
+	// SlaveStartDeadline is the deadline for starting a slave
 	SlaveStartDeadline = 30
 )
 
@@ -45,7 +47,7 @@ func fillStringTemplate(tmpl string, vars interface{}) (string, error) {
 	return data.String(), nil
 }
 
-func changeMasterArgs(params *mysql.ConnectionParams, status *proto.ReplicationStatus) []string {
+func changeMasterArgs(params *sqldbconn.ConnectionParams, status *proto.ReplicationStatus) []string {
 	var args []string
 	args = append(args, fmt.Sprintf("MASTER_HOST = '%s'", status.MasterHost))
 	args = append(args, fmt.Sprintf("MASTER_PORT = %d", status.MasterPort))
@@ -53,7 +55,7 @@ func changeMasterArgs(params *mysql.ConnectionParams, status *proto.ReplicationS
 	args = append(args, fmt.Sprintf("MASTER_PASSWORD = '%s'", params.Pass))
 	args = append(args, fmt.Sprintf("MASTER_CONNECT_RETRY = %d", status.MasterConnectRetry))
 
-	if params.SslEnabled() {
+	if mysql.SslEnabled(params) {
 		args = append(args, "MASTER_SSL = 1")
 	}
 	if params.SslCa != "" {
@@ -87,6 +89,7 @@ func parseSlaveStatus(fields map[string]string) *proto.ReplicationStatus {
 	return status
 }
 
+// WaitForSlaveStart waits a slave until given deadline passed
 func (mysqld *Mysqld) WaitForSlaveStart(slaveStartDeadline int) error {
 	var rowMap map[string]string
 	for slaveWait := 0; slaveWait < slaveStartDeadline; slaveWait++ {
@@ -114,6 +117,7 @@ func (mysqld *Mysqld) WaitForSlaveStart(slaveStartDeadline int) error {
 	return nil
 }
 
+// StartSlave starts a slave
 func (mysqld *Mysqld) StartSlave(hookExtraEnv map[string]string) error {
 	if err := mysqld.ExecuteSuperQuery("START SLAVE"); err != nil {
 		return err
@@ -124,6 +128,7 @@ func (mysqld *Mysqld) StartSlave(hookExtraEnv map[string]string) error {
 	return h.ExecuteOptional()
 }
 
+// StopSlave stops a slave
 func (mysqld *Mysqld) StopSlave(hookExtraEnv map[string]string) error {
 	h := hook.NewSimpleHook("preflight_stop_slave")
 	h.ExtraEnv = hookExtraEnv
@@ -134,6 +139,7 @@ func (mysqld *Mysqld) StopSlave(hookExtraEnv map[string]string) error {
 	return mysqld.ExecuteSuperQuery("STOP SLAVE")
 }
 
+// GetMasterAddr returns master address
 func (mysqld *Mysqld) GetMasterAddr() (string, error) {
 	slaveStatus, err := mysqld.SlaveStatus()
 	if err != nil {
@@ -142,6 +148,7 @@ func (mysqld *Mysqld) GetMasterAddr() (string, error) {
 	return slaveStatus.MasterAddr(), nil
 }
 
+// GetMysqlPort returns mysql port
 func (mysqld *Mysqld) GetMysqlPort() (int, error) {
 	qr, err := mysqld.fetchSuperQuery("SHOW VARIABLES LIKE 'port'")
 	if err != nil {
@@ -157,6 +164,7 @@ func (mysqld *Mysqld) GetMysqlPort() (int, error) {
 	return int(utemp), nil
 }
 
+// IsReadOnly return true if the instance is read only
 func (mysqld *Mysqld) IsReadOnly() (bool, error) {
 	qr, err := mysqld.fetchSuperQuery("SHOW VARIABLES LIKE 'read_only'")
 	if err != nil {
@@ -171,6 +179,7 @@ func (mysqld *Mysqld) IsReadOnly() (bool, error) {
 	return false, nil
 }
 
+// SetReadOnly set/unset the read_only flag
 func (mysqld *Mysqld) SetReadOnly(on bool) error {
 	query := "SET GLOBAL read_only = "
 	if on {
@@ -182,11 +191,13 @@ func (mysqld *Mysqld) SetReadOnly(on bool) error {
 }
 
 var (
-	ErrNotSlave  = errors.New("no slave status")
+	// ErrNotSlave means there is no slave status
+	ErrNotSlave = errors.New("no slave status")
+	// ErrNotMaster means there is no master status
 	ErrNotMaster = errors.New("no master status")
 )
 
-// Return a replication state that will reparent a slave to the
+// ReparentPosition returns a replication state that will reparent a slave to the
 // correct master for a specified position.
 func (mysqld *Mysqld) ReparentPosition(slavePosition proto.ReplicationPosition) (rs *proto.ReplicationStatus, waitPosition proto.ReplicationPosition, reparentTime int64, err error) {
 	qr, err := mysqld.fetchSuperQuery(fmt.Sprintf("SELECT time_created_ns, new_addr, new_position, wait_position FROM _vt.reparent_log WHERE last_position = '%v'", slavePosition))
@@ -225,6 +236,7 @@ func (mysqld *Mysqld) ReparentPosition(slavePosition proto.ReplicationPosition) 
 	return
 }
 
+// WaitMasterPos lets slaves wait to given replication position
 func (mysqld *Mysqld) WaitMasterPos(targetPos proto.ReplicationPosition, waitTimeout time.Duration) error {
 	flavor, err := mysqld.flavor()
 	if err != nil {
@@ -233,6 +245,7 @@ func (mysqld *Mysqld) WaitMasterPos(targetPos proto.ReplicationPosition, waitTim
 	return flavor.WaitMasterPos(mysqld, targetPos, waitTimeout)
 }
 
+// SlaveStatus returns the slave replication statuses
 func (mysqld *Mysqld) SlaveStatus() (*proto.ReplicationStatus, error) {
 	flavor, err := mysqld.flavor()
 	if err != nil {
@@ -241,6 +254,7 @@ func (mysqld *Mysqld) SlaveStatus() (*proto.ReplicationStatus, error) {
 	return flavor.SlaveStatus(mysqld)
 }
 
+// MasterPosition returns master replication position
 func (mysqld *Mysqld) MasterPosition() (rp proto.ReplicationPosition, err error) {
 	flavor, err := mysqld.flavor()
 	if err != nil {
@@ -249,6 +263,7 @@ func (mysqld *Mysqld) MasterPosition() (rp proto.ReplicationPosition, err error)
 	return flavor.MasterPosition(mysqld)
 }
 
+// StartReplicationCommands starts a replication
 func (mysqld *Mysqld) StartReplicationCommands(status *proto.ReplicationStatus) ([]string, error) {
 	flavor, err := mysqld.flavor()
 	if err != nil {
@@ -268,6 +283,7 @@ func (mysqld *Mysqld) StartReplicationCommands(status *proto.ReplicationStatus) 
 	Pos: 1194
 	Server_ID: 41983
 */
+
 // BinlogInfo returns the filename and position for a Google MySQL group_id.
 // This command only exists in Google MySQL.
 func (mysqld *Mysqld) BinlogInfo(pos proto.ReplicationPosition) (fileName string, filePos uint, err error) {
@@ -293,6 +309,7 @@ func (mysqld *Mysqld) BinlogInfo(pos proto.ReplicationPosition) (fileName string
 	return fileName, filePos, err
 }
 
+// WaitForSlave waits for a slave if its lag is larger than given maxLag
 func (mysqld *Mysqld) WaitForSlave(maxLag int) (err error) {
 	// FIXME(msolomon) verify that slave started based on show slave status;
 	var rowMap map[string]string
@@ -329,8 +346,8 @@ func (mysqld *Mysqld) WaitForSlave(maxLag int) (err error) {
 	return errors.New("replication stopped, it will never catch up")
 }
 
-// Force all slaves to error and stop. This is extreme, but helpful for emergencies
-// and tests.
+// BreakSlaves forces all slaves to error and stop.
+// This is extreme, but helpful for emergencies and tests.
 // Insert a row, block the propagation of its subsequent delete and reinsert it. This
 // forces a failure on slaves only.
 func (mysqld *Mysqld) BreakSlaves() error {
@@ -360,7 +377,7 @@ func (mysqld *Mysqld) BreakSlaves() error {
 //
 // Array indices for the results of SHOW PROCESSLIST.
 const (
-	colConnectionId = iota
+	colConnectionID = iota
 	colUsername
 	colClientAddr
 	colDbName
@@ -372,7 +389,7 @@ const (
 	binlogDumpCommand = "Binlog Dump"
 )
 
-// Get IP addresses for all currently connected slaves.
+// FindSlaves gets IP addresses for all currently connected slaves.
 func (mysqld *Mysqld) FindSlaves() ([]string, error) {
 	qr, err := mysqld.fetchSuperQuery("SHOW PROCESSLIST")
 	if err != nil {
@@ -392,8 +409,7 @@ func (mysqld *Mysqld) FindSlaves() ([]string, error) {
 	return addrs, nil
 }
 
-// Helper function to make sure we can write to the local snapshot area,
-// before we actually do any action
+// ValidateSnapshotPath is a helper function to make sure we can write to the local snapshot area, before we actually do any action
 // (can be used for both partial and full snapshots)
 func (mysqld *Mysqld) ValidateSnapshotPath() error {
 	_path := path.Join(mysqld.SnapshotDir, "validate_test")

--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/youtube/vitess/go/history"
 	"github.com/youtube/vitess/go/jscfg"
 	"github.com/youtube/vitess/go/netutil"
+	"github.com/youtube/vitess/go/sqldbconn"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -128,11 +129,12 @@ func NewActionAgent(
 	port, securePort int,
 	overridesFile string,
 	lockTimeout time.Duration,
+	newSqlDBConn sqldbconn.NewSqlDBConnFunc,
 ) (agent *ActionAgent, err error) {
 	schemaOverrides := loadSchemaOverrides(overridesFile)
 
 	topoServer := topo.GetServer()
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl, newSqlDBConn)
 
 	agent = &ActionAgent{
 		QueryServiceControl: queryServiceControl,

--- a/go/vt/tabletserver/connpool_test.go
+++ b/go/vt/tabletserver/connpool_test.go
@@ -5,20 +5,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldbconn"
 	"github.com/youtube/vitess/go/stats"
 	"golang.org/x/net/context"
 )
 
 var (
-	appParams = &mysql.ConnectionParams{
+	appParams = &sqldbconn.ConnectionParams{
 		Uname:      "vt_app",
 		DbName:     "sougou",
 		UnixSocket: os.Getenv("VTDATAROOT") + "/vt_0000062347/mysql.sock",
 		Charset:    "utf8",
 	}
-	dbaParams = &mysql.ConnectionParams{
+	dbaParams = &sqldbconn.ConnectionParams{
 		Uname:      "vt_dba",
 		DbName:     "sougou",
 		UnixSocket: os.Getenv("VTDATAROOT") + "/vt_0000062347/mysql.sock",
@@ -42,7 +42,7 @@ func TestConnectivity(t *testing.T) {
 	killStats = stats.NewCounters("TestKills")
 	internalErrors = stats.NewCounters("TestInternalErrors")
 	mysqlStats = stats.NewTimings("TestMySQLStats")
-	pool := NewConnPool("p1", 1, 30*time.Second)
+	pool := NewConnPool("p1", nil, 1, 30*time.Second)
 	pool.Open(appParams, dbaParams)
 
 	conn, err := pool.Get(ctx)

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -15,6 +15,7 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/acl"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldbconn"
 	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -248,9 +249,9 @@ type realQueryServiceControl struct {
 }
 
 // NewQueryServiceControl returns a real implementation of QueryServiceControl
-func NewQueryServiceControl() QueryServiceControl {
+func NewQueryServiceControl(newSqlDBConn sqldbconn.NewSqlDBConnFunc) QueryServiceControl {
 	return &realQueryServiceControl{
-		sqlQueryRPCService: NewSqlQuery(qsConfig),
+		sqlQueryRPCService: NewSqlQuery(qsConfig, newSqlDBConn),
 	}
 }
 

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/pools"
+	"github.com/youtube/vitess/go/sqldbconn"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
@@ -59,9 +59,15 @@ type TxPool struct {
 }
 
 // NewTxPool creates a new TxPool. It's not operational until it's Open'd.
-func NewTxPool(name string, capacity int, timeout, poolTimeout, idleTimeout time.Duration) *TxPool {
+func NewTxPool(
+	name string,
+	newSqlDBConn sqldbconn.NewSqlDBConnFunc,
+	capacity int,
+	timeout time.Duration,
+	poolTimeout time.Duration,
+	idleTimeout time.Duration) *TxPool {
 	axp := &TxPool{
-		pool:        NewConnPool(name, capacity, idleTimeout),
+		pool:        NewConnPool(name, newSqlDBConn, capacity, idleTimeout),
 		activePool:  pools.NewNumbered(),
 		lastID:      sync2.AtomicInt64(time.Now().UnixNano()),
 		timeout:     sync2.AtomicDuration(timeout),
@@ -78,7 +84,7 @@ func NewTxPool(name string, capacity int, timeout, poolTimeout, idleTimeout time
 
 // Open makes the TxPool operational. This also starts the transaction killer
 // that will kill long-running transactions.
-func (axp *TxPool) Open(appParams, dbaParams *mysql.ConnectionParams) {
+func (axp *TxPool) Open(appParams, dbaParams *sqldbconn.ConnectionParams) {
 	log.Infof("Starting transaction id: %d", axp.lastID)
 	axp.pool.Open(appParams, dbaParams)
 	axp.ticks.Start(func() { axp.transactionKiller() })


### PR DESCRIPTION
1. add SqlDBConn and move mysql.ConnectionParams to sqldbconn package
2. change mysql.Connect function to return sqldbconn.SqlDBConn
3. update places using *mysql.Connection to sqldbconn.SqlDBConn
4. update places using *mysql.ConnectionParams to *sqldbconn.ConnectionParams
5. define sqldbconn.NewSqlDBConnFunc factory method
6. add new command line config "db" in queryctl, default value is "mysql".
   SqlQuery uses "db" config to decide the right NewSqlDBConnFunc to use.
7. Some randome go style fix (suggested by golint)

primecache:
    mysql.Connect is injected in go/cmd/vtprimecache/main.go

mysqld:
    mysql.Connect is injected in NewMysqld function

binlogplayer/dbclient:
    mysql.Connect is injected in go/vt/tabletmanager/binlog.go

ConnPool, DBConn, QueryEngine, SqlQuery:
    mysql.Connect is injected in NewSqlQuery

TxPool:
    mysql.Connect is injected in NewTxPool