### PR TITLE
Splitting out service map to protocol_flavors. That way non-default

### DIFF
--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -52,9 +52,11 @@ func DialTablet(ctx context.Context, endPoint topo.EndPoint, keyspace, shard str
 		Shard:    shard,
 	})
 	if err != nil {
+		cc.Close()
 		return nil, err
 	}
 	if gsir.Error != nil {
+		cc.Close()
 		return nil, tabletErrorFromRPCError(gsir.Error)
 	}
 

--- a/test/protocols_flavor.py
+++ b/test/protocols_flavor.py
@@ -32,6 +32,12 @@ class ProtocolsFlavor(object):
     """Returns the error message used by the protocol to indicate a timeout."""
     raise NotImplementedError('Not implemented in the base class')
 
+  def service_map(self):
+    """Returns a list of entries for the service map to enable all
+    relevant protocols in all servers."""
+    raise NotImplementedError('Not implemented in the base class')
+
+
 class GoRpcProtocolsFlavor(ProtocolsFlavor):
   """Overrides to use go rpc everywhere"""
 
@@ -52,6 +58,10 @@ class GoRpcProtocolsFlavor(ProtocolsFlavor):
 
   def rpc_timeout_message(self):
     return 'timeout waiting for'
+
+  def service_map(self):
+    return []
+
 
 class GRpcProtocolsFlavor(ProtocolsFlavor):
   """Overrides to use gRPC everywhere where it is supported.
@@ -74,6 +84,10 @@ class GRpcProtocolsFlavor(ProtocolsFlavor):
 
   def rpc_timeout_message(self):
     return 'timeout waiting for'
+
+  def service_map(self):
+    return ['grpc-queryservice', 'grpc-vtctl']
+
 
 __knows_protocols_flavor_map = {
   'gorpc': GoRpcProtocolsFlavor,

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -382,9 +382,10 @@ class Tablet(object):
                    '-key', key])
       if ca_cert:
         args.extend(['-ca_cert', ca_cert])
+    if protocols_flavor().service_map():
+      args.extend(['-service_map', ",".join(protocols_flavor().service_map())])
     if protocols_flavor().tabletconn_protocol() == 'grpc':
-      args.extend(['-grpc_port', str(self.grpc_port),
-                   '-service_map', 'grpc-queryservice'])
+      args.extend(['-grpc_port', str(self.grpc_port)])
     if lameduck_period:
       args.extend(['-lameduck-period', lameduck_period])
     if security_policy:

--- a/test/utils.py
+++ b/test/utils.py
@@ -876,9 +876,10 @@ class Vtctld(object):
             environment.topo_server().flags() + \
             protocols_flavor().tablet_manager_protocol_flags() + \
             protocols_flavor().vtgate_protocol_flags()
+    if protocols_flavor().service_map():
+      args.extend(['-service_map', ",".join(protocols_flavor().service_map())])
     if protocols_flavor().vtctl_client_protocol() == 'grpc':
-      args += ['-grpc_port', str(self.grpc_port),
-              '-service_map', 'grpc-vtctl']
+      args.extend(['-grpc_port', str(self.grpc_port)])
     stderr_fd = open(os.path.join(environment.tmproot, 'vtctld.stderr'), 'w')
     self.proc = run_bg(args, stderr=stderr_fd)
 


### PR DESCRIPTION
protocols can be enabled more easily.

Also closing a grpc tabletconn rpc link in case of error.

@sougou @guoliang100 