### PR TITLE
docker/test/run.sh: Make repo world readable for access from docker.

### DIFF
--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -18,8 +18,9 @@ if [[ ! -f bootstrap.sh ]]; then
   exit 1
 fi
 
-# To avoid AUFS permission issues, files must allow access by "other"
-chmod -R o=g *
+# To avoid AUFS permission issues, files must allow access by "other" (permissions rX required).
+# Mirror permissions to "other" from the owning group (for which we assume it has at least rX permissions).
+chmod -R o=g .
 
 args="$args --rm -e USER=vitess -v /dev/log:/dev/log"
 args="$args -v $PWD:/tmp/src"


### PR DESCRIPTION
@enisoc

Previously, the permissions of all items *within* the repository were already updated, but not the repository itself.

This resulted into the error 'cp: cannot stat `/tmp/src/*': Permission denied' when running "docker/test/run.sh mariadb".