### PR TITLE
fakecacheservice only returns keys hit the memcache

### DIFF
--- a/go/vt/tabletserver/fakecacheservice/fakecacheservice.go
+++ b/go/vt/tabletserver/fakecacheservice/fakecacheservice.go
@@ -27,10 +27,10 @@ func NewFakeCacheService() *FakeCacheService {
 
 // Get returns cached data for given keys.
 func (service *FakeCacheService) Get(keys ...string) ([]cs.Result, error) {
-	results := make([]cs.Result, len(keys))
-	for i, key := range keys {
+	results := make([]cs.Result, 0, len(keys))
+	for _, key := range keys {
 		if val, ok := service.cacheMap[key]; ok {
-			results[i] = *val
+			results = append(results, *val)
 		}
 	}
 	return results, nil
@@ -40,11 +40,11 @@ func (service *FakeCacheService) Get(keys ...string) ([]cs.Result, error) {
 // for using with CAS. Gets returns a CAS identifier with the item. If
 // the item's CAS value has changed since you Gets'ed it, it will not be stored.
 func (service *FakeCacheService) Gets(keys ...string) ([]cs.Result, error) {
-	results := make([]cs.Result, len(keys))
-	for i, key := range keys {
+	results := make([]cs.Result, 0, len(keys))
+	for _, key := range keys {
 		if val, ok := service.cacheMap[key]; ok {
 			val.Cas = uint64(rand.Int63())
-			results[i] = *val
+			results = append(results, *val)
 		}
 	}
 	return results, nil

--- a/go/vt/tabletserver/fakecacheservice/fakecacheservice_test.go
+++ b/go/vt/tabletserver/fakecacheservice/fakecacheservice_test.go
@@ -31,7 +31,7 @@ func TestFakeCacheService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get error: %v", err)
 	}
-	if !reflect.DeepEqual(results, []cs.Result{cs.Result{}, cs.Result{}}) {
+	if !reflect.DeepEqual(results, []cs.Result{}) {
 		t.Fatalf("get should return empty results, but get: %v", results)
 	}
 	// test Set then Get
@@ -105,8 +105,8 @@ func TestFakeCacheService(t *testing.T) {
 		t.Fatalf("delete should succeed")
 	}
 	results, err = service.Get(key2)
-	if !reflect.DeepEqual(results[0], cs.Result{}) {
-		t.Fatalf("key does not exists, should get empty result")
+	if !reflect.DeepEqual(results, []cs.Result{}) {
+		t.Fatalf("key does not exists, should get empty result, but got: %v", results)
 	}
 	// test FlushAll
 	service.Set(key1, 0, 0, []byte("aaa"))
@@ -116,7 +116,7 @@ func TestFakeCacheService(t *testing.T) {
 		t.Fatalf("FlushAll failed")
 	}
 	results, err = service.Get(key1, key2)
-	if !reflect.DeepEqual(results, []cs.Result{cs.Result{}, cs.Result{}}) {
+	if !reflect.DeepEqual(results, []cs.Result{}) {
 		t.Fatalf("cache has been flushed, should only get empty results")
 	}
 	service.Stats("")


### PR DESCRIPTION
go/memcache only returns keys that hit the memcache, so make fakecacheservice
have the same behavior.