### PR TITLE
Port vschema editor to new vtctld UI.

### DIFF
--- a/go/cmd/vtctld/api.go
+++ b/go/cmd/vtctld/api.go
@@ -239,4 +239,35 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository) {
 		schemamanager.Run(ctx,
 			schemamanager.NewUIController(req.SQL, req.Keyspace, w), executor)
 	})
+
+	// VSchema
+	http.HandleFunc(apiPrefix+"vschema/", func(w http.ResponseWriter, r *http.Request) {
+		schemafier, ok := ts.(topo.Schemafier)
+		if !ok {
+			httpErrorf(w, r, "%T doesn't support schemafier API", ts)
+			return
+		}
+
+		// Save VSchema
+		if r.Method == "POST" {
+			vschema, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				httpErrorf(w, r, "can't read request body: %v", err)
+				return
+			}
+			if err := schemafier.SaveVSchema(ctx, string(vschema)); err != nil {
+				httpErrorf(w, r, "can't save vschema: %v", err)
+			}
+			return
+		}
+
+		// Get VSchema
+		vschema, err := schemafier.GetVSchema(ctx)
+		if err != nil {
+			httpErrorf(w, r, "can't get vschema: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", jsonContentType)
+		w.Write([]byte(vschema))
+	})
 }

--- a/go/cmd/vtctld/vtctld.go
+++ b/go/cmd/vtctld/vtctld.go
@@ -294,7 +294,7 @@ func main() {
 	})
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		templateLoader.ServeTemplate("index.html", indexContent, w, r)
+		http.Redirect(w, r, "/app/", http.StatusFound)
 	})
 
 	http.HandleFunc("/content/", func(w http.ResponseWriter, r *http.Request) {

--- a/web/vtctld/api.js
+++ b/web/vtctld/api.js
@@ -31,3 +31,7 @@ app.factory('endpoints', function($resource) {
 app.factory('topodata', function($resource) {
   return $resource('/api/topodata/:path');
 });
+
+app.factory('vschema', function($resource) {
+  return $resource('/api/vschema/');
+});

--- a/web/vtctld/app.css
+++ b/web/vtctld/app.css
@@ -80,3 +80,12 @@ md-toolbar h1 {
 textarea.code {
   font-family: monospace;
 }
+
+.notice {
+  background-color: #FFC107;
+}
+
+.input-header {
+  color: black !important;
+  font-weight: bold;
+}

--- a/web/vtctld/app.js
+++ b/web/vtctld/app.js
@@ -1,4 +1,4 @@
-app = angular.module('vtctld', ['ngMaterial', 'ngRoute', 'ngResource']);
+app = angular.module('vtctld', ['ngMaterial', 'ngRoute', 'ngResource', 'ngMessages']);
 
 vtTabletTypes = [
   'unknown', 'idle', 'master', 'replica', 'rdonly', 'spare', 'experimental',
@@ -12,7 +12,7 @@ app.constant('routes', [
   },
   {
     name: 'keyspaces',
-    title: 'Keyspaces',
+    title: 'Dashboard',
     urlBase: '/keyspaces/',
     urlPattern: '/keyspaces/',
     templateUrl: 'keyspaces.html',
@@ -29,6 +29,16 @@ app.constant('routes', [
     controller: 'ShardCtrl'
   },
   {
+    name: 'topo',
+    title: 'Topology Browser',
+    urlBase: '/topo/',
+    urlPattern: '/topo/:path*?',
+    templateUrl: 'topo.html',
+    controller: 'TopoCtrl',
+    showInNav: true,
+    icon: 'folder'
+  },
+  {
     name: 'schema',
     title: 'Schema Manager',
     urlBase: '/schema/',
@@ -39,15 +49,15 @@ app.constant('routes', [
     icon: 'storage'
   },
   {
-    name: 'topo',
-    title: 'Topology Browser',
-    urlBase: '/topo/',
-    urlPattern: '/topo/:path*?',
-    templateUrl: 'topo.html',
-    controller: 'TopoCtrl',
+    name: 'vschema',
+    title: 'Routing Indexes',
+    urlBase: '/vschema/',
+    urlPattern: '/vschema/',
+    templateUrl: 'vschema/vschema.html',
+    controller: 'VSchemaCtrl',
     showInNav: true,
-    icon: 'folder'
-  },
+    icon: 'directions'
+  }
 ]);
 
 app.config(function($mdThemingProvider, $routeProvider,

--- a/web/vtctld/index.html
+++ b/web/vtctld/index.html
@@ -47,6 +47,7 @@
     <h1 ng-bind="navTitle()"></h1>
 
     <md-button class="md-icon-button" ng-click="refreshRoute()" aria-label="Refresh">
+      <md-tooltip>Refresh</md-tooltip>
       <md-icon md-font-set="material-icons">refresh</md-icon>
     </md-button>
   </md-toolbar>
@@ -60,6 +61,7 @@
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.2/angular-animate.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.2/angular-aria.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.2/angular-resource.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.2/angular-messages.min.js"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/angular_material/0.10.0/angular-material.min.js"></script>
 
 <script src="./config.js"></script>
@@ -70,6 +72,7 @@
 <script src="./topo.js"></script>
 <script src="./actions.js"></script>
 <script src="./schema.js"></script>
+<script src="./vschema/vschema.js"></script>
 
 </body>
 </html>

--- a/web/vtctld/keyspaces.html
+++ b/web/vtctld/keyspaces.html
@@ -16,6 +16,7 @@
     <span flex></span>
     <md-menu>
     <md-button class="md-icon-button" aria-label="Keyspace actions" ng-click="$mdOpenMenu()" md-menu-origin>
+      <md-tooltip>Keyspace Actions</md-tooltip>
       <md-icon md-font-set="material-icons">more_vert</md-icon>
     </md-button>
     <md-menu-content>

--- a/web/vtctld/schema.html
+++ b/web/vtctld/schema.html
@@ -4,13 +4,15 @@
   <md-tab label="Apply Schema">
   <md-content class="md-padding">
 
+  <form ng-submit="submitSchema($event)">
+
   <md-autocomplete md-floating-label="Keyspace" md-min-length="0"
       md-selected-item="schemaChange.Keyspace"
       md-selected-item-change=""
       md-search-text="keyspaceSelector.searchText"
       md-search-text-change=""
       md-items="item in keyspaceSelector.items()"
-      md-item-text="item">
+      md-item-text="item" md-autofocus="false">
     <md-item-template>
       <span md-highlight-text="keyspaceSelector.searchText">{{item}}</span>
     </md-item-template>
@@ -22,7 +24,10 @@
     <textarea ng-model="schemaChange.SQL" class="code"></textarea>
   </md-input-container>
 
-  <md-button class="md-primary" ng-click="submitSchema($event)">Submit</md-button>
+  <md-button type="submit" class="md-primary md-raised" style="margin-left:0"
+    ng-disabled="!schemaChange.Keyspace || !schemaChange.SQL">Submit</md-button>
+
+  </form>
 
   </md-content>
   </md-tab>

--- a/web/vtctld/schema.html
+++ b/web/vtctld/schema.html
@@ -4,9 +4,10 @@
   <md-tab label="Apply Schema">
   <md-content class="md-padding">
 
-  <form ng-submit="submitSchema($event)">
+  <form name="applyForm" ng-submit="submitSchema($event)">
 
   <md-autocomplete md-floating-label="Keyspace" md-min-length="0"
+      md-input-name="keyspace" required
       md-selected-item="schemaChange.Keyspace"
       md-selected-item-change=""
       md-search-text="keyspaceSelector.searchText"
@@ -17,15 +18,21 @@
       <span md-highlight-text="keyspaceSelector.searchText">{{item}}</span>
     </md-item-template>
     <md-not-found>No keyspaces found matching "{{keyspaceSelector.searchText}}".</md-not-found>
+    <div ng-messages="applyForm.keyspace.$error">
+      <div ng-message="required">Required</div>
+    </div>
   </md-autocomplete>
 
   <md-input-container flex>
     <label>Schema Change SQL</label>
-    <textarea ng-model="schemaChange.SQL" class="code"></textarea>
+    <textarea ng-model="schemaChange.SQL" class="code" name="sql" required></textarea>
+    <div ng-messages="applyForm.sql.$error">
+      <div ng-message="required">Required</div>
+    </div>
   </md-input-container>
 
   <md-button type="submit" class="md-primary md-raised" style="margin-left:0"
-    ng-disabled="!schemaChange.Keyspace || !schemaChange.SQL">Submit</md-button>
+    ng-disabled="applyForm.$invalid">Submit</md-button>
 
   </form>
 

--- a/web/vtctld/schema.html
+++ b/web/vtctld/schema.html
@@ -1,11 +1,21 @@
-<md-content class="md-padding">
+<md-content>
 
 <md-tabs md-border-bottom md-center-tabs="false">
   <md-tab label="Apply Schema">
+  <md-content class="md-padding">
 
-  <md-select placeholder="Select Keyspace" ng-model="schemaChange.Keyspace">
-    <md-option ng-repeat="keyspace in keyspaces" value="{{keyspace}}">{{keyspace}}</md-option>
-  </md-select>
+  <md-autocomplete md-floating-label="Keyspace" md-min-length="0"
+      md-selected-item="schemaChange.Keyspace"
+      md-selected-item-change=""
+      md-search-text="keyspaceSelector.searchText"
+      md-search-text-change=""
+      md-items="item in keyspaceSelector.items()"
+      md-item-text="item">
+    <md-item-template>
+      <span md-highlight-text="keyspaceSelector.searchText">{{item}}</span>
+    </md-item-template>
+    <md-not-found>No keyspaces found matching "{{keyspaceSelector.searchText}}".</md-not-found>
+  </md-autocomplete>
 
   <md-input-container flex>
     <label>Schema Change SQL</label>
@@ -14,6 +24,7 @@
 
   <md-button class="md-primary" ng-click="submitSchema($event)">Submit</md-button>
 
+  </md-content>
   </md-tab>
 </md-tabs>
 

--- a/web/vtctld/schema.js
+++ b/web/vtctld/schema.js
@@ -1,11 +1,21 @@
 app.controller('SchemaCtrl', function($scope, $http, $mdDialog,
                actions, keyspaces) {
-  $scope.schemaChange = {Keyspace: '', SQL: ''};
-
   $scope.refreshData = function() {
     $scope.keyspaces = keyspaces.query();
   };
   $scope.refreshData();
+
+  $scope.schemaChange = {Keyspace: '', SQL: ''};
+  $scope.keyspaceSelector = {
+    searchText: '',
+    items: function() {
+      var searchText = this.searchText;
+      if (!searchText) return $scope.keyspaces;
+      return $scope.keyspaces.filter(function(item) {
+        return item.indexOf(searchText) != -1;
+      });
+    }
+  };
 
   $scope.submitSchema = function(ev) {
     var action = {

--- a/web/vtctld/shard.html
+++ b/web/vtctld/shard.html
@@ -7,6 +7,7 @@
   <span flex></span>
     <md-menu>
     <md-button class="md-icon-button" aria-label="Shard actions" ng-click="$mdOpenMenu()" md-menu-origin>
+      <md-tooltip>Shard Actions</md-tooltip>
       <md-icon md-font-set="material-icons">more_vert</md-icon>
     </md-button>
     <md-menu-content>
@@ -60,6 +61,7 @@
     <span flex></span>
     <md-menu>
     <md-button class="md-icon-button" aria-label="Tablet actions" ng-click="$mdOpenMenu()" md-menu-origin>
+      <md-tooltip>Tablet Actions</md-tooltip>
       <md-icon md-font-set="material-icons">more_vert</md-icon>
     </md-button>
     <md-menu-content>

--- a/web/vtctld/shard.html
+++ b/web/vtctld/shard.html
@@ -32,9 +32,8 @@
     <h3 flex="50">Master Tablet</h3>
     <div flex>
       <span ng-if="!shard.MasterAlias.Uid">None</span>
-      <a ng-if="shard.MasterAlias.Uid"
-        ng-href="#/tablets/{{shard.MasterAlias.Cell}}-{{shard.MasterAlias.Uid}}"
-        ng-bind="shard.MasterAlias.Cell+'-'+shard.MasterAlias.Uid"></a>
+      <span ng-if="shard.MasterAlias.Uid"
+        ng-bind="shard.MasterAlias.Cell+'-'+shard.MasterAlias.Uid"></span>
     </div>
   </div>
 </div>

--- a/web/vtctld/topo.html
+++ b/web/vtctld/topo.html
@@ -7,6 +7,7 @@
 
 <div class="breadcrumb md-whiteframe-z1">
   <md-button href="#/topo/">
+    <md-tooltip>Topo Root</md-tooltip>
     <md-icon md-font-set="material-icons">folder</md-icon>
   </md-button>
   <span class="breadcrumb-divider">/</span>

--- a/web/vtctld/vschema/add-keyspace-dialog.html
+++ b/web/vtctld/vschema/add-keyspace-dialog.html
@@ -1,0 +1,35 @@
+<md-dialog aria-label="Add Keyspace">
+
+<md-toolbar>
+  <div class="md-toolbar-tools">
+  <h2>Add Keyspace</h2>
+  <span flex></span>
+  <md-button class="md-icon-button" ng-click="hide()">
+    <md-icon md-font-set="material-icons">close</md-icon>
+  </md-button>
+  </div>
+</md-toolbar>
+
+<md-dialog-content layout="column">
+
+  <md-autocomplete md-floating-label="Keyspace" md-min-length="0"
+      md-selected-item=""
+      md-selected-item-change=""
+      md-search-text="keyspace"
+      md-search-text-change=""
+      md-items="item in keyspaceSelector(keyspace)"
+      md-item-text="item" md-autofocus="false">
+    <md-item-template>
+      <span md-highlight-text="keyspace">{{item}}</span>
+    </md-item-template>
+    <md-not-found>No keyspaces found matching "{{keyspace}}".</md-not-found>
+  </md-autocomplete>
+
+</md-dialog-content>
+
+<div class="md-actions" layout="row" layout-align="end center">
+  <md-button ng-click="hide()">Cancel</md-button>
+  <md-button ng-click="addKeyspace(keyspace); hide()" class="md-primary">Add</md-button>
+</div>
+
+</md-dialog>

--- a/web/vtctld/vschema/add-keyspace-dialog.html
+++ b/web/vtctld/vschema/add-keyspace-dialog.html
@@ -10,9 +10,12 @@
   </div>
 </md-toolbar>
 
+<form name="addKeyspaceForm" ng-submit="addKeyspace(keyspace); hide()">
+
 <md-dialog-content layout="column">
 
   <md-autocomplete md-floating-label="Keyspace" md-min-length="0"
+      md-input-name="keyspace" required
       md-selected-item=""
       md-selected-item-change=""
       md-search-text="keyspace"
@@ -23,13 +26,19 @@
       <span md-highlight-text="keyspace">{{item}}</span>
     </md-item-template>
     <md-not-found>No keyspaces found matching "{{keyspace}}".</md-not-found>
+    <div ng-messages="addKeyspaceForm.keyspace.$error">
+      <div ng-message="required">Required</div>
+    </div>
   </md-autocomplete>
 
 </md-dialog-content>
 
 <div class="md-actions" layout="row" layout-align="end center">
   <md-button ng-click="hide()">Cancel</md-button>
-  <md-button ng-click="addKeyspace(keyspace); hide()" class="md-primary">Add</md-button>
+  <md-button type="submit" class="md-primary"
+      ng-disabled="addKeyspaceForm.$invalid">Add</md-button>
 </div>
+
+</form>
 
 </md-dialog>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -285,6 +285,7 @@ They are only used with the
             <div ng-messages="vindexForm.vindexType.$error">
               <div ng-message="required">Required</div>
               <div ng-message="vdefined">Undefined Vindex Type</div>
+              <div ng-message="vprimaryUnique">Primary vindex must be unique.</div>
               <div ng-message="vownedPrimaryFunctional">Owned primary vindex must have a functional type.</div>
               <div ng-message="vownedNonPrimaryLookup">Owned non-primary vindex must have a lookup type.</div>
             </div>
@@ -345,6 +346,7 @@ They are only used with the
         <md-not-found>No vindex types found matching "{{newVindexType}}".</md-not-found>
         <div ng-messages="vindexForm.vindexType.$error">
           <div ng-message="vdefined">Undefined Vindex Type</div>
+          <div ng-message="vprimaryUnique">Primary vindex must be unique.</div>
           <div ng-message="vownedPrimaryFunctional">Owned primary vindex must have a functional type.</div>
           <div ng-message="vownedNonPrimaryLookup">Owned non-primary vindex must have a lookup type.</div>
         </div>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -266,7 +266,7 @@ They are only used with the
 
       <md-input-container flex="30">
         <label>Vindex</label>
-        <input type="text" ng-model="vindexname" disabled class="input-header">
+        <input type="text" ng-model="vindexname" name="vindex" disabled class="input-header">
       </md-input-container>
 
       <div layout="column" flex>
@@ -285,14 +285,28 @@ They are only used with the
             <div ng-messages="vindexForm.vindexType.$error">
               <div ng-message="required">Required</div>
               <div ng-message="vdefined">Undefined Vindex Type</div>
+              <div ng-message="vownedPrimaryFunctional">Owned primary vindex must have a functional type.</div>
+              <div ng-message="vownedNonPrimaryLookup">Owned non-primary vindex must have a lookup type.</div>
             </div>
           </md-autocomplete>
           <input ng-hide="true" name="vindexType" ng-model="vindex.Type" vindex-type required>
 
-          <md-input-container flex>
-            <label>Owner</label>
-            <input type="text" ng-model="vindex.Owner">
-          </md-input-container>
+          <md-autocomplete flex md-floating-label="Owner" md-min-length="0"
+              md-selected-item=""
+              md-selected-item-change=""
+              md-search-text="vindex.Owner"
+              md-search-text-change=""
+              md-items="item in tableSelector(keyspace, vindex.Owner)"
+              md-item-text="item" md-autofocus="false">
+            <md-item-template>
+              <span md-highlight-text="vindex.Owner">{{item}}</span>
+            </md-item-template>
+            <md-not-found>No tables found matching "{{vindex.Owner}}".</md-not-found>
+            <div ng-messages="vindexForm.vindexOwner.$error">
+              <div ng-message="vdefined">Undefined Table</div>
+            </div>
+          </md-autocomplete>
+          <input ng-hide="true" name="vindexOwner" ng-model="vindex.Owner" vindex-owner>
         </div>
 
         <div layout="row" layout-wrap>
@@ -305,10 +319,10 @@ They are only used with the
       </form>
     </div>
 
-    <form name="addVindexForm" layout="row"
-        ng-submit="addVindex(keyspace, newVindex, newVindexType, newVindexOwner); newVindex=''; newVindexType=''; newVindexOwner=''; addVindexForm.$setUntouched()">
+    <form name="vindexForm" layout="row"
+        ng-submit="addVindex(keyspace, newVindex, newVindexType, newVindexOwner); newVindex=''; newVindexType=''; newVindexOwner=''; vindexForm.$setUntouched()">
       <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Vindex"
-          type="submit" ng-disabled="addVindexForm.$invalid">
+          type="submit" ng-disabled="vindexForm.$invalid">
         <md-tooltip>Add Vindex</md-tooltip>
         <md-icon md-font-set="material-icons">add</md-icon>
       </md-button>
@@ -329,16 +343,30 @@ They are only used with the
           <span md-highlight-text="newVindexType">{{item}}</span>
         </md-item-template>
         <md-not-found>No vindex types found matching "{{newVindexType}}".</md-not-found>
-        <div ng-messages="addVindexForm.vindexType.$error">
+        <div ng-messages="vindexForm.vindexType.$error">
           <div ng-message="vdefined">Undefined Vindex Type</div>
+          <div ng-message="vownedPrimaryFunctional">Owned primary vindex must have a functional type.</div>
+          <div ng-message="vownedNonPrimaryLookup">Owned non-primary vindex must have a lookup type.</div>
         </div>
       </md-autocomplete>
       <input ng-hide="true" name="vindexType" ng-model="newVindexType" vindex-type required>
 
-      <md-input-container flex>
-        <label>Owner</label>
-        <input type="text" ng-model="newVindexOwner">
-      </md-input-container>
+      <md-autocomplete flex md-floating-label="Owner" md-min-length="0"
+          md-selected-item=""
+          md-selected-item-change=""
+          md-search-text="newVindexOwner"
+          md-search-text-change=""
+          md-items="item in tableSelector(keyspace, newVindexOwner)"
+          md-item-text="item" md-autofocus="false">
+        <md-item-template>
+          <span md-highlight-text="newVindexOwner">{{item}}</span>
+        </md-item-template>
+        <md-not-found>No tables found matching "{{newVindexOwner}}".</md-not-found>
+        <div ng-messages="vindexForm.vindexOwner.$error">
+          <div ng-message="vdefined">Undefined Table</div>
+        </div>
+      </md-autocomplete>
+      <input ng-hide="true" name="vindexOwner" ng-model="newVindexOwner" vindex-owner>
     </div>
 
     </md-card-content>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -1,0 +1,307 @@
+<div class="md-padding md-whiteframe-z1 notice">
+Routing indexes are part of an experimental new feature.
+They are only used with the
+<a href="http://vitess.io/doc/VTGateV3/">VTGate V3 API</a>.
+</div>
+
+<md-content class="md-padding">
+
+<md-card>
+<md-toolbar>
+<div class="md-toolbar-tools">
+  <h2>Keyspaces</h2>
+
+  <span flex></span>
+
+  <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Keyspace"
+      ng-click="addKeyspaceDialog($event)">
+    <md-tooltip>Add Keyspace</md-tooltip>
+    <md-icon md-font-set="material-icons">add</md-icon>
+  </md-button>
+
+  <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Revert"
+      ng-disabled="!vschema.$resolved"
+      ng-click="refreshData()">
+    <md-tooltip>Revert All</md-tooltip>
+    <md-icon md-font-set="material-icons">undo</md-icon>
+  </md-button>
+
+  <md-button class="md-icon-button md-raised md-accent" aria-label="Save"
+      ng-disabled="!vschema.$resolved"
+      ng-click="submitVSchema($event)">
+    <md-tooltip>Save All</md-tooltip>
+    <md-icon md-font-set="material-icons">save</md-icon>
+  </md-button>
+</div>
+</md-toolbar>
+
+<div ng-if="!vschema.$resolved" flex layout="column" layout-align="center center" class="md-padding">
+  <md-progress-circular md-mode="indeterminate"></md-progress-circular>
+  <h3>Loading...</h3>
+</div>
+
+<div ng-if="vschema.$resolved && !hasKeys(vschema.Keyspaces)" flex layout="column" layout-align="center center" class="md-padding">
+  <h3>No keyspaces defined.</h3>
+</div>
+
+<md-tabs md-border-bottom md-center-tabs="false" ng-if="hasKeys(vschema.Keyspaces)" md-autoselect="true">
+  <md-tab ng-repeat="(key, value) in vschema.Keyspaces" label="{{key}}"
+      md-on-select="setKeyspace(key, value)">
+  </md-tab>
+</md-tabs>
+
+<md-card-content layout="column" ng-if="hasKeys(vschema.Keyspaces) && keyspace">
+
+  <div layout="row" layout-align="space-between">
+    <md-switch ng-model="keyspace.Sharded" ng-change="onShardedChange(keyspace)">
+      <h3>{{keyspace.Sharded ? 'Sharded' : 'Unsharded'}}</h3>
+    </md-switch>
+    <md-button class="md-icon-button md-raised"
+        ng-click="removeKeyspace(keyspacename)">
+        <md-tooltip>Remove Keyspace</md-tooltip>
+        <md-icon md-font-set="material-icons">remove</md-icon>
+    </md-button>
+  </div>
+
+  <md-card>
+    <md-toolbar class="md-primary md-hue-3">
+    <div class="md-toolbar-tools">
+      <h2>Tables</h2>
+    </div>
+    </md-toolbar>
+
+    <md-card-content layout="column">
+
+    <div layout="row" ng-repeat="(table, class) in keyspace.Tables">
+      <md-button class="md-icon-button md-raised" aria-label="Remove Table" ng-click="removeTable(keyspace, table)">
+        <md-tooltip>Remove Table</md-tooltip>
+        <md-icon md-font-set="material-icons">remove</md-icon>
+      </md-button>
+
+      <md-input-container flex>
+        <label>Table</label>
+        <input type="text" ng-model="table" disabled class="input-header">
+      </md-input-container>
+
+      <md-autocomplete flex md-floating-label="Class" md-min-length="0"
+          md-selected-item=""
+          md-selected-item-change=""
+          md-search-text="keyspace.Tables[table]"
+          md-search-text-change=""
+          md-items="item in classSelector(keyspace, keyspace.Tables[table])"
+          md-item-text="item" md-autofocus="false">
+        <md-item-template>
+          <span md-highlight-text="keyspace.Tables[table]">{{item}}</span>
+        </md-item-template>
+        <md-not-found>No classes found matching "{{keyspace.Tables[table]}}".</md-not-found>
+      </md-autocomplete>
+    </div>
+
+    <div layout="row">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Table" ng-click="addTable(keyspace, newTable, newTableClass); newTable=''; newTableClass=''">
+        <md-tooltip>Add Table</md-tooltip>
+        <md-icon md-font-set="material-icons">add</md-icon>
+      </md-button>
+
+      <md-input-container flex>
+        <label>Table</label>
+        <input type="text" ng-model="newTable" class="input-header">
+      </md-input-container>
+
+      <md-autocomplete flex md-floating-label="Class" md-min-length="0"
+          md-selected-item=""
+          md-selected-item-change=""
+          md-search-text="newTableClass"
+          md-search-text-change=""
+          md-items="item in classSelector(keyspace, newTableClass)"
+          md-item-text="item" md-autofocus="false">
+        <md-item-template>
+          <span md-highlight-text="keyspace.Tables[table]">{{item}}</span>
+        </md-item-template>
+        <md-not-found>No classes found matching "{{keyspace.Tables[table]}}".</md-not-found>
+      </md-autocomplete>
+    </div>
+
+    </md-card-content>
+  </md-card>
+
+  <md-card ng-if="keyspace.Sharded">
+    <md-toolbar class="md-primary md-hue-3">
+    <div class="md-toolbar-tools">
+      <h2>Classes</h2>
+    </div>
+    </md-toolbar>
+
+    <md-card-content layout="column">
+
+    <div layout="row" layout-align="start start"
+        ng-repeat="(classname, classval) in keyspace.Classes">
+      <md-button class="md-icon-button md-raised" aria-label="Remove Class" ng-click="removeClass(keyspace, classname)">
+        <md-tooltip>Remove Class</md-tooltip>
+        <md-icon md-font-set="material-icons">remove</md-icon>
+      </md-button>
+
+      <md-input-container flex="30">
+        <label>Class</label>
+        <input type="text" ng-model="classname" disabled class="input-header">
+      </md-input-container>
+
+      <div layout="column" flex>
+
+      <div layout="row" ng-repeat="col in classval.ColVindexes">
+        <md-input-container flex>
+          <label>Column</label>
+          <input type="text" ng-model="col.Col">
+        </md-input-container>
+
+        <md-autocomplete flex md-floating-label="Vindex" md-min-length="0"
+            md-selected-item=""
+            md-selected-item-change=""
+            md-search-text="col.Name"
+            md-search-text-change=""
+            md-items="item in vindexSelector(keyspace, col.Name)"
+            md-item-text="item" md-autofocus="false">
+          <md-item-template>
+            <span md-highlight-text="col.Name">{{item}}</span>
+          </md-item-template>
+          <md-not-found>No vindexes found matching "{{col.Name}}".</md-not-found>
+        </md-autocomplete>
+
+        <md-button class="md-icon-button md-raised" aria-label="Remove Column" ng-click="removeColumn(keyspace, classname, $index)">
+          <md-tooltip>Remove Column</md-tooltip>
+          <md-icon md-font-set="material-icons">remove</md-icon>
+        </md-button>
+      </div>
+
+      <div layout="row">
+        <md-input-container flex>
+          <label>Column</label>
+          <input type="text" ng-model="newCol">
+        </md-input-container>
+
+        <md-autocomplete flex md-floating-label="Vindex" md-min-length="0"
+            md-selected-item=""
+            md-selected-item-change=""
+            md-search-text="newColVindex"
+            md-search-text-change=""
+            md-items="item in vindexSelector(keyspace, newColVindex)"
+            md-item-text="item" md-autofocus="false">
+          <md-item-template>
+            <span md-highlight-text="newColVindex">{{item}}</span>
+          </md-item-template>
+          <md-not-found>No vindexes found matching "{{newColVindex}}".</md-not-found>
+        </md-autocomplete>
+
+        <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Column" ng-click="addColumn(keyspace, classname, newCol, newColVindex); newCol=''; newColVindex=''">
+          <md-tooltip>Add Column</md-tooltip>
+          <md-icon md-font-set="material-icons">add</md-icon>
+        </md-button>
+      </div>
+
+      </div>
+    </div>
+
+    <div layout="row">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Class" ng-click="addClass(keyspace, newClass); newClass=''">
+        <md-tooltip>Add Class</md-tooltip>
+        <md-icon md-font-set="material-icons">add</md-icon>
+      </md-button>
+
+      <md-input-container flex="30">
+        <label>Class</label>
+        <input type="text" ng-model="newClass" class="input-header">
+      </md-input-container>
+    </div>
+
+    </md-card-content>
+  </md-card>
+
+  <md-card ng-if="keyspace.Sharded">
+    <md-toolbar class="md-primary md-hue-3">
+    <div class="md-toolbar-tools">
+      <h2>Vindexes</h2>
+    </div>
+    </md-toolbar>
+
+    <md-card-content layout="column">
+
+    <div layout="row" layout-align="start start"
+        ng-repeat="(vindexname, vindex) in keyspace.Vindexes">
+      <md-button class="md-icon-button md-raised" aria-label="Remove Vindex" ng-click="removeVindex(keyspace, vindexname)">
+        <md-tooltip>Remove Vindex</md-tooltip>
+        <md-icon md-font-set="material-icons">remove</md-icon>
+      </md-button>
+
+      <md-input-container flex="30">
+        <label>Vindex</label>
+        <input type="text" ng-model="vindexname" disabled class="input-header">
+      </md-input-container>
+
+      <div layout="column" flex>
+        <div layout="row">
+          <md-autocomplete flex md-floating-label="Type" md-min-length="0"
+              md-selected-item="selectedVindexType[keyspacename][vindexname]"
+              md-selected-item-change="onVindexTypeChange(vindex, selectedVindexType[keyspacename][vindexname])"
+              md-search-text="vindex.Type"
+              md-search-text-change="onVindexTypeChange(vindex, vindex.Type)"
+              md-items="item in vindexTypeSelector(vindex.Type)"
+              md-item-text="item" md-autofocus="false">
+            <md-item-template>
+              <span md-highlight-text="vindex.Type">{{item}}</span>
+            </md-item-template>
+            <md-not-found>No vindex types found matching "{{vindex.Type}}".</md-not-found>
+          </md-autocomplete>
+
+          <md-input-container flex>
+            <label>Owner</label>
+            <input type="text" ng-model="vindex.Owner">
+          </md-input-container>
+        </div>
+
+        <div layout="row" layout-wrap>
+          <md-input-container flex ng-repeat="(param, val) in vindex.Params">
+            <label>{{param}}</label>
+            <input type="text" ng-model="vindex.Params[param]">
+          </md-input-container>
+        </div>
+      </div>
+    </div>
+
+    <div layout="row">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Vindex" ng-click="addVindex(keyspace, newVindex, newVindexType, newVindexOwner); newVindex=''; newVindexType=''; newVindexOwner=''">
+        <md-tooltip>Add Vindex</md-tooltip>
+        <md-icon md-font-set="material-icons">add</md-icon>
+      </md-button>
+
+      <md-input-container flex="30">
+        <label>Vindex</label>
+        <input type="text" ng-model="newVindex" class="input-header">
+      </md-input-container>
+
+      <md-autocomplete flex md-floating-label="Type" md-min-length="0"
+          md-selected-item=""
+          md-selected-item-change=""
+          md-search-text="newVindexType"
+          md-search-text-change=""
+          md-items="item in vindexTypeSelector(newVindexType)"
+          md-item-text="item" md-autofocus="false">
+        <md-item-template>
+          <span md-highlight-text="newVindexType">{{item}}</span>
+        </md-item-template>
+        <md-not-found>No vindex types found matching "{{newVindexType}}".</md-not-found>
+      </md-autocomplete>
+
+      <md-input-container flex>
+        <label>Owner</label>
+        <input type="text" ng-model="newVindexOwner">
+      </md-input-container>
+    </div>
+
+    </md-card-content>
+  </md-card>
+
+</md-card-content>
+
+</md-card>
+
+</md-content>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -305,6 +305,7 @@ They are only used with the
             <md-not-found>No tables found matching "{{vindex.Owner}}".</md-not-found>
             <div ng-messages="vindexForm.vindexOwner.$error">
               <div ng-message="vdefined">Undefined Table</div>
+              <div ng-message="vcontained">Table's class doesn't contain this vindex.</div>
             </div>
           </md-autocomplete>
           <input ng-hide="true" name="vindexOwner" ng-model="vindex.Owner" vindex-owner>
@@ -366,6 +367,7 @@ They are only used with the
         <md-not-found>No tables found matching "{{newVindexOwner}}".</md-not-found>
         <div ng-messages="vindexForm.vindexOwner.$error">
           <div ng-message="vdefined">Undefined Table</div>
+          <div ng-message="vcontained">Table's class doesn't contain this vindex.</div>
         </div>
       </md-autocomplete>
       <input ng-hide="true" name="vindexOwner" ng-model="newVindexOwner" vindex-owner>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -6,8 +6,6 @@ They are only used with the
 
 <md-content class="md-padding">
 
-<md-form name="keyspacesForm">
-
 <md-card>
 <md-toolbar>
 <div class="md-toolbar-tools">
@@ -74,7 +72,8 @@ They are only used with the
 
     <md-card-content layout="column">
 
-    <div layout="row" ng-repeat="(table, class) in keyspace.Tables">
+    <div ng-repeat="(table, class) in keyspace.Tables">
+      <form name="tableForm" layout="row">
       <md-button class="md-icon-button md-raised" aria-label="Remove Table" ng-click="removeTable(keyspace, table)">
         <md-tooltip>Remove Table</md-tooltip>
         <md-icon md-font-set="material-icons">remove</md-icon>
@@ -85,7 +84,8 @@ They are only used with the
         <input type="text" ng-model="table" disabled class="input-header">
       </md-input-container>
 
-      <md-autocomplete flex md-floating-label="Class" md-min-length="0"
+      <md-autocomplete flex md-floating-label="Class"
+          md-min-length="keyspace.Sharded ? 0 : 1000"
           md-selected-item=""
           md-selected-item-change=""
           md-search-text="keyspace.Tables[table]"
@@ -96,21 +96,31 @@ They are only used with the
           <span md-highlight-text="keyspace.Tables[table]">{{item}}</span>
         </md-item-template>
         <md-not-found>No classes found matching "{{keyspace.Tables[table]}}".</md-not-found>
+        <div ng-messages="tableForm.classname.$error">
+          <div ng-message="vempty">Class should be empty for non-sharded keyspace.</div>
+          <div ng-message="vrequired">Required</div>
+          <div ng-message="vdefined">Undefined Class</div>
+        </div>
       </md-autocomplete>
+      <input ng-hide="true" name="classname" ng-model="keyspace.Tables[table]" vclass>
+      </form>
     </div>
 
-    <div layout="row">
-      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Table" ng-click="addTable(keyspace, newTable, newTableClass); newTable=''; newTableClass=''">
+    <form name="addTableForm" layout="row"
+          ng-submit="addTable(keyspace, newTable, newTableClass); newTable=''; newTableClass=''; addTableForm.$setUntouched()">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3"
+          type="submit" aria-label="Add Table" ng-disabled="addTableForm.$invalid">
         <md-tooltip>Add Table</md-tooltip>
         <md-icon md-font-set="material-icons">add</md-icon>
       </md-button>
 
       <md-input-container flex>
         <label>Table</label>
-        <input type="text" ng-model="newTable" class="input-header">
+        <input type="text" ng-model="newTable" name="table" class="input-header" required>
       </md-input-container>
 
-      <md-autocomplete flex md-floating-label="Class" md-min-length="0"
+      <md-autocomplete flex md-floating-label="Class"
+          md-min-length="keyspace.Sharded ? 0 : 1000"
           md-selected-item=""
           md-selected-item-change=""
           md-search-text="newTableClass"
@@ -121,8 +131,13 @@ They are only used with the
           <span md-highlight-text="keyspace.Tables[table]">{{item}}</span>
         </md-item-template>
         <md-not-found>No classes found matching "{{keyspace.Tables[table]}}".</md-not-found>
+        <div ng-messages="addTableForm.classname.$error">
+          <div ng-message="vempty">Class should be empty for non-sharded keyspace.</div>
+          <div ng-message="vdefined">Undefined Class</div>
+        </div>
       </md-autocomplete>
-    </div>
+      <input ng-hide="true" name="classname" ng-model="newTableClass" vclass>
+    </form>
 
     </md-card-content>
   </md-card>
@@ -150,7 +165,8 @@ They are only used with the
 
       <div layout="column" flex>
 
-      <div layout="row" ng-repeat="col in classval.ColVindexes">
+      <div ng-repeat="col in classval.ColVindexes">
+        <form name="classForm" layout="row">
         <md-input-container flex>
           <label>Column</label>
           <input type="text" ng-model="col.Col">
@@ -167,18 +183,25 @@ They are only used with the
             <span md-highlight-text="col.Name">{{item}}</span>
           </md-item-template>
           <md-not-found>No vindexes found matching "{{col.Name}}".</md-not-found>
+          <div ng-messages="classForm.vindex.$error">
+            <div ng-message="required">Required</div>
+            <div ng-message="vdefined">Undefined Vindex</div>
+          </div>
         </md-autocomplete>
+        <input ng-hide="true" name="vindex" ng-model="col.Name" vindex required>
 
         <md-button class="md-icon-button md-raised" aria-label="Remove Column" ng-click="removeColumn(keyspace, classname, $index)">
           <md-tooltip>Remove Column</md-tooltip>
           <md-icon md-font-set="material-icons">remove</md-icon>
         </md-button>
+        </form>
       </div>
 
-      <div layout="row">
+      <form name="addColumnForm" layout="row"
+          ng-submit="addColumn(keyspace, classname, newCol, newColVindex); newCol=''; newColVindex=''; addColumnForm.$setUntouched()">
         <md-input-container flex>
           <label>Column</label>
-          <input type="text" ng-model="newCol">
+          <input type="text" ng-model="newCol" name="column" required>
         </md-input-container>
 
         <md-autocomplete flex md-floating-label="Vindex" md-min-length="0"
@@ -192,28 +215,35 @@ They are only used with the
             <span md-highlight-text="newColVindex">{{item}}</span>
           </md-item-template>
           <md-not-found>No vindexes found matching "{{newColVindex}}".</md-not-found>
+          <div ng-messages="addColumnForm.vindex.$error">
+            <div ng-message="vdefined">Undefined Vindex</div>
+          </div>
         </md-autocomplete>
+        <input ng-hide="true" name="vindex" ng-model="newColVindex" vindex required>
 
-        <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Column" ng-click="addColumn(keyspace, classname, newCol, newColVindex); newCol=''; newColVindex=''">
+        <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Column"
+            type="submit" ng-disabled="addColumnForm.$invalid">
           <md-tooltip>Add Column</md-tooltip>
           <md-icon md-font-set="material-icons">add</md-icon>
         </md-button>
-      </div>
+      </form>
 
       </div>
     </div>
 
-    <div layout="row">
-      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Class" ng-click="addClass(keyspace, newClass); newClass=''">
+    <form name="addClassForm" layout="row"
+        ng-submit="addClass(keyspace, newClass); newClass=''; addClassForm.$setUntouched()">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Class"
+          ng-disabled="addClassForm.$invalid">
         <md-tooltip>Add Class</md-tooltip>
         <md-icon md-font-set="material-icons">add</md-icon>
       </md-button>
 
       <md-input-container flex="30">
         <label>Class</label>
-        <input type="text" ng-model="newClass" class="input-header">
+        <input type="text" ng-model="newClass" class="input-header" name="class" required>
       </md-input-container>
-    </div>
+    </form>
 
     </md-card-content>
   </md-card>
@@ -227,8 +257,8 @@ They are only used with the
 
     <md-card-content layout="column">
 
-    <div layout="row" layout-align="start start"
-        ng-repeat="(vindexname, vindex) in keyspace.Vindexes">
+    <div ng-repeat="(vindexname, vindex) in keyspace.Vindexes">
+      <form name="vindexForm" layout="row" layout-align="start start">
       <md-button class="md-icon-button md-raised" aria-label="Remove Vindex" ng-click="removeVindex(keyspace, vindexname)">
         <md-tooltip>Remove Vindex</md-tooltip>
         <md-icon md-font-set="material-icons">remove</md-icon>
@@ -252,7 +282,12 @@ They are only used with the
               <span md-highlight-text="vindex.Type">{{item}}</span>
             </md-item-template>
             <md-not-found>No vindex types found matching "{{vindex.Type}}".</md-not-found>
+            <div ng-messages="vindexForm.vindexType.$error">
+              <div ng-message="required">Required</div>
+              <div ng-message="vdefined">Undefined Vindex Type</div>
+            </div>
           </md-autocomplete>
+          <input ng-hide="true" name="vindexType" ng-model="vindex.Type" vindex-type required>
 
           <md-input-container flex>
             <label>Owner</label>
@@ -267,17 +302,20 @@ They are only used with the
           </md-input-container>
         </div>
       </div>
+      </form>
     </div>
 
-    <div layout="row">
-      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Vindex" ng-click="addVindex(keyspace, newVindex, newVindexType, newVindexOwner); newVindex=''; newVindexType=''; newVindexOwner=''">
+    <form name="addVindexForm" layout="row"
+        ng-submit="addVindex(keyspace, newVindex, newVindexType, newVindexOwner); newVindex=''; newVindexType=''; newVindexOwner=''; addVindexForm.$setUntouched()">
+      <md-button class="md-icon-button md-raised md-primary md-hue-3" aria-label="Add Vindex"
+          type="submit" ng-disabled="addVindexForm.$invalid">
         <md-tooltip>Add Vindex</md-tooltip>
         <md-icon md-font-set="material-icons">add</md-icon>
       </md-button>
 
       <md-input-container flex="30">
         <label>Vindex</label>
-        <input type="text" ng-model="newVindex" class="input-header">
+        <input type="text" ng-model="newVindex" class="input-header" name="vindex" required>
       </md-input-container>
 
       <md-autocomplete flex md-floating-label="Type" md-min-length="0"
@@ -291,7 +329,11 @@ They are only used with the
           <span md-highlight-text="newVindexType">{{item}}</span>
         </md-item-template>
         <md-not-found>No vindex types found matching "{{newVindexType}}".</md-not-found>
+        <div ng-messages="addVindexForm.vindexType.$error">
+          <div ng-message="vdefined">Undefined Vindex Type</div>
+        </div>
       </md-autocomplete>
+      <input ng-hide="true" name="vindexType" ng-model="newVindexType" vindex-type required>
 
       <md-input-container flex>
         <label>Owner</label>
@@ -305,7 +347,5 @@ They are only used with the
 </md-card-content>
 
 </md-card>
-
-</md-form>
 
 </md-content>

--- a/web/vtctld/vschema/vschema.html
+++ b/web/vtctld/vschema/vschema.html
@@ -6,6 +6,8 @@ They are only used with the
 
 <md-content class="md-padding">
 
+<md-form name="keyspacesForm">
+
 <md-card>
 <md-toolbar>
 <div class="md-toolbar-tools">
@@ -303,5 +305,7 @@ They are only used with the
 </md-card-content>
 
 </md-card>
+
+</md-form>
 
 </md-content>

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -295,6 +295,22 @@ app.directive('vindexType', function() {
           return viewValue in vindexInfo.types;
         return true;
       };
+      ctrl.$validators.vprimaryUnique = function(modelValue, viewValue) {
+        var form = scope.vindexForm;
+        var type = viewValue;
+        var vindex = form.vindex.$modelValue;
+        if (vindexInfo.types[type] && !vindexInfo.types[type].unique) {
+          // It's not unique. Make sure it isn't primary.
+          for (var classname in scope.keyspace.Classes) {
+            var cls = scope.keyspace.Classes[classname];
+            if (cls.ColVindexes && cls.ColVindexes[0]
+                  && cls.ColVindexes[0].Name == vindex) {
+              return false;
+            }
+          }
+        }
+        return true;
+      };
       ctrl.$validators.vownedPrimaryFunctional = function(modelValue, viewValue) {
         var form = scope.vindexForm;
         var type = viewValue;

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -74,7 +74,7 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
         },
         function(httpErr) {
           result.$resolved = true;
-          result.Output = httpErr;
+          result.Output = httpErr.data;
           result.Error = true;
         });
 
@@ -164,7 +164,7 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
       if (!keyspace.Classes)
         keyspace.Classes = {};
       if (!keyspace.Classes[classname])
-        keyspace.Classes[classname] = {};
+        keyspace.Classes[classname] = {ColVindexes: []};
     }
   };
 

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -362,6 +362,25 @@ app.directive('vindexOwner', function() {
           return viewValue in scope.keyspace.Tables;
         return true;
       };
+      ctrl.$validators.vcontained = function(modelValue, viewValue) {
+        var form = scope.vindexForm;
+        var vindex = form.vindex.$modelValue;
+
+        if (viewValue && scope.keyspace.Tables[viewValue]) {
+          var classname = scope.keyspace.Tables[viewValue];
+          if (classname && scope.keyspace.Classes[classname]) {
+            var cls = scope.keyspace.Classes[classname];
+            if (cls.ColVindexes) {
+              for (var i = 0; i < cls.ColVindexes.length; i++) {
+                if (cls.ColVindexes[i].Name == vindex)
+                  return true;
+              }
+            }
+            return false;
+          }
+        }
+        return true;
+      };
     }
   };
 });

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -155,7 +155,7 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
       if (!keyspace.Tables)
         keyspace.Tables = {};
       if (!keyspace.Tables[table])
-        keyspace.Tables[table] = classname;
+        keyspace.Tables[table] = keyspace.Sharded ? classname : '';
     }
   };
 
@@ -216,6 +216,8 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
     } else {
       delete keyspace.Classes;
       delete keyspace.Vindexes;
+      for (var table in keyspace.Tables)
+        keyspace.Tables[table] = '';
     }
   };
 
@@ -235,6 +237,55 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
         if (!vindex.Params[param])
           vindex.Params[param] = '';
       });
+    }
+  };
+});
+
+app.directive('vclass', function() {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attrs, ctrl) {
+      ctrl.$validators.vempty = function(modelValue, viewValue) {
+        if (!scope.keyspace.Sharded)
+          return viewValue == '';
+        return true;
+      };
+      ctrl.$validators.vrequired = function(modelValue, viewValue) {
+        if (scope.keyspace.Sharded)
+          return !!viewValue;
+        return true;
+      };
+      ctrl.$validators.vdefined = function(modelValue, viewValue) {
+        if (viewValue && scope.keyspace.Sharded)
+          return viewValue in scope.keyspace.Classes;
+        return true;
+      };
+    }
+  };
+});
+
+app.directive('vindex', function() {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attrs, ctrl) {
+      ctrl.$validators.vdefined = function(modelValue, viewValue) {
+        if (viewValue)
+          return viewValue in scope.keyspace.Vindexes;
+        return true;
+      };
+    }
+  };
+});
+
+app.directive('vindexType', function() {
+  return {
+    require: 'ngModel',
+    link: function(scope, elem, attrs, ctrl) {
+      ctrl.$validators.vdefined = function(modelValue, viewValue) {
+        if (viewValue)
+          return viewValue in vindexInfo.types;
+        return true;
+      };
     }
   };
 });

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -58,6 +58,30 @@ app.controller('VSchemaCtrl', function($scope, $mdDialog,
   };
   $scope.refreshData();
 
+  $scope.submitVSchema = function(ev) {
+    var action = {
+      title: 'Save VSchema',
+      confirm: 'This will update the stored VSchema in topology.'
+    };
+    actions.applyFunc(ev, action, function() {
+      var result = {$resolved: false};
+
+      $scope.vschema.$save(
+        function() {
+          result.$resolved = true;
+          result.Output = 'VSchema Saved';
+          result.Error = false;
+        },
+        function(httpErr) {
+          result.$resolved = true;
+          result.Output = httpErr;
+          result.Error = true;
+        });
+
+      return result;
+    });
+  };
+
   $scope.hasKeys = function(obj) {
     if (obj) {
       for (var key in obj)

--- a/web/vtctld/vschema/vschema.js
+++ b/web/vtctld/vschema/vschema.js
@@ -1,0 +1,216 @@
+vindexInfo = {};
+vindexInfo.types = {
+  "numeric": {
+      "Type": "functional",
+      "Unique": true,
+      "Params": []
+  },
+  "hash": {
+      "Type": "functional",
+      "Unique": true,
+      "Params": [
+          "Table", "Column"
+      ]
+  },
+  "hash_autoinc": {
+      "Type": "functional",
+      "Unique": true,
+      "Params": [
+          "Table", "Column"
+      ]
+  },
+  "lookup_hash": {
+      "Type": "lookup",
+      "Unique": false,
+      "Params": [
+          "Table", "From", "To"
+      ]
+  },
+  "lookup_hash_unique": {
+      "Type": "lookup",
+      "Unique": true,
+      "Params": [
+          "Table", "From", "To"
+      ]
+  },
+  "lookup_hash_autoinc": {
+      "Type": "lookup",
+      "Unique": false,
+      "Params": [
+          "Table", "From", "To"
+      ]
+  },
+  "lookup_hash_unique_autoinc": {
+      "Type": "lookup",
+      "Unique": true,
+      "Params": [
+          "Table", "From", "To"
+      ]
+  }
+};
+vindexInfo.typeNames = Object.keys(vindexInfo.types).sort();
+
+app.controller('VSchemaCtrl', function($scope, $mdDialog,
+               actions, vschema, keyspaces) {
+  $scope.refreshData = function() {
+    $scope.vschema = vschema.get();
+    $scope.keyspaces = keyspaces.query();
+  };
+  $scope.refreshData();
+
+  $scope.hasKeys = function(obj) {
+    if (obj) {
+      for (var key in obj)
+        return true;
+    }
+    return false;
+  };
+
+  keyspaceSelector = function(searchText) {
+    if (!searchText) return $scope.keyspaces;
+    return $scope.keyspaces.filter(function(item) {
+      return item.indexOf(searchText) != -1;
+    });
+  };
+
+  $scope.classSelector = function(keyspace, searchText) {
+    if (!keyspace.Classes) return [];
+    var items = Object.keys(keyspace.Classes).sort();
+    if (!searchText) return items;
+    return items.filter(function(item) {
+      return item.indexOf(searchText) != -1;
+    });
+  };
+
+  $scope.vindexSelector = function(keyspace, searchText) {
+    if (!keyspace.Vindexes) return [];
+    var items = Object.keys(keyspace.Vindexes).sort();
+    if (!searchText) return items;
+    return items.filter(function(item) {
+      return item.indexOf(searchText) != -1;
+    });
+  };
+
+  $scope.vindexTypeSelector = function(searchText) {
+    if (!searchText) return vindexInfo.typeNames;
+    return vindexInfo.typeNames.filter(function(item) {
+      return item.indexOf(searchText) != -1;
+    });
+  };
+
+  $scope.setKeyspace = function(name, keyspace) {
+    $scope.keyspace = keyspace;
+    $scope.keyspacename = name;
+  };
+
+  function addKeyspace(keyspace) {
+    if (keyspace) {
+      if (!$scope.vschema.Keyspaces)
+        $scope.vschema.Keyspaces = {};
+      if (!$scope.vschema.Keyspaces[keyspace])
+        $scope.vschema.Keyspaces[keyspace] = {};
+    }
+  }
+
+  $scope.addKeyspaceDialog = function(ev) {
+    $mdDialog.show({
+      controller: function($scope, $mdDialog) {
+        $scope.hide = function() { $mdDialog.hide(); };
+        $scope.keyspace = '';
+        $scope.addKeyspace = addKeyspace;
+        $scope.keyspaceSelector = keyspaceSelector;
+      },
+      templateUrl: 'vschema/add-keyspace-dialog.html',
+      parent: angular.element(document.body),
+      targetEvent: ev
+    });
+  };
+
+  $scope.addTable = function(keyspace, table, classname) {
+    if (table) {
+      if (!keyspace.Tables)
+        keyspace.Tables = {};
+      if (!keyspace.Tables[table])
+        keyspace.Tables[table] = classname;
+    }
+  };
+
+  $scope.addClass = function(keyspace, classname) {
+    if (classname) {
+      if (!keyspace.Classes)
+        keyspace.Classes = {};
+      if (!keyspace.Classes[classname])
+        keyspace.Classes[classname] = {};
+    }
+  };
+
+  $scope.addColumn = function(keyspace, classname, col, vindex) {
+    if (!keyspace.Classes[classname].ColVindexes)
+      keyspace.Classes[classname].ColVindexes = [];
+    keyspace.Classes[classname].ColVindexes.push(
+      {Col: col, Name: vindex}
+    );
+  };
+
+  $scope.addVindex = function(keyspace, vindex, type, owner) {
+    if (vindex) {
+      if (!keyspace.Vindexes)
+        keyspace.Vindexes = {};
+      if (!keyspace.Vindexes[vindex]) {
+        keyspace.Vindexes[vindex] = {Type: type, Owner: owner};
+        $scope.onVindexTypeChange(keyspace.Vindexes[vindex], type);
+      }
+    }
+  };
+
+  $scope.removeTable = function(keyspace, table) {
+    delete keyspace.Tables[table];
+  };
+
+  $scope.removeKeyspace = function(keyspacename) {
+    delete $scope.vschema.Keyspaces[keyspacename];
+  };
+
+  $scope.removeClass = function(keyspace, classname) {
+    delete keyspace.Classes[classname];
+  };
+
+  $scope.removeColumn = function(keyspace, classname, index) {
+    keyspace.Classes[classname].ColVindexes.splice(index, 1);
+  };
+
+  $scope.removeVindex = function(keyspace, vindex) {
+    delete keyspace.Vindexes[vindex];
+  };
+
+  $scope.onShardedChange = function(keyspace) {
+    if (keyspace.Sharded) {
+      if (!keyspace.Classes)
+        keyspace.Classes = {};
+      if (!keyspace.Vindexes)
+        keyspace.Vindexes = {};
+    } else {
+      delete keyspace.Classes;
+      delete keyspace.Vindexes;
+    }
+  };
+
+  $scope.onVindexTypeChange = function(vindex, type) {
+    if (type in vindexInfo.types) {
+      params = vindexInfo.types[type].Params;
+      if (!vindex.Params)
+        vindex.Params = {};
+
+      // Remove params that shouldn't be there.
+      for (var param in vindex.Params) {
+        if (params.indexOf(param) == -1)
+          delete vindex.Params[param];
+      }
+      // Add params that should be there but aren't.
+      params.forEach(function (param) {
+        if (!vindex.Params[param])
+          vindex.Params[param] = '';
+      });
+    }
+  };
+});


### PR DESCRIPTION
@sougou @alainjobart 

With this, I believe the new UI is essentially at feature parity with the old one. So I've set it to default to the new one with a redirect.

The old, non-Angular pages like /dbtopo and /serving_graph are still available as fallback if you know the URLs. Once we're comfortable with the new UI, we can remove those and delete a bunch of old code and templates.