### PR TITLE
Using right DBA abstraction in copy_schema_shard_test.go.

### DIFF
--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -160,9 +160,6 @@ type FakeMysqlDaemon struct {
 	// If nil we'll return an error.
 	ApplySchemaChangeResult *proto.SchemaChangeResult
 
-	// DbaConnectionFactory is the factory for making fake dba connections
-	DbaConnectionFactory func() (dbconnpool.PoolConnection, error)
-
 	// DbAppConnectionFactory is the factory for making fake db app connections
 	DbAppConnectionFactory func() (dbconnpool.PoolConnection, error)
 


### PR DESCRIPTION
Also using VtctlPipe.

@yaoshengzhe 
By the way, the fake db thing needs to be stricter, if the SQL is not in the map, it should return an error... Now it's just logging errors and returning empty result, which for DDLs is the normal thing...