### PR TITLE
add SqlDBConn interface for low level db connection

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -16,6 +16,9 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
+
+	// import mysql to register mysql connection function
+	_ "github.com/youtube/vitess/go/mysql"
 )
 
 var (
@@ -202,7 +205,7 @@ func main() {
 		log.Errorf("%v", err)
 		exit.Return(1)
 	}
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl)
 	defer mysqld.Close()
 
 	action := flag.Arg(0)

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -17,6 +17,9 @@ import (
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
+
+	// import mysql to register mysql connection function
+	_ "github.com/youtube/vitess/go/mysql"
 )
 
 var (
@@ -60,7 +63,7 @@ func main() {
 		log.Errorf("%v", err)
 		exit.Return(255)
 	}
-	mysqld = mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld = mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl)
 
 	// Register OnTerm handler before mysqld starts, so we get notified if mysqld
 	// dies on its own without us (or our RPC client) telling it to.

--- a/go/cmd/vtocc/vtocc.go
+++ b/go/cmd/vtocc/vtocc.go
@@ -18,6 +18,9 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	"github.com/youtube/vitess/go/vt/tabletserver"
+
+	// import mysql to register mysql connection function
+	_ "github.com/youtube/vitess/go/mysql"
 )
 
 var (
@@ -61,7 +64,7 @@ func main() {
 		}
 	}
 	mycnf := &mysqlctl.Mycnf{BinLogPath: *binlogPath}
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbConfigs.Dba, &dbConfigs.App.ConnectionParams, &dbConfigs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbConfigs.Dba, &dbConfigs.App.ConnParams, &dbConfigs.Repl)
 
 	if err := unmarshalFile(*overridesFile, &schemaOverrides); err != nil {
 		log.Error(err)

--- a/go/cmd/vtprimecache/main.go
+++ b/go/cmd/vtprimecache/main.go
@@ -14,6 +14,9 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/primecache"
+
+	// import mysql to register mysql connection function
+	_ "github.com/youtube/vitess/go/mysql"
 )
 
 var (

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -20,6 +20,9 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
+
+	// import mysql to register mysql connection function
+	_ "github.com/youtube/vitess/go/mysql"
 )
 
 var (

--- a/go/sqldb/conn.go
+++ b/go/sqldb/conn.go
@@ -1,0 +1,92 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sqldb defines an interface for low level db connection.
+package sqldb
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+// NewConnFunc is a factory method that creates a Conn instance
+// using given ConnParams.
+type NewConnFunc func(params ConnParams) (Conn, error)
+
+// conns stores all supported db connection.
+var conns = make(map[string]NewConnFunc)
+
+var mu sync.Mutex
+
+// DefaultDB decides the default db connection.
+var DefaultDB string
+
+// Conn defines the behavior for the low level db connection
+type Conn interface {
+	// ExecuteFetch executes the query on the connection
+	ExecuteFetch(query string, maxrows int, wantfields bool) (*proto.QueryResult, error)
+	// ExecuteFetchMap returns a map from column names to cell data for a query
+	// that should return exactly 1 row.
+	ExecuteFetchMap(query string) (map[string]string, error)
+	// ExecuteStreamFetch starts a streaming query to db server. Use FetchNext
+	// on the Connection until it returns nil or error
+	ExecuteStreamFetch(query string) error
+	// Close closes the db connection
+	Close()
+	// IsClosed returns if the connection was ever closed
+	IsClosed() bool
+	// CloseResult finishes the result set
+	CloseResult()
+	// Shutdown invokes the low-level shutdown call on the socket associated with
+	// a connection to stop ongoing communication.
+	Shutdown()
+	// Fields returns the current fields description for the query
+	Fields() []proto.Field
+	// ID returns the connection id.
+	ID() int64
+	// FetchNext returns the next row for a query
+	FetchNext() ([]sqltypes.Value, error)
+	// ReadPacket reads a raw packet from the connection.
+	ReadPacket() ([]byte, error)
+	// SendCommand sends a raw command to the db server.
+	SendCommand(command uint32, data []byte) error
+	// GetCharset returns the current numerical values of the per-session character
+	// set variables.
+	GetCharset() (cs proto.Charset, err error)
+	// SetCharset changes the per-session character set variables.
+	SetCharset(cs proto.Charset) error
+}
+
+// Register a db connection.
+func Register(name string, fn NewConnFunc) {
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := conns[name]; ok {
+		panic(fmt.Sprintf("register a registered key: %s", name))
+	}
+	conns[name] = fn
+}
+
+// Connect returns a sqldb.Conn using the default connection creation function.
+func Connect(params ConnParams) (Conn, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if DefaultDB == "" {
+		if len(conns) == 1 {
+			for _, fn := range conns {
+				return fn(params)
+			}
+		}
+		panic("there are more than one conn func " +
+			"registered but no default db has been given.")
+	}
+	fn, ok := conns[DefaultDB]
+	if !ok {
+		panic(fmt.Sprintf("connection function for given default db: %s is not found.", DefaultDB))
+	}
+	return fn(params)
+}

--- a/go/sqldb/conn_params.go
+++ b/go/sqldb/conn_params.go
@@ -1,0 +1,25 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package sqldb defines an interface for low level db connection
+package sqldb
+
+// ConnParams contains all the parameters to use to connect to mysql
+type ConnParams struct {
+	Host       string `json:"host"`
+	Port       int    `json:"port"`
+	Uname      string `json:"uname"`
+	Pass       string `json:"pass"`
+	DbName     string `json:"dbname"`
+	UnixSocket string `json:"unix_socket"`
+	Charset    string `json:"charset"`
+	Flags      uint64 `json:"flags"`
+
+	// the following flags are only used for 'Change Master' command
+	// for now (along with flags |= 2048 for CLIENT_SSL)
+	SslCa     string `json:"ssl_ca"`
+	SslCaPath string `json:"ssl_ca_path"`
+	SslCert   string `json:"ssl_cert"`
+	SslKey    string `json:"ssl_key"`
+}

--- a/go/sqldb/sql_error.go
+++ b/go/sqldb/sql_error.go
@@ -1,0 +1,32 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package sqldb
+
+import "fmt"
+
+// SqlError is the error structure returned from calling a db library function
+type SqlError struct {
+	Num     int
+	Message string
+	Query   string
+}
+
+// NewSqlError returns a new SqlError
+func NewSqlError(number int, format string, args ...interface{}) *SqlError {
+	return &SqlError{Num: number, Message: fmt.Sprintf(format, args...)}
+}
+
+// Error implements the error interface
+func (se *SqlError) Error() string {
+	if se.Query == "" {
+		return fmt.Sprintf("%v (errno %v)", se.Message, se.Num)
+	}
+	return fmt.Sprintf("%v (errno %v) during query: %s", se.Message, se.Num, se.Query)
+}
+
+// Number returns the internal mysql error code
+func (se *SqlError) Number() int {
+	return se.Num
+}

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -8,18 +8,19 @@ import (
 	"fmt"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 )
 
 // DBClient is a real VtClient backed by a mysql connection
 type DBClient struct {
-	dbConfig *mysql.ConnectionParams
-	dbConn   *mysql.Connection
+	dbConfig *sqldb.ConnParams
+	dbConn   sqldb.Conn
 }
 
-func NewDbClient(params *mysql.ConnectionParams) *DBClient {
+// NewDbClient creates a DBClient instance
+func NewDbClient(params *sqldb.ConnParams) *DBClient {
 	return &DBClient{
 		dbConfig: params,
 	}
@@ -27,7 +28,7 @@ func NewDbClient(params *mysql.ConnectionParams) *DBClient {
 
 func (dc *DBClient) handleError(err error) {
 	// log.Errorf("in DBClient handleError %v", err.(error))
-	if sqlErr, ok := err.(*mysql.SqlError); ok {
+	if sqlErr, ok := err.(*sqldb.SqlError); ok {
 		if sqlErr.Number() >= 2000 && sqlErr.Number() <= 2018 { // mysql connection errors
 			dc.Close()
 		}
@@ -37,18 +38,20 @@ func (dc *DBClient) handleError(err error) {
 	}
 }
 
+// Connect connects to a db server
 func (dc *DBClient) Connect() error {
 	params, err := dbconfigs.MysqlParams(dc.dbConfig)
 	if err != nil {
 		return err
 	}
-	dc.dbConn, err = mysql.Connect(params)
+	dc.dbConn, err = sqldb.Connect(params)
 	if err != nil {
 		return fmt.Errorf("error in connecting to mysql db, err %v", err)
 	}
 	return nil
 }
 
+// Begin starts a transaction
 func (dc *DBClient) Begin() error {
 	_, err := dc.dbConn.ExecuteFetch("begin", 1, false)
 	if err != nil {
@@ -58,6 +61,7 @@ func (dc *DBClient) Begin() error {
 	return err
 }
 
+// Commit commits the current transaction
 func (dc *DBClient) Commit() error {
 	_, err := dc.dbConn.ExecuteFetch("commit", 1, false)
 	if err != nil {
@@ -67,6 +71,7 @@ func (dc *DBClient) Commit() error {
 	return err
 }
 
+// Rollback rollbacks the current transaction
 func (dc *DBClient) Rollback() error {
 	_, err := dc.dbConn.ExecuteFetch("rollback", 1, false)
 	if err != nil {
@@ -76,6 +81,7 @@ func (dc *DBClient) Rollback() error {
 	return err
 }
 
+// Close closes connection to the db server
 func (dc *DBClient) Close() {
 	if dc.dbConn != nil {
 		dc.dbConn.Close()
@@ -83,6 +89,7 @@ func (dc *DBClient) Close() {
 	}
 }
 
+// ExecuteFetch sends query to the db server and fetch the result
 func (dc *DBClient) ExecuteFetch(query string, maxrows int, wantfields bool) (*mproto.QueryResult, error) {
 	mqr, err := dc.dbConn.ExecuteFetch(query, maxrows, wantfields)
 	if err != nil {

--- a/go/vt/dbconnpool/pooled_connection.go
+++ b/go/vt/dbconnpool/pooled_connection.go
@@ -5,14 +5,14 @@
 package dbconnpool
 
 import (
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 )
 
 // PooledDBConnection re-exposes DBConnection as a PoolConnection
 type PooledDBConnection struct {
 	*DBConnection
-	info       *mysql.ConnectionParams
+	info       *sqldb.ConnParams
 	mysqlStats *stats.Timings
 	pool       *ConnectionPool
 }
@@ -48,7 +48,7 @@ func (pc *PooledDBConnection) Reconnect() error {
 // ...
 // conn, err := pool.Get()
 // ...
-func DBConnectionCreator(info *mysql.ConnectionParams, mysqlStats *stats.Timings) CreateConnectionFunc {
+func DBConnectionCreator(info *sqldb.ConnParams, mysqlStats *stats.Timings) CreateConnectionFunc {
 	return func(pool *ConnectionPool) (PoolConnection, error) {
 		c, err := NewDBConnection(info, mysqlStats)
 		if err != nil {

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -19,7 +19,7 @@ var MycnfPath = "/tmp/my.cnf"
 func TestMycnf(t *testing.T) {
 	os.Setenv("MYSQL_FLAVOR", "GoogleMysql")
 	dbaConfig := dbconfigs.DefaultDBConfigs.Dba
-	appConfig := dbconfigs.DefaultDBConfigs.App.ConnectionParams
+	appConfig := dbconfigs.DefaultDBConfigs.App.ConnParams
 	replConfig := dbconfigs.DefaultDBConfigs.Repl
 	tablet0 := NewMysqld("Dba", "App", NewMycnf(0, 6802), &dbaConfig, &appConfig, &replConfig)
 	defer tablet0.Close()

--- a/go/vt/mysqlctl/mysql_flavor.go
+++ b/go/vt/mysqlctl/mysql_flavor.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -37,7 +37,7 @@ type MysqlFlavor interface {
 
 	// StartReplicationCommands returns the commands to start replicating from
 	// a given master and position as specified in a ReplicationStatus.
-	StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error)
+	StartReplicationCommands(params *sqldb.ConnParams, status *proto.ReplicationStatus) ([]string, error)
 
 	// ParseGTID parses a GTID in the canonical format of this MySQL flavor into
 	// a proto.GTID interface value.
@@ -68,7 +68,7 @@ type MysqlFlavor interface {
 	DisableBinlogPlayback(mysqld *Mysqld) error
 }
 
-var mysqlFlavors map[string]MysqlFlavor = make(map[string]MysqlFlavor)
+var mysqlFlavors = make(map[string]MysqlFlavor)
 
 // registerFlavorBuiltin adds a flavor to the map only if the name is unused.
 // The flavor implementation passed to this function will only be used if there

--- a/go/vt/mysqlctl/mysql_flavor_google_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_google_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	proto "github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -196,7 +197,7 @@ func TestGoogleBinlogEventStripChecksum(t *testing.T) {
 }
 
 func TestGoogleStartReplicationCommands(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldb.ConnParams{
 		Uname: "username",
 		Pass:  "password",
 	}
@@ -231,7 +232,7 @@ func TestGoogleStartReplicationCommands(t *testing.T) {
 }
 
 func TestGoogleStartReplicationCommandsSSL(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldb.ConnParams{
 		Uname:     "username",
 		Pass:      "password",
 		SslCa:     "ssl-ca",
@@ -239,7 +240,7 @@ func TestGoogleStartReplicationCommandsSSL(t *testing.T) {
 		SslCert:   "ssl-cert",
 		SslKey:    "ssl-key",
 	}
-	params.EnableSSL()
+	mysql.EnableSSL(params)
 	status := &proto.ReplicationStatus{
 		Position:           proto.ReplicationPosition{GTIDSet: proto.GoogleGTID{ServerID: 41983, GroupID: 12345}},
 		MasterHost:         "localhost",

--- a/go/vt/mysqlctl/mysql_flavor_mariadb_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_mariadb_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -175,7 +176,7 @@ func TestMariadbMakeBinlogEvent(t *testing.T) {
 }
 
 func TestMariadbStartReplicationCommands(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldb.ConnParams{
 		Uname: "username",
 		Pass:  "password",
 	}
@@ -210,7 +211,7 @@ func TestMariadbStartReplicationCommands(t *testing.T) {
 }
 
 func TestMariadbStartReplicationCommandsSSL(t *testing.T) {
-	params := &mysql.ConnectionParams{
+	params := &sqldb.ConnParams{
 		Uname:     "username",
 		Pass:      "password",
 		SslCa:     "ssl-ca",
@@ -218,7 +219,7 @@ func TestMariadbStartReplicationCommandsSSL(t *testing.T) {
 		SslCert:   "ssl-cert",
 		SslKey:    "ssl-key",
 	}
-	params.EnableSSL()
+	mysql.EnableSSL(params)
 	status := &proto.ReplicationStatus{
 		Position:           proto.ReplicationPosition{GTIDSet: proto.MariadbGTID{Domain: 1, Server: 41983, Sequence: 12345}},
 		MasterHost:         "localhost",

--- a/go/vt/mysqlctl/mysql_flavor_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
 )
@@ -33,7 +33,7 @@ func (fakeMysqlFlavor) MasterPosition(mysqld *Mysqld) (proto.ReplicationPosition
 	return proto.ReplicationPosition{}, nil
 }
 func (fakeMysqlFlavor) SlaveStatus(mysqld *Mysqld) (*proto.ReplicationStatus, error) { return nil, nil }
-func (fakeMysqlFlavor) StartReplicationCommands(params *mysql.ConnectionParams, status *proto.ReplicationStatus) ([]string, error) {
+func (fakeMysqlFlavor) StartReplicationCommands(params *sqldb.ConnParams, status *proto.ReplicationStatus) ([]string, error) {
 	return nil, nil
 }
 func (fakeMysqlFlavor) EnableBinlogPlayback(mysqld *Mysqld) error  { return nil }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/netutil"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
@@ -55,11 +55,11 @@ var (
 // Mysqld is the object that represents a mysqld daemon running on this server.
 type Mysqld struct {
 	config      *Mycnf
-	dba         *mysql.ConnectionParams
-	dbApp       *mysql.ConnectionParams
+	dba         *sqldb.ConnParams
+	dbApp       *sqldb.ConnParams
 	dbaPool     *dbconnpool.ConnectionPool
 	appPool     *dbconnpool.ConnectionPool
-	replParams  *mysql.ConnectionParams
+	replParams  *sqldb.ConnParams
 	TabletDir   string
 	SnapshotDir string
 
@@ -73,7 +73,7 @@ type Mysqld struct {
 // NewMysqld creates a Mysqld object based on the provided configuration
 // and connection parameters.
 // dbaName and appName are the base for stats exports, use 'Dba' and 'App', except in tests
-func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *mysql.ConnectionParams) *Mysqld {
+func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.ConnParams) *Mysqld {
 	if *dba == dbconfigs.DefaultDBConfigs.Dba {
 		dba.UnixSocket = config.SocketFile
 	}

--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -132,7 +132,7 @@ func NewActionAgent(
 	schemaOverrides := loadSchemaOverrides(overridesFile)
 
 	topoServer := topo.GetServer()
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnectionParams, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl)
 
 	agent = &ActionAgent{
 		QueryServiceControl: queryServiceControl,

--- a/go/vt/tabletserver/connpool.go
+++ b/go/vt/tabletserver/connpool.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/pools"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"golang.org/x/net/context"
@@ -38,7 +38,10 @@ type ConnPool struct {
 
 // NewConnPool creates a new ConnPool. The name is used
 // to publish stats only.
-func NewConnPool(name string, capacity int, idleTimeout time.Duration) *ConnPool {
+func NewConnPool(
+	name string,
+	capacity int,
+	idleTimeout time.Duration) *ConnPool {
 	cp := &ConnPool{
 		capacity:    capacity,
 		idleTimeout: idleTimeout,
@@ -64,7 +67,7 @@ func (cp *ConnPool) pool() (p *pools.ResourcePool) {
 }
 
 // Open must be called before starting to use the pool.
-func (cp *ConnPool) Open(appParams, dbaParams *mysql.ConnectionParams) {
+func (cp *ConnPool) Open(appParams, dbaParams *sqldb.ConnParams) {
 	cp.mu.Lock()
 	defer cp.mu.Unlock()
 

--- a/go/vt/tabletserver/connpool_test.go
+++ b/go/vt/tabletserver/connpool_test.go
@@ -5,20 +5,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"golang.org/x/net/context"
 )
 
 var (
-	appParams = &mysql.ConnectionParams{
+	appParams = &sqldb.ConnParams{
 		Uname:      "vt_app",
 		DbName:     "sougou",
 		UnixSocket: os.Getenv("VTDATAROOT") + "/vt_0000062347/mysql.sock",
 		Charset:    "utf8",
 	}
-	dbaParams = &mysql.ConnectionParams{
+	dbaParams = &sqldb.ConnParams{
 		Uname:      "vt_dba",
 		DbName:     "sougou",
 		UnixSocket: os.Getenv("VTDATAROOT") + "/vt_0000062347/mysql.sock",

--- a/go/vt/tabletserver/dbconn.go
+++ b/go/vt/tabletserver/dbconn.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"golang.org/x/net/context"
@@ -23,14 +23,14 @@ import (
 // It will also trigger a CheckMySQL whenever applicable.
 type DBConn struct {
 	conn *dbconnpool.DBConnection
-	info *mysql.ConnectionParams
+	info *sqldb.ConnParams
 	pool *ConnPool
 
 	current sync2.AtomicString
 }
 
 // NewDBConn creates a new DBConn. It triggers a CheckMySQL if creation fails.
-func NewDBConn(cp *ConnPool, appParams, dbaParams *mysql.ConnectionParams) (*DBConn, error) {
+func NewDBConn(cp *ConnPool, appParams, dbaParams *sqldb.ConnParams) (*DBConn, error) {
 	c, err := dbconnpool.NewDBConnection(appParams, mysqlStats)
 	if err != nil {
 		go checkMySQL()

--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -192,10 +192,10 @@ func NewQueryEngine(config Config) *QueryEngine {
 // Open must be called before sending requests to QueryEngine.
 func (qe *QueryEngine) Open(dbconfigs *dbconfigs.DBConfigs, schemaOverrides []SchemaOverride, mysqld *mysqlctl.Mysqld) {
 	qe.dbconfigs = dbconfigs
-	appParams := dbconfigs.App.ConnectionParams
+	appParams := dbconfigs.App.ConnParams
 	// Create dba params based on App connection params
 	// and Dba credentials.
-	dbaParams := dbconfigs.App.ConnectionParams
+	dbaParams := dbconfigs.App.ConnParams
 	if dbconfigs.Dba.Uname != "" {
 		dbaParams.Uname = dbconfigs.Dba.Uname
 		dbaParams.Pass = dbconfigs.Dba.Pass
@@ -256,7 +256,7 @@ func (qe *QueryEngine) Launch(f func()) {
 
 // CheckMySQL returns true if we can connect to MySQL.
 func (qe *QueryEngine) CheckMySQL() bool {
-	conn, err := dbconnpool.NewDBConnection(&qe.dbconfigs.App.ConnectionParams, mysqlStats)
+	conn, err := dbconnpool.NewDBConnection(&qe.dbconfigs.App.ConnParams, mysqlStats)
 	if err != nil {
 		if IsConnErr(err) {
 			return false

--- a/go/vt/tabletserver/schema_info.go
+++ b/go/vt/tabletserver/schema_info.go
@@ -16,8 +16,8 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/cache"
-	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/timer"
 	"github.com/youtube/vitess/go/vt/schema"
@@ -102,7 +102,10 @@ type SchemaInfo struct {
 }
 
 // NewSchemaInfo creates a new SchemaInfo.
-func NewSchemaInfo(queryCacheSize int, reloadTime time.Duration, idleTimeout time.Duration) *SchemaInfo {
+func NewSchemaInfo(
+	queryCacheSize int,
+	reloadTime time.Duration,
+	idleTimeout time.Duration) *SchemaInfo {
 	si := &SchemaInfo{
 		queries:  cache.NewLRUCache(int64(queryCacheSize)),
 		connPool: NewConnPool("", 2, idleTimeout),
@@ -129,7 +132,7 @@ func NewSchemaInfo(queryCacheSize int, reloadTime time.Duration, idleTimeout tim
 }
 
 // Open initializes the current SchemaInfo for service by loading the necessary info from the specified database.
-func (si *SchemaInfo) Open(appParams, dbaParams *mysql.ConnectionParams, schemaOverrides []SchemaOverride, cachePool *CachePool, strictMode bool) {
+func (si *SchemaInfo) Open(appParams, dbaParams *sqldb.ConnParams, schemaOverrides []SchemaOverride, cachePool *CachePool, strictMode bool) {
 	ctx := context.Background()
 	si.connPool.Open(appParams, dbaParams)
 	// Get time first because it needs a connection from the pool.

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -136,7 +136,7 @@ func (sq *SqlQuery) allowQueries(dbconfigs *dbconfigs.DBConfigs, schemaOverrides
 	sq.setState(StateInitializing)
 	sq.mu.Unlock()
 
-	c, err := dbconnpool.NewDBConnection(&dbconfigs.App.ConnectionParams, mysqlStats)
+	c, err := dbconnpool.NewDBConnection(&dbconfigs.App.ConnParams, mysqlStats)
 	if err != nil {
 		log.Infof("allowQueries failed: %v", err)
 		sq.mu.Lock()

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/pools"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
@@ -59,7 +59,12 @@ type TxPool struct {
 }
 
 // NewTxPool creates a new TxPool. It's not operational until it's Open'd.
-func NewTxPool(name string, capacity int, timeout, poolTimeout, idleTimeout time.Duration) *TxPool {
+func NewTxPool(
+	name string,
+	capacity int,
+	timeout time.Duration,
+	poolTimeout time.Duration,
+	idleTimeout time.Duration) *TxPool {
 	axp := &TxPool{
 		pool:        NewConnPool(name, capacity, idleTimeout),
 		activePool:  pools.NewNumbered(),
@@ -78,7 +83,7 @@ func NewTxPool(name string, capacity int, timeout, poolTimeout, idleTimeout time
 
 // Open makes the TxPool operational. This also starts the transaction killer
 // that will kill long-running transactions.
-func (axp *TxPool) Open(appParams, dbaParams *mysql.ConnectionParams) {
+func (axp *TxPool) Open(appParams, dbaParams *sqldb.ConnParams) {
 	log.Infof("Starting transaction id: %d", axp.lastID)
 	axp.pool.Open(appParams, dbaParams)
 	axp.ticks.Start(func() { axp.transactionKiller() })

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -585,7 +585,7 @@ func (scw *SplitCloneWorker) copy() error {
 		queries = append(queries, binlogplayer.CreateBlpCheckpoint()...)
 		flags := ""
 		if scw.strategy.DontStartBinlogPlayer {
-			flags = binlogplayer.BLP_FLAG_DONT_START
+			flags = binlogplayer.BlpFlagDontStart
 		}
 
 		// get the current position from the sources

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -520,7 +520,7 @@ func (vscw *VerticalSplitCloneWorker) copy() error {
 		queries = append(queries, binlogplayer.CreateBlpCheckpoint()...)
 		flags := ""
 		if vscw.strategy.DontStartBinlogPlayer {
-			flags = binlogplayer.BLP_FLAG_DONT_START
+			flags = binlogplayer.BlpFlagDontStart
 		}
 		queries = append(queries, binlogplayer.PopulateBlpCheckpoint(0, status.Position, time.Now().Unix(), flags))
 		destinationWaitGroup.Add(1)


### PR DESCRIPTION
1. add SqlDBConn and move mysql.ConnectionParams to sqldbconn package
2. change mysql.Connect function to return sqldbconn.SqlDBConn
3. update places using *mysql.Connection to sqldbconn.SqlDBConn
4. update places using *mysql.ConnectionParams to *sqldbconn.ConnectionParams
5. define sqldbconn.NewSqlDBConnFunc factory method
6. Some randome go style fix (suggested by golint)
7. define package level variable NewSqlDBConn in sqldbconn
8. create package mysqldbconn which inits sqldbconn.NewSqlDBConn to mysql.Connect