### PR TITLE
delete duplicate ErrConnPoolClosed defined in ConnPool

### DIFF
--- a/go/vt/tabletserver/connpool.go
+++ b/go/vt/tabletserver/connpool.go
@@ -5,7 +5,6 @@
 package tabletserver
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -14,12 +13,6 @@ import (
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"golang.org/x/net/context"
-)
-
-var (
-	// ErrConnPoolClosed is returned / panicked when the
-	// connection pool is closed.
-	ErrConnPoolClosed = errors.New("connection pool is closed")
 )
 
 // ConnPool implements a custom connection pool for tabletserver.

--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -89,8 +89,6 @@ var (
 	qpsRates       *stats.Rates
 
 	resultBuckets = []int64{0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000}
-
-	connPoolClosedErr = NewTabletError(ErrFatal, "connection pool is closed")
 )
 
 // CacheInvalidator provides the abstraction needed for an instant invalidation
@@ -106,7 +104,7 @@ func getOrPanic(ctx context.Context, pool *ConnPool) *DBConn {
 		return conn
 	}
 	if err == ErrConnPoolClosed {
-		panic(connPoolClosedErr)
+		panic(ErrConnPoolClosed)
 	}
 	panic(NewTabletErrorSql(ErrFatal, err))
 }

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -518,7 +518,7 @@ func (qre *QueryExecutor) getConn(pool *ConnPool) *DBConn {
 		qre.logStats.WaitingForConnection += time.Now().Sub(start)
 		return conn
 	case ErrConnPoolClosed:
-		panic(connPoolClosedErr)
+		panic(err)
 	}
 	panic(NewTabletErrorSql(ErrFatal, err))
 }

--- a/go/vt/tabletserver/tablet_error.go
+++ b/go/vt/tabletserver/tablet_error.go
@@ -38,6 +38,9 @@ const (
 	maxErrLen = 5000
 )
 
+// ErrConnPoolClosed is returned / panicked when the connection pool is closed.
+var ErrConnPoolClosed = NewTabletError(ErrFatal, "connection pool is closed")
+
 var logTxPoolFull = logutil.NewThrottledLogger("TxPoolFull", 1*time.Minute)
 
 // TabletError is the erro type we use in this library

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -135,7 +135,7 @@ func (axp *TxPool) Begin(ctx context.Context) int64 {
 	if err != nil {
 		switch err {
 		case ErrConnPoolClosed:
-			panic(connPoolClosedErr)
+			panic(err)
 		case pools.ErrTimeout:
 			axp.LogActive()
 			panic(NewTabletError(ErrTxPoolFull, "Transaction pool connection limit exceeded"))

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -107,8 +107,8 @@ func TestBeginAfterConnPoolClosed(t *testing.T) {
 			t.Fatalf("expect to get an error")
 		}
 		err, ok := r.(*TabletError)
-		if !ok || err != connPoolClosedErr {
-			t.Fatalf("get error: %v, but expect: %v", err, connPoolClosedErr)
+		if !ok || err != ErrConnPoolClosed {
+			t.Fatalf("get error: %v, but expect: %v", err, ErrConnPoolClosed)
 		}
 	}()
 	txPool.Begin(ctx)


### PR DESCRIPTION
1. move ErrConnPoolClosed from query_engine.go to tablet_error.go.
2. delete duplicate ErrConnPoolClosed in ConnPool.