### PR TITLE
add streamlogger unit test

### DIFF
--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -252,7 +252,7 @@ func (qre *QueryExecutor) fetchMulti(pkRows [][]sqltypes.Value, limit int64) (re
 	qre.logStats.CacheAbsent = absent
 	qre.logStats.CacheMisses = misses
 
-	qre.logStats.QuerySources |= QUERY_SOURCE_ROWCACHE
+	qre.logStats.QuerySources |= QuerySourceRowcache
 
 	tableInfo.hits.Add(hits)
 	tableInfo.absent.Add(absent)
@@ -538,7 +538,7 @@ func (qre *QueryExecutor) qFetch(logStats *SQLQueryStats, parsedQuery *sqlparser
 			q.Result, q.Err = qre.execSQLNoPanic(conn, sql, false)
 		}
 	} else {
-		logStats.QuerySources |= QUERY_SOURCE_CONSOLIDATOR
+		logStats.QuerySources |= QuerySourceConsolidator
 		startTime := time.Now()
 		q.Wait()
 		waitStats.Record("Consolidations", startTime)

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -6,7 +6,6 @@ package tabletserver
 
 import (
 	"fmt"
-	"html/template"
 	"math/rand"
 	"reflect"
 	"testing"
@@ -23,27 +22,6 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"golang.org/x/net/context"
 )
-
-type fakeCallInfo struct {
-	remoteAddr string
-	username   string
-}
-
-func (fci *fakeCallInfo) RemoteAddr() string {
-	return fci.remoteAddr
-}
-
-func (fci *fakeCallInfo) Username() string {
-	return fci.username
-}
-
-func (fci *fakeCallInfo) Text() string {
-	return ""
-}
-
-func (fci *fakeCallInfo) HTML() template.HTML {
-	return template.HTML("")
-}
 
 func TestQueryExecutorPlanDDL(t *testing.T) {
 	db := setUpQueryExecutorTest()

--- a/go/vt/tabletserver/sqlquery_stats.go
+++ b/go/vt/tabletserver/sqlquery_stats.go
@@ -23,9 +23,12 @@ import (
 var SqlQueryLogger = streamlog.New("SqlQuery", 50)
 
 const (
-	QUERY_SOURCE_ROWCACHE = 1 << iota
-	QUERY_SOURCE_CONSOLIDATOR
-	QUERY_SOURCE_MYSQL
+	// QuerySourceRowcache means query result is found in rowcache.
+	QuerySourceRowcache = 1 << iota
+	// QuerySourceConsolidator means query result is found in consolidator.
+	QuerySourceConsolidator
+	// QuerySourceMySQL means query result is returned from MySQL.
+	QuerySourceMySQL
 )
 
 // SQLQueryStats records the stats for a single query
@@ -68,7 +71,7 @@ func (stats *SQLQueryStats) Send() {
 
 // AddRewrittenSql adds a single sql statement to the rewritten list
 func (stats *SQLQueryStats) AddRewrittenSql(sql string, start time.Time) {
-	stats.QuerySources |= QUERY_SOURCE_MYSQL
+	stats.QuerySources |= QuerySourceMySQL
 	stats.NumberOfQueries++
 	stats.rewrittenSqls = append(stats.rewrittenSqls, sql)
 	stats.MysqlResponseTime += time.Now().Sub(start)
@@ -140,15 +143,15 @@ func (stats *SQLQueryStats) FmtQuerySources() string {
 	}
 	sources := make([]string, 3)
 	n := 0
-	if stats.QuerySources&QUERY_SOURCE_MYSQL != 0 {
+	if stats.QuerySources&QuerySourceMySQL != 0 {
 		sources[n] = "mysql"
 		n++
 	}
-	if stats.QuerySources&QUERY_SOURCE_ROWCACHE != 0 {
+	if stats.QuerySources&QuerySourceRowcache != 0 {
 		sources[n] = "rowcache"
 		n++
 	}
-	if stats.QuerySources&QUERY_SOURCE_CONSOLIDATOR != 0 {
+	if stats.QuerySources&QuerySourceConsolidator != 0 {
 		sources[n] = "consolidator"
 		n++
 	}

--- a/go/vt/tabletserver/sqlquery_stats_test.go
+++ b/go/vt/tabletserver/sqlquery_stats_test.go
@@ -1,0 +1,142 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/callinfo"
+	"golang.org/x/net/context"
+)
+
+func TestSqlQueryStats(t *testing.T) {
+	logStats := newSqlQueryStats("test", context.Background())
+	logStats.AddRewrittenSql("sql1", time.Now())
+
+	if !strings.Contains(logStats.RewrittenSql(), "sql1") {
+		t.Fatalf("RewrittenSql should contains sql: sql1")
+	}
+
+	if logStats.SizeOfResponse() != 0 {
+		t.Fatalf("there is no rows in log stats, estimated size should be 0 bytes")
+	}
+
+	logStats.Rows = [][]sqltypes.Value{[]sqltypes.Value{sqltypes.MakeString([]byte("a"))}}
+	if logStats.SizeOfResponse() <= 0 {
+		t.Fatalf("log stats has some rows, should have positive response size")
+	}
+
+	params := map[string][]string{"full": []string{}}
+
+	logStats.Format(url.Values(params))
+}
+
+func TestSqlQueryStatsFormatBindVariables(t *testing.T) {
+	logStats := newSqlQueryStats("test", context.Background())
+	logStats.BindVariables = make(map[string]interface{})
+	logStats.BindVariables["key_1"] = "val_1"
+	logStats.BindVariables["key_2"] = 789
+
+	formattedStr := logStats.FmtBindVariables(true)
+	if !strings.Contains(formattedStr, "key_1") ||
+		!strings.Contains(formattedStr, "val_1") {
+		t.Fatalf("bind variable 'key_1': 'val_1' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_2") ||
+		!strings.Contains(formattedStr, "789") {
+		t.Fatalf("bind variable 'key_2': '789' is not formatted")
+	}
+
+	logStats.BindVariables["key_3"] = []byte("val_3")
+	formattedStr = logStats.FmtBindVariables(false)
+	if !strings.Contains(formattedStr, "key_1") {
+		t.Fatalf("bind variable 'key_1' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_2") ||
+		!strings.Contains(formattedStr, "789") {
+		t.Fatalf("bind variable 'key_2': '789' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_3") {
+		t.Fatalf("bind variable 'key_3' is not formatted")
+	}
+}
+
+func TestSqlQueryStatsFormatQuerySources(t *testing.T) {
+	logStats := newSqlQueryStats("test", context.Background())
+	if logStats.FmtQuerySources() != "none" {
+		t.Fatalf("should return none since log stats does not have any query source, but got: %s", logStats.FmtQuerySources())
+	}
+
+	logStats.QuerySources |= QuerySourceMySQL
+	if !strings.Contains(logStats.FmtQuerySources(), "mysql") {
+		t.Fatalf("'mysql' should be in formated query sources")
+	}
+
+	logStats.QuerySources |= QuerySourceRowcache
+	if !strings.Contains(logStats.FmtQuerySources(), "rowcache") {
+		t.Fatalf("'rowcache' should be in formated query sources")
+	}
+
+	logStats.QuerySources |= QuerySourceConsolidator
+	if !strings.Contains(logStats.FmtQuerySources(), "consolidator") {
+		t.Fatalf("'consolidator' should be in formated query sources")
+	}
+}
+
+func TestSqlQueryStatsContextHTML(t *testing.T) {
+	html := "HtmlContext"
+	callInfo := &fakeCallInfo{
+		html: html,
+	}
+	ctx := callinfo.NewContext(context.Background(), callInfo)
+	logStats := newSqlQueryStats("test", ctx)
+	if string(logStats.ContextHTML()) != html {
+		t.Fatalf("expect to get html: %s, but got: %s", html, string(logStats.ContextHTML()))
+	}
+}
+
+func TestSqlQueryStatsErrorStr(t *testing.T) {
+	logStats := newSqlQueryStats("test", context.Background())
+	if logStats.ErrorStr() != "" {
+		t.Fatalf("should not get error in stats, but got: %s", logStats.ErrorStr())
+	}
+	errStr := "unknown error"
+	logStats.Error = fmt.Errorf(errStr)
+	if logStats.ErrorStr() != errStr {
+		t.Fatalf("expect to get error string: %s, but got: %s", errStr, logStats.ErrorStr())
+	}
+}
+
+func TestSqlQueryStatsRemoteAddrUsername(t *testing.T) {
+	logStats := newSqlQueryStats("test", context.Background())
+	addr, user := logStats.RemoteAddrUsername()
+	if addr != "" {
+		t.Fatalf("remote addr should be empty")
+	}
+	if user != "" {
+		t.Fatalf("username should be empty")
+	}
+
+	remoteAddr := "1.2.3.4"
+	username := "vt"
+	callInfo := &fakeCallInfo{
+		remoteAddr: remoteAddr,
+		username:   username,
+	}
+	ctx := callinfo.NewContext(context.Background(), callInfo)
+	logStats = newSqlQueryStats("test", ctx)
+	addr, user = logStats.RemoteAddrUsername()
+	if addr != remoteAddr {
+		t.Fatalf("expected to get remote addr: %s, but got: %s", remoteAddr, addr)
+	}
+	if user != username {
+		t.Fatalf("expected to get username: %s, but got: %s", username, user)
+	}
+}

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import "html/template"
+
+type fakeCallInfo struct {
+	remoteAddr string
+	username   string
+	text       string
+	html       string
+}
+
+func (fci *fakeCallInfo) RemoteAddr() string {
+	return fci.remoteAddr
+}
+
+func (fci *fakeCallInfo) Username() string {
+	return fci.username
+}
+
+func (fci *fakeCallInfo) Text() string {
+	return fci.text
+}
+
+func (fci *fakeCallInfo) HTML() template.HTML {
+	return template.HTML(fci.html)
+}


### PR DESCRIPTION
1. Rename streamlogger.go to sqlstats_stats.go since this matches file content better.
2. Rename QUERY_SOURCE_* contants to use camel case as suggested by golint.
3. Create a testutils_test.go to contain common test unitilies that could share among
   all queryservice unit tests.