### PR TITLE
Makefile: Enable debug logging for worker.py.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ small_integration_test_files = \
 	initial_sharding.py \
 	zkocc_test.py
 
+# TODO(mberlin): Remove -v option to worker.py when we found out what causes 10 minute Travis timeouts.
 medium_integration_test_files = \
 	tabletmanager.py \
 	reparent.py \
@@ -121,7 +122,7 @@ medium_integration_test_files = \
 	client_test.py \
 	vtgate_utils_test.py \
 	rowcache_invalidator.py \
-	worker.py \
+	"worker.py -v" \
 	automation_horizontal_resharding.py
 
 large_integration_test_files = \
@@ -149,12 +150,19 @@ SHELL = /bin/bash
 
 # function to execute a list of integration test files
 # exits on first failure
+# TODO(mberlin): Remove special handling for worker.py when we found out what causes 10 minute Travis timeouts.
 define run_integration_tests
 	cd test ; \
 	for t in $1 ; do \
 		echo $$(date): Running test/$$t... ; \
-		output=$$(time ./$$t $$VT_TEST_FLAGS 2>&1) ; \
-		if [[ $$? != 0 ]]; then \
+		if [[ $$t == *worker.py* ]]; then \
+			time ./$$t $$VT_TEST_FLAGS 2>&1 ; \
+			rc=$$? ; \
+		else \
+			output=$$(time ./$$t $$VT_TEST_FLAGS 2>&1) ; \
+			rc=$$? ; \
+		fi ; \
+		if [[ $$rc != 0 ]]; then \
 			echo "$$output" >&2 ; \
 			exit 1 ; \
 		fi ; \


### PR DESCRIPTION
We sporadically see that the worker.py test times out on Travis CI after 10 minutes. Enabling logging will give us better visibility to debug the problem.