### PR TITLE
add MemcacheStats unit test

### DIFF
--- a/go/vt/tabletserver/cache_pool.go
+++ b/go/vt/tabletserver/cache_pool.go
@@ -22,9 +22,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// CreateCacheFunc defines the function signature to create a memcache connection.
-type CreateCacheFunc func() (cacheservice.CacheService, error)
-
 // CachePool re-exposes ResourcePool as a pool of Memcache connection objects.
 type CachePool struct {
 	name           string
@@ -49,7 +46,21 @@ func NewCachePool(
 	cp := &CachePool{name: name, idleTimeout: idleTimeout, statsURL: statsURL}
 	if name != "" {
 		cp.memcacheStats = NewMemcacheStats(
-			cp, rowCacheConfig.StatsPrefix, true, false, false)
+			rowCacheConfig.StatsPrefix+name, 10*time.Second, enableMain,
+			func(key string) string {
+				conn := cp.Get(context.Background())
+				// This is not the same as defer cachePool.Put(conn)
+				defer func() { cp.Put(conn) }()
+				stats, err := conn.Stats(key)
+				if err != nil {
+					conn.Close()
+					conn = nil
+					log.Errorf("Cannot export memcache %v stats: %v", key, err)
+					internalErrors.Add("MemcacheStats", 1)
+					return ""
+				}
+				return string(stats)
+			})
 		stats.Publish(name+"ConnPoolCapacity", stats.IntFunc(cp.Capacity))
 		stats.Publish(name+"ConnPoolAvailable", stats.IntFunc(cp.Available))
 		stats.Publish(name+"ConnPoolMaxCap", stats.IntFunc(cp.MaxCap))

--- a/go/vt/tabletserver/cache_pool_test.go
+++ b/go/vt/tabletserver/cache_pool_test.go
@@ -109,6 +109,7 @@ func TestCachePoolState(t *testing.T) {
 	idleTimeout := 1 * time.Second
 	cachePool.idleTimeout = idleTimeout
 	cachePool.Open()
+	cachePool.memcacheStats.update()
 	defer cachePool.Close()
 	if cachePool.Available() <= 0 {
 		t.Fatalf("cache pool should have connections available")

--- a/go/vt/tabletserver/fakecacheservice/fakecacheservice.go
+++ b/go/vt/tabletserver/fakecacheservice/fakecacheservice.go
@@ -182,7 +182,7 @@ func (service *FakeCacheService) FlushAll() error {
 }
 
 // Stats returns a list of basic stats.
-func (service *FakeCacheService) Stats(argument string) ([]byte, error) {
+func (service *FakeCacheService) Stats(key string) ([]byte, error) {
 	return []byte{}, nil
 }
 
@@ -191,14 +191,14 @@ func (service *FakeCacheService) Close() {
 }
 
 // Register registers a fake implementation of cacheservice.CacaheService and returns its registered name
-func Register() string {
+func Register() *Cache {
 	name := fmt.Sprintf("fake-%d", rand.Int63())
 	cache := &Cache{data: make(map[string]*cs.Result)}
 	cs.Register(name, func(cs.Config) (cs.CacheService, error) {
 		return NewFakeCacheService(cache), nil
 	})
 	cs.DefaultCacheService = name
-	return name
+	return cache
 }
 
 func init() {

--- a/go/vt/tabletserver/memcache_stats_test.go
+++ b/go/vt/tabletserver/memcache_stats_test.go
@@ -1,0 +1,183 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"expvar"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestMemcacheStats(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 1*time.Second, enableMain,
+		func(key string) string {
+			switch key {
+			case "slabs":
+				return ""
+			case "items":
+				return ""
+			}
+			return "STAT threads 1\n"
+		},
+	)
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheThreads", "1")
+}
+
+func TestMemcacheStatsInvalidMainStatsValueType(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 1*time.Second, enableMain,
+		func(key string) string {
+			switch key {
+			case "slabs":
+				return ""
+			case "items":
+				return ""
+			}
+			return "STAT threads invalid_val\n" +
+				// incomplete stats
+				"STAT threads"
+		},
+	)
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheThreads", "-1")
+}
+
+func TestMemcacheStatsSlabsStats(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 1*time.Second, enableSlabs,
+		func(key string) string {
+			switch key {
+			case "slabs":
+				return "STAT active_slabs 5\n" +
+					"STAT 1:total_pages 1\n" +
+					// invalid value
+					"STAT 1:total_chunks invalid_val\n" +
+					// invalid key format
+					"STAT 1:used_chunks:invalid 10081\n" +
+					// unknown slab metric
+					"STAT 1:unknown_metrics 123\n" +
+					"STAT 1:free_chunks 1\n" +
+					"STAT 1:free_chunks_end 10079\n"
+			case "items":
+				return ""
+			}
+			return ""
+		},
+	)
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsActiveSlabs", `5`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsTotalPages", `{"1": 1}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsTotalChunks", `{}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsUsedChunks", `{}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsFreeChunks", `{"1": 1}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheSlabsFreeChunksEnd", `{"1": 10079}`)
+
+	if expvar.Get(statsPrefix+"MemcacheSlabsUnknownMetrics") != nil {
+		t.Fatalf("%s should not be exported", statsPrefix+"MemcacheSlabsUnknownMetrics")
+	}
+}
+
+func TestMemcacheStatsItemsStats(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 1*time.Second, enableItems,
+		func(key string) string {
+			switch key {
+			case "slabs":
+				return ""
+			case "items":
+				return "STAT items:2:number 1\n" +
+					// invalid item value
+					"STAT items:2:age invalid_value\n" +
+					// invalid item key format
+					"STAT items:2:age:invalid 10\n" +
+					// unknown item metric
+					"STAT items:2:unknown_item 20\n" +
+					"STAT items:2:evicted 4\n" +
+					"STAT items:2:evicted_nonzero 5\n" +
+					"STAT items:2:evicted_time 2\n" +
+					"STAT items:2:outofmemory 7\n" +
+					"STAT items:2:tailrepairs 11\n"
+			}
+			return ""
+		},
+	)
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsNumber", `{"2": 1}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsEvicted", `{"2": 4}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsEvictedNonzero", `{"2": 5}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsEvictedTime", `{"2": 2}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsOutofmemory", `{"2": 7}`)
+	checkMemcacheExpvar(t, statsPrefix+"MemcacheItemsTailrepairs", `{"2": 11}`)
+
+	if expvar.Get(statsPrefix+"MemcacheItemsUnknownItem") != nil {
+		t.Fatalf("%s should not be exported", statsPrefix+"MemcacheItemsUnknownItem")
+	}
+}
+
+func TestMemcacheStatsPanic(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 100*time.Second, enableMain,
+		func(key string) string {
+			panic("unknown error")
+		},
+	)
+	errCountBefore := internalErrors.Counts()["MemcacheStats"]
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	errCountAfter := internalErrors.Counts()["MemcacheStats"]
+	if errCountAfter-errCountBefore != 1 {
+		t.Fatalf("got unknown panic, MemcacheStats counter should increase by 1")
+	}
+}
+
+func TestMemcacheStatsTabletError(t *testing.T) {
+	statsPrefix := newStatsPrefix()
+	memcacheStats := NewMemcacheStats(
+		statsPrefix, 100*time.Second, enableMain,
+		func(key string) string {
+			panic(NewTabletError(ErrFail, "unknown tablet error"))
+		},
+	)
+	errCountBefore := internalErrors.Counts()["MemcacheStats"]
+	memcacheStats.Open()
+	defer memcacheStats.Close()
+	memcacheStats.update()
+	errCountAfter := internalErrors.Counts()["MemcacheStats"]
+	if errCountAfter-errCountBefore != 1 {
+		t.Fatalf("got tablet error, MemcacheStats counter should increase by 1")
+	}
+}
+
+func checkMemcacheExpvar(t *testing.T, name string, expectedVal string) {
+	val := expvar.Get(name)
+	if val == nil {
+		t.Fatalf("cannot find exported variable: %s", name)
+	}
+	if val.String() != expectedVal {
+		t.Fatalf("name: %s, expect to get %s, but got: %s", name, expectedVal, val.String())
+	}
+}
+
+func newStatsPrefix() string {
+	return fmt.Sprintf("TestMemcache-%d-", rand.Int63())
+}


### PR DESCRIPTION
1. remove cache pool dependency from MemcacheStats; instead, NewMemcacheStats func takes
   a func param to return memcache stats. This change makes MemcacheStats more lightweight
   and easy to unit test.
2. replace bool params in original NewMemcacheStats func by flags: enableMain, enableSlabs
   and enableItems.
3. Pre-allocate memory for MemcacheStats.main, slabs and items. This removes several null checks.
4. expose refresh freq to let caller decide how frequent to refresh the stats.
5. replace one log error place by panic in updateSlabsStats func. Since slabsSingleMetrics and
   MemcacheStats.slabs should always be in sync (keys presents in slabsSingleMetrics should also
   presents in MemcacheStats.slabs, this is guaranteed by publishSlabsStats func), always panic
   if a key is found presents in slabsSingleMetrics but not in MemcacheStats.slabs.