### PR TITLE
Fix atomic file write to force a Sync and not shadow an error.

### DIFF
--- a/go/ioutil2/ioutil.go
+++ b/go/ioutil2/ioutil.go
@@ -20,11 +20,16 @@ func WriteFileAtomic(filename string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	n, err := f.Write(data)
+	if err == nil {
+		f.Sync()
+	}
 	f.Close()
-	if err == nil && n < len(data) {
-		err = io.ErrShortWrite
-	} else {
-		err = os.Chmod(f.Name(), perm)
+	if err == nil {
+		if n < len(data) {
+			err = io.ErrShortWrite
+		} else {
+			err = os.Chmod(f.Name(), perm)
+		}
 	}
 	if err != nil {
 		os.Remove(f.Name())


### PR DESCRIPTION
Was looking at this code and realized it was not pedantic enough in the original state.