### PR TITLE
Change all unused RPC args or replies to rpc.Unused instead of empty strings

### DIFF
--- a/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
+++ b/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
@@ -7,6 +7,7 @@ package gorpcqueryservice
 import (
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/vt/callinfo"
+	"github.com/youtube/vitess/go/vt/rpc"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/proto"
@@ -32,13 +33,13 @@ func (sq *SqlQuery) Begin(ctx context.Context, session *proto.Session, txInfo *p
 }
 
 // Commit is exposing tabletserver.SqlQuery.Commit
-func (sq *SqlQuery) Commit(ctx context.Context, session *proto.Session, noOutput *string) (err error) {
+func (sq *SqlQuery) Commit(ctx context.Context, session *proto.Session, noOutput *rpc.Unused) (err error) {
 	defer sq.server.HandlePanic(&err)
 	return sq.server.Commit(callinfo.RPCWrapCallInfo(ctx), session)
 }
 
 // Rollback is exposing tabletserver.SqlQuery.Rollback
-func (sq *SqlQuery) Rollback(ctx context.Context, session *proto.Session, noOutput *string) (err error) {
+func (sq *SqlQuery) Rollback(ctx context.Context, session *proto.Session, noOutput *rpc.Unused) (err error) {
 	defer sq.server.HandlePanic(&err)
 	return sq.server.Rollback(callinfo.RPCWrapCallInfo(ctx), session)
 }


### PR DESCRIPTION
@alainjobart @sougou 

This is necessary before changing these end-points to returning a proto response with RPCError type. Otherwise, new clients (expecting a defined struct) will not be able to communicate with old servers (expecting a string).

The client is already using rpc.Unused.