### PR TITLE
Add tabletmanager StateChange event.

### DIFF
--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/event"
 	"github.com/youtube/vitess/go/history"
 	"github.com/youtube/vitess/go/jscfg"
 	"github.com/youtube/vitess/go/netutil"
@@ -41,6 +42,7 @@ import (
 	"github.com/youtube/vitess/go/vt/health"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
+	"github.com/youtube/vitess/go/vt/tabletmanager/events"
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/topo"
 )
@@ -221,7 +223,16 @@ func (agent *ActionAgent) updateState(ctx context.Context, oldTablet *topo.Table
 	newTablet := agent._tablet.Tablet
 	agent.mutex.Unlock()
 	log.Infof("Running tablet callback because: %v", reason)
-	return agent.changeCallback(ctx, oldTablet, newTablet)
+	if err := agent.changeCallback(ctx, oldTablet, newTablet); err != nil {
+		return err
+	}
+
+	event.Dispatch(&events.StateChange{
+		OldTablet: *oldTablet,
+		NewTablet: *newTablet,
+		Reason:    reason,
+	})
+	return nil
 }
 
 func (agent *ActionAgent) readTablet(ctx context.Context) (*topo.TabletInfo, error) {

--- a/go/vt/tabletmanager/events/state_change.go
+++ b/go/vt/tabletmanager/events/state_change.go
@@ -1,0 +1,23 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package events contains event structs used by the tabletmanager package.
+package events
+
+import (
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// StateChange is an event that describes state changes in the tablet as seen
+// by the TabletManager. It is triggered after the tablet has processed a state
+// change, which might have been initiated internally, or when the tablet
+// noticed that an external process modified its topo record.
+type StateChange struct {
+	// OldTablet is the topo record of the tablet before the change.
+	OldTablet topo.Tablet
+	// NewTablet is the topo record representing the current state.
+	NewTablet topo.Tablet
+	// Reason is an optional string that describes the source of the change.
+	Reason string
+}

--- a/go/vt/topo/events/tablet_change.go
+++ b/go/vt/topo/events/tablet_change.go
@@ -4,7 +4,11 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 )
 
-// TabletChange is an event that describes changes to a tablet.
+// TabletChange is an event that describes changes to a tablet's topo record.
+// It is triggered when the CURRENT process changes ANY tablet's record.
+// It is NOT triggered when a DIFFERENT process changes THIS tablet's record.
+// To be notified when THIS tablet's record changes, even if it was changed
+// by a different process, listen for go/vt/tabletmanager/events.StateChange.
 type TabletChange struct {
 	Tablet topo.Tablet
 	Status string


### PR DESCRIPTION
This event triggers based on actual state changes, rather than updates
to topology like the existing topo TabletChange event.