### PR TITLE
refactor sqlquery unit test and improve coverage

### DIFF
--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -807,6 +807,10 @@ func handleAndVerifyTabletError(t *testing.T, msg string, tabletErrType int) {
 	if err == nil {
 		t.Fatalf(msg)
 	}
+	verifyTabletError(t, err, tabletErrType)
+}
+
+func verifyTabletError(t *testing.T, err interface{}, tabletErrType int) {
 	tabletError, ok := err.(*TabletError)
 	if !ok {
 		t.Fatalf("should return a TabletError, but got err: %v", err)

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -20,19 +20,46 @@ import (
 	"golang.org/x/net/context"
 )
 
-var testSqlQuery *SqlQuery
+func TestSqlQueryAllowQueriesFailBadConn(t *testing.T) {
+	db := setUpSqlQueryTest()
+	db.EnableConnFail()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err == nil {
+		t.Fatalf("SqlQuery.allowQueries should fail")
+	}
+	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+}
+
+func TestSqlQueryAllowQueriesFailStrictModeConflictWithRowCache(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	// disable strict mode
+	config.StrictMode = false
+	sqlQuery := NewSqlQuery(config)
+	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	dbconfigs := newTestDBConfigs()
+	// enable rowcache
+	dbconfigs.App.EnableRowcache = true
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err == nil {
+		t.Fatalf("SqlQuery.allowQueries should fail because strict mode is disabled while rowcache is enabled.")
+	}
+	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+}
 
 func TestSqlQueryAllowQueries(t *testing.T) {
-	fakesqldb.Register()
-	sqlQuery := getSqlQuery()
-	if sqlQuery.GetState() != "NOT_SERVING" {
-		t.Fatalf("sqlquery should in state: NOT_SERVING, but get state: %s", sqlQuery.GetState())
-	}
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	dbconfigs := newTestDBConfigs()
 	sqlQuery.setState(StateServing)
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success, but get error: %v", err)
 	}
@@ -41,46 +68,81 @@ func TestSqlQueryAllowQueries(t *testing.T) {
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail")
 	}
-	sqlQuery.setState(StateNotServing)
-	db := fakesqldb.Register()
-	// cause db connection to fail
-	db.EnableConnFail()
-	err = sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
-	if err == nil {
-		t.Fatalf("SqlQuery.allowQueries should fail because of failed to create a new connection")
+	sqlQuery.disallowQueries()
+}
+
+func TestSqlQueryCheckMysql(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	defer sqlQuery.disallowQueries()
+	if err != nil {
+		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
+	}
+	if !sqlQuery.checkMySQL() {
+		t.Fatalf("checkMySQL should return true")
 	}
 }
 
-func TestCheckMysql(t *testing.T) {
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
+func TestSqlQueryCheckMysqlFailInvalidConn(t *testing.T) {
+	db := setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	defer sqlQuery.disallowQueries()
+	if err != nil {
+		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
 	}
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	// make mysql conn fail
+	db.EnableConnFail()
+	if sqlQuery.checkMySQL() {
+		t.Fatalf("checkMySQL should return false")
+	}
+}
+
+func TestSqlQueryCheckMysqlFailUninitializedQueryEngine(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	// this causes QueryEngine not being initialized properly
 	sqlQuery.setState(StateServing)
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	defer sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
 	}
-	sqlQuery.checkMySQL()
+	// QueryEngine.CheckMySQL shoudl panic and checkMySQL should return false
+	if sqlQuery.checkMySQL() {
+		t.Fatalf("checkMySQL should return false")
+	}
 }
 
-func TestGetSessionId(t *testing.T) {
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
+func TestSqlQueryCheckMysqlInNotServingState(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	// sqlquery start request fail because we are in StateNotServing;
+	// however, checkMySQL should return true. Here, we always assume
+	// MySQL is healthy unless we've verified it is not.
+	if !sqlQuery.checkMySQL() {
+		t.Fatalf("checkMySQL should return true")
 	}
-	sqlQuery := getSqlQuery()
+}
+
+func TestSqlQueryGetSessionId(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
 	if err := sqlQuery.GetSessionId(nil, nil); err == nil {
 		t.Fatalf("call GetSessionId should get an error")
 	}
 	keyspace := "test_keyspace"
 	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -115,24 +177,113 @@ func TestGetSessionId(t *testing.T) {
 	}
 }
 
-func TestTransactionCommit(t *testing.T) {
+func TestSqlQueryCommandFailUnMatchedSessionId(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	session := proto.Session{
+		SessionId:     0,
+		TransactionId: 0,
+	}
+	txInfo := proto.TransactionInfo{TransactionId: 0}
+	if err = sqlQuery.Begin(ctx, &session, &txInfo); err == nil {
+		t.Fatalf("call SqlQuery.Begin should fail because of an invalid session id: 0")
+	}
+
+	if err = sqlQuery.Commit(ctx, &session); err == nil {
+		t.Fatalf("call SqlQuery.Commit should fail because of an invalid session id: 0")
+	}
+
+	if err = sqlQuery.Rollback(ctx, &session); err == nil {
+		t.Fatalf("call SqlQuery.Rollback should fail because of an invalid session id: 0")
+	}
+
+	query := proto.Query{
+		Sql:           "select * from test_table limit 1000",
+		BindVariables: nil,
+		SessionId:     session.SessionId,
+		TransactionId: session.TransactionId,
+	}
+	reply := mproto.QueryResult{}
+	if err := sqlQuery.Execute(ctx, &query, &reply); err == nil {
+		t.Fatalf("call SqlQuery.Execute should fail because of an invalid session id: 0")
+	}
+
+	streamSendReply := func(*mproto.QueryResult) error { return nil }
+	if err = sqlQuery.StreamExecute(ctx, &query, streamSendReply); err == nil {
+		t.Fatalf("call SqlQuery.StreamExecute should fail because of an invalid session id: 0")
+	}
+
+	batchQuery := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "begin",
+				BindVariables: nil,
+			},
+			proto.BoundQuery{
+				Sql:           "commit",
+				BindVariables: nil,
+			},
+		},
+		SessionId: session.SessionId,
+	}
+
+	batchReply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+			mproto.QueryResult{},
+		},
+	}
+	if err = sqlQuery.ExecuteBatch(ctx, &batchQuery, &batchReply); err == nil {
+		t.Fatalf("call SqlQuery.ExecuteBatch should fail because of an invalid session id: 0")
+	}
+
+	splitQuery := proto.SplitQueryRequest{
+		Query: proto.BoundQuery{
+			Sql:           "select * from test_table where count > :count",
+			BindVariables: nil,
+		},
+		SplitCount: 10,
+		SessionID:  session.SessionId,
+	}
+
+	splitQueryReply := proto.SplitQueryResult{
+		Queries: []proto.QuerySplit{
+			proto.QuerySplit{
+				Query: proto.BoundQuery{
+					Sql:           "",
+					BindVariables: nil,
+				},
+				RowCount: 10,
+			},
+		},
+	}
+	if err = sqlQuery.SplitQuery(ctx, &splitQuery, &splitQueryReply); err == nil {
+		t.Fatalf("call SqlQuery.SplitQuery should fail because of an invalid session id: 0")
+	}
+}
+
+func TestSqlQueryCommitTransaciton(t *testing.T) {
+	db := setUpSqlQueryTest()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table"
+	executeSql := "select * from test_table limit 1000"
 	executeSqlResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
 	db.AddQuery(executeSql, executeSqlResult)
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -163,25 +314,21 @@ func TestTransactionCommit(t *testing.T) {
 	}
 }
 
-func TestTransactionRollback(t *testing.T) {
+func TestSqlQueryRollback(t *testing.T) {
+	db := setUpSqlQueryTest()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table"
+	executeSql := "select * from test_table limit 1000"
 	executeSqlResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
 	db.AddQuery(executeSql, executeSqlResult)
 
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -212,25 +359,22 @@ func TestTransactionRollback(t *testing.T) {
 	}
 }
 
-func TestStreamExecute(t *testing.T) {
+func TestSqlQueryStreamExecute(t *testing.T) {
+	db := setUpSqlQueryTest()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table"
+	executeSql := "select * from test_table limit 1000"
 	executeSqlResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
 	db.AddQuery(executeSql, executeSqlResult)
 
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -266,21 +410,19 @@ func TestStreamExecute(t *testing.T) {
 	}
 }
 
-func TestExecuteBatch(t *testing.T) {
-	sql := "INSERT INTO test_table VALUES(1, 2)"
-	sqlResult := &mproto.QueryResult{
-		RowsAffected: 1,
-	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
-	db.AddQuery(sql, sqlResult)
+func TestSqlQueryExecuteBatch(t *testing.T) {
+	db := setUpSqlQueryTest()
+	sql := "insert into test_table values (1, 2)"
+	sqlResult := &mproto.QueryResult{}
+	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
 
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	db.AddQuery(sql, sqlResult)
+	db.AddQuery(expanedSql, sqlResult)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -313,25 +455,306 @@ func TestExecuteBatch(t *testing.T) {
 		},
 	}
 	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err != nil {
-		t.Fatalf("SqlQuery.Execute should success: %v, but get error: %v",
+		t.Fatalf("SqlQuery.ExecuteBatch should success: %v, but get error: %v",
 			query, err)
 	}
 }
 
-func TestExecuteBatchNestedTransaction(t *testing.T) {
-	sql := "INSERT INTO test_table VALUES(1, 2)"
-	sqlResult := &mproto.QueryResult{
-		RowsAffected: 1,
+func TestSqlQueryExecuteBatchFailEmptyQueryList(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
 	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries:   []proto.BoundQuery{},
+		SessionId: sqlQuery.sessionID,
 	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{},
+	}
+	err = sqlQuery.ExecuteBatch(ctx, &query, &reply)
+	verifyTabletError(t, err, ErrFail)
+}
+
+func TestSqlQueryExecuteBatchBeginFail(t *testing.T) {
+	db := setUpSqlQueryTest()
+	// make "begin" query fail
+	db.AddRejectedQuery("begin")
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "begin",
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+		},
+	}
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+}
+
+func TestSqlQueryExecuteBatchCommitFail(t *testing.T) {
+	db := setUpSqlQueryTest()
+	// make "commit" query fail
+	db.AddRejectedQuery("commit")
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "begin",
+				BindVariables: nil,
+			},
+			proto.BoundQuery{
+				Sql:           "commit",
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+			mproto.QueryResult{},
+		},
+	}
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+}
+
+func TestSqlQueryExecuteBatchSqlExecFailInTransaction(t *testing.T) {
+	db := setUpSqlQueryTest()
+	sql := "insert into test_table values (1, 2)"
+	sqlResult := &mproto.QueryResult{}
+	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+
 	db.AddQuery(sql, sqlResult)
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	db.AddQuery(expanedSql, sqlResult)
+
+	// make this query fail
+	db.AddRejectedQuery(sql)
+	db.AddRejectedQuery(expanedSql)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "begin",
+				BindVariables: nil,
+			},
+			proto.BoundQuery{
+				Sql:           sql,
+				BindVariables: nil,
+			},
+			proto.BoundQuery{
+				Sql:           "commit",
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+			*sqlResult,
+			mproto.QueryResult{},
+		},
+	}
+
+	if db.GetQueryCalledNum("rollback") != 0 {
+		t.Fatalf("rollback should not be executed.")
+	}
+
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+
+	if db.GetQueryCalledNum("rollback") != 1 {
+		t.Fatalf("rollback should be executed only once.")
+	}
+}
+
+func TestSqlQueryExecuteBatchFailBeginWithoutCommit(t *testing.T) {
+	db := setUpSqlQueryTest()
+	sql := "insert into test_table values (1, 2)"
+	sqlResult := &mproto.QueryResult{}
+	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+
+	db.AddQuery(sql, sqlResult)
+	db.AddQuery(expanedSql, sqlResult)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "begin",
+				BindVariables: nil,
+			},
+			proto.BoundQuery{
+				Sql:           sql,
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+			*sqlResult,
+		},
+	}
+
+	if db.GetQueryCalledNum("rollback") != 0 {
+		t.Fatalf("rollback should not be executed.")
+	}
+
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+
+	if db.GetQueryCalledNum("rollback") != 1 {
+		t.Fatalf("rollback should be executed only once.")
+	}
+}
+
+func TestSqlQueryExecuteBatchSqlExecFailNotInTransaction(t *testing.T) {
+	db := setUpSqlQueryTest()
+	sql := "insert into test_table values (1, 2)"
+	sqlResult := &mproto.QueryResult{}
+	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+
+	db.AddQuery(sql, sqlResult)
+	db.AddQuery(expanedSql, sqlResult)
+
+	// cause execution error for this particular sql query
+	db.AddRejectedQuery(sql)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           sql,
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			*sqlResult,
+		},
+	}
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+}
+
+func TestSqlQueryExecuteBatchCallCommitWithoutABegin(t *testing.T) {
+	setUpSqlQueryTest()
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.QueryList{
+		Queries: []proto.BoundQuery{
+			proto.BoundQuery{
+				Sql:           "commit",
+				BindVariables: nil,
+			},
+		},
+		SessionId: sqlQuery.sessionID,
+	}
+
+	reply := proto.QueryResultList{
+		List: []mproto.QueryResult{
+			mproto.QueryResult{},
+		},
+	}
+	if err := sqlQuery.ExecuteBatch(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.ExecuteBatch should fail")
+	}
+}
+
+func TestExecuteBatchNestedTransaction(t *testing.T) {
+	db := setUpSqlQueryTest()
+	sql := "insert into test_table values (1, 2)"
+	sqlResult := &mproto.QueryResult{}
+	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+
+	db.AddQuery(sql, sqlResult)
+	db.AddQuery(expanedSql, sqlResult)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -380,19 +803,12 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 }
 
 func TestSqlQuerySplitQuery(t *testing.T) {
-	sql := "INSERT INTO test_table VALUES(1, 2)"
-	sqlResult := &mproto.QueryResult{
-		RowsAffected: 1,
-	}
-	db := fakesqldb.Register()
-	for query, result := range getSupportedQueries() {
-		db.AddQuery(query, result)
-	}
-	db.AddQuery(sql, sqlResult)
-	sqlQuery := getSqlQuery()
-	keyspace := "test_keyspace"
-	shard := "0"
-	dbconfigs := getTestDBConfigs(keyspace, shard)
+	setUpSqlQueryTest()
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
@@ -422,6 +838,98 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 	if err := sqlQuery.SplitQuery(ctx, &query, &reply); err != nil {
 		t.Fatalf("SqlQuery.SplitQuery should success: %v, but get error: %v",
 			query, err)
+	}
+}
+
+func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
+	setUpSqlQueryTest()
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.SplitQueryRequest{
+		Query: proto.BoundQuery{
+			// add limit clause to make SplitQuery fail
+			Sql:           "select * from test_table where count > :count limit 1000",
+			BindVariables: nil,
+		},
+		SplitCount: 10,
+		SessionID:  sqlQuery.sessionID,
+	}
+
+	reply := proto.SplitQueryResult{
+		Queries: []proto.QuerySplit{
+			proto.QuerySplit{
+				Query: proto.BoundQuery{
+					Sql:           "",
+					BindVariables: nil,
+				},
+				RowCount: 10,
+			},
+		},
+	}
+	if err := sqlQuery.SplitQuery(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.SplitQuery should fail")
+	}
+}
+
+func TestSqlQuerySplitQueryInvalidMinMax(t *testing.T) {
+	db := setUpSqlQueryTest()
+	pkMinMaxQuery := "SELECT MIN(pk), MAX(pk) FROM test_table"
+	pkMinMaxQueryResp := &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			// this make SplitQueryFail
+			[]sqltypes.Value{
+				sqltypes.MakeString([]byte("invalid")),
+				sqltypes.MakeString([]byte("invalid")),
+			},
+		},
+	}
+	db.AddQuery(pkMinMaxQuery, pkMinMaxQueryResp)
+
+	config := newTestSqlQueryConfig()
+	sqlQuery := NewSqlQuery(config)
+
+	dbconfigs := newTestDBConfigs()
+	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, newMysqld(&dbconfigs))
+	if err != nil {
+		t.Fatalf("allowQueries failed: %v", err)
+	}
+	defer sqlQuery.disallowQueries()
+	ctx := context.Background()
+	query := proto.SplitQueryRequest{
+		Query: proto.BoundQuery{
+			Sql:           "select * from test_table where count > :count",
+			BindVariables: nil,
+		},
+		SplitCount: 10,
+		SessionID:  sqlQuery.sessionID,
+	}
+
+	reply := proto.SplitQueryResult{
+		Queries: []proto.QuerySplit{
+			proto.QuerySplit{
+				Query: proto.BoundQuery{
+					Sql:           "",
+					BindVariables: nil,
+				},
+				RowCount: 10,
+			},
+		},
+	}
+	if err := sqlQuery.SplitQuery(ctx, &query, &reply); err == nil {
+		t.Fatalf("SqlQuery.SplitQuery should fail")
 	}
 }
 
@@ -501,7 +1009,15 @@ func TestTerseErrors2(t *testing.T) {
 	})
 }
 
-func getSqlQuery() *SqlQuery {
+func setUpSqlQueryTest() *fakesqldb.DB {
+	db := fakesqldb.Register()
+	for query, result := range getSupportedQueries() {
+		db.AddQuery(query, result)
+	}
+	return db
+}
+
+func newTestSqlQueryConfig() Config {
 	randID := rand.Int63()
 	config := DefaultQsConfig
 	config.StatsPrefix = fmt.Sprintf("Stats-%d-", randID)
@@ -509,7 +1025,9 @@ func getSqlQuery() *SqlQuery {
 	config.RowCache.StatsPrefix = fmt.Sprintf("Stats-%d-", randID)
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
 	config.StrictMode = true
-	return NewSqlQuery(config)
+	config.RowCache.Binary = "ls"
+	config.RowCache.Connections = 100
+	return config
 }
 
 func newMysqld(dbconfigs *dbconfigs.DBConfigs) *mysqlctl.Mysqld {
@@ -524,11 +1042,11 @@ func newMysqld(dbconfigs *dbconfigs.DBConfigs) *mysqlctl.Mysqld {
 	)
 }
 
-func getTestDBConfigs(keyspace string, shard string) dbconfigs.DBConfigs {
+func newTestDBConfigs() dbconfigs.DBConfigs {
 	appDBConfig := dbconfigs.DBConfig{
 		ConnParams:        sqldb.ConnParams{},
-		Keyspace:          keyspace,
-		Shard:             shard,
+		Keyspace:          "test_keyspace",
+		Shard:             "0",
 		EnableRowcache:    false,
 		EnableInvalidator: false,
 	}
@@ -537,8 +1055,12 @@ func getTestDBConfigs(keyspace string, shard string) dbconfigs.DBConfigs {
 	}
 }
 
-// getSupportedQueries returns a list of queries along with their expected responses
-// that a fake sqldb.Conn should support in order to unit test SqlQuery.
+func checkSqlQueryState(t *testing.T, sqlQuery *SqlQuery, expectState string) {
+	if sqlQuery.GetState() != expectState {
+		t.Fatalf("sqlquery should in state: %s, but get state: %s", expectState, sqlQuery.GetState())
+	}
+}
+
 func getSupportedQueries() map[string]*mproto.QueryResult {
 	return map[string]*mproto.QueryResult{
 		// queries for schema info
@@ -547,6 +1069,15 @@ func getSupportedQueries() map[string]*mproto.QueryResult {
 			Rows: [][]sqltypes.Value{
 				[]sqltypes.Value{sqltypes.MakeString([]byte("1427325875"))},
 			},
+		},
+		"select @@global.sql_mode": &mproto.QueryResult{
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				[]sqltypes.Value{sqltypes.MakeString([]byte("STRICT_TRANS_TABLES"))},
+			},
+		},
+		"select * from test_table where 1 != 1": &mproto.QueryResult{
+			Fields: getTestTableFields(),
 		},
 		baseShowTables: &mproto.QueryResult{
 			RowsAffected: 1,
@@ -559,17 +1090,27 @@ func getSupportedQueries() map[string]*mproto.QueryResult {
 				},
 			},
 		},
-		"select @@global.sql_mode": &mproto.QueryResult{
-			RowsAffected: 1,
-			Rows: [][]sqltypes.Value{
-				[]sqltypes.Value{sqltypes.MakeString([]byte("STRICT_TRANS_TABLES"))},
-			},
-		},
 		"describe `test_table`": &mproto.QueryResult{
-			RowsAffected: 1,
+			RowsAffected: 3,
 			Rows: [][]sqltypes.Value{
 				[]sqltypes.Value{
-					sqltypes.MakeString([]byte("column_01")),
+					sqltypes.MakeString([]byte("pk")),
+					sqltypes.MakeString([]byte("int")),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte("1")),
+					sqltypes.MakeString([]byte{}),
+				},
+				[]sqltypes.Value{
+					sqltypes.MakeString([]byte("name")),
+					sqltypes.MakeString([]byte("int")),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte("1")),
+					sqltypes.MakeString([]byte{}),
+				},
+				[]sqltypes.Value{
+					sqltypes.MakeString([]byte("addr")),
 					sqltypes.MakeString([]byte("int")),
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte{}),
@@ -580,16 +1121,39 @@ func getSupportedQueries() map[string]*mproto.QueryResult {
 		},
 		// for SplitQuery because it needs a primary key column
 		"show index from `test_table`": &mproto.QueryResult{
-			RowsAffected: 1,
+			RowsAffected: 2,
 			Rows: [][]sqltypes.Value{
 				[]sqltypes.Value{
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte("PRIMARY")),
 					sqltypes.MakeString([]byte{}),
-					sqltypes.MakeString([]byte("column_01")),
+					sqltypes.MakeString([]byte("pk")),
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte("300")),
+				},
+				[]sqltypes.Value{
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte("INDEX")),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte("name")),
+					sqltypes.MakeString([]byte{}),
+					sqltypes.MakeString([]byte("300")),
+				},
+			},
+		},
+		"begin":    &mproto.QueryResult{},
+		"commit":   &mproto.QueryResult{},
+		"rollback": &mproto.QueryResult{},
+		baseShowTables + " and table_name = 'test_table'": &mproto.QueryResult{
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				[]sqltypes.Value{
+					sqltypes.MakeString([]byte("test_table")),
+					sqltypes.MakeString([]byte("USER TABLE")),
+					sqltypes.MakeString([]byte("1427325875")),
+					sqltypes.MakeString([]byte("")),
 				},
 			},
 		},

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -4,7 +4,11 @@
 
 package tabletserver
 
-import "html/template"
+import (
+	"html/template"
+	"reflect"
+	"testing"
+)
 
 type fakeCallInfo struct {
 	remoteAddr string
@@ -27,4 +31,12 @@ func (fci *fakeCallInfo) Text() string {
 
 func (fci *fakeCallInfo) HTML() template.HTML {
 	return template.HTML(fci.html)
+}
+
+type testUtils struct{}
+
+func (util *testUtils) checkEqual(t *testing.T, expected interface{}, result interface{}) {
+	if !reflect.DeepEqual(expected, result) {
+		t.Fatalf("expect to get: %v, but got: %v", expected, result)
+	}
 }


### PR DESCRIPTION
this change effectively brings sqlquery.go test coverage to 99%

1. add "queryCalled" in fakesqldb.DB so that tests could know number of
   times a query hits a database.
2. add testUtils struct in testutils_test and this struct contains common
   test funcs that could be used in tabletserver package.
3. add sqlquery tests to test SqlQuery.allowQueries failure modes.
4. add sqlquery tests to test SqlQuery.checkMySQL failure modes.
5. add sqlquery tests to test transaction failure modes.
6. add sqlquery tests to test SqlQuery.ExecuteBatch failure modes.
7. add sqlquery tests to test SqlQuery.SplitQuery failure modes.