### PR TITLE
make tableacl.load public

### DIFF
--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -23,20 +23,20 @@ func Init(configFile string) {
 	if err != nil {
 		log.Fatalf("unable to read tableACL config file: %v", err)
 	}
-	tableAcl, err = load(config)
+	tableAcl, err = Load(config)
 	if err != nil {
 		log.Fatalf("tableACL initialization error: %v", err)
 	}
 }
 
-// load loads configurations from a JSON byte array
+// Load loads configurations from a JSON byte array
 //
 // Sample configuration
 // []byte (`{
 //	<tableRegexPattern1>: {"READER": "*", "WRITER": "<u2>,<u4>...","ADMIN": "<u5>"},
 //	<tableRegexPattern2>: {"ADMIN": "<u5>"}
 //}`)
-func load(config []byte) (map[*regexp.Regexp]map[Role]ACL, error) {
+func Load(config []byte) (map[*regexp.Regexp]map[Role]ACL, error) {
 	var contents map[string]map[string]string
 	err := json.Unmarshal(config, &contents)
 	if err != nil {

--- a/go/vt/tableacl/tableacl_test.go
+++ b/go/vt/tableacl/tableacl_test.go
@@ -76,7 +76,7 @@ func TestDisabled(t *testing.T) {
 
 func checkLoad(configData []byte, valid bool, t *testing.T) {
 	var err error
-	tableAcl, err = load(configData)
+	tableAcl, err = Load(configData)
 	if !valid && err == nil {
 		t.Errorf("expecting parse error none returned")
 	}


### PR DESCRIPTION
This small change eases the table acl related unit tests in other components.
One can inject new table acl from a byte array instead of loading it from a
file.