### PR TITLE
Add DeleteKeyspace command in vtctl.

### DIFF
--- a/go/vt/etcdtopo/config.go
+++ b/go/vt/etcdtopo/config.go
@@ -73,8 +73,12 @@ func tabletFilePath(tablet string) string {
 	return path.Join(tabletDirPath(tablet), tabletFilename)
 }
 
+func keyspaceReplicationDirPath(keyspace string) string {
+	return path.Join(replicationDirPath, keyspace)
+}
+
 func shardReplicationDirPath(keyspace, shard string) string {
-	return path.Join(replicationDirPath, keyspace, shard)
+	return path.Join(keyspaceReplicationDirPath(keyspace), shard)
 }
 
 func shardReplicationFilePath(keyspace, shard string) string {

--- a/go/vt/etcdtopo/keyspace.go
+++ b/go/vt/etcdtopo/keyspace.go
@@ -125,3 +125,17 @@ func (s *Server) DeleteKeyspaceShards(ctx context.Context, keyspace string) erro
 	})
 	return nil
 }
+
+// DeleteKeyspace implements topo.Server.
+func (s *Server) DeleteKeyspace(ctx context.Context, keyspace string) error {
+	_, err := s.getGlobal().Delete(keyspaceDirPath(keyspace), true /* recursive */)
+	if err != nil {
+		return convertError(err)
+	}
+
+	event.Dispatch(&events.KeyspaceChange{
+		KeyspaceInfo: *topo.NewKeyspaceInfo(keyspace, nil, -1),
+		Status:       "deleted",
+	})
+	return nil
+}

--- a/go/vt/etcdtopo/replication_graph.go
+++ b/go/vt/etcdtopo/replication_graph.go
@@ -120,3 +120,14 @@ func (s *Server) DeleteShardReplication(ctx context.Context, cellName, keyspace,
 	_, err = cell.Delete(shardReplicationDirPath(keyspace, shard), true /* recursive */)
 	return convertError(err)
 }
+
+// DeleteKeyspaceReplication implements topo.Server.
+func (s *Server) DeleteKeyspaceReplication(ctx context.Context, cellName, keyspace string) error {
+	cell, err := s.getCell(cellName)
+	if err != nil {
+		return err
+	}
+
+	_, err = cell.Delete(keyspaceReplicationDirPath(keyspace), true /* recursive */)
+	return convertError(err)
+}

--- a/go/vt/etcdtopo/serving_graph.go
+++ b/go/vt/etcdtopo/serving_graph.go
@@ -200,6 +200,17 @@ func (s *Server) UpdateSrvKeyspace(ctx context.Context, cellName, keyspace strin
 	return convertError(err)
 }
 
+// DeleteSrvKeyspace implements topo.Server.
+func (s *Server) DeleteSrvKeyspace(ctx context.Context, cellName, keyspace string) error {
+	cell, err := s.getCell(cellName)
+	if err != nil {
+		return err
+	}
+
+	_, err = cell.Delete(srvKeyspaceDirPath(keyspace), true /* recursive */)
+	return convertError(err)
+}
+
 // GetSrvKeyspace implements topo.Server.
 func (s *Server) GetSrvKeyspace(ctx context.Context, cellName, keyspace string) (*topo.SrvKeyspace, error) {
 	cell, err := s.getCell(cellName)

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -81,6 +81,10 @@ type Server interface {
 	// Do not use directly, but instead use topo.UpdateKeyspace.
 	UpdateKeyspace(ctx context.Context, ki *KeyspaceInfo, existingVersion int64) (newVersion int64, err error)
 
+	// DeleteKeyspace deletes the specified keyspace.
+	// Can return ErrNoNode if the keyspace doesn't exist.
+	DeleteKeyspace(ctx context.Context, keyspace string) error
+
 	// GetKeyspace reads a keyspace and returns it.
 	// Can return ErrNoNode
 	GetKeyspace(ctx context.Context, keyspace string) (*KeyspaceInfo, error)
@@ -182,6 +186,10 @@ type Server interface {
 	// Can return ErrNoNode if the object doesn't exist.
 	DeleteShardReplication(ctx context.Context, cell, keyspace, shard string) error
 
+	// DeleteKeyspaceReplication deletes the replication data for all shards.
+	// Can return ErrNoNode if the object doesn't exist.
+	DeleteKeyspaceReplication(ctx context.Context, cell, keyspace string) error
+
 	//
 	// Serving Graph management, per cell.
 	//
@@ -257,6 +265,10 @@ type Server interface {
 
 	// UpdateSrvKeyspace updates the serving records for a cell, keyspace.
 	UpdateSrvKeyspace(ctx context.Context, cell, keyspace string, srvKeyspace *SrvKeyspace) error
+
+	// DeleteSrvKeyspace deletes the cell-local serving records for a keyspace.
+	// Can return ErrNoNode.
+	DeleteSrvKeyspace(ctx context.Context, cell, keyspace string) error
 
 	// GetSrvKeyspace reads a SrvKeyspace record.
 	// Can return ErrNoNode.

--- a/go/vt/topo/test/faketopo/faketopo.go
+++ b/go/vt/topo/test/faketopo/faketopo.go
@@ -47,6 +47,11 @@ func (ft FakeTopo) UpdateKeyspace(ctx context.Context, ki *topo.KeyspaceInfo, ex
 	return 0, errNotImplemented
 }
 
+// DeleteKeyspace implements topo.Server.
+func (ft FakeTopo) DeleteKeyspace(ctx context.Context, keyspace string) error {
+	return errNotImplemented
+}
+
 // GetKeyspace implements topo.Server.
 func (ft FakeTopo) GetKeyspace(ctx context.Context, keyspace string) (*topo.KeyspaceInfo, error) {
 	return nil, errNotImplemented
@@ -137,6 +142,11 @@ func (ft FakeTopo) DeleteShardReplication(ctx context.Context, cell, keyspace, s
 	return errNotImplemented
 }
 
+// DeleteKeyspaceReplication implements topo.Server.
+func (ft FakeTopo) DeleteKeyspaceReplication(ctx context.Context, cell, keyspace string) error {
+	return errNotImplemented
+}
+
 // LockSrvShardForAction implements topo.Server.
 func (ft FakeTopo) LockSrvShardForAction(ctx context.Context, cell, keyspace, shard, contents string) (string, error) {
 	return "", errNotImplemented
@@ -189,6 +199,11 @@ func (ft FakeTopo) DeleteSrvShard(ctx context.Context, cell, keyspace, shard str
 
 // UpdateSrvKeyspace implements topo.Server.
 func (ft FakeTopo) UpdateSrvKeyspace(ctx context.Context, cell, keyspace string, srvKeyspace *topo.SrvKeyspace) error {
+	return errNotImplemented
+}
+
+// DeleteSrvKeyspace implements topo.Server.
+func (ft FakeTopo) DeleteSrvKeyspace(ctx context.Context, cell, keyspace string) error {
 	return errNotImplemented
 }
 

--- a/go/vt/topo/test/keyspace.go
+++ b/go/vt/topo/test/keyspace.go
@@ -31,6 +31,14 @@ func CheckKeyspace(ctx context.Context, t *testing.T, ts topo.Server) {
 		t.Errorf("CreateKeyspace(again) is not ErrNodeExists: %v", err)
 	}
 
+	// Delete and re-create.
+	if err := ts.DeleteKeyspace(ctx, "test_keyspace"); err != nil {
+		t.Errorf("DeleteKeyspace: %v", err)
+	}
+	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topo.Keyspace{}); err != nil {
+		t.Errorf("CreateKeyspace: %v", err)
+	}
+
 	keyspaces, err = ts.GetKeyspaces(ctx)
 	if err != nil {
 		t.Errorf("GetKeyspaces: %v", err)

--- a/go/vt/topo/test/replication.go
+++ b/go/vt/topo/test/replication.go
@@ -75,4 +75,11 @@ func CheckShardReplication(ctx context.Context, t *testing.T, ts topo.Server) {
 	if err := ts.DeleteShardReplication(ctx, cell, "test_keyspace", "-10"); err != topo.ErrNoNode {
 		t.Errorf("DeleteShardReplication(again) returned: %v", err)
 	}
+
+	if err := ts.DeleteKeyspaceReplication(ctx, cell, "test_keyspace"); err != nil {
+		t.Errorf("DeleteKeyspaceReplication(existing) failed: %v", err)
+	}
+	if err := ts.DeleteKeyspaceReplication(ctx, cell, "test_keyspace"); err != topo.ErrNoNode {
+		t.Errorf("DeleteKeyspaceReplication(again) returned: %v", err)
+	}
 }

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -40,7 +40,7 @@ func CheckServingGraph(ctx context.Context, t *testing.T, ts topo.Server) {
 	}
 	// Try to create again.
 	if err := ts.CreateEndPoints(ctx, cell, "test_keyspace", "-10", topo.TYPE_MASTER, &endPoints); err != topo.ErrNodeExists {
-		t.Fatalf("UpdateEndPoints(master): err = %v, want topo.ErrNodeExists", err)
+		t.Fatalf("CreateEndPoints(master): err = %v, want topo.ErrNodeExists", err)
 	}
 
 	// Get version.
@@ -195,6 +195,14 @@ func CheckServingGraph(ctx context.Context, t *testing.T, ts topo.Server) {
 		k.ShardingColumnType != key.KIT_UINT64 ||
 		k.ServedFrom[topo.TYPE_REPLICA] != "other_keyspace" {
 		t.Errorf("GetSrvKeyspace(out of the blue): %v %v", err, *k)
+	}
+
+	// Delete the SrvKeyspace.
+	if err := ts.DeleteSrvKeyspace(ctx, cell, "unknown_keyspace_so_far"); err != nil {
+		t.Fatalf("DeleteSrvShard: %v", err)
+	}
+	if _, err := ts.GetSrvKeyspace(ctx, cell, "unknown_keyspace_so_far"); err != topo.ErrNoNode {
+		t.Errorf("GetSrvKeyspace(deleted) got %v, want ErrNoNode", err)
 	}
 }
 

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -241,7 +241,7 @@ var commands = []commandGroup{
 				"Removes the cell from the shard's Cells list."},
 			command{"DeleteShard", commandDeleteShard,
 				"<keyspace/shard> ...",
-				"Deletes the specified shard(s)."},
+				"Deletes the specified shard(s). There must be no tablets left in them."},
 		},
 	},
 	commandGroup{
@@ -249,6 +249,9 @@ var commands = []commandGroup{
 			command{"CreateKeyspace", commandCreateKeyspace,
 				"[-sharding_column_name=name] [-sharding_column_type=type] [-served_from=tablettype1:ks1,tablettype2,ks2,...] [-split_shard_count=N] [-force] <keyspace name>",
 				"Creates the specified keyspace."},
+			command{"DeleteKeyspace", commandDeleteKeyspace,
+				"<keyspace>",
+				"Deletes the specified keyspace. There must be no shards left in it."},
 			command{"GetKeyspace", commandGetKeyspace,
 				"<keyspace>",
 				"Outputs a JSON structure that contains information about the Keyspace."},
@@ -1406,6 +1409,17 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		err = nil
 	}
 	return err
+}
+
+func commandDeleteKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
+	if err := subFlags.Parse(args); err != nil {
+		return err
+	}
+	if subFlags.NArg() != 1 {
+		return fmt.Errorf("Must specify the <keyspace> argument for DeleteKeyspace.")
+	}
+
+	return wr.DeleteKeyspace(ctx, subFlags.Arg(0))
 }
 
 func commandGetKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/zktopo/serving_graph.go
+++ b/go/vt/zktopo/serving_graph.go
@@ -208,6 +208,19 @@ func (zkts *Server) UpdateSrvKeyspace(ctx context.Context, cell, keyspace string
 	return err
 }
 
+// DeleteSrvKeyspace is part of the topo.Server interface
+func (zkts *Server) DeleteSrvKeyspace(ctx context.Context, cell, keyspace string) error {
+	path := zkPathForVtKeyspace(cell, keyspace)
+	err := zkts.zconn.Delete(path, -1)
+	if err != nil {
+		if zookeeper.IsError(err, zookeeper.ZNONODE) {
+			err = topo.ErrNoNode
+		}
+		return err
+	}
+	return nil
+}
+
 // GetSrvKeyspace is part of the topo.Server interface
 func (zkts *Server) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*topo.SrvKeyspace, error) {
 	path := zkPathForVtKeyspace(cell, keyspace)

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -182,6 +182,16 @@ class TestKeyspace(unittest.TestCase):
     self.assertEqual('keyspace_id', ki['ShardingColumnName'])
     self.assertEqual('uint64', ki['ShardingColumnType'])
 
+  def test_delete_keyspace(self):
+    utils.run_vtctl(['CreateKeyspace', 'test_delete_keyspace'])
+    utils.run_vtctl(['CreateShard', 'test_delete_keyspace/0'])
+
+    # Can't delete if there are shards present.
+    utils.run_vtctl(['DeleteKeyspace', 'test_delete_keyspace'], expect_fail=True)
+
+    utils.run_vtctl(['DeleteShard', 'test_delete_keyspace/0'])
+    utils.run_vtctl(['DeleteKeyspace', 'test_delete_keyspace'])
+
   def test_shard_count(self):
     sharded_ks = self._read_keyspace(SHARDED_KEYSPACE)
     for db_type in ALL_DB_TYPES:


### PR DESCRIPTION
@alainjobart 

This cleans up global and cell-local topology entries for a keyspace.
It only works if there are no shards left in the keyspace.
Similarly, DeleteShard only works if there are no tablets left in
the shard.