### PR TITLE
WIP: vtworker: Fix SIGINT handling for interactive worker.

### DIFF
--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -59,7 +59,9 @@ func installSignalHandlers() {
 		// we got a signal, notify our modules
 		currentWorkerMutex.Lock()
 		defer currentWorkerMutex.Unlock()
-		currentWorker.Cancel()
+		if currentWorker != nil {
+			currentWorker.Cancel()
+		}
 	}()
 }
 


### PR DESCRIPTION
Shutting down an interactive worker was broken because of:
"panic: runtime error: invalid memory address or nil pointer
dereference"

Before this fix the process terminated due to the panic.

Now the process does not terminate. For example, "proc.Wait()" in run.go
seems to be still running because it only stops in case of a SIGTERM.

This is probably not the intended behavior? Otherwise, a user cannot stop a vtworker from his shell using Ctrl+C. A regular "kill" with SIGTERM still works however.

Let's discuss how to best fix this with somebody who is more familiar
with the rest of the code.

@aaijazi 