### PR TITLE
Restart queryservice after InitMaster or InitSlave.

### DIFF
--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -81,6 +81,10 @@ type ActionAgent struct {
 	// take actionMutex first.
 	actionMutex sync.Mutex
 
+	// initReplication remembers whether an action has initialized replication.
+	// It is protected by actionMutex.
+	initReplication bool
+
 	// mutex protects the following fields
 	mutex            sync.Mutex
 	_tablet          *topo.TabletInfo

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -440,6 +440,7 @@ func (agent *ActionAgent) InitMaster(ctx context.Context) (myproto.ReplicationPo
 		return myproto.ReplicationPosition{}, err
 	}
 
+	agent.initReplication = true
 	return rp, nil
 }
 
@@ -472,6 +473,7 @@ func (agent *ActionAgent) InitSlave(ctx context.Context, parent topo.TabletAlias
 	if err := agent.MysqlDaemon.ExecuteSuperQueryList(cmds); err != nil {
 		return err
 	}
+	agent.initReplication = true
 
 	// wait until we get the replicated row, or our context times out
 	return agent.MysqlDaemon.WaitForReparentJournal(ctx, timeCreatedNS)


### PR DESCRIPTION
@alainjobart 

If queryservice was already running before a RESET MASTER,
the rowcache invalidator will silently stop working.

This is because the invalidator connects as a slave, and executing
RESET MASTER while slaves are connected is unsupported:

https://dev.mysql.com/doc/refman/5.6/en/reset-master.html