### PR TITLE
add name prefix for txStats

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -144,6 +144,7 @@ func NewQueryEngine(config Config) *QueryEngine {
 	// Services
 	qe.txPool = NewTxPool(
 		"TransactionPool",
+		"",
 		config.TransactionCap,
 		time.Duration(config.TransactionTimeout*1e9),
 		time.Duration(config.TxPoolTimeout*1e9),

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -61,6 +61,7 @@ type TxPool struct {
 // NewTxPool creates a new TxPool. It's not operational until it's Open'd.
 func NewTxPool(
 	name string,
+	txStatsPrefix string,
 	capacity int,
 	timeout time.Duration,
 	poolTimeout time.Duration,
@@ -72,7 +73,7 @@ func NewTxPool(
 		timeout:     sync2.AtomicDuration(timeout),
 		poolTimeout: sync2.AtomicDuration(poolTimeout),
 		ticks:       timer.NewTimer(timeout / 10),
-		txStats:     stats.NewTimings("Transactions"),
+		txStats:     stats.NewTimings(txStatsPrefix + "Transactions"),
 	}
 	// Careful: pool also exports name+"xxx" vars,
 	// but we know it doesn't export Timeout.


### PR DESCRIPTION
NewTxPool always creates a new txStats instance with a hard coded name.
This is good until some unit tests need to create two TxPool instances.
The second NewTxPool call will fail because of the hard coded stats variable
has been exported in the first call.

This happens when there are two unit tests for TxPool and SqlQuery, since SqlQuery
will implicitly create a TxPool instance.

One possible fix would be to add an extra txStatsPrefix in NewTxPool function
so that unit test is able to register its own txStats with an unique name.
Given the fact that NewTxPool function is only called once in QueryEngine, this
fix might be simpler than other alternative options.

In addition, this fix also allows unit test to create different TxPool instances
and makes each test function independent to each other.