### PR TITLE
add exempt acl feature in tableacl

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -64,6 +64,7 @@ type QueryEngine struct {
 	streamBufferSize sync2.AtomicInt64
 	strictTableAcl   bool
 	enableAutoCommit bool
+	exemptACL        string
 
 	// Loggers
 	accessCheckerLogger *logutil.ThrottledLogger
@@ -165,6 +166,7 @@ func NewQueryEngine(config Config) *QueryEngine {
 		qe.strictMode.Set(1)
 	}
 	qe.strictTableAcl = config.StrictTableAcl
+	qe.exemptACL = config.TableAclExemptACL
 	qe.maxResultSize = sync2.AtomicInt64(config.MaxResultSize)
 	qe.maxDMLRows = sync2.AtomicInt64(config.MaxDMLRows)
 	qe.streamBufferSize = sync2.AtomicInt64(config.StreamBufferSize)

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -207,7 +207,10 @@ func (qre *QueryExecutor) checkPermissions() error {
 	case QR_FAIL_RETRY:
 		return NewTabletError(ErrRetry, "Query disallowed due to rule: %s", desc)
 	}
-
+	// a superuser that exempts from table ACL checking
+	if qre.qe.exemptACL == username {
+		return nil
+	}
 	// Perform table ACL check if it is enabled
 	if qre.plan.Authorized != nil && !qre.plan.Authorized.IsMember(username) {
 		errStr := fmt.Sprintf("table acl error: %q cannot run %v on table %q", username, qre.plan.PlanId, qre.plan.TableName)

--- a/go/vt/tabletserver/queryctl.go
+++ b/go/vt/tabletserver/queryctl.go
@@ -48,7 +48,9 @@ func init() {
 	flag.Float64Var(&qsConfig.IdleTimeout, "queryserver-config-idle-timeout", DefaultQsConfig.IdleTimeout, "query server idle timeout (in seconds), vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance.")
 	flag.Float64Var(&qsConfig.SpotCheckRatio, "queryserver-config-spot-check-ratio", DefaultQsConfig.SpotCheckRatio, "query server rowcache spot check frequency (in [0, 1]), if rowcache is enabled, this value determines how often a row retrieved from the rowcache is spot-checked against MySQL.")
 	flag.BoolVar(&qsConfig.StrictMode, "queryserver-config-strict-mode", DefaultQsConfig.StrictMode, "allow only predictable DMLs and enforces MySQL's STRICT_TRANS_TABLES")
+	// tableacl related configurations.
 	flag.BoolVar(&qsConfig.StrictTableAcl, "queryserver-config-strict-table-acl", DefaultQsConfig.StrictTableAcl, "only allow queries that pass table acl checks")
+	flag.StringVar(&qsConfig.TableAclExemptACL, "queryserver-config-acl-exempt-acl", DefaultQsConfig.TableAclExemptACL, "an acl that exempt from table acl checking (this acl is free to access any vitess tables).")
 	flag.BoolVar(&qsConfig.TerseErrors, "queryserver-config-terse-errors", DefaultQsConfig.TerseErrors, "prevent bind vars from escaping in returned errors")
 	flag.BoolVar(&qsConfig.EnablePublishStats, "queryserver-config-enable-publish-stats", DefaultQsConfig.EnablePublishStats, "set this flag to true makes queryservice publish monitoring stats")
 	flag.StringVar(&qsConfig.RowCache.Binary, "rowcache-bin", DefaultQsConfig.RowCache.Binary, "rowcache binary file, vttablet launches a memcached if rowcache is enabled. This config specifies the location of the memcache binary.")
@@ -123,6 +125,7 @@ type Config struct {
 	StatsPrefix        string
 	DebugURLPrefix     string
 	PoolNamePrefix     string
+	TableAclExemptACL  string
 }
 
 // DefaultQSConfig is the default value for the query service config.
@@ -156,6 +159,7 @@ var DefaultQsConfig = Config{
 	StatsPrefix:        "",
 	DebugURLPrefix:     "/debug",
 	PoolNamePrefix:     "",
+	TableAclExemptACL:  "",
 }
 
 var qsConfig Config


### PR DESCRIPTION
1. an exempt user will skip tableacl checking and have access to all Vitess tables.
2. add queryservice flag "queryserver-config-acl-exempt-acl" to specify exempt acl name.