### PR TITLE
Check for unconverted Markdown lists after running Jekyll.

### DIFF
--- a/publish-site.sh
+++ b/publish-site.sh
@@ -55,6 +55,19 @@ git mv vitess.io/LICENSE .
 
 rm -rf vitess.io
 
+# pre-commit checks
+set +e
+list=$(find . -name '*.html' | xargs grep -lE '^\s*([\-\*]|\d\.) ')
+if [ -n "$list" ]; then
+  echo
+  echo "ERROR: The following pages appear to contain bulleted lists that weren't properly converted."
+  echo "Make sure all bulleted lists have a blank line before them."
+  echo
+  echo "$list"
+  exit 1
+fi
+set -e
+
 git add -u
 
 git commit -m "publish site `date`"


### PR DESCRIPTION
@yaoshengzhe @alainjobart 

If the writer doesn't put a newline before the list, it might look fine
in GitHub, but get passed through as plain text in Jekyll.

It's hard to detect this case in the raw Markdown without actually
parsing Markdown, because we'd need to distinguish between the first
item of a list, and subsequent items.

However, after running Jekyll, all Markdown lists should have been
converted, so we look for any unconverted lists before publishing.