### PR TITLE
Fixing contexts in these file. Short context is now

### DIFF
--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -75,8 +75,8 @@ func findChecker(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrangler.C
 	defer wrangler.RecordTabletTagAction(cleaner, tabletAlias, "worker", "")
 
 	wr.Logger().Infof("Changing tablet %v to 'checker'", tabletAlias)
-	ctx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
-	err = wr.ChangeType(ctx, tabletAlias, topo.TYPE_CHECKER, false /*force*/)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	err = wr.ChangeType(shortCtx, tabletAlias, topo.TYPE_CHECKER, false /*force*/)
 	cancel()
 	if err != nil {
 		return topo.TabletAlias{}, err


### PR DESCRIPTION
always named shortCtx, and never overrides the ctx variable.
Fixes vertical_split.py.

@enisoc @yaoshengzhe @aaijazi 