### PR TITLE
remove applyFieldFilter func in schema_info.go

### DIFF
--- a/go/vt/tabletserver/schema_info.go
+++ b/go/vt/tabletserver/schema_info.go
@@ -657,13 +657,3 @@ func (si *SchemaInfo) handleHTTPSchema(response http.ResponseWriter, request *ht
 	json.HTMLEscape(buf, b)
 	response.Write(buf.Bytes())
 }
-
-func applyFieldFilter(columnNumbers []int, input []mproto.Field) (output []mproto.Field) {
-	output = make([]mproto.Field, len(columnNumbers))
-	for colIndex, colPointer := range columnNumbers {
-		if colPointer >= 0 {
-			output[colIndex] = input[colPointer]
-		}
-	}
-	return output
-}


### PR DESCRIPTION
applyFieldFilter func in schema_info.go has never been used in the
Vitess code base. Remove it.