### PR TITLE
add SplitColumn field to SplitQuery

### DIFF
--- a/go/vt/tabletserver/proto/structs.go
+++ b/go/vt/tabletserver/proto/structs.go
@@ -11,15 +11,20 @@ import (
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 )
 
+// SessionParams is passed to GetSessionId. The server will
+// double-check the keyspace and shard are what the tablet is serving.
 type SessionParams struct {
 	Keyspace string
 	Shard    string
 }
 
+// SessionInfo is returned by GetSessionId. Use the provided
+// session_id in the Session object for any subsequent call.
 type SessionInfo struct {
 	SessionId int64
 }
 
+// Query is the payload to Execute.
 type Query struct {
 	Sql           string
 	BindVariables map[string]interface{}
@@ -56,6 +61,7 @@ func slimit(s string) string {
 	return s[:l]
 }
 
+// BoundQuery is one query in a QueryList.
 type BoundQuery struct {
 	Sql           string
 	BindVariables map[string]interface{}
@@ -63,6 +69,7 @@ type BoundQuery struct {
 
 //go:generate bsongen -file $GOFILE -type BoundQuery -o bound_query_bson.go
 
+// QueryList is the payload to ExecuteBatch.
 type QueryList struct {
 	Queries       []BoundQuery
 	SessionId     int64
@@ -71,12 +78,14 @@ type QueryList struct {
 
 //go:generate bsongen -file $GOFILE -type QueryList -o query_list_bson.go
 
+// QueryResultList is the return type for ExecuteBatch.
 type QueryResultList struct {
 	List []mproto.QueryResult
 }
 
 //go:generate bsongen -file $GOFILE -type QueryResultList -o query_result_list_bson.go
 
+// Session is passed to all calls.
 type Session struct {
 	SessionId     int64
 	TransactionId int64
@@ -84,17 +93,23 @@ type Session struct {
 
 //go:generate bsongen -file $GOFILE -type Session -o session_bson.go
 
+// TransactionInfo is returned by Begin. Use the provided
+// transaction_id in the Session object for any subsequent call to be inside
+// the transaction.
 type TransactionInfo struct {
 	TransactionId int64
 }
 
 // SplitQueryRequest represents a request to split a Query into queries that
 // each return a subset of the original query.
-// TODO(anandhenry): Add SessionId to this struct.
+// SplitColumn: preferred column to split. Server will pick a random PK column
+//              if this field is empty or returns an error if this field is not
+//              empty but not found in schema info or not be indexed.
 type SplitQueryRequest struct {
-	Query      BoundQuery
-	SplitCount int
-	SessionID  int64
+	Query       BoundQuery
+	SplitColumn string
+	SplitCount  int
+	SessionID   int64
 }
 
 // QuerySplit represents a split of SplitQueryRequest.Query. RowCount is only

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/SplitQueryRequest.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/SplitQueryRequest.java
@@ -3,23 +3,29 @@ package com.youtube.vitess.vtgate;
 public class SplitQueryRequest {
   private String sql;
   private String keyspace;
+  private String splitColumn;
   private int splitCount;
 
-  public SplitQueryRequest(String sql, String keyspace, int splitCount) {
+  public SplitQueryRequest(String sql, String keyspace, int splitCount, String splitColumn) {
     this.sql = sql;
     this.keyspace = keyspace;
     this.splitCount = splitCount;
+    this.splitColumn = splitColumn;
   }
 
   public String getSql() {
-    return sql;
+    return this.sql;
   }
 
   public String getKeyspace() {
-    return keyspace;
+    return this.keyspace;
   }
 
   public int getSplitCount() {
-    return splitCount;
+    return this.splitCount;
+  }
+
+  public String getSplitColumn() {
+    return this.splitColumn;
   }
 }

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/VtGate.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/VtGate.java
@@ -114,9 +114,9 @@ public class VtGate {
    * instances. Batch jobs or MapReduce jobs that needs to scan all rows can use these queries to
    * parallelize full table scans.
    */
-  public Map<Query, Long> splitQuery(String keyspace, String sql, int splitCount)
+  public Map<Query, Long> splitQuery(String keyspace, String sql, int splitCount, String pkColumn)
       throws ConnectionException, DatabaseException {
-    SplitQueryRequest req = new SplitQueryRequest(sql, keyspace, splitCount);
+    SplitQueryRequest req = new SplitQueryRequest(sql, keyspace, splitCount, pkColumn);
     SplitQueryResponse response = client.splitQuery(req);
     if (response.getError() != null) {
       throw new DatabaseException(response.getError());

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessConf.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessConf.java
@@ -11,6 +11,7 @@ public class VitessConf {
   public static final String INPUT_KEYSPACE = "vitess.vtgate.hadoop.keyspace";
   public static final String INPUT_QUERY = "vitess.vtgate.hadoop.input_query";
   public static final String SPLITS = "vitess.vtgate.hadoop.splits";
+  public static final String SPLIT_COLUMN = "vitess.vtgate.hadoop.splitcolumn";
   public static final String HOSTS_DELIM = ",";
 
   private Configuration conf;
@@ -57,5 +58,13 @@ public class VitessConf {
 
   public void setSplits(int splits) {
     conf.setInt(SPLITS, splits);
+  }
+
+  public String getSplitColumn() {
+    return conf.get(SPLIT_COLUMN);
+  }
+
+  public void setSplitColumn(String splitColumn) {
+    conf.set(SPLIT_COLUMN, splitColumn);
   }
 }

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessInputFormat.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/hadoop/VitessInputFormat.java
@@ -33,7 +33,7 @@ public class VitessInputFormat extends InputFormat<NullWritable, RowWritable> {
       VitessConf conf = new VitessConf(context.getConfiguration());
       VtGate vtgate = VtGate.connect(conf.getHosts(), conf.getTimeoutMs());
       Map<Query, Long> queries =
-          vtgate.splitQuery(conf.getKeyspace(), conf.getInputQuery(), conf.getSplits());
+          vtgate.splitQuery(conf.getKeyspace(), conf.getInputQuery(), conf.getSplits(), conf.getSplitColumn());
       List<InputSplit> splits = new LinkedList<>();
       for (Query query : queries.keySet()) {
         Long size = queries.get(query);

--- a/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/rpcclient/gorpc/Bsonify.java
+++ b/java/vtgate-client/src/main/java/com/youtube/vitess/vtgate/rpcclient/gorpc/Bsonify.java
@@ -185,6 +185,7 @@ public class Bsonify {
     query.put("Sql", request.getSql());
     BSONObject b = new BasicBSONObject();
     b.put("Keyspace", request.getKeyspace());
+    b.put("SplitColumn", request.getSplitColumn());
     b.put("Query", query);
     b.put("SplitCount", request.getSplitCount());
     return b;

--- a/java/vtgate-client/src/test/java/com/youtube/vitess/vtgate/integration/VtGateIT.java
+++ b/java/vtgate-client/src/test/java/com/youtube/vitess/vtgate/integration/VtGateIT.java
@@ -306,7 +306,7 @@ public class VtGateIT {
     Util.waitForTablet("rdonly", 40, 3, testEnv);
     VtGate vtgate = VtGate.connect("localhost:" + testEnv.port, 0);
     Map<Query, Long> queries =
-        vtgate.splitQuery("test_keyspace", "select id,keyspace_id from vtgate_test", 1);
+        vtgate.splitQuery("test_keyspace", "select id,keyspace_id from vtgate_test", 1, "");
     vtgate.close();
 
     // Verify 2 splits, one per shard
@@ -342,7 +342,7 @@ public class VtGateIT {
     VtGate vtgate = VtGate.connect("localhost:" + testEnv.port, 0);
     int splitCount = 6;
     Map<Query, Long> queries =
-        vtgate.splitQuery("test_keyspace", "select id,keyspace_id from vtgate_test", splitCount);
+        vtgate.splitQuery("test_keyspace", "select id,keyspace_id from vtgate_test", splitCount, "");
     vtgate.close();
 
     // Verify 6 splits, 3 per shard
@@ -370,7 +370,7 @@ public class VtGateIT {
   public void testSplitQueryInvalidTable() throws Exception {
     VtGate vtgate = VtGate.connect("localhost:" + testEnv.port, 0);
     try {
-      vtgate.splitQuery("test_keyspace", "select id from invalid_table", 1);
+      vtgate.splitQuery("test_keyspace", "select id from invalid_table", 1, "");
       Assert.fail("failed to raise connection exception");
     } catch (ConnectionException e) {
       Assert.assertTrue(


### PR DESCRIPTION
1. Add SplitColumn field to SplitQuery so that caller could hint SplitQuery endpoint
   which column is best for splitting query.
2. The split column must be indexed and this will be verified on the server side.
3. coding style fixes suggested by golint.