### PR TITLE
add querylogz unit test

### DIFF
--- a/go/vt/tabletserver/logz_utils.go
+++ b/go/vt/tabletserver/logz_utils.go
@@ -7,6 +7,8 @@ package tabletserver
 import (
 	"bytes"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 func startHTMLTable(w http.ResponseWriter) {
@@ -127,4 +129,29 @@ func wrappable(in string) string {
 		}
 	}
 	return buf.String()
+}
+
+func adjustValue(val int, lower int, upper int) int {
+	if val < lower {
+		return lower
+	} else if val > upper {
+		return upper
+	}
+	return val
+}
+
+func parseTimeoutLimitParams(req *http.Request) (time.Duration, int) {
+	timeout := 10
+	limit := 300
+	if ts, ok := req.URL.Query()["timeout"]; ok {
+		if t, err := strconv.Atoi(ts[0]); err == nil {
+			timeout = adjustValue(t, 0, 60)
+		}
+	}
+	if l, ok := req.URL.Query()["limit"]; ok {
+		if lim, err := strconv.Atoi(l[0]); err == nil {
+			limit = adjustValue(lim, 1, 200000)
+		}
+	}
+	return time.Duration(timeout) * time.Second, limit
 }

--- a/go/vt/tabletserver/querylogz_test.go
+++ b/go/vt/tabletserver/querylogz_test.go
@@ -1,0 +1,142 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/streamlog"
+	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
+	"golang.org/x/net/context"
+)
+
+func TestQuerylogzHandlerInvalidSqlQueryStats(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=0&limit=10", nil)
+	response := httptest.NewRecorder()
+	testLogger := streamlog.New("TestLogger", 100)
+	testLogger.Send("test msg")
+	querylogzHandler(testLogger, response, req)
+	if !strings.Contains(response.Body.String(), "error") {
+		t.Fatalf("should show an error page for an non SqlQueryStats")
+	}
+}
+
+func TestQuerylogzHandler(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=0&limit=10", nil)
+	logStats := newSqlQueryStats("Execute", context.Background())
+	logStats.PlanType = planbuilder.PLAN_PASS_SELECT.String()
+	logStats.OriginalSql = "select name from test_table limit 1000"
+	logStats.RowsAffected = 1000
+	logStats.NumberOfQueries = 1
+	logStats.StartTime = time.Unix(123456789, 0)
+	logStats.MysqlResponseTime = 1 * time.Millisecond
+	logStats.WaitingForConnection = 10 * time.Nanosecond
+	logStats.CacheHits = 17
+	logStats.CacheAbsent = 5
+	logStats.CacheMisses = 2
+	logStats.CacheInvalidations = 3
+	logStats.TransactionID = 131
+
+	testLogger := streamlog.New("TestLogger", 100)
+
+	// fast query
+	fastQueryPattern := []string{
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.001000</td>`,
+		`<td>0.001</td>`,
+		`<td>0.001</td>`,
+		`<td>1e-08</td>`,
+		`<td>PASS_SELECT</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>none</td>`,
+		`<td>1000</td>`,
+		`<td>0</td>`,
+		`<td>17</td>`,
+		`<td>2</td>`,
+		`<td>5</td>`,
+		`<td>3</td>`,
+		`<td>131</td>`,
+		`<td></td>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(1 * time.Millisecond)
+	testLogger.Send(logStats)
+	response := httptest.NewRecorder()
+	querylogzHandler(testLogger, response, req)
+	body, _ := ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
+
+	// medium query
+	mediumQueryPattern := []string{
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.020000</td>`,
+		`<td>0.02</td>`,
+		`<td>0.001</td>`,
+		`<td>1e-08</td>`,
+		`<td>PASS_SELECT</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>none</td>`,
+		`<td>1000</td>`,
+		`<td>0</td>`,
+		`<td>17</td>`,
+		`<td>2</td>`,
+		`<td>5</td>`,
+		`<td>3</td>`,
+		`<td>131</td>`,
+		`<td></td>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(20 * time.Millisecond)
+	testLogger.Send(logStats)
+	response = httptest.NewRecorder()
+	querylogzHandler(testLogger, response, req)
+	body, _ = ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
+
+	// slow query
+	slowQueryPattern := []string{
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.500000</td>`,
+		`<td>0.5</td>`,
+		`<td>0.001</td>`,
+		`<td>1e-08</td>`,
+		`<td>PASS_SELECT</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>none</td>`,
+		`<td>1000</td>`,
+		`<td>0</td>`,
+		`<td>17</td>`,
+		`<td>2</td>`,
+		`<td>5</td>`,
+		`<td>3</td>`,
+		`<td>131</td>`,
+		`<td></td>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(500 * time.Millisecond)
+	testLogger.Send(logStats)
+	querylogzHandler(testLogger, response, req)
+	body, _ = ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
+}
+
+func checkQuerylogzHasStats(t *testing.T, pattern []string, logStats *SQLQueryStats, page []byte) {
+	matcher := regexp.MustCompile(strings.Join(pattern, `\s*`))
+	if !matcher.Match(page) {
+		t.Fatalf("querylogz page does not contain stats: %v, page: %s", logStats, string(page))
+	}
+}

--- a/go/vt/tabletserver/queryz_test.go
+++ b/go/vt/tabletserver/queryz_test.go
@@ -104,6 +104,6 @@ func TestQueryzHandler(t *testing.T) {
 func checkQueryzHasPlan(t *testing.T, planPattern []string, plan *ExecPlan, page []byte) {
 	matcher := regexp.MustCompile(strings.Join(planPattern, `\s*`))
 	if !matcher.Match(page) {
-		t.Fatalf("schemaz page does not contain plan: %v, page: %s", plan, string(page))
+		t.Fatalf("queryz page does not contain plan: %v, page: %s", plan, string(page))
 	}
 }

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -125,6 +125,7 @@ func (util *testUtils) newQueryServiceConfig() Config {
 	config.StrictMode = true
 	config.RowCache.Binary = "ls"
 	config.RowCache.Connections = 100
+	config.EnablePublishStats = false
 	return config
 }
 

--- a/go/vt/tabletserver/txlogz.go
+++ b/go/vt/tabletserver/txlogz.go
@@ -9,7 +9,6 @@ import (
 	"html/template"
 	"io"
 	"net/http"
-	"strconv"
 	"time"
 
 	log "github.com/golang/glog"
@@ -51,31 +50,6 @@ func init() {
 	http.HandleFunc("/txlogz", txlogzHandler)
 }
 
-func adjustValue(val int, lower int, upper int) int {
-	if val < lower {
-		return lower
-	} else if val > upper {
-		return upper
-	}
-	return val
-}
-
-func parseReqParam(req *http.Request) (time.Duration, int) {
-	timeout := 10
-	limit := 300
-	if ts, ok := req.URL.Query()["timeout"]; ok {
-		if t, err := strconv.Atoi(ts[0]); err == nil {
-			timeout = adjustValue(t, 0, 60)
-		}
-	}
-	if l, ok := req.URL.Query()["limit"]; ok {
-		if lim, err := strconv.Atoi(l[0]); err == nil {
-			limit = adjustValue(lim, 1, 200000)
-		}
-	}
-	return time.Duration(timeout) * time.Second, limit
-}
-
 // txlogzHandler serves a human readable snapshot of the
 // current transaction log.
 // Endpoint: /txlogz?timeout=%d&limit=%d
@@ -87,7 +61,7 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	timeout, limit := parseReqParam(req)
+	timeout, limit := parseTimeoutLimitParams(req)
 	ch := TxLogger.Subscribe("txlogz")
 	defer TxLogger.Unsubscribe(ch)
 	startHTMLTable(w)


### PR DESCRIPTION
1. rename logzcss.go to logz_utils.go and move two util funcs from txlogz.go to it.
2. let querylogzHandler accept a streamlog.StreamLogger instance instead of always
   using SqlQueryLogger.
3. add two params timeout and limit to /querylogz, this allows one to control how many
   queries the querylogz page shows.