### PR TITLE
remove panic out of queryservice

### DIFF
--- a/go/vt/tabletserver/dbconn.go
+++ b/go/vt/tabletserver/dbconn.go
@@ -5,6 +5,7 @@
 package tabletserver
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -67,7 +68,7 @@ func (dbc *DBConn) Exec(ctx context.Context, query string, maxrows int, wantfiel
 			return nil, NewTabletErrorSql(ErrFatal, err)
 		}
 	}
-	panic("unreachable")
+	return nil, NewTabletErrorSql(ErrFatal, errors.New("dbconn.Exec: unreachable code"))
 }
 
 func (dbc *DBConn) execOnce(ctx context.Context, query string, maxrows int, wantfields bool) (*mproto.QueryResult, error) {


### PR DESCRIPTION
1. Remove panics out of QueryExecutor and return error instead.
2. Some places like TxPool, CachePool, SchemaInfo still panics and will be captured
   and handled in SqlQuery.