### PR TITLE
Re-add test for vtctl CopySchemaShard.

### DIFF
--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -201,7 +201,7 @@ func (wr *Wrangler) ApplySchema(ctx context.Context, tabletAlias topo.TabletAlia
 	return wr.tmc.ApplySchema(ctx, ti, sc)
 }
 
-// ApplySchemaShard applies a shcema change on a shard.
+// ApplySchemaShard applies a schema change on a shard.
 // Note for 'complex' mode (the 'simple' mode is easy enough that we
 // don't need to handle recovery that much): this method is able to
 // recover if interrupted in the middle, because it knows which server
@@ -449,7 +449,7 @@ func (wr *Wrangler) CopySchemaShard(ctx context.Context, srcTabletAlias topo.Tab
 // SQL statements, but doesn't return any results, so it's only useful for SQL statements
 // that would be run for their effects (e.g., CREATE).
 // It works by applying the SQL statement on the shard's master tablet with replication turned on.
-// Thus it should be used only for changes that can be applies on a live instance without causing issues;
+// Thus it should be used only for changes that can be applied on a live instance without causing issues;
 // it shouldn't be used for anything that will require a pivot.
 // The SQL statement string is expected to have {{.DatabaseName}} in place of the actual db name.
 func (wr *Wrangler) applySqlShard(ctx context.Context, tabletInfo *topo.TabletInfo, change string, reloadSchema bool) error {

--- a/test/schema.py
+++ b/test/schema.py
@@ -3,6 +3,7 @@
 import logging
 import unittest
 import os
+import sys
 import time
 
 import environment
@@ -18,6 +19,9 @@ shard_1_master = tablet.Tablet()
 shard_1_replica1 = tablet.Tablet()
 shard_2_master = tablet.Tablet()
 shard_2_replica1 = tablet.Tablet()
+# shard_2 tablets are not used by all tests and not included by default.
+tablets = [shard_0_master, shard_0_replica1, shard_0_replica2, shard_0_rdonly, shard_0_backup,
+           shard_1_master, shard_1_replica1]
 test_keyspace = 'test_keyspace'
 db_name = 'vt_' + test_keyspace
 
@@ -25,58 +29,10 @@ def setUpModule():
   try:
     environment.topo_server().setup()
 
-    setup_procs = [
-        shard_0_master.init_mysql(),
-        shard_0_replica1.init_mysql(),
-        shard_0_replica2.init_mysql(),
-        shard_0_rdonly.init_mysql(),
-        shard_0_backup.init_mysql(),
-        shard_1_master.init_mysql(),
-        shard_1_replica1.init_mysql(),
-        shard_2_master.init_mysql(),
-        shard_2_replica1.init_mysql(),
-        ]
-    utils.wait_procs(setup_procs)
-  except:
-    tearDownModule()
-    raise
+    _init_mysql(tablets)
 
-  utils.run_vtctl(['CreateKeyspace', test_keyspace])
+    utils.run_vtctl(['CreateKeyspace', test_keyspace])
 
-def tearDownModule():
-  if utils.options.skip_teardown:
-    return
-
-  teardown_procs = [
-      shard_0_master.teardown_mysql(),
-      shard_0_replica1.teardown_mysql(),
-      shard_0_replica2.teardown_mysql(),
-      shard_0_rdonly.teardown_mysql(),
-      shard_0_backup.teardown_mysql(),
-      shard_1_master.teardown_mysql(),
-      shard_1_replica1.teardown_mysql(),
-      shard_2_master.teardown_mysql(),
-      shard_2_replica1.teardown_mysql(),
-      ]
-  utils.wait_procs(teardown_procs, raise_on_error=False)
-
-  environment.topo_server().teardown()
-  utils.kill_sub_processes()
-  utils.remove_tmp_files()
-
-  shard_0_master.remove_tree()
-  shard_0_replica1.remove_tree()
-  shard_0_replica2.remove_tree()
-  shard_0_rdonly.remove_tree()
-  shard_0_backup.remove_tree()
-  shard_1_master.remove_tree()
-  shard_1_replica1.remove_tree()
-  shard_2_master.remove_tree()
-  shard_2_replica1.remove_tree()
-
-class TestSchema(unittest.TestCase):
-
-  def setUp(self):
     shard_0_master.init_tablet(  'master',  test_keyspace, '0')
     shard_0_replica1.init_tablet('replica', test_keyspace, '0')
     shard_0_replica2.init_tablet('replica', test_keyspace, '0')
@@ -84,8 +40,6 @@ class TestSchema(unittest.TestCase):
     shard_0_backup.init_tablet(  'backup',  test_keyspace, '0')
     shard_1_master.init_tablet(  'master',  test_keyspace, '1')
     shard_1_replica1.init_tablet('replica', test_keyspace, '1')
-    shard_2_master.init_tablet(  'master',  test_keyspace, '2')
-    shard_2_replica1.init_tablet('replica', test_keyspace, '2')
 
     utils.run_vtctl(['RebuildKeyspaceGraph', test_keyspace], auto_log=True)
 
@@ -95,9 +49,7 @@ class TestSchema(unittest.TestCase):
     utils.Vtctld().start()
 
     # create databases, start the tablets
-    for t in [shard_0_master, shard_0_replica1, shard_0_replica2,
-           shard_0_rdonly, shard_0_backup, shard_1_master, shard_1_replica1,
-           shard_2_master, shard_2_replica1]:
+    for t in tablets:
       t.create_db(db_name)
       t.start_vttablet(wait_for_state=None)
 
@@ -109,34 +61,65 @@ class TestSchema(unittest.TestCase):
     shard_0_backup.wait_for_vttablet_state('NOT_SERVING')
     shard_1_master.wait_for_vttablet_state('SERVING')
     shard_1_replica1.wait_for_vttablet_state('SERVING')
-    shard_2_master.wait_for_vttablet_state('SERVING')
-    shard_2_replica1.wait_for_vttablet_state('SERVING')
 
     # make sure all replication is good
-    for t in [shard_0_master, shard_0_replica1, shard_0_replica2,
-              shard_0_rdonly, shard_0_backup, shard_1_master, shard_1_replica1, shard_2_master, shard_2_replica1]:
+    for t in tablets:
       t.reset_replication()
 
     utils.run_vtctl(['InitShardMaster', test_keyspace+'/0',
                      shard_0_master.tablet_alias], auto_log=True)
     utils.run_vtctl(['InitShardMaster', test_keyspace+'/1',
                      shard_1_master.tablet_alias], auto_log=True)
-    utils.run_vtctl(['InitShardMaster', test_keyspace+'/2',
-                     shard_2_master.tablet_alias], auto_log=True)
     utils.run_vtctl(['ValidateKeyspace', '-ping-tablets', test_keyspace])
 
     # check after all tablets are here and replication is fixed
     utils.validate_topology(ping_tablets=True)
+  except Exception as setup_exception:
+    try:
+      tearDownModule()
+    except Exception as e:
+      logging.exception("Tearing down a failed setUpModule() failed: %s", e)
+    raise setup_exception
 
+def _init_mysql(tablets):
+  setup_procs = []
+  for t in tablets:
+    setup_procs.append(t.init_mysql())
+  utils.wait_procs(setup_procs)
+
+def tearDownModule():
+  if utils.options.skip_teardown:
+    return
+
+  tablet.kill_tablets(tablets)
+
+  teardown_procs = []
+  for t in tablets:
+    teardown_procs.append(t.teardown_mysql())
+  utils.wait_procs(teardown_procs, raise_on_error=False)
+
+  environment.topo_server().teardown()
+  utils.kill_sub_processes()
+  utils.remove_tmp_files()
+
+  for t in tablets:
+    t.remove_tree()
+
+class TestSchema(unittest.TestCase):
+  def setUp(self):
+    for t in tablets:
+      t.create_db(db_name)
+    
   def tearDown(self):
-    tablet.kill_tablets([shard_0_master, shard_0_replica1, shard_0_replica2,
-                         shard_0_rdonly, shard_0_backup, shard_1_master,
-                         shard_1_replica1, shard_2_master, shard_2_replica1])
+    # This test assumes that it can reset the tablets by simply cleaning their
+    # databases without restarting the tablets.
+    for t in tablets:
+      t.clean_dbs()
 
   def _check_tables(self, tablet, expectedCount):
     tables = tablet.mquery(db_name, 'show tables')
     self.assertEqual(len(tables), expectedCount,
-                     'Unexpected table count on %s (not %u): %s' %
+                     'Unexpected table count on %s (not %u): got tables: %s' %
                      (tablet.tablet_alias, expectedCount, str(tables)))
 
   def _check_db_not_created(self, tablet):
@@ -155,9 +138,8 @@ class TestSchema(unittest.TestCase):
 
     return out
 
-  def _get_schema(self, tablet_alias, tables):
+  def _get_schema(self, tablet_alias):
     out, err = utils.run_vtctl(['GetSchema',
-                                '-tables='+tables,
                                 tablet_alias],
                                 trap_output=True,
                                 log_level='INFO',
@@ -179,7 +161,7 @@ class TestSchema(unittest.TestCase):
             ADD INDEX idx_column(%s) \
             ' % (table, index_column_name)
 
-  def test_schema_changes(self):
+  def _apply_initial_schema(self):
     schema_changes = ';'.join([
       self._create_test_table_sql('vt_select_test01'),
       self._create_test_table_sql('vt_select_test02'),
@@ -196,26 +178,26 @@ class TestSchema(unittest.TestCase):
     # check number of tables
     self._check_tables(shard_0_master, 4)
     self._check_tables(shard_1_master, 4)
-    self._check_tables(shard_2_master, 4)
 
     # get schema for each shard
-    shard_0_schema = self._get_schema(shard_0_master.tablet_alias, tables)
-    shard_1_schema = self._get_schema(shard_1_master.tablet_alias, tables)
-    shard_2_schema = self._get_schema(shard_2_master.tablet_alias, tables)
+    shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
+    shard_1_schema = self._get_schema(shard_1_master.tablet_alias)
 
     # all shards should have the same schema
     self.assertEqual(shard_0_schema, shard_1_schema)
-    self.assertEqual(shard_0_schema, shard_2_schema)
+
+    return tables
+
+  def test_schema_changes(self):
+    tables = self._apply_initial_schema()
 
     self._apply_schema(test_keyspace, self._alter_test_table_sql('vt_select_test03', 'msg'))
 
-    shard_0_schema = self._get_schema(shard_0_master.tablet_alias, tables)
-    shard_1_schema = self._get_schema(shard_1_master.tablet_alias, tables)
-    shard_2_schema = self._get_schema(shard_2_master.tablet_alias, tables)
+    shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
+    shard_1_schema = self._get_schema(shard_1_master.tablet_alias)
 
     # all shards should have the same schema
     self.assertEqual(shard_0_schema, shard_1_schema)
-    self.assertEqual(shard_0_schema, shard_2_schema)
 
     # test schema changes
     os.makedirs(os.path.join(utils.vtctld.schema_change_dir, test_keyspace))
@@ -235,7 +217,52 @@ class TestSchema(unittest.TestCase):
     # check number of tables
     self._check_tables(shard_0_master, 5)
     self._check_tables(shard_1_master, 5)
-    self._check_tables(shard_2_master, 5)
+
+  def _setUp_tablets_shard_2(self):
+    tablets_shard2 = [shard_2_master, shard_2_replica1]
+    try:
+      _init_mysql(tablets_shard2)
+    finally:
+      # Include shard2 tablets for tearDown.
+      tablets.extend(tablets_shard2)
+    
+    shard_2_master.init_tablet(  'master',  'test_keyspace', '2')
+    shard_2_replica1.init_tablet('replica', 'test_keyspace', '2')
+    
+    # We intentionally don't want to create a db on these tablets.
+    shard_2_master.start_vttablet(wait_for_state=None)
+    shard_2_replica1.start_vttablet(wait_for_state=None)
+    
+    shard_2_master.wait_for_vttablet_state('NOT_SERVING')
+    shard_2_replica1.wait_for_vttablet_state('NOT_SERVING')
+    
+    for t in tablets_shard2:
+      t.reset_replication()
+    utils.run_vtctl(['InitShardMaster', test_keyspace+'/2',
+                     shard_2_master.tablet_alias], auto_log=True)
+    utils.run_vtctl(['ValidateKeyspace', '-ping-tablets', test_keyspace])
+    
+  def test_vtctl_copyschemashard(self):
+    self._apply_initial_schema()
+    
+    self._setUp_tablets_shard_2()
+    
+    # CopySchemaShard is responsible for creating the db; one shouldn't exist before
+    # the command is run.
+    self._check_db_not_created(shard_2_master)
+    self._check_db_not_created(shard_2_replica1)
+
+    utils.run_vtctl(['CopySchemaShard',
+                     shard_0_master.tablet_alias,
+                     'test_keyspace/2'],
+                    auto_log=True)
+
+    # shard_2_master should look the same as the replica we copied from
+    self._check_tables(shard_2_master, 4)
+    self._check_tables(shard_2_replica1, 4)
+    shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
+    shard_2_schema = self._get_schema(shard_2_master.tablet_alias)
+    self.assertEqual(shard_0_schema, shard_2_schema)
 
 if __name__ == '__main__':
   utils.main()

--- a/test/schema.py
+++ b/test/schema.py
@@ -250,6 +250,7 @@ class TestSchema(unittest.TestCase):
 
     # shard_2_master should look the same as the replica we copied from
     self._check_tables(shard_2_master, 4)
+    utils.wait_for_replication_pos(shard_2_master, shard_2_replica1)
     self._check_tables(shard_2_replica1, 4)
     shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
     shard_2_schema = self._get_schema(shard_2_master.tablet_alias)

--- a/test/schema.py
+++ b/test/schema.py
@@ -3,8 +3,6 @@
 import logging
 import unittest
 import os
-import sys
-import time
 
 import environment
 import utils
@@ -126,24 +124,23 @@ class TestSchema(unittest.TestCase):
     # Broadly catch all exceptions, since the exception being raised is internal to MySQL.
     # We're strictly checking the error message though, so should be fine.
     with self.assertRaisesRegexp(Exception, '(1049, "Unknown database \'%s\'")' % db_name):
-      tables = tablet.mquery(db_name, 'show tables')
+      tablet.mquery(db_name, 'show tables')
 
   def _apply_schema(self, keyspace, sql):
-    out, err  = utils.run_vtctl(['ApplySchema',
-                                 '-sql='+sql,
-                                 keyspace],
-                                 trap_output=True,
-                                 log_level='INFO',
-                                 raise_on_error=True)
-
+    out, _  = utils.run_vtctl(['ApplySchema',
+                               '-sql='+sql,
+                               keyspace],
+                               trap_output=True,
+                               log_level='INFO',
+                               raise_on_error=True)
     return out
 
   def _get_schema(self, tablet_alias):
-    out, err = utils.run_vtctl(['GetSchema',
-                                tablet_alias],
-                                trap_output=True,
-                                log_level='INFO',
-                                raise_on_error=True)
+    out, _ = utils.run_vtctl(['GetSchema',
+                              tablet_alias],
+                              trap_output=True,
+                              log_level='INFO',
+                              raise_on_error=True)
     return out
 
   def _create_test_table_sql(self, table):
@@ -168,10 +165,6 @@ class TestSchema(unittest.TestCase):
       self._create_test_table_sql('vt_select_test03'),
       self._create_test_table_sql('vt_select_test04')])
 
-    tables = ','.join([
-      'vt_select_test01', 'vt_select_test02',
-      'vt_select_test03', 'vt_select_test04'])
-
     # apply schema changes to the test keyspace
     self._apply_schema(test_keyspace, schema_changes)
 
@@ -186,10 +179,8 @@ class TestSchema(unittest.TestCase):
     # all shards should have the same schema
     self.assertEqual(shard_0_schema, shard_1_schema)
 
-    return tables
-
   def test_schema_changes(self):
-    tables = self._apply_initial_schema()
+    self._apply_initial_schema()
 
     self._apply_schema(test_keyspace, self._alter_test_table_sql('vt_select_test03', 'msg'))
 

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -541,6 +541,7 @@ class Tablet(object):
   def wait_for_vtocc_state(self, expected, timeout=60.0, port=None):
     while True:
       v = utils.get_vars(port or self.port)
+      last_seen_state = "?"
       if v == None:
         logging.debug(
             '  vttablet %s not answering at /debug/vars, waiting...',
@@ -552,13 +553,15 @@ class Tablet(object):
               self.tablet_alias)
         else:
           s = v['TabletStateName']
+          last_seen_state = s
           if s != expected:
             logging.debug(
                 '  vttablet %s in state %s != %s', self.tablet_alias, s,
                 expected)
           else:
             break
-      timeout = utils.wait_step('waiting for state %s' % expected, timeout,
+      timeout = utils.wait_step('waiting for state %s (last seen state: %s)' % (expected, last_seen_state),
+                                timeout,
                                 sleep_time=0.1)
 
   def wait_for_mysqlctl_socket(self, timeout=10.0):


### PR DESCRIPTION
@yaoshengzhe @aaijazi 

Test was initially added in commit 058214740ce8bdea2fa24686b4db91919835144b in https://github.com/youtube/vitess/pull/211 and accidentally removed in https://github.com/youtube/vitess/pull/692
    
Minor changes:
- ApplySchema is only run against shard_1 and not shard_2 as well. This was the case in the original CL and should be good enough for its coverage.
- When comparing schemas, all tables are considered now instead of filtering only the tables we added.
- Database gets cleaned up between tests. Tablets will not be restarted. This should be good enough for a schema integration test.
