### PR TITLE
go 1.5 prep

### DIFF
--- a/go/hack/hack.go
+++ b/go/hack/hack.go
@@ -31,6 +31,9 @@ func NewStringArena(size int) *StringArena {
 // NewString copies a byte slice into the arena and returns it as a string.
 // If the arena is full, it returns a traditional go string.
 func (sa *StringArena) NewString(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
 	if len(sa.buf)+len(b) > cap(sa.buf) {
 		return string(b)
 	}
@@ -47,6 +50,9 @@ func (sa *StringArena) SpaceLeft() int {
 // String force casts a []byte to a string.
 // USE AT YOUR OWN RISK
 func String(b []byte) (s string) {
+	if len(b) == 0 {
+		return ""
+	}
 	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	pstring.Data = pbytes.Data

--- a/go/hack/hack_test.go
+++ b/go/hack/hack_test.go
@@ -4,35 +4,34 @@
 
 package hack
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestStringArena(t *testing.T) {
 	sarena := NewStringArena(10)
-	buf1 := []byte("01234")
-	buf2 := []byte("5678")
-	buf3 := []byte("ab")
-	buf4 := []byte("9")
 
-	s1 := sarena.NewString(buf1)
+	s0 := sarena.NewString(nil)
+	checkint(t, len(sarena.buf), 0)
+	checkint(t, sarena.SpaceLeft(), 10)
+	checkstring(t, s0, "")
+
+	s1 := sarena.NewString([]byte("01234"))
 	checkint(t, len(sarena.buf), 5)
 	checkint(t, sarena.SpaceLeft(), 5)
 	checkstring(t, s1, "01234")
 
-	s2 := sarena.NewString(buf2)
+	s2 := sarena.NewString([]byte("5678"))
 	checkint(t, len(sarena.buf), 9)
 	checkint(t, sarena.SpaceLeft(), 1)
 	checkstring(t, s2, "5678")
 
 	// s3 will be allocated outside of sarena
-	s3 := sarena.NewString(buf3)
+	s3 := sarena.NewString([]byte("ab"))
 	checkint(t, len(sarena.buf), 9)
 	checkint(t, sarena.SpaceLeft(), 1)
 	checkstring(t, s3, "ab")
 
 	// s4 should still fit in sarena
-	s4 := sarena.NewString(buf4)
+	s4 := sarena.NewString([]byte("9"))
 	checkint(t, len(sarena.buf), 10)
 	checkint(t, sarena.SpaceLeft(), 0)
 	checkstring(t, s4, "9")
@@ -59,5 +58,22 @@ func checkstring(t *testing.T, actual, expected string) {
 func checkint(t *testing.T, actual, expected int) {
 	if actual != expected {
 		t.Errorf("received %d, expecting %d", actual, expected)
+	}
+}
+
+func TestByteToString(t *testing.T) {
+	v1 := []byte("1234")
+	if s := String(v1); s != "1234" {
+		t.Errorf("String(\"1234\"): %q, want 1234", s)
+	}
+
+	v1 = []byte("")
+	if s := String(v1); s != "" {
+		t.Errorf("String(\"\"): %q, want empty", s)
+	}
+
+	v1 = nil
+	if s := String(v1); s != "" {
+		t.Errorf("String(\"\"): %q, want empty", s)
 	}
 }

--- a/go/memcache/memcache_test.go
+++ b/go/memcache/memcache_test.go
@@ -265,9 +265,9 @@ func TestMemcache(t *testing.T) {
 	// timeout test
 	c.timeout = 1 * time.Nanosecond
 	results, err = c.Gets("key1", "key3", "key2")
-	want := "write unix /tmp/vt_memcache_test.sock: i/o timeout"
-	if err == nil || err.Error() != want {
-		t.Errorf("want %s, got %v", want, err)
+	want := "i/o timeout"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("\"%v\" does not contain \"%s\"", err, want)
 	}
 
 	// test double close

--- a/go/proc/proc.go
+++ b/go/proc/proc.go
@@ -29,7 +29,9 @@ const pidURL = "/debug/pid"
 // signal requesting the server to shutdown, and then attempts to
 // to create the listener.
 func Listen(port string) (l net.Listener, err error) {
-	killPredecessor(port)
+	if port != "" {
+		killPredecessor(port)
+	}
 	return listen(port)
 }
 


### PR DESCRIPTION
In go 1.5, empty strings have a unique representation. So, i've
changed hack.go to use the go-defined way rather than our own.
Some connection error strings have changed. Changed memcache
test to be more agnostic of that.
A new warning was printed for counting_listener_test.go, which indicated
a minor bug. Fixed.