### PR TITLE
automation: Add newlines between LoggerEvents returned by vtctld and …

### DIFF
--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -32,15 +32,8 @@ func ExecuteVtctl(ctx context.Context, server string, args []string) (string, er
 // structs to a given buffer, one line per event.
 // The buffer can be used to return a multi-line string with all events.
 func CreateLoggerEventToBufferFunction(output *bytes.Buffer) func(*logutil.LoggerEvent) {
-	passedFirstLine := false
-
 	return func(e *logutil.LoggerEvent) {
-		if !passedFirstLine {
-			passedFirstLine = true
-		} else {
-			// After the first line, add a newline before each subsequent line.
-			output.WriteRune('\n')
-		}
 		e.ToBuffer(output)
+		output.WriteRune('\n')
 	}
 }

--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -23,9 +23,24 @@ func ExecuteVtctl(ctx context.Context, server string, args []string) (string, er
 		30*time.Second, // dialTimeout
 		time.Hour,      // actionTimeout
 		10*time.Second, // lockWaitTimeout
-		func(e *logutil.LoggerEvent) {
-			e.ToBuffer(&output)
-		})
+		CreateLoggerEventToBufferFunction(&output))
 
 	return output.String(), err
+}
+
+// CreateLoggerEventToBufferFunction returns a function to add LoggerEvent
+// structs to a given buffer, one line per event.
+// The buffer can be used to return a multi-line string with all events.
+func CreateLoggerEventToBufferFunction(output *bytes.Buffer) func(*logutil.LoggerEvent) {
+	passedFirstLine := false
+
+	return func(e *logutil.LoggerEvent) {
+		if !passedFirstLine {
+			passedFirstLine = true
+		} else {
+			// After the first line, add a newline before each subsequent line.
+			output.WriteRune('\n')
+		}
+		e.ToBuffer(output)
+	}
 }

--- a/go/vt/automation/vtworkerclient_wrapper.go
+++ b/go/vt/automation/vtworkerclient_wrapper.go
@@ -7,7 +7,6 @@ package automation
 import (
 	"bytes"
 
-	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 	"golang.org/x/net/context"
 )
@@ -18,9 +17,7 @@ func ExecuteVtworker(ctx context.Context, server string, args []string) (string,
 
 	err := vtworkerclient.RunCommandAndWait(
 		ctx, server, args,
-		func(e *logutil.LoggerEvent) {
-			e.ToBuffer(&output)
-		})
+		CreateLoggerEventToBufferFunction(&output))
 
 	return output.String(), err
 }


### PR DESCRIPTION
…vtworker.

This makes the output more readable. Otherwise, all lines would show up on a single line.

@aaijazi 