### PR TITLE
Full CallerID support for Bson/gRPC APIs and tabletconn

### DIFF
--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -94,6 +94,11 @@ func (conn *gRPCQueryClient) Execute(ctx context.Context, query string, bindVars
 	return mproto.Proto3ToQueryResult(er.Result), nil
 }
 
+// Execute2 is the same with Execute in gRPC, since Execute is already CallerID enabled
+func (conn *gRPCQueryClient) Execute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (*mproto.QueryResult, error) {
+	return conn.Execute(ctx, query, bindVars, transactionID)
+}
+
 // ExecuteBatch sends a batch query to VTTablet.
 func (conn *gRPCQueryClient) ExecuteBatch(ctx context.Context, queries []tproto.BoundQuery, transactionID int64) (*tproto.QueryResultList, error) {
 	conn.mu.RLock()
@@ -118,6 +123,11 @@ func (conn *gRPCQueryClient) ExecuteBatch(ctx context.Context, queries []tproto.
 		return nil, tabletErrorFromRPCError(ebr.Error)
 	}
 	return tproto.Proto3ToQueryResultList(ebr.Results), nil
+}
+
+// ExecuteBatch2 is the same with ExecuteBatch in gRPC, which is already CallerID enabled
+func (conn *gRPCQueryClient) ExecuteBatch2(ctx context.Context, queries []tproto.BoundQuery, transactionID int64) (*tproto.QueryResultList, error) {
+	return conn.ExecuteBatch(ctx, queries, transactionID)
 }
 
 // StreamExecute starts a streaming query to VTTablet.

--- a/go/vt/tabletserver/proto/structs.go
+++ b/go/vt/tabletserver/proto/structs.go
@@ -18,6 +18,15 @@ type SessionParams struct {
 	Shard    string
 }
 
+// GetSessionIdRequest is the CallerID enabled version of SessionParams. It
+// contains SessionParams, which is passed to GetSessionId. The server will
+// double-check the keyspace and shard are what the tablet is serving.
+type GetSessionIdRequest struct {
+	Params            SessionParams
+	EffectiveCallerID *CallerID
+	ImmediateCallerID *VTGateCallerID
+}
+
 // SessionInfo is returned by GetSessionId. Use the provided
 // session_id in the Session object for any subsequent call.
 type SessionInfo struct {
@@ -33,6 +42,14 @@ type Query struct {
 	BindVariables map[string]interface{}
 	SessionId     int64
 	TransactionId int64
+}
+
+// ExecuteRequest contains Query and CallerIDs. it is the payload to
+// Execute2, which is the CallerID enabled version of Execute
+type ExecuteRequest struct {
+	QueryRequest      Query
+	EffectiveCallerID *CallerID
+	ImmediateCallerID *VTGateCallerID
 }
 
 //go:generate bsongen -file $GOFILE -type Query -o query_bson.go
@@ -79,6 +96,14 @@ type QueryList struct {
 	TransactionId int64
 }
 
+// ExecuteBatchRequest is the payload to ExecuteBatch2, it contains
+// both QueryList which is the actual payload and the CallerIDs
+type ExecuteBatchRequest struct {
+	QueryBatch        QueryList
+	EffectiveCallerID *CallerID
+	ImmediateCallerID *VTGateCallerID
+}
+
 //go:generate bsongen -file $GOFILE -type QueryList -o query_list_bson.go
 
 // QueryResultList is the return type for ExecuteBatch.
@@ -113,10 +138,12 @@ type TransactionInfo struct {
 //              if this field is empty or returns an error if this field is not
 //              empty but not found in schema info or not be indexed.
 type SplitQueryRequest struct {
-	Query       BoundQuery
-	SplitColumn string
-	SplitCount  int
-	SessionID   int64
+	Query             BoundQuery
+	SplitColumn       string
+	SplitCount        int
+	SessionID         int64
+	EffectiveCallerID *CallerID
+	ImmediateCallerID *VTGateCallerID
 }
 
 // QuerySplit represents a split of SplitQueryRequest.Query. RowCount is only

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -83,6 +83,8 @@ type TabletConn interface {
 
 	// These should not be used for anything except tests for now; they will eventually
 	// replace the existing methods.
+	Execute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionId int64) (*mproto.QueryResult, error)
+	ExecuteBatch2(ctx context.Context, queries []tproto.BoundQuery, transactionId int64) (*tproto.QueryResultList, error)
 	Begin2(ctx context.Context) (transactionId int64, err error)
 	Commit2(ctx context.Context, transactionId int64) error
 	Rollback2(ctx context.Context, transactionId int64) error

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -399,6 +399,10 @@ func (sbc *sandboxConn) Execute(ctx context.Context, query string, bindVars map[
 	return sbc.getNextResult(), nil
 }
 
+func (sbc *sandboxConn) Execute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (*mproto.QueryResult, error) {
+	return sbc.Execute(ctx, query, bindVars, transactionID)
+}
+
 func (sbc *sandboxConn) ExecuteBatch(ctx context.Context, queries []tproto.BoundQuery, transactionID int64) (*tproto.QueryResultList, error) {
 	sbc.ExecCount.Add(1)
 	if sbc.mustDelay != 0 {
@@ -413,6 +417,10 @@ func (sbc *sandboxConn) ExecuteBatch(ctx context.Context, queries []tproto.Bound
 		qrl.List = append(qrl.List, *(sbc.getNextResult()))
 	}
 	return qrl, nil
+}
+
+func (sbc *sandboxConn) ExecuteBatch2(ctx context.Context, queries []tproto.BoundQuery, transactionID int64) (*tproto.QueryResultList, error) {
+	return sbc.ExecuteBatch(ctx, queries, transactionID)
 }
 
 func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (<-chan *mproto.QueryResult, tabletconn.ErrFunc, error) {


### PR DESCRIPTION
@alainjobart 

Now the VTTablet & tabletconn should fully support CallerID