### PR TITLE
add InitFromBytes func in tableacl

### DIFF
--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-// ACL is an interface for Access Control List
+// ACL is an interface for Access Control List.
 type ACL interface {
 	// IsMember checks the membership of a principal in this ACL
 	IsMember(principal string) bool
@@ -17,7 +17,7 @@ type ACL interface {
 
 var tableAcl map[*regexp.Regexp]map[Role]ACL
 
-// Init initiates table ACLs
+// Init initiates table ACLs.
 func Init(configFile string) {
 	config, err := ioutil.ReadFile(configFile)
 	if err != nil {
@@ -27,6 +27,12 @@ func Init(configFile string) {
 	if err != nil {
 		log.Fatalf("tableACL initialization error: %v", err)
 	}
+}
+
+// InitFromBytes inits table ACLs from a byte array.
+func InitFromBytes(config []byte) (err error) {
+	tableAcl, err = load(config)
+	return
 }
 
 // load loads configurations from a JSON byte array
@@ -77,7 +83,7 @@ func load(config []byte) (map[*regexp.Regexp]map[Role]ACL, error) {
 }
 
 // Authorized returns the list of entities who have at least the
-// minimum specified Role on a table
+// minimum specified Role on a table.
 func Authorized(table string, minRole Role) ACL {
 	// If table ACL is disabled, return nil
 	if tableAcl == nil {

--- a/go/vt/tableacl/tableacl_test.go
+++ b/go/vt/tableacl/tableacl_test.go
@@ -33,7 +33,6 @@ func TestValidConfigs(t *testing.T) {
 		"table[0-9]+":{"Reader":"u1,`+ALL+`", "WRITER":"u3"},
 		"tbl[0-9]+":{"Reader":"u1,`+ALL+`", "WRITER":"u3", "ADMIN":"u4"}
 	}`), true, t)
-
 }
 
 func TestDenyReaderInsert(t *testing.T) {
@@ -75,8 +74,7 @@ func TestDisabled(t *testing.T) {
 }
 
 func checkLoad(configData []byte, valid bool, t *testing.T) {
-	var err error
-	tableAcl, err = load(configData)
+	err := InitFromBytes(configData)
 	if !valid && err == nil {
 		t.Errorf("expecting parse error none returned")
 	}


### PR DESCRIPTION
InitFromBytes loads tableacl config from a byte array instead of a file.
This makes table acl related unit tests in other components  a little bit easy to write.