### PR TITLE
fix flaky querylogz tests

### DIFF
--- a/go/vt/tabletserver/querylogz.go
+++ b/go/vt/tabletserver/querylogz.go
@@ -95,6 +95,11 @@ func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Reques
 	for i := 0; i < limit; i++ {
 		select {
 		case out := <-ch:
+			select {
+			case <-tmr.C:
+				return
+			default:
+			}
 			stats, ok := out.(*SQLQueryStats)
 			if !ok {
 				err := fmt.Errorf("Unexpected value in %s: %#v (expecting value of type %T)", TxLogger.Name(), out, &SQLQueryStats{})

--- a/go/vt/tabletserver/querylogz_test.go
+++ b/go/vt/tabletserver/querylogz_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestQuerylogzHandlerInvalidSqlQueryStats(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/querylogz?timeout=0&limit=10", nil)
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
 	response := httptest.NewRecorder()
 	ch := make(chan interface{}, 1)
 	ch <- "test msg"
@@ -30,7 +30,7 @@ func TestQuerylogzHandlerInvalidSqlQueryStats(t *testing.T) {
 }
 
 func TestQuerylogzHandler(t *testing.T) {
-	req, _ := http.NewRequest("GET", "/querylogz?timeout=0&limit=10", nil)
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
 	logStats := newSqlQueryStats("Execute", context.Background())
 	logStats.PlanType = planbuilder.PLAN_PASS_SELECT.String()
 	logStats.OriginalSql = "select name from test_table limit 1000"


### PR DESCRIPTION
Go's select will randomly pick a case if one or more of the communications can
proceed. In querylogz_test.go, timeout is set to zero and then it inserts a
message to the channel. This sometimes trigers timeout and thus message is not
retrieved and rendered.

1. double check the timeout condition when there is a message in the channel.
2. add a large timeout in the unit test to avoid run into the race condition.