### PR TITLE
refactor java client pom structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ site_test: unit_test site_integration_test
 
 clean:
 	go clean -i ./go/...
-	rm -rf java/vtocc-client/target java/vtocc-jdbc-driver/target third_party/acolyte
+	rm -rf third_party/acolyte
 
 unit_test:
 	godep go test $(VT_GO_PARALLEL) ./go/...
@@ -194,7 +194,7 @@ site_integration_test:
 	$(call run_integration_tests, $(site_integration_test_files))
 
 java_vtgate_client_test:
-	mvn -f java/vtgate-client/pom.xml clean verify
+	mvn -f java/pom.xml clean verify
 
 v3_test:
 	cd test && ./vtgatev3_test.py

--- a/java/gorpc/pom.xml
+++ b/java/gorpc/pom.xml
@@ -1,26 +1,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.youtube.vitess</groupId>
+    <artifactId>vitess-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
   <groupId>com.youtube.vitess</groupId>
   <artifactId>gorpc-client</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <distributionManagement>
-    <repository>
-      <id>repo</id>
-      <url>https://github.com/youtube/mvn-repo/raw/master/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>snapshot-repo</id>
-      <url>https://github.com/youtube/mvn-repo/raw/master/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
@@ -37,19 +26,9 @@
       <version>2.3.1</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>
-    <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
       <version>2.12.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>11.0.2</version>
     </dependency>
   </dependencies>
   <build>
@@ -68,23 +47,8 @@
         <version>2.17</version>
         <configuration>
           <argLine>${surefireArgLine}</argLine>
+          <skipTests>true</skipTests>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>2.13</version>
-        <configuration>
-          <argLine>${failsafeArgLine}</argLine>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/java/gorpc/src/main/java/com/youtube/vitess/gorpc/Client.java
+++ b/java/gorpc/src/main/java/com/youtube/vitess/gorpc/Client.java
@@ -99,7 +99,7 @@ public class Client {
     if (isStreaming) {
       throw new GoRpcException("request not allowed as client is in the middle of streaming");
     }
-    seq = seq.add(UnsignedLong.ONE);
+    seq = seq.plus(UnsignedLong.ONE);
     Request request = new Request(serviceMethod, seq);
     try {
       codec.WriteRequest(request, args);

--- a/java/gorpc/src/main/java/com/youtube/vitess/gorpc/codecs/bson/GoRpcBsonDecoder.java
+++ b/java/gorpc/src/main/java/com/youtube/vitess/gorpc/codecs/bson/GoRpcBsonDecoder.java
@@ -51,7 +51,7 @@ public class GoRpcBsonDecoder extends ExtendableBsonDecoder {
 
   public static class GoRpcBSONCallBack extends BasicBSONCallback {
     public void gotULong(final String name, final long v) {
-      final UnsignedLong ulv = UnsignedLong.asUnsigned(v);
+      final UnsignedLong ulv = UnsignedLong.fromLongBits(v);
       _put(name, ulv);
     }
   }

--- a/java/gorpc/src/test/java/com/youtube/vitess/gorpc/ClientIT.java
+++ b/java/gorpc/src/test/java/com/youtube/vitess/gorpc/ClientIT.java
@@ -118,7 +118,7 @@ public class ClientIT extends ClientTest {
     BSONObject mArgs = new BasicBSONObject();
     mArgs.put("Num", a);
     Response response = client.call("Arith.Increment", mArgs);
-    Assert.assertEquals(a.add(UnsignedLong.ONE), (UnsignedLong) response.getReply());
+    Assert.assertEquals(a.plus(UnsignedLong.ONE), (UnsignedLong) response.getReply());
     client.close();
   }
 }

--- a/java/gorpc/src/test/java/com/youtube/vitess/gorpc/FakeGoServer.java
+++ b/java/gorpc/src/test/java/com/youtube/vitess/gorpc/FakeGoServer.java
@@ -37,8 +37,9 @@ public class FakeGoServer extends Thread {
         new ArithThread(clientSocket).start();
       }
     } catch (SocketException e) {
+      throw new RuntimeException(e);
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new RuntimeException(e);
     }
   }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -3,10 +3,10 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0   http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.youtube.vitess</groupId>
+    <groupId>com.youtube.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <packaging>pom</packaging>
     <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
     <url>https://github.com/youtube/vitess/</url>
     <description>Umbrella project for all Java activities for Vitess</description>
     <inceptionYear>2014</inceptionYear>
@@ -57,4 +57,30 @@
             <archive>https://groups.google.com/forum/#!forum/vitess</archive>
         </mailingList>
     </mailingLists>
+
+    <!-- define dependency versions -->
+    <properties>
+      <guava.version>18.0</guava.version>
+      <junit.version>4.12</junit.version>
+      <log4j.version>1.2.17</log4j.version>
+    </properties>
+
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
 </project>

--- a/java/vtgate-client/pom.xml
+++ b/java/vtgate-client/pom.xml
@@ -1,44 +1,22 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.youtube.vitess</groupId>
+    <artifactId>vitess-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
   <groupId>com.youtube.vitess</groupId>
   <artifactId>vtgate-client</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-  <distributionManagement>
-    <repository>
-      <id>repo</id>
-      <url>https://github.com/youtube/mvn-repo/raw/master/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>snapshot-repo</id>
-      <url>https://github.com/youtube/mvn-repo/raw/master/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-  <repositories>
-    <repository>
-      <id>youtube-snapshots</id>
-      <url>https://github.com/youtube/mvn-repo/raw/master/snapshots</url>
-    </repository>
-  </repositories>
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.youtube.vitess</groupId>
       <artifactId>gorpc-client</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>


### PR DESCRIPTION
1. move common dependencies into parent pom.
2. upgrade com.google.guava to 18.0.