### PR TITLE
Splitting up the go client into a user API (using structs),

### DIFF
--- a/go/vt/client/client.go
+++ b/go/vt/client/client.go
@@ -52,17 +52,13 @@ type conn struct {
 	TabletType topo.TabletType `json:"tablet_type"`
 	Streaming  bool
 	Timeout    time.Duration
-	vtgateConn vtgateconn.VTGateConn
-	tx         vtgateconn.VTGateTx
+	vtgateConn *vtgateconn.VTGateConn
+	tx         *vtgateconn.VTGateTx
 }
 
 func (c *conn) dial() error {
-	dialer := vtgateconn.GetDialerWithProtocol(c.Protocol)
-	if dialer == nil {
-		return fmt.Errorf("could not find dialer for protocol %s", c.Protocol)
-	}
 	var err error
-	c.vtgateConn, err = dialer(context.Background(), c.Address, c.Timeout)
+	c.vtgateConn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address, c.Timeout)
 	return err
 }
 

--- a/go/vt/client/client_test.go
+++ b/go/vt/client/client_test.go
@@ -94,7 +94,7 @@ func TestDial(t *testing.T) {
 	_ = c.Close()
 
 	_, err = drv{}.Open(`{"protocol": "none"}`)
-	want := "could not find dialer for protocol none"
+	want := "no dialer registered for VTGate protocol none"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("err: %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -6,6 +6,7 @@ package vtgateconn
 
 import (
 	"flag"
+	"fmt"
 	"time"
 
 	log "github.com/golang/glog"
@@ -40,16 +41,119 @@ type OperationalError string
 
 func (e OperationalError) Error() string { return string(e) }
 
-// DialerFunc represents a function that will return a VTGateConn object that can communicate with a VTGate.
-type DialerFunc func(ctx context.Context, address string, timeout time.Duration) (VTGateConn, error)
-
 // VTGateConn defines the interface for a vtgate client.
 // It can be used concurrently across goroutines.
-type VTGateConn interface {
+type VTGateConn struct {
+	impl Impl
+}
+
+// Execute executes a non-streaming query on vtgate.
+func (conn *VTGateConn) Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error) {
+	res, _, err := conn.impl.Execute(ctx, query, bindVars, tabletType, nil)
+	return res, err
+}
+
+// ExecuteShard executes a non-streaming query for multiple shards on vtgate.
+func (conn *VTGateConn) ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error) {
+	res, _, err := conn.impl.ExecuteShard(ctx, query, keyspace, shards, bindVars, tabletType, nil)
+	return res, err
+}
+
+// StreamExecute executes a streaming query on vtgate. It returns a channel, ErrFunc and error.
+// If error is non-nil, it means that the StreamExecute failed to send the request. Otherwise,
+// you can pull values from the channel till it's closed. Following this, you can call ErrFunc
+// to see if the stream ended normally or due to a failure.
+func (conn *VTGateConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc) {
+	return conn.impl.StreamExecute(ctx, query, bindVars, tabletType)
+}
+
+// Begin starts a transaction and returns a VTGateTX.
+func (conn *VTGateConn) Begin(ctx context.Context) (*VTGateTx, error) {
+	session, err := conn.impl.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VTGateTx{
+		impl:    conn.impl,
+		session: session,
+	}, nil
+}
+
+// Close must be called for releasing resources.
+func (conn *VTGateConn) Close() {
+	conn.impl.Close()
+	conn.impl = nil
+}
+
+// SplitQuery splits a query into equally sized smaller queries by
+// appending primary key range clauses to the original query
+func (conn *VTGateConn) SplitQuery(ctx context.Context, keyspace string, query tproto.BoundQuery, splitCount int) ([]proto.SplitQueryPart, error) {
+	return conn.impl.SplitQuery(ctx, keyspace, query, splitCount)
+}
+
+// VTGateTx defines an ongoing transaction.
+// It should not be concurrently used across goroutines.
+type VTGateTx struct {
+	impl    Impl
+	session interface{}
+}
+
+// Execute executes a query on vtgate within the current transaction.
+func (tx *VTGateTx) Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error) {
+	if tx.session == nil {
+		return nil, fmt.Errorf("execute: not in transaction")
+	}
+	res, session, err := tx.impl.Execute(ctx, query, bindVars, tabletType, tx.session)
+	tx.session = session
+	return res, err
+}
+
+// ExecuteShard executes a query for multiple shards on vtgate within the current transaction.
+func (tx *VTGateTx) ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error) {
+	if tx.session == nil {
+		return nil, fmt.Errorf("executeShard: not in transaction")
+	}
+	res, session, err := tx.impl.ExecuteShard(ctx, query, keyspace, shards, bindVars, tabletType, tx.session)
+	tx.session = session
+	return res, err
+}
+
+// Commit commits the current transaction.
+func (tx *VTGateTx) Commit(ctx context.Context) error {
+	if tx.session == nil {
+		return fmt.Errorf("commit: not in transaction")
+	}
+	err := tx.impl.Commit(ctx, tx.session)
+	tx.session = nil
+	return err
+}
+
+// Rollback rolls back the current transaction.
+func (tx *VTGateTx) Rollback(ctx context.Context) error {
+	if tx.session == nil {
+		return nil
+	}
+	err := tx.impl.Rollback(ctx, tx.session)
+	tx.session = nil
+	return err
+}
+
+// ErrFunc is used to check for streaming errors.
+type ErrFunc func() error
+
+//
+// The rest of this file is for the protocol implementations.
+//
+
+// Impl defines the interface for a vtgate client protocol
+// implementation. It can be used concurrently across goroutines.
+type Impl interface {
 	// Execute executes a non-streaming query on vtgate.
-	Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
+	Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType, session interface{}) (*mproto.QueryResult, interface{}, error)
+
 	// ExecuteShard executes a non-streaming query for multiple shards on vtgate.
-	ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
+	ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType, session interface{}) (*mproto.QueryResult, interface{}, error)
 
 	// StreamExecute executes a streaming query on vtgate. It returns a channel, ErrFunc and error.
 	// If error is non-nil, it means that the StreamExecute failed to send the request. Otherwise,
@@ -58,32 +162,24 @@ type VTGateConn interface {
 	StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc)
 
 	// Begin starts a transaction and returns a VTGateTX.
-	Begin(ctx context.Context) (VTGateTx, error)
+	Begin(ctx context.Context) (interface{}, error)
 
-	// Close must be called for releasing resources.
-	Close()
+	// Commit commits the current transaction.
+	Commit(ctx context.Context, session interface{}) error
+
+	// Rollback rolls back the current transaction.
+	Rollback(ctx context.Context, session interface{}) error
 
 	// SplitQuery splits a query into equally sized smaller queries by
 	// appending primary key range clauses to the original query
 	SplitQuery(ctx context.Context, keyspace string, query tproto.BoundQuery, splitCount int) ([]proto.SplitQueryPart, error)
+
+	// Close must be called for releasing resources.
+	Close()
 }
 
-// VTGateTx defines the interface for the transaction object created by Begin.
-// It should not be concurrently used across goroutines.
-type VTGateTx interface {
-	// Execute executes a query on vtgate within the current transaction.
-	Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
-	// ExecuteShard executes a query for multiple shards on vtgate within the current transaction.
-	ExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (*mproto.QueryResult, error)
-
-	// Commit commits the current transaction.
-	Commit(ctx context.Context) error
-	// Rollback rolls back the current transaction.
-	Rollback(ctx context.Context) error
-}
-
-// ErrFunc is used to check for streaming errors.
-type ErrFunc func() error
+// DialerFunc represents a function that will return a VTGateConn object that can communicate with a VTGate.
+type DialerFunc func(ctx context.Context, address string, timeout time.Duration) (Impl, error)
 
 var dialers = make(map[string]DialerFunc)
 
@@ -97,17 +193,23 @@ func RegisterDialer(name string, dialer DialerFunc) {
 	dialers[name] = dialer
 }
 
-// GetDialer returns the dialer to use, described by the command line flag
-func GetDialer() DialerFunc {
-	return GetDialerWithProtocol(*vtgateProtocol)
+// DialProtocol dials a specific protocol, and returns the *VTGateConn
+func DialProtocol(ctx context.Context, protocol string, address string, timeout time.Duration) (*VTGateConn, error) {
+	dialer, ok := dialers[protocol]
+	if !ok {
+		return nil, fmt.Errorf("no dialer registered for VTGate protocol %s", protocol)
+	}
+	impl, err := dialer(ctx, address, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &VTGateConn{
+		impl: impl,
+	}, nil
 }
 
-// GetDialerWithProtocol returns the dialer to use, described by the given protocol
-func GetDialerWithProtocol(protocol string) DialerFunc {
-	td, ok := dialers[protocol]
-	if !ok {
-		log.Warningf("No dialer registered for VTGate protocol %s", protocol)
-		return nil
-	}
-	return td
+// Dial dials using the command-line specified protocol, and returns
+// the *VTGateConn.
+func Dial(ctx context.Context, address string, timeout time.Duration) (*VTGateConn, error) {
+	return DialProtocol(ctx, *vtgateProtocol, address, timeout)
 }

--- a/go/vt/vtgate/vtgateconn/vtgateconn_test.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRegisterDialer(t *testing.T) {
-	dialerFunc := func(context.Context, string, time.Duration) (VTGateConn, error) {
+	dialerFunc := func(context.Context, string, time.Duration) (Impl, error) {
 		return nil, nil
 	}
 	RegisterDialer("test1", dialerFunc)
@@ -20,17 +20,17 @@ func TestRegisterDialer(t *testing.T) {
 }
 
 func TestGetDialerWithProtocol(t *testing.T) {
-	var protocol = "test2"
-	var dialerFunc = GetDialerWithProtocol(protocol)
-	if dialerFunc != nil {
-		t.Fatalf("protocol: %s is not registered, should return nil", protocol)
+	protocol := "test2"
+	c, err := DialProtocol(context.Background(), protocol, "", 0)
+	if err == nil || err.Error() != "no dialer registered for VTGate protocol "+protocol {
+		t.Fatalf("protocol: %s is not registered, should return error: %v", protocol, err)
 	}
-	RegisterDialer(protocol, func(context.Context, string, time.Duration) (VTGateConn, error) {
+	RegisterDialer(protocol, func(context.Context, string, time.Duration) (Impl, error) {
 		return nil, nil
 	})
-	dialerFunc = GetDialerWithProtocol(protocol)
-	if dialerFunc == nil {
-		t.Fatalf("dialerFunc has been registered, should not get nil")
+	c, err = DialProtocol(context.Background(), protocol, "", 0)
+	if err != nil || c == nil {
+		t.Fatalf("dialerFunc has been registered, should not get nil: %v %v", err, c)
 	}
 }
 


### PR DESCRIPTION
and a connection layer API (using an interface).
That way the RPC implementations are smaller.