### PR TITLE
java: Use gson 2.3.1 to fix compilation for maven2 users.

### DIFF
--- a/java/gorpc/pom.xml
+++ b/java/gorpc/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
Newer Maven versions fail compilation of Vitess with the error "Invalid
JDK version in profile 'doclint-java8-disable': Unbounded range [1.8,".

The original issue is documented here:
https://code.google.com/p/google-gson/issues/detail?id=588

The fix is to use gson-2.3.1 instead of gson-2.3.

@henryanand 