### PR TITLE
Initialize ExternalReparents timings to 0.

### DIFF
--- a/go/stats/timings.go
+++ b/go/stats/timings.go
@@ -22,8 +22,14 @@ type Timings struct {
 }
 
 // NewTimings creates a new Timings object, and publishes it if name is set.
-func NewTimings(name string) *Timings {
+// categories is an optional list of categories to initialize to 0.
+// Categories that aren't initialized will be missing from the map until the
+// first time they are updated.
+func NewTimings(name string, categories ...string) *Timings {
 	t := &Timings{histograms: make(map[string]*Histogram)}
+	for _, cat := range categories {
+		t.histograms[cat] = NewGenericHistogram("", bucketCutoffs, bucketLabels, "Count", "Time")
+	}
 	if name != "" {
 		Publish(name, t)
 	}
@@ -143,6 +149,7 @@ func NewMultiTimings(name string, labels []string) *MultiTimings {
 	return t
 }
 
+// Labels returns descriptions of the parts of each compound category name.
 func (mt *MultiTimings) Labels() []string {
 	return mt.labels
 }

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -27,7 +27,7 @@ var (
 
 	finalizeReparentTimeout = flag.Duration("finalize_external_reparent_timeout", 10*time.Second, "Timeout for the finalize stage of a fast external reparent reconciliation.")
 
-	externalReparentStats = stats.NewTimings("ExternalReparents")
+	externalReparentStats = stats.NewTimings("ExternalReparents", "NewMasterVisible", "FullRebuild")
 )
 
 // SetReparentFlags changes flag values. It should only be used in tests.


### PR DESCRIPTION
@apmichaud 

When a category of the timings map goes from undefined to defined,
that event will be missed by rate aggregations. For events that happen
often (like queries), missing one is fine. But many reparent events will
be the first time that tablet has become master (since the last restart)
so missing the first event skews aggregations significantly.