### PR TITLE
Deflake keyspace_test.

### DIFF
--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -208,9 +208,8 @@ class TestKeyspace(unittest.TestCase):
       self.assertEqual(unsharded_ks.keyspace_id_to_shard_name_for_db_type(keyspace_id, 'master'), '0')
 
   def test_get_srv_keyspace_names(self):
-    stdout, stderr = utils.run_vtctl(['GetSrvKeyspaceNames', 'test_nj'],
-                                     trap_output=True)
-    self.assertFalse(stderr)
+    stdout, _ = utils.run_vtctl(['GetSrvKeyspaceNames', 'test_nj'],
+                                trap_output=True)
     self.assertEqual(set(stdout.splitlines()), {SHARDED_KEYSPACE, UNSHARDED_KEYSPACE})
 
 


### PR DESCRIPTION
@aaijazi @thompsonja 

There's no need to assert that stderr is empty. The run_vtctl()
function will raise a TestError if the command returns an error code.

This check was making the test flaky because sometimes the spawned
process would emit an incidental log message despite succeeding.