### PR TITLE
rename query rules and query rule info tests

### DIFF
--- a/go/vt/tabletserver/query_rule_info.go
+++ b/go/vt/tabletserver/query_rule_info.go
@@ -36,7 +36,8 @@ func (qri *QueryRuleInfo) RegisterQueryRuleSource(ruleSource string) {
 	qri.mu.Lock()
 	defer qri.mu.Unlock()
 	if _, existed := qri.queryRulesMap[ruleSource]; existed {
-		log.Fatal("Query rule source " + ruleSource + " has been registered")
+		log.Errorf("Query rule source " + ruleSource + " has been registered")
+		panic("Query rule source " + ruleSource + " has been registered")
 	}
 	qri.queryRulesMap[ruleSource] = NewQueryRules()
 }

--- a/go/vt/tabletserver/query_rules.go
+++ b/go/vt/tabletserver/query_rules.go
@@ -268,7 +268,7 @@ func (qr *QueryRule) AddBindVarCond(name string, onAbsent, onMismatch bool, op O
 			goto Error
 		}
 	case key.KeyRange:
-		if op < QR_IN && op > QR_NOTIN {
+		if op < QR_IN || op > QR_NOTIN {
 			goto Error
 		}
 		converted = bvcKeyRange(v)
@@ -904,7 +904,7 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 	}
 	onMismatch, ok = v.(bool)
 	if !ok {
-		err = NewTabletError(ErrFail, "want bool for OnAbsent")
+		err = NewTabletError(ErrFail, "want bool for OnMismatch")
 		return
 	}
 	return


### PR DESCRIPTION
1. use panic in query rule info when registering a registered query rule.
2. fix a bug in query_rules.go that should get an error if "op" is < QR_IN or > QR_NOTIN.
3. add more test cases to test query rules failure cases.
4. fix a comment that the returned error should be "want bool for OnMismatch" when OnMismatched is not a boolean (instead of "want bool for OnAbsent").