### PR TITLE
Pin gRPC to a known working version

### DIFF
--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -13,6 +13,7 @@ fi
 
 git clone https://github.com/grpc/grpc.git
 cd grpc
+git checkout fa507530590944683a0c672fcd4ea5a54977c903
 git submodule update --init
 make
 if [ "$grpc_dist" != "" ]; then


### PR DESCRIPTION
@enisoc @alainjobart 

This is the version that worked for me, I'm not sure why later versions aren't working...

Regardless, it seems like a good idea to pin to a specific version instead of always building against head.