### PR TITLE
add stats prefixes to SqlQuery and QueryEngine

### DIFF
--- a/go/vt/tabletserver/cache_pool.go
+++ b/go/vt/tabletserver/cache_pool.go
@@ -48,7 +48,8 @@ func NewCachePool(
 	statsURL string) *CachePool {
 	cp := &CachePool{name: name, idleTimeout: idleTimeout, statsURL: statsURL}
 	if name != "" {
-		cp.memcacheStats = NewMemcacheStats(cp, true, false, false)
+		cp.memcacheStats = NewMemcacheStats(
+			cp, rowCacheConfig.StatsPrefix, true, false, false)
 		stats.Publish(name+"ConnPoolCapacity", stats.IntFunc(cp.Capacity))
 		stats.Publish(name+"ConnPoolAvailable", stats.IntFunc(cp.Available))
 		stats.Publish(name+"ConnPoolMaxCap", stats.IntFunc(cp.MaxCap))

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -54,6 +54,10 @@ func init() {
 	flag.IntVar(&qsConfig.RowCache.Connections, "rowcache-connections", DefaultQsConfig.RowCache.Connections, "rowcache max simultaneous connections")
 	flag.IntVar(&qsConfig.RowCache.Threads, "rowcache-threads", DefaultQsConfig.RowCache.Threads, "rowcache number of threads")
 	flag.BoolVar(&qsConfig.RowCache.LockPaged, "rowcache-lock-paged", DefaultQsConfig.RowCache.LockPaged, "whether rowcache locks down paged memory")
+	flag.StringVar(&qsConfig.RowCache.StatsPrefix, "rowcache-stats-prefix", DefaultQsConfig.RowCache.StatsPrefix, "rowcache stats prefix")
+	flag.StringVar(&qsConfig.StatsPrefix, "stats-prefix", DefaultQsConfig.StatsPrefix, "prefix for variable names exported via expvar")
+	flag.StringVar(&qsConfig.DebugURLPrefix, "debug-url-prefix", DefaultQsConfig.DebugURLPrefix, "debug url prefix")
+	flag.StringVar(&qsConfig.PoolNamePrefix, "pool-name-prefix", DefaultQsConfig.PoolNamePrefix, "pool name prefix")
 }
 
 // RowCacheConfig encapsulates the configuration for RowCache
@@ -64,6 +68,7 @@ type RowCacheConfig struct {
 	Connections int
 	Threads     int
 	LockPaged   bool
+	StatsPrefix string
 }
 
 // GetSubprocessFlags returns the flags to use to call memcached
@@ -109,6 +114,9 @@ type Config struct {
 	StrictMode         bool
 	StrictTableAcl     bool
 	TerseErrors        bool
+	StatsPrefix        string
+	DebugURLPrefix     string
+	PoolNamePrefix     string
 }
 
 // DefaultQSConfig is the default value for the query service config.
@@ -137,6 +145,9 @@ var DefaultQsConfig = Config{
 	StrictMode:         true,
 	StrictTableAcl:     false,
 	TerseErrors:        false,
+	StatsPrefix:        "",
+	DebugURLPrefix:     "/debug",
+	PoolNamePrefix:     "",
 }
 
 var qsConfig Config

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -68,11 +68,11 @@ func (rci *RowcacheInvalidator) PositionString() string {
 // NewRowcacheInvalidator creates a new RowcacheInvalidator.
 // Just like QueryEngine, this is a singleton class.
 // You must call this only once.
-func NewRowcacheInvalidator(qe *QueryEngine) *RowcacheInvalidator {
+func NewRowcacheInvalidator(statsPrefix string, qe *QueryEngine) *RowcacheInvalidator {
 	rci := &RowcacheInvalidator{qe: qe}
-	stats.Publish("RowcacheInvalidatorState", stats.StringFunc(rci.svm.StateName))
-	stats.Publish("RowcacheInvalidatorPosition", stats.StringFunc(rci.PositionString))
-	stats.Publish("RowcacheInvalidatorLagSeconds", stats.IntFunc(rci.lagSeconds.Get))
+	stats.Publish(statsPrefix+"RowcacheInvalidatorState", stats.StringFunc(rci.svm.StateName))
+	stats.Publish(statsPrefix+"RowcacheInvalidatorPosition", stats.StringFunc(rci.PositionString))
+	stats.Publish(statsPrefix+"RowcacheInvalidatorLagSeconds", stats.IntFunc(rci.lagSeconds.Get))
 	return rci
 }
 

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -91,13 +91,13 @@ func NewSqlQuery(config Config) *SqlQuery {
 		config: config,
 	}
 	sq.qe = NewQueryEngine(config)
-	stats.Publish("TabletState", stats.IntFunc(func() int64 {
+	stats.Publish(config.StatsPrefix+"TabletState", stats.IntFunc(func() int64 {
 		sq.mu.Lock()
 		state := sq.state
 		sq.mu.Unlock()
 		return state
 	}))
-	stats.Publish("TabletStateName", stats.StringFunc(sq.GetState))
+	stats.Publish(config.StatsPrefix+"TabletStateName", stats.StringFunc(sq.GetState))
 	return sq
 }
 

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -502,14 +502,14 @@ func TestTerseErrors2(t *testing.T) {
 }
 
 func getSqlQuery() *SqlQuery {
-	if testSqlQuery == nil {
-		config := DefaultQsConfig
-		config.StrictMode = true
-		testSqlQuery = NewSqlQuery(config)
-	}
-	// make sure SqlQuery is in StateNotServing state
-	testSqlQuery.disallowQueries()
-	return testSqlQuery
+	randID := rand.Int63()
+	config := DefaultQsConfig
+	config.StatsPrefix = fmt.Sprintf("Stats-%d-", randID)
+	config.DebugURLPrefix = fmt.Sprintf("/debug-%d-", randID)
+	config.RowCache.StatsPrefix = fmt.Sprintf("Stats-%d-", randID)
+	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
+	config.StrictMode = true
+	return NewSqlQuery(config)
 }
 
 func newMysqld(dbconfigs *dbconfigs.DBConfigs) *mysqlctl.Mysqld {


### PR DESCRIPTION
this change allows code to create multiple SqlQuery instances by assigning different
values to newly added configs. This avoids using a global SqlQuery instance in unit
tests and also may benefit with other use cases.