### PR TITLE
Fixing data race condition in this test.

### DIFF
--- a/go/vt/vtctl/vtctlclienttest/client.go
+++ b/go/vt/vtctl/vtctlclienttest/client.go
@@ -48,10 +48,6 @@ func TestSuite(t *testing.T, ts topo.Server, client vtctlclient.VtctlClient) {
 
 	// run a command that's gonna return something on the log channel
 	logs, errFunc := client.ExecuteVtctlCommand(ctx, []string{"ListAllTablets", "cell1"}, 30*time.Second, 10*time.Second)
-	if err := errFunc(); err != nil {
-		t.Fatalf("Cannot execute remote command: %v", err)
-	}
-
 	count := 0
 	for e := range logs {
 		expected := "cell1-0000000001 test_keyspace <null> master localhost:3333 localhost:3334 [tag: \"value\"]\n"
@@ -70,10 +66,6 @@ func TestSuite(t *testing.T, ts topo.Server, client vtctlclient.VtctlClient) {
 
 	// run a command that's gonna fail
 	logs, errFunc = client.ExecuteVtctlCommand(ctx, []string{"ListAllTablets", "cell2"}, 30*time.Second, 10*time.Second)
-	if err := errFunc(); err != nil {
-		t.Fatalf("Cannot execute remote command: %v", err)
-	}
-
 	if e, ok := <-logs; ok {
 		t.Errorf("Got unexpected line for logs: %v", e.String())
 	}
@@ -85,9 +77,6 @@ func TestSuite(t *testing.T, ts topo.Server, client vtctlclient.VtctlClient) {
 
 	// run a command that's gonna panic
 	logs, errFunc = client.ExecuteVtctlCommand(ctx, []string{"Panic"}, 30*time.Second, 10*time.Second)
-	if err := errFunc(); err != nil {
-		t.Fatalf("Cannot execute remote command: %v", err)
-	}
 	if e, ok := <-logs; ok {
 		t.Errorf("Got unexpected line for logs: %v", e.String())
 	}


### PR DESCRIPTION
errFunc can only be called after the log channel is closed.

@aaijazi thread sanitizer found this one, easy fix.