### PR TITLE
test.go: Add a pseudo-shebang line.

### DIFF
--- a/test.go
+++ b/test.go
@@ -1,3 +1,5 @@
+///bin/true; exec /usr/bin/env go run "$0" "$@"
+
 // Copyright 2015, Google Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
@michael-berlin 

This is not actually a shebang. Go doesn't support those.
This hack only works when run from within a shell.
The file gets treated as a shell script, and the first line
replaces the process with an invocation of "go run".