### PR TITLE
Fix skewed layout on home page, which is caused by other pages using …

### DIFF
--- a/vitess.io/_layouts/home.liquid
+++ b/vitess.io/_layouts/home.liquid
@@ -12,7 +12,7 @@ layout: homebase
 </div><!-- /.page-lead -->
 {% endif %}
 
-<main class="clear">
+<main class="clear clear-home">
   <div class="container">
 
     {{ content}}

--- a/vitess.io/css/extra.css
+++ b/vitess.io/css/extra.css
@@ -228,6 +228,9 @@ main {
   margin-left: 30%;
   width: 100%;
 }
+main.clear-home {
+  margin: 0 auto;
+}
 
 footer {
   padding: 16px;


### PR DESCRIPTION
If you look at the home page of vitess.io, you will see that the content below the image is skewed a bit to the right. That is because the page is applying a 30% margin to account for the left nav, which appears on the documentation pages. Since the left nav doesn't show here, we don't need that 30% margin.