### PR TITLE
add error as killable.Kill's return value

### DIFF
--- a/go/vt/tabletserver/query_list.go
+++ b/go/vt/tabletserver/query_list.go
@@ -22,7 +22,7 @@ type QueryDetail struct {
 type killable interface {
 	Current() string
 	ID() int64
-	Kill()
+	Kill() error
 }
 
 // NewQueryDetail creates a new QueryDetail

--- a/go/vt/tabletserver/query_list_test.go
+++ b/go/vt/tabletserver/query_list_test.go
@@ -16,7 +16,10 @@ func (tc *testConn) Current() string { return tc.query }
 
 func (tc *testConn) ID() int64 { return tc.id }
 
-func (tc *testConn) Kill() { tc.killed = true }
+func (tc *testConn) Kill() error {
+	tc.killed = true
+	return nil
+}
 
 func (tc *testConn) IsKilled() bool {
 	return tc.killed


### PR DESCRIPTION
DBConn implements killable interface, it logs error but then ignores it. It is
better to let Kill func has error as return value.