### PR TITLE
use an empty name to prevent publishing stats

### DIFF
--- a/go/vt/tabletserver/cache_pool_test.go
+++ b/go/vt/tabletserver/cache_pool_test.go
@@ -105,7 +105,7 @@ func TestCachePoolState(t *testing.T) {
 		Binary:      "ls",
 		Connections: 100,
 	}
-	cachePool := newTestCachePool(rowCacheConfig)
+	cachePool := newTestCachePoolWithStats(rowCacheConfig)
 	idleTimeout := 1 * time.Second
 	cachePool.idleTimeout = idleTimeout
 	cachePool.Open()
@@ -204,9 +204,15 @@ func TestCachePoolStatsURL(t *testing.T) {
 	cachePool.ServeHTTP(response, request)
 }
 
-func newTestCachePool(rowcacheConfig RowCacheConfig) *CachePool {
+func newTestCachePoolWithStats(rowcacheConfig RowCacheConfig) *CachePool {
 	randID := rand.Int63()
 	name := fmt.Sprintf("TestCachePool-%d-", randID)
 	statsURL := fmt.Sprintf("/debug/cache-%d", randID)
 	return NewCachePool(name, rowcacheConfig, 1*time.Second, statsURL)
+}
+
+func newTestCachePool(rowcacheConfig RowCacheConfig) *CachePool {
+	randID := rand.Int63()
+	statsURL := fmt.Sprintf("/debug/cache-%d", randID)
+	return NewCachePool("", rowcacheConfig, 1*time.Second, statsURL)
 }

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -746,7 +746,7 @@ func newTestQueryExecutor(sql string, ctx context.Context, flags executorFlags) 
 	} else {
 		config.StrictTableAcl = false
 	}
-	sqlQuery := NewSqlQuery(config)
+	sqlQuery := NewSqlQuery(config, "")
 	txID := int64(0)
 	dbconfigs := newTestDBConfigs()
 	if flags&enableRowCache > 0 {

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -262,7 +262,7 @@ type realQueryServiceControl struct {
 // NewQueryServiceControl returns a real implementation of QueryServiceControl
 func NewQueryServiceControl() QueryServiceControl {
 	return &realQueryServiceControl{
-		sqlQueryRPCService: NewSqlQuery(qsConfig),
+		sqlQueryRPCService: NewSqlQuery(qsConfig, "SqlQuery"),
 	}
 }
 

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -416,10 +416,10 @@ func TestSchemaInfoQueryCache(t *testing.T) {
 	for query, result := range getSchemaInfoTestSupportedQueries() {
 		db.AddQuery(query, result)
 	}
-	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second)
+	schemaInfo := newTestSchemaInfoWithStats(10, 10*time.Second, 10*time.Second)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool()
+	cachePool := newTestSchemaInfoCachePoolWithStats()
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
@@ -452,10 +452,10 @@ func TestSchemaInfoExportVars(t *testing.T) {
 	for query, result := range getSchemaInfoTestSupportedQueries() {
 		db.AddQuery(query, result)
 	}
-	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second)
+	schemaInfo := newTestSchemaInfoWithStats(10, 1*time.Second, 1*time.Second)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool()
+	cachePool := newTestSchemaInfoCachePoolWithStats()
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
@@ -507,6 +507,16 @@ func TestSchemaInfoStatsURL(t *testing.T) {
 }
 
 func newTestSchemaInfoCachePool() *CachePool {
+	rowCacheConfig := RowCacheConfig{
+		Binary:      "ls",
+		Connections: 100,
+	}
+	randID := rand.Int63()
+	statsURL := fmt.Sprintf("/debug/cache-%d", randID)
+	return NewCachePool("", rowCacheConfig, 1*time.Second, statsURL)
+}
+
+func newTestSchemaInfoCachePoolWithStats() *CachePool {
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,

--- a/go/vt/tabletserver/table_info_test.go
+++ b/go/vt/tabletserver/table_info_test.go
@@ -293,9 +293,8 @@ func newTestTableInfoCachePool() *CachePool {
 		Connections: 100,
 	}
 	randID := rand.Int63()
-	name := fmt.Sprintf("TestCachePool-TableInfo-%d-", randID)
 	statsURL := fmt.Sprintf("/debug/tableinfo-cache-%d", randID)
-	return NewCachePool(name, rowCacheConfig, 1*time.Second, statsURL)
+	return NewCachePool("", rowCacheConfig, 1*time.Second, statsURL)
 }
 
 func getTestTableInfoQueries() map[string]*mproto.QueryResult {

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -44,12 +44,32 @@ func (util *testUtils) checkEqual(t *testing.T, expected interface{}, result int
 	}
 }
 
+func newTestSchemaInfoWithStats(
+	queryCacheSize int,
+	reloadTime time.Duration,
+	idleTimeout time.Duration) *SchemaInfo {
+	randID := rand.Int63()
+	return NewSchemaInfo(
+		fmt.Sprintf("SchemaInfo-%d-", randID),
+		queryCacheSize,
+		fmt.Sprintf("TestSchemaInfo-%d-", randID),
+		map[string]string{
+			debugQueryPlansKey: fmt.Sprintf("/debug/query_plans_%d", randID),
+			debugQueryStatsKey: fmt.Sprintf("/debug/query_stats_%d", randID),
+			debugTableStatsKey: fmt.Sprintf("/debug/table_stats_%d", randID),
+			debugSchemaKey:     fmt.Sprintf("/debug/schema_%d", randID),
+		},
+		reloadTime,
+		idleTimeout)
+}
+
 func newTestSchemaInfo(
 	queryCacheSize int,
 	reloadTime time.Duration,
 	idleTimeout time.Duration) *SchemaInfo {
 	randID := rand.Int63()
 	return NewSchemaInfo(
+		"",
 		queryCacheSize,
 		fmt.Sprintf("TestSchemaInfo-%d-", randID),
 		map[string]string{

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -75,10 +75,12 @@ func NewTxPool(
 		ticks:       timer.NewTimer(timeout / 10),
 		txStats:     stats.NewTimings(txStatsPrefix + "Transactions"),
 	}
-	// Careful: pool also exports name+"xxx" vars,
-	// but we know it doesn't export Timeout.
-	stats.Publish(name+"Timeout", stats.DurationFunc(axp.timeout.Get))
-	stats.Publish(name+"PoolTimeout", stats.DurationFunc(axp.poolTimeout.Get))
+	if name != "" {
+		// Careful: pool also exports name+"xxx" vars,
+		// but we know it doesn't export Timeout.
+		stats.Publish(name+"Timeout", stats.DurationFunc(axp.timeout.Get))
+		stats.Publish(name+"PoolTimeout", stats.DurationFunc(axp.poolTimeout.Get))
+	}
 	return axp
 }
 

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -21,7 +21,7 @@ func TestExecuteCommit(t *testing.T) {
 	tableName := "test_table"
 	sql := fmt.Sprintf("ALTER TABLE %s ADD test_column INT", tableName)
 	fakesqldb.Register()
-	txPool := newTxPool()
+	txPool := newTxPoolWithStats()
 	txPool.SetTimeout(1 * time.Second)
 	txPool.SetPoolTimeout(1 * time.Second)
 	appParams := sqldb.ConnParams{}
@@ -238,6 +238,23 @@ func TestTxPoolExecFailDueToConnFail(t *testing.T) {
 }
 
 func newTxPool() *TxPool {
+	randID := rand.Int63()
+	txStatsPrefix := fmt.Sprintf("TxStats-%d-", randID)
+	transactionCap := 300
+	transactionTimeout := time.Duration(30 * time.Second)
+	txPoolTimeout := time.Duration(30 * time.Second)
+	idleTimeout := time.Duration(30 * time.Second)
+	return NewTxPool(
+		"",
+		txStatsPrefix,
+		transactionCap,
+		transactionTimeout,
+		txPoolTimeout,
+		idleTimeout,
+	)
+}
+
+func newTxPoolWithStats() *TxPool {
 	randID := rand.Int63()
 	poolName := fmt.Sprintf("TestTransactionPool-%d", randID)
 	txStatsPrefix := fmt.Sprintf("TxStats-%d-", randID)


### PR DESCRIPTION
1. add name to SqlQuery, QueryEngine and SchemaInfo.
2. queryservice component will stop publishing stats if its name is empty.