### PR TITLE
tablet: Do not allow healthchecker to be started with target type

### DIFF
--- a/go/vt/tabletmanager/init_tablet.go
+++ b/go/vt/tabletmanager/init_tablet.go
@@ -63,6 +63,10 @@ func (agent *ActionAgent) InitTablet(port, securePort, gRPCPort int) error {
 		}
 
 	} else if *targetTabletType != "" {
+		if tabletType := topo.TabletType(*targetTabletType); tabletType == topo.TYPE_MASTER {
+			log.Fatalf("target_tablet_type cannot be '%v'. Use '%v' instead.", tabletType, topo.TYPE_REPLICA)
+		}
+
 		// use spare, the healthcheck will turn us into what
 		// we need to be eventually
 		tabletType = topo.TYPE_SPARE


### PR DESCRIPTION
"master".

@alainjobart 

I ran into this problem on Friday where I accidentally set the target type to "master".

This didn't work anyway because every tablet starts as "spare" and
healthcheck isn't allowed to transition a "spare" to "master".
(Healthcheck is only responsible for returning "replica" and "rdonly"
tablets which caught up while in "spare".)

(This was caught in topo.IsTrivialTypeChange().)