### PR TITLE
vtworker: Make adding commands public.

### DIFF
--- a/go/vt/worker/interactive.go
+++ b/go/vt/worker/interactive.go
@@ -86,7 +86,7 @@ func (wi *Instance) InitInteractiveMode() {
 			pc := c
 			http.HandleFunc("/"+cg.Name+"/"+c.Name, func(w http.ResponseWriter, r *http.Request) {
 				ctx := context.Background()
-				wrk, template, data, err := pc.Interactive(wi, ctx, wi.wr, w, r)
+				wrk, template, data, err := pc.Interactive(ctx, wi, wi.wr, w, r)
 				if err != nil {
 					httpError(w, "%s", err)
 				} else if template != nil && data != nil {

--- a/go/vt/worker/panic_cmd.go
+++ b/go/vt/worker/panic_cmd.go
@@ -22,7 +22,7 @@ func commandPanic(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, a
 	return worker, nil
 }
 
-func interactivePanic(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactivePanic(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	wrk, err := NewPanicWorker(wr)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Could not create Panic worker: %v", err)
@@ -31,7 +31,7 @@ func interactivePanic(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, 
 }
 
 func init() {
-	addCommand("Debugging", command{"Panic",
+	AddCommand("Debugging", Command{"Panic",
 		commandPanic, interactivePanic,
 		"<message>",
 		"For internal tests only. Will call panic() when executed."})

--- a/go/vt/worker/ping_cmd.go
+++ b/go/vt/worker/ping_cmd.go
@@ -53,7 +53,7 @@ func commandPing(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, ar
 	return worker, nil
 }
 
-func interactivePing(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactivePing(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, nil, nil, fmt.Errorf("Cannot parse form: %s", err)
 	}
@@ -72,7 +72,7 @@ func interactivePing(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w
 }
 
 func init() {
-	addCommand("Debugging", command{"Ping",
+	AddCommand("Debugging", Command{"Ping",
 		commandPing, interactivePing,
 		"<message>",
 		"For internal tests only. <message> will be logged as CONSOLE output."})

--- a/go/vt/worker/split_clone_cmd.go
+++ b/go/vt/worker/split_clone_cmd.go
@@ -150,7 +150,7 @@ func keyspacesWithOverlappingShards(ctx context.Context, wr *wrangler.Wrangler) 
 	return result, nil
 }
 
-func interactiveSplitClone(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactiveSplitClone(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot parse form: %s", err)
 	}
@@ -219,7 +219,7 @@ func interactiveSplitClone(wi *Instance, ctx context.Context, wr *wrangler.Wrang
 }
 
 func init() {
-	addCommand("Clones", command{"SplitClone",
+	AddCommand("Clones", Command{"SplitClone",
 		commandSplitClone, interactiveSplitClone,
 		"[--exclude_tables=''] [--strategy=''] <keyspace/shard>",
 		"Replicates the data and creates configuration for a horizontal split."})

--- a/go/vt/worker/split_diff_cmd.go
+++ b/go/vt/worker/split_diff_cmd.go
@@ -131,7 +131,7 @@ func shardsWithSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[string
 	return result, nil
 }
 
-func interactiveSplitDiff(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactiveSplitDiff(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot parse form: %s", err)
 	}
@@ -175,7 +175,7 @@ func interactiveSplitDiff(wi *Instance, ctx context.Context, wr *wrangler.Wrangl
 }
 
 func init() {
-	addCommand("Diffs", command{"SplitDiff",
+	AddCommand("Diffs", Command{"SplitDiff",
 		commandSplitDiff, interactiveSplitDiff,
 		"[--exclude_tables=''] <keyspace/shard>",
 		"Diffs a rdonly destination shard against its SourceShards"})

--- a/go/vt/worker/vertical_split_clone_cmd.go
+++ b/go/vt/worker/vertical_split_clone_cmd.go
@@ -147,7 +147,7 @@ func keyspacesWithServedFrom(ctx context.Context, wr *wrangler.Wrangler) ([]stri
 	return result, nil
 }
 
-func interactiveVerticalSplitClone(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactiveVerticalSplitClone(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot parse form: %s", err)
 	}
@@ -210,7 +210,7 @@ func interactiveVerticalSplitClone(wi *Instance, ctx context.Context, wr *wrangl
 }
 
 func init() {
-	addCommand("Clones", command{"VerticalSplitClone",
+	AddCommand("Clones", Command{"VerticalSplitClone",
 		commandVerticalSplitClone, interactiveVerticalSplitClone,
 		"[--tables=''] [--strategy=''] <destination keyspace/shard>",
 		"Replicates the data and creates configuration for a vertical split."})

--- a/go/vt/worker/vertical_split_diff_cmd.go
+++ b/go/vt/worker/vertical_split_diff_cmd.go
@@ -130,7 +130,7 @@ func shardsWithTablesSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[
 	return result, nil
 }
 
-func interactiveVerticalSplitDiff(wi *Instance, ctx context.Context, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+func interactiveVerticalSplitDiff(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
 	if err := r.ParseForm(); err != nil {
 		return nil, nil, nil, fmt.Errorf("cannot parse form: %s", err)
 	}
@@ -171,7 +171,7 @@ func interactiveVerticalSplitDiff(wi *Instance, ctx context.Context, wr *wrangle
 }
 
 func init() {
-	addCommand("Diffs", command{"VerticalSplitDiff",
+	AddCommand("Diffs", Command{"VerticalSplitDiff",
 		commandVerticalSplitDiff, interactiveVerticalSplitDiff,
 		"[--exclude_tables=''] <keyspace/shard>",
 		"Diffs a rdonly destination keyspace against its SourceShard for a vertical split"})


### PR DESCRIPTION
This way, we support commands which aren't located in the vt/worker package.

Changed the position of the context parameter from the second to the first position back. This is recommended.

@alainjobart I'm merging this right away. Otherwise, your next import will overwrite it.