### PR TITLE
vtgate batch API

### DIFF
--- a/go/vt/vtgate/resolver_test.go
+++ b/go/vt/vtgate/resolver_test.go
@@ -512,6 +512,51 @@ func TestResolverDmlOnMultipleKeyspaceIds(t *testing.T) {
 	}
 }
 
+func TestResolverExecBatchAsTransaction(t *testing.T) {
+	s := createSandbox(KsTestUnshardedServedFrom)
+	sbc := &sandboxConn{mustFailRetry: 20}
+	s.MapTestConn("0", sbc)
+
+	res := NewResolver(new(sandboxTopo), "", "aa", 1*time.Millisecond, 2, 2*time.Millisecond, 1*time.Millisecond, 24*time.Hour)
+
+	callcount := 0
+	buildBatchRequest := func() (*scatterBatchRequest, error) {
+		callcount++
+		queries := []proto.BoundShardQuery{{
+			Sql:           "query",
+			BindVariables: nil,
+			Keyspace:      KsTestUnshardedServedFrom,
+			Shards:        []string{"0"},
+		}}
+		return boundShardQueriesToScatterBatchRequest(queries), nil
+	}
+
+	_, err := res.ExecuteBatch(context.Background(), topo.TYPE_MASTER, false, nil, buildBatchRequest)
+	if err == nil {
+		t.Errorf("want got, got none")
+	}
+	// Ensure scatter tried a re-resolve
+	if callcount != 2 {
+		t.Errorf("want 2, got %v", callcount)
+	}
+	if sbc.AsTransactionCount != 0 {
+		t.Errorf("want 0, got %v", sbc.AsTransactionCount)
+	}
+
+	callcount = 0
+	_, err = res.ExecuteBatch(context.Background(), topo.TYPE_MASTER, true, nil, buildBatchRequest)
+	if err == nil {
+		t.Errorf("want got, got none")
+	}
+	// Ensure scatter did not re-resolve
+	if callcount != 1 {
+		t.Errorf("want 1, got %v", callcount)
+	}
+	if sbc.AsTransactionCount != 1 {
+		t.Errorf("want 1, got %v", sbc.AsTransactionCount)
+	}
+}
+
 func TestIsConnError(t *testing.T) {
 	var connErrorTests = []struct {
 		in      error

--- a/go/vt/vtgate/resolver_test.go
+++ b/go/vt/vtgate/resolver_test.go
@@ -98,8 +98,6 @@ func TestResolverExecuteEntityIds(t *testing.T) {
 }
 
 func TestResolverExecuteBatchKeyspaceIds(t *testing.T) {
-	//TODO(sougou): Fix test
-	t.Skip()
 	testResolverGeneric(t, "TestResolverExecuteBatchKeyspaceIds", func() (*mproto.QueryResult, error) {
 		kid10, err := key.HexKeyspaceId("10").Unhex()
 		if err != nil {
@@ -117,7 +115,7 @@ func TestResolverExecuteBatchKeyspaceIds(t *testing.T) {
 				KeyspaceIds:   []key.KeyspaceId{kid10, kid25},
 			}},
 			TabletType:    topo.TYPE_MASTER,
-			AsTransaction: true,
+			AsTransaction: false,
 		}
 		res := NewResolver(new(sandboxTopo), "", "aa", 1*time.Millisecond, 0, 2*time.Millisecond, 1*time.Millisecond, 24*time.Hour)
 		qrs, err := res.ExecuteBatchKeyspaceIds(context.Background(), query)

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -327,11 +327,12 @@ type sandboxConn struct {
 
 	// These Count vars report how often the corresponding
 	// functions were called.
-	ExecCount     sync2.AtomicInt64
-	BeginCount    sync2.AtomicInt64
-	CommitCount   sync2.AtomicInt64
-	RollbackCount sync2.AtomicInt64
-	CloseCount    sync2.AtomicInt64
+	ExecCount          sync2.AtomicInt64
+	BeginCount         sync2.AtomicInt64
+	CommitCount        sync2.AtomicInt64
+	RollbackCount      sync2.AtomicInt64
+	CloseCount         sync2.AtomicInt64
+	AsTransactionCount sync2.AtomicInt64
 
 	// Queries stores the requests received.
 	Queries []tproto.BoundQuery
@@ -405,6 +406,9 @@ func (sbc *sandboxConn) Execute2(ctx context.Context, query string, bindVars map
 
 func (sbc *sandboxConn) ExecuteBatch(ctx context.Context, queries []tproto.BoundQuery, asTransaction bool, transactionID int64) (*tproto.QueryResultList, error) {
 	sbc.ExecCount.Add(1)
+	if asTransaction {
+		sbc.AsTransactionCount.Add(1)
+	}
 	if sbc.mustDelay != 0 {
 		time.Sleep(sbc.mustDelay)
 	}

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -46,10 +46,7 @@ func TestScatterConnExecuteBatch(t *testing.T) {
 			Keyspace:      "TestScatterConnExecuteBatch",
 			Shards:        shards,
 		}}
-		scatterRequest, err := boundShardQueriesToScatterBatchRequest(queries)
-		if err != nil {
-			t.Error(err)
-		}
+		scatterRequest := boundShardQueriesToScatterBatchRequest(queries)
 		qrs, err := stc.ExecuteBatch(context.Background(), scatterRequest, "", false, nil)
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -125,6 +125,7 @@ func (sdc *ShardConn) Execute(ctx context.Context, query string, bindVars map[st
 
 // ExecuteBatch executes a group of queries. The retry rules are the same as Execute.
 func (sdc *ShardConn) ExecuteBatch(ctx context.Context, queries []tproto.BoundQuery, asTransaction bool, transactionID int64) (qrs *tproto.QueryResultList, err error) {
+	// FIXME(sougou): don't retry if asTransaction is true.
 	err = sdc.withRetry(ctx, func(conn tabletconn.TabletConn) error {
 		var innerErr error
 		qrs, innerErr = conn.ExecuteBatch(ctx, queries, asTransaction, transactionID)

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -222,10 +222,6 @@ func (sdc *ShardConn) withRetry(ctx context.Context, action func(conn tabletconn
 	for i := 0; i < sdc.retryCount+1; i++ {
 		conn, endPoint, isTimeout, err = sdc.getConn(ctx)
 		if err != nil {
-			// CAUTION: if we decide to retry on timeout, remember to only
-			// retry read queries. We now allow DMLs in autocommit mode,
-			// and we also allow AsTransaction flag in ExecuteBatch. In those
-			// cases, we should not retry on timeout.
 			if isTimeout || i == sdc.retryCount {
 				break
 			}

--- a/go/vt/vtgate/topo_utils.go
+++ b/go/vt/vtgate/topo_utils.go
@@ -153,7 +153,7 @@ func mapExactShards(ctx context.Context, topoServ SrvTopoServer, cell, keyspace 
 	return keyspace, nil, fmt.Errorf("keyrange %v does not exactly match shards", kr)
 }
 
-func boundShardQueriesToScatterBatchRequest(boundQueries []proto.BoundShardQuery) (*scatterBatchRequest, error) {
+func boundShardQueriesToScatterBatchRequest(boundQueries []proto.BoundShardQuery) *scatterBatchRequest {
 	requests := &scatterBatchRequest{
 		Length:   len(boundQueries),
 		Requests: make(map[string]*shardBatchRequest),
@@ -176,5 +176,22 @@ func boundShardQueriesToScatterBatchRequest(boundQueries []proto.BoundShardQuery
 			request.ResultIndexes = append(request.ResultIndexes, i)
 		}
 	}
-	return requests, nil
+	return requests
+}
+
+func boundKeyspaceIdQueriesToBoundShardQueries(ctx context.Context, topoServ SrvTopoServer, cell string, tabletType topo.TabletType, idQueries []proto.BoundKeyspaceIdQuery) ([]proto.BoundShardQuery, error) {
+	shardQueries := make([]proto.BoundShardQuery, len(idQueries))
+	for i, idQuery := range idQueries {
+		keyspace, shards, err := mapKeyspaceIdsToShards(ctx, topoServ, cell, idQuery.Keyspace, tabletType, idQuery.KeyspaceIds)
+		if err != nil {
+			return nil, err
+		}
+		shardQueries[i] = proto.BoundShardQuery{
+			Sql:           idQuery.Sql,
+			BindVariables: idQuery.BindVariables,
+			Keyspace:      keyspace,
+			Shards:        shards,
+		}
+	}
+	return shardQueries, nil
 }

--- a/go/vt/vtgate/topo_utils.go
+++ b/go/vt/vtgate/topo_utils.go
@@ -159,7 +159,7 @@ func boundShardQueriesToScatterBatchRequest(boundQueries []proto.BoundShardQuery
 		Requests: make(map[string]*shardBatchRequest),
 	}
 	for i, boundQuery := range boundQueries {
-		for _, shard := range boundQuery.Shards {
+		for shard := range unique(boundQuery.Shards) {
 			key := boundQuery.Keyspace + ":" + shard
 			request := requests.Requests[key]
 			if request == nil {

--- a/go/vt/vtgate/topo_utils_test.go
+++ b/go/vt/vtgate/topo_utils_test.go
@@ -170,6 +170,32 @@ func TestBoundShardQueriesToScatterBatchRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			boundQueries: []proto.BoundShardQuery{
+				{
+					Sql:           "q1",
+					BindVariables: map[string]interface{}{"q1var": 1},
+					Keyspace:      "ks1",
+					Shards:        []string{"0", "0"},
+				},
+			},
+			requests: &scatterBatchRequest{
+				Length: 1,
+				Requests: map[string]*shardBatchRequest{
+					"ks1:0": &shardBatchRequest{
+						Queries: []tproto.BoundQuery{
+							{
+								Sql:           "q1",
+								BindVariables: map[string]interface{}{"q1var": 1},
+							},
+						},
+						Keyspace:      "ks1",
+						Shard:         "0",
+						ResultIndexes: []int{0},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/go/vt/vtgate/vertical_split_test.go
+++ b/go/vt/vtgate/vertical_split_test.go
@@ -32,10 +32,7 @@ func TestBatchExecuteKeyspaceAlias(t *testing.T) {
 			Keyspace:      KsTestUnshardedServedFrom,
 			Shards:        shards,
 		}}
-		scatterRequest, err := boundShardQueriesToScatterBatchRequest(queries)
-		if err != nil {
-			t.Error(err)
-		}
+		scatterRequest := boundShardQueriesToScatterBatchRequest(queries)
 		qrs, err := stc.ExecuteBatch(context.Background(), scatterRequest, topo.TYPE_RDONLY, false, nil)
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -295,7 +295,7 @@ func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, batchQuery *proto.Batc
 		batchQuery.AsTransaction,
 		batchQuery.Session,
 		func() (*scatterBatchRequest, error) {
-			return boundShardQueriesToScatterBatchRequest(batchQuery.Queries)
+			return boundShardQueriesToScatterBatchRequest(batchQuery.Queries), nil
 		})
 	if err == nil {
 		reply.List = qrs.List

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -288,7 +288,6 @@ func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, batchQuery *proto.Batc
 		return errTooManyInFlight
 	}
 
-	// TODO(sougou): implement functionality
 	qrs, err := vtg.resolver.ExecuteBatch(
 		ctx,
 		batchQuery.TabletType,

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -356,8 +356,6 @@ func TestVTGateExecuteEntityIds(t *testing.T) {
 }
 
 func TestVTGateExecuteBatchShard(t *testing.T) {
-	// TODO(sougou): Fix test.
-	t.Skip()
 	s := createSandbox("TestVTGateExecuteBatchShard")
 	s.MapTestConn("-20", &sandboxConn{})
 	s.MapTestConn("20-40", &sandboxConn{})
@@ -398,8 +396,6 @@ func TestVTGateExecuteBatchShard(t *testing.T) {
 }
 
 func TestVTGateExecuteBatchKeyspaceIds(t *testing.T) {
-	//TODO(sougou): Fix test
-	t.Skip()
 	s := createSandbox("TestVTGateExecuteBatchKeyspaceIds")
 	s.MapTestConn("-20", &sandboxConn{})
 	s.MapTestConn("20-40", &sandboxConn{})

--- a/py/vtdb/cursor.py
+++ b/py/vtdb/cursor.py
@@ -115,9 +115,10 @@ class BatchCursor(BaseCursor):
     self.query_list.append(sql)
     self.bind_vars_list.append(bind_variables)
 
-  def flush(self):
+  def flush(self, as_transaction=False):
     self.rowsets = self.connection._execute_batch(self.query_list,
-                                                  self.bind_vars_list)
+                                                  self.bind_vars_list,
+                                                  as_transaction)
     self.query_list = []
     self.bind_vars_list = []
 

--- a/py/vtdb/db_object.py
+++ b/py/vtdb/db_object.py
@@ -138,9 +138,8 @@ def create_batch_cursor_from_cursor(original_cursor, writable=False):
     raise dbexceptions.ProgrammingError(
         "Original cursor should be of VTGateCursor type.")
   batch_cursor = vtgate_cursor.BatchVTGateCursor(
-      original_cursor._conn, original_cursor.keyspace,
+      original_cursor._conn,
       original_cursor.tablet_type,
-      keyspace_ids=original_cursor.keyspace_ids,
       writable=writable)
   return batch_cursor
 
@@ -193,80 +192,6 @@ def write_db_class_method(*pargs, **kwargs):
 def db_class_method(*pargs, **kwargs):
   """This function calls db_wrapper to create the appropriate cursor."""
   return classmethod(db_wrapper(*pargs, **kwargs))
-
-
-def execute_batch_read(cursor, query_list, bind_vars_list, as_transaction=False):
-  """Method for executing select queries in batch.
-
-  Args:
-    cursor: original cursor - that is converted to read-only BatchVTGateCursor.
-    query_list: query_list.
-    bind_vars_list: bind variables list.
-
-  Returns:
-    Result of the form [[q1row1, q1row2,...], [q2row1, ...],..]
-
-  Raises:
-   dbexceptions.ProgrammingError when dmls are issued to read batch cursor.
-  """
-  if not isinstance(cursor, vtgate_cursor.VTGateCursor):
-    raise dbexceptions.ProgrammingError(
-        "cursor is not of the type VTGateCursor.")
-  batch_cursor = create_batch_cursor_from_cursor(cursor)
-  for q, bv in zip(query_list, bind_vars_list):
-    if is_dml(q):
-      raise dbexceptions.ProgrammingError("Dml %s for read batch cursor." % q)
-    batch_cursor.execute(q, bv)
-
-  batch_cursor.flush(as_transaction)
-  rowsets = batch_cursor.rowsets
-  result = []
-  # rowset is of the type [(results, rowcount, lastrowid, fields),..]
-  for rowset in rowsets:
-    rowset_results = rowset[0]
-    fields = [f[0] for f in rowset[3]]
-    rows = []
-    for row in rowset_results:
-      rows.append(sql_builder.DBRow(fields, row))
-    result.append(rows)
-  return result
-
-
-def execute_batch_write(cursor, query_list, bind_vars_list, as_transaction=False):
-  """Method for executing dml queries in batch.
-
-  Args:
-    cursor: original cursor - that is converted to read-only BatchVTGateCursor.
-    query_list: query_list.
-    bind_vars_list: bind variables list.
-
-  Returns:
-    Result of the form [{'rowcount':rowcount, 'lastrowid':lastrowid}, ...]
-    since for dmls those two values are valuable.
-
-  Raises:
-    dbexceptions.ProgrammingError when non-dmls are issued to writable batch cursor.
-  """
-  if not isinstance(cursor, vtgate_cursor.VTGateCursor):
-    raise dbexceptions.ProgrammingError(
-        "cursor is not of the type VTGateCursor.")
-  batch_cursor = create_batch_cursor_from_cursor(cursor, writable=True)
-  if batch_cursor.is_writable() and len(batch_cursor.keyspace_ids) != 1:
-    raise dbexceptions.ProgrammingError(
-        "writable batch execute can also execute on one keyspace_id.")
-  for q, bv in zip(query_list, bind_vars_list):
-    if not is_dml(q):
-      raise dbexceptions.ProgrammingError("query %s is not a dml" % q)
-    batch_cursor.execute(q, bv)
-
-  batch_cursor.flush(as_transaction)
-
-  rowsets = batch_cursor.rowsets
-  result = []
-  # rowset is of the type [(results, rowcount, lastrowid, fields),..]
-  for rowset in rowsets:
-    result.append({'rowcount':rowset[1], 'lastrowid':rowset[2]})
-  return result
 
 
 class InvalidUtf8DbWrite(dbexceptions.Error):

--- a/py/vtdb/db_object.py
+++ b/py/vtdb/db_object.py
@@ -195,7 +195,7 @@ def db_class_method(*pargs, **kwargs):
   return classmethod(db_wrapper(*pargs, **kwargs))
 
 
-def execute_batch_read(cursor, query_list, bind_vars_list):
+def execute_batch_read(cursor, query_list, bind_vars_list, as_transaction=False):
   """Method for executing select queries in batch.
 
   Args:
@@ -218,7 +218,7 @@ def execute_batch_read(cursor, query_list, bind_vars_list):
       raise dbexceptions.ProgrammingError("Dml %s for read batch cursor." % q)
     batch_cursor.execute(q, bv)
 
-  batch_cursor.flush()
+  batch_cursor.flush(as_transaction)
   rowsets = batch_cursor.rowsets
   result = []
   # rowset is of the type [(results, rowcount, lastrowid, fields),..]
@@ -232,7 +232,7 @@ def execute_batch_read(cursor, query_list, bind_vars_list):
   return result
 
 
-def execute_batch_write(cursor, query_list, bind_vars_list):
+def execute_batch_write(cursor, query_list, bind_vars_list, as_transaction=False):
   """Method for executing dml queries in batch.
 
   Args:
@@ -259,7 +259,7 @@ def execute_batch_write(cursor, query_list, bind_vars_list):
       raise dbexceptions.ProgrammingError("query %s is not a dml" % q)
     batch_cursor.execute(q, bv)
 
-  batch_cursor.flush()
+  batch_cursor.flush(as_transaction)
 
   rowsets = batch_cursor.rowsets
   result = []

--- a/py/vtdb/tablet.py
+++ b/py/vtdb/tablet.py
@@ -213,7 +213,7 @@ class TabletConnection(object):
       raise
     return results, rowcount, lastrowid, fields
 
-  def _execute_batch(self, sql_list, bind_variables_list, as_transaction=False):
+  def _execute_batch(self, sql_list, bind_variables_list, as_transaction):
     query_list = []
     for sql, bind_vars in zip(sql_list, bind_variables_list):
       query = {}

--- a/py/vtdb/tablet.py
+++ b/py/vtdb/tablet.py
@@ -213,7 +213,7 @@ class TabletConnection(object):
       raise
     return results, rowcount, lastrowid, fields
 
-  def _execute_batch(self, sql_list, bind_variables_list):
+  def _execute_batch(self, sql_list, bind_variables_list, as_transaction=False):
     query_list = []
     for sql, bind_vars in zip(sql_list, bind_variables_list):
       query = {}
@@ -226,6 +226,7 @@ class TabletConnection(object):
     try:
       req = self._make_req()
       req['Queries'] = query_list
+      req['AsTransaction'] = as_transaction
       response = self.rpc_call_and_extract_error('SqlQuery.ExecuteBatch', req)
       for reply in response.reply['List']:
         fields = []

--- a/py/vtdb/vtclient.py
+++ b/py/vtdb/vtclient.py
@@ -158,7 +158,7 @@ class VtOCCConnection(object):
     return result
 
   @reconnect
-  def _execute_batch(self, sql_list, bind_variables_list):
+  def _execute_batch(self, sql_list, bind_variables_list, as_transaction):
     sane_sql_list = []
     sane_bind_vars_list = []
     for sql, bind_variables in zip(sql_list, bind_variables_list):
@@ -167,7 +167,7 @@ class VtOCCConnection(object):
       sane_bind_vars_list.append(sane_bind_vars)
 
     try:
-      result = self.conn._execute_batch(sane_sql_list, sane_bind_vars_list)
+      result = self.conn._execute_batch(sane_sql_list, sane_bind_vars_list, as_transaction)
     except dbexceptions.IntegrityError as e:
       vtdb_logger.get_logger().integrity_error(e)
       raise

--- a/py/vtdb/vtgate_cursor.py
+++ b/py/vtdb/vtgate_cursor.py
@@ -199,28 +199,32 @@ class BatchVTGateCursor(VTGateCursor):
   This only supports keyspace_ids right now since that is what
   the underlying vtgate server supports.
   """
-  def __init__(self, connection, keyspace, tablet_type, keyspace_ids=None,
-               writable=False):
+  def __init__(self, connection, tablet_type, writable=False):
     # rowset is [(results, rowcount, lastrowid, fields),]
     self.rowsets = None
     self.query_list = []
     self.bind_vars_list = []
-    VTGateCursor.__init__(self, connection, keyspace, tablet_type,
-                          keyspace_ids=keyspace_ids, writable=writable)
+    self.keyspace_list = []
+    self.keyspace_ids_list = []
+    VTGateCursor.__init__(self, connection, "", tablet_type, writable=writable)
 
-  def execute(self, sql, bind_variables=None):
+  def execute(self, sql, bind_variables, keyspace, keyspace_ids):
     self.query_list.append(sql)
     self.bind_vars_list.append(bind_variables)
+    self.keyspace_list.append(keyspace)
+    self.keyspace_ids_list.append(keyspace_ids)
 
   def flush(self, as_transaction=False):
     self.rowsets = self._conn._execute_batch(self.query_list,
                                               self.bind_vars_list,
-                                              self.keyspace,
+                                              self.keyspace_list,
+                                              self.keyspace_ids_list,
                                               self.tablet_type,
-                                              self.keyspace_ids,
                                               as_transaction)
     self.query_list = []
     self.bind_vars_list = []
+    self.keyspace_list = []
+    self.keyspace_ids_list = []
 
 
 class StreamVTGateCursor(VTGateCursor):

--- a/py/vtdb/vtgate_cursor.py
+++ b/py/vtdb/vtgate_cursor.py
@@ -212,13 +212,13 @@ class BatchVTGateCursor(VTGateCursor):
     self.query_list.append(sql)
     self.bind_vars_list.append(bind_variables)
 
-  def flush(self):
+  def flush(self, as_transaction=False):
     self.rowsets = self._conn._execute_batch(self.query_list,
                                               self.bind_vars_list,
                                               self.keyspace,
                                               self.tablet_type,
                                               self.keyspace_ids,
-                                              not_in_transaction=(not self.is_writable()))
+                                              as_transaction)
     self.query_list = []
     self.bind_vars_list = []
 

--- a/py/vtdb/vtgatev2.py
+++ b/py/vtdb/vtgatev2.py
@@ -278,9 +278,9 @@ class VTGateConnection(object):
 
 
   @vtgate_utils.exponential_backoff_retry((dbexceptions.RequestBacklog))
-  def _execute_batch(self, sql_list, bind_variables_list, keyspace, tablet_type, keyspace_ids, as_transaction):
+  def _execute_batch(self, sql_list, bind_variables_list, keyspace_list, keyspace_ids_list, tablet_type, as_transaction):
     query_list = []
-    for sql, bind_vars in zip(sql_list, bind_variables_list):
+    for sql, bind_vars, keyspace, keyspace_ids in zip(sql_list, bind_variables_list, keyspace_list, keyspace_ids_list):
       sql, bind_vars = dbapi.prepare_query_bind_vars(sql, bind_vars)
       query = {}
       query['Sql'] = sql

--- a/py/vtdb/vtgatev3.py
+++ b/py/vtdb/vtgatev3.py
@@ -197,7 +197,7 @@ class VTGateConnection(object):
     return results, rowcount, lastrowid, fields
 
 
-  def _execute_batch(self, sql_list, bind_variables_list, tablet_type, not_in_transaction=False):
+  def _execute_batch(self, sql_list, bind_variables_list, tablet_type, as_transaction):
     query_list = []
     for sql, bind_vars in zip(sql_list, bind_variables_list):
       query = {}
@@ -211,7 +211,7 @@ class VTGateConnection(object):
       req = {
           'Queries': query_list,
           'TabletType': tablet_type,
-          'NotInTransaction': not_in_transaction,
+          'AsTransaction': as_transaction,
       }
       self._add_session(req)
       response = self.client.call('VTGate.ExecuteBatch', req)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -566,8 +566,6 @@ class TestRangeSharded(unittest.TestCase):
       self.assertEqual(max_id, expected, "wrong max value fetched; expected %d got %d" % (expected, max_id))
 
   def test_batch_read(self):
-    # TODO(sougou): fix
-    return
     # 1. Create select queries using DB classes.
     query_list = []
     bv_list = []
@@ -594,8 +592,6 @@ class TestRangeSharded(unittest.TestCase):
       self.assertEqual(res_user_ids, user_id_list)
 
   def test_batch_write(self):
-    # TODO(sougou): fix
-    return
     # 1. Create DMLs using DB Classes.
     query_list = []
     bv_list = []
@@ -635,7 +631,7 @@ class TestRangeSharded(unittest.TestCase):
       cursor = context.get_cursor(entity_id_map=entity_id_map)(db_class_sharded.VtUser)
       # 3. Execute the writable batch query.
       results = db_object.execute_batch_write(
-          cursor, query_list, bv_list)
+          cursor, query_list, bv_list, False)
 
       # 4. Verify results
       self.assertEqual(len(results), len(query_list))

--- a/test/queryservice_tests/nocache_tests.py
+++ b/test/queryservice_tests/nocache_tests.py
@@ -413,7 +413,7 @@ class TestNocache(framework.TestCase):
   def test_batch(self):
     queries = ["select * from vtocc_a where id = :a", "select * from vtocc_b where id = :b"]
     bvars = [{"a":2}, {"b":2}]
-    results = self.env.conn._execute_batch(queries, bvars)
+    results = self.env.conn._execute_batch(queries, bvars, False)
     self.assertEqual(results, [([(1L, 2L, 'bcde', 'fghi')], 1, 0, [('eid', 8), ('id', 3), ('name', 253), ('foo', 253)]), ([(1L, 2L)], 1, 0, [('eid', 8), ('id', 3)])])
 
     # Not in transaction, as_transaction false
@@ -422,12 +422,12 @@ class TestNocache(framework.TestCase):
         "select * from vtocc_test where intval = 4",
         "delete from vtocc_test where intval = 4",
         ]
-    results = self.env.conn._execute_batch(queries, [{}, {}, {}])
+    results = self.env.conn._execute_batch(queries, [{}, {}, {}], False)
     self.assertEqual(results[1][0], [(4L, None, None, None)])
 
     # In transaction, as_transaction false
     self.env.conn.begin()
-    results = self.env.conn._execute_batch(queries, [{}, {}, {}])
+    results = self.env.conn._execute_batch(queries, [{}, {}, {}], False)
     self.assertEqual(results[1][0], [(4L, None, None, None)])
     self.env.conn.commit()
 
@@ -438,7 +438,7 @@ class TestNocache(framework.TestCase):
     self.env.conn.rollback()
 
     # Not in transaction, as_transaction true
-    results = self.env.conn._execute_batch(queries, [{}, {}, {}])
+    results = self.env.conn._execute_batch(queries, [{}, {}, {}], True)
     self.assertEqual(results[1][0], [(4L, None, None, None)])
 
   def test_bind_in_select(self):

--- a/test/vtdb_test.py
+++ b/test/vtdb_test.py
@@ -259,7 +259,7 @@ class TestTabletFunctions(unittest.TestCase):
                               {'eid': x, 'id': x, 'keyspace_id': keyspace_id})
       master_conn.commit()
       rowsets = master_conn._execute_batch(["select * from vt_insert_test",
-                                            "select * from vt_a"], [{}, {}])
+                                            "select * from vt_a"], [{}, {}], False)
       self.assertEqual(rowsets[0][1], count)
       self.assertEqual(rowsets[1][1], count)
     except Exception, e:
@@ -285,9 +285,7 @@ class TestTabletFunctions(unittest.TestCase):
         keyspace_id = kid_list[count%len(kid_list)]
         query_list.append("insert into vt_a (eid, id, keyspace_id) values (%(eid)s, %(id)s, %(keyspace_id)s)")
         bind_vars_list.append({'eid': x, 'id': x, 'keyspace_id': keyspace_id})
-      master_conn.begin()
-      master_conn._execute_batch(query_list, bind_vars_list)
-      master_conn.commit()
+      master_conn._execute_batch(query_list, bind_vars_list, True)
       results, rowcount, _, _ = master_conn._execute("select * from vt_insert_test", {})
       self.assertEqual(rowcount, count)
       results, rowcount, _, _ = master_conn._execute("select * from vt_a", {})

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -362,8 +362,6 @@ class TestVTGateFunctions(unittest.TestCase):
                  traceback.print_exc()))
 
   def test_batch_read(self):
-    # TODO(sougou): fix this.
-    return
     try:
       vtgate_conn = get_connection()
       count = 10
@@ -405,8 +403,6 @@ class TestVTGateFunctions(unittest.TestCase):
                                                    traceback.print_exc()))
 
   def test_batch_write(self):
-    # TODO(sougou): fix this.
-    return
     try:
       vtgate_conn = get_connection()
       count = 10
@@ -425,11 +421,10 @@ class TestVTGateFunctions(unittest.TestCase):
         keyspace_id = kid_list[x%len(kid_list)]
         query_list.append("insert into vt_a (eid, id, keyspace_id) values (%(eid)s, %(id)s, %(keyspace_id)s)")
         bind_vars_list.append({'eid': x, 'id': x, 'keyspace_id': keyspace_id})
-      vtgate_conn.begin()
       vtgate_conn._execute_batch(
           query_list, bind_vars_list,
-          KEYSPACE_NAME, 'master', keyspace_ids=[pack_kid(kid) for kid in kid_list])
-      vtgate_conn.commit()
+          KEYSPACE_NAME, 'master', keyspace_ids=[pack_kid(kid) for kid in kid_list],
+          as_transaction=True)
       results, rowcount, _, _ = vtgate_conn._execute(
           "select * from vt_insert_test", {},
           KEYSPACE_NAME, 'master',

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -390,11 +390,9 @@ class TestVTGateFunctions(unittest.TestCase):
             {'eid': x, 'id': x, 'keyspace_id': keyspace_id})
         cursor.commit()
       kid_list = [pack_kid(kid) for kid in kid_list]
-      cursor = vtgate_conn.cursor(KEYSPACE_NAME, 'master',
-                                  keyspace_ids=kid_list,
-                                  cursorclass=vtgate_cursor.BatchVTGateCursor)
-      cursor.execute("select * from vt_insert_test", {})
-      cursor.execute("select * from vt_a", {})
+      cursor = vtgate_conn.cursor('master', cursorclass=vtgate_cursor.BatchVTGateCursor)
+      cursor.execute("select * from vt_insert_test", {}, KEYSPACE_NAME, kid_list)
+      cursor.execute("select * from vt_a", {}, KEYSPACE_NAME, kid_list)
       cursor.flush()
       self.assertEqual(cursor.rowsets[0][1], count)
       self.assertEqual(cursor.rowsets[1][1], count)
@@ -405,26 +403,23 @@ class TestVTGateFunctions(unittest.TestCase):
   def test_batch_write(self):
     try:
       vtgate_conn = get_connection()
-      count = 10
-      query_list = []
-      bind_vars_list = []
-      query_list.append("delete from vt_insert_test")
-      bind_vars_list.append({})
+      cursor = vtgate_conn.cursor('master', cursorclass=vtgate_cursor.BatchVTGateCursor)
       kid_list = shard_kid_map[shard_names[self.shard_index]]
+      all_ids = [pack_kid(kid) for kid in kid_list]
+      count = 10
+      cursor.execute("delete from vt_insert_test", None, KEYSPACE_NAME, all_ids)
       for x in xrange(count):
         keyspace_id = kid_list[x%len(kid_list)]
-        query_list.append("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)")
-        bind_vars_list.append({'msg': 'test %s' % x, 'keyspace_id': keyspace_id})
-      query_list.append("delete from vt_a")
-      bind_vars_list.append({})
+        cursor.execute("insert into vt_insert_test (msg, keyspace_id) values (%(msg)s, %(keyspace_id)s)",
+                       {'msg': 'test %s' % x, 'keyspace_id': keyspace_id},
+                       KEYSPACE_NAME, [pack_kid(keyspace_id)])
+      cursor.execute("delete from vt_a", None, KEYSPACE_NAME, all_ids)
       for x in xrange(count):
         keyspace_id = kid_list[x%len(kid_list)]
-        query_list.append("insert into vt_a (eid, id, keyspace_id) values (%(eid)s, %(id)s, %(keyspace_id)s)")
-        bind_vars_list.append({'eid': x, 'id': x, 'keyspace_id': keyspace_id})
-      vtgate_conn._execute_batch(
-          query_list, bind_vars_list,
-          KEYSPACE_NAME, 'master', keyspace_ids=[pack_kid(kid) for kid in kid_list],
-          as_transaction=True)
+        cursor.execute("insert into vt_a (eid, id, keyspace_id) values (%(eid)s, %(id)s, %(keyspace_id)s)",
+                       {'eid': x, 'id': x, 'keyspace_id': keyspace_id},
+                       KEYSPACE_NAME, [pack_kid(keyspace_id)])
+      cursor.flush(True)
       results, rowcount, _, _ = vtgate_conn._execute(
           "select * from vt_insert_test", {},
           KEYSPACE_NAME, 'master',


### PR DESCRIPTION
This makes vtgate batch API feature-complete. I've also changed the python client API and the tests to be more practical. The keyspace & keyspace_ids used to be bound to a cursor, which is not convenient for multiple queries. The new API instead allows you to specify those for each query.