### PR TITLE
add Vitess schema manager

### DIFF
--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -1,0 +1,86 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	log "github.com/golang/glog"
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+)
+
+// DataSourcer defines how the autoschema system get schema change commands
+type DataSourcer interface {
+	Open() error
+	Read() ([]string, error)
+	Close() error
+}
+
+// EventHandler defines callbacks for events happen during schema management
+type EventHandler interface {
+	OnDataSourcerReadSuccess([]string) error
+	OnDataSourcerReadFail(error) error
+	OnValidationSuccess([]string) error
+	OnValidationFail(error) error
+	OnExecutorComplete(*ExecuteResult) error
+}
+
+// Executor applies schema changes to underlying system
+type Executor interface {
+	Open() error
+	Validate(sqls []string) error
+	Execute(sqls []string, shards []string) *ExecuteResult
+	Close() error
+}
+
+// ExecuteResult contains information about schema management state
+type ExecuteResult struct {
+	FailedShards  []ShardWithError
+	SuccessShards []ShardResult
+	CurSqlIndex   int
+	Sqls          []string
+	ExecutorErr   string
+}
+
+// ShardWithError contains information why a shard failed to execute given sql
+type ShardWithError struct {
+	Shard string
+	Err   string
+}
+
+// ShardResult contains sql execute information on a particula shard
+type ShardResult struct {
+	Shard  string
+	Result *mproto.QueryResult
+}
+
+// Run schema changes on Vitess through VtGate
+func Run(sourcer DataSourcer,
+	exec Executor,
+	handler EventHandler,
+	shards []string) error {
+	if err := sourcer.Open(); err != nil {
+		log.Errorf("failed to open data sourcer: %v", err)
+		return err
+	}
+	defer sourcer.Close()
+	sqls, err := sourcer.Read()
+	if err != nil {
+		log.Errorf("failed to read data from data sourcer: %v", err)
+		return handler.OnDataSourcerReadFail(err)
+	}
+	handler.OnDataSourcerReadSuccess(sqls)
+	if err := exec.Open(); err != nil {
+		log.Errorf("failed to open executor: %v", err)
+		return err
+	}
+	defer exec.Close()
+	if err := exec.Validate(sqls); err != nil {
+		log.Errorf("validation fail: %v", err)
+		return handler.OnValidationFail(err)
+	}
+	handler.OnValidationSuccess(sqls)
+	result := exec.Execute(sqls, shards)
+	handler.OnExecutorComplete(result)
+	return nil
+}

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -1,0 +1,168 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	fakevtgateconn "github.com/youtube/vitess/go/vt/vtgate/fakerpcvtgateconn"
+	"golang.org/x/net/context"
+)
+
+var (
+	errDataSourcerOpen  = errors.New("Open Fail")
+	errDataSourcerRead  = errors.New("Read Fail")
+	errDataSourcerClose = errors.New("Close Fail")
+)
+
+func TestRunSchemaChangesDataSourcerOpenFail(t *testing.T) {
+	dataSourcer := newFakeDataSourcer([]string{"select * from test_db"}, true, false, false)
+	handler := newFakeHandler()
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
+	if err != errDataSourcerOpen {
+		t.Fatalf("data sourcer open fail, shoud get error: %v, but get error: %v",
+			errDataSourcerOpen, err)
+	}
+}
+
+func TestRunSchemaChangesDataSourcerReadFail(t *testing.T) {
+	dataSourcer := newFakeDataSourcer([]string{"select * from test_db"}, false, true, false)
+	handler := newFakeHandler()
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
+	if err != errDataSourcerRead {
+		t.Fatalf("data sourcer read fail, shoud get error: %v, but get error: %v",
+			errDataSourcerRead, err)
+	}
+	if !handler.onDataSourcerReadFailTriggered {
+		t.Fatalf("event handler should call OnDataSourcerReadFail but it didn't")
+	}
+}
+
+func TestRunSchemaChangesValidationFail(t *testing.T) {
+	dataSourcer := newFakeDataSourcer([]string{"invalid sql"}, false, false, false)
+	handler := newFakeHandler()
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
+	if err == nil {
+		t.Fatalf("run schema change should fail due to executor.Open fail")
+	}
+}
+
+func TestRunSchemaChanges(t *testing.T) {
+	dataSourcer := NewSimepleDataSourcer("select * from test_db;")
+	handler := newFakeHandler()
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
+	if err != nil {
+		t.Fatalf("schema change should success but get error: %v", err)
+	}
+	if !handler.onDataSourcerReadSuccessTriggered {
+		t.Fatalf("event handler should call OnDataSourcerReadSuccess but it didn't")
+	}
+	if handler.onDataSourcerReadFailTriggered {
+		t.Fatalf("event handler should not call OnDataSourcerReadFail but it did")
+	}
+	if !handler.onValidationSuccessTriggered {
+		t.Fatalf("event handler should call OnDataSourcerValidateSuccess but it didn't")
+	}
+	if handler.onValidationFailTriggered {
+		t.Fatalf("event handler should not call OnValidationFail but it did")
+	}
+	if !handler.onExecutorCompleteTriggered {
+		t.Fatalf("event handler should call OnExecutorComplete but it didn't")
+	}
+}
+
+func newFakeVtGateConn() *fakevtgateconn.FakeVTGateConn {
+	return fakevtgateconn.NewFakeVTGateConn(context.Background(), "", 1*time.Second)
+}
+
+func newFakeVtGateExecutor(addr string, conn *fakevtgateconn.FakeVTGateConn) *VtGateExecutor {
+	return NewVtGateExecutor(
+		"test_keyspace",
+		addr,
+		conn,
+		1*time.Second)
+}
+
+type fakeDataSourcer struct {
+	sqls      []string
+	openFail  bool
+	readFail  bool
+	closeFail bool
+}
+
+func newFakeDataSourcer(sqls []string, openFail bool, readFail bool, closeFail bool) *fakeDataSourcer {
+	return &fakeDataSourcer{sqls, openFail, readFail, closeFail}
+}
+
+func (sourcer fakeDataSourcer) Open() error {
+	if sourcer.openFail {
+		return errDataSourcerOpen
+	}
+	return nil
+}
+
+func (sourcer fakeDataSourcer) Read() ([]string, error) {
+	if sourcer.readFail {
+		return nil, errDataSourcerRead
+	}
+	return sourcer.sqls, nil
+}
+
+func (sourcer fakeDataSourcer) Close() error {
+	if sourcer.closeFail {
+		return errDataSourcerClose
+	}
+	return nil
+}
+
+type fakeEventHandler struct {
+	onDataSourcerReadSuccessTriggered bool
+	onDataSourcerReadFailTriggered    bool
+	onValidationSuccessTriggered      bool
+	onValidationFailTriggered         bool
+	onExecutorCompleteTriggered       bool
+}
+
+func newFakeHandler() *fakeEventHandler {
+	return &fakeEventHandler{}
+}
+
+func (handler *fakeEventHandler) OnDataSourcerReadSuccess([]string) error {
+	handler.onDataSourcerReadSuccessTriggered = true
+	return nil
+}
+
+func (handler *fakeEventHandler) OnDataSourcerReadFail(err error) error {
+	handler.onDataSourcerReadFailTriggered = true
+	return err
+}
+
+func (handler *fakeEventHandler) OnValidationSuccess([]string) error {
+	handler.onValidationSuccessTriggered = true
+	return nil
+}
+
+func (handler *fakeEventHandler) OnValidationFail(err error) error {
+	handler.onValidationFailTriggered = true
+	return err
+}
+
+func (handler *fakeEventHandler) OnExecutorComplete(*ExecuteResult) error {
+	handler.onExecutorCompleteTriggered = true
+	return nil
+}
+
+var _ EventHandler = (*fakeEventHandler)(nil)
+var _ DataSourcer = (*fakeDataSourcer)(nil)

--- a/go/vt/schemamanager/simple_data_sourcer.go
+++ b/go/vt/schemamanager/simple_data_sourcer.go
@@ -1,0 +1,41 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import "strings"
+
+// SimpleDataSourcer is really simple
+type SimpleDataSourcer struct {
+	sqls []string
+}
+
+// NewSimepleDataSourcer creates a new SimpleDataSourcer instance
+func NewSimepleDataSourcer(sqlStr string) *SimpleDataSourcer {
+	result := SimpleDataSourcer{}
+	for _, sql := range strings.Split(sqlStr, ";") {
+		s := strings.TrimSpace(sql)
+		if s != "" {
+			result.sqls = append(result.sqls, s)
+		}
+	}
+	return &result
+}
+
+// Open is a no-op
+func (ds *SimpleDataSourcer) Open() error {
+	return nil
+}
+
+// Read reads schema changes
+func (ds *SimpleDataSourcer) Read() ([]string, error) {
+	return ds.sqls, nil
+}
+
+// Close is a no-op
+func (ds *SimpleDataSourcer) Close() error {
+	return nil
+}
+
+var _ DataSourcer = (*SimpleDataSourcer)(nil)

--- a/go/vt/schemamanager/vtgate_executor.go
+++ b/go/vt/schemamanager/vtgate_executor.go
@@ -1,0 +1,153 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
+
+	"golang.org/x/net/context"
+)
+
+// VtGateExecutor applies schema changes via VtGate
+type VtGateExecutor struct {
+	keyspace   string
+	conn       vtgateconn.VTGateConn
+	vtGateAddr string
+	timeout    time.Duration
+	isClosed   bool
+}
+
+// NewVtGateExecutor creates a new VtGateExecutor instance
+func NewVtGateExecutor(
+	keyspace string,
+	addr string,
+	conn vtgateconn.VTGateConn,
+	timeout time.Duration) *VtGateExecutor {
+	return &VtGateExecutor{
+		keyspace:   keyspace,
+		vtGateAddr: addr,
+		conn:       conn,
+		timeout:    timeout,
+		isClosed:   true,
+	}
+}
+
+// Open opens a connection to VtGate
+func (exec *VtGateExecutor) Open() error {
+	exec.isClosed = false
+	return nil
+}
+
+// Validate validates a list of sql statements
+func (exec *VtGateExecutor) Validate(sqls []string) error {
+	for _, sql := range sqls {
+		if _, err := sqlparser.Parse(sql); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Execute applies schema changes through VtGate
+func (exec *VtGateExecutor) Execute(sqls []string, shards []string) *ExecuteResult {
+	execResult := ExecuteResult{}
+	execResult.Sqls = sqls
+	if exec.isClosed {
+		execResult.ExecutorErr = "executor is closed"
+		return &execResult
+	}
+	for index, sql := range sqls {
+		execResult.CurSqlIndex = index
+		stat, err := sqlparser.Parse(sql)
+		if err != nil {
+			execResult.ExecutorErr = err.Error()
+			return &execResult
+		}
+		_, ok := stat.(*sqlparser.DDL)
+		if !ok {
+			exec.execute(&execResult, sql, shards, true)
+		} else {
+			exec.execute(&execResult, sql, shards, false)
+		}
+		if len(execResult.FailedShards) > 0 {
+			break
+		}
+	}
+	return &execResult
+}
+
+func (exec *VtGateExecutor) execute(execResult *ExecuteResult, sql string, shards []string, enableTx bool) {
+	var wg sync.WaitGroup
+	wg.Add(len(shards))
+	errChan := make(chan ShardWithError, len(shards))
+	resultChan := make(chan ShardResult, len(shards))
+	for _, s := range shards {
+		go func(keyspace string, shard string) {
+			defer wg.Done()
+			ctx := context.Background()
+			if enableTx {
+				exec.executeTx(ctx, sql, keyspace, shard, errChan, resultChan)
+			} else {
+				queryResult, err := exec.conn.ExecuteShard(ctx, sql, keyspace, []string{shard}, nil, topo.TYPE_MASTER)
+				if err != nil {
+					errChan <- ShardWithError{Shard: shard, Err: err.Error()}
+				} else {
+					resultChan <- ShardResult{Shard: shard, Result: queryResult}
+				}
+			}
+		}(exec.keyspace, s)
+	}
+	wg.Wait()
+	close(errChan)
+	close(resultChan)
+	execResult.FailedShards = make([]ShardWithError, 0, len(errChan))
+	execResult.SuccessShards = make([]ShardResult, 0, len(resultChan))
+	for e := range errChan {
+		execResult.FailedShards = append(execResult.FailedShards, e)
+	}
+	for r := range resultChan {
+		execResult.SuccessShards = append(execResult.SuccessShards, r)
+	}
+}
+
+func (exec *VtGateExecutor) executeTx(ctx context.Context, sql string, keyspace string, shard string, errChan chan ShardWithError, resultChan chan ShardResult) {
+	tx, err := exec.conn.Begin(ctx)
+	if err != nil {
+		errChan <- ShardWithError{Shard: shard, Err: err.Error()}
+		return
+	}
+	queryResult, err := tx.ExecuteShard(ctx, sql, keyspace, []string{shard}, nil, topo.TYPE_MASTER)
+	if err == nil {
+		err = tx.Commit(ctx)
+	}
+	if err != nil {
+		errChan <- ShardWithError{Shard: shard, Err: err.Error()}
+		err = tx.Rollback(ctx)
+		if err != nil {
+			log.Errorf("failed to rollback transaction: %s on shard %s, error: %v", sql, shard, err)
+		}
+	} else {
+		resultChan <- ShardResult{Shard: shard, Result: queryResult}
+	}
+
+}
+
+// Close closes VtGate connection
+func (exec *VtGateExecutor) Close() error {
+	if !exec.isClosed {
+		exec.conn.Close()
+		exec.isClosed = true
+	}
+	return nil
+}
+
+var _ Executor = (*VtGateExecutor)(nil)

--- a/go/vt/schemamanager/vtgate_executor_test.go
+++ b/go/vt/schemamanager/vtgate_executor_test.go
@@ -1,0 +1,140 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"testing"
+
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vtgate/proto"
+)
+
+func TestOpenVtGateExecutor(t *testing.T) {
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	if err := exec.Open(); err != nil {
+		t.Fatalf("failed to call executor.Open: %v", err)
+	}
+	exec.Close()
+}
+
+func TestValidate(t *testing.T) {
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	defer exec.Close()
+
+	invalidSelect := []string{"select  from test_table"}
+	if err := exec.Validate(invalidSelect); err == nil {
+		t.Fatalf("exec.Validate should fail due to given invalid select statement")
+	}
+	invalidUpdate := []string{"update from test_table"}
+	if err := exec.Validate(invalidUpdate); err == nil {
+		t.Fatalf("exec.Validate should fail due to given invalid update statement")
+	}
+	invalidDelete := []string{"delete * from test_table"}
+	if err := exec.Validate(invalidDelete); err == nil {
+		t.Fatalf("exec.Validate should fail due to given invalid delete statement")
+	}
+	validSelect := []string{"select * from test_table"}
+	if err := exec.Validate(validSelect); err != nil {
+		t.Fatalf("exec.Validate should success but get error: %v", err)
+	}
+	validUpdate := []string{"update test_table set col1=1"}
+	if err := exec.Validate(validUpdate); err != nil {
+		t.Fatalf("exec.Validate should success but get error: %v", err)
+	}
+	validDelete := []string{"delete from test_table where col1=1"}
+	if err := exec.Validate(validDelete); err != nil {
+		t.Fatalf("exec.Validate should success but get error: %v", err)
+	}
+}
+
+func TestExecuteWithoutOpen(t *testing.T) {
+	shards := []string{"0", "1"}
+	sqls := []string{"insert into  test_table values (1, 2)"}
+	fakeConn := newFakeVtGateConn()
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	result := exec.Execute(sqls, shards)
+	if result.ExecutorErr == "" {
+		t.Fatalf("execute should fail because Execute() is being called before Open()")
+	}
+}
+
+func TestExecuteDML(t *testing.T) {
+	shards := []string{"0", "1"}
+	validSqls := []string{"insert into  test_table values (1, 2)"}
+	invalidSqls := []string{"insert into test_table ..."}
+	fakeConn := newFakeVtGateConn()
+
+	for _, sql := range validSqls {
+		for _, shard := range shards {
+			fakeConn.AddShardQuery(
+				&proto.QueryShard{
+					Sql:           sql,
+					BindVariables: nil,
+					Keyspace:      "test_keyspace",
+					Shards:        []string{shard},
+					TabletType:    topo.TYPE_MASTER,
+					Session: &proto.Session{
+						InTransaction: true,
+					},
+				},
+				&mproto.QueryResult{})
+		}
+	}
+
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec.Open()
+	defer exec.Close()
+	result := exec.Execute(invalidSqls, shards)
+	if len(result.FailedShards) == 0 && result.ExecutorErr == "" {
+		t.Fatalf("execute should fail due to an invalid sql")
+	}
+	result = exec.Execute(validSqls, shards)
+	if len(result.FailedShards) > 0 {
+		t.Fatalf("execute failed, error: %v", result.FailedShards)
+	}
+	if result.ExecutorErr != "" {
+		t.Fatalf("execute failed, sqls: %v, error: %s", validSqls, result.ExecutorErr)
+	}
+}
+
+func TestExecuteDDL(t *testing.T) {
+	fakeConn := newFakeVtGateConn()
+	shards := []string{"0", "1"}
+
+	validSqls := []string{"alter table test_table add column_01 int"}
+	for _, sql := range validSqls {
+		for _, shard := range shards {
+			fakeConn.AddShardQuery(
+				&proto.QueryShard{
+					Sql:           sql,
+					BindVariables: nil,
+					Keyspace:      "test_keyspace",
+					Shards:        []string{shard},
+					TabletType:    topo.TYPE_MASTER,
+					Session:       nil,
+				},
+				&mproto.QueryResult{})
+		}
+	}
+	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec.Open()
+	defer exec.Close()
+	result := exec.Execute(validSqls, shards)
+	if len(result.FailedShards) > 0 {
+		t.Fatalf("execute failed, error: %v", result.FailedShards)
+	}
+	if result.ExecutorErr != "" {
+		t.Fatalf("execute failed, sqls: %v, error: %s", validSqls, result.ExecutorErr)
+	}
+	// alter a non exist table
+	invalidSqls := []string{"alter table table_not_exist add column_01 int"}
+	result = exec.Execute(invalidSqls, shards)
+	if len(result.FailedShards) == 0 {
+		t.Fatalf("execute should fail")
+	}
+}


### PR DESCRIPTION
schemamanager provides an easy way to apply Vitess schema changes
through VTGate.

schemamanager contains three components: DataSourcer, Executor and EventHandler.
DataSourcer: retrieve all schema changes from some data source and return them as a list of sql strings.
Executor: do runtime schema validation  and executes schema changes for specified keyspace
EventHandler: callbacks that handles particular events.