### PR TITLE
add a fake DB struct to make fakesqldb easy to use

### DIFF
--- a/go/vt/tabletserver/cache_pool_test.go
+++ b/go/vt/tabletserver/cache_pool_test.go
@@ -19,14 +19,14 @@ import (
 
 func TestCachePoolWithEmptyBinary(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	cachePool := newTestCachePool(RowCacheConfig{})
 	cachePool.Close()
 }
 
 func TestCachePool(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -47,7 +47,7 @@ func TestCachePool(t *testing.T) {
 
 func TestCachePoolOpenTwice(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -65,7 +65,7 @@ func TestCachePoolOpenTwice(t *testing.T) {
 
 func TestCachePoolOpenWithEmptyBinary(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -83,7 +83,7 @@ func TestCachePoolOpenWithEmptyBinary(t *testing.T) {
 
 func TestCachePoolOpenWithInvalidBinary(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "invalid_binary",
 		Connections: 100,
@@ -100,7 +100,7 @@ func TestCachePoolOpenWithInvalidBinary(t *testing.T) {
 
 func TestCachePoolState(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -135,7 +135,7 @@ func TestCachePoolState(t *testing.T) {
 
 func TestCachePoolStateWithoutOpen(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -169,7 +169,7 @@ func TestCachePoolStateWithoutOpen(t *testing.T) {
 
 func TestCachePoolGetFailedBecauseCachePoolIsClosed(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -188,7 +188,7 @@ func TestCachePoolGetFailedBecauseCachePoolIsClosed(t *testing.T) {
 
 func TestCachePoolStatsURL(t *testing.T) {
 	fakecacheservice.Register()
-	fakesqldb.Register(nil, false)
+	fakesqldb.Register()
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,

--- a/go/vt/tabletserver/fakesqldb/conn.go
+++ b/go/vt/tabletserver/fakesqldb/conn.go
@@ -8,6 +8,7 @@ package fakesqldb
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 
 	log "github.com/golang/glog"
@@ -16,9 +17,9 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 )
 
-// Conn provides a fake implementation of sqldb.Conn
+// Conn provides a fake implementation of sqldb.Conn.
 type Conn struct {
-	queryMap       map[string]*proto.QueryResult
+	db             *DB
 	isClosed       bool
 	id             int64
 	curQueryResult *proto.QueryResult
@@ -26,20 +27,65 @@ type Conn struct {
 	charset        *proto.Charset
 }
 
+// DB is a fake database and all its methods are thread safe.
+type DB struct {
+	isConnFail bool
+	data       map[string]*proto.QueryResult
+	mu         sync.Mutex
+}
+
+// AddQuery adds a query and its exptected result.
+func (db *DB) AddQuery(query string, expectedResult *proto.QueryResult) {
+	result := &proto.QueryResult{}
+	*result = *expectedResult
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.data[query] = result
+}
+
+// GetQuery gets a query from the fake DB.
+func (db *DB) GetQuery(query string) (*proto.QueryResult, bool) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	result, ok := db.data[query]
+	return result, ok
+}
+
+// DeleteQuery deletes query from the fake DB.
+func (db *DB) DeleteQuery(query string) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	delete(db.data, query)
+}
+
+// EnableConnFail makes connection to this fake DB fail.
+func (db *DB) EnableConnFail() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.isConnFail = true
+}
+
+// DisableConnFail makes connection to this fake DB success.
+func (db *DB) DisableConnFail() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.isConnFail = false
+}
+
+// IsConnFail tests whether there is a connection failure.
+func (db *DB) IsConnFail() bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.isConnFail
+}
+
 // NewFakeSqlDBConn creates a new FakeSqlDBConn instance
-func NewFakeSqlDBConn(queryMap map[string]*proto.QueryResult) *Conn {
+func NewFakeSqlDBConn(db *DB) *Conn {
 	return &Conn{
-		queryMap: queryMap,
+		db:       db,
 		isClosed: false,
 		id:       rand.Int63(),
 	}
-}
-
-// AddQuery adds a query and its exptected result
-func (conn *Conn) AddQuery(query string, expectedResult *proto.QueryResult) {
-	result := &proto.QueryResult{}
-	*result = *expectedResult
-	conn.queryMap[query] = result
 }
 
 // ExecuteFetch executes the query on the connection
@@ -48,7 +94,7 @@ func (conn *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (*pro
 		return nil, fmt.Errorf("Connection is closed")
 	}
 
-	result, ok := conn.queryMap[query]
+	result, ok := conn.db.GetQuery(query)
 	if !ok {
 		log.Warningf("unexpected query: %s, will return an empty result", query)
 		return &proto.QueryResult{}, nil
@@ -101,7 +147,7 @@ func (conn *Conn) ExecuteStreamFetch(query string) error {
 	if conn.IsClosed() {
 		return fmt.Errorf("Connection is closed")
 	}
-	result, ok := conn.queryMap[query]
+	result, ok := conn.db.GetQuery(query)
 	if !ok {
 		log.Warningf("unexpected query: %s, will return an empty result", query)
 		result = &proto.QueryResult{}
@@ -174,20 +220,21 @@ func (conn *Conn) SetCharset(cs proto.Charset) error {
 }
 
 // Register registers a fake implementation of sqldb.Conn and returns its registered name
-func Register(queryMap map[string]*proto.QueryResult, connFail bool) string {
+func Register() *DB {
 	name := fmt.Sprintf("fake-%d", rand.Int63())
+	db := &DB{data: make(map[string]*proto.QueryResult)}
 	sqldb.Register(name, func(sqldb.ConnParams) (sqldb.Conn, error) {
-		if connFail {
+		if db.IsConnFail() {
 			return nil, &sqldb.SqlError{
 				Num:     2012,
 				Message: "connection fail",
 				Query:   "",
 			}
 		}
-		return NewFakeSqlDBConn(queryMap), nil
+		return NewFakeSqlDBConn(db), nil
 	})
 	sqldb.DefaultDB = name
-	return name
+	return db
 }
 
 var _ (sqldb.Conn) = (*Conn)(nil)

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/tabletserver/fakesqldb"
@@ -20,10 +19,7 @@ import (
 func TestExecuteCommit(t *testing.T) {
 	tableName := "test_table"
 	sql := fmt.Sprintf("ALTER TABLE %s ADD test_column INT", tableName)
-	fakesqldb.Register(map[string]*proto.QueryResult{
-		"begin": &proto.QueryResult{},
-		sql:     &proto.QueryResult{},
-	}, false)
+	fakesqldb.Register()
 	txPool := newTxPool()
 	txPool.SetTimeout(1 * time.Second)
 	txPool.SetPoolTimeout(1 * time.Second)
@@ -52,11 +48,7 @@ func TestExecuteCommit(t *testing.T) {
 
 func TestExecuteRollback(t *testing.T) {
 	sql := "ALTER TABLE test_table ADD test_column INT"
-	fakesqldb.Register(map[string]*proto.QueryResult{
-		"begin":    &proto.QueryResult{},
-		sql:        &proto.QueryResult{},
-		"rollback": &proto.QueryResult{},
-	}, false)
+	fakesqldb.Register()
 	txPool := newTxPool()
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
@@ -76,10 +68,7 @@ func TestExecuteRollback(t *testing.T) {
 
 func TestTransactionKiller(t *testing.T) {
 	sql := "ALTER TABLE test_table ADD test_column INT"
-	fakesqldb.Register(map[string]*proto.QueryResult{
-		"begin": &proto.QueryResult{},
-		sql:     &proto.QueryResult{},
-	}, false)
+	fakesqldb.Register()
 	txPool := newTxPool()
 	// make sure transaction killer will run frequent enough
 	txPool.SetTimeout(time.Duration(10))
@@ -102,11 +91,7 @@ func TestTransactionKiller(t *testing.T) {
 }
 
 func TestBeginAfterConnPoolClosed(t *testing.T) {
-	sql := "ALTER TABLE test_table ADD test_column INT"
-	fakesqldb.Register(map[string]*proto.QueryResult{
-		"begin": &proto.QueryResult{},
-		sql:     &proto.QueryResult{},
-	}, false)
+	fakesqldb.Register()
 	txPool := newTxPool()
 	txPool.SetTimeout(time.Duration(10))
 	appParams := sqldb.ConnParams{}
@@ -128,11 +113,7 @@ func TestBeginAfterConnPoolClosed(t *testing.T) {
 }
 
 func TestBeginWithPoolTimeout(t *testing.T) {
-	sql := "ALTER TABLE test_table ADD test_column INT"
-	fakesqldb.Register(map[string]*proto.QueryResult{
-		"begin": &proto.QueryResult{},
-		sql:     &proto.QueryResult{},
-	}, false)
+	fakesqldb.Register()
 	txPool := newTxPool()
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}


### PR DESCRIPTION
fakesqldb.Register currently takes two params, one is a set of queries it supports
and the other is whether it returns a connection error. This make fakesqldb not very
intuitive to use for unit test.

1. Add a fakesqldb.DB struct that stores all queries supported by a fake sqldbconn.
   Let fakesqldb.Register return a *fakesqldb.DB
2. Unit test is able to add or remove a query via the returned *DB.