### PR TITLE
vtworker: Moved handling the "Reset" command from the gRPC server

### DIFF
--- a/go/vt/worker/command.go
+++ b/go/vt/worker/command.go
@@ -103,7 +103,13 @@ func commandWorker(wi *Instance, wr *wrangler.Wrangler, args []string, cell stri
 // RunCommand executes the vtworker command specified by "args". Use WaitForCommand() to block on the returned done channel.
 // If wr is nil, the default wrangler will be used.
 // If you pass a wr wrangler, note that a MemoryLogger will be added to its current logger.
+// The returned worker and done channel may be nil if no worker was started e.g. in case of a "Reset".
 func (wi *Instance) RunCommand(args []string, wr *wrangler.Wrangler, runFromCli bool) (Worker, chan struct{}, error) {
+	if len(args) >= 1 && args[0] == "Reset" {
+		err := wi.Reset()
+		return nil, nil, err
+	}
+
 	if wr == nil {
 		wr = wi.wr
 	}

--- a/go/vt/worker/grpcvtworkerserver/server.go
+++ b/go/vt/worker/grpcvtworkerserver/server.go
@@ -72,16 +72,9 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *pb.ExecuteVtworkerCommandR
 	wr := s.wi.CreateWrangler(logger)
 
 	// execute the command
-	if len(args.Args) >= 1 && args.Args[0] == "Reset" {
-		err = s.wi.Reset()
-	} else {
-		// Make sure we use the global "err" variable and do not redeclare it in this scope.
-		var worker worker.Worker
-		var done chan struct{}
-		worker, done, err = s.wi.RunCommand(args.Args, wr, false /*runFromCli*/)
-		if err == nil {
-			err = s.wi.WaitForCommand(worker, done)
-		}
+	worker, done, err := s.wi.RunCommand(args.Args, wr, false /*runFromCli*/)
+	if err == nil && worker != nil && done != nil {
+		err = s.wi.WaitForCommand(worker, done)
 	}
 
 	// close the log channel, and wait for them all to be sent


### PR DESCRIPTION
implementation into the framework itself.

This way, we don't have to duplicate this code for every server
implementation.

@alainjobart @aaijazi 