### PR TITLE
autoschema rework

### DIFF
--- a/go/vt/schemamanager/console_event_handler.go
+++ b/go/vt/schemamanager/console_event_handler.go
@@ -26,7 +26,7 @@ func (handler *ConsoleEventHandler) OnDataSourcerReadSuccess(sql []string) error
 // OnDataSourcerReadFail is called when schemamanager fails to read all sql statements.
 func (handler *ConsoleEventHandler) OnDataSourcerReadFail(err error) error {
 	fmt.Printf("Failed to read schema changes, error: %v\n", err)
-	return nil
+	return err
 }
 
 // OnValidationSuccess is called when schemamanager successfully validates all sql statements.
@@ -38,7 +38,7 @@ func (handler *ConsoleEventHandler) OnValidationSuccess([]string) error {
 // OnValidationFail is called when schemamanager fails to validate sql statements.
 func (handler *ConsoleEventHandler) OnValidationFail(err error) error {
 	fmt.Printf("Failed to validate sqls, error: %v\n", err)
-	return nil
+	return err
 }
 
 // OnExecutorComplete  is called when schemamanager finishes applying schema changes.

--- a/go/vt/schemamanager/console_event_handler_test.go
+++ b/go/vt/schemamanager/console_event_handler_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestConsoleEventHandler(t *testing.T) {
+	sqls := []string{"CREATE TABLE test_table (pk int)"}
+	handler := NewConsoleEventHandler()
+	err := handler.OnDataSourcerReadSuccess(sqls)
+	if err != nil {
+		t.Fatalf("OnDataSourcerReadSuccess should succeed")
+	}
+
+	errReadFail := fmt.Errorf("read fail")
+	err = handler.OnDataSourcerReadFail(errReadFail)
+	if err != errReadFail {
+		t.Fatalf("should get error:%v, but get: %v", errReadFail, err)
+	}
+
+	err = handler.OnValidationSuccess(sqls)
+	if err != nil {
+		t.Fatalf("OnValidationSuccess should succeed")
+	}
+
+	errValidationFail := fmt.Errorf("validation fail")
+	err = handler.OnValidationFail(errValidationFail)
+	if err != errValidationFail {
+		t.Fatalf("should get error:%v, but get: %v", errValidationFail, err)
+	}
+
+	err = handler.OnExecutorComplete(&ExecuteResult{})
+	if err != nil {
+		t.Fatalf("OnExecutorComplete should succeed")
+	}
+}

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -69,7 +69,8 @@ func Run(sourcer DataSourcer,
 	sqls, err := sourcer.Read()
 	if err != nil {
 		log.Errorf("failed to read data from data sourcer: %v", err)
-		return handler.OnDataSourcerReadFail(err)
+		handler.OnDataSourcerReadFail(err)
+		return err
 	}
 	handler.OnDataSourcerReadSuccess(sqls)
 	if err := exec.Open(); err != nil {
@@ -79,7 +80,8 @@ func Run(sourcer DataSourcer,
 	defer exec.Close()
 	if err := exec.Validate(sqls); err != nil {
 		log.Errorf("validation fail: %v", err)
-		return handler.OnValidationFail(err)
+		handler.OnValidationFail(err)
+		return err
 	}
 	handler.OnValidationSuccess(sqls)
 	result := exec.Execute(sqls)

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -71,6 +71,19 @@ func TestRunSchemaChangesExecutorOpenFail(t *testing.T) {
 	}
 }
 
+func TestRunSchemaChangesExecutorExecuteFail(t *testing.T) {
+	dataSourcer := newFakeDataSourcer([]string{"create table test_table (pk int);"}, false, false, false)
+	handler := newFakeHandler()
+	exec := NewTabletExecutor(
+		newFakeTabletManagerClient(),
+		newFakeTopo(),
+		"test_keyspace")
+	err := Run(dataSourcer, exec, handler)
+	if err == nil {
+		t.Fatalf("run schema change should fail due to executor.Execute fail")
+	}
+}
+
 func TestRunSchemaChanges(t *testing.T) {
 	sql := "create table test_table (pk int)"
 	dataSourcer := NewSimpleDataSourcer(sql)

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -1,0 +1,118 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
+)
+
+func TestTabletExecutorOpen(t *testing.T) {
+	executor := newFakeExecutor()
+	if err := executor.Open(); err != nil {
+		t.Fatalf("executor.Open() should succeed")
+	}
+
+	defer executor.Close()
+
+	if err := executor.Open(); err != nil {
+		t.Fatalf("open an opened executor should also succeed")
+	}
+}
+
+func TestTabletExecutorValidate(t *testing.T) {
+	fakeTmc := newFakeTabletManagerClient()
+
+	fakeTmc.AddSchemaDefinition("vt_test_keyspace", &proto.SchemaDefinition{
+		DatabaseSchema: "CREATE DATABASE `{{.DatabaseName}}` /*!40100 DEFAULT CHARACTER SET utf8 */",
+		TableDefinitions: []*proto.TableDefinition{
+			&proto.TableDefinition{
+				Name:   "test_table",
+				Schema: "table schema",
+				Type:   proto.TableBaseTable,
+			},
+			&proto.TableDefinition{
+				Name:     "test_table_03",
+				Schema:   "table schema",
+				Type:     proto.TableBaseTable,
+				RowCount: 200000,
+			},
+			&proto.TableDefinition{
+				Name:     "test_table_04",
+				Schema:   "table schema",
+				Type:     proto.TableBaseTable,
+				RowCount: 3000000,
+			},
+		},
+	})
+
+	executor := NewTabletExecutor(
+		fakeTmc,
+		newFakeTopo(),
+		"test_keyspace")
+
+	sqls := []string{
+		"ALTER TABLE test_table ADD COLUMN new_id bigint(20)",
+		"CREATE TABLE test_table_02 (pk int)",
+	}
+
+	if err := executor.Validate(sqls); err == nil {
+		t.Fatalf("validate should fail because executor is closed")
+	}
+
+	executor.Open()
+	defer executor.Close()
+
+	// schema changes with DMLs should fail
+	if err := executor.Validate([]string{
+		"INSERT INTO test_table VALUES(1)"}); err == nil {
+		t.Fatalf("schema changes are for DDLs")
+	}
+
+	// validates valid ddls
+	if err := executor.Validate(sqls); err != nil {
+		t.Fatalf("executor.Validate should succeed, but got error: %v", err)
+	}
+
+	// alter a table with more than 100,000 rows
+	if err := executor.Validate([]string{
+		"ALTER TABLE test_table_03 ADD COLUMN new_id bigint(20)",
+	}); err == nil {
+		t.Fatalf("executor.Validate should fail, alter a table more than 100,000 rows")
+	}
+
+	// change a table with more than 2,000,000 rows
+	if err := executor.Validate([]string{
+		"RENAME TABLE test_table_04 TO test_table_05",
+	}); err == nil {
+		t.Fatalf("executor.Validate should fail, change a table more than 2,000,000 rows")
+	}
+
+	if err := executor.Validate([]string{
+		"DROP TABLE test_table_04",
+	}); err != nil {
+		t.Fatalf("executor.Validate should succeed, drop a table with more than 2,000,000 rows is allowed")
+	}
+}
+
+func TestTabletExecutorExecute(t *testing.T) {
+	executor := newFakeExecutor()
+
+	sqls := []string{"DROP TABLE unknown_table"}
+
+	result := executor.Execute(sqls)
+	if result.ExecutorErr == "" {
+		t.Fatalf("execute should fail, call execute.Open first")
+	}
+
+	executor.Open()
+	defer executor.Close()
+
+	result = executor.Execute(sqls)
+	if result.ExecutorErr == "" {
+		t.Fatalf("execute should fail, ddl does not introduce any table schema change")
+	}
+}


### PR DESCRIPTION
detect big schema change and reject it
1. Detect big schema change based on number of table rows. A schema change is
   considered big if 1) alter more than 100,000 rows, or 2) change a
   table with more than 2,000,000 rows.
2. Add unit test for TabletExecutor and also improve existing test cases.