### PR TITLE
add EnableAutoCommit flag to allow one enable/disable autocommit feature

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -63,6 +63,7 @@ type QueryEngine struct {
 	maxDMLRows       sync2.AtomicInt64
 	streamBufferSize sync2.AtomicInt64
 	strictTableAcl   bool
+	enableAutoCommit bool
 
 	// Loggers
 	accessCheckerLogger *logutil.ThrottledLogger
@@ -100,7 +101,7 @@ func getOrPanic(ctx context.Context, pool *ConnPool) *DBConn {
 // This is a singleton class.
 // You must call this only once.
 func NewQueryEngine(config Config) *QueryEngine {
-	qe := &QueryEngine{}
+	qe := &QueryEngine{enableAutoCommit: config.EnableAutoCommit}
 	qe.queryServiceStats = NewQueryServiceStats(config.StatsPrefix, config.EnablePublishStats)
 	qe.schemaInfo = NewSchemaInfo(
 		config.QueryCacheSize,

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -107,6 +107,9 @@ func (qre *QueryExecutor) Execute() (reply *mproto.QueryResult) {
 			defer conn.Recycle()
 			reply = qre.execSQL(conn, qre.query, true)
 		default:
+			if !qre.qe.enableAutoCommit {
+				panic(NewTabletError(ErrFatal, "unsupported query: %s", qre.query))
+			}
 			reply = qre.execDmlAutoCommit()
 		}
 	}

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -824,6 +824,8 @@ func newTestQueryExecutor(sql string, ctx context.Context, flags executorFlags) 
 	config.TransactionCap = 100
 	config.SpotCheckRatio = 1.0
 	config.EnablePublishStats = false
+	config.EnableAutoCommit = true
+
 	if flags&enableStrict > 0 {
 		config.StrictMode = true
 	} else {

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -59,6 +59,7 @@ func init() {
 	flag.StringVar(&qsConfig.StatsPrefix, "stats-prefix", DefaultQsConfig.StatsPrefix, "prefix for variable names exported via expvar")
 	flag.StringVar(&qsConfig.DebugURLPrefix, "debug-url-prefix", DefaultQsConfig.DebugURLPrefix, "debug url prefix, vttablet will report various system debug pages and this config controls the prefix of these debug urls")
 	flag.StringVar(&qsConfig.PoolNamePrefix, "pool-name-prefix", DefaultQsConfig.PoolNamePrefix, "pool name prefix, vttablet has several pools and each of them has a name. This config specifies the prefix of these pool names")
+	flag.BoolVar(&qsConfig.EnableAutoCommit, "enable-autocommit", DefaultQsConfig.EnableAutoCommit, "if the flag is on, a DML outsides a transaction will be auto committed.")
 }
 
 // RowCacheConfig encapsulates the configuration for RowCache
@@ -116,6 +117,7 @@ type Config struct {
 	StrictTableAcl     bool
 	TerseErrors        bool
 	EnablePublishStats bool
+	EnableAutoCommit   bool
 	StatsPrefix        string
 	DebugURLPrefix     string
 	PoolNamePrefix     string
@@ -148,6 +150,7 @@ var DefaultQsConfig = Config{
 	StrictTableAcl:     false,
 	TerseErrors:        false,
 	EnablePublishStats: true,
+	EnableAutoCommit:   false,
 	StatsPrefix:        "",
 	DebugURLPrefix:     "/debug",
 	PoolNamePrefix:     "",

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -705,6 +705,7 @@ func TestSqlQueryExecuteBatchSqlSucceedInTransaction(t *testing.T) {
 	db.AddRejectedQuery(sql)
 
 	config := testUtils.newQueryServiceConfig()
+	config.EnableAutoCommit = true
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
 	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -393,6 +393,7 @@ class Tablet(object):
     if extra_args:
       args.extend(extra_args)
 
+    args.extend(['-enable-autocommit'])
     stderr_fd = open(os.path.join(environment.vtlogroot, '%s-%d.stderr' % (binary, self.tablet_uid)), 'w')
     # increment count only the first time
     if not self.proc:


### PR DESCRIPTION
1. Add EnableAutoCommit in queryservice, false by default.
2. If EnableAutoCommit is true, a DML outsides a transaction will be accepted
   by querservice and it will starts a transaction to execute this DML.
3. Turn on this flag in integration tests to make existing tests pass.