### PR TITLE
Log

### DIFF
--- a/go/cmd/vtworker/command.go
+++ b/go/cmd/vtworker/command.go
@@ -116,6 +116,7 @@ func runCommand(args []string) error {
 				err := lastRunError
 				currentWorkerMutex.Unlock()
 				if err != nil {
+					log.Errorf("Ended with an error: %v", err)
 					os.Exit(1)
 				}
 				os.Exit(0)

--- a/go/cmd/vtworker/command.go
+++ b/go/cmd/vtworker/command.go
@@ -112,7 +112,10 @@ func runCommand(args []string) error {
 			case <-done:
 				log.Infof("Command is done:")
 				log.Info(wrk.StatusAsText())
-				if wrk.Error() != nil {
+				currentWorkerMutex.Lock()
+				err := lastRunError
+				currentWorkerMutex.Unlock()
+				if err != nil {
 					os.Exit(1)
 				}
 				os.Exit(0)

--- a/go/cmd/vtworker/status.go
+++ b/go/cmd/vtworker/status.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"html/template"
 	"net/http"
 	"strings"
@@ -69,14 +70,19 @@ func initStatusHandling() {
 		wrk := currentWorker
 		logger := currentMemoryLogger
 		ctx := currentContext
+		err := lastRunError
 		currentWorkerMutex.Unlock()
 
 		data := make(map[string]interface{})
 		if wrk != nil {
-			data["Status"] = wrk.StatusAsHTML()
+			status := template.HTML("Current worker:<br>\n") + wrk.StatusAsHTML()
 			if ctx == nil {
 				data["Done"] = true
+				if err != nil {
+					status += template.HTML(fmt.Sprintf("<br>\nEnded with an error: %v<br>\n", err))
+				}
 			}
+			data["Status"] = status
 			if logger != nil {
 				data["Logs"] = template.HTML(strings.Replace(logger.String(), "\n", "</br>\n", -1))
 			} else {

--- a/go/vt/worker/clone_utils.go
+++ b/go/vt/worker/clone_utils.go
@@ -212,7 +212,7 @@ func executeFetchWithRetries(ctx context.Context, wr *wrangler.Wrangler, ti *top
 			return ti, fmt.Errorf("interrupted while trying to run %v on tablet %v", command, ti)
 		case <-t.C:
 			// Re-resolve and retry 30s after the failure
-			err = r.ResolveDestinationMasters()
+			err = r.ResolveDestinationMasters(ctx)
 			if err != nil {
 				return ti, fmt.Errorf("unable to re-resolve masters for ExecuteFetch, due to: %v", err)
 			}

--- a/go/vt/worker/clone_utils.go
+++ b/go/vt/worker/clone_utils.go
@@ -30,7 +30,7 @@ import (
 // Does a topo lookup for a single shard, and returns the tablet record of the master tablet.
 func resolveDestinationShardMaster(ctx context.Context, keyspace, shard string, wr *wrangler.Wrangler) (*topo.TabletInfo, error) {
 	var ti *topo.TabletInfo
-	newCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	newCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	si, err := topo.GetShard(newCtx, wr.TopoServer(), keyspace, shard)
 	cancel()
 	if err != nil {
@@ -43,7 +43,7 @@ func resolveDestinationShardMaster(ctx context.Context, keyspace, shard string, 
 
 	wr.Logger().Infof("Found target master alias %v in shard %v/%v", si.MasterAlias, keyspace, shard)
 
-	newCtx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	newCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
 	ti, err = topo.GetTablet(newCtx, wr.TopoServer(), si.MasterAlias)
 	cancel()
 	if err != nil {
@@ -280,7 +280,7 @@ func findChunks(ctx context.Context, wr *wrangler.Wrangler, ti *topo.TabletInfo,
 
 	// get the min and max of the leading column of the primary key
 	query := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v.%v", td.PrimaryKeyColumns[0], td.PrimaryKeyColumns[0], ti.DbName(), td.Name)
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	qr, err := wr.TabletManagerClient().ExecuteFetchAsApp(ctx, ti, query, 1, true)
 	cancel()
 	if err != nil {

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -42,7 +42,7 @@ func NewQueryResultReaderForTablet(ctx context.Context, ts topo.Server, tabletAl
 		return nil, err
 	}
 
-	conn, err := tabletconn.GetDialer()(ctx, *endPoint, tablet.Keyspace, tablet.Shard, 30*time.Second)
+	conn, err := tabletconn.GetDialer()(ctx, *endPoint, tablet.Keyspace, tablet.Shard, *remoteActionsTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -153,6 +153,7 @@ func (qrr *QueryResultReader) Error() error {
 	return qrr.clientErrFn()
 }
 
+// Close closes the connection to the tablet.
 func (qrr *QueryResultReader) Close() {
 	qrr.conn.Close()
 }

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -189,7 +189,7 @@ func (scw *SplitCloneWorker) run(ctx context.Context) error {
 	if err := scw.init(); err != nil {
 		return fmt.Errorf("init() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -197,7 +197,7 @@ func (scw *SplitCloneWorker) run(ctx context.Context) error {
 	if err := scw.findTargets(ctx); err != nil {
 		return fmt.Errorf("findTargets() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -331,7 +331,7 @@ func testSplitClone(t *testing.T, strategy string) {
 	// Only wait 1 ms between retries, so that the test passes faster
 	executeFetchRetryTime = (1 * time.Millisecond)
 
-	wrk.Run()
+	wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
 	if wrk.err != nil || wrk.state != stateSCDone {

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -331,10 +331,10 @@ func testSplitClone(t *testing.T, strategy string) {
 	// Only wait 1 ms between retries, so that the test passes faster
 	*executeFetchRetryTime = (1 * time.Millisecond)
 
-	wrk.Run(ctx)
+	err = wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
-	if wrk.err != nil || wrk.state != stateSCDone {
+	if err != nil || wrk.State != WorkerStateDone {
 		t.Errorf("Worker run failed")
 	}
 

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -119,7 +119,7 @@ func (sdw *SplitDiffWorker) run(ctx context.Context) error {
 	if err := sdw.init(); err != nil {
 		return fmt.Errorf("init() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -127,7 +127,7 @@ func (sdw *SplitDiffWorker) run(ctx context.Context) error {
 	if err := sdw.findTargets(ctx); err != nil {
 		return fmt.Errorf("findTargets() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (sdw *SplitDiffWorker) run(ctx context.Context) error {
 	if err := sdw.synchronizeReplication(ctx); err != nil {
 		return fmt.Errorf("synchronizeReplication() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -43,8 +43,6 @@ type SplitDiffWorker struct {
 	shard         string
 	excludeTables []string
 	cleaner       *wrangler.Cleaner
-	ctx           context.Context
-	ctxCancel     context.CancelFunc
 
 	// all subsequent fields are protected by the mutex
 	mu    sync.Mutex
@@ -68,7 +66,6 @@ type SplitDiffWorker struct {
 
 // NewSplitDiffWorker returns a new SplitDiffWorker object.
 func NewSplitDiffWorker(wr *wrangler.Wrangler, cell, keyspace, shard string, excludeTables []string) Worker {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &SplitDiffWorker{
 		wr:            wr,
 		cell:          cell,
@@ -76,8 +73,6 @@ func NewSplitDiffWorker(wr *wrangler.Wrangler, cell, keyspace, shard string, exc
 		shard:         shard,
 		excludeTables: excludeTables,
 		cleaner:       &wrangler.Cleaner{},
-		ctx:           ctx,
-		ctxCancel:     cancel,
 
 		state: stateSDNotSarted,
 	}
@@ -133,28 +128,21 @@ func (sdw *SplitDiffWorker) StatusAsText() string {
 	return result
 }
 
-// Cancel is part of the Worker interface
-func (sdw *SplitDiffWorker) Cancel() {
-	sdw.ctxCancel()
-}
-
-func (sdw *SplitDiffWorker) checkInterrupted() bool {
+func (sdw *SplitDiffWorker) checkInterrupted(ctx context.Context) error {
 	select {
-	case <-sdw.ctx.Done():
-		if sdw.ctx.Err() == context.DeadlineExceeded {
-			return false
-		}
-		sdw.recordError(topo.ErrInterrupted)
-		return true
+	case <-ctx.Done():
+		err := ctx.Err()
+		sdw.recordError(err)
+		return err
 	default:
 	}
-	return false
+	return nil
 }
 
 // Run is mostly a wrapper to run the cleanup at the end.
-func (sdw *SplitDiffWorker) Run() {
+func (sdw *SplitDiffWorker) Run(ctx context.Context) error {
 	resetVars()
-	err := sdw.run()
+	err := sdw.run(ctx)
 
 	sdw.setState(stateSDCleanUp)
 	cerr := sdw.cleaner.CleanUp(sdw.wr)
@@ -167,48 +155,39 @@ func (sdw *SplitDiffWorker) Run() {
 	}
 	if err != nil {
 		sdw.recordError(err)
-		return
+		return err
 	}
 	sdw.setState(stateSDDone)
+	return nil
 }
 
-func (sdw *SplitDiffWorker) Error() error {
-	return sdw.err
-}
-
-func (sdw *SplitDiffWorker) run() error {
+func (sdw *SplitDiffWorker) run(ctx context.Context) error {
 	// first state: read what we need to do
 	if err := sdw.init(); err != nil {
 		return fmt.Errorf("init() failed: %v", err)
 	}
-	if sdw.checkInterrupted() {
-		return topo.ErrInterrupted
+	if err := sdw.checkInterrupted(ctx); err != nil {
+		return err
 	}
 
 	// second state: find targets
-	if err := sdw.findTargets(); err != nil {
+	if err := sdw.findTargets(ctx); err != nil {
 		return fmt.Errorf("findTargets() failed: %v", err)
 	}
-	if sdw.checkInterrupted() {
-		return topo.ErrInterrupted
+	if err := sdw.checkInterrupted(ctx); err != nil {
+		return err
 	}
 
 	// third phase: synchronize replication
-	if err := sdw.synchronizeReplication(); err != nil {
-		if sdw.checkInterrupted() {
-			return topo.ErrInterrupted
-		}
+	if err := sdw.synchronizeReplication(ctx); err != nil {
 		return fmt.Errorf("synchronizeReplication() failed: %v", err)
 	}
-	if sdw.checkInterrupted() {
-		return topo.ErrInterrupted
+	if err := sdw.checkInterrupted(ctx); err != nil {
+		return err
 	}
 
 	// fourth phase: diff
-	if err := sdw.diff(); err != nil {
-		if sdw.checkInterrupted() {
-			return topo.ErrInterrupted
-		}
+	if err := sdw.diff(ctx); err != nil {
 		return fmt.Errorf("diff() failed: %v", err)
 	}
 
@@ -244,12 +223,12 @@ func (sdw *SplitDiffWorker) init() error {
 // - find one rdonly per source shard
 // - find one rdonly in destination shard
 // - mark them all as 'checker' pointing back to us
-func (sdw *SplitDiffWorker) findTargets() error {
+func (sdw *SplitDiffWorker) findTargets(ctx context.Context) error {
 	sdw.setState(stateSDFindTargets)
 
 	// find an appropriate endpoint in destination shard
 	var err error
-	sdw.destinationAlias, err = findChecker(sdw.ctx, sdw.wr, sdw.cleaner, sdw.cell, sdw.keyspace, sdw.shard)
+	sdw.destinationAlias, err = findChecker(ctx, sdw.wr, sdw.cleaner, sdw.cell, sdw.keyspace, sdw.shard)
 	if err != nil {
 		return fmt.Errorf("cannot find checker for %v/%v/%v: %v", sdw.cell, sdw.keyspace, sdw.shard, err)
 	}
@@ -257,7 +236,7 @@ func (sdw *SplitDiffWorker) findTargets() error {
 	// find an appropriate endpoint in the source shards
 	sdw.sourceAliases = make([]topo.TabletAlias, len(sdw.shardInfo.SourceShards))
 	for i, ss := range sdw.shardInfo.SourceShards {
-		sdw.sourceAliases[i], err = findChecker(sdw.ctx, sdw.wr, sdw.cleaner, sdw.cell, sdw.keyspace, ss.Shard)
+		sdw.sourceAliases[i], err = findChecker(ctx, sdw.wr, sdw.cleaner, sdw.cell, sdw.keyspace, ss.Shard)
 		if err != nil {
 			return fmt.Errorf("cannot find checker for %v/%v/%v: %v", sdw.cell, sdw.keyspace, ss.Shard, err)
 		}
@@ -284,7 +263,7 @@ func (sdw *SplitDiffWorker) findTargets() error {
 //   (remove the cleanup task that does the same)
 // At this point, all checker instances are stopped at the same point.
 
-func (sdw *SplitDiffWorker) synchronizeReplication() error {
+func (sdw *SplitDiffWorker) synchronizeReplication(ctx context.Context) error {
 	sdw.setState(stateSDSynchronizeReplication)
 
 	masterInfo, err := sdw.wr.TopoServer().GetTablet(sdw.shardInfo.MasterAlias)
@@ -294,8 +273,8 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 
 	// 1 - stop the master binlog replication, get its current position
 	sdw.wr.Logger().Infof("Stopping master binlog replication on %v", sdw.shardInfo.MasterAlias)
-	ctx, cancel := context.WithTimeout(sdw.ctx, 60*time.Second)
-	blpPositionList, err := sdw.wr.TabletManagerClient().StopBlp(ctx, masterInfo)
+	shortCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	blpPositionList, err := sdw.wr.TabletManagerClient().StopBlp(shortCtx, masterInfo)
 	cancel()
 	if err != nil {
 		return fmt.Errorf("StopBlp for %v failed: %v", sdw.shardInfo.MasterAlias, err)
@@ -322,8 +301,8 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 
 		// stop replication
 		sdw.wr.Logger().Infof("Stopping slave[%v] %v at a minimum of %v", i, sdw.sourceAliases[i], blpPos.Position)
-		ctx, cancel := context.WithTimeout(sdw.ctx, 60*time.Second)
-		stoppedAt, err := sdw.wr.TabletManagerClient().StopSlaveMinimum(ctx, sourceTablet, blpPos.Position, 30*time.Second)
+		shortCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		stoppedAt, err := sdw.wr.TabletManagerClient().StopSlaveMinimum(shortCtx, sourceTablet, blpPos.Position, 30*time.Second)
 		cancel()
 		if err != nil {
 			return fmt.Errorf("cannot stop slave %v at right binlog position %v: %v", sdw.sourceAliases[i], blpPos.Position, err)
@@ -344,8 +323,8 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 	// 3 - ask the master of the destination shard to resume filtered
 	//     replication up to the new list of positions
 	sdw.wr.Logger().Infof("Restarting master %v until it catches up to %v", sdw.shardInfo.MasterAlias, stopPositionList)
-	ctx, cancel = context.WithTimeout(sdw.ctx, 60*time.Second)
-	masterPos, err := sdw.wr.TabletManagerClient().RunBlpUntil(ctx, masterInfo, &stopPositionList, 30*time.Second)
+	shortCtx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	masterPos, err := sdw.wr.TabletManagerClient().RunBlpUntil(shortCtx, masterInfo, &stopPositionList, 30*time.Second)
 	cancel()
 	if err != nil {
 		return fmt.Errorf("RunBlpUntil for %v until %v failed: %v", sdw.shardInfo.MasterAlias, stopPositionList, err)
@@ -358,8 +337,8 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel = context.WithTimeout(sdw.ctx, 60*time.Second)
-	_, err = sdw.wr.TabletManagerClient().StopSlaveMinimum(ctx, destinationTablet, masterPos, 30*time.Second)
+	shortCtx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	_, err = sdw.wr.TabletManagerClient().StopSlaveMinimum(shortCtx, destinationTablet, masterPos, 30*time.Second)
 	cancel()
 	if err != nil {
 		return fmt.Errorf("StopSlaveMinimum for %v at %v failed: %v", sdw.destinationAlias, masterPos, err)
@@ -373,8 +352,8 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 
 	// 5 - restart filtered replication on destination master
 	sdw.wr.Logger().Infof("Restarting filtered replication on master %v", sdw.shardInfo.MasterAlias)
-	ctx, cancel = context.WithTimeout(sdw.ctx, 60*time.Second)
-	err = sdw.wr.TabletManagerClient().StartBlp(ctx, masterInfo)
+	shortCtx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	err = sdw.wr.TabletManagerClient().StartBlp(shortCtx, masterInfo)
 	if err := sdw.cleaner.RemoveActionByName(wrangler.StartBlpActionName, sdw.shardInfo.MasterAlias.String()); err != nil {
 		sdw.wr.Logger().Warningf("Cannot find cleaning action %v/%v: %v", wrangler.StartBlpActionName, sdw.shardInfo.MasterAlias.String(), err)
 	}
@@ -391,7 +370,7 @@ func (sdw *SplitDiffWorker) synchronizeReplication() error {
 // - if some table schema mismatches, record them (use existing schema diff tools).
 // - for each table in destination, run a diff pipeline.
 
-func (sdw *SplitDiffWorker) diff() error {
+func (sdw *SplitDiffWorker) diff(ctx context.Context) error {
 	sdw.setState(stateSDDiff)
 
 	sdw.wr.Logger().Infof("Gathering schema information...")
@@ -401,9 +380,9 @@ func (sdw *SplitDiffWorker) diff() error {
 	wg.Add(1)
 	go func() {
 		var err error
-		ctx, cancel := context.WithTimeout(sdw.ctx, 60*time.Second)
+		shortCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		sdw.destinationSchemaDefinition, err = sdw.wr.GetSchema(
-			ctx, sdw.destinationAlias, nil /* tables */, sdw.excludeTables, false /* includeViews */)
+			shortCtx, sdw.destinationAlias, nil /* tables */, sdw.excludeTables, false /* includeViews */)
 		cancel()
 		rec.RecordError(err)
 		sdw.wr.Logger().Infof("Got schema from destination %v", sdw.destinationAlias)
@@ -413,9 +392,9 @@ func (sdw *SplitDiffWorker) diff() error {
 		wg.Add(1)
 		go func(i int, sourceAlias topo.TabletAlias) {
 			var err error
-			ctx, cancel := context.WithTimeout(sdw.ctx, 60*time.Second)
+			shortCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
 			sdw.sourceSchemaDefinitions[i], err = sdw.wr.GetSchema(
-				ctx, sourceAlias, nil /* tables */, sdw.excludeTables, false /* includeViews */)
+				shortCtx, sourceAlias, nil /* tables */, sdw.excludeTables, false /* includeViews */)
 			cancel()
 			rec.RecordError(err)
 			sdw.wr.Logger().Infof("Got schema from source[%v] %v", i, sourceAlias)
@@ -462,14 +441,14 @@ func (sdw *SplitDiffWorker) diff() error {
 				sdw.wr.Logger().Errorf("Source shard doesn't overlap with destination????: %v", err)
 				return
 			}
-			sourceQueryResultReader, err := TableScanByKeyRange(sdw.ctx, sdw.wr.Logger(), sdw.wr.TopoServer(), sdw.sourceAliases[0], tableDefinition, overlap, sdw.keyspaceInfo.ShardingColumnType)
+			sourceQueryResultReader, err := TableScanByKeyRange(ctx, sdw.wr.Logger(), sdw.wr.TopoServer(), sdw.sourceAliases[0], tableDefinition, overlap, sdw.keyspaceInfo.ShardingColumnType)
 			if err != nil {
 				sdw.wr.Logger().Errorf("TableScanByKeyRange(source) failed: %v", err)
 				return
 			}
 			defer sourceQueryResultReader.Close()
 
-			destinationQueryResultReader, err := TableScanByKeyRange(sdw.ctx, sdw.wr.Logger(), sdw.wr.TopoServer(), sdw.destinationAlias, tableDefinition, key.KeyRange{}, sdw.keyspaceInfo.ShardingColumnType)
+			destinationQueryResultReader, err := TableScanByKeyRange(ctx, sdw.wr.Logger(), sdw.wr.TopoServer(), sdw.destinationAlias, tableDefinition, key.KeyRange{}, sdw.keyspaceInfo.ShardingColumnType)
 			if err != nil {
 				sdw.wr.Logger().Errorf("TableScanByKeyRange(destination) failed: %v", err)
 				return

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -225,7 +225,7 @@ func TestSplitDiff(t *testing.T) {
 	sourceRdonly1.RPCServer.Register(gorpcqueryservice.New(&sourceSqlQuery{t: t, excludedTable: excludedTable}))
 	sourceRdonly2.RPCServer.Register(gorpcqueryservice.New(&sourceSqlQuery{t: t, excludedTable: excludedTable}))
 
-	wrk.Run()
+	wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
 	if wrk.err != nil || wrk.state != stateSCDone {

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -225,10 +225,10 @@ func TestSplitDiff(t *testing.T) {
 	sourceRdonly1.RPCServer.Register(gorpcqueryservice.New(&sourceSqlQuery{t: t, excludedTable: excludedTable}))
 	sourceRdonly2.RPCServer.Register(gorpcqueryservice.New(&sourceSqlQuery{t: t, excludedTable: excludedTable}))
 
-	wrk.Run(ctx)
+	err := wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
-	if wrk.err != nil || wrk.state != stateSCDone {
+	if err != nil || wrk.State != WorkerStateDone {
 		t.Errorf("Worker run failed")
 	}
 }

--- a/go/vt/worker/sqldiffer.go
+++ b/go/vt/worker/sqldiffer.go
@@ -117,7 +117,7 @@ func (worker *SQLDiffWorker) run(ctx context.Context) error {
 	if err := worker.findTargets(ctx); err != nil {
 		return err
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -125,7 +125,7 @@ func (worker *SQLDiffWorker) run(ctx context.Context) error {
 	if err := worker.synchronizeReplication(ctx); err != nil {
 		return err
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -180,7 +180,7 @@ func (worker *SQLDiffWorker) synchronizeReplication(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("Cannot stop slave %v: %v", worker.subset.alias, err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -195,7 +195,7 @@ func (worker *SQLDiffWorker) synchronizeReplication(ctx context.Context) error {
 
 	// sleep for a few seconds
 	time.Sleep(5 * time.Second)
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 

--- a/go/vt/worker/sqldiffer.go
+++ b/go/vt/worker/sqldiffer.go
@@ -174,7 +174,7 @@ func (worker *SQLDiffWorker) synchronizeReplication(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	shortCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	err = worker.wr.TabletManagerClient().StopSlave(shortCtx, subsetTablet)
 	cancel()
 	if err != nil {
@@ -205,7 +205,7 @@ func (worker *SQLDiffWorker) synchronizeReplication(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	shortCtx, cancel = context.WithTimeout(ctx, 60*time.Second)
+	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
 	err = worker.wr.TabletManagerClient().StopSlave(shortCtx, supersetTablet)
 	cancel()
 	if err != nil {

--- a/go/vt/worker/sqldiffer_test.go
+++ b/go/vt/worker/sqldiffer_test.go
@@ -134,10 +134,10 @@ func TestSqlDiffer(t *testing.T) {
 		rdonly.RPCServer.Register(gorpcqueryservice.New(&sqlDifferSqlQuery{t: t}))
 	}
 
-	wrk.Run(ctx)
+	err := wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
-	if wrk.err != nil || wrk.state != stateSCDone {
+	if err != nil || wrk.State != WorkerStateDone {
 		t.Errorf("Worker run failed")
 	}
 }

--- a/go/vt/worker/sqldiffer_test.go
+++ b/go/vt/worker/sqldiffer_test.go
@@ -134,7 +134,7 @@ func TestSqlDiffer(t *testing.T) {
 		rdonly.RPCServer.Register(gorpcqueryservice.New(&sqlDifferSqlQuery{t: t}))
 	}
 
-	wrk.Run()
+	wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
 	if wrk.err != nil || wrk.state != stateSCDone {

--- a/go/vt/worker/status_worker.go
+++ b/go/vt/worker/status_worker.go
@@ -38,7 +38,12 @@ func (state StatusWorkerState) String() string {
 // and StatusAsText to make it easier on workers if they don't need to
 // export more.
 type StatusWorker struct {
-	Mu    *sync.Mutex
+	// Mu is protecting the state variable, and can also be used
+	// by implementations to protect their own variables.
+	Mu *sync.Mutex
+
+	// State contains the worker's current state, and should only
+	// be accessed under Mu.
 	State StatusWorkerState
 }
 

--- a/go/vt/worker/status_worker.go
+++ b/go/vt/worker/status_worker.go
@@ -1,0 +1,73 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package worker
+
+import (
+	"html/template"
+	"sync"
+)
+
+// StatusWorkerState is the type for a StatusWorker's status
+type StatusWorkerState string
+
+// All possible status strings (if your implementation needs more,
+// just add them)
+
+const (
+	WorkerStateNotSarted       StatusWorkerState = "not started"
+	WorkerStateDone            StatusWorkerState = "done"
+	WorkerStateError           StatusWorkerState = "error"
+	WorkerStateInit            StatusWorkerState = "initializing"
+	WorkerStateFindTargets     StatusWorkerState = "finding target instances"
+	WorkerStateSyncReplication StatusWorkerState = "synchronizing replication"
+	WorkerStateCopy            StatusWorkerState = "copying the data"
+	WorkerStateDiff            StatusWorkerState = "running the diff"
+	WorkerStateCleanUp         StatusWorkerState = "cleaning up"
+)
+
+func (state StatusWorkerState) String() string {
+	return string(state)
+}
+
+// StatusWorker is the base type for a worker which keeps a status.
+// The status is protected by a mutex. Any other internal variable
+// can also be protected by that mutex.
+// StatusWorker also provides default implementations for StatusAsHTML
+// and StatusAsText to make it easier on workers if they don't need to
+// export more.
+type StatusWorker struct {
+	Mu    *sync.Mutex
+	State StatusWorkerState
+}
+
+// NewStatusWorker returns a StatusWorker in state WorkerStateNotSarted
+func NewStatusWorker() StatusWorker {
+	return StatusWorker{
+		Mu:    &sync.Mutex{},
+		State: WorkerStateNotSarted,
+	}
+}
+
+// SetState is a convenience function for workers
+func (worker *StatusWorker) SetState(state StatusWorkerState) {
+	worker.Mu.Lock()
+	worker.State = state
+	statsState.Set(string(state))
+	worker.Mu.Unlock()
+}
+
+// StatusAsHTML is part of the Worker interface
+func (worker *StatusWorker) StatusAsHTML() template.HTML {
+	worker.Mu.Lock()
+	defer worker.Mu.Unlock()
+	return template.HTML("<b>State:</b> " + worker.State.String() + "</br>\n")
+}
+
+// StatusAsText is part of the Worker interface
+func (worker *StatusWorker) StatusAsText() string {
+	worker.Mu.Lock()
+	defer worker.Mu.Unlock()
+	return "State: " + worker.State.String() + "\n"
+}

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -75,7 +75,7 @@ func findChecker(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrangler.C
 	defer wrangler.RecordTabletTagAction(cleaner, tabletAlias, "worker", "")
 
 	wr.Logger().Infof("Changing tablet %v to 'checker'", tabletAlias)
-	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	err = wr.ChangeType(ctx, tabletAlias, topo.TYPE_CHECKER, false /*force*/)
 	cancel()
 	if err != nil {

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -176,7 +176,7 @@ func (vscw *VerticalSplitCloneWorker) run(ctx context.Context) error {
 	if err := vscw.init(); err != nil {
 		return fmt.Errorf("init() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -184,7 +184,7 @@ func (vscw *VerticalSplitCloneWorker) run(ctx context.Context) error {
 	if err := vscw.findTargets(ctx); err != nil {
 		return fmt.Errorf("findTargets() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -192,7 +192,7 @@ func (vscw *VerticalSplitCloneWorker) run(ctx context.Context) error {
 	if err := vscw.copy(ctx); err != nil {
 		return fmt.Errorf("copy() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -377,6 +377,11 @@ func (vscw *VerticalSplitCloneWorker) copy(ctx context.Context) error {
 		}
 		mu.Unlock()
 	}
+	shouldStop := func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return firstError != nil
+	}
 
 	destinationWaitGroup := sync.WaitGroup{}
 
@@ -421,6 +426,10 @@ func (vscw *VerticalSplitCloneWorker) copy(ctx context.Context) error {
 
 				sema.Acquire()
 				defer sema.Release()
+
+				if shouldStop() {
+					return
+				}
 
 				vscw.tableStatus[tableIndex].threadStarted()
 

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -316,7 +316,7 @@ func testVerticalSplitClone(t *testing.T, strategy string) {
 	// Only wait 1 ms between retries, so that the test passes faster
 	executeFetchRetryTime = (1 * time.Millisecond)
 
-	wrk.Run()
+	wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
 	if wrk.err != nil || wrk.state != stateSCDone {

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -316,10 +316,10 @@ func testVerticalSplitClone(t *testing.T, strategy string) {
 	// Only wait 1 ms between retries, so that the test passes faster
 	*executeFetchRetryTime = (1 * time.Millisecond)
 
-	wrk.Run(ctx)
+	err = wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
-	if wrk.err != nil || wrk.state != stateSCDone {
+	if err != nil || wrk.State != WorkerStateDone {
 		t.Errorf("Worker run failed")
 	}
 

--- a/go/vt/worker/vertical_split_diff.go
+++ b/go/vt/worker/vertical_split_diff.go
@@ -119,7 +119,7 @@ func (vsdw *VerticalSplitDiffWorker) run(ctx context.Context) error {
 	if err := vsdw.init(); err != nil {
 		return fmt.Errorf("init() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -127,7 +127,7 @@ func (vsdw *VerticalSplitDiffWorker) run(ctx context.Context) error {
 	if err := vsdw.findTargets(ctx); err != nil {
 		return fmt.Errorf("findTargets() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 
@@ -135,7 +135,7 @@ func (vsdw *VerticalSplitDiffWorker) run(ctx context.Context) error {
 	if err := vsdw.synchronizeReplication(ctx); err != nil {
 		return fmt.Errorf("synchronizeReplication() failed: %v", err)
 	}
-	if err := checkInterrupted(ctx); err != nil {
+	if err := checkDone(ctx); err != nil {
 		return err
 	}
 

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -159,10 +159,10 @@ func TestVerticalSplitDiff(t *testing.T) {
 		rdonly.RPCServer.Register(gorpcqueryservice.New(&verticalDiffSqlQuery{t: t, excludedTable: excludedTable}))
 	}
 
-	wrk.Run(ctx)
+	err := wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
-	if wrk.err != nil || wrk.state != stateSCDone {
+	if err != nil || wrk.State != WorkerStateDone {
 		t.Errorf("Worker run failed")
 	}
 }

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -159,7 +159,7 @@ func TestVerticalSplitDiff(t *testing.T) {
 		rdonly.RPCServer.Register(gorpcqueryservice.New(&verticalDiffSqlQuery{t: t, excludedTable: excludedTable}))
 	}
 
-	wrk.Run()
+	wrk.Run(ctx)
 	status := wrk.StatusAsText()
 	t.Logf("Got status: %v", status)
 	if wrk.err != nil || wrk.state != stateSCDone {

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -66,8 +66,8 @@ func resetVars() {
 	statsRetryCounters.Reset()
 }
 
-// checkInterrupted returns ctx.Err() iff ctx.Done()
-func checkInterrupted(ctx context.Context) error {
+// checkDone returns ctx.Err() iff ctx.Done()
+func checkDone(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -47,6 +47,7 @@ type Resolver interface {
 var (
 	resolveTTL            = flag.Duration("resolve_ttl", 15*time.Second, "Amount of time that a topo resolution can be cached for")
 	executeFetchRetryTime = flag.Duration("executefetch_retry_time", 30*time.Second, "Amount of time we should wait before retrying ExecuteFetch calls")
+	remoteActionsTimeout  = flag.Duration("remote_actions_timeout", time.Minute, "Amount of time to wait for remote actions (like replication stop, ...)")
 
 	statsState = stats.NewString("WorkerState")
 	// the number of times that the worker attempst to reresolve the masters

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -65,3 +65,13 @@ func resetVars() {
 	statsDestinationActualResolves.Set(0)
 	statsRetryCounters.Reset()
 }
+
+// checkInterrupted returns ctx.Err() iff ctx.Done()
+func checkInterrupted(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	return nil
+}


### PR DESCRIPTION
@aaijazi @ryszard 
This should address both bugs:
- Worker interface is changed to Run(context) error (and the framework remembers the error, so the worker doesn't have to)
- if you use a StatusWorker (where I put a lot of common code), you get the StatusXXX methods for free.