### PR TITLE
Process new "Flags" MySQL field when converting a result set to Go ty…

### DIFF
--- a/go/mysql/proto/structs_test.go
+++ b/go/mysql/proto/structs_test.go
@@ -12,81 +12,79 @@ import (
 
 func TestConvert(t *testing.T) {
 	cases := []struct {
-		Desc string
-		Typ  int64
-		Val  sqltypes.Value
-		Want interface{}
+		Field Field
+		Val   sqltypes.Value
+		Want  interface{}
 	}{{
-		Desc: "null",
-		Typ:  VT_LONG,
-		Val:  sqltypes.Value{},
-		Want: nil,
+		Field: Field{"null", VT_LONG, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.Value{},
+		Want:  nil,
 	}, {
-		Desc: "decimal",
-		Typ:  VT_DECIMAL,
-		Val:  sqltypes.MakeString([]byte("aa")),
-		Want: "aa",
+		Field: Field{"decimal", VT_DECIMAL, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("aa")),
+		Want:  "aa",
 	}, {
-		Desc: "tiny",
-		Typ:  VT_TINY,
-		Val:  sqltypes.MakeString([]byte("1")),
+		Field: Field{"tiny", VT_TINY, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  int64(1),
+	}, {
+		Field: Field{"short", VT_SHORT, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  int64(1),
+	}, {
+		Field: Field{"long", VT_LONG, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  int64(1),
+	}, {
+		Field: Field{"unsigned long", VT_LONG, VT_UNSIGNED_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		// Unsigned types which aren't VT_LONGLONG are mapped to int64.
 		Want: int64(1),
 	}, {
-		Desc: "short",
-		Typ:  VT_SHORT,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: int64(1),
+		Field: Field{"longlong", VT_LONGLONG, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  int64(1),
 	}, {
-		Desc: "long",
-		Typ:  VT_LONG,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: int64(1),
+		Field: Field{"int24", VT_INT24, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  int64(1),
 	}, {
-		Desc: "longlong",
-		Typ:  VT_LONGLONG,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: int64(1),
+		Field: Field{"float", VT_FLOAT, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  float64(1),
 	}, {
-		Desc: "int24",
-		Typ:  VT_INT24,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: int64(1),
+		Field: Field{"double", VT_DOUBLE, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1")),
+		Want:  float64(1),
 	}, {
-		Desc: "float",
-		Typ:  VT_FLOAT,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: float64(1),
+		Field: Field{"large int out of range for int64", VT_LONGLONG, VT_ZEROVALUE_FLAG},
+		// 2^63, out of range for int64
+		Val:  sqltypes.MakeString([]byte("9223372036854775808")),
+		Want: `strconv.ParseInt: parsing "9223372036854775808": value out of range`,
 	}, {
-		Desc: "double",
-		Typ:  VT_DOUBLE,
-		Val:  sqltypes.MakeString([]byte("1")),
-		Want: float64(1),
-	}, {
-		Desc: "large int",
-		Typ:  VT_LONGLONG,
+		Field: Field{"large int", VT_LONGLONG, VT_UNSIGNED_FLAG},
+		// 2^63, not out of range for uint64
 		Val:  sqltypes.MakeString([]byte("9223372036854775808")),
 		Want: uint64(9223372036854775808),
 	}, {
-		Desc: "float for int",
-		Typ:  VT_LONGLONG,
-		Val:  sqltypes.MakeString([]byte("1.1")),
-		Want: `strconv.ParseUint: parsing "1.1": invalid syntax`,
+		Field: Field{"float for int", VT_LONGLONG, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("1.1")),
+		Want:  `strconv.ParseInt: parsing "1.1": invalid syntax`,
 	}, {
-		Desc: "string for float",
-		Typ:  VT_FLOAT,
-		Val:  sqltypes.MakeString([]byte("aa")),
-		Want: `strconv.ParseFloat: parsing "aa": invalid syntax`,
+		Field: Field{"string for float", VT_FLOAT, VT_ZEROVALUE_FLAG},
+		Val:   sqltypes.MakeString([]byte("aa")),
+		Want:  `strconv.ParseFloat: parsing "aa": invalid syntax`,
 	}}
 
 	for _, c := range cases {
-		r, err := Convert(c.Typ, c.Val)
+		r, err := Convert(c.Field, c.Val)
 		if err != nil {
 			r = err.Error()
 		} else if _, ok := r.([]byte); ok {
 			r = string(r.([]byte))
 		}
 		if r != c.Want {
-			t.Errorf("%s: %+v, want %+v", c.Desc, r, c.Want)
+			t.Errorf("%s: %+v, want %+v", c.Field.Name, r, c.Want)
 		}
 	}
 }

--- a/go/vt/client2/tablet/tclient.go
+++ b/go/vt/client2/tablet/tclient.go
@@ -257,7 +257,7 @@ func (result *Result) Next() (row []interface{}) {
 	row = make([]interface{}, len(result.qr.Rows[result.index]))
 	for i, v := range result.qr.Rows[result.index] {
 		var err error
-		row[i], err = mproto.Convert(result.qr.Fields[i].Type, v)
+		row[i], err = mproto.Convert(result.qr.Fields[i], v)
 		if err != nil {
 			panic(err) // unexpected
 		}
@@ -311,7 +311,7 @@ func (sr *StreamResult) Next() (row []interface{}) {
 	row = make([]interface{}, len(sr.qr.Rows[sr.index]))
 	for i, v := range sr.qr.Rows[sr.index] {
 		var err error
-		row[i], err = mproto.Convert(sr.columns.Fields[i].Type, v)
+		row[i], err = mproto.Convert(sr.columns.Fields[i], v)
 		if err != nil {
 			panic(err) // unexpected
 		}

--- a/go/vt/vtgate/router.go
+++ b/go/vt/vtgate/router.go
@@ -437,7 +437,7 @@ func (rtr *Router) deleteVindexEntries(vcursor *requestContext, plan *planbuilde
 	for i, colVindex := range plan.Table.Owned {
 		keys := make(map[interface{}]bool)
 		for _, row := range result.Rows {
-			k, err := mproto.Convert(result.Fields[i].Type, row[i])
+			k, err := mproto.Convert(result.Fields[i], row[i])
 			if err != nil {
 				return err
 			}

--- a/go/vt/vtgate/router_dml_test.go
+++ b/go/vt/vtgate/router_dml_test.go
@@ -268,7 +268,7 @@ func TestDeleteVindexFail(t *testing.T) {
 		}},
 	}})
 	_, err = routerExec(router, "delete from user where id = 1", nil)
-	want = `execDeleteEqual: strconv.ParseUint: parsing "foo": invalid syntax`
+	want = `execDeleteEqual: strconv.ParseInt: parsing "foo": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("routerExec: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -243,7 +243,7 @@ func (lkp *lookup) Map1(vcursor planbuilder.VCursor, ids []interface{}) ([]key.K
 		if len(result.Rows) != 1 {
 			return nil, fmt.Errorf("lookup.Map: unexpected multiple results from vindex %s: %v", lkp.Table, id)
 		}
-		inum, err := mproto.Convert(result.Fields[0].Type, result.Rows[0][0])
+		inum, err := mproto.Convert(result.Fields[0], result.Rows[0][0])
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Map: %v", err)
 		}
@@ -272,7 +272,7 @@ func (lkp *lookup) Map2(vcursor planbuilder.VCursor, ids []interface{}) ([][]key
 		}
 		var ksids []key.KeyspaceId
 		for _, row := range result.Rows {
-			inum, err := mproto.Convert(result.Fields[0].Type, row[0])
+			inum, err := mproto.Convert(result.Fields[0], row[0])
 			if err != nil {
 				return nil, fmt.Errorf("lookup.Map: %v", err)
 			}

--- a/go/vt/vtgate/vindexes/lookup_hash_auto_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_auto_test.go
@@ -72,7 +72,7 @@ func TestLookupHashAutoMapBadData(t *testing.T) {
 	}
 	vc := &vcursor{result: result}
 	_, err := lha.(planbuilder.NonUnique).Map(vc, []interface{}{1, int32(2)})
-	want := `lookup.Map: strconv.ParseUint: parsing "1.1": invalid syntax`
+	want := `lookup.Map: strconv.ParseInt: parsing "1.1": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("lha.Map: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_auto_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_auto_test.go
@@ -81,7 +81,7 @@ func TestLookupHashUniqueAutoMapBadData(t *testing.T) {
 	}
 	vc := &vcursor{result: result}
 	_, err := lhua.(planbuilder.Unique).Map(vc, []interface{}{1, int32(2)})
-	want := `lookup.Map: strconv.ParseUint: parsing "1.1": invalid syntax`
+	want := `lookup.Map: strconv.ParseInt: parsing "1.1": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("lhua.Map: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vtgateconn/rows.go
+++ b/go/vt/vtgate/vtgateconn/rows.go
@@ -46,6 +46,10 @@ func (ri *rows) Next(dest []driver.Value) error {
 	return err
 }
 
+// populateRow populates a row of data using the table's field descriptions.
+// The returned types for "dest" include the list from the interface
+// specification at https://golang.org/pkg/database/sql/driver/#Value
+// and in addition the type "uint64" for unsigned BIGINT MySQL records.
 func populateRow(dest []driver.Value, fields []mproto.Field, row []sqltypes.Value) error {
 	if len(dest) != len(fields) {
 		return fmt.Errorf("length mismatch: dest is %d, fields are %d", len(dest), len(fields))
@@ -55,7 +59,7 @@ func populateRow(dest []driver.Value, fields []mproto.Field, row []sqltypes.Valu
 	}
 	var err error
 	for i := range dest {
-		dest[i], err = mproto.Convert(fields[i].Type, row[i])
+		dest[i], err = mproto.Convert(fields[i], row[i])
 		if err != nil {
 			return fmt.Errorf("conversion error: field: %v, val: %v: %v", fields[i], row[i], err)
 		}

--- a/go/vt/vtgate/vtgateconn/rows_test.go
+++ b/go/vt/vtgate/vtgateconn/rows_test.go
@@ -24,21 +24,49 @@ var result1 = mproto.QueryResult{
 			Name: "field3",
 			Type: mproto.VT_VAR_STRING,
 		},
+		// Signed types which are smaller than uint64, will become an int64.
+		mproto.Field{
+			Name:  "field4",
+			Type:  mproto.VT_LONG,
+			Flags: mproto.VT_UNSIGNED_FLAG,
+		},
+		// Signed uint64 values must be mapped to uint64.
+		mproto.Field{
+			Name:  "field5",
+			Type:  mproto.VT_LONGLONG,
+			Flags: mproto.VT_UNSIGNED_FLAG,
+		},
 	},
-	RowsAffected: 3,
+	RowsAffected: 2,
 	InsertId:     0,
 	Rows: [][]sqltypes.Value{
 		[]sqltypes.Value{
 			sqltypes.MakeString([]byte("1")),
 			sqltypes.MakeString([]byte("1.1")),
 			sqltypes.MakeString([]byte("value1")),
+			sqltypes.MakeString([]byte("2147483647")),          // 2^31-1, NOT out of range for int32 => should become int64
+			sqltypes.MakeString([]byte("9223372036854775807")), // 2^63-1, NOT out of range for int64
 		},
 		[]sqltypes.Value{
 			sqltypes.MakeString([]byte("2")),
 			sqltypes.MakeString([]byte("2.2")),
 			sqltypes.MakeString([]byte("value2")),
+			sqltypes.MakeString([]byte("4294967295")),           // 2^32, out of range for int32 => should become int64
+			sqltypes.MakeString([]byte("18446744073709551615")), // 2^64, out of range for int64
 		},
 	},
+}
+
+func logMismatchedTypes(t *testing.T, gotRow, wantRow []driver.Value) {
+	for i := 1; i < len(wantRow); i++ {
+		got := gotRow[i]
+		want := wantRow[i]
+		v1 := reflect.ValueOf(got)
+		v2 := reflect.ValueOf(want)
+		if v1.Type() != v2.Type() {
+			t.Errorf("Wrong type: field: %d got: %T want: %T", i+1, got, want)
+		}
+	}
 }
 
 func TestRows(t *testing.T) {
@@ -47,6 +75,8 @@ func TestRows(t *testing.T) {
 		"field1",
 		"field2",
 		"field3",
+		"field4",
+		"field5",
 	}
 	gotCols := ri.Columns()
 	if !reflect.DeepEqual(gotCols, wantCols) {
@@ -57,20 +87,25 @@ func TestRows(t *testing.T) {
 		int64(1),
 		float64(1.1),
 		[]byte("value1"),
+		int64(2147483647),
+		uint64(9223372036854775807),
 	}
-	gotRow := make([]driver.Value, 3)
+	gotRow := make([]driver.Value, len(wantRow))
 	err := ri.Next(gotRow)
 	if err != nil {
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(gotRow, wantRow) {
-		t.Errorf("row1: %v, want %v", gotRow, wantRow)
+		t.Errorf("row1: %v, want %v type: %T", gotRow, wantRow, wantRow[3])
+		logMismatchedTypes(t, gotRow, wantRow)
 	}
 
 	wantRow = []driver.Value{
 		int64(2),
 		float64(2.2),
 		[]byte("value2"),
+		int64(4294967295),
+		uint64(18446744073709551615),
 	}
 	err = ri.Next(gotRow)
 	if err != nil {
@@ -78,6 +113,7 @@ func TestRows(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotRow, wantRow) {
 		t.Errorf("row1: %v, want %v", gotRow, wantRow)
+		logMismatchedTypes(t, gotRow, wantRow)
 	}
 
 	err = ri.Next(gotRow)
@@ -131,7 +167,7 @@ func TestRowsFail(t *testing.T) {
 	ri = NewRows(&badResult2)
 	dest = make([]driver.Value, 1)
 	err = ri.Next(dest)
-	want = `conversion error: field: {field1 3 0}, val: value: strconv.ParseUint: parsing "value": invalid syntax`
+	want = `conversion error: field: {field1 3 0}, val: value: strconv.ParseInt: parsing "value": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("Next: %v, want %s", err, want)
 	}

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -263,12 +263,11 @@ func RowsEqual(left, right []sqltypes.Value) int {
 // TODO: This can panic if types for left and right don't match.
 func CompareRows(fields []mproto.Field, compareCount int, left, right []sqltypes.Value) (int, error) {
 	for i := 0; i < compareCount; i++ {
-		fieldType := fields[i].Type
-		lv, err := mproto.Convert(fieldType, left[i])
+		lv, err := mproto.Convert(fields[i], left[i])
 		if err != nil {
 			return 0, err
 		}
-		rv, err := mproto.Convert(fieldType, right[i])
+		rv, err := mproto.Convert(fields[i], right[i])
 		if err != nil {
 			return 0, err
 		}

--- a/go/vt/worker/diff_utils_test.go
+++ b/go/vt/worker/diff_utils_test.go
@@ -50,15 +50,15 @@ func TestCompareRows(t *testing.T) {
 		want        int
 	}{
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_LONG}},
+			fields: []mproto.Field{{"a", mproto.VT_LONG, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Numeric("123")}},
 			right:  []sqltypes.Value{{sqltypes.Numeric("14")}},
 			want:   1,
 		},
 		{
 			fields: []mproto.Field{
-				{Name: "a", Type: mproto.VT_LONG},
-				{Name: "b", Type: mproto.VT_LONG},
+				{"a", mproto.VT_LONG, mproto.VT_ZEROVALUE_FLAG},
+				{"b", mproto.VT_LONG, mproto.VT_ZEROVALUE_FLAG},
 			},
 			left: []sqltypes.Value{
 				{sqltypes.Numeric("555")},
@@ -71,43 +71,43 @@ func TestCompareRows(t *testing.T) {
 			want: -1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_LONG}},
+			fields: []mproto.Field{{"a", mproto.VT_LONG, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Numeric("144")}},
 			right:  []sqltypes.Value{{sqltypes.Numeric("144")}},
 			want:   0,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_LONGLONG}},
+			fields: []mproto.Field{{"a", mproto.VT_LONGLONG, mproto.VT_UNSIGNED_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Numeric("9223372036854775809")}},
 			right:  []sqltypes.Value{{sqltypes.Numeric("9223372036854775810")}},
 			want:   -1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_LONGLONG}},
+			fields: []mproto.Field{{"a", mproto.VT_LONGLONG, mproto.VT_UNSIGNED_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Numeric("9223372036854775819")}},
 			right:  []sqltypes.Value{{sqltypes.Numeric("9223372036854775810")}},
 			want:   1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_DOUBLE}},
+			fields: []mproto.Field{{"a", mproto.VT_DOUBLE, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Fractional("3.14")}},
 			right:  []sqltypes.Value{{sqltypes.Fractional("3.2")}},
 			want:   -1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_DOUBLE}},
+			fields: []mproto.Field{{"a", mproto.VT_DOUBLE, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.Fractional("123.4")}},
 			right:  []sqltypes.Value{{sqltypes.Fractional("123.2")}},
 			want:   1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_STRING}},
+			fields: []mproto.Field{{"a", mproto.VT_STRING, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.String("abc")}},
 			right:  []sqltypes.Value{{sqltypes.String("abb")}},
 			want:   1,
 		},
 		{
-			fields: []mproto.Field{{Name: "a", Type: mproto.VT_STRING}},
+			fields: []mproto.Field{{"a", mproto.VT_STRING, mproto.VT_ZEROVALUE_FLAG}},
 			left:   []sqltypes.Value{{sqltypes.String("abc")}},
 			right:  []sqltypes.Value{{sqltypes.String("abd")}},
 			want:   -1,


### PR DESCRIPTION
…pes.

@sougou @alainjobart 

This change breaks the previous behavior: Before, unsigned BIGINT fields were always mapped to an int64 unless they were out of range for it. Now BIGINT are mapped to int64 or uint64 based on the unsigned information in the schema.

Smaller MySQL integer types are mapped to int64 as before, regardless of their signed information.