### PR TITLE
vtctl: CopySchemaShard optionally allows source shard instead of source tablet as argument.

### DIFF
--- a/go/vt/vttest/fakesqldb/conn.go
+++ b/go/vt/vttest/fakesqldb/conn.go
@@ -36,7 +36,7 @@ type DB struct {
 	mu           sync.Mutex
 }
 
-// AddQuery adds a query and its exptected result.
+// AddQuery adds a query and its expected result.
 func (db *DB) AddQuery(query string, expectedResult *proto.QueryResult) {
 	result := &proto.QueryResult{}
 	*result = *expectedResult

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -126,24 +126,36 @@ func TestCopySchemaShard(t *testing.T) {
 		},
 	}
 
+	createDb := "CREATE DATABASE `vt_ks` /*!40100 DEFAULT CHARACTER SET utf8 */"
+	createTable := "CREATE TABLE `vt_ks`.`resharding1` (\n"+
+		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
+		"  `msg` varchar(64) DEFAULT NULL,\n"+
+		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
+		"  PRIMARY KEY (`id`),\n"+
+		"  KEY `by_msg` (`msg`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8"
+	createTableView := "CREATE TABLE `view1` (\n"+
+		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
+		"  `msg` varchar(64) DEFAULT NULL,\n"+
+		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
+		"  PRIMARY KEY (`id`),\n"+
+		"  KEY `by_msg` (`msg`)\n"+
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8"
 	db.AddQuery("USE vt_ks", &mproto.QueryResult{})
-	db.AddQuery("CREATE DATABASE `vt_ks` /*!40100 DEFAULT CHARACTER SET utf8 */", &mproto.QueryResult{})
-	db.AddQuery("CREATE TABLE `vt_ks`.`resharding1` (\n"+
-		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
-		"  `msg` varchar(64) DEFAULT NULL,\n"+
-		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
-		"  PRIMARY KEY (`id`),\n"+
-		"  KEY `by_msg` (`msg`)\n"+
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8", &mproto.QueryResult{})
-	db.AddQuery("CREATE TABLE `view1` (\n"+
-		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
-		"  `msg` varchar(64) DEFAULT NULL,\n"+
-		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
-		"  PRIMARY KEY (`id`),\n"+
-		"  KEY `by_msg` (`msg`)\n"+
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8", &mproto.QueryResult{})
+	db.AddQuery(createDb, &mproto.QueryResult{})
+	db.AddQuery(createTable, &mproto.QueryResult{})
+	db.AddQuery(createTableView, &mproto.QueryResult{})
 
 	if err := vp.Run([]string{"CopySchemaShard", "-include-views", sourceRdonly.Tablet.Alias.String(), "ks/-40"}); err != nil {
 		t.Fatalf("CopySchemaShard failed: %v", err)
+	}
+	if count := db.GetQueryCalledNum(createDb); count != 1 {
+		t.Fatalf("CopySchemaShard did not create the db exactly once. Query count: %v", count)
+	}
+	if count := db.GetQueryCalledNum(createTable); count != 1 {
+		t.Fatalf("CopySchemaShard did not create the table exactly once. Query count: %v", count)
+	}
+	if count := db.GetQueryCalledNum(createTableView); count != 1 {
+		t.Fatalf("CopySchemaShard did not create the table view exactly once. Query count: %v", count)
 	}
 }

--- a/test/schema.py
+++ b/test/schema.py
@@ -107,8 +107,7 @@ def tearDownModule():
 class TestSchema(unittest.TestCase):
   def setUp(self):
     for t in tablets:
-      if t != shard_2_master and t != shard_2_replica1:
-        t.create_db(db_name)
+      t.create_db(db_name)
     
   def tearDown(self):
     # This test assumes that it can reset the tablets by simply cleaning their

--- a/test/schema.py
+++ b/test/schema.py
@@ -243,10 +243,10 @@ class TestSchema(unittest.TestCase):
     utils.run_vtctl(['ValidateKeyspace', '-ping-tablets', test_keyspace])
     
   def test_vtctl_copyschemashard_use_tablet_as_source(self):
-    self._test_vtctl_copyschema_shard(shard_0_master.tablet_alias)
+    self._test_vtctl_copyschemashard(shard_0_master.tablet_alias)
 
   def test_vtctl_copyschemashard_use_shard_as_source(self):
-    self._test_vtctl_copyschema_shard('test_keyspace/0')
+    self._test_vtctl_copyschemashard('test_keyspace/0')
 
   def _test_vtctl_copyschemashard(self, source):
     self._apply_initial_schema()

--- a/test/schema.py
+++ b/test/schema.py
@@ -258,18 +258,20 @@ class TestSchema(unittest.TestCase):
     self._check_db_not_created(shard_2_master)
     self._check_db_not_created(shard_2_replica1)
 
-    utils.run_vtctl(['CopySchemaShard',
-                     source,
-                     'test_keyspace/2'],
-                    auto_log=True)
-
-    # shard_2_master should look the same as the replica we copied from
-    self._check_tables(shard_2_master, 4)
-    utils.wait_for_replication_pos(shard_2_master, shard_2_replica1)
-    self._check_tables(shard_2_replica1, 4)
-    shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
-    shard_2_schema = self._get_schema(shard_2_master.tablet_alias)
-    self.assertEqual(shard_0_schema, shard_2_schema)
+    # Run the command twice to make sure it's idempotent.
+    for _ in range(2):
+      utils.run_vtctl(['CopySchemaShard',
+                       source,
+                       'test_keyspace/2'],
+                      auto_log=True)
+  
+      # shard_2_master should look the same as the replica we copied from
+      self._check_tables(shard_2_master, 4)
+      utils.wait_for_replication_pos(shard_2_master, shard_2_replica1)
+      self._check_tables(shard_2_replica1, 4)
+      shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
+      shard_2_schema = self._get_schema(shard_2_master.tablet_alias)
+      self.assertEqual(shard_0_schema, shard_2_schema)
 
 if __name__ == '__main__':
   utils.main()

--- a/test/schema.py
+++ b/test/schema.py
@@ -243,29 +243,12 @@ class TestSchema(unittest.TestCase):
     utils.run_vtctl(['ValidateKeyspace', '-ping-tablets', test_keyspace])
     
   def test_vtctl_copyschemashard_use_tablet_as_source(self):
-    self._apply_initial_schema()
-    
-    self._setUp_tablets_shard_2()
-    
-    # CopySchemaShard is responsible for creating the db; one shouldn't exist before
-    # the command is run.
-    self._check_db_not_created(shard_2_master)
-    self._check_db_not_created(shard_2_replica1)
-
-    utils.run_vtctl(['CopySchemaShard',
-                     shard_0_master.tablet_alias,
-                     'test_keyspace/2'],
-                    auto_log=True)
-
-    # shard_2_master should look the same as the replica we copied from
-    self._check_tables(shard_2_master, 4)
-    utils.wait_for_replication_pos(shard_2_master, shard_2_replica1)
-    self._check_tables(shard_2_replica1, 4)
-    shard_0_schema = self._get_schema(shard_0_master.tablet_alias)
-    shard_2_schema = self._get_schema(shard_2_master.tablet_alias)
-    self.assertEqual(shard_0_schema, shard_2_schema)
+    self._test_vtctl_copyschema_shard(shard_0_master.tablet_alias)
 
   def test_vtctl_copyschemashard_use_shard_as_source(self):
+    self._test_vtctl_copyschema_shard('test_keyspace/0')
+
+  def _test_vtctl_copyschemashard(self, source):
     self._apply_initial_schema()
     
     self._setUp_tablets_shard_2()
@@ -276,7 +259,7 @@ class TestSchema(unittest.TestCase):
     self._check_db_not_created(shard_2_replica1)
 
     utils.run_vtctl(['CopySchemaShard',
-                     'test_keyspace/0',
+                     source,
                      'test_keyspace/2'],
                     auto_log=True)
 


### PR DESCRIPTION
@alainjobart @aaijazi @yaoshengzhe 

First three commits are also part of https://github.com/youtube/vitess/pull/790 and can be ignored for this review.

I also want to rename the command from "CopySchemaShard" to "CopySchema". Any objections?