### PR TITLE
refactor schema info to make unit test easy to write

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -118,6 +118,13 @@ func NewQueryEngine(config Config) *QueryEngine {
 	qe := &QueryEngine{}
 	qe.schemaInfo = NewSchemaInfo(
 		config.QueryCacheSize,
+		"",
+		map[string]string{
+			debugQueryPlansKey: "/debug/query_plans",
+			debugQueryStatsKey: "/debug/query_stats",
+			debugTableStatsKey: "/debug/table_stats",
+			debugSchemaKey:     "/debug/schema",
+		},
 		time.Duration(config.SchemaReloadTime*1e9),
 		time.Duration(config.IdleTimeout*1e9),
 	)


### PR DESCRIPTION
1. add statsPrefix to allow caller to add prefix for schema info stats
2. add endpoints param in NewSchemaInfo to allow caller provides a different
   http endpoints to serve