### PR TITLE
Queries that have their contexts cancelled are logged as Info, not Error...

### DIFF
--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -95,7 +95,7 @@ func (conn *TabletBson) Execute(ctx context.Context, query string, bindVars map[
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return nil, tabletconn.CONN_CLOSED
+		return nil, tabletconn.ConnClosed
 	}
 
 	req := &tproto.Query{
@@ -119,7 +119,7 @@ func (conn *TabletBson) ExecuteBatch(ctx context.Context, queries []tproto.Bound
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return nil, tabletconn.CONN_CLOSED
+		return nil, tabletconn.ConnClosed
 	}
 
 	req := tproto.QueryList{
@@ -142,7 +142,7 @@ func (conn *TabletBson) StreamExecute(ctx context.Context, query string, bindVar
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return nil, nil, tabletconn.CONN_CLOSED
+		return nil, nil, tabletconn.ConnClosed
 	}
 
 	req := &tproto.Query{
@@ -173,7 +173,7 @@ func (conn *TabletBson) Begin(ctx context.Context) (transactionID int64, err err
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return 0, tabletconn.CONN_CLOSED
+		return 0, tabletconn.ConnClosed
 	}
 
 	req := &tproto.Session{
@@ -192,7 +192,7 @@ func (conn *TabletBson) Commit(ctx context.Context, transactionID int64) error {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return tabletconn.CONN_CLOSED
+		return tabletconn.ConnClosed
 	}
 
 	req := &tproto.Session{
@@ -211,7 +211,7 @@ func (conn *TabletBson) Rollback(ctx context.Context, transactionID int64) error
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		return tabletconn.CONN_CLOSED
+		return tabletconn.ConnClosed
 	}
 
 	req := &tproto.Session{
@@ -230,7 +230,7 @@ func (conn *TabletBson) SplitQuery(ctx context.Context, query tproto.BoundQuery,
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.rpcClient == nil {
-		err = tabletconn.CONN_CLOSED
+		err = tabletconn.ConnClosed
 		return
 	}
 	req := &tproto.SplitQueryRequest{
@@ -287,6 +287,9 @@ func tabletError(err error) error {
 			code = tabletconn.ERR_NORMAL
 		}
 		return &tabletconn.ServerError{Code: code, Err: fmt.Sprintf("vttablet: %v", err)}
+	}
+	if err == context.Canceled {
+		return tabletconn.Cancelled
 	}
 	return tabletconn.OperationalError(fmt.Sprintf("vttablet: %v", err))
 }

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -24,8 +24,8 @@ const (
 )
 
 const (
-	CONN_CLOSED = OperationalError("vttablet: Connection Closed")
-	CANCELLED   = OperationalError("vttablet: Context cancelled")
+	ConnClosed = OperationalError("vttablet: Connection Closed")
+	Cancelled  = OperationalError("vttablet: Context Cancelled")
 )
 
 var (

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -25,6 +25,7 @@ const (
 
 const (
 	CONN_CLOSED = OperationalError("vttablet: Connection Closed")
+	CANCELLED   = OperationalError("vttablet: Context cancelled")
 )
 
 var (

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -337,7 +337,7 @@ func TestScatterConnError(t *testing.T) {
 		Errs: []error{
 			&ShardConnError{Code: 10, Err: &tabletconn.ServerError{Err: "tabletconn error"}},
 			fmt.Errorf("generic error"),
-			tabletconn.CONN_CLOSED,
+			tabletconn.ConnClosed,
 		},
 	}
 

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -572,8 +572,8 @@ func isErrorCausedByVTGate(err error) bool {
 		case *ShardConnError:
 			errQueue = append(errQueue, e.Err)
 		case tabletconn.OperationalError:
-			// tabletconn.CANCELLED errors are due to client behavior, not VTGate errors.
-			if e != tabletconn.CANCELLED {
+			// tabletconn.Cancelled errors are due to client behavior, not VTGate errors.
+			if e != tabletconn.Cancelled {
 				return true
 			}
 		case *tabletconn.ServerError:

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -571,6 +571,11 @@ func isErrorCausedByVTGate(err error) bool {
 			errQueue = append(errQueue, e.Errs...)
 		case *ShardConnError:
 			errQueue = append(errQueue, e.Err)
+		case tabletconn.OperationalError:
+			// tabletconn.CANCELLED errors are due to client behavior, not VTGate errors.
+			if e != tabletconn.CANCELLED {
+				return true
+			}
 		case *tabletconn.ServerError:
 			break
 		default:

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -743,7 +743,7 @@ func TestIsErrorCausedByVTGate(t *testing.T) {
 	}
 	shardConnUnknownErr := &ShardConnError{Err: unknownError}
 	shardConnServerErr := &ShardConnError{Err: serverError}
-	shardConnCancelledErr := &ShardConnError{Err: tabletconn.CANCELLED}
+	shardConnCancelledErr := &ShardConnError{Err: tabletconn.Cancelled}
 
 	scatterConnErrAllUnknownErrs := &ScatterConnError{
 		Errs: []error{unknownError, unknownError, unknownError},
@@ -758,14 +758,14 @@ func TestIsErrorCausedByVTGate(t *testing.T) {
 	inputToWant := map[error]bool{
 		unknownError:         true,
 		serverError:          false,
-		tabletconn.CANCELLED: false,
-		// OperationalErrors that are not tabletconn.CANCELLED might be from VTGate
-		tabletconn.CONN_CLOSED: true,
+		tabletconn.Cancelled: false,
+		// OperationalErrors that are not tabletconn.Cancelled might be from VTGate
+		tabletconn.ConnClosed: true,
 		// Errors wrapped in ShardConnError should get unwrapped
 		shardConnUnknownErr:   true,
 		shardConnServerErr:    false,
 		shardConnCancelledErr: false,
-		// We consider a ScatterConnErr with all uknown errors to be from VTGate
+		// We consider a ScatterConnErr with all unknown errors to be from VTGate
 		scatterConnErrAllUnknownErrs: true,
 		// We consider a ScatterConnErr with a mix of errors to be from VTGate
 		scatterConnErrMixed: true,


### PR DESCRIPTION
..., in VTGate.

Can't do better testing than this, because bson RPC's StreamGo doesn't actually use a context (and it probably doesn't make sense to add functionality to bsonrpc at this point).

@guoliang100 