### PR TITLE
add schema manager tab in vtctld

### DIFF
--- a/go/cmd/vtctld/templates/app.js
+++ b/go/cmd/vtctld/templates/app.js
@@ -13,6 +13,7 @@ angular.module('app', ['ngRoute'])
 .controller('ClassController', ClassController)
 .controller('LoadController', LoadController)
 .controller('SubmitController', SubmitController)
+.controller('SchemaManagerController', SchemaManagerController)
 .config(['$routeProvider', function($routeProvider) {
   $routeProvider
   .when('/editor',{
@@ -34,6 +35,10 @@ angular.module('app', ['ngRoute'])
   .when('/submit',{
     templateUrl: "/content/submit/submit.html",
     controller: "SubmitController"
+  })
+  .when('/schema-manager',{
+    templateUrl: "/content/schema_manager/index.html",
+    controller: "SchemaManagerController"
   })
   .otherwise({redirectTo: '/'});
 }]);

--- a/go/cmd/vtctld/templates/index.html
+++ b/go/cmd/vtctld/templates/index.html
@@ -6,25 +6,27 @@ license that can be found in the LICENSE file.
 -->
 
 <html data-ng-app="app">
-<link rel="stylesheet"
-  href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
-<head>
-<base href="/" />
-<meta charset="US-ASCII">
-<title>VTGate schema editor</title>
-</head>
-<body>
+  <link rel="stylesheet"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+  <head>
+    <base href="/" />
+    <meta charset="US-ASCII">
+    <title>Vitess Vtctld</title>
+  </head>
+
+  <body>
     <nav class="navbar navbar-inverse">
       <div class="container-fluid">
         <div class="navbar-header">
           <a class="navbar-brand" href="/">Vitess</a>
         </div>
-        <div id="navbar" class="navbar-collapse collapse">
+        <div id="navbar" class="navbar-collapse">
           <ul class="nav navbar-nav">
             <li><a href="/dbtopo">Topology</a></li>
             <li><a href="/serving_graph">Serving graph</a></li>
             <li><a href="#/editor">Schema editor</a></li>
             <li><a href="/vschema">Schema View</a></li>
+            <li><a href="#/schema-manager">Schema Manager</a></li>
             {{with .ToplevelLinks}}
             {{range $name, $href := .}}
             <li><a href="{{$href}}">{{$name}}</a></li>
@@ -34,49 +36,24 @@ license that can be found in the LICENSE file.
         </div>
       </div>
     </nav>
-  <div data-ng-view></div>
-  <script src="https://code.jquery.com/jquery-2.1.3.js"
-    type="text/javascript">
-
-    </script>
-  <script
-    src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.js"
-    type="text/javascript">
-
-    </script>
-  <script
-    src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.js"
-    type="text/javascript">
-
-    </script>
-  <script
-    src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular-route.min.js"
-    type="text/javascript">
-
-    </script>
-  <script src="content/vindex_info.js" type="text/javascript">
-
-    </script>
-  <script src="content/curschema.js" type="text/javascript">
-
-    </script>
-  <script src="content/editor/sidebar.js" type="text/javascript">
-
-    </script>
-  <script src="content/editor/keyspace.js" type="text/javascript">
-
-    </script>
-  <script src="content/editor/class/class.js" type="text/javascript">
-
-    </script>
-  <script src="content/load/load.js" type="text/javascript">
-
-    </script>
-  <script src="content/submit/submit.js" type="text/javascript">
-
-    </script>
-  <script src="content/app.js" type="text/javascript">
-
-    </script>
-</body>
+    <div class="container-fluid">
+      <div data-ng-view></div>
+    </div>
+    <script src="https://code.jquery.com/jquery-2.1.3.js" type="text/javascript"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.js"
+            type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.js"
+            type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular-route.min.js"
+            type="text/javascript"></script>
+    <script src="content/vindex_info.js" type="text/javascript"></script>
+    <script src="content/curschema.js" type="text/javascript"></script>
+    <script src="content/editor/sidebar.js" type="text/javascript"></script>
+    <script src="content/editor/keyspace.js" type="text/javascript"></script>
+    <script src="content/editor/class/class.js" type="text/javascript"></script>
+    <script src="content/load/load.js" type="text/javascript"></script>
+    <script src="content/submit/submit.js" type="text/javascript"></script>
+    <script src="content/schema_manager/index.js" type="text/javascript"></script>
+    <script src="content/app.js" type="text/javascript"></script>
+  </body>
 </html>

--- a/go/cmd/vtctld/templates/schema_manager/index.html
+++ b/go/cmd/vtctld/templates/schema_manager/index.html
@@ -1,0 +1,29 @@
+<div class="container">
+  <div class="row-fluid">
+    <div class="col-xs-2">
+      <label>Keyspaces</label>
+      <div class="list-group">
+        <a href="" class="list-group-item"
+           ng-class="{active:selected == keyspace}"
+           ng-click="$parent.selected = keyspace; selectKeyspace(keyspace)"
+           ng-repeat="keyspace in keyspaces">
+          {{keyspace}}
+        </a>
+      </div>
+    </div>
+    <div>
+      <textarea class="col-xs-8" rows="20" data-ng-model="schemaChanges"></textarea>
+    </div>
+    <div class="col-xs-2">
+      <button type="button" class="btn btn-success" data-ng-click="submitSchema()" >Submit</button>
+      <div ng-if="shouldShowSchemaChangeStatus">
+        <label>Schema Change Status</label>
+        <label>{{schemaStatus}}</label>
+        <div class="progress">
+          <div class="progress-bar progress-bar-success progress-bar-striped" role="progressbar" aria-valuenow="40" aria-valuemin="0" aria-valuemax="100" style="width: 40%">
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/go/cmd/vtctld/templates/schema_manager/index.js
+++ b/go/cmd/vtctld/templates/schema_manager/index.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015, Google Inc. All rights reserved. Use of this source code is
+ * governed by a BSD-style license that can be found in the LICENSE file.
+ */
+'use strict';
+
+function SchemaManagerController($scope, $http) {
+  init();
+
+  function init() {
+    $scope.schemaChanges = "";
+    $scope.selectedKeyspace = "";
+    $scope.shouldShowSchemaChangeStatus = false;
+    $scope.keyspaces = [];
+    $http.get('/json/Keyspaces').
+    success(function(data, status, headers, config) {
+      $scope.keyspaces = data.Keyspaces;
+    }).
+    error(function(data, status, headers, config) {
+    });
+  }
+
+  $scope.selectKeyspace = function(selectedKeyspace) {
+    $scope.selectedKeyspace = selectedKeyspace;
+  }
+
+  $scope.submitSchema = function() {
+    $.ajax({
+      type: 'POST',
+      url: '/json/schema-manager',
+      data: {"keyspace": $scope.selectedKeyspace, "data": $scope.schemaChanges},
+      dataType: 'json'
+    }).success(function(data) {
+      $scope.schemaStatus = data.responseText;
+      $scope.shouldShowSchemaChangeStatus = true;
+      $scope.$apply();
+    }).error(function(data) {
+      $scope.schemaStatus = data.responseText;
+      $scope.shouldShowSchemaChangeStatus = true;
+      $scope.$apply();
+    });
+  };
+}

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -23,7 +23,7 @@ func TestRunSchemaChangesDataSourcerOpenFail(t *testing.T) {
 	dataSourcer := newFakeDataSourcer([]string{"select * from test_db"}, true, false, false)
 	handler := newFakeHandler()
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
 	if err != errDataSourcerOpen {
 		t.Fatalf("data sourcer open fail, shoud get error: %v, but get error: %v",
@@ -35,7 +35,7 @@ func TestRunSchemaChangesDataSourcerReadFail(t *testing.T) {
 	dataSourcer := newFakeDataSourcer([]string{"select * from test_db"}, false, true, false)
 	handler := newFakeHandler()
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
 	if err != errDataSourcerRead {
 		t.Fatalf("data sourcer read fail, shoud get error: %v, but get error: %v",
@@ -50,7 +50,7 @@ func TestRunSchemaChangesValidationFail(t *testing.T) {
 	dataSourcer := newFakeDataSourcer([]string{"invalid sql"}, false, false, false)
 	handler := newFakeHandler()
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
 	if err == nil {
 		t.Fatalf("run schema change should fail due to executor.Open fail")
@@ -61,7 +61,7 @@ func TestRunSchemaChanges(t *testing.T) {
 	dataSourcer := NewSimepleDataSourcer("select * from test_db;")
 	handler := newFakeHandler()
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	err := Run(dataSourcer, exec, handler, []string{"0", "1", "2"})
 	if err != nil {
 		t.Fatalf("schema change should success but get error: %v", err)
@@ -87,10 +87,9 @@ func newFakeVtGateConn() *fakevtgateconn.FakeVTGateConn {
 	return fakevtgateconn.NewFakeVTGateConn(context.Background(), "", 1*time.Second)
 }
 
-func newFakeVtGateExecutor(addr string, conn *fakevtgateconn.FakeVTGateConn) *VtGateExecutor {
+func newFakeVtGateExecutor(conn *fakevtgateconn.FakeVTGateConn) *VtGateExecutor {
 	return NewVtGateExecutor(
 		"test_keyspace",
-		addr,
 		conn,
 		1*time.Second)
 }

--- a/go/vt/schemamanager/uihandler/handler.go
+++ b/go/vt/schemamanager/uihandler/handler.go
@@ -1,0 +1,61 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uihandler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/vt/schemamanager"
+)
+
+// UIEventHandler handles schema events
+type UIEventHandler struct {
+	writer http.ResponseWriter
+}
+
+// NewUIEventHandler creates a UIEventHandler instance
+func NewUIEventHandler(writer http.ResponseWriter) *UIEventHandler {
+	return &UIEventHandler{writer: writer}
+}
+
+// OnDataSourcerReadSuccess is no-op
+func (handler *UIEventHandler) OnDataSourcerReadSuccess(sqls []string) error {
+	handler.writer.Write([]byte(fmt.Sprintf("OnDataSourcerReadSuccess, sqls: %v\n", sqls)))
+	return nil
+}
+
+// OnDataSourcerReadFail is no-op
+func (handler *UIEventHandler) OnDataSourcerReadFail(err error) error {
+	handler.writer.Write([]byte(fmt.Sprintf("OnDataSourcerReadFail, error: %v\n", err)))
+	return err
+}
+
+// OnValidationSuccess is no-op
+func (handler *UIEventHandler) OnValidationSuccess(sqls []string) error {
+	handler.writer.Write([]byte(fmt.Sprintf("OnValidationSuccess, sqls: %v\n", sqls)))
+	return nil
+}
+
+// OnValidationFail is no-op
+func (handler *UIEventHandler) OnValidationFail(err error) error {
+	handler.writer.Write([]byte(fmt.Sprintf("OnValidationFail, error: %v\n", err)))
+	return err
+}
+
+// OnExecutorComplete is no-op
+func (handler *UIEventHandler) OnExecutorComplete(result *schemamanager.ExecuteResult) error {
+	str, err := json.Marshal(result)
+	if err != nil {
+		log.Errorf("Failed to serialize ExecuteResult: %v", err)
+		return err
+	}
+	handler.writer.Write(str)
+	return nil
+}
+
+var _ schemamanager.EventHandler = (*UIEventHandler)(nil)

--- a/go/vt/schemamanager/vtgate_executor.go
+++ b/go/vt/schemamanager/vtgate_executor.go
@@ -19,25 +19,22 @@ import (
 
 // VtGateExecutor applies schema changes via VtGate
 type VtGateExecutor struct {
-	keyspace   string
-	conn       vtgateconn.VTGateConn
-	vtGateAddr string
-	timeout    time.Duration
-	isClosed   bool
+	keyspace string
+	conn     vtgateconn.VTGateConn
+	timeout  time.Duration
+	isClosed bool
 }
 
 // NewVtGateExecutor creates a new VtGateExecutor instance
 func NewVtGateExecutor(
 	keyspace string,
-	addr string,
 	conn vtgateconn.VTGateConn,
 	timeout time.Duration) *VtGateExecutor {
 	return &VtGateExecutor{
-		keyspace:   keyspace,
-		vtGateAddr: addr,
-		conn:       conn,
-		timeout:    timeout,
-		isClosed:   true,
+		keyspace: keyspace,
+		conn:     conn,
+		timeout:  timeout,
+		isClosed: true,
 	}
 }
 

--- a/go/vt/schemamanager/vtgate_executor_test.go
+++ b/go/vt/schemamanager/vtgate_executor_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestOpenVtGateExecutor(t *testing.T) {
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	if err := exec.Open(); err != nil {
 		t.Fatalf("failed to call executor.Open: %v", err)
 	}
@@ -23,7 +23,7 @@ func TestOpenVtGateExecutor(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	defer exec.Close()
 
 	invalidSelect := []string{"select  from test_table"}
@@ -56,7 +56,7 @@ func TestExecuteWithoutOpen(t *testing.T) {
 	shards := []string{"0", "1"}
 	sqls := []string{"insert into  test_table values (1, 2)"}
 	fakeConn := newFakeVtGateConn()
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	result := exec.Execute(sqls, shards)
 	if result.ExecutorErr == "" {
 		t.Fatalf("execute should fail because Execute() is being called before Open()")
@@ -86,7 +86,7 @@ func TestExecuteDML(t *testing.T) {
 		}
 	}
 
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	exec.Open()
 	defer exec.Close()
 	result := exec.Execute(invalidSqls, shards)
@@ -121,7 +121,7 @@ func TestExecuteDDL(t *testing.T) {
 				&mproto.QueryResult{})
 		}
 	}
-	exec := newFakeVtGateExecutor("localhost:12345", fakeConn)
+	exec := newFakeVtGateExecutor(fakeConn)
 	exec.Open()
 	defer exec.Close()
 	result := exec.Execute(validSqls, shards)


### PR DESCRIPTION
The idea is that user could apply schema changes (DDLs) via schema manager tab.
Current code uses vtgate to do the schema change and this will be replaced by
an executor that applies directly to all vttablets.