### PR TITLE
Updated locate.go to fail if glob search directory does not exist.

### DIFF
--- a/go/testfiles/locate.go
+++ b/go/testfiles/locate.go
@@ -25,10 +25,25 @@ func Glob(pattern string) []string {
 	if vtroot == "" {
 		panic(fmt.Errorf("VTROOT is not set"))
 	}
-	resolved := path.Join(vtroot, "data", "test", pattern)
+	dir := path.Join(vtroot, "data", "test")
+	if exists, err := exists(dir); !exists {
+		panic(err)
+	}
+	resolved := path.Join(dir, pattern)
 	out, err := filepath.Glob(resolved)
 	if err != nil {
 		panic(err)
 	}
 	return out
+}
+
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, err
+	}
+	return false, err
 }


### PR DESCRIPTION
I found that if VTROOT variable was not set to a valid directory than some unit tests like [go/vt/sqlparser/parse_test.go TestParse](https://github.com/youtube/vitess/blob/master/go/vt/sqlparser/parse_test.go#L25)  would incorrectly pass. This is due to the [go/testfiles/locate.go Glob Method](https://github.com/youtube/vitess/blob/master/go/testfiles/locate.go#L23) returning an empty []string even if the directory does not exist. The fix includes panicking if the $VTROOT/data/test directory does not exist.