### PR TITLE
add ExecuteFetchAsDba in tabletmanager server

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -529,16 +529,10 @@ func (mysqld *Mysqld) ExecuteMysqlCommand(sql string) error {
 	return nil
 }
 
-// GetDbConnection returns a connection from the pool chosen by dbconfigName.
+// GetAppConnection returns a connection from the app pool.
 // Recycle needs to be called on the result.
-func (mysqld *Mysqld) GetDbConnection(dbconfigName dbconfigs.DbConfigName) (dbconnpool.PoolConnection, error) {
-	switch dbconfigName {
-	case dbconfigs.DbaConfigName:
-		return mysqld.dbaPool.Get(0)
-	case dbconfigs.AppConfigName:
-		return mysqld.appPool.Get(0)
-	}
-	return nil, fmt.Errorf("unknown dbconfigName: %v", dbconfigName)
+func (mysqld *Mysqld) GetAppConnection() (dbconnpool.PoolConnection, error) {
+	return mysqld.appPool.Get(0)
 }
 
 // GetDbaConnection creates a new DBConnection.

--- a/go/vt/tabletmanager/actionnode/actionnode.go
+++ b/go/vt/tabletmanager/actionnode/actionnode.go
@@ -152,8 +152,11 @@ const (
 	// TabletActionApplySchema will actually apply the schema change
 	TabletActionApplySchema = "ApplySchema"
 
-	// TabletActionExecuteFetch uses the DBA connection pool to run queries.
-	TabletActionExecuteFetch = "ExecuteFetch"
+	// TabletActionExecuteFetchAsDba uses the DBA connection to run queries.
+	TabletActionExecuteFetchAsDba = "ExecuteFetchAsDba"
+
+	// TabletActionExecuteFetchAsApp uses the App connection to run queries.
+	TabletActionExecuteFetchAsApp = "ExecuteFetchAsApp"
 
 	// TabletActionGetPermissions returns the mysql permissions set
 	TabletActionGetPermissions = "GetPermissions"

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -283,9 +283,9 @@ func (agent *ActionAgent) ExecuteFetchAsDba(ctx context.Context, query string, d
 	}
 
 	if dbName != "" {
-		if _, err := conn.ExecuteFetch("USE "+dbName, 1, false); err != nil {
-			return nil, err
-		}
+		// This execute might fail if db does not exist.
+		// Error is ignored because given query might create this database.
+		conn.ExecuteFetch("USE "+dbName, 1, false)
 	}
 
 	// run the query

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -16,7 +16,6 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/mysql/proto"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
-	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/hook"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -71,7 +70,7 @@ type RPCAgent interface {
 
 	ExecuteFetchAsDba(ctx context.Context, query string, dbName string, maxrows int, wantFields, disableBinlogs bool, reloadSchema bool) (*proto.QueryResult, error)
 
-	ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error)
+	ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool) (*proto.QueryResult, error)
 
 	// Replication related methods
 
@@ -310,9 +309,9 @@ func (agent *ActionAgent) ExecuteFetchAsDba(ctx context.Context, query string, d
 
 // ExecuteFetchAsApp will execute the given query, possibly disabling binlogs.
 // Should be called under RPCWrap.
-func (agent *ActionAgent) ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error) {
+func (agent *ActionAgent) ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool) (*proto.QueryResult, error) {
 	// get a connection
-	conn, err := agent.MysqlDaemon.GetDbConnection(dbconfigName)
+	conn, err := agent.MysqlDaemon.GetAppConnection()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -69,7 +69,9 @@ type RPCAgent interface {
 
 	ApplySchema(ctx context.Context, change *myproto.SchemaChange) (*myproto.SchemaChangeResult, error)
 
-	ExecuteFetch(ctx context.Context, query string, maxrows int, wantFields, disableBinlogs bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error)
+	ExecuteFetchAsDba(ctx context.Context, query string, maxrows int, wantFields, disableBinlogs bool, reloadSchema bool) (*proto.QueryResult, error)
+
+	ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error)
 
 	// Replication related methods
 
@@ -263,15 +265,15 @@ func (agent *ActionAgent) ApplySchema(ctx context.Context, change *myproto.Schem
 	return scr, nil
 }
 
-// ExecuteFetch will execute the given query, possibly disabling binlogs.
+// ExecuteFetchAsDba will execute the given query, possibly disabling binlogs and reload schema.
 // Should be called under RPCWrap.
-func (agent *ActionAgent) ExecuteFetch(ctx context.Context, query string, maxrows int, wantFields, disableBinlogs bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error) {
+func (agent *ActionAgent) ExecuteFetchAsDba(ctx context.Context, query string, maxrows int, wantFields bool, disableBinlogs bool, reloadSchema bool) (*proto.QueryResult, error) {
 	// get a connection
-	conn, err := agent.MysqlDaemon.GetDbConnection(dbconfigName)
+	conn, err := agent.MysqlDaemon.GetDbaConnection()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Recycle()
+	defer conn.Close()
 
 	// disable binlogs if necessary
 	if disableBinlogs {
@@ -286,7 +288,7 @@ func (agent *ActionAgent) ExecuteFetch(ctx context.Context, query string, maxrow
 
 	// re-enable binlogs if necessary
 	if disableBinlogs && !conn.IsClosed() {
-		conn.ExecuteFetch("SET sql_log_bin = ON", 0, false)
+		_, err := conn.ExecuteFetch("SET sql_log_bin = ON", 0, false)
 		if err != nil {
 			// if we can't reset the sql_log_bin flag,
 			// let's just close the connection.
@@ -294,7 +296,22 @@ func (agent *ActionAgent) ExecuteFetch(ctx context.Context, query string, maxrow
 		}
 	}
 
+	if err == nil && reloadSchema {
+		agent.QueryServiceControl.ReloadSchema()
+	}
 	return qr, err
+}
+
+// ExecuteFetchAsApp will execute the given query, possibly disabling binlogs.
+// Should be called under RPCWrap.
+func (agent *ActionAgent) ExecuteFetchAsApp(ctx context.Context, query string, maxrows int, wantFields bool, dbconfigName dbconfigs.DbConfigName) (*proto.QueryResult, error) {
+	// get a connection
+	conn, err := agent.MysqlDaemon.GetDbConnection(dbconfigName)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+	return conn.ExecuteFetch(query, maxrows, wantFields)
 }
 
 // SlaveStatus returns the replication status

--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -592,7 +592,7 @@ var testExecuteFetchResult = &mproto.QueryResult{
 }
 var testExecuteFetchDbConfigName dbconfigs.DbConfigName
 
-func (fra *fakeRPCAgent) ExecuteFetchAsDba(ctx context.Context, query string, maxrows int, wantFields, disableBinlogs bool, reloadSchema bool) (*mproto.QueryResult, error) {
+func (fra *fakeRPCAgent) ExecuteFetchAsDba(ctx context.Context, query string, dbName string, maxrows int, wantFields, disableBinlogs bool, reloadSchema bool) (*mproto.QueryResult, error) {
 	if fra.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}

--- a/go/vt/tabletmanager/gorpcproto/structs.go
+++ b/go/vt/tabletmanager/gorpcproto/structs.go
@@ -87,6 +87,7 @@ type RunBlpUntilArgs struct {
 // ExecuteFetchArgs has arguments for ExecuteFetch
 type ExecuteFetchArgs struct {
 	Query          string
+	DbName         string
 	MaxRows        int
 	WantFields     bool
 	DisableBinlogs bool

--- a/go/vt/tabletmanager/gorpcproto/structs.go
+++ b/go/vt/tabletmanager/gorpcproto/structs.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
-	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
 	myproto "github.com/youtube/vitess/go/vt/mysqlctl/proto"
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
@@ -92,7 +91,6 @@ type ExecuteFetchArgs struct {
 	WantFields     bool
 	DisableBinlogs bool
 	ReloadSchema   bool
-	DBConfigName   dbconfigs.DbConfigName
 }
 
 // gorpc doesn't support returning a streaming type during streaming

--- a/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
+++ b/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
@@ -227,6 +227,7 @@ func (client *GoRPCTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, t
 	var qr mproto.QueryResult
 	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetchAsDba, &gorpcproto.ExecuteFetchArgs{
 		Query:          query,
+		DbName:         tablet.DbName(),
 		MaxRows:        maxRows,
 		WantFields:     wantFields,
 		DisableBinlogs: disableBinlogs,

--- a/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
+++ b/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
@@ -11,7 +11,6 @@ import (
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
 	blproto "github.com/youtube/vitess/go/vt/binlog/proto"
-	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/hook"
 	"github.com/youtube/vitess/go/vt/logutil"
 	myproto "github.com/youtube/vitess/go/vt/mysqlctl/proto"
@@ -242,10 +241,9 @@ func (client *GoRPCTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, t
 func (client *GoRPCTabletManagerClient) ExecuteFetchAsApp(ctx context.Context, tablet *topo.TabletInfo, query string, maxRows int, wantFields bool) (*mproto.QueryResult, error) {
 	var qr mproto.QueryResult
 	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetchAsApp, &gorpcproto.ExecuteFetchArgs{
-		Query:        query,
-		MaxRows:      maxRows,
-		WantFields:   wantFields,
-		DBConfigName: dbconfigs.AppConfigName,
+		Query:      query,
+		MaxRows:    maxRows,
+		WantFields: wantFields,
 	}, &qr); err != nil {
 		return nil, err
 	}

--- a/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
+++ b/go/vt/tabletmanager/gorpctmclient/gorpc_client.go
@@ -225,13 +225,12 @@ func (client *GoRPCTabletManagerClient) ApplySchema(ctx context.Context, tablet 
 // ExecuteFetchAsDba is part of the tmclient.TabletManagerClient interface
 func (client *GoRPCTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, tablet *topo.TabletInfo, query string, maxRows int, wantFields, disableBinlogs, reloadSchema bool) (*mproto.QueryResult, error) {
 	var qr mproto.QueryResult
-	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetch, &gorpcproto.ExecuteFetchArgs{
+	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetchAsDba, &gorpcproto.ExecuteFetchArgs{
 		Query:          query,
 		MaxRows:        maxRows,
 		WantFields:     wantFields,
 		DisableBinlogs: disableBinlogs,
 		ReloadSchema:   reloadSchema,
-		DBConfigName:   dbconfigs.DbaConfigName,
 	}, &qr); err != nil {
 		return nil, err
 	}
@@ -241,12 +240,11 @@ func (client *GoRPCTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, t
 // ExecuteFetchAsApp is part of the tmclient.TabletManagerClient interface
 func (client *GoRPCTabletManagerClient) ExecuteFetchAsApp(ctx context.Context, tablet *topo.TabletInfo, query string, maxRows int, wantFields bool) (*mproto.QueryResult, error) {
 	var qr mproto.QueryResult
-	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetch, &gorpcproto.ExecuteFetchArgs{
-		Query:          query,
-		MaxRows:        maxRows,
-		WantFields:     wantFields,
-		DisableBinlogs: false,
-		DBConfigName:   dbconfigs.AppConfigName,
+	if err := client.rpcCallTablet(ctx, tablet, actionnode.TabletActionExecuteFetchAsApp, &gorpcproto.ExecuteFetchArgs{
+		Query:        query,
+		MaxRows:      maxRows,
+		WantFields:   wantFields,
+		DBConfigName: dbconfigs.AppConfigName,
 	}, &qr); err != nil {
 		return nil, err
 	}

--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
@@ -200,16 +200,25 @@ func (tm *TabletManager) ApplySchema(ctx context.Context, args *myproto.SchemaCh
 	})
 }
 
-// ExecuteFetch wraps RPCAgent.ExecuteFetch
-func (tm *TabletManager) ExecuteFetch(ctx context.Context, args *gorpcproto.ExecuteFetchArgs, reply *mproto.QueryResult) error {
+// ExecuteFetchAsDba wraps RPCAgent.ExecuteFetchAsDba
+func (tm *TabletManager) ExecuteFetchAsDba(ctx context.Context, args *gorpcproto.ExecuteFetchArgs, reply *mproto.QueryResult) error {
 	ctx = callinfo.RPCWrapCallInfo(ctx)
-	return tm.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetch, args, reply, func() error {
-		qr, err := tm.agent.ExecuteFetch(ctx, args.Query, args.MaxRows, args.WantFields, args.DisableBinlogs, args.DBConfigName)
+	return tm.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsDba, args, reply, func() error {
+		qr, err := tm.agent.ExecuteFetchAsDba(ctx, args.Query, args.MaxRows, args.WantFields, args.DisableBinlogs, args.ReloadSchema)
 		if err == nil {
 			*reply = *qr
-			if args.ReloadSchema {
-				tm.agent.ReloadSchema(ctx)
-			}
+		}
+		return err
+	})
+}
+
+// ExecuteFetchAsApp wraps RPCAgent.ExecuteFetchAsApp
+func (tm *TabletManager) ExecuteFetchAsApp(ctx context.Context, args *gorpcproto.ExecuteFetchArgs, reply *mproto.QueryResult) error {
+	ctx = callinfo.RPCWrapCallInfo(ctx)
+	return tm.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsApp, args, reply, func() error {
+		qr, err := tm.agent.ExecuteFetchAsApp(ctx, args.Query, args.MaxRows, args.WantFields, args.DBConfigName)
+		if err == nil {
+			*reply = *qr
 		}
 		return err
 	})

--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
@@ -216,7 +216,7 @@ func (tm *TabletManager) ExecuteFetchAsDba(ctx context.Context, args *gorpcproto
 func (tm *TabletManager) ExecuteFetchAsApp(ctx context.Context, args *gorpcproto.ExecuteFetchArgs, reply *mproto.QueryResult) error {
 	ctx = callinfo.RPCWrapCallInfo(ctx)
 	return tm.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsApp, args, reply, func() error {
-		qr, err := tm.agent.ExecuteFetchAsApp(ctx, args.Query, args.MaxRows, args.WantFields, args.DBConfigName)
+		qr, err := tm.agent.ExecuteFetchAsApp(ctx, args.Query, args.MaxRows, args.WantFields)
 		if err == nil {
 			*reply = *qr
 		}

--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
@@ -204,7 +204,7 @@ func (tm *TabletManager) ApplySchema(ctx context.Context, args *myproto.SchemaCh
 func (tm *TabletManager) ExecuteFetchAsDba(ctx context.Context, args *gorpcproto.ExecuteFetchArgs, reply *mproto.QueryResult) error {
 	ctx = callinfo.RPCWrapCallInfo(ctx)
 	return tm.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsDba, args, reply, func() error {
-		qr, err := tm.agent.ExecuteFetchAsDba(ctx, args.Query, args.MaxRows, args.WantFields, args.DisableBinlogs, args.ReloadSchema)
+		qr, err := tm.agent.ExecuteFetchAsDba(ctx, args.Query, args.DbName, args.MaxRows, args.WantFields, args.DisableBinlogs, args.ReloadSchema)
 		if err == nil {
 			*reply = *qr
 		}

--- a/go/vt/vttest/fakesqldb/conn.go
+++ b/go/vt/vttest/fakesqldb/conn.go
@@ -8,6 +8,7 @@ package fakesqldb
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -42,16 +43,18 @@ func (db *DB) AddQuery(query string, expectedResult *proto.QueryResult) {
 	*result = *expectedResult
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.data[query] = result
-	db.queryCalled[query] = 0
+	key := strings.ToLower(query)
+	db.data[key] = result
+	db.queryCalled[key] = 0
 }
 
 // GetQuery gets a query from the fake DB.
 func (db *DB) GetQuery(query string) (*proto.QueryResult, bool) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	result, ok := db.data[query]
-	db.queryCalled[query]++
+	key := strings.ToLower(query)
+	result, ok := db.data[key]
+	db.queryCalled[key]++
 	return result, ok
 }
 
@@ -59,22 +62,23 @@ func (db *DB) GetQuery(query string) (*proto.QueryResult, bool) {
 func (db *DB) DeleteQuery(query string) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	delete(db.data, query)
-	delete(db.queryCalled, query)
+	key := strings.ToLower(query)
+	delete(db.data, key)
+	delete(db.queryCalled, key)
 }
 
 // AddRejectedQuery adds a query which will be rejected at execution time.
 func (db *DB) AddRejectedQuery(query string) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	db.rejectedData[query] = &proto.QueryResult{}
+	db.rejectedData[strings.ToLower(query)] = &proto.QueryResult{}
 }
 
 // HasRejectedQuery returns true if this query will be rejected.
 func (db *DB) HasRejectedQuery(query string) bool {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	_, ok := db.rejectedData[query]
+	_, ok := db.rejectedData[strings.ToLower(query)]
 	return ok
 }
 
@@ -82,14 +86,14 @@ func (db *DB) HasRejectedQuery(query string) bool {
 func (db *DB) DeleteRejectedQuery(query string) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	delete(db.rejectedData, query)
+	delete(db.rejectedData, strings.ToLower(query))
 }
 
 // GetQueryCalledNum returns how many times db executes a certain query.
 func (db *DB) GetQueryCalledNum(query string) int {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	num, ok := db.queryCalled[query]
+	num, ok := db.queryCalled[strings.ToLower(query)]
 	if !ok {
 		return 0
 	}

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	_ "github.com/youtube/vitess/go/vt/tabletserver/gorpctabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"golang.org/x/net/context"
@@ -124,6 +125,7 @@ func DestinationsFactory(t *testing.T) func() (dbconnpool.PoolConnection, error)
 }
 
 func TestCopySchemaShard(t *testing.T) {
+	fakesqldb.Register()
 	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient(), time.Second)
 


### PR DESCRIPTION
1. Add ExecuteFetchAsDba api in tabletmanager server.
2. Rename the existing ExecuteFetch to ExecuteFetchAsApp.
3. ExecuteFetchAsDba creates a dba connection on demand and takes care
   of enable/disable binlog and reload schema.
4. Add GetDbaConnection func in MysqlDaemon interface.
5. make sure fakesqldb package always store queries in lower case.