### PR TITLE
make sure queryservice not publish stats when not required

### DIFF
--- a/go/stats/export.go
+++ b/go/stats/export.go
@@ -187,7 +187,9 @@ type Int struct {
 // NewInt returns a new Int
 func NewInt(name string) *Int {
 	v := new(Int)
-	Publish(name, v)
+	if name != "" {
+		Publish(name, v)
+	}
 	return v
 }
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -79,13 +79,25 @@ func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.Con
 	}
 
 	// create and open the connection pool for dba access
-	dbaMysqlStats := stats.NewTimings("Mysql" + dbaName)
-	dbaPool := dbconnpool.NewConnectionPool(dbaName+"ConnPool", *dbaPoolSize, *dbaIdleTimeout)
+	dbaMysqlStatsName := ""
+	dbaPoolName := ""
+	if dbaName != "" {
+		dbaMysqlStatsName = "Mysql" + dbaName
+		dbaPoolName = dbaName + "ConnPool"
+	}
+	dbaMysqlStats := stats.NewTimings(dbaMysqlStatsName)
+	dbaPool := dbconnpool.NewConnectionPool(dbaPoolName, *dbaPoolSize, *dbaIdleTimeout)
 	dbaPool.Open(dbconnpool.DBConnectionCreator(dba, dbaMysqlStats))
 
 	// create and open the connection pool for app access
-	appMysqlStats := stats.NewTimings("Mysql" + appName)
-	appPool := dbconnpool.NewConnectionPool(appName+"ConnPool", *appPoolSize, *appIdleTimeout)
+	appMysqlStatsName := ""
+	appPoolName := ""
+	if appName != "" {
+		appMysqlStatsName = "Mysql" + appName
+		appPoolName = appName + "ConnPool"
+	}
+	appMysqlStats := stats.NewTimings(appMysqlStatsName)
+	appPool := dbconnpool.NewConnectionPool(appPoolName, *appPoolSize, *appIdleTimeout)
 	appPool.Open(dbconnpool.DBConnectionCreator(app, appMysqlStats))
 
 	return &Mysqld{

--- a/go/vt/tabletserver/codex_test.go
+++ b/go/vt/tabletserver/codex_test.go
@@ -332,7 +332,7 @@ func TestCodexValidateRow(t *testing.T) {
 	err := validateRow(&tableInfo, []int{1}, []sqltypes.Value{})
 	testUtils.checkTabletError(t, err, ErrFail, "data inconsistency")
 	// column 0 is int type but row is in string type
-	err = validateRow(&tableInfo, []int{0}, []sqltypes.Value{sqltypes.MakeString([]byte{})})
+	err = validateRow(&tableInfo, []int{0}, []sqltypes.Value{sqltypes.MakeString([]byte("str"))})
 	testUtils.checkTabletError(t, err, ErrFail, "type mismatch")
 }
 

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -68,11 +68,13 @@ func (rci *RowcacheInvalidator) PositionString() string {
 // NewRowcacheInvalidator creates a new RowcacheInvalidator.
 // Just like QueryEngine, this is a singleton class.
 // You must call this only once.
-func NewRowcacheInvalidator(statsPrefix string, qe *QueryEngine) *RowcacheInvalidator {
+func NewRowcacheInvalidator(statsPrefix string, qe *QueryEngine, enablePublishStats bool) *RowcacheInvalidator {
 	rci := &RowcacheInvalidator{qe: qe}
-	stats.Publish(statsPrefix+"RowcacheInvalidatorState", stats.StringFunc(rci.svm.StateName))
-	stats.Publish(statsPrefix+"RowcacheInvalidatorPosition", stats.StringFunc(rci.PositionString))
-	stats.Publish(statsPrefix+"RowcacheInvalidatorLagSeconds", stats.IntFunc(rci.lagSeconds.Get))
+	if enablePublishStats {
+		stats.Publish(statsPrefix+"RowcacheInvalidatorState", stats.StringFunc(rci.svm.StateName))
+		stats.Publish(statsPrefix+"RowcacheInvalidatorPosition", stats.StringFunc(rci.PositionString))
+		stats.Publish(statsPrefix+"RowcacheInvalidatorLagSeconds", stats.IntFunc(rci.lagSeconds.Get))
+	}
 	return rci
 }
 

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -91,10 +91,9 @@ func (util *testUtils) getTabletErrorString(tabletErrorType int) string {
 }
 
 func (util *testUtils) newMysqld(dbconfigs *dbconfigs.DBConfigs) *mysqlctl.Mysqld {
-	randID := rand.Int63()
 	return mysqlctl.NewMysqld(
-		fmt.Sprintf("Dba_%d", randID),
-		fmt.Sprintf("App_%d", randID),
+		"",
+		"",
 		mysqlctl.NewMycnf(0, 6802),
 		&dbconfigs.Dba,
 		&dbconfigs.App.ConnParams,


### PR DESCRIPTION
1. queryservice should not publish stats if either flag EnablePublishStats
    is enabled or var name is empty.
2. stats.NewInt should call Publish if name is empty.
3. mysqlctl.NewMysqld publishes dba stats only if dbaName is not empty.
4. mysqlctl.NewMysqld publishes app stats only if appName is not empty.
5. QueryEngine publishes stats only if flag EnablePublishStats is enabled.
6. RowCacheInvalidator publishes stats only if flag EnablePublishStats is enabled.