### PR TITLE
make fakesqldb returns an error for unrecognized query

### DIFF
--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -826,7 +826,20 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 }
 
 func TestSqlQuerySplitQuery(t *testing.T) {
-	setUpSqlQueryTest()
+	db := setUpSqlQueryTest()
+	db.AddQuery("SELECT MIN(pk), MAX(pk) FROM test_table", &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.MakeNumeric([]byte("1")),
+				sqltypes.MakeNumeric([]byte("100")),
+			},
+		},
+	})
+
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)

--- a/go/vt/vttest/fakesqldb/conn.go
+++ b/go/vt/vttest/fakesqldb/conn.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -144,8 +143,7 @@ func (conn *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (*pro
 	}
 	result, ok := conn.db.GetQuery(query)
 	if !ok {
-		log.Warningf("unexpected query: %s, will return an empty result", query)
-		return &proto.QueryResult{}, nil
+		return nil, fmt.Errorf("query: %s is not supported", query)
 	}
 	qr := &proto.QueryResult{}
 	qr.RowsAffected = result.RowsAffected
@@ -211,8 +209,7 @@ func (conn *Conn) ExecuteStreamFetch(query string) error {
 	}
 	result, ok := conn.db.GetQuery(query)
 	if !ok {
-		log.Warningf("unexpected query: %s, will return an empty result", query)
-		result = &proto.QueryResult{}
+		return fmt.Errorf("query: %s is not supported", query)
 	}
 	conn.curQueryResult = result
 	conn.curQueryRow = 0


### PR DESCRIPTION
fakesqldb returns an empty QueryResult if a query is not recognized.
This behavior reduces typing in unit tests but also causes confusions.
In general, if caller does not set the mock result for a particular
query, fakesqldb should return an error.