### PR TITLE
sleep 100 millis for the second attempt

### DIFF
--- a/go/vt/tabletserver/cache_pool.go
+++ b/go/vt/tabletserver/cache_pool.go
@@ -142,11 +142,11 @@ func (cp *CachePool) startCacheService() {
 	}
 	attempts := 0
 	for {
-		time.Sleep(100 * time.Millisecond)
 		c, err := cacheservice.Connect(cacheservice.Config{
 			Address: cp.socket,
 			Timeout: 30 * time.Millisecond,
 		})
+
 		if err != nil {
 			attempts++
 			if attempts >= 50 {
@@ -156,6 +156,7 @@ func (cp *CachePool) startCacheService() {
 				// FIXME(sougou): Throw proper error if we can recover
 				log.Fatalf("Can't connect to cache service: %s", cp.socket)
 			}
+			time.Sleep(100 * time.Millisecond)
 			continue
 		}
 		if _, err = c.Set("health", 0, 0, []byte("ok")); err != nil {


### PR DESCRIPTION
CachePool launches a memcache process, if failed, it will sleep 100 millis
before the next attempt. This slows down the unit test since a fake memcache
service is guaranteed to succeed.