### PR TITLE
Resharding

### DIFF
--- a/go/cmd/vtctld/plugin_gorpctabletconn.go
+++ b/go/cmd/vtctld/plugin_gorpctabletconn.go
@@ -1,0 +1,11 @@
+// Copyright 2013, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+// Imports and register the gorpc tabletconn client
+
+import (
+	_ "github.com/youtube/vitess/go/vt/tabletserver/gorpctabletconn"
+)

--- a/go/cmd/vtctld/plugin_grpctabletconn.go
+++ b/go/cmd/vtctld/plugin_grpctabletconn.go
@@ -1,0 +1,11 @@
+// Copyright 2013, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+// Imports and register the gRPC tabletconn client
+
+import (
+	_ "github.com/youtube/vitess/go/vt/tabletserver/grpctabletconn"
+)

--- a/go/cmd/vtctld/tablet_data.go
+++ b/go/cmd/vtctld/tablet_data.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"reflect"
 	"sync"
+	"time"
 
-	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
-	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
+	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // This file maintains a tablet health cache. It establishes streaming
@@ -23,18 +25,17 @@ type TabletHealth struct {
 	// mu protects the entire data structure
 	mu sync.Mutex
 
-	Version           int
-	HealthStreamReply actionnode.HealthStreamReply
-	result            []byte
-	lastError         error
+	Version              int
+	TabletAlias          topo.TabletAlias
+	StreamHealthResponse *pb.StreamHealthResponse
+	result               []byte
+	lastError            error
 }
 
 func newTabletHealth(thc *tabletHealthCache, tabletAlias topo.TabletAlias) (*TabletHealth, error) {
 	th := &TabletHealth{
-		Version: 1,
-	}
-	th.HealthStreamReply.Tablet = &topo.Tablet{
-		Alias: tabletAlias,
+		Version:     1,
+		TabletAlias: tabletAlias,
 	}
 	var err error
 	th.result, err = json.MarshalIndent(th, "", "  ")
@@ -54,15 +55,25 @@ func (th *TabletHealth) update(thc *tabletHealthCache, tabletAlias topo.TabletAl
 		return
 	}
 
-	c, errFunc, err := thc.tmc.HealthStream(ctx, ti)
+	ep, err := ti.EndPoint()
 	if err != nil {
 		return
 	}
 
-	for hsr := range c {
+	conn, err := tabletconn.GetDialer()(ctx, *ep, ti.Keyspace, ti.Shard, 30*time.Second)
+	if err != nil {
+		return
+	}
+
+	stream, errFunc, err := conn.StreamHealth(ctx)
+	if err != nil {
+		return
+	}
+
+	for shr := range stream {
 		th.mu.Lock()
-		if !reflect.DeepEqual(hsr, &th.HealthStreamReply) {
-			th.HealthStreamReply = *hsr
+		if !reflect.DeepEqual(shr, th.StreamHealthResponse) {
+			th.StreamHealthResponse = shr
 			th.Version++
 			th.result, th.lastError = json.MarshalIndent(th, "", "  ")
 		}
@@ -81,17 +92,15 @@ func (th *TabletHealth) get() ([]byte, error) {
 }
 
 type tabletHealthCache struct {
-	ts  topo.Server
-	tmc tmclient.TabletManagerClient
+	ts topo.Server
 
 	mu        sync.Mutex
 	tabletMap map[topo.TabletAlias]*TabletHealth
 }
 
-func newTabletHealthCache(ts topo.Server, tmc tmclient.TabletManagerClient) *tabletHealthCache {
+func newTabletHealthCache(ts topo.Server) *tabletHealthCache {
 	return &tabletHealthCache{
 		ts:        ts,
-		tmc:       tmc,
 		tabletMap: make(map[topo.TabletAlias]*TabletHealth),
 	}
 }

--- a/go/cmd/vtctld/tablet_data.go
+++ b/go/cmd/vtctld/tablet_data.go
@@ -60,7 +60,8 @@ func (th *TabletHealth) update(thc *tabletHealthCache, tabletAlias topo.TabletAl
 		return
 	}
 
-	conn, err := tabletconn.GetDialer()(ctx, *ep, ti.Keyspace, ti.Shard, 30*time.Second)
+	// pass in empty keyspace and shard to not ask for sessionId
+	conn, err := tabletconn.GetDialer()(ctx, *ep, "", "", 30*time.Second)
 	if err != nil {
 		return
 	}

--- a/go/cmd/vtctld/tablet_data_test.go
+++ b/go/cmd/vtctld/tablet_data_test.go
@@ -62,7 +62,6 @@ func (s *streamHealthSQLQuery) StreamHealthUnregister(id int) error {
 
 // BroadcastHealth will broadcast the current health to all listeners
 func (s *streamHealthSQLQuery) BroadcastHealth(terTimestamp int64, stats *pb.RealtimeStats) {
-	// FIXME(alainjobart) also send Target
 	shr := &pb.StreamHealthResponse{
 		TabletExternallyReparentedTimestamp: terTimestamp,
 		RealtimeStats:                       stats,

--- a/go/cmd/vtctld/tablet_data_test.go
+++ b/go/cmd/vtctld/tablet_data_test.go
@@ -23,7 +23,7 @@ type streamHealthSQLQuery struct {
 	queryservice.ErrorQueryService
 	t *testing.T
 
-	// healthStreamMutex protects all the following fields
+	// streamHealthMutex protects all the following fields
 	streamHealthMutex sync.Mutex
 	streamHealthIndex int
 	streamHealthMap   map[int]chan<- *pb.StreamHealthResponse

--- a/go/cmd/vtctld/vtctld.go
+++ b/go/cmd/vtctld/vtctld.go
@@ -463,7 +463,7 @@ func main() {
 	})
 
 	// handle tablet cache
-	tabletHealthCache := newTabletHealthCache(ts, tmclient.NewTabletManagerClient())
+	tabletHealthCache := newTabletHealthCache(ts)
 	http.HandleFunc("/json/TabletHealth", func(w http.ResponseWriter, r *http.Request) {
 		cell := r.FormValue("cell")
 		if cell == "" {

--- a/go/cmd/vtocc/vtocc.go
+++ b/go/cmd/vtocc/vtocc.go
@@ -88,7 +88,7 @@ func main() {
 	// back up if it went down.
 	go func() {
 		for {
-			_ = qsc.AllowQueries(dbConfigs, schemaOverrides, mysqld)
+			_ = qsc.AllowQueries(nil, dbConfigs, schemaOverrides, mysqld)
 			time.Sleep(30 * time.Second)
 		}
 	}()

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -256,7 +256,7 @@ func (x Field_Flag) String() string {
 type Target struct {
 	Keyspace   string              `protobuf:"bytes,1,opt,name=keyspace" json:"keyspace,omitempty"`
 	Shard      string              `protobuf:"bytes,2,opt,name=shard" json:"shard,omitempty"`
-	TabletType topodata.TabletType `protobuf:"varint,3,opt,enum=topodata.TabletType" json:"TabletType,omitempty"`
+	TabletType topodata.TabletType `protobuf:"varint,3,opt,name=tablet_type,enum=topodata.TabletType" json:"tablet_type,omitempty"`
 }
 
 func (m *Target) Reset()         { *m = Target{} }

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -38,8 +38,6 @@ It has these top-level messages:
 	RefreshStateResponse
 	RunHealthCheckRequest
 	RunHealthCheckResponse
-	StreamHealthRequest
-	StreamHealthResponse
 	ReloadSchemaRequest
 	ReloadSchemaResponse
 	PreflightSchemaRequest
@@ -449,32 +447,6 @@ type RunHealthCheckResponse struct {
 func (m *RunHealthCheckResponse) Reset()         { *m = RunHealthCheckResponse{} }
 func (m *RunHealthCheckResponse) String() string { return proto.CompactTextString(m) }
 func (*RunHealthCheckResponse) ProtoMessage()    {}
-
-type StreamHealthRequest struct {
-}
-
-func (m *StreamHealthRequest) Reset()         { *m = StreamHealthRequest{} }
-func (m *StreamHealthRequest) String() string { return proto.CompactTextString(m) }
-func (*StreamHealthRequest) ProtoMessage()    {}
-
-type StreamHealthResponse struct {
-	Tablet              *topodata.Tablet `protobuf:"bytes,1,opt,name=tablet" json:"tablet,omitempty"`
-	BinlogPlayerMapSize int64            `protobuf:"varint,2,opt,name=binlog_player_map_size" json:"binlog_player_map_size,omitempty"`
-	HealthError         string           `protobuf:"bytes,3,opt,name=health_error" json:"health_error,omitempty"`
-	// replication_delay is in nanoseconds
-	ReplicationDelay int64 `protobuf:"varint,4,opt,name=replication_delay" json:"replication_delay,omitempty"`
-}
-
-func (m *StreamHealthResponse) Reset()         { *m = StreamHealthResponse{} }
-func (m *StreamHealthResponse) String() string { return proto.CompactTextString(m) }
-func (*StreamHealthResponse) ProtoMessage()    {}
-
-func (m *StreamHealthResponse) GetTablet() *topodata.Tablet {
-	if m != nil {
-		return m.Tablet
-	}
-	return nil
-}
 
 type ReloadSchemaRequest struct {
 }

--- a/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
+++ b/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
@@ -47,7 +47,6 @@ type TabletManagerClient interface {
 	Scrap(ctx context.Context, in *tabletmanagerdata.ScrapRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ScrapResponse, error)
 	RefreshState(ctx context.Context, in *tabletmanagerdata.RefreshStateRequest, opts ...grpc.CallOption) (*tabletmanagerdata.RefreshStateResponse, error)
 	RunHealthCheck(ctx context.Context, in *tabletmanagerdata.RunHealthCheckRequest, opts ...grpc.CallOption) (*tabletmanagerdata.RunHealthCheckResponse, error)
-	StreamHealth(ctx context.Context, in *tabletmanagerdata.StreamHealthRequest, opts ...grpc.CallOption) (TabletManager_StreamHealthClient, error)
 	ReloadSchema(ctx context.Context, in *tabletmanagerdata.ReloadSchemaRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ReloadSchemaResponse, error)
 	PreflightSchema(ctx context.Context, in *tabletmanagerdata.PreflightSchemaRequest, opts ...grpc.CallOption) (*tabletmanagerdata.PreflightSchemaResponse, error)
 	ApplySchema(ctx context.Context, in *tabletmanagerdata.ApplySchemaRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ApplySchemaResponse, error)
@@ -235,38 +234,6 @@ func (c *tabletManagerClient) RunHealthCheck(ctx context.Context, in *tabletmana
 		return nil, err
 	}
 	return out, nil
-}
-
-func (c *tabletManagerClient) StreamHealth(ctx context.Context, in *tabletmanagerdata.StreamHealthRequest, opts ...grpc.CallOption) (TabletManager_StreamHealthClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_TabletManager_serviceDesc.Streams[0], c.cc, "/tabletmanagerservice.TabletManager/StreamHealth", opts...)
-	if err != nil {
-		return nil, err
-	}
-	x := &tabletManagerStreamHealthClient{stream}
-	if err := x.ClientStream.SendMsg(in); err != nil {
-		return nil, err
-	}
-	if err := x.ClientStream.CloseSend(); err != nil {
-		return nil, err
-	}
-	return x, nil
-}
-
-type TabletManager_StreamHealthClient interface {
-	Recv() (*tabletmanagerdata.StreamHealthResponse, error)
-	grpc.ClientStream
-}
-
-type tabletManagerStreamHealthClient struct {
-	grpc.ClientStream
-}
-
-func (x *tabletManagerStreamHealthClient) Recv() (*tabletmanagerdata.StreamHealthResponse, error) {
-	m := new(tabletmanagerdata.StreamHealthResponse)
-	if err := x.ClientStream.RecvMsg(m); err != nil {
-		return nil, err
-	}
-	return m, nil
 }
 
 func (c *tabletManagerClient) ReloadSchema(ctx context.Context, in *tabletmanagerdata.ReloadSchemaRequest, opts ...grpc.CallOption) (*tabletmanagerdata.ReloadSchemaResponse, error) {
@@ -522,7 +489,7 @@ func (c *tabletManagerClient) PromoteSlave(ctx context.Context, in *tabletmanage
 }
 
 func (c *tabletManagerClient) Backup(ctx context.Context, in *tabletmanagerdata.BackupRequest, opts ...grpc.CallOption) (TabletManager_BackupClient, error) {
-	stream, err := grpc.NewClientStream(ctx, &_TabletManager_serviceDesc.Streams[1], c.cc, "/tabletmanagerservice.TabletManager/Backup", opts...)
+	stream, err := grpc.NewClientStream(ctx, &_TabletManager_serviceDesc.Streams[0], c.cc, "/tabletmanagerservice.TabletManager/Backup", opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +540,6 @@ type TabletManagerServer interface {
 	Scrap(context.Context, *tabletmanagerdata.ScrapRequest) (*tabletmanagerdata.ScrapResponse, error)
 	RefreshState(context.Context, *tabletmanagerdata.RefreshStateRequest) (*tabletmanagerdata.RefreshStateResponse, error)
 	RunHealthCheck(context.Context, *tabletmanagerdata.RunHealthCheckRequest) (*tabletmanagerdata.RunHealthCheckResponse, error)
-	StreamHealth(*tabletmanagerdata.StreamHealthRequest, TabletManager_StreamHealthServer) error
 	ReloadSchema(context.Context, *tabletmanagerdata.ReloadSchemaRequest) (*tabletmanagerdata.ReloadSchemaResponse, error)
 	PreflightSchema(context.Context, *tabletmanagerdata.PreflightSchemaRequest) (*tabletmanagerdata.PreflightSchemaResponse, error)
 	ApplySchema(context.Context, *tabletmanagerdata.ApplySchemaRequest) (*tabletmanagerdata.ApplySchemaResponse, error)
@@ -790,27 +756,6 @@ func _TabletManager_RunHealthCheck_Handler(srv interface{}, ctx context.Context,
 		return nil, err
 	}
 	return out, nil
-}
-
-func _TabletManager_StreamHealth_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(tabletmanagerdata.StreamHealthRequest)
-	if err := stream.RecvMsg(m); err != nil {
-		return err
-	}
-	return srv.(TabletManagerServer).StreamHealth(m, &tabletManagerStreamHealthServer{stream})
-}
-
-type TabletManager_StreamHealthServer interface {
-	Send(*tabletmanagerdata.StreamHealthResponse) error
-	grpc.ServerStream
-}
-
-type tabletManagerStreamHealthServer struct {
-	grpc.ServerStream
-}
-
-func (x *tabletManagerStreamHealthServer) Send(m *tabletmanagerdata.StreamHealthResponse) error {
-	return x.ServerStream.SendMsg(m)
 }
 
 func _TabletManager_ReloadSchema_Handler(srv interface{}, ctx context.Context, codec grpc.Codec, buf []byte) (interface{}, error) {
@@ -1332,11 +1277,6 @@ var _TabletManager_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams: []grpc.StreamDesc{
-		{
-			StreamName:    "StreamHealth",
-			Handler:       _TabletManager_StreamHealth_Handler,
-			ServerStreams: true,
-		},
 		{
 			StreamName:    "Backup",
 			Handler:       _TabletManager_Backup_Handler,

--- a/go/vt/proto/vtworkerservice/vtworkerservice.pb.go
+++ b/go/vt/proto/vtworkerservice/vtworkerservice.pb.go
@@ -30,6 +30,8 @@ var _ = proto.Marshal
 // Client API for Vtworker service
 
 type VtworkerClient interface {
+	// ExecuteVtworkerCommand allows to run a vtworker command by specifying the
+	// same arguments as on the command line.
 	ExecuteVtworkerCommand(ctx context.Context, in *vtworkerdata.ExecuteVtworkerCommandRequest, opts ...grpc.CallOption) (Vtworker_ExecuteVtworkerCommandClient, error)
 }
 
@@ -76,6 +78,8 @@ func (x *vtworkerExecuteVtworkerCommandClient) Recv() (*vtworkerdata.ExecuteVtwo
 // Server API for Vtworker service
 
 type VtworkerServer interface {
+	// ExecuteVtworkerCommand allows to run a vtworker command by specifying the
+	// same arguments as on the command line.
 	ExecuteVtworkerCommand(*vtworkerdata.ExecuteVtworkerCommandRequest, Vtworker_ExecuteVtworkerCommandServer) error
 }
 

--- a/go/vt/tabletmanager/actionnode/actionnode.go
+++ b/go/vt/tabletmanager/actionnode/actionnode.go
@@ -140,9 +140,6 @@ const (
 	// tablet record from the topo server.
 	TabletActionRunHealthCheck = "RunHealthCheck"
 
-	// TabletActionHealthStream will stream the health status
-	TabletActionHealthStream = "HealthStream"
-
 	// TabletActionReloadSchema tells the tablet to reload its schema.
 	TabletActionReloadSchema = "ReloadSchema"
 

--- a/go/vt/tabletmanager/actionnode/structs.go
+++ b/go/vt/tabletmanager/actionnode/structs.go
@@ -4,11 +4,7 @@
 
 package actionnode
 
-import (
-	"time"
-
-	"github.com/youtube/vitess/go/vt/topo"
-)
+import "github.com/youtube/vitess/go/vt/topo"
 
 /*
 This file defines all the payload structures for the ActionNode objects.
@@ -22,27 +18,6 @@ Note it's OK to rename the structures as the type name is not saved in json.
 */
 
 // tablet action node structures
-
-// HealthStreamReply is the structure we stream from HealthStream
-type HealthStreamReply struct {
-	// Tablet is the current tablet record, as cached by tabletmanager
-	Tablet *topo.Tablet
-
-	// BinlogPlayerMapSize is the size of the binlog player map.
-	// If non zero, the ReplicationDelay is the binlog players' maximum
-	// replication delay.
-	BinlogPlayerMapSize int64
-
-	// HealthError is the last error we got from health check,
-	// or empty is the server is healthy.
-	HealthError string
-
-	// ReplicationDelay is either from MySQL replication, or from
-	// filtered replication
-	ReplicationDelay time.Duration
-
-	// TODO(alainjobart) add some QPS reporting data here
-}
 
 // SlaveWasRestartedArgs is the paylod for SlaveWasRestarted
 type SlaveWasRestartedArgs struct {

--- a/go/vt/tabletmanager/after_action.go
+++ b/go/vt/tabletmanager/after_action.go
@@ -21,6 +21,8 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/topo"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 var (
@@ -67,7 +69,11 @@ func (agent *ActionAgent) allowQueries(tablet *topo.Tablet, blacklistedTables []
 		return err
 	}
 
-	return agent.QueryServiceControl.AllowQueries(agent.DBConfigs, agent.SchemaOverrides, agent.MysqlDaemon)
+	return agent.QueryServiceControl.AllowQueries(&pb.Target{
+		Keyspace:   tablet.Keyspace,
+		Shard:      tablet.Shard,
+		TabletType: topo.TabletTypeToProto(tablet.Type),
+	}, agent.DBConfigs, agent.SchemaOverrides, agent.MysqlDaemon)
 }
 
 // loadKeyspaceAndBlacklistRules does what the name suggests:

--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -84,7 +84,8 @@ type ActionAgent struct {
 	// It is protected by actionMutex.
 	initReplication bool
 
-	// mutex protects the following fields
+	// mutex protects the following fields, only hold the mutex
+	// to update the fields, nothing else.
 	mutex            sync.Mutex
 	_tablet          *topo.TabletInfo
 	_tabletControl   *topo.TabletControl
@@ -99,6 +100,9 @@ type ActionAgent struct {
 
 	// replication delay the last time we got it
 	_replicationDelay time.Duration
+
+	// last time we ran TabletExternallyReparented
+	_tabletExternallyReparentedTime time.Time
 }
 
 func loadSchemaOverrides(overridesFile string) []tabletserver.SchemaOverride {

--- a/go/vt/tabletmanager/agent_rpc_actions.go
+++ b/go/vt/tabletmanager/agent_rpc_actions.go
@@ -52,9 +52,6 @@ type RPCAgent interface {
 
 	RunHealthCheck(ctx context.Context, targetTabletType topo.TabletType)
 
-	RegisterHealthStream(chan<- *actionnode.HealthStreamReply) (int, error)
-	UnregisterHealthStream(int) error
-
 	ReloadSchema(ctx context.Context)
 
 	PreflightSchema(ctx context.Context, change string) (*myproto.SchemaChangeResult, error)
@@ -188,26 +185,6 @@ func (agent *ActionAgent) RefreshState(ctx context.Context) {
 // Should be called under RPCWrap.
 func (agent *ActionAgent) RunHealthCheck(ctx context.Context, targetTabletType topo.TabletType) {
 	agent.runHealthCheck(targetTabletType)
-}
-
-// RegisterHealthStream adds a health stream channel to our list
-func (agent *ActionAgent) RegisterHealthStream(c chan<- *actionnode.HealthStreamReply) (int, error) {
-	agent.healthStreamMutex.Lock()
-	defer agent.healthStreamMutex.Unlock()
-
-	id := agent.healthStreamIndex
-	agent.healthStreamIndex++
-	agent.healthStreamMap[id] = c
-	return id, nil
-}
-
-// UnregisterHealthStream removes a health stream channel from our list
-func (agent *ActionAgent) UnregisterHealthStream(id int) error {
-	agent.healthStreamMutex.Lock()
-	defer agent.healthStreamMutex.Unlock()
-
-	delete(agent.healthStreamMap, id)
-	return nil
 }
 
 // ReloadSchema will reload the schema

--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -412,96 +412,6 @@ func agentRPCTestRunHealthCheckPanic(ctx context.Context, t *testing.T, client t
 	expectRPCWrapPanic(t, err)
 }
 
-// this test is a bit of a hack: we write something on the channel
-// upon registration, and we also return an error, so the streaming query
-// ends right there. Otherwise we have no real way to trigger a real
-// communication error, that ends the streaming.
-var testHealthStreamHealthStreamReply = &actionnode.HealthStreamReply{
-	Tablet: &topo.Tablet{
-		Alias: topo.TabletAlias{
-			Cell: "cell1",
-			Uid:  123,
-		},
-		Hostname: "host",
-		IPAddr:   "1.2.3.4",
-		Portmap: map[string]int{
-			"vt": 2345,
-		},
-		Tags: map[string]string{
-			"tag1": "value1",
-		},
-		Health: map[string]string{
-			"health1": "value1",
-		},
-		Keyspace:       "keyspace",
-		Shard:          "shard",
-		Type:           topo.TYPE_MASTER,
-		DbNameOverride: "overruled!",
-	},
-	BinlogPlayerMapSize: 3,
-	HealthError:         "bad rep bad",
-	ReplicationDelay:    50 * time.Second,
-}
-var testRegisterHealthStreamError = "to trigger a server error"
-
-// The server side should write the response to the stream, then wait for
-// this channel to close, then return the error
-var healthStreamSynchronization chan struct{}
-
-func (fra *fakeRPCAgent) RegisterHealthStream(c chan<- *actionnode.HealthStreamReply) (int, error) {
-	if fra.panics {
-		panic(fmt.Errorf("test-triggered panic"))
-	}
-	c <- testHealthStreamHealthStreamReply
-	<-healthStreamSynchronization
-	return 0, fmt.Errorf(testRegisterHealthStreamError)
-}
-
-func (fra *fakeRPCAgent) UnregisterHealthStream(int) error {
-	return nil
-}
-
-func agentRPCTestHealthStream(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo) {
-	healthStreamSynchronization = make(chan struct{})
-	c, errFunc, err := client.HealthStream(ctx, ti)
-	if err != nil {
-		t.Fatalf("HealthStream failed: %v", err)
-	}
-	// channel should have one response, then closed
-	hsr, ok := <-c
-	if !ok {
-		t.Fatalf("HealthStream got no response")
-	}
-
-	// close healthStreamSynchronization so server side knows we
-	// got the response, and it can send the error
-	close(healthStreamSynchronization)
-
-	_, ok = <-c
-	if ok {
-		t.Fatalf("HealthStream wasn't closed")
-	}
-	err = errFunc()
-	if !strings.Contains(err.Error(), testRegisterHealthStreamError) {
-		t.Fatalf("HealthStream failed with the wrong error: %v", err)
-	}
-	compareError(t, "HealthStream", nil, *hsr, *testHealthStreamHealthStreamReply)
-}
-
-func agentRPCTestHealthStreamPanic(ctx context.Context, t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo) {
-	c, errFunc, err := client.HealthStream(ctx, ti)
-	if err != nil {
-		t.Fatalf("HealthStream failed: %v", err)
-	}
-	// channel should have no response, just closed
-	_, ok := <-c
-	if ok {
-		t.Fatalf("HealthStream wasn't closed")
-	}
-	err = errFunc()
-	expectRPCWrapPanic(t, err)
-}
-
 var testReloadSchemaCalled = false
 
 func (fra *fakeRPCAgent) ReloadSchema(ctx context.Context) {
@@ -1229,7 +1139,6 @@ func Run(t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo,
 	agentRPCTestExecuteHook(ctx, t, client, ti)
 	agentRPCTestRefreshState(ctx, t, client, ti)
 	agentRPCTestRunHealthCheck(ctx, t, client, ti)
-	agentRPCTestHealthStream(ctx, t, client, ti)
 	agentRPCTestReloadSchema(ctx, t, client, ti)
 	agentRPCTestPreflightSchema(ctx, t, client, ti)
 	agentRPCTestApplySchema(ctx, t, client, ti)
@@ -1282,7 +1191,6 @@ func Run(t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo,
 	agentRPCTestExecuteHookPanic(ctx, t, client, ti)
 	agentRPCTestRefreshStatePanic(ctx, t, client, ti)
 	agentRPCTestRunHealthCheckPanic(ctx, t, client, ti)
-	agentRPCTestHealthStreamPanic(ctx, t, client, ti)
 	agentRPCTestReloadSchemaPanic(ctx, t, client, ti)
 	agentRPCTestPreflightSchemaPanic(ctx, t, client, ti)
 	agentRPCTestApplySchemaPanic(ctx, t, client, ti)

--- a/go/vt/tabletmanager/faketmclient/fake_client.go
+++ b/go/vt/tabletmanager/faketmclient/fake_client.go
@@ -116,14 +116,6 @@ func (client *FakeTabletManagerClient) RunHealthCheck(ctx context.Context, table
 	return nil
 }
 
-// HealthStream is part of the tmclient.TabletManagerClient interface
-func (client *FakeTabletManagerClient) HealthStream(ctx context.Context, tablet *topo.TabletInfo) (<-chan *actionnode.HealthStreamReply, tmclient.ErrFunc, error) {
-	logstream := make(chan *actionnode.HealthStreamReply, 10)
-	return logstream, func() error {
-		return nil
-	}, nil
-}
-
 // ReloadSchema is part of the tmclient.TabletManagerClient interface
 func (client *FakeTabletManagerClient) ReloadSchema(ctx context.Context, tablet *topo.TabletInfo) error {
 	return nil

--- a/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
+++ b/go/vt/tabletmanager/gorpctmserver/gorpc_server.go
@@ -139,34 +139,6 @@ func (tm *TabletManager) RunHealthCheck(ctx context.Context, args *topo.TabletTy
 	})
 }
 
-// HealthStream registers an agent health stream
-func (tm *TabletManager) HealthStream(ctx context.Context, args *rpc.Unused, sendReply func(interface{}) error) error {
-	ctx = callinfo.RPCWrapCallInfo(ctx)
-	return tm.agent.RPCWrap(ctx, actionnode.TabletActionHealthStream, args, nil, func() error {
-		c := make(chan *actionnode.HealthStreamReply, 10)
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for hsr := range c {
-				// we send until the client disconnects
-				if err := sendReply(hsr); err != nil {
-					return
-				}
-			}
-		}()
-
-		id, err := tm.agent.RegisterHealthStream(c)
-		if err != nil {
-			close(c)
-			wg.Wait()
-			return err
-		}
-		wg.Wait()
-		return tm.agent.UnregisterHealthStream(id)
-	})
-}
-
 // ReloadSchema wraps RPCAgent.ReloadSchema
 func (tm *TabletManager) ReloadSchema(ctx context.Context, args *rpc.Unused, reply *rpc.Unused) error {
 	ctx = callinfo.RPCWrapCallInfo(ctx)

--- a/go/vt/tabletmanager/grpctmserver/server.go
+++ b/go/vt/tabletmanager/grpctmserver/server.go
@@ -172,7 +172,6 @@ func (s *server) StreamHealth(request *pb.StreamHealthRequest, stream pbs.Tablet
 		}
 		wg.Wait()
 		return s.agent.UnregisterHealthStream(id)
-
 	})
 }
 

--- a/go/vt/tabletmanager/grpctmserver/server.go
+++ b/go/vt/tabletmanager/grpctmserver/server.go
@@ -143,38 +143,6 @@ func (s *server) RunHealthCheck(ctx context.Context, request *pb.RunHealthCheckR
 	})
 }
 
-func (s *server) StreamHealth(request *pb.StreamHealthRequest, stream pbs.TabletManager_StreamHealthServer) error {
-	ctx := callinfo.GRPCCallInfo(stream.Context())
-	return s.agent.RPCWrap(ctx, actionnode.TabletActionHealthStream, request, nil, func() error {
-		c := make(chan *actionnode.HealthStreamReply, 10)
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for hsr := range c {
-				// we send until the client disconnects
-				if err := stream.Send(&pb.StreamHealthResponse{
-					Tablet:              topo.TabletToProto(hsr.Tablet),
-					BinlogPlayerMapSize: hsr.BinlogPlayerMapSize,
-					HealthError:         hsr.HealthError,
-					ReplicationDelay:    int64(hsr.ReplicationDelay),
-				}); err != nil {
-					return
-				}
-			}
-		}()
-
-		id, err := s.agent.RegisterHealthStream(c)
-		if err != nil {
-			close(c)
-			wg.Wait()
-			return err
-		}
-		wg.Wait()
-		return s.agent.UnregisterHealthStream(id)
-	})
-}
-
 func (s *server) ReloadSchema(ctx context.Context, request *pb.ReloadSchemaRequest) (*pb.ReloadSchemaResponse, error) {
 	ctx = callinfo.GRPCCallInfo(ctx)
 	response := &pb.ReloadSchemaResponse{}

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -175,8 +175,17 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 	isQueryServiceRunning := agent.QueryServiceControl.IsServing()
 	if shouldQueryServiceBeRunning {
 		if !isQueryServiceRunning {
+			// send the type we want to be, not the type we are
+			currentType := tablet.Type
+			if tablet.Type == topo.TYPE_SPARE {
+				tablet.Type = targetTabletType
+			}
+
 			// we remember this new possible error
 			err = agent.allowQueries(tablet.Tablet, blacklistedTables)
+
+			// restore the current type
+			tablet.Type = currentType
 		}
 	} else {
 		if isQueryServiceRunning {

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -239,12 +239,12 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 	agent._healthy = err
 	agent._healthyTime = time.Now()
 	agent._replicationDelay = replicationDelay
+	terTime := agent._tabletExternallyReparentedTime
 	agent.mutex.Unlock()
 
 	// send it to our observers
 	// (the Target has already been updated when restarting the
 	// query service earlier)
-	// FIXME(alainjobart,liguo) add TabletExternallyReparentedTimestamp
 	// FIXME(alainjobart,liguo) add CpuUsage
 	stats := &pb.RealtimeStats{
 		SecondsBehindMaster: uint32(replicationDelay.Seconds()),
@@ -253,7 +253,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 		stats.HealthError = err.Error()
 	}
 	defer func() {
-		agent.QueryServiceControl.BroadcastHealth(0, stats)
+		agent.QueryServiceControl.BroadcastHealth(terTime.Unix(), stats)
 	}()
 
 	// Update our topo.Server state, start with no change

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -18,7 +18,6 @@ import (
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/timer"
 	"github.com/youtube/vitess/go/vt/servenv"
-	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topotools"
 
@@ -233,20 +232,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 	agent._replicationDelay = replicationDelay
 	agent.mutex.Unlock()
 
-	// send it to our observers, after we've updated the tablet state
-	// (Tablet is a pointer, and below we will alter the Tablet
-	// record to be correct.
-	hsr := &actionnode.HealthStreamReply{
-		Tablet:              tablet.Tablet,
-		BinlogPlayerMapSize: agent.BinlogPlayerMap.size(),
-		ReplicationDelay:    replicationDelay,
-	}
-	if err != nil {
-		hsr.HealthError = err.Error()
-	}
-	defer agent.BroadcastHealthStreamReply(hsr)
-
-	// send it to our other observers
+	// send it to our observers
 	// (the Target has already been updated when restarting the
 	// query service earlier)
 	// FIXME(alainjobart,liguo) add TabletExternallyReparentedTimestamp

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -253,7 +253,11 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topo.TabletType) {
 		stats.HealthError = err.Error()
 	}
 	defer func() {
-		agent.QueryServiceControl.BroadcastHealth(terTime.Unix(), stats)
+		var ts int64
+		if !terTime.IsZero() {
+			ts = terTime.Unix()
+		}
+		agent.QueryServiceControl.BroadcastHealth(ts, stats)
 	}()
 
 	// Update our topo.Server state, start with no change

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -93,6 +93,10 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 		return fmt.Errorf("fastTabletExternallyReparented: failed to change tablet state to MASTER: %v", err)
 	}
 
+	agent.mutex.Lock()
+	agent._tabletExternallyReparentedTime = time.Now()
+	agent.mutex.Unlock()
+
 	// Directly write the new master endpoint in the serving graph.
 	// We will do a true rebuild in the background soon, but in the meantime,
 	// this will be enough for clients to re-resolve the new master.

--- a/go/vt/tabletmanager/tmclient/rpc_client_api.go
+++ b/go/vt/tabletmanager/tmclient/rpc_client_api.go
@@ -67,10 +67,6 @@ type TabletManagerClient interface {
 	// RunHealthCheck asks the remote tablet to run a health check cycle
 	RunHealthCheck(ctx context.Context, tablet *topo.TabletInfo, targetTabletType topo.TabletType) error
 
-	// HealthStream asks the tablet to stream its health status on
-	// a regular basis
-	HealthStream(ctx context.Context, tablet *topo.TabletInfo) (<-chan *actionnode.HealthStreamReply, ErrFunc, error)
-
 	// ReloadSchema asks the remote tablet to reload its schema
 	ReloadSchema(ctx context.Context, tablet *topo.TabletInfo) error
 

--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -442,9 +442,9 @@ func (conn *TabletBson) StreamHealth(ctx context.Context) (<-chan *pb.StreamHeal
 		return nil, nil, tabletconn.ConnClosed
 	}
 
-	healthStream := make(chan *pb.StreamHealthResponse, 10)
-	c := conn.rpcClient.StreamGo("SqlQuery.StreamHealth", &rpc.Unused{}, healthStream)
-	return healthStream, func() error {
+	result := make(chan *pb.StreamHealthResponse, 10)
+	c := conn.rpcClient.StreamGo("SqlQuery.StreamHealth", &rpc.Unused{}, result)
+	return result, func() error {
 		return c.Error
 	}, nil
 }

--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -275,7 +275,7 @@ func (conn *gRPCQueryClient) StreamHealth(ctx context.Context) (<-chan *pb.Strea
 		return nil, nil, tabletconn.ConnClosed
 	}
 
-	healthStream := make(chan *pb.StreamHealthResponse, 10)
+	result := make(chan *pb.StreamHealthResponse, 10)
 	stream, err := conn.c.StreamHealth(ctx, &pb.StreamHealthRequest{})
 	if err != nil {
 		return nil, nil, err
@@ -289,13 +289,13 @@ func (conn *gRPCQueryClient) StreamHealth(ctx context.Context) (<-chan *pb.Strea
 				if err != io.EOF {
 					finalErr = err
 				}
-				close(healthStream)
+				close(result)
 				return
 			}
-			healthStream <- hsr
+			result <- hsr
 		}
 	}()
-	return healthStream, func() error {
+	return result, func() error {
 		return finalErr
 	}, nil
 }

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -886,7 +886,7 @@ func newTestQueryExecutor(sql string, ctx context.Context, flags executorFlags) 
 	if flags&enableSchemaOverrides > 0 {
 		schemaOverrides = getTestTableSchemaOverrides()
 	}
-	sqlQuery.allowQueries(&dbconfigs, schemaOverrides, testUtils.newMysqld(&dbconfigs))
+	sqlQuery.allowQueries(nil, &dbconfigs, schemaOverrides, testUtils.newMysqld(&dbconfigs))
 	if flags&enableTx > 0 {
 		session := proto.Session{
 			SessionId:     sqlQuery.sessionID,

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -170,7 +170,7 @@ type QueryServiceControl interface {
 	AddStatusPart()
 
 	// AllowQueries enables queries.
-	AllowQueries(*dbconfigs.DBConfigs, []SchemaOverride, mysqlctl.MysqlDaemon) error
+	AllowQueries(*pb.Target, *dbconfigs.DBConfigs, []SchemaOverride, mysqlctl.MysqlDaemon) error
 
 	// DisallowQueries shuts down the query service.
 	DisallowQueries()
@@ -230,7 +230,7 @@ func (tqsc *TestQueryServiceControl) AddStatusPart() {
 }
 
 // AllowQueries is part of the QueryServiceControl interface
-func (tqsc *TestQueryServiceControl) AllowQueries(*dbconfigs.DBConfigs, []SchemaOverride, mysqlctl.MysqlDaemon) error {
+func (tqsc *TestQueryServiceControl) AllowQueries(*pb.Target, *dbconfigs.DBConfigs, []SchemaOverride, mysqlctl.MysqlDaemon) error {
 	tqsc.QueryServiceEnabled = tqsc.AllowQueriesError == nil
 	return tqsc.AllowQueriesError
 }
@@ -305,8 +305,8 @@ func (rqsc *realQueryServiceControl) Register() {
 }
 
 // AllowQueries starts the query service.
-func (rqsc *realQueryServiceControl) AllowQueries(dbconfigs *dbconfigs.DBConfigs, schemaOverrides []SchemaOverride, mysqld mysqlctl.MysqlDaemon) error {
-	return rqsc.sqlQueryRPCService.allowQueries(dbconfigs, schemaOverrides, mysqld)
+func (rqsc *realQueryServiceControl) AllowQueries(target *pb.Target, dbconfigs *dbconfigs.DBConfigs, schemaOverrides []SchemaOverride, mysqld mysqlctl.MysqlDaemon) error {
+	return rqsc.sqlQueryRPCService.allowQueries(target, dbconfigs, schemaOverrides, mysqld)
 }
 
 // DisallowQueries can take a long time to return (not indefinite) because

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -22,6 +22,8 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice"
 	"golang.org/x/net/context"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 var (
@@ -188,6 +190,9 @@ type QueryServiceControl interface {
 	// QueryService returns the QueryService object used by this
 	// QueryServiceControl
 	QueryService() queryservice.QueryService
+
+	// BroadcastHealth sends the current health to all listeners
+	BroadcastHealth(terTimestamp int64, stats *pb.RealtimeStats)
 }
 
 // TestQueryServiceControl is a fake version of QueryServiceControl
@@ -258,6 +263,10 @@ func (tqsc *TestQueryServiceControl) SetQueryRules(ruleSource string, qrs *Query
 // QueryService is part of the QueryServiceControl interface
 func (tqsc *TestQueryServiceControl) QueryService() queryservice.QueryService {
 	return nil
+}
+
+// BroadcastHealth is part of the QueryServiceControl interface
+func (tqsc *TestQueryServiceControl) BroadcastHealth(terTimestamp int64, stats *pb.RealtimeStats) {
 }
 
 // realQueryServiceControl implements QueryServiceControl for real
@@ -357,6 +366,11 @@ func (rqsc *realQueryServiceControl) SetQueryRules(ruleSource string, qrs *Query
 // QueryService is part of the QueryServiceControl interface
 func (rqsc *realQueryServiceControl) QueryService() queryservice.QueryService {
 	return rqsc.sqlQueryRPCService
+}
+
+// BroadcastHealth is part of the QueryServiceControl interface
+func (rqsc *realQueryServiceControl) BroadcastHealth(terTimestamp int64, stats *pb.RealtimeStats) {
+	rqsc.sqlQueryRPCService.BroadcastHealth(terTimestamp, stats)
 }
 
 // IsHealthy returns nil if the query service is healthy (able to

--- a/go/vt/tabletserver/queryservice/queryservice.go
+++ b/go/vt/tabletserver/queryservice/queryservice.go
@@ -12,6 +12,8 @@ import (
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"golang.org/x/net/context"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // QueryService is the interface implemented by the tablet's query service.
@@ -31,6 +33,12 @@ type QueryService interface {
 
 	// Map reduce helper
 	SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) error
+
+	// StreamHealthRegister registers a listener for StreamHealth
+	StreamHealthRegister(chan<- *pb.StreamHealthResponse) (int, error)
+
+	// StreamHealthUnregister unregisters a listener for StreamHealth
+	StreamHealthUnregister(int) error
 
 	// Helper for RPC panic handling: call this in a defer statement
 	// at the beginning of each RPC handling method.
@@ -80,6 +88,16 @@ func (e *ErrorQueryService) ExecuteBatch(ctx context.Context, queryList *proto.Q
 
 // SplitQuery is part of QueryService interface
 func (e *ErrorQueryService) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest, reply *proto.SplitQueryResult) error {
+	return fmt.Errorf("ErrorQueryService does not implement any method")
+}
+
+// StreamHealthRegister is part of QueryService interface
+func (e *ErrorQueryService) StreamHealthRegister(chan<- *pb.StreamHealthResponse) (int, error) {
+	return 0, fmt.Errorf("ErrorQueryService does not implement any method")
+}
+
+// StreamHealthUnregister is part of QueryService interface
+func (e *ErrorQueryService) StreamHealthUnregister(int) error {
 	return fmt.Errorf("ErrorQueryService does not implement any method")
 }
 

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -91,7 +91,7 @@ type SqlQuery struct {
 	sessionID int64
 	dbconfig  *dbconfigs.DBConfig
 
-	// healthStreamMutex protects all the following fields
+	// streamHealthMutex protects all the following fields
 	streamHealthMutex sync.Mutex
 	streamHealthIndex int
 	streamHealthMap   map[int]chan<- *pb.StreamHealthResponse

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -26,7 +26,7 @@ func TestSqlQueryAllowQueriesFailBadConn(t *testing.T) {
 	sqlQuery := NewSqlQuery(config)
 	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail")
 	}
@@ -44,7 +44,7 @@ func TestSqlQueryAllowQueriesFailStrictModeConflictWithRowCache(t *testing.T) {
 	dbconfigs := testUtils.newDBConfigs()
 	// enable rowcache
 	dbconfigs.App.EnableRowcache = true
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail because strict mode is disabled while rowcache is enabled.")
 	}
@@ -59,13 +59,13 @@ func TestSqlQueryAllowQueries(t *testing.T) {
 	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
 	dbconfigs := testUtils.newDBConfigs()
 	sqlQuery.setState(StateServing)
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success, but get error: %v", err)
 	}
 	sqlQuery.setState(StateShuttingTx)
-	err = sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err = sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail")
 	}
@@ -78,7 +78,7 @@ func TestSqlQueryCheckMysql(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	defer sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
@@ -94,7 +94,7 @@ func TestSqlQueryCheckMysqlFailInvalidConn(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	defer sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
@@ -114,7 +114,7 @@ func TestSqlQueryCheckMysqlFailUninitializedQueryEngine(t *testing.T) {
 	dbconfigs := testUtils.newDBConfigs()
 	// this causes QueryEngine not being initialized properly
 	sqlQuery.setState(StateServing)
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	defer sqlQuery.disallowQueries()
 	if err != nil {
 		t.Fatalf("SqlQuery.allowQueries should success but get error: %v", err)
@@ -161,7 +161,7 @@ func TestSqlQueryGetSessionId(t *testing.T) {
 	keyspace := "test_keyspace"
 	shard := "0"
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -201,7 +201,7 @@ func TestSqlQueryCommandFailUnMatchedSessionId(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestSqlQueryCommitTransaciton(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestSqlQueryRollback(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestSqlQueryStreamExecute(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -442,7 +442,7 @@ func TestSqlQueryExecuteBatch(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestSqlQueryExecuteBatchFailEmptyQueryList(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -511,7 +511,7 @@ func TestSqlQueryExecuteBatchBeginFail(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestSqlQueryExecuteBatchCommitFail(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -593,7 +593,7 @@ func TestSqlQueryExecuteBatchSqlExecFailInTransaction(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -651,7 +651,7 @@ func TestSqlQueryExecuteBatchFailBeginWithoutCommit(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -708,7 +708,7 @@ func TestSqlQueryExecuteBatchSqlSucceedInTransaction(t *testing.T) {
 	config.EnableAutoCommit = true
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -740,7 +740,7 @@ func TestSqlQueryExecuteBatchCallCommitWithoutABegin(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -844,7 +844,7 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -882,7 +882,7 @@ func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}
@@ -936,7 +936,7 @@ func TestSqlQuerySplitQueryInvalidMinMax(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
-	err := sqlQuery.allowQueries(&dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
+	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err != nil {
 		t.Fatalf("allowQueries failed: %v", err)
 	}

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -55,7 +55,10 @@ func (e OperationalError) Error() string { return string(e) }
 // protocol and outgoing protocols support forwarding information, use
 // context.
 
-// TabletDialer represents a function that will return a TabletConn object that can communicate with a tablet.
+// TabletDialer represents a function that will return a TabletConn
+// object that can communicate with a tablet.
+// If both keyspace and shard are empty, we will not ask for a sessionId
+// (and assume we're using the target field for the queries).
 type TabletDialer func(context context.Context, endPoint topo.EndPoint, keyspace, shard string, timeout time.Duration) (TabletConn, error)
 
 // TabletConn defines the interface for a vttablet client. It should

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -13,6 +13,8 @@ import (
 	tproto "github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 const (
@@ -92,6 +94,9 @@ type TabletConn interface {
 	// SplitQuery splits a query into equally sized smaller queries by
 	// appending primary key range clauses to the original query
 	SplitQuery(context context.Context, query tproto.BoundQuery, splitCount int) ([]tproto.QuerySplit, error)
+
+	// StreamHealth streams StreamHealthResponse to the client
+	StreamHealth(context context.Context) (<-chan *pb.StreamHealthResponse, ErrFunc, error)
 }
 
 type ErrFunc func() error

--- a/go/vt/tabletserver/tabletconntest/tabletconntest.go
+++ b/go/vt/tabletserver/tabletconntest/tabletconntest.go
@@ -903,7 +903,7 @@ func testStreamHealth(t *testing.T, conn tabletconn.TabletConn) {
 		t.Errorf("invalid StreamHealthResponse: got %v expected %v", *shr, *testStreamHealthStreamHealthResponse)
 	}
 
-	// close HealthStreamSynchronization so server side knows we
+	// close streamHealthSynchronization so server side knows we
 	// got the response, and it can send the error
 	close(streamHealthSynchronization)
 

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -204,7 +204,8 @@ func commandVtTabletStreamHealth(ctx context.Context, wr *wrangler.Wrangler, sub
 		return fmt.Errorf("cannot get EndPoint from tablet record: %v", err)
 	}
 
-	conn, err := tabletconn.GetDialer()(ctx, *ep, tabletInfo.Keyspace, tabletInfo.Shard, *connectTimeout)
+	// pass in empty keyspace and shard to not ask for sessionId
+	conn, err := tabletconn.GetDialer()(ctx, *ep, "", "", *connectTimeout)
 	if err != nil {
 		return fmt.Errorf("cannot connect to tablet %v: %v", tabletAlias, err)
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -173,9 +173,6 @@ var commands = []commandGroup{
 			command{"RunHealthCheck", commandRunHealthCheck,
 				"<tablet alias> <target tablet type>",
 				"Runs a health check on a remote tablet with the specified target type."},
-			command{"HealthStream", commandHealthStream,
-				"<tablet alias>",
-				"Streams the health status of a tablet."},
 			command{"Sleep", commandSleep,
 				"<tablet alias> <duration>",
 				"Blocks the action queue on the specified tablet for the specified amount of time. This is typically used for testing."},
@@ -884,31 +881,6 @@ func commandRunHealthCheck(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	return wr.TabletManagerClient().RunHealthCheck(ctx, tabletInfo, servedType)
-}
-
-func commandHealthStream(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	if err := subFlags.Parse(args); err != nil {
-		return err
-	}
-	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the HealthStream command.")
-	}
-	tabletAlias, err := topo.ParseTabletAliasString(subFlags.Arg(0))
-	if err != nil {
-		return err
-	}
-	tabletInfo, err := wr.TopoServer().GetTablet(ctx, tabletAlias)
-	if err != nil {
-		return err
-	}
-	c, errFunc, err := wr.TabletManagerClient().HealthStream(ctx, tabletInfo)
-	if err != nil {
-		return err
-	}
-	for hsr := range c {
-		wr.Logger().Printf("%v\n", jscfg.ToJSON(hsr))
-	}
-	return errFunc()
 }
 
 func commandSleep(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
+
+	pb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // sandbox_test.go provides a sandbox for unit testing VTGate.
@@ -497,6 +499,11 @@ func (sbc *sandboxConn) SplitQuery(ctx context.Context, query tproto.BoundQuery,
 		splits = append(splits, split)
 	}
 	return splits, nil
+}
+
+// StreamHealth does nothing
+func (sbc *sandboxConn) StreamHealth(context context.Context) (<-chan *pb.StreamHealthResponse, tabletconn.ErrFunc, error) {
+	return nil, nil, fmt.Errorf("Not implemented in test")
 }
 
 // Close does not change ExecCount

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -13,7 +13,7 @@ import "vtrpc.proto";
 message Target {
   string keyspace = 1;
   string shard = 2;
-  topodata.TabletType TabletType = 3;
+  topodata.TabletType tablet_type = 3;
 }
 
 // VTGateCallerID is sent by VTGate to VTTablet to describe the

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -276,3 +276,41 @@ message SplitQueryResponse {
   vtrpc.RPCError error = 1;
   repeated QuerySplit queries = 2;
 }
+
+// StreamHealthRequest is the payload for StreamHealth
+message StreamHealthRequest {
+}
+
+// RealtimeStats contains information about the tablet status
+message RealtimeStats {
+  // health_error is the last error we got from health check,
+  // or empty is the server is healthy. This is used for subset selection,
+  // we do not send queries to servers that are not healthy.
+  string health_error = 1;
+
+  // seconds_behind_master is populated for slaves only. It indicates
+  // how far nehind on replication a slave currently is.  It is used
+  // by clients for subset selection (so we don't try to send traffic
+  // to tablets that are too far behind).
+  uint32 seconds_behind_master = 2;
+
+  // cpu_usage is used for load-based balancing
+  double cpu_usage = 3;
+}
+
+// StreamHealthResponse is streamed by StreamHealth on a regular basis
+message StreamHealthResponse {
+  // target is the current server type. Only queries with that exact Target
+  // record will be accepted.
+  Target target = 1;
+
+  // tablet_externally_reparented_timestamp contains the last time
+  // tabletmanager.TabletExternallyReparented was called on this tablet,
+  // or 0 if it was never called. This is meant to differentiate two tablets
+  // that report a target.TabletType of MASTER, only the one with the latest
+  // timestamp should be trusted.
+  int64 tablet_externally_reparented_timestamp = 2;
+
+  // realtime_stats contains information about the tablet status
+  RealtimeStats realtime_stats = 3;
+}

--- a/proto/queryservice.proto
+++ b/proto/queryservice.proto
@@ -39,4 +39,8 @@ service Query {
   // SplitQuery is the API to facilitate MapReduce-type iterations
   // over large data sets (like full table dumps).
   rpc SplitQuery(query.SplitQueryRequest) returns (query.SplitQueryResponse) {};
+
+  // StreamHealth runs a streaming RPC to the tablet, that returns the
+  // current health of the tablet on a regular basis.
+  rpc StreamHealth(query.StreamHealthRequest) returns (stream query.StreamHealthResponse) {};
 }

--- a/proto/tabletmanagerdata.proto
+++ b/proto/tabletmanagerdata.proto
@@ -171,18 +171,6 @@ message RunHealthCheckRequest {
 message RunHealthCheckResponse {
 }
 
-message StreamHealthRequest {
-}
-
-message StreamHealthResponse {
-  topodata.Tablet tablet = 1;
-  int64 binlog_player_map_size = 2;
-  string health_error = 3;
-
-  // replication_delay is in nanoseconds
-  int64 replication_delay = 4;
-}
-
 message ReloadSchemaRequest {
 }
 

--- a/proto/tabletmanagerservice.proto
+++ b/proto/tabletmanagerservice.proto
@@ -45,8 +45,6 @@ service TabletManager {
 
   rpc RunHealthCheck(tabletmanagerdata.RunHealthCheckRequest) returns (tabletmanagerdata.RunHealthCheckResponse) {};
 
-  rpc StreamHealth(tabletmanagerdata.StreamHealthRequest) returns (stream tabletmanagerdata.StreamHealthResponse) {};
-
   rpc ReloadSchema(tabletmanagerdata.ReloadSchemaRequest) returns (tabletmanagerdata.ReloadSchemaResponse) {};
 
   rpc PreflightSchema(tabletmanagerdata.PreflightSchemaRequest) returns (tabletmanagerdata.PreflightSchemaResponse) {};

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -494,7 +494,7 @@ class TestTabletManager(unittest.TestCase):
       self.assertNotIn('health_error', data['realtime_stats'])
       self.assertEqual('test_keyspace', data['target']['keyspace'])
       self.assertEqual('0', data['target']['shard'])
-      self.assertEqual(3, data['target']['TabletType'])
+      self.assertEqual(3, data['target']['tablet_type'])
 
     # kill the tablets
     tablet.kill_tablets([tablet_62344, tablet_62044])

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -492,6 +492,7 @@ class TestTabletManager(unittest.TestCase):
       data = json.loads(line)
       self.assertIn('realtime_stats', data)
       self.assertNotIn('health_error', data['realtime_stats'])
+      self.assertNotIn('tablet_externally_reparented_timestamp', data)
       self.assertEqual('test_keyspace', data['target']['keyspace'])
       self.assertEqual('0', data['target']['shard'])
       self.assertEqual(3, data['target']['tablet_type'])

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -482,9 +482,12 @@ class TestTabletManager(unittest.TestCase):
     lines = stdout.splitlines()
     self.assertEqual(len(lines), 2)
     for line in lines:
-      logging.debug("Got stats: %s", line)
+      logging.debug("Got health: %s", line)
       data = json.loads(line)
       self.assertIn('realtime_stats', data)
+      self.assertEqual('test_keyspace', data['target']['keyspace'])
+      self.assertEqual('0', data['target']['shard'])
+      self.assertEqual(3, data['target']['TabletType'])
 
     # kill the tablets
     tablet.kill_tablets([tablet_62344, tablet_62044])


### PR DESCRIPTION
This is a big change, I couldn't figure out how to split it, sorry. In short:
- adding a streaming RPC to queryservice to get the tablet health. See Liang's doc for details.
- removing the old tabletserver streaming RPC call, that used to do a similar but different thing. Only vtctld was using it to build its health cache, and nobody is using that.
- plumbing a bunch more of the 'target' support in sqlquery. Now if the query service has a valid target, and the client sends a valid target too, and they match, we won't look at sessionId. (not this is not plumbed all the way yet).
- note I use the proto3 structures extensively, even on bson rpc. Cleaner.

This is not used by anyone yet, so we can fix forward for incompatible changes if necessary.

Upon import, I'll add the stubby and stubbyp3 versions.

@enisoc @guoliang100 (Liang is on vacation for a few more days, so Anthony, you're it :) ).