### PR TITLE
Add more info about old master in reparent event.

### DIFF
--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -23,8 +23,6 @@ import (
 )
 
 var (
-	_ = flag.Bool("fast_external_reparent", false, "Unused.")
-
 	finalizeReparentTimeout = flag.Duration("finalize_external_reparent_timeout", 10*time.Second, "Timeout for the finalize stage of a fast external reparent reconciliation.")
 
 	externalReparentStats = stats.NewTimings("ExternalReparents", "NewMasterVisible", "FullRebuild")

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -186,6 +186,9 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 			}
 
 			if oldMasterTablet != nil {
+				// We now know more about the old master, so add it to event data.
+				ev.OldMaster = *oldMasterTablet
+
 				// Update the serving graph.
 				errs.RecordError(
 					topotools.UpdateTabletEndpoints(ctx, agent.TopoServer, oldMasterTablet))


### PR DESCRIPTION
@alainjobart 

We only populate partial info on the old master at the beginning,
based on what's available without extra topo queries. Later, we do
need to fetch the old master's record, so let's take the opportunity
to update the info for all subsequent dispatches.