### PR TITLE
remove queryservice global stats variables

### DIFF
--- a/go/vt/tabletserver/cache_pool_test.go
+++ b/go/vt/tabletserver/cache_pool_test.go
@@ -230,11 +230,11 @@ func TestCachePoolMemcacheStatsFail(t *testing.T) {
 	cachePool.idleTimeout = idleTimeout
 	cachePool.Open()
 	defer cachePool.Close()
-	memcacheStatsBefore := internalErrors.Counts()["MemcacheStats"]
+	memcacheStatsBefore := cachePool.queryServiceStats.InternalErrors.Counts()["MemcacheStats"]
 	// any memcache calls should fail
 	cache.EnableCacheServiceError()
 	cachePool.memcacheStats.update()
-	memcacheStatsAfter := internalErrors.Counts()["MemcacheStats"]
+	memcacheStatsAfter := cachePool.queryServiceStats.InternalErrors.Counts()["MemcacheStats"]
 	if memcacheStatsAfter <= memcacheStatsBefore {
 		t.Fatalf("memcache stats should cause an internal error")
 	}
@@ -261,5 +261,12 @@ func newTestCachePool(rowcacheConfig RowCacheConfig, enablePublishStats bool) *C
 	randID := rand.Int63()
 	name := fmt.Sprintf("TestCachePool-%d-", randID)
 	statsURL := fmt.Sprintf("/debug/cache-%d/", randID)
-	return NewCachePool(name, rowcacheConfig, 1*time.Second, statsURL, enablePublishStats)
+	queryServiceStats := NewQueryServiceStats(name, enablePublishStats)
+	return NewCachePool(
+		name,
+		rowcacheConfig,
+		1*time.Second,
+		statsURL,
+		enablePublishStats,
+		queryServiceStats)
 }

--- a/go/vt/tabletserver/codex.go
+++ b/go/vt/tabletserver/codex.go
@@ -276,7 +276,7 @@ func applyFilterWithPKDefaults(tableInfo *TableInfo, columnNumbers []int, input 
 	return output
 }
 
-func validateKey(tableInfo *TableInfo, key string) (newKey string) {
+func validateKey(tableInfo *TableInfo, key string, qStats *QueryServiceStats) (newKey string) {
 	if key == "" {
 		// TODO: Verify auto-increment table
 		return
@@ -292,7 +292,7 @@ func validateKey(tableInfo *TableInfo, key string) (newKey string) {
 			s, err := base64.StdEncoding.DecodeString(piece[1 : len(piece)-1])
 			if err != nil {
 				log.Warningf("Error decoding key %s for table %s: %v", key, tableInfo.Name, err)
-				internalErrors.Add("Mismatch", 1)
+				qStats.InternalErrors.Add("Mismatch", 1)
 				return
 			}
 			pkValues[i] = sqltypes.MakeString(s)
@@ -303,7 +303,7 @@ func validateKey(tableInfo *TableInfo, key string) (newKey string) {
 			n, err := sqltypes.BuildNumeric(piece)
 			if err != nil {
 				log.Warningf("Error decoding key %s for table %s: %v", key, tableInfo.Name, err)
-				internalErrors.Add("Mismatch", 1)
+				qStats.InternalErrors.Add("Mismatch", 1)
 				return
 			}
 			pkValues[i] = n
@@ -311,7 +311,7 @@ func validateKey(tableInfo *TableInfo, key string) (newKey string) {
 	}
 	if newKey = buildKey(pkValues); newKey != key {
 		log.Warningf("Error: Key mismatch, received: %s, computed: %s", key, newKey)
-		internalErrors.Add("Mismatch", 1)
+		qStats.InternalErrors.Add("Mismatch", 1)
 	}
 	return newKey
 }

--- a/go/vt/tabletserver/connpool_test.go
+++ b/go/vt/tabletserver/connpool_test.go
@@ -15,7 +15,8 @@ import (
 
 func TestConnPoolTryGetWhilePoolIsClosed(t *testing.T) {
 	fakesqldb.Register()
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	testUtils := newTestUtils()
+	connPool := testUtils.newConnPool()
 	_, err := connPool.TryGet()
 	if err != ErrConnPoolClosed {
 		t.Fatalf("pool is closed, should get ErrConnPoolClosed")
@@ -24,10 +25,11 @@ func TestConnPoolTryGetWhilePoolIsClosed(t *testing.T) {
 
 func TestConnPoolTryGetWhenFailedToConnectToDB(t *testing.T) {
 	db := fakesqldb.Register()
+	testUtils := newTestUtils()
 	db.EnableConnFail()
 	appParams := &sqldb.ConnParams{}
 	dbaParams := &sqldb.ConnParams{}
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	connPool := testUtils.newConnPool()
 	connPool.Open(appParams, dbaParams)
 	defer connPool.Close()
 	_, err := connPool.TryGet()
@@ -38,9 +40,10 @@ func TestConnPoolTryGetWhenFailedToConnectToDB(t *testing.T) {
 
 func TestConnPoolTryGet(t *testing.T) {
 	fakesqldb.Register()
+	testUtils := newTestUtils()
 	appParams := &sqldb.ConnParams{}
 	dbaParams := &sqldb.ConnParams{}
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	connPool := testUtils.newConnPool()
 	connPool.Open(appParams, dbaParams)
 	defer connPool.Close()
 	dbConn, err := connPool.TryGet()
@@ -55,9 +58,10 @@ func TestConnPoolTryGet(t *testing.T) {
 
 func TestConnPoolGet(t *testing.T) {
 	fakesqldb.Register()
+	testUtils := newTestUtils()
 	appParams := &sqldb.ConnParams{}
 	dbaParams := &sqldb.ConnParams{}
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	connPool := testUtils.newConnPool()
 	connPool.Open(appParams, dbaParams)
 	defer connPool.Close()
 	dbConn, err := connPool.Get(context.Background())
@@ -72,7 +76,8 @@ func TestConnPoolGet(t *testing.T) {
 
 func TestConnPoolPutWhilePoolIsClosed(t *testing.T) {
 	fakesqldb.Register()
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	testUtils := newTestUtils()
+	connPool := testUtils.newConnPool()
 	defer func() {
 		if recover() == nil {
 			t.Fatalf("pool is closed, should get an error")
@@ -83,9 +88,10 @@ func TestConnPoolPutWhilePoolIsClosed(t *testing.T) {
 
 func TestConnPoolSetCapacity(t *testing.T) {
 	fakesqldb.Register()
+	testUtils := newTestUtils()
 	appParams := &sqldb.ConnParams{}
 	dbaParams := &sqldb.ConnParams{}
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	connPool := testUtils.newConnPool()
 	connPool.Open(appParams, dbaParams)
 	defer connPool.Close()
 	err := connPool.SetCapacity(-10)
@@ -103,7 +109,8 @@ func TestConnPoolSetCapacity(t *testing.T) {
 
 func TestConnPoolStatJSON(t *testing.T) {
 	fakesqldb.Register()
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	testUtils := newTestUtils()
+	connPool := testUtils.newConnPool()
 	if connPool.StatsJSON() != "{}" {
 		t.Fatalf("pool is closed, stats json should be empty: {}")
 	}
@@ -119,7 +126,8 @@ func TestConnPoolStatJSON(t *testing.T) {
 
 func TestConnPoolStateWhilePoolIsClosed(t *testing.T) {
 	fakesqldb.Register()
-	connPool := NewConnPool("ConnPool", 100, 10*time.Second, false)
+	testUtils := newTestUtils()
+	connPool := testUtils.newConnPool()
 	if connPool.Capacity() != 0 {
 		t.Fatalf("pool capacity should be 0 because it is still closed")
 	}
@@ -142,10 +150,11 @@ func TestConnPoolStateWhilePoolIsClosed(t *testing.T) {
 
 func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 	fakesqldb.Register()
+	testUtils := newTestUtils()
 	appParams := &sqldb.ConnParams{}
 	dbaParams := &sqldb.ConnParams{}
 	idleTimeout := 10 * time.Second
-	connPool := NewConnPool("ConnPool", 100, idleTimeout, false)
+	connPool := testUtils.newConnPool()
 	connPool.Open(appParams, dbaParams)
 	defer connPool.Close()
 	if connPool.Capacity() != 100 {

--- a/go/vt/tabletserver/query_service_stats.go
+++ b/go/vt/tabletserver/query_service_stats.go
@@ -1,0 +1,75 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"time"
+
+	"github.com/youtube/vitess/go/stats"
+)
+
+// QueryServiceStats contains stats that used in queryservice level.
+type QueryServiceStats struct {
+	// MySQLStats shows the time histogram for operations spent on mysql side.
+	MySQLStats *stats.Timings
+	// QueryStats shows the time histogram for each type of queries.
+	QueryStats *stats.Timings
+	// WaitStats shows the time histogram for wait operations
+	WaitStats *stats.Timings
+	// KillStats shows number of connections being killed.
+	KillStats *stats.Counters
+	// InfoErrors shows number of various non critical errors happened.
+	InfoErrors *stats.Counters
+	// ErrorStats shows number of critial erros happened.
+	ErrorStats *stats.Counters
+	// InternalErros shows number of errors from internal components.
+	InternalErrors *stats.Counters
+	// QPSRates shows the qps.
+	QPSRates *stats.Rates
+	// ResultStats shows the histogram of number of rows returned.
+	ResultStats *stats.Histogram
+	// SpotCheckCount shows the number of spot check events happened.
+	SpotCheckCount *stats.Int
+}
+
+// NewQueryServiceStats returns a new QueryServiceStats instance.
+func NewQueryServiceStats(statsPrefix string, enablePublishStats bool) *QueryServiceStats {
+	mysqlStatsName := ""
+	queryStatsName := ""
+	qpsRateName := ""
+	waitStatsName := ""
+	killStatsName := ""
+	infoErrorsName := ""
+	errorStatsName := ""
+	internalErrorsName := ""
+	resultStatsName := ""
+	spotCheckCountName := ""
+	if enablePublishStats {
+		mysqlStatsName = statsPrefix + "Mysql"
+		queryStatsName = statsPrefix + "Queries"
+		qpsRateName = statsPrefix + "QPS"
+		waitStatsName = statsPrefix + "Waits"
+		killStatsName = statsPrefix + "Kills"
+		infoErrorsName = statsPrefix + "InfoErrors"
+		errorStatsName = statsPrefix + "Errors"
+		internalErrorsName = statsPrefix + "InternalErrors"
+		resultStatsName = statsPrefix + "Results"
+		spotCheckCountName = statsPrefix + "RowcacheSpotCheckCount"
+	}
+	resultBuckets := []int64{0, 1, 5, 10, 50, 100, 500, 1000, 5000, 10000}
+	queryStats := stats.NewTimings(queryStatsName)
+	return &QueryServiceStats{
+		MySQLStats:     stats.NewTimings(mysqlStatsName),
+		QueryStats:     queryStats,
+		WaitStats:      stats.NewTimings(waitStatsName),
+		KillStats:      stats.NewCounters(killStatsName),
+		InfoErrors:     stats.NewCounters(infoErrorsName),
+		ErrorStats:     stats.NewCounters(errorStatsName),
+		InternalErrors: stats.NewCounters(internalErrorsName),
+		QPSRates:       stats.NewRates(qpsRateName, queryStats, 15, 60*time.Second),
+		ResultStats:    stats.NewHistogram(resultStatsName, resultBuckets),
+		SpotCheckCount: stats.NewInt(spotCheckCountName),
+	}
+}

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -301,7 +301,7 @@ func (rqsc *realQueryServiceControl) AllowQueries(dbconfigs *dbconfigs.DBConfigs
 // it has to wait for queries & transactions to be completed or killed,
 // and also for house keeping goroutines to be terminated.
 func (rqsc *realQueryServiceControl) DisallowQueries() {
-	defer logError()
+	defer logError(rqsc.sqlQueryRPCService.qe.queryServiceStats)
 	rqsc.sqlQueryRPCService.disallowQueries()
 }
 
@@ -312,7 +312,7 @@ func (rqsc *realQueryServiceControl) IsServing() bool {
 
 // Reload the schema. If the query service is not running, nothing will happen
 func (rqsc *realQueryServiceControl) ReloadSchema() {
-	defer logError()
+	defer logError(rqsc.sqlQueryRPCService.qe.queryServiceStats)
 	rqsc.sqlQueryRPCService.qe.schemaInfo.triggerReload()
 }
 
@@ -332,7 +332,7 @@ func (rqsc *realQueryServiceControl) registerCheckMySQL() {
 			time.Sleep(1 * time.Second)
 			checkMySLQThrottler.Release()
 		}()
-		defer logError()
+		defer logError(rqsc.sqlQueryRPCService.qe.queryServiceStats)
 		if rqsc.sqlQueryRPCService.checkMySQL() {
 			return
 		}

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -32,7 +32,7 @@ func TestSchemaInfoStrictMode(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -57,7 +57,7 @@ func TestSchemaInfoOpenFailedDueToMissMySQLTime(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -81,7 +81,7 @@ func TestSchemaInfoOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -105,7 +105,7 @@ func TestSchemaInfoOpenFailedDueToInvalidTimeFormat(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -129,7 +129,7 @@ func TestSchemaInfoOpenFailedDueToExecErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -159,7 +159,7 @@ func TestSchemaInfoOpenFailedDueToTableInfoErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -179,7 +179,7 @@ func TestSchemaInfoOpenWithSchemaOverride(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
@@ -209,7 +209,7 @@ func TestSchemaInfoReload(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, idleTimeout, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	// test cache type RW
@@ -292,7 +292,7 @@ func TestSchemaInfoCreateOrUpdateTableFailedDuetoExecErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	defer handleAndVerifyTabletError(
@@ -320,7 +320,7 @@ func TestSchemaInfoCreateOrUpdateTable(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), cachePool, false)
@@ -343,7 +343,7 @@ func TestSchemaInfoDropTable(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), cachePool, false)
@@ -368,7 +368,7 @@ func TestSchemaInfoGetPlanPanicDuetoEmptyQuery(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
@@ -395,7 +395,7 @@ func TestSchemaInfoQueryCacheFailDueToInvalidCacheSize(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
@@ -419,7 +419,7 @@ func TestSchemaInfoQueryCache(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, true)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(true)
+	cachePool := newTestSchemaInfoCachePool(true, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
@@ -455,7 +455,7 @@ func TestSchemaInfoExportVars(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, true)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(true)
+	cachePool := newTestSchemaInfoCachePool(true, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
@@ -474,7 +474,7 @@ func TestSchemaInfoStatsURL(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false)
+	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
 	cachePool.Open()
 	defer cachePool.Close()
 	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
@@ -506,7 +506,7 @@ func TestSchemaInfoStatsURL(t *testing.T) {
 	schemaInfo.ServeHTTP(response, request)
 }
 
-func newTestSchemaInfoCachePool(enablePublishStats bool) *CachePool {
+func newTestSchemaInfoCachePool(enablePublishStats bool, queryServiceStats *QueryServiceStats) *CachePool {
 	rowCacheConfig := RowCacheConfig{
 		Binary:      "ls",
 		Connections: 100,
@@ -514,7 +514,14 @@ func newTestSchemaInfoCachePool(enablePublishStats bool) *CachePool {
 	randID := rand.Int63()
 	name := fmt.Sprintf("TestCachePool-%d-", randID)
 	statsURL := fmt.Sprintf("/debug/cache-%d", randID)
-	return NewCachePool(name, rowCacheConfig, 1*time.Second, statsURL, enablePublishStats)
+	return NewCachePool(
+		name,
+		rowCacheConfig,
+		1*time.Second,
+		statsURL,
+		enablePublishStats,
+		queryServiceStats,
+	)
 }
 
 func getSchemaInfoBaseTestQueries() map[string]*mproto.QueryResult {

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -961,8 +961,10 @@ func TestHandleExecUnknownError(t *testing.T) {
 		BindVariables: nil,
 	}
 	var err error
-	sq := &SqlQuery{}
-	defer sq.handleExecError(&query, &err, logStats)
+	testUtils := newTestUtils()
+	config := testUtils.newQueryServiceConfig()
+	sqlQuery := NewSqlQuery(config)
+	defer sqlQuery.handleExecError(&query, &err, logStats)
 	panic("unknown exec error")
 }
 
@@ -980,8 +982,10 @@ func TestHandleExecTabletError(t *testing.T) {
 			t.Errorf("Error: %v, want '%s'", err, want)
 		}
 	}()
-	sq := &SqlQuery{}
-	defer sq.handleExecError(&query, &err, logStats)
+	testUtils := newTestUtils()
+	config := testUtils.newQueryServiceConfig()
+	sqlQuery := NewSqlQuery(config)
+	defer sqlQuery.handleExecError(&query, &err, logStats)
 	panic(NewTabletError(ErrFatal, "tablet error"))
 }
 
@@ -999,9 +1003,11 @@ func TestTerseErrors1(t *testing.T) {
 			t.Errorf("Error: %v, want '%s'", err, want)
 		}
 	}()
-	sq := &SqlQuery{}
-	sq.config.TerseErrors = true
-	defer sq.handleExecError(&query, &err, logStats)
+	testUtils := newTestUtils()
+	config := testUtils.newQueryServiceConfig()
+	sqlQuery := NewSqlQuery(config)
+	sqlQuery.config.TerseErrors = true
+	defer sqlQuery.handleExecError(&query, &err, logStats)
 	panic(NewTabletError(ErrFatal, "tablet error"))
 }
 
@@ -1019,9 +1025,11 @@ func TestTerseErrors2(t *testing.T) {
 			t.Errorf("Error: %v, want '%s'", err, want)
 		}
 	}()
-	sq := &SqlQuery{}
-	sq.config.TerseErrors = true
-	defer sq.handleExecError(&query, &err, logStats)
+	testUtils := newTestUtils()
+	config := testUtils.newQueryServiceConfig()
+	sqlQuery := NewSqlQuery(config)
+	sqlQuery.config.TerseErrors = true
+	defer sqlQuery.handleExecError(&query, &err, logStats)
 	panic(&TabletError{
 		ErrorType: ErrFail,
 		Message:   "msg",

--- a/go/vt/tabletserver/status.go
+++ b/go/vt/tabletserver/status.go
@@ -89,7 +89,7 @@ func (rqsc *realQueryServiceControl) AddStatusPart() {
 		status := queryserviceStatus{
 			State: rqsc.sqlQueryRPCService.GetState(),
 		}
-		rates := qpsRates.Get()
+		rates := rqsc.sqlQueryRPCService.qe.queryServiceStats.QPSRates.Get()
 		if qps, ok := rates["All"]; ok && len(qps) > 0 {
 			status.CurrentQPS = qps[0]
 

--- a/go/vt/tabletserver/table_info_test.go
+++ b/go/vt/tabletserver/table_info_test.go
@@ -268,9 +268,9 @@ func newTestTableInfo(cachePool *CachePool, tableType string, comment string) (*
 	ctx := context.Background()
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-
+	queryServiceStats := NewQueryServiceStats("", false)
 	connPoolIdleTimeout := 10 * time.Second
-	connPool := NewConnPool("", 2, connPoolIdleTimeout, false)
+	connPool := NewConnPool("", 2, connPoolIdleTimeout, false, queryServiceStats)
 	connPool.Open(&appParams, &dbaParams)
 	conn, err := connPool.Get(ctx)
 	if err != nil {
@@ -295,7 +295,14 @@ func newTestTableInfoCachePool() *CachePool {
 	randID := rand.Int63()
 	name := fmt.Sprintf("TestCachePool-TableInfo-%d-", randID)
 	statsURL := fmt.Sprintf("/debug/tableinfo-cache-%d", randID)
-	return NewCachePool(name, rowCacheConfig, 1*time.Second, statsURL, false)
+	return NewCachePool(
+		name,
+		rowCacheConfig,
+		1*time.Second,
+		statsURL,
+		false,
+		NewQueryServiceStats("", false),
+	)
 }
 
 func getTestTableInfoQueries() map[string]*mproto.QueryResult {

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -128,15 +128,27 @@ func (util *testUtils) newQueryServiceConfig() Config {
 	return config
 }
 
+func (util *testUtils) newConnPool() *ConnPool {
+	return NewConnPool(
+		"ConnPool",
+		100,
+		10*time.Second,
+		false,
+		NewQueryServiceStats("", false),
+	)
+}
+
 func newTestSchemaInfo(
 	queryCacheSize int,
 	reloadTime time.Duration,
 	idleTimeout time.Duration,
 	enablePublishStats bool) *SchemaInfo {
 	randID := rand.Int63()
+	name := fmt.Sprintf("TestSchemaInfo-%d-", randID)
+	queryServiceStats := NewQueryServiceStats(name, enablePublishStats)
 	return NewSchemaInfo(
 		queryCacheSize,
-		fmt.Sprintf("TestSchemaInfo-%d-", randID),
+		name,
 		map[string]string{
 			debugQueryPlansKey: fmt.Sprintf("/debug/query_plans_%d", randID),
 			debugQueryStatsKey: fmt.Sprintf("/debug/query_stats_%d", randID),
@@ -146,5 +158,6 @@ func newTestSchemaInfo(
 		reloadTime,
 		idleTimeout,
 		enablePublishStats,
+		queryServiceStats,
 	)
 }


### PR DESCRIPTION
1. remove global stats variables defined in query_engine.go.
2. introduce QueryServiceStats struct to be a holder of these stats.
3. use a dependency injection way to push QueryServiceStats instance from
   QueryEngine to ConnPool, DBConn, TxPool, etc.