### PR TITLE
Add ability to create rdonly vttablets on kubernetes

### DIFF
--- a/examples/kubernetes/cluster-up.sh
+++ b/examples/kubernetes/cluster-up.sh
@@ -19,6 +19,7 @@ GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-'example'}
 GKE_SSD_SIZE_GB=${GKE_SSD_SIZE_GB:-0}
 SHARDS=${SHARDS:-'-80,80-'}
 TABLETS_PER_SHARD=${TABLETS_PER_SHARD:-3}
+RDONLY_COUNT=${RDONLY_COUNT:-0}
 MAX_TASK_WAIT_RETRIES=${MAX_TASK_WAIT_RETRIES:-300}
 MAX_VTTABLET_TOPO_WAIT_RETRIES=${MAX_VTTABLET_TOPO_WAIT_RETRIES:-180}
 BENCHMARK_CLUSTER=${BENCHMARK_CLUSTER:-true}
@@ -36,6 +37,7 @@ fi
 # export for vttablet scripts
 export SHARDS=$SHARDS
 export TABLETS_PER_SHARD=$TABLETS_PER_SHARD
+export RDONLY_COUNT=$RDONLY_COUNT
 
 function update_spinner_value () {
   spinner='-\|/'
@@ -108,6 +110,7 @@ echo "*  Num nodes: $num_nodes"
 echo "*  SSD Size: $GKE_SSD_SIZE_GB"
 echo "*  Shards: $SHARDS"
 echo "*  Tablets per shard: $TABLETS_PER_SHARD"
+echo "*  Rdonly per shard: $RDONLY_COUNT"
 echo "*  VTGate count: $vtgate_count"
 echo "*  Cluster name: $GKE_CLUSTER_NAME"
 echo "*  Project ID: $project_id"

--- a/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
+++ b/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
@@ -46,7 +46,7 @@ spec:
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}
           -init_shard {{shard}}
-          -target_tablet_type replica
+          -target_tablet_type {{tablet_type}}
           -mysqlctl_socket $VTDATAROOT/mysqlctl.sock
           -db-config-app-uname vt_app
           -db-config-app-dbname vt_{{keyspace}}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -46,7 +46,7 @@ spec:
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}
           -init_shard {{shard}}
-          -target_tablet_type replica
+          -target_tablet_type {{vttablet_type}}
           -mysqlctl_socket $VTDATAROOT/mysqlctl.sock
           -db-config-app-uname vt_app
           -db-config-app-dbname vt_{{keyspace}}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -46,7 +46,7 @@ spec:
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}
           -init_shard {{shard}}
-          -target_tablet_type {{vttablet_type}}
+          -target_tablet_type {{tablet_type}}
           -mysqlctl_socket $VTDATAROOT/mysqlctl.sock
           -db-config-app-uname vt_app
           -db-config-app-dbname vt_{{keyspace}}


### PR DESCRIPTION
export RDONLY_COUNT when using vttablet-up.sh or cluster-up.sh to set the number of rdonly tablets on each shard.  I presume I don't need to do much else other than setting target_tablet_type in the yaml file, I created a cluster and was able to get rdonly and replica tablets to show up in the topology, but feel free to let me know if there are steps I'm missing!

@enisoc 