### PR TITLE
pools: Fix problem that Err() must not be called before Done was closed.

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -104,9 +104,12 @@ func (rp *ResourcePool) TryGet() (resource Resource, err error) {
 
 func (rp *ResourcePool) get(ctx context.Context, wait bool) (resource Resource, err error) {
 	// If ctx has already expired, avoid racing with rp's resource channel.
-	if ctx.Err() != nil {
+	select {
+	case <-ctx.Done():
 		return nil, ErrTimeout
+	default:
 	}
+
 	// Fetch
 	var wrapper resourceWrapper
 	var ok bool


### PR DESCRIPTION
@sougou 