### PR TITLE
vtgate api: delete tests in client_test.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ medium_integration_test_files = \
 	tabletmanager.py \
 	reparent.py \
 	vtdb_test.py \
+	client_test.py \
 	vtgate_utils_test.py \
 	rowcache_invalidator.py \
 	worker.py \


### PR DESCRIPTION
I removed functions from client.py because they need
to be rethought in light of the new API, but missed
removing them from client_test.py.
I've now added client_test to our integration tests
to make sure it doesn't get missed.
I'll submit this right away because it breaks import.