### PR TITLE
Fixing the context cancellation during streaming queries.

### DIFF
--- a/go/vt/client/client.go
+++ b/go/vt/client/client.go
@@ -147,11 +147,11 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.c.Timeout)
-	defer cancel()
 	if s.c.Streaming {
 		qrc, errFunc := s.c.vtgateConn.StreamExecute(ctx, s.query, makeBindVars(args), s.c.TabletType)
-		return newStreamingRows(qrc, errFunc), nil
+		return newStreamingRows(qrc, errFunc, cancel), nil
 	}
+	defer cancel()
 	var qr *mproto.QueryResult
 	var err error
 	if s.c.tx == nil {

--- a/go/vt/client/streaming_rows_test.go
+++ b/go/vt/client/streaming_rows_test.go
@@ -65,7 +65,7 @@ func TestStreamingRows(t *testing.T) {
 		}()
 		return ch, func() error { return nil }
 	}()
-	ri := newStreamingRows(qrc, errFunc)
+	ri := newStreamingRows(qrc, errFunc, nil)
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -122,7 +122,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 		}()
 		return ch, func() error { return nil }
 	}()
-	ri := newStreamingRows(qrc, errFunc)
+	ri := newStreamingRows(qrc, errFunc, nil)
 
 	wantRow := []driver.Value{
 		int64(1),
@@ -159,7 +159,7 @@ func TestStreamingRowsError(t *testing.T) {
 		}()
 		return ch, func() error { return errors.New("error before fields") }
 	}()
-	ri := newStreamingRows(qrc, errFunc)
+	ri := newStreamingRows(qrc, errFunc, nil)
 	gotCols := ri.Columns()
 	if gotCols != nil {
 		t.Errorf("cols: %v, want nil", gotCols)
@@ -180,7 +180,7 @@ func TestStreamingRowsError(t *testing.T) {
 		}()
 		return ch, func() error { return errors.New("error after fields") }
 	}()
-	ri = newStreamingRows(qrc, errFunc)
+	ri = newStreamingRows(qrc, errFunc, nil)
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -212,7 +212,7 @@ func TestStreamingRowsError(t *testing.T) {
 		}()
 		return ch, func() error { return errors.New("error after rows") }
 	}()
-	ri = newStreamingRows(qrc, errFunc)
+	ri = newStreamingRows(qrc, errFunc, nil)
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	if err != nil {
@@ -233,7 +233,7 @@ func TestStreamingRowsError(t *testing.T) {
 		}()
 		return ch, func() error { return nil }
 	}()
-	ri = newStreamingRows(qrc, errFunc)
+	ri = newStreamingRows(qrc, errFunc, nil)
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	wantErr = "first packet did not return fields"


### PR DESCRIPTION
@sougou 
(vtgatev3 test fails because of this internally, as stubby actually looks at contexts, once submitted, along with the bindVariables fix, I can enable it).