### PR TITLE
Make vtctl print human-readable QueryResults.

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -757,7 +757,7 @@
     3
   ],
   "PKValues": [
-    "Zm9v"
+    "foo"
   ],
   "Limit": null,
   "SecondaryPKValues": null,
@@ -784,7 +784,7 @@
     3
   ],
   "PKValues": [
-    "Zm9v"
+    "foo"
   ],
   "Limit": 1,
   "SecondaryPKValues": null,
@@ -811,7 +811,7 @@
     3
   ],
   "PKValues":[
-    "Zm9v"
+    "foo"
   ],
   "Limit": 0,
   "SecondaryPKValues": null,
@@ -838,7 +838,7 @@
     3
   ],
   "PKValues":[
-    "Zm9v"
+    "foo"
   ],
   "Limit": ":a",
   "SecondaryPKValues": null,
@@ -927,8 +927,8 @@
     3
   ],
   "PKValues": [[
-    "Zm9v",
-    "YmFy"
+    "foo",
+    "bar"
   ]],
   "Limit": null,
   "SecondaryPKValues": null,
@@ -983,7 +983,7 @@
     3
   ],
   "PKValues": [[
-    "Zm9v"
+    "foo"
   ]],
   "Limit": null,
   "SecondaryPKValues": null,
@@ -1162,7 +1162,7 @@
     3
   ],
   "PKValues": [
-    "Zm9v"
+    "foo"
   ],
   "Limit": null,
   "SecondaryPKValues": null,
@@ -1531,7 +1531,7 @@
   "IndexUsed": "",
   "ColumnNumbers": null,
   "PKValues": [
-    "MA=="
+    "0"
   ],
   "Limit": null,
   "SecondaryPKValues": null,

--- a/go/sqltypes/sqltypes.go
+++ b/go/sqltypes/sqltypes.go
@@ -309,6 +309,10 @@ func (f Fractional) encodeAscii(b BinWriter) {
 	}
 }
 
+func (s String) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s.raw()))
+}
+
 func (s String) raw() []byte {
 	return []byte(s)
 }

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -142,13 +142,13 @@ func TestString(t *testing.T) {
 	if b.String() != HARDASCII {
 		t.Errorf("Expecting %s, received %#v", HARDASCII, b.String())
 	}
-	s = Value{String([]byte("abcd"))}
+	s = Value{String([]byte("ab\x01cd"))}
 	js, err := s.MarshalJSON()
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	if string(js) != "\"YWJjZA==\"" {
-		t.Errorf("Expecting \"YWJjZA==\", received %s", js)
+	if got, want := string(js), "\"ab\\u0001cd\""; got != want {
+		t.Errorf("%#v.MarshalJSON() = %#v, want %#v", s, got, want)
 	}
 }
 

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -137,19 +137,19 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	sourceRdonly.FakeMysqlDaemon.Schema = schema
 
 	createDb := "CREATE DATABASE `vt_ks` /*!40100 DEFAULT CHARACTER SET utf8 */"
-	createTable := "CREATE TABLE `vt_ks`.`resharding1` (\n"+
-		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
-		"  `msg` varchar(64) DEFAULT NULL,\n"+
-		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
-		"  PRIMARY KEY (`id`),\n"+
-		"  KEY `by_msg` (`msg`)\n"+
+	createTable := "CREATE TABLE `vt_ks`.`resharding1` (\n" +
+		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n" +
+		"  `msg` varchar(64) DEFAULT NULL,\n" +
+		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n" +
+		"  PRIMARY KEY (`id`),\n" +
+		"  KEY `by_msg` (`msg`)\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8"
-	createTableView := "CREATE TABLE `view1` (\n"+
-		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n"+
-		"  `msg` varchar(64) DEFAULT NULL,\n"+
-		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n"+
-		"  PRIMARY KEY (`id`),\n"+
-		"  KEY `by_msg` (`msg`)\n"+
+	createTableView := "CREATE TABLE `view1` (\n" +
+		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n" +
+		"  `msg` varchar(64) DEFAULT NULL,\n" +
+		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n" +
+		"  PRIMARY KEY (`id`),\n" +
+		"  KEY `by_msg` (`msg`)\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8"
 	db.AddQuery("USE vt_ks", &mproto.QueryResult{})
 	db.AddQuery(createDb, &mproto.QueryResult{})

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a BSD-style license that can
 # be found in the LICENSE file.
 
-import base64
 import unittest
 
 import environment
@@ -77,9 +76,7 @@ class TestCustomSharding(unittest.TestCase):
       qr = utils.vtgate.execute_shard(sql, 'test_keyspace', shard,
                                       bindvars=bindvars)
       self.assertEqual(len(qr['Rows']), 1)
-      # vtctl_json will print the JSON-encoded version of QueryResult,
-      # which is a []byte. That translates into a base64-endoded string.
-      v = base64.b64decode(qr['Rows'][0][0])
+      v = qr['Rows'][0][0]
       self.assertEqual(v, 'row %u' % (start+x))
 
   def test_custom_end_to_end(self):
@@ -198,8 +195,8 @@ primary key (id)
       qr = utils.vtgate.execute_shard(q['QueryShard']['Sql'],
                                       'test_keyspace', ",".join(q['QueryShard']['Shards']))
       for r in qr['Rows']:
-        id = int(base64.b64decode(r[0]))
-        rows[id] = base64.b64decode(r[1])
+        id = int(r[0])
+        rows[id] = r[1]
     self.assertEqual(len(rows), 20)
     expected = {}
     for i in xrange(10):

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -4,7 +4,6 @@
 # Use of this source code is governed by a BSD-style license that can
 # be found in the LICENSE file.
 
-import base64
 import logging
 import threading
 import struct

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import base64
 import hmac
 import json
 import logging
@@ -651,7 +650,7 @@ class TestVTGateFunctions(unittest.TestCase):
     qr = utils.vtgate.execute('select user_id, email from vt_user_extra where user_id = :user_id', bindvars={'user_id': 11})
     logging.debug('Original row: %s', str(qr))
     self.assertEqual(len(qr['Rows']), 1)
-    v = base64.b64decode(qr['Rows'][0][1])
+    v = qr['Rows'][0][1]
     self.assertEqual(v, 'test 11')
 
     utils.vtgate.execute('update vt_user_extra set email=:email where user_id = :user_id', bindvars={'user_id': 11, 'email':'test 1100'})
@@ -659,7 +658,7 @@ class TestVTGateFunctions(unittest.TestCase):
     qr = utils.vtgate.execute('select user_id, email from vt_user_extra where user_id = :user_id', bindvars={'user_id': 11})
     logging.debug('Modified row: %s', str(qr))
     self.assertEqual(len(qr['Rows']), 1)
-    v = base64.b64decode(qr['Rows'][0][1])
+    v = qr['Rows'][0][1]
     self.assertEqual(v, 'test 1100')
 
     utils.vtgate.execute('delete from vt_user_extra where user_id = :user_id', bindvars={'user_id': 11})


### PR DESCRIPTION
@alainjobart This may stop working again when we switch to proto3, but I think we'll need to fix vtctl somehow to restore human-readability at that point anyway. This fix allows the query results printed by vtctl to be human-readable in the meantime.

The values within each row of a QueryResult were being JSON-encoded as
base64 byte arrays for every type. This JSON encoding was only being
used for tests, until the recent addition of vtctl commands that display
JSON-encoded QueryResults.

Now that we are displaying these to humans, we should display the
results as strings instead of as byte arrays.