### PR TITLE
add LocalController to apply schema changes from local file system.

### DIFF
--- a/go/cmd/vtctld/vtctld.go
+++ b/go/cmd/vtctld/vtctld.go
@@ -26,6 +26,7 @@ var (
 	schemaChangeDir           = flag.String("schema-change-dir", "", "directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change")
 	schemaChangeController    = flag.String("schema-change-controller", "", "schema change controller is responsible for finding schema changes and responsing schema change events")
 	schemaChangeCheckInterval = flag.Int("schema-change-check-interval", 60, "this value decides how often we check schema change dir, in seconds")
+	schemaChangeUser          = flag.String("schema-change-user", "", "The user who submits this schema change.")
 )
 
 func init() {
@@ -519,6 +520,7 @@ func main() {
 		timer.Start(func() {
 			controller, err := controllerFactory(map[string]string{
 				schemamanager.SchemaChangeDirName: *schemaChangeDir,
+				schemamanager.SchemaChangeUser:    *schemaChangeUser,
 			})
 			if err != nil {
 				log.Errorf("failed to get controller, error: %v", err)

--- a/go/vt/schemamanager/local_controller.go
+++ b/go/vt/schemamanager/local_controller.go
@@ -1,0 +1,220 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	log "github.com/golang/glog"
+)
+
+// LocalController listens to the specified schema change dir and applies schema changes.
+// schema change dir lay out
+//            |
+//            |----keyspace_01
+//                 |----input
+//                      |---- create_test_table.sql
+//                      |---- alter_test_table_02.sql
+//                      |---- ...
+//                 |----complete // contains completed schema changes in yyyy/MM/dd
+//                      |----2015
+//                           |----01
+//                                |----01
+//                                     |--- create_table_table_02.sql
+//                 |----log // contains detailed execution information about schema changes
+//                      |----2015
+//                           |----01
+//                                |----01
+//                                     |--- create_table_table_02.sql
+//                 |----error // contains failed schema changes
+//                      |----2015
+//                           |----01
+//                                |----01
+//                                     |--- create_table_table_03.sql
+// Schema Change Files: ${keyspace}/input/*.sql
+// Error Files:         ${keysapce}/error/${YYYY}/${MM}/${DD}/*.sql
+// Log Files:           ${keysapce}/log/${YYYY}/${MM}/${DD}/*.sql
+// Complete Files:      ${keysapce}/compelte/${YYYY}/${MM}/${DD}/*.sql
+type LocalController struct {
+	schemaChangeDir string
+	keyspace        string
+	sqlPath         string
+	sqlFilename     string
+	errorDir        string
+	logDir          string
+	completeDir     string
+}
+
+// NewLocalController creates a new LocalController instance.
+func NewLocalController(schemaChangeDir string) *LocalController {
+	return &LocalController{
+		schemaChangeDir: schemaChangeDir,
+	}
+}
+
+// Open goes through the schema change dir and find a keyspace with a pending
+// schema change.
+func (controller *LocalController) Open() error {
+	// find all keyspace directories.
+	fileInfos, err := ioutil.ReadDir(controller.schemaChangeDir)
+	if err != nil {
+		return err
+	}
+	for _, fileinfo := range fileInfos {
+		if !fileinfo.IsDir() {
+			continue
+		}
+		dirpath := path.Join(controller.schemaChangeDir, fileinfo.Name())
+		schemaChanges, err := ioutil.ReadDir(path.Join(dirpath, "input"))
+		if err != nil {
+			log.Warningf("there is no input dir in %s", dirpath)
+			continue
+		}
+		// found a schema change
+		if len(schemaChanges) > 0 {
+			controller.keyspace = fileinfo.Name()
+			controller.sqlFilename = schemaChanges[0].Name()
+			controller.sqlPath = path.Join(dirpath, "input", schemaChanges[0].Name())
+
+			currentTime := time.Now()
+			datePart := fmt.Sprintf(
+				"%d/%d/%d",
+				currentTime.Year(),
+				currentTime.Month(),
+				currentTime.Day())
+
+			controller.errorDir = path.Join(dirpath, "error", datePart)
+			controller.completeDir = path.Join(dirpath, "complete", datePart)
+			controller.logDir = path.Join(dirpath, "log", datePart)
+			// the remaining schema changes will be picked by the next runs
+			break
+		}
+	}
+	return nil
+}
+
+// Read reads schema changes.
+func (controller *LocalController) Read() ([]string, error) {
+	if controller.keyspace == "" || controller.sqlPath == "" {
+		return []string{}, nil
+	}
+	data, err := ioutil.ReadFile(controller.sqlPath)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Split(string(data), ";"), nil
+}
+
+// GetKeyspace returns current keyspace that is ready for applying schema change.
+func (controller *LocalController) GetKeyspace() string {
+	return controller.keyspace
+}
+
+// Close reset keyspace, sqlPath, errorDir, logDir and completeDir.
+func (controller *LocalController) Close() {
+	controller.keyspace = ""
+	controller.sqlPath = ""
+	controller.sqlFilename = ""
+	controller.errorDir = ""
+	controller.logDir = ""
+	controller.completeDir = ""
+}
+
+// OnReadSuccess is no-op
+func (controller *LocalController) OnReadSuccess() error {
+	return nil
+}
+
+// OnReadFail is no-op
+func (controller *LocalController) OnReadFail(err error) error {
+	log.Errorf("failed to read file: %s, error: %v", controller.sqlPath, err)
+	return nil
+}
+
+// OnValidationSuccess is no-op
+func (controller *LocalController) OnValidationSuccess() error {
+	return nil
+}
+
+// OnValidationFail is no-op
+func (controller *LocalController) OnValidationFail(err error) error {
+	return controller.moveToErrorDir()
+}
+
+// OnExecutorComplete is no-op
+func (controller *LocalController) OnExecutorComplete(result *ExecuteResult) error {
+	if len(result.FailedShards) > 0 || result.ExecutorErr != "" {
+		return controller.moveToErrorDir()
+	}
+	if err := os.MkdirAll(controller.completeDir, os.ModePerm); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(controller.logDir, os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := controller.writeToLogDir(result); err != nil {
+		return err
+	}
+
+	return os.Rename(
+		controller.sqlPath,
+		path.Join(controller.completeDir, controller.sqlFilename))
+}
+
+func (controller *LocalController) moveToErrorDir() error {
+	if err := os.MkdirAll(controller.errorDir, os.ModePerm); err != nil {
+		return err
+	}
+	return os.Rename(
+		controller.sqlPath,
+		path.Join(controller.errorDir, controller.sqlFilename))
+}
+
+func (controller *LocalController) writeToLogDir(result *ExecuteResult) error {
+	logFile, err := os.Create(path.Join(controller.logDir, controller.sqlFilename))
+	if err != nil {
+		return err
+	}
+	defer logFile.Close()
+
+	logFile.WriteString(fmt.Sprintf("-- new file: %s\n", controller.sqlPath))
+	for _, sql := range result.Sqls {
+		logFile.WriteString(sql)
+		logFile.WriteString(";\n")
+	}
+	rowsReturned := uint64(0)
+	rowsAffected := uint64(0)
+	for _, queryResult := range result.SuccessShards {
+		rowsReturned += uint64(len(queryResult.Result.Rows))
+		rowsAffected += queryResult.Result.RowsAffected
+	}
+	logFile.WriteString(fmt.Sprintf("-- Rows returned: %d\n", rowsReturned))
+	logFile.WriteString(fmt.Sprintf("-- Rows affected: %d\n", rowsAffected))
+	logFile.WriteString("-- \n")
+	logFile.WriteString(fmt.Sprintf("-- ran in %fs\n", result.TotalTimeSpent.Seconds()))
+	logFile.WriteString("-- Execution succeeded\n")
+	return nil
+}
+
+var _ Controller = (*LocalController)(nil)
+
+func init() {
+	RegisterControllerFactory(
+		"local",
+		func(params map[string]string) (Controller, error) {
+			schemaChangeDir, ok := params[SchemaChangeDirName]
+			if !ok {
+				return nil, fmt.Errorf("unable to construct a LocalController instance because param: %s is missing in params: %v", SchemaChangeDirName, params)
+			}
+			return NewLocalController(schemaChangeDir), nil
+		},
+	)
+}

--- a/go/vt/schemamanager/local_controller.go
+++ b/go/vt/schemamanager/local_controller.go
@@ -112,8 +112,8 @@ func (controller *LocalController) Read() ([]string, error) {
 	return strings.Split(string(data), ";"), nil
 }
 
-// GetKeyspace returns current keyspace that is ready for applying schema change.
-func (controller *LocalController) GetKeyspace() string {
+// Keyspace returns current keyspace that is ready for applying schema change.
+func (controller *LocalController) Keyspace() string {
 	return controller.keyspace
 }
 

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -1,0 +1,204 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package schemamanager
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+)
+
+func TestLocalControllerNoSchemaChanges(t *testing.T) {
+	schemaChangeDir, err := ioutil.TempDir("", "localcontroller-test")
+	defer os.RemoveAll(schemaChangeDir)
+	if err != nil {
+		t.Fatalf("failed to create temp schema change dir, error: %v", err)
+	}
+	controller := NewLocalController(schemaChangeDir)
+	if err := controller.Open(); err != nil {
+		t.Fatalf("Open should succeed, but got error: %v", err)
+	}
+	defer controller.Close()
+	data, err := controller.Read()
+	if err != nil {
+		t.Fatalf("Read should succeed, but got error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("there is no schema change, Read should return empty data")
+	}
+}
+
+func TestLocalControllerOpen(t *testing.T) {
+	controller := NewLocalController("")
+
+	if err := controller.Open(); err == nil {
+		t.Fatalf("Open should fail, no such dir")
+	}
+
+	schemaChangeDir, err := ioutil.TempDir("", "localcontroller-test")
+	defer os.RemoveAll(schemaChangeDir)
+
+	// create a file under schema change dir
+	_, err = os.Create(path.Join(schemaChangeDir, "create_test_table.sql"))
+	if err != nil {
+		t.Fatalf("failed to create sql file, error: %v", err)
+	}
+
+	controller = NewLocalController(schemaChangeDir)
+	if err := controller.Open(); err != nil {
+		t.Fatalf("Open should succeed")
+	}
+	data, err := controller.Read()
+	if err != nil {
+		t.Fatalf("Read should succeed, but got error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("there is no schema change, Read should return empty data")
+	}
+	controller.Close()
+
+	testKeyspaceDir := path.Join(schemaChangeDir, "test_keyspace")
+	if err := os.MkdirAll(testKeyspaceDir, os.ModePerm); err != nil {
+		t.Fatalf("failed to create test_keyspace dir, error: %v", err)
+	}
+
+	controller = NewLocalController(schemaChangeDir)
+	if err := controller.Open(); err != nil {
+		t.Fatalf("Open should succeed")
+	}
+	data, err = controller.Read()
+	if err != nil {
+		t.Fatalf("Read should succeed, but got error: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("there is no schema change, Read should return empty data")
+	}
+	controller.Close()
+}
+
+func TestLocalControllerSchemaChange(t *testing.T) {
+	schemaChangeDir, err := ioutil.TempDir("", "localcontroller-test")
+	if err != nil {
+		t.Fatalf("failed to create temp schema change dir, error: %v", err)
+	}
+	defer os.RemoveAll(schemaChangeDir)
+
+	testKeyspaceInputDir := path.Join(schemaChangeDir, "test_keyspace/input")
+	if err := os.MkdirAll(testKeyspaceInputDir, os.ModePerm); err != nil {
+		t.Fatalf("failed to create test_keyspace dir, error: %v", err)
+	}
+
+	file, err := os.Create(path.Join(testKeyspaceInputDir, "create_test_table.sql"))
+	if err != nil {
+		t.Fatalf("failed to create sql file, error: %v", err)
+	}
+
+	sqls := []string{
+		"create table test_table_01 (id int)",
+		"create table test_table_02 (id string)",
+	}
+
+	file.WriteString(strings.Join(sqls, ";"))
+	file.Close()
+
+	controller := NewLocalController(schemaChangeDir)
+	if err := controller.Open(); err != nil {
+		t.Fatalf("Open should succeed, but got error: %v", err)
+	}
+
+	defer controller.Close()
+
+	data, err := controller.Read()
+	if err != nil {
+		t.Fatalf("Read should succeed, but got error: %v", err)
+	}
+
+	if !reflect.DeepEqual(sqls, data) {
+		t.Fatalf("expect to get sqls: %v, but got: %v", sqls, data)
+	}
+
+	if controller.GetKeyspace() != "test_keyspace" {
+		t.Fatalf("expect to get keyspace: 'test_keyspace', but got: '%s'",
+			controller.GetKeyspace())
+	}
+
+	// test various callbacks
+	if err := controller.OnReadSuccess(); err != nil {
+		t.Fatalf("OnReadSuccess should succeed, but got error: %v", err)
+	}
+
+	if err := controller.OnReadFail(fmt.Errorf("read fail")); err != nil {
+		t.Fatalf("OnReadFail should succeed, but got error: %v", err)
+	}
+
+	errorPath := path.Join(controller.errorDir, controller.sqlFilename)
+
+	if err := controller.OnValidationSuccess(); err != nil {
+		t.Fatalf("OnReadSuccess should succeed, but got error: %v", err)
+	}
+
+	// move sql file from error dir to input dir for OnValidationFail test
+	os.Rename(errorPath, controller.sqlPath)
+
+	if err := controller.OnValidationFail(fmt.Errorf("validation fail")); err != nil {
+		t.Fatalf("OnValidationFail should succeed, but got error: %v", err)
+	}
+
+	if _, err := os.Stat(errorPath); os.IsNotExist(err) {
+		t.Fatalf("sql file should be moved to error dir, error: %v", err)
+	}
+
+	// move sql file from error dir to input dir for OnExecutorComplete test
+	os.Rename(errorPath, controller.sqlPath)
+
+	result := &ExecuteResult{
+		Sqls: []string{"create table test_table (id int)"},
+		SuccessShards: []ShardResult{
+			ShardResult{
+				Shard:  "0",
+				Result: &mproto.QueryResult{},
+			},
+		},
+	}
+	logPath := path.Join(controller.logDir, controller.sqlFilename)
+	completePath := path.Join(controller.completeDir, controller.sqlFilename)
+	if err := controller.OnExecutorComplete(result); err != nil {
+		t.Fatalf("OnExecutorComplete should succeed, but got error: %v", err)
+	}
+	if _, err := os.Stat(completePath); os.IsNotExist(err) {
+		t.Fatalf("sql file should be moved to complete dir, error: %v", err)
+	}
+
+	if _, err := os.Stat(logPath); os.IsNotExist(err) {
+		t.Fatalf("sql file should be moved to log dir, error: %v", err)
+	}
+
+	// move sql file from error dir to input dir for OnExecutorComplete test
+	os.Rename(completePath, controller.sqlPath)
+
+	result = &ExecuteResult{
+		Sqls: []string{"create table test_table (id int)"},
+		FailedShards: []ShardWithError{
+			ShardWithError{
+				Shard: "0",
+				Err:   "execute error",
+			},
+		},
+	}
+
+	if err := controller.OnExecutorComplete(result); err != nil {
+		t.Fatalf("OnExecutorComplete should succeed, but got error: %v", err)
+	}
+
+	if _, err := os.Stat(errorPath); os.IsNotExist(err) {
+		t.Fatalf("sql file should be moved to error dir, error: %v", err)
+	}
+}

--- a/go/vt/schemamanager/local_controller_test.go
+++ b/go/vt/schemamanager/local_controller_test.go
@@ -125,9 +125,9 @@ func TestLocalControllerSchemaChange(t *testing.T) {
 		t.Fatalf("expect to get sqls: %v, but got: %v", sqls, data)
 	}
 
-	if controller.GetKeyspace() != "test_keyspace" {
+	if controller.Keyspace() != "test_keyspace" {
 		t.Fatalf("expect to get keyspace: 'test_keyspace', but got: '%s'",
-			controller.GetKeyspace())
+			controller.Keyspace())
 	}
 
 	// test various callbacks

--- a/go/vt/schemamanager/plain_controller.go
+++ b/go/vt/schemamanager/plain_controller.go
@@ -45,8 +45,8 @@ func (controller *PlainController) Read() ([]string, error) {
 func (controller *PlainController) Close() {
 }
 
-// GetKeyspace returns keyspace to apply schema.
-func (controller *PlainController) GetKeyspace() string {
+// Keyspace returns keyspace to apply schema.
+func (controller *PlainController) Keyspace() string {
 	return controller.keyspace
 }
 

--- a/go/vt/schemamanager/plain_controller_test.go
+++ b/go/vt/schemamanager/plain_controller_test.go
@@ -17,7 +17,7 @@ func TestPlainController(t *testing.T) {
 		t.Fatalf("controller.Open should succeed, but got error: %v", err)
 	}
 
-	keyspace := controller.GetKeyspace()
+	keyspace := controller.Keyspace()
 	if keyspace != "test_keyspace" {
 		t.Fatalf("expect to get keyspace: 'test_keyspace', but got keyspace: '%s'", keyspace)
 	}

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -36,7 +36,7 @@ type Controller interface {
 	Open() error
 	Read() (sqls []string, err error)
 	Close()
-	GetKeyspace() string
+	Keyspace() string
 	OnReadSuccess() error
 	OnReadFail(err error) error
 	OnValidationSuccess() error
@@ -89,7 +89,7 @@ func Run(controller Controller, executor Executor) error {
 	}
 
 	controller.OnReadSuccess()
-	keyspace := controller.GetKeyspace()
+	keyspace := controller.Keyspace()
 	if err := executor.Open(keyspace); err != nil {
 		log.Errorf("failed to open executor: %v", err)
 		return err

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -15,7 +15,11 @@ import (
 
 const (
 	// SchemaChangeDirName is the key name in the ControllerFactory params.
+	// It specifies the schema change directory.
 	SchemaChangeDirName = "schema_change_dir"
+	// SchemaChangeUser is the key name in the ControllerFactory params.
+	// It specifies the user who submits this schema change.
+	SchemaChangeUser = "schema_change_user"
 )
 
 // ControllerFactory takes a set params and construct a Controller instance.

--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -467,7 +467,7 @@ func (controller *fakeController) Read() ([]string, error) {
 func (controller *fakeController) Close() {
 }
 
-func (controller *fakeController) GetKeyspace() string {
+func (controller *fakeController) Keyspace() string {
 	return controller.keyspace
 }
 

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -7,6 +7,7 @@ package schemamanager
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/mysqlctl/proto"
@@ -155,6 +156,8 @@ func (exec *TabletExecutor) Execute(sqls []string) *ExecuteResult {
 		execResult.ExecutorErr = "executor is closed"
 		return &execResult
 	}
+	startTime := time.Now()
+	defer func() { execResult.TotalTimeSpent = time.Since(startTime) }()
 
 	// make sure every schema change introduces a table definition change
 	if err := exec.preflightSchemaChanges(sqls); err != nil {

--- a/go/vt/schemamanager/ui_controller.go
+++ b/go/vt/schemamanager/ui_controller.go
@@ -52,8 +52,8 @@ func (controller *UIController) Read() ([]string, error) {
 func (controller *UIController) Close() {
 }
 
-// GetKeyspace returns keyspace to apply schema.
-func (controller *UIController) GetKeyspace() string {
+// Keyspace returns keyspace to apply schema.
+func (controller *UIController) Keyspace() string {
 	return controller.keyspace
 }
 

--- a/go/vt/schemamanager/ui_controller_test.go
+++ b/go/vt/schemamanager/ui_controller_test.go
@@ -20,7 +20,7 @@ func TestUIController(t *testing.T) {
 		t.Fatalf("controller.Open should succeed, but got error: %v", err)
 	}
 
-	keyspace := controller.GetKeyspace()
+	keyspace := controller.Keyspace()
 	if keyspace != "test_keyspace" {
 		t.Fatalf("expect to get keyspace: 'test_keyspace', but got keyspace: '%s'", keyspace)
 	}

--- a/test/utils.py
+++ b/test/utils.py
@@ -764,6 +764,7 @@ class Vtctld(object):
 
   def __init__(self):
     self.port = environment.reserve_ports(1)
+    self.schema_change_dir = os.path.join(environment.tmproot, 'schema_change_test')
     if protocols_flavor().vtctl_client_protocol() == "grpc":
       self.grpc_port = environment.reserve_ports(1)
 
@@ -786,6 +787,9 @@ class Vtctld(object):
             '-templates', environment.vttop + '/go/cmd/vtctld/templates',
             '-log_dir', environment.vtlogroot,
             '-port', str(self.port),
+            '-schema-change-dir', self.schema_change_dir,
+            '-schema-change-controller', 'local',
+            '-schema-change-check-interval', '1',
             ] + \
             environment.topo_server().flags() + \
             protocols_flavor().tablet_manager_protocol_flags()


### PR DESCRIPTION
1. A LocalController monitors a given directory, it first finds a
   schema change sql in the directory and then applies to its keyspace.
2. If a schema change is applied successfully, it moves the original
   sql file to a "complete" dir and coressponding execution log to
   a "log" dir. If it fails, the original sql file will be moved to
   a "error" dir.
3. Add a test case to test/schema.py so it creates a sql file in the
   schema change dir and this change will be picked up by vtctld.