### PR TITLE
Moving the panic handling into the RPC layer.

### DIFF
--- a/go/vt/client/fakeserver_test.go
+++ b/go/vt/client/fakeserver_test.go
@@ -131,6 +131,13 @@ func (f *fakeVTGateService) SplitQuery(ctx context.Context, req *proto.SplitQuer
 	return nil
 }
 
+// HandlePanic is part of the VTGateService interface
+func (f *fakeVTGateService) HandlePanic(err *error) {
+	if x := recover(); x != nil {
+		*err = fmt.Errorf("uncaught panic: %v", x)
+	}
+}
+
 // CreateFakeServer returns the fake server for the tests
 func CreateFakeServer() vtgateservice.VTGateService {
 	return &fakeVTGateService{}

--- a/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
@@ -48,7 +48,7 @@ func TestGoRPCVTGateConn(t *testing.T) {
 	}
 
 	// run the test suite
-	vtgateconntest.TestSuite(t, client)
+	vtgateconntest.TestSuite(t, client, service)
 
 	// and clean up
 	client.Close()

--- a/go/vt/vtgate/gorpcvtgateservice/server.go
+++ b/go/vt/vtgate/gorpcvtgateservice/server.go
@@ -27,42 +27,48 @@ type VTGate struct {
 }
 
 // Execute is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) Execute(ctx context.Context, query *proto.Query, reply *proto.QueryResult) error {
+func (vtg *VTGate) Execute(ctx context.Context, query *proto.Query, reply *proto.QueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.Execute(ctx, query, reply)
 }
 
 // ExecuteShard is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteShard(ctx context.Context, query *proto.QueryShard, reply *proto.QueryResult) error {
+func (vtg *VTGate) ExecuteShard(ctx context.Context, query *proto.QueryShard, reply *proto.QueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteShard(ctx, query, reply)
 }
 
 // ExecuteKeyspaceIds is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, reply *proto.QueryResult) error {
+func (vtg *VTGate) ExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, reply *proto.QueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteKeyspaceIds(ctx, query, reply)
 }
 
 // ExecuteKeyRanges is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, reply *proto.QueryResult) error {
+func (vtg *VTGate) ExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, reply *proto.QueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteKeyRanges(ctx, query, reply)
 }
 
 // ExecuteEntityIds is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteEntityIds(ctx context.Context, query *proto.EntityIdsQuery, reply *proto.QueryResult) error {
+func (vtg *VTGate) ExecuteEntityIds(ctx context.Context, query *proto.EntityIdsQuery, reply *proto.QueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteEntityIds(ctx, query, reply)
 }
 
 // ExecuteBatchShard is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, batchQuery *proto.BatchQueryShard, reply *proto.QueryResultList) error {
+func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, batchQuery *proto.BatchQueryShard, reply *proto.QueryResultList) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteBatchShard(ctx, batchQuery, reply)
@@ -70,21 +76,24 @@ func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, batchQuery *proto.Batc
 
 // ExecuteBatchKeyspaceIds is the RPC version of
 // vtgateservice.VTGateService method
-func (vtg *VTGate) ExecuteBatchKeyspaceIds(ctx context.Context, batchQuery *proto.KeyspaceIdBatchQuery, reply *proto.QueryResultList) error {
+func (vtg *VTGate) ExecuteBatchKeyspaceIds(ctx context.Context, batchQuery *proto.KeyspaceIdBatchQuery, reply *proto.QueryResultList) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.ExecuteBatchKeyspaceIds(ctx, batchQuery, reply)
 }
 
 // StreamExecute is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) StreamExecute(ctx context.Context, query *proto.Query, sendReply func(interface{}) error) error {
+func (vtg *VTGate) StreamExecute(ctx context.Context, query *proto.Query, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	return vtg.server.StreamExecute(ctx, query, func(value *proto.QueryResult) error {
 		return sendReply(value)
 	})
 }
 
 // StreamExecuteShard is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) StreamExecuteShard(ctx context.Context, query *proto.QueryShard, sendReply func(interface{}) error) error {
+func (vtg *VTGate) StreamExecuteShard(ctx context.Context, query *proto.QueryShard, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	return vtg.server.StreamExecuteShard(ctx, query, func(value *proto.QueryResult) error {
 		return sendReply(value)
 	})
@@ -92,7 +101,8 @@ func (vtg *VTGate) StreamExecuteShard(ctx context.Context, query *proto.QuerySha
 
 // StreamExecuteKeyRanges is the RPC version of
 // vtgateservice.VTGateService method
-func (vtg *VTGate) StreamExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, sendReply func(interface{}) error) error {
+func (vtg *VTGate) StreamExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	return vtg.server.StreamExecuteKeyRanges(ctx, query, func(value *proto.QueryResult) error {
 		return sendReply(value)
 	})
@@ -100,35 +110,40 @@ func (vtg *VTGate) StreamExecuteKeyRanges(ctx context.Context, query *proto.KeyR
 
 // StreamExecuteKeyspaceIds is the RPC version of
 // vtgateservice.VTGateService method
-func (vtg *VTGate) StreamExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, sendReply func(interface{}) error) error {
+func (vtg *VTGate) StreamExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	return vtg.server.StreamExecuteKeyspaceIds(ctx, query, func(value *proto.QueryResult) error {
 		return sendReply(value)
 	})
 }
 
 // Begin is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) Begin(ctx context.Context, noInput *rpc.Unused, outSession *proto.Session) error {
+func (vtg *VTGate) Begin(ctx context.Context, noInput *rpc.Unused, outSession *proto.Session) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.Begin(ctx, outSession)
 }
 
 // Commit is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) Commit(ctx context.Context, inSession *proto.Session, noOutput *rpc.Unused) error {
+func (vtg *VTGate) Commit(ctx context.Context, inSession *proto.Session, noOutput *rpc.Unused) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.Commit(ctx, inSession)
 }
 
 // Rollback is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) Rollback(ctx context.Context, inSession *proto.Session, noOutput *rpc.Unused) error {
+func (vtg *VTGate) Rollback(ctx context.Context, inSession *proto.Session, noOutput *rpc.Unused) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.Rollback(ctx, inSession)
 }
 
 // SplitQuery is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGate) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) error {
+func (vtg *VTGate) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) (err error) {
+	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	return vtg.server.SplitQuery(ctx, req, reply)

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -26,11 +26,15 @@ import (
 
 // fakeVTGateService has the server side of this fake
 type fakeVTGateService struct {
-	t *testing.T
+	t      *testing.T
+	panics bool
 }
 
 // Execute is part of the VTGateService interface
 func (f *fakeVTGateService) Execute(ctx context.Context, query *proto.Query, reply *proto.QueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	execCase, ok := execMap[query.Sql]
 	if !ok {
 		return fmt.Errorf("no match for: %s", query.Sql)
@@ -45,6 +49,9 @@ func (f *fakeVTGateService) Execute(ctx context.Context, query *proto.Query, rep
 
 // ExecuteShard is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteShard(ctx context.Context, query *proto.QueryShard, reply *proto.QueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	execCase, ok := execMap[query.Sql]
 	if !ok {
 		return fmt.Errorf("no match for: %s", query.Sql)
@@ -59,31 +66,49 @@ func (f *fakeVTGateService) ExecuteShard(ctx context.Context, query *proto.Query
 
 // ExecuteKeyspaceIds is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, reply *proto.QueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // ExecuteKeyRanges is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, reply *proto.QueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // ExecuteEntityIds is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteEntityIds(ctx context.Context, query *proto.EntityIdsQuery, reply *proto.QueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // ExecuteBatchShard is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteBatchShard(ctx context.Context, batchQuery *proto.BatchQueryShard, reply *proto.QueryResultList) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // ExecuteBatchKeyspaceIds is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteBatchKeyspaceIds(ctx context.Context, batchQuery *proto.KeyspaceIdBatchQuery, reply *proto.QueryResultList) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // StreamExecute is part of the VTGateService interface
 func (f *fakeVTGateService) StreamExecute(ctx context.Context, query *proto.Query, sendReply func(*proto.QueryResult) error) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	execCase, ok := execMap[query.Sql]
 	if !ok {
 		return fmt.Errorf("no match for: %s", query.Sql)
@@ -114,27 +139,42 @@ func (f *fakeVTGateService) StreamExecute(ctx context.Context, query *proto.Quer
 
 // StreamExecuteShard is part of the VTGateService interface
 func (f *fakeVTGateService) StreamExecuteShard(ctx context.Context, query *proto.QueryShard, sendReply func(*proto.QueryResult) error) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // StreamExecuteKeyRanges is part of the VTGateService interface
 func (f *fakeVTGateService) StreamExecuteKeyRanges(ctx context.Context, query *proto.KeyRangeQuery, sendReply func(*proto.QueryResult) error) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // StreamExecuteKeyspaceIds is part of the VTGateService interface
 func (f *fakeVTGateService) StreamExecuteKeyspaceIds(ctx context.Context, query *proto.KeyspaceIdQuery, sendReply func(*proto.QueryResult) error) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	return nil
 }
 
 // Begin is part of the VTGateService interface
 func (f *fakeVTGateService) Begin(ctx context.Context, outSession *proto.Session) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	*outSession = *session1
 	return nil
 }
 
 // Commit is part of the VTGateService interface
 func (f *fakeVTGateService) Commit(ctx context.Context, inSession *proto.Session) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	if !reflect.DeepEqual(inSession, session2) {
 		return errors.New("commit: session mismatch")
 	}
@@ -143,6 +183,9 @@ func (f *fakeVTGateService) Commit(ctx context.Context, inSession *proto.Session
 
 // Rollback is part of the VTGateService interface
 func (f *fakeVTGateService) Rollback(ctx context.Context, inSession *proto.Session) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	if !reflect.DeepEqual(inSession, session2) {
 		return errors.New("rollback: session mismatch")
 	}
@@ -151,6 +194,9 @@ func (f *fakeVTGateService) Rollback(ctx context.Context, inSession *proto.Sessi
 
 // SplitQuery is part of the VTGateService interface
 func (f *fakeVTGateService) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) error {
+	if f.panics {
+		panic(fmt.Errorf("test forced panic"))
+	}
 	if !reflect.DeepEqual(req, splitQueryRequest) {
 		f.t.Errorf("SplitQuery has wrong input: got %#v wanted %#v", req, splitQueryRequest)
 	}
@@ -160,17 +206,43 @@ func (f *fakeVTGateService) SplitQuery(ctx context.Context, req *proto.SplitQuer
 
 // CreateFakeServer returns the fake server for the tests
 func CreateFakeServer(t *testing.T) vtgateservice.VTGateService {
-	return &fakeVTGateService{t}
+	return &fakeVTGateService{
+		t:      t,
+		panics: false,
+	}
+}
+
+// HandlePanic is part of the VTGateService interface
+func (f *fakeVTGateService) HandlePanic(err *error) {
+	if x := recover(); x != nil {
+		*err = fmt.Errorf("uncaught panic: %v", x)
+	}
 }
 
 // TestSuite runs all the tests
-func TestSuite(t *testing.T, conn vtgateconn.VTGateConn) {
+func TestSuite(t *testing.T, conn vtgateconn.VTGateConn, fakeServer vtgateservice.VTGateService) {
 	testExecute(t, conn)
 	testExecuteShard(t, conn)
 	testStreamExecute(t, conn)
 	testTxPass(t, conn)
 	testTxFail(t, conn)
 	testSplitQuery(t, conn)
+
+	// force a panic at every call, then test that works
+	fakeServer.(*fakeVTGateService).panics = true
+	testExecutePanic(t, conn)
+	testExecuteShardPanic(t, conn)
+	testStreamExecutePanic(t, conn)
+	testBeginPanic(t, conn)
+	testSplitQueryPanic(t, conn)
+}
+
+func expectPanic(t *testing.T, err error) {
+	expected1 := "test forced panic"
+	expected2 := "uncaught panic"
+	if err == nil || !strings.Contains(err.Error(), expected1) || !strings.Contains(err.Error(), expected2) {
+		t.Fatalf("Expected a panic error with '%v' or '%v' but got: %v", expected1, expected2, err)
+	}
 }
 
 func testExecute(t *testing.T, conn vtgateconn.VTGateConn) {
@@ -197,6 +269,13 @@ func testExecute(t *testing.T, conn vtgateconn.VTGateConn) {
 	}
 }
 
+func testExecutePanic(t *testing.T, conn vtgateconn.VTGateConn) {
+	ctx := context.Background()
+	execCase := execMap["request1"]
+	_, err := conn.Execute(ctx, execCase.execQuery.Sql, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	expectPanic(t, err)
+}
+
 func testExecuteShard(t *testing.T, conn vtgateconn.VTGateConn) {
 	ctx := context.Background()
 	execCase := execMap["request1"]
@@ -219,6 +298,13 @@ func testExecuteShard(t *testing.T, conn vtgateconn.VTGateConn) {
 	if err == nil || err.Error() != want {
 		t.Errorf("errorRequst: %v, want %v", err, want)
 	}
+}
+
+func testExecuteShardPanic(t *testing.T, conn vtgateconn.VTGateConn) {
+	ctx := context.Background()
+	execCase := execMap["request1"]
+	_, err := conn.ExecuteShard(ctx, execCase.execQuery.Sql, "ks", []string{"1", "2"}, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	expectPanic(t, err)
 }
 
 func testStreamExecute(t *testing.T, conn vtgateconn.VTGateConn) {
@@ -266,6 +352,17 @@ func testStreamExecute(t *testing.T, conn vtgateconn.VTGateConn) {
 	}
 }
 
+func testStreamExecutePanic(t *testing.T, conn vtgateconn.VTGateConn) {
+	ctx := context.Background()
+	execCase := execMap["request1"]
+	packets, errFunc := conn.StreamExecute(ctx, execCase.execQuery.Sql, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	if _, ok := <-packets; ok {
+		t.Fatalf("Received packets instead of panic?")
+	}
+	err := errFunc()
+	expectPanic(t, err)
+}
+
 func testTxPass(t *testing.T, conn vtgateconn.VTGateConn) {
 	ctx := context.Background()
 	tx, err := conn.Begin(ctx)
@@ -295,6 +392,12 @@ func testTxPass(t *testing.T, conn vtgateconn.VTGateConn) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+func testBeginPanic(t *testing.T, conn vtgateconn.VTGateConn) {
+	ctx := context.Background()
+	_, err := conn.Begin(ctx)
+	expectPanic(t, err)
 }
 
 func testTxFail(t *testing.T, conn vtgateconn.VTGateConn) {
@@ -352,6 +455,12 @@ func testSplitQuery(t *testing.T, conn vtgateconn.VTGateConn) {
 	if !reflect.DeepEqual(qsl, splitQueryResult.Splits) {
 		t.Errorf("SplitQuery returned worng result: got %v wanted %v", qsl, splitQueryResult.Splits)
 	}
+}
+
+func testSplitQueryPanic(t *testing.T, conn vtgateconn.VTGateConn) {
+	ctx := context.Background()
+	_, err := conn.SplitQuery(ctx, splitQueryRequest.Keyspace, splitQueryRequest.Query, splitQueryRequest.SplitCount)
+	expectPanic(t, err)
 }
 
 var execMap = map[string]struct {

--- a/go/vt/vtgate/vtgateservice/interface.go
+++ b/go/vt/vtgate/vtgateservice/interface.go
@@ -36,4 +36,8 @@ type VTGateService interface {
 
 	// Map Reduce support
 	SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) error
+
+	// HandlePanic should be called with defer at the beginning of each
+	// RPC implementation method, before calling any of the previous methods
+	HandlePanic(err *error)
 }


### PR DESCRIPTION
That way we can remove one recover layer in other RPC implementations.