### PR TITLE
Adding panic handler tests to vtctl client/server RPC code.

### DIFF
--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server_test.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server_test.go
@@ -28,7 +28,8 @@ func TestGoRPCTMServer(t *testing.T) {
 
 	// Create a Go Rpc server and listen on the port
 	server := rpcplus.NewServer()
-	server.Register(&TabletManager{agentrpctest.NewFakeRPCAgent(t)})
+	fakeAgent := agentrpctest.NewFakeRPCAgent(t)
+	server.Register(&TabletManager{fakeAgent})
 
 	// create the HTTP server, serve the server from it
 	handler := http.NewServeMux()
@@ -52,5 +53,5 @@ func TestGoRPCTMServer(t *testing.T) {
 	}, 0)
 
 	// and run the test suite
-	agentrpctest.Run(t, client, ti)
+	agentrpctest.Run(t, client, ti, fakeAgent)
 }

--- a/go/vt/tabletmanager/rpc_server.go
+++ b/go/vt/tabletmanager/rpc_server.go
@@ -29,17 +29,18 @@ const rpcTimeout = time.Second * 30
 
 // rpcWrapper handles all the logic for rpc calls.
 func (agent *ActionAgent) rpcWrapper(ctx context.Context, name string, args, reply interface{}, verbose bool, f func() error, lock, runAfterAction bool) (err error) {
-	from := ""
-	ci, ok := callinfo.FromContext(ctx)
-	if ok {
-		from = ci.Text
-	}
 	defer func() {
 		if x := recover(); x != nil {
 			log.Errorf("TabletManager.%v(%v) panic: %v", name, args, x)
 			err = fmt.Errorf("caught panic during %v: %v", name, x)
 		}
 	}()
+
+	from := ""
+	ci, ok := callinfo.FromContext(ctx)
+	if ok {
+		from = ci.Text
+	}
 
 	if lock {
 		beforeLock := time.Now()

--- a/go/vt/vtctl/gorpcvtctlserver/server.go
+++ b/go/vt/vtctl/gorpcvtctlserver/server.go
@@ -28,7 +28,9 @@ type VtctlServer struct {
 
 // ExecuteVtctlCommand is the server side method that will execute the query,
 // and stream the results.
-func (s *VtctlServer) ExecuteVtctlCommand(ctx context.Context, query *gorpcproto.ExecuteVtctlCommandArgs, sendReply func(interface{}) error) error {
+func (s *VtctlServer) ExecuteVtctlCommand(ctx context.Context, query *gorpcproto.ExecuteVtctlCommandArgs, sendReply func(interface{}) error) (err error) {
+	defer vtctl.HandlePanic(&err)
+
 	// create a logger, send the result back to the caller
 	logstream := logutil.NewChannelLogger(10)
 	logger := logutil.NewTeeLogger(logstream, logutil.NewConsoleLogger())
@@ -53,7 +55,7 @@ func (s *VtctlServer) ExecuteVtctlCommand(ctx context.Context, query *gorpcproto
 	ctx, cancel := context.WithTimeout(context.TODO(), query.ActionTimeout)
 
 	// execute the command
-	err := vtctl.RunCommand(ctx, wr, query.Args)
+	err = vtctl.RunCommand(ctx, wr, query.Args)
 	cancel()
 
 	// close the log channel, and wait for them all to be sent

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -221,6 +221,9 @@ var commands = []commandGroup{
 			command{"ListTablets", commandListTablets,
 				"<tablet alias> ...",
 				"List specified tablets in an awk-friendly way."},
+			command{"Panic", commandPanic,
+				"",
+				"HIDDEN Triggers a panic on the server side, to test the handling."},
 		},
 	},
 	commandGroup{
@@ -2166,6 +2169,10 @@ func commandHelp(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Flag
 	return nil
 }
 
+func commandPanic(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	panic(fmt.Errorf("this command panics on purpose"))
+}
+
 type rTablet struct {
 	*topo.TabletInfo
 	*myproto.ReplicationStatus
@@ -2257,5 +2264,13 @@ func PrintAllCommands(logger logutil.Logger) {
 			logger.Printf("  %s %s\n", cmd.name, cmd.params)
 		}
 		logger.Printf("\n")
+	}
+}
+
+// HandlePanic should be called using 'defer' in the RPC code that executes
+// the command
+func HandlePanic(err *error) {
+	if x := recover(); x != nil {
+		*err = fmt.Errorf("uncaught vtctl panic: %v", x)
 	}
 }


### PR DESCRIPTION
This is a model of what we should be doing for other libraries.
Turns out panics were not correctly handled, so it's also
a bug fix...

@yaoshengzhe @sougou @aaijazi @enisoc 