### PR TITLE
always return non nil Rows in fakesqldb.Conn

### DIFF
--- a/go/vt/tabletserver/fakesqldb/conn.go
+++ b/go/vt/tabletserver/fakesqldb/conn.go
@@ -106,17 +106,20 @@ func (conn *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (*pro
 	if qr.RowsAffected > uint64(maxrows) {
 		return nil, fmt.Errorf("Row count exceeded %d", maxrows)
 	}
+
 	if wantfields {
 		copy(qr.Fields, result.Fields)
 	}
+
 	rowCount := int(qr.RowsAffected)
+	rows := make([][]sqltypes.Value, rowCount)
 	if rowCount > 0 {
-		rows := make([][]sqltypes.Value, rowCount)
 		for i := 0; i < rowCount; i++ {
 			rows[i] = result.Rows[i]
 		}
-		qr.Rows = rows
 	}
+	qr.Rows = rows
+
 	return qr, nil
 }
 

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -809,7 +809,7 @@ func handleAndVerifySchemaInfoError(t *testing.T, msg string, tabletErrType int)
 	}
 	tabletError, ok := err.(*TabletError)
 	if !ok {
-		t.Fatalf("should return a TabletError")
+		t.Fatalf("should return a TabletError, but got err: %v", err)
 	}
 	if tabletError.ErrorType != tabletErrType {
 		t.Fatalf("should return a TabletError with error type: %s", getTabletErrorString(tabletErrType))


### PR DESCRIPTION
fakesqldb.Conn will not init proto.QueryResult.Rows if RowsAffected is zero.
However, according to go/mysql/mysql.go, the ideal response should be an empty
proto.QueryResult.Rows.