### PR TITLE
sqlparser: escape keyword names correctly

### DIFF
--- a/data/test/sqlparser_test/parse_pass.sql
+++ b/data/test/sqlparser_test/parse_pass.sql
@@ -8,10 +8,11 @@ select -1 from t where b = -2
 select 1 from t // aa#select 1 from t
 select 1 from t -- aa#select 1 from t
 select /* simplest */ 1 from t
+select /* keyword col */ `By` from t#select /* keyword col */ `by` from t
 select /* double star **/ 1 from t
 select /* double */ /* comment */ 1 from t
 select /* back-quote */ 1 from `t`#select /* back-quote */ 1 from t
-select /* back-quote keyword */ 1 from `from`#select /* back-quote keyword */ 1 from `from`
+select /* back-quote keyword */ 1 from `By`#select /* back-quote keyword */ 1 from `By`
 select /* @ */ @@a from b
 select /* \0 */ '\0' from a
 select 1 /* drop this comment */ from t#select 1 from t
@@ -28,7 +29,9 @@ select /* select list */ 1, 2 from t
 select /* * */ * from t
 select /* column alias */ a b from t#select /* column alias */ a as b from t
 select /* column alias with as */ a as b from t
+select /* keyword column alias */ a as `By` from t#select /* keyword column alias */ a as `by` from t
 select /* a.* */ a.* from t
+select /* `By`.* */ `By`.* from t
 select /* select with bool expr */ a = b from t
 select /* case_when */ case when a = b then c end from t
 select /* case_when_else */ case when a = b then c else d end from t
@@ -39,11 +42,13 @@ select /* table list */ 1 from t1, t2
 select /* parenthessis in table list 1 */ 1 from (t1), t2
 select /* parenthessis in table list 2 */ 1 from t1, (t2)
 select /* use */ 1 from t1 use index (a) where b = 1
+select /* keyword index */ 1 from t1 use index (`By`) where b = 1#select /* keyword index */ 1 from t1 use index (`by`) where b = 1
 select /* ignore */ 1 from t1 as t2 ignore index (a), t3 use index (b) where b = 1
 select /* use */ 1 from t1 as t2 use index (a), t3 use index (b) where b = 1
 select /* force */ 1 from t1 as t2 force index (a), t3 force index (b) where b = 1
 select /* table alias */ 1 from t t1#select /* table alias */ 1 from t as t1
 select /* table alias with as */ 1 from t as t1
+select /* keyword table alias */ 1 from t as `By`
 select /* join */ 1 from t1 join t2
 select /* straight_join */ 1 from t1 straight_join t2
 select /* left join */ 1 from t1 left join t2
@@ -55,6 +60,7 @@ select /* cross join */ 1 from t1 cross join t2
 select /* natural join */ 1 from t1 natural join t2
 select /* join on */ 1 from t1 join t2 on a = b
 select /* s.t */ 1 from s.t
+select /* keyword schema & table name */ 1 from `By`.`bY`
 select /* select in from */ 1 from (select 1 from t)
 select /* where */ 1 from t where a = b
 select /* and */ 1 from t where a = b and a = c
@@ -103,6 +109,7 @@ select /* if as func */ 1 from t where a = if(b)
 select /* function with distinct */ count(distinct a) from t
 select /* a */ a from t
 select /* a.b */ a.b from t
+select /* keyword a.b */ `By`.`bY` from t#select /* keyword a.b */ `By`.`by` from t
 select /* string */ 'a' from t
 select /* double quoted string */ "a" from t#select /* double quoted string */ 'a' from t
 select /* quote quote in string */ 'a''a' from t#select /* quote quote in string */ 'a\'a' from t
@@ -161,6 +168,7 @@ set /* simple */ a = 3
 set /* list */ a = 3, b = 4
 alter ignore table a add foo#alter table a
 alter table a add foo#alter table a
+alter table `By` add foo#alter table `By`
 alter table a alter foo#alter table a
 alter table a change foo#alter table a
 alter table a modify foo#alter table a
@@ -172,8 +180,10 @@ alter table a default foo#alter table a
 alter table a discard foo#alter table a
 alter table a import foo#alter table a
 alter table a rename b#rename table a b
+alter table `By` rename `bY`#rename table `By` `bY`
 alter table a rename to b#rename table a b
 create table a
+create table `by`
 create table if not exists a#create table a
 create index a on b#alter table b
 create unique index a on b#alter table b

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -15,7 +15,7 @@ import (
 // GetTableName returns the table name from the SimpleTableExpr
 // only if it's a simple expression. Otherwise, it returns "".
 func GetTableName(node SimpleTableExpr) string {
-	if n, ok := node.(*TableName); ok && n.Qualifier == nil {
+	if n, ok := node.(*TableName); ok && n.Qualifier == "" {
 		return string(n.Name)
 	}
 	// sub-select or '.' expression
@@ -47,7 +47,7 @@ func IsValue(node ValExpr) bool {
 	return false
 }
 
-// HasINCaluse returns true if any of the conditions has an IN clause.
+// HasINClause returns true if any of the conditions has an IN clause.
 func HasINClause(conditions []BoolExpr) bool {
 	for _, node := range conditions {
 		if c, ok := node.(*ComparisonExpr); ok && c.Operator == AST_IN {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -197,8 +197,8 @@ func (node *Set) Format(buf *TrackedBuffer) {
 // NewName is set for AST_ALTER, AST_CREATE, AST_RENAME.
 type DDL struct {
 	Action  string
-	Table   TableID
-	NewName TableID
+	Table   SQLName
+	NewName SQLName
 }
 
 const (
@@ -259,7 +259,7 @@ func (*NonStarExpr) ISelectExpr() {}
 
 // StarExpr defines a '*' or 'table.*' expression.
 type StarExpr struct {
-	TableName TableID
+	TableName SQLName
 }
 
 func (node *StarExpr) Format(buf *TrackedBuffer) {
@@ -320,7 +320,7 @@ func (*JoinTableExpr) ITableExpr()    {}
 // coupled with an optional alias or index hint.
 type AliasedTableExpr struct {
 	Expr  SimpleTableExpr
-	As    TableID
+	As    SQLName
 	Hints *IndexHints
 }
 
@@ -346,7 +346,7 @@ func (*Subquery) ISimpleTableExpr()  {}
 
 // TableName represents a table  name.
 type TableName struct {
-	Name, Qualifier TableID
+	Name, Qualifier SQLName
 }
 
 func (node *TableName) Format(buf *TrackedBuffer) {
@@ -647,7 +647,7 @@ func (node *NullVal) Format(buf *TrackedBuffer) {
 // ColName represents a column name.
 type ColName struct {
 	Name      SQLName
-	Qualifier TableID
+	Qualifier SQLName
 }
 
 func (node *ColName) Format(buf *TrackedBuffer) {
@@ -964,20 +964,10 @@ func (node OnDup) Format(buf *TrackedBuffer) {
 	buf.Myprintf(" on duplicate key update %v", UpdateExprs(node))
 }
 
-type TableID string
-
-func (node TableID) Format(buf *TrackedBuffer) {
-	if _, ok := keywords[strings.ToLower(string(node))]; ok {
-		buf.Myprintf("`%s`", string(node))
-		return
-	}
-	buf.Myprintf("%s", string(node))
-}
-
 type SQLName string
 
 func (node SQLName) Format(buf *TrackedBuffer) {
-	if _, ok := keywords[string(node)]; ok {
+	if _, ok := keywords[strings.ToLower(string(node))]; ok {
 		buf.Myprintf("`%s`", string(node))
 		return
 	}

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -35,7 +35,7 @@ func TestParse(t *testing.T) {
 			out = String(tree)
 		}
 		if out != tcase.output {
-			t.Error(fmt.Sprintf("File:%s Line:%v\n%q\n%q", tcase.file, tcase.lineno, tcase.output, out))
+			t.Errorf("File:%s Line:%v\n%q\n%q", tcase.file, tcase.lineno, tcase.output, out)
 		}
 	}
 }
@@ -43,20 +43,22 @@ func TestParse(t *testing.T) {
 func BenchmarkParse1(b *testing.B) {
 	sql := "select 'abcd', 20, 30.0, eid from a where 1=eid and name='3'"
 	for i := 0; i < b.N; i++ {
-		_, err := Parse(sql)
+		ast, err := Parse(sql)
 		if err != nil {
 			b.Fatal(err)
 		}
+		_ = String(ast)
 	}
 }
 
 func BenchmarkParse2(b *testing.B) {
 	sql := "select aaaa, bbb, ccc, ddd, eeee, ffff, gggg, hhhh, iiii from tttt, ttt1, ttt3 where aaaa = bbbb and bbbb = cccc and dddd+1 = eeee group by fff, gggg having hhhh = iiii and iiii = jjjj order by kkkk, llll limit 3, 4"
 	for i := 0; i < b.N; i++ {
-		_, err := Parse(sql)
+		ast, err := Parse(sql)
 		if err != nil {
 			b.Fatal(err)
 		}
+		_ = String(ast)
 	}
 }
 

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -158,7 +158,10 @@ const SHOW = 57425
 const DESCRIBE = 57426
 const EXPLAIN = 57427
 
-var yyToknames = []string{
+var yyToknames = [...]string{
+	"$end",
+	"error",
+	"$unk",
 	"LEX_ERROR",
 	"SELECT",
 	"INSERT",
@@ -256,15 +259,16 @@ var yyToknames = []string{
 	"SHOW",
 	"DESCRIBE",
 	"EXPLAIN",
+	"')'",
 }
-var yyStatenames = []string{}
+var yyStatenames = [...]string{}
 
 const yyEofCode = 1
 const yyErrCode = 2
 const yyMaxDepth = 200
 
 //line yacctab:1
-var yyExca = []int{
+var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
@@ -278,7 +282,7 @@ var yyStates []string
 
 const yyLast = 625
 
-var yyAct = []int{
+var yyAct = [...]int{
 
 	94, 163, 160, 366, 229, 333, 90, 91, 250, 62,
 	199, 296, 241, 288, 92, 63, 210, 179, 28, 29,
@@ -344,7 +348,7 @@ var yyAct = []int{
 	0, 0, 0, 0, 0, 0, 140, 144, 145, 146,
 	147, 148, 149, 150, 151,
 }
-var yyPact = []int{
+var yyPact = [...]int{
 
 	313, -1000, -1000, 195, -1000, -1000, -1000, -1000, -1000, -1000,
 	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -27,
@@ -386,7 +390,7 @@ var yyPact = []int{
 	143, -1000, 410, 356, -1000, 232, -1000, -1000, -1000, 232,
 	-1000, 232, -1000,
 }
-var yyPgo = []int{
+var yyPgo = [...]int{
 
 	0, 549, 548, 22, 543, 541, 539, 537, 535, 534,
 	532, 526, 524, 523, 443, 522, 521, 516, 25, 27,
@@ -397,7 +401,7 @@ var yyPgo = []int{
 	13, 9, 15, 205, 445, 434, 428, 425, 424, 423,
 	0, 26, 421, 166, 4,
 }
-var yyR1 = []int{
+var yyR1 = [...]int{
 
 	0, 1, 2, 2, 2, 2, 2, 2, 2, 2,
 	2, 2, 2, 3, 3, 4, 4, 5, 6, 7,
@@ -421,7 +425,7 @@ var yyR1 = []int{
 	66, 66, 66, 66, 66, 67, 67, 68, 68, 69,
 	69, 70, 73, 74, 71,
 }
-var yyR2 = []int{
+var yyR2 = [...]int{
 
 	0, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 	1, 1, 1, 12, 3, 7, 7, 8, 7, 3,
@@ -445,7 +449,7 @@ var yyR2 = []int{
 	1, 1, 1, 1, 1, 0, 1, 0, 1, 0,
 	2, 1, 1, 1, 0,
 }
-var yyChk = []int{
+var yyChk = [...]int{
 
 	-1000, -1, -2, -3, -4, -5, -6, -7, -8, -9,
 	-10, -11, -12, -13, 5, 6, 7, 8, 33, 85,
@@ -487,7 +491,7 @@ var yyChk = []int{
 	-61, -57, 16, 34, -74, 55, -74, -74, 7, 21,
 	-70, -70, -70,
 }
-var yyDef = []int{
+var yyDef = [...]int{
 
 	0, -2, 1, 2, 3, 4, 5, 6, 7, 8,
 	9, 10, 11, 12, 34, 34, 34, 34, 34, 197,
@@ -529,7 +533,7 @@ var yyDef = []int{
 	174, 13, 0, 0, 79, 0, 80, 81, 167, 0,
 	83, 0, 168,
 }
-var yyTok1 = []int{
+var yyTok1 = [...]int{
 
 	1, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
@@ -545,7 +549,7 @@ var yyTok1 = []int{
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 71, 3, 50,
 }
-var yyTok2 = []int{
+var yyTok2 = [...]int{
 
 	2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
 	12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
@@ -557,28 +561,56 @@ var yyTok2 = []int{
 	87, 88, 89, 90, 91, 92, 93, 94, 95, 96,
 	97, 98, 99, 100,
 }
-var yyTok3 = []int{
+var yyTok3 = [...]int{
 	0,
 }
+
+var yyErrorMessages = [...]struct {
+	state int
+	token int
+	msg   string
+}{}
 
 //line yaccpar:1
 
 /*	parser for yacc output	*/
 
-var yyDebug = 0
+var (
+	yyDebug        = 0
+	yyErrorVerbose = false
+)
 
 type yyLexer interface {
 	Lex(lval *yySymType) int
 	Error(s string)
 }
 
+type yyParser interface {
+	Parse(yyLexer) int
+	Lookahead() int
+}
+
+type yyParserImpl struct {
+	lookahead func() int
+}
+
+func (p *yyParserImpl) Lookahead() int {
+	return p.lookahead()
+}
+
+func yyNewParser() yyParser {
+	p := &yyParserImpl{
+		lookahead: func() int { return -1 },
+	}
+	return p
+}
+
 const yyFlag = -1000
 
 func yyTokname(c int) string {
-	// 4 is TOKSTART above
-	if c >= 4 && c-4 < len(yyToknames) {
-		if yyToknames[c-4] != "" {
-			return yyToknames[c-4]
+	if c >= 1 && c-1 < len(yyToknames) {
+		if yyToknames[c-1] != "" {
+			return yyToknames[c-1]
 		}
 	}
 	return __yyfmt__.Sprintf("tok-%v", c)
@@ -593,51 +625,128 @@ func yyStatname(s int) string {
 	return __yyfmt__.Sprintf("state-%v", s)
 }
 
-func yylex1(lex yyLexer, lval *yySymType) int {
-	c := 0
-	char := lex.Lex(lval)
+func yyErrorMessage(state, lookAhead int) string {
+	const TOKSTART = 4
+
+	if !yyErrorVerbose {
+		return "syntax error"
+	}
+
+	for _, e := range yyErrorMessages {
+		if e.state == state && e.token == lookAhead {
+			return "syntax error: " + e.msg
+		}
+	}
+
+	res := "syntax error: unexpected " + yyTokname(lookAhead)
+
+	// To match Bison, suggest at most four expected tokens.
+	expected := make([]int, 0, 4)
+
+	// Look for shiftable tokens.
+	base := yyPact[state]
+	for tok := TOKSTART; tok-1 < len(yyToknames); tok++ {
+		if n := base + tok; n >= 0 && n < yyLast && yyChk[yyAct[n]] == tok {
+			if len(expected) == cap(expected) {
+				return res
+			}
+			expected = append(expected, tok)
+		}
+	}
+
+	if yyDef[state] == -2 {
+		i := 0
+		for yyExca[i] != -1 || yyExca[i+1] != state {
+			i += 2
+		}
+
+		// Look for tokens that we accept or reduce.
+		for i += 2; yyExca[i] >= 0; i += 2 {
+			tok := yyExca[i]
+			if tok < TOKSTART || yyExca[i+1] == 0 {
+				continue
+			}
+			if len(expected) == cap(expected) {
+				return res
+			}
+			expected = append(expected, tok)
+		}
+
+		// If the default action is to accept or reduce, give up.
+		if yyExca[i+1] != 0 {
+			return res
+		}
+	}
+
+	for i, tok := range expected {
+		if i == 0 {
+			res += ", expecting "
+		} else {
+			res += " or "
+		}
+		res += yyTokname(tok)
+	}
+	return res
+}
+
+func yylex1(lex yyLexer, lval *yySymType) (char, token int) {
+	token = 0
+	char = lex.Lex(lval)
 	if char <= 0 {
-		c = yyTok1[0]
+		token = yyTok1[0]
 		goto out
 	}
 	if char < len(yyTok1) {
-		c = yyTok1[char]
+		token = yyTok1[char]
 		goto out
 	}
 	if char >= yyPrivate {
 		if char < yyPrivate+len(yyTok2) {
-			c = yyTok2[char-yyPrivate]
+			token = yyTok2[char-yyPrivate]
 			goto out
 		}
 	}
 	for i := 0; i < len(yyTok3); i += 2 {
-		c = yyTok3[i+0]
-		if c == char {
-			c = yyTok3[i+1]
+		token = yyTok3[i+0]
+		if token == char {
+			token = yyTok3[i+1]
 			goto out
 		}
 	}
 
 out:
-	if c == 0 {
-		c = yyTok2[1] /* unknown char */
+	if token == 0 {
+		token = yyTok2[1] /* unknown char */
 	}
 	if yyDebug >= 3 {
-		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(c), uint(char))
+		__yyfmt__.Printf("lex %s(%d)\n", yyTokname(token), uint(char))
 	}
-	return c
+	return char, token
 }
 
 func yyParse(yylex yyLexer) int {
+	return yyNewParser().Parse(yylex)
+}
+
+func (yyrcvr *yyParserImpl) Parse(yylex yyLexer) int {
 	var yyn int
 	var yylval yySymType
 	var yyVAL yySymType
+	var yyDollar []yySymType
 	yyS := make([]yySymType, yyMaxDepth)
 
 	Nerrs := 0   /* number of errors */
 	Errflag := 0 /* error recovery flag */
 	yystate := 0
 	yychar := -1
+	yytoken := -1 // yychar translated into internal numbering
+	yyrcvr.lookahead = func() int { return yychar }
+	defer func() {
+		// Make sure we report no lookahead when not parsing.
+		yystate = -1
+		yychar = -1
+		yytoken = -1
+	}()
 	yyp := -1
 	goto yystack
 
@@ -650,7 +759,7 @@ ret1:
 yystack:
 	/* put a state and value onto the stack */
 	if yyDebug >= 4 {
-		__yyfmt__.Printf("char %v in %v\n", yyTokname(yychar), yyStatname(yystate))
+		__yyfmt__.Printf("char %v in %v\n", yyTokname(yytoken), yyStatname(yystate))
 	}
 
 	yyp++
@@ -668,15 +777,16 @@ yynewstate:
 		goto yydefault /* simple state */
 	}
 	if yychar < 0 {
-		yychar = yylex1(yylex, &yylval)
+		yychar, yytoken = yylex1(yylex, &yylval)
 	}
-	yyn += yychar
+	yyn += yytoken
 	if yyn < 0 || yyn >= yyLast {
 		goto yydefault
 	}
 	yyn = yyAct[yyn]
-	if yyChk[yyn] == yychar { /* valid shift */
+	if yyChk[yyn] == yytoken { /* valid shift */
 		yychar = -1
+		yytoken = -1
 		yyVAL = yylval
 		yystate = yyn
 		if Errflag > 0 {
@@ -690,7 +800,7 @@ yydefault:
 	yyn = yyDef[yystate]
 	if yyn == -2 {
 		if yychar < 0 {
-			yychar = yylex1(yylex, &yylval)
+			yychar, yytoken = yylex1(yylex, &yylval)
 		}
 
 		/* look through exception table */
@@ -703,7 +813,7 @@ yydefault:
 		}
 		for xi += 2; ; xi += 2 {
 			yyn = yyExca[xi+0]
-			if yyn < 0 || yyn == yychar {
+			if yyn < 0 || yyn == yytoken {
 				break
 			}
 		}
@@ -716,11 +826,11 @@ yydefault:
 		/* error ... attempt to resume parsing */
 		switch Errflag {
 		case 0: /* brand new error */
-			yylex.Error("syntax error")
+			yylex.Error(yyErrorMessage(yystate, yytoken))
 			Nerrs++
 			if yyDebug >= 1 {
 				__yyfmt__.Printf("%s", yyStatname(yystate))
-				__yyfmt__.Printf(" saw %s\n", yyTokname(yychar))
+				__yyfmt__.Printf(" saw %s\n", yyTokname(yytoken))
 			}
 			fallthrough
 
@@ -748,12 +858,13 @@ yydefault:
 
 		case 3: /* no shift yet; clobber input char */
 			if yyDebug >= 2 {
-				__yyfmt__.Printf("error recovery discards %s\n", yyTokname(yychar))
+				__yyfmt__.Printf("error recovery discards %s\n", yyTokname(yytoken))
 			}
-			if yychar == yyEofCode {
+			if yytoken == yyEofCode {
 				goto ret1
 			}
 			yychar = -1
+			yytoken = -1
 			goto yynewstate /* try again in the same state */
 		}
 	}
@@ -768,6 +879,13 @@ yydefault:
 	_ = yypt // guard against "declared and not used"
 
 	yyp -= yyR2[yyn]
+	// yyp is now the index of $0. Perform the default action. Iff the
+	// reduced production is ε, $1 is possibly out of range.
+	if yyp+1 >= len(yyS) {
+		nyys := make([]yySymType, len(yyS)*2)
+		copy(nyys, yyS)
+		yyS = nyys
+	}
 	yyVAL = yyS[yyp+1]
 
 	/* consult goto table to find next state */
@@ -787,1007 +905,1176 @@ yydefault:
 	switch yynt {
 
 	case 1:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:163
 		{
-			setParseTree(yylex, yyS[yypt-0].statement)
+			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:169
 		{
-			yyVAL.statement = yyS[yypt-0].selStmt
+			yyVAL.statement = yyDollar[1].selStmt
 		}
-	case 3:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 4:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 5:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 6:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 7:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 8:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 9:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 10:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 11:
-		yyVAL.statement = yyS[yypt-0].statement
-	case 12:
-		yyVAL.statement = yyS[yypt-0].statement
 	case 13:
+		yyDollar = yyS[yypt-12 : yypt+1]
 		//line sql.y:185
 		{
-			yyVAL.selStmt = &Select{Comments: Comments(yyS[yypt-10].bytes2), Distinct: yyS[yypt-9].str, SelectExprs: yyS[yypt-8].selectExprs, From: yyS[yypt-6].tableExprs, Where: NewWhere(AST_WHERE, yyS[yypt-5].boolExpr), GroupBy: GroupBy(yyS[yypt-4].valExprs), Having: NewWhere(AST_HAVING, yyS[yypt-3].boolExpr), OrderBy: yyS[yypt-2].orderBy, Limit: yyS[yypt-1].limit, Lock: yyS[yypt-0].str}
+			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Distinct: yyDollar[3].str, SelectExprs: yyDollar[4].selectExprs, From: yyDollar[6].tableExprs, Where: NewWhere(AST_WHERE, yyDollar[7].boolExpr), GroupBy: GroupBy(yyDollar[8].valExprs), Having: NewWhere(AST_HAVING, yyDollar[9].boolExpr), OrderBy: yyDollar[10].orderBy, Limit: yyDollar[11].limit, Lock: yyDollar[12].str}
 		}
 	case 14:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:189
 		{
-			yyVAL.selStmt = &Union{Type: yyS[yypt-1].str, Left: yyS[yypt-2].selStmt, Right: yyS[yypt-0].selStmt}
+			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt}
 		}
 	case 15:
+		yyDollar = yyS[yypt-7 : yypt+1]
 		//line sql.y:195
 		{
-			yyVAL.statement = &Insert{Comments: Comments(yyS[yypt-5].bytes2), Table: yyS[yypt-3].tableName, Columns: yyS[yypt-2].columns, Rows: yyS[yypt-1].insRows, OnDup: OnDup(yyS[yypt-0].updateExprs)}
+			yyVAL.statement = &Insert{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Columns: yyDollar[5].columns, Rows: yyDollar[6].insRows, OnDup: OnDup(yyDollar[7].updateExprs)}
 		}
 	case 16:
+		yyDollar = yyS[yypt-7 : yypt+1]
 		//line sql.y:199
 		{
-			cols := make(Columns, 0, len(yyS[yypt-1].updateExprs))
-			vals := make(ValTuple, 0, len(yyS[yypt-1].updateExprs))
-			for _, col := range yyS[yypt-1].updateExprs {
+			cols := make(Columns, 0, len(yyDollar[6].updateExprs))
+			vals := make(ValTuple, 0, len(yyDollar[6].updateExprs))
+			for _, col := range yyDollar[6].updateExprs {
 				cols = append(cols, &NonStarExpr{Expr: col.Name})
 				vals = append(vals, col.Expr)
 			}
-			yyVAL.statement = &Insert{Comments: Comments(yyS[yypt-5].bytes2), Table: yyS[yypt-3].tableName, Columns: cols, Rows: Values{vals}, OnDup: OnDup(yyS[yypt-0].updateExprs)}
+			yyVAL.statement = &Insert{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Columns: cols, Rows: Values{vals}, OnDup: OnDup(yyDollar[7].updateExprs)}
 		}
 	case 17:
+		yyDollar = yyS[yypt-8 : yypt+1]
 		//line sql.y:211
 		{
-			yyVAL.statement = &Update{Comments: Comments(yyS[yypt-6].bytes2), Table: yyS[yypt-5].tableName, Exprs: yyS[yypt-3].updateExprs, Where: NewWhere(AST_WHERE, yyS[yypt-2].boolExpr), OrderBy: yyS[yypt-1].orderBy, Limit: yyS[yypt-0].limit}
+			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[3].tableName, Exprs: yyDollar[5].updateExprs, Where: NewWhere(AST_WHERE, yyDollar[6].boolExpr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 18:
+		yyDollar = yyS[yypt-7 : yypt+1]
 		//line sql.y:217
 		{
-			yyVAL.statement = &Delete{Comments: Comments(yyS[yypt-5].bytes2), Table: yyS[yypt-3].tableName, Where: NewWhere(AST_WHERE, yyS[yypt-2].boolExpr), OrderBy: yyS[yypt-1].orderBy, Limit: yyS[yypt-0].limit}
+			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Where: NewWhere(AST_WHERE, yyDollar[5].boolExpr), OrderBy: yyDollar[6].orderBy, Limit: yyDollar[7].limit}
 		}
 	case 19:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:223
 		{
-			yyVAL.statement = &Set{Comments: Comments(yyS[yypt-1].bytes2), Exprs: yyS[yypt-0].updateExprs}
+			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].updateExprs}
 		}
 	case 20:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:229
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyS[yypt-1].bytes}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[4].bytes}
 		}
 	case 21:
+		yyDollar = yyS[yypt-8 : yypt+1]
 		//line sql.y:233
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyS[yypt-1].bytes, NewName: yyS[yypt-1].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[7].bytes, NewName: yyDollar[7].bytes}
 		}
 	case 22:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:238
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyS[yypt-1].bytes}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[3].bytes}
 		}
 	case 23:
+		yyDollar = yyS[yypt-6 : yypt+1]
 		//line sql.y:244
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyS[yypt-2].bytes, NewName: yyS[yypt-2].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[4].bytes, NewName: yyDollar[4].bytes}
 		}
 	case 24:
+		yyDollar = yyS[yypt-7 : yypt+1]
 		//line sql.y:248
 		{
 			// Change this to a rename statement
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyS[yypt-3].bytes, NewName: yyS[yypt-0].bytes}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[4].bytes, NewName: yyDollar[7].bytes}
 		}
 	case 25:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:253
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyS[yypt-1].bytes, NewName: yyS[yypt-1].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].bytes, NewName: yyDollar[3].bytes}
 		}
 	case 26:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:259
 		{
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyS[yypt-2].bytes, NewName: yyS[yypt-0].bytes}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[3].bytes, NewName: yyDollar[5].bytes}
 		}
 	case 27:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:265
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyS[yypt-0].bytes}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].bytes}
 		}
 	case 28:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:269
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyS[yypt-0].bytes, NewName: yyS[yypt-0].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[5].bytes, NewName: yyDollar[5].bytes}
 		}
 	case 29:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:274
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyS[yypt-1].bytes}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].bytes}
 		}
 	case 30:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:280
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyS[yypt-0].bytes, NewName: yyS[yypt-0].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].bytes, NewName: yyDollar[3].bytes}
 		}
 	case 31:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:286
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 32:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:290
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 33:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:294
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 34:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:299
 		{
 			setAllowComments(yylex, true)
 		}
 	case 35:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:303
 		{
-			yyVAL.bytes2 = yyS[yypt-0].bytes2
+			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 36:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:309
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 37:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:313
 		{
-			yyVAL.bytes2 = append(yyS[yypt-1].bytes2, yyS[yypt-0].bytes)
+			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 38:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:319
 		{
 			yyVAL.str = AST_UNION
 		}
 	case 39:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:323
 		{
 			yyVAL.str = AST_UNION_ALL
 		}
 	case 40:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:327
 		{
 			yyVAL.str = AST_SET_MINUS
 		}
 	case 41:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:331
 		{
 			yyVAL.str = AST_EXCEPT
 		}
 	case 42:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:335
 		{
 			yyVAL.str = AST_INTERSECT
 		}
 	case 43:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:340
 		{
 			yyVAL.str = ""
 		}
 	case 44:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:344
 		{
 			yyVAL.str = AST_DISTINCT
 		}
 	case 45:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:350
 		{
-			yyVAL.selectExprs = SelectExprs{yyS[yypt-0].selectExpr}
+			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 46:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:354
 		{
-			yyVAL.selectExprs = append(yyVAL.selectExprs, yyS[yypt-0].selectExpr)
+			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 47:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:360
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 48:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:364
 		{
-			yyVAL.selectExpr = &NonStarExpr{Expr: yyS[yypt-1].expr, As: yyS[yypt-0].bytes}
+			yyVAL.selectExpr = &NonStarExpr{Expr: yyDollar[1].expr, As: yyDollar[2].bytes}
 		}
 	case 49:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:368
 		{
-			yyVAL.selectExpr = &StarExpr{TableName: yyS[yypt-2].bytes}
+			yyVAL.selectExpr = &StarExpr{TableName: yyDollar[1].bytes}
 		}
 	case 50:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:374
 		{
-			yyVAL.expr = yyS[yypt-0].boolExpr
+			yyVAL.expr = yyDollar[1].boolExpr
 		}
 	case 51:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:378
 		{
-			yyVAL.expr = yyS[yypt-0].valExpr
+			yyVAL.expr = yyDollar[1].valExpr
 		}
 	case 52:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:383
 		{
 			yyVAL.bytes = nil
 		}
 	case 53:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:387
 		{
-			yyVAL.bytes = yyS[yypt-0].bytes
+			yyVAL.bytes = yyDollar[1].bytes
 		}
 	case 54:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:391
 		{
-			yyVAL.bytes = yyS[yypt-0].bytes
+			yyVAL.bytes = yyDollar[2].bytes
 		}
 	case 55:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:397
 		{
-			yyVAL.tableExprs = TableExprs{yyS[yypt-0].tableExpr}
+			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 56:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:401
 		{
-			yyVAL.tableExprs = append(yyVAL.tableExprs, yyS[yypt-0].tableExpr)
+			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 57:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:407
 		{
-			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyS[yypt-2].smTableExpr, As: yyS[yypt-1].bytes, Hints: yyS[yypt-0].indexHints}
+			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].smTableExpr, As: yyDollar[2].bytes, Hints: yyDollar[3].indexHints}
 		}
 	case 58:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:411
 		{
-			yyVAL.tableExpr = &ParenTableExpr{Expr: yyS[yypt-1].tableExpr}
+			yyVAL.tableExpr = &ParenTableExpr{Expr: yyDollar[2].tableExpr}
 		}
 	case 59:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:415
 		{
-			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyS[yypt-2].tableExpr, Join: yyS[yypt-1].str, RightExpr: yyS[yypt-0].tableExpr}
+			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 60:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:419
 		{
-			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyS[yypt-4].tableExpr, Join: yyS[yypt-3].str, RightExpr: yyS[yypt-2].tableExpr, On: yyS[yypt-0].boolExpr}
+			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, On: yyDollar[5].boolExpr}
 		}
 	case 61:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:424
 		{
 			yyVAL.bytes = nil
 		}
 	case 62:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:428
 		{
-			yyVAL.bytes = yyS[yypt-0].bytes
+			yyVAL.bytes = yyDollar[1].bytes
 		}
 	case 63:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:432
 		{
-			yyVAL.bytes = yyS[yypt-0].bytes
+			yyVAL.bytes = yyDollar[2].bytes
 		}
 	case 64:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:438
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 65:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:442
 		{
 			yyVAL.str = AST_STRAIGHT_JOIN
 		}
 	case 66:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:446
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 67:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:450
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 68:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:454
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 69:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:458
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 70:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:462
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 71:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:466
 		{
 			yyVAL.str = AST_CROSS_JOIN
 		}
 	case 72:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:470
 		{
 			yyVAL.str = AST_NATURAL_JOIN
 		}
 	case 73:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:476
 		{
-			yyVAL.smTableExpr = &TableName{Name: yyS[yypt-0].bytes}
+			yyVAL.smTableExpr = &TableName{Name: yyDollar[1].bytes}
 		}
 	case 74:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:480
 		{
-			yyVAL.smTableExpr = &TableName{Qualifier: yyS[yypt-2].bytes, Name: yyS[yypt-0].bytes}
+			yyVAL.smTableExpr = &TableName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
 		}
 	case 75:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:484
 		{
-			yyVAL.smTableExpr = yyS[yypt-0].subquery
+			yyVAL.smTableExpr = yyDollar[1].subquery
 		}
 	case 76:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:490
 		{
-			yyVAL.tableName = &TableName{Name: yyS[yypt-0].bytes}
+			yyVAL.tableName = &TableName{Name: yyDollar[1].bytes}
 		}
 	case 77:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:494
 		{
-			yyVAL.tableName = &TableName{Qualifier: yyS[yypt-2].bytes, Name: yyS[yypt-0].bytes}
+			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
 		}
 	case 78:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:499
 		{
 			yyVAL.indexHints = nil
 		}
 	case 79:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:503
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_USE, Indexes: yyS[yypt-1].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_USE, Indexes: yyDollar[4].bytes2}
 		}
 	case 80:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:507
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_IGNORE, Indexes: yyS[yypt-1].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_IGNORE, Indexes: yyDollar[4].bytes2}
 		}
 	case 81:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:511
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_FORCE, Indexes: yyS[yypt-1].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_FORCE, Indexes: yyDollar[4].bytes2}
 		}
 	case 82:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:517
 		{
-			yyVAL.bytes2 = [][]byte{yyS[yypt-0].bytes}
+			yyVAL.bytes2 = [][]byte{yyDollar[1].bytes}
 		}
 	case 83:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:521
 		{
-			yyVAL.bytes2 = append(yyS[yypt-2].bytes2, yyS[yypt-0].bytes)
+			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[3].bytes)
 		}
 	case 84:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:526
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 85:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:530
 		{
-			yyVAL.boolExpr = yyS[yypt-0].boolExpr
+			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
-	case 86:
-		yyVAL.boolExpr = yyS[yypt-0].boolExpr
 	case 87:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:537
 		{
-			yyVAL.boolExpr = &AndExpr{Left: yyS[yypt-2].boolExpr, Right: yyS[yypt-0].boolExpr}
+			yyVAL.boolExpr = &AndExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 88:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:541
 		{
-			yyVAL.boolExpr = &OrExpr{Left: yyS[yypt-2].boolExpr, Right: yyS[yypt-0].boolExpr}
+			yyVAL.boolExpr = &OrExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 89:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:545
 		{
-			yyVAL.boolExpr = &NotExpr{Expr: yyS[yypt-0].boolExpr}
+			yyVAL.boolExpr = &NotExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 90:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:549
 		{
-			yyVAL.boolExpr = &ParenBoolExpr{Expr: yyS[yypt-1].boolExpr}
+			yyVAL.boolExpr = &ParenBoolExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 91:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:555
 		{
-			yyVAL.boolExpr = &ComparisonExpr{Left: yyS[yypt-2].valExpr, Operator: yyS[yypt-1].str, Right: yyS[yypt-0].valExpr}
+			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: yyDollar[2].str, Right: yyDollar[3].valExpr}
 		}
 	case 92:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:559
 		{
-			yyVAL.boolExpr = &ComparisonExpr{Left: yyS[yypt-2].valExpr, Operator: AST_IN, Right: yyS[yypt-0].colTuple}
+			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_IN, Right: yyDollar[3].colTuple}
 		}
 	case 93:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:563
 		{
-			yyVAL.boolExpr = &ComparisonExpr{Left: yyS[yypt-3].valExpr, Operator: AST_NOT_IN, Right: yyS[yypt-0].colTuple}
+			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_IN, Right: yyDollar[4].colTuple}
 		}
 	case 94:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:567
 		{
-			yyVAL.boolExpr = &ComparisonExpr{Left: yyS[yypt-2].valExpr, Operator: AST_LIKE, Right: yyS[yypt-0].valExpr}
+			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_LIKE, Right: yyDollar[3].valExpr}
 		}
 	case 95:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:571
 		{
-			yyVAL.boolExpr = &ComparisonExpr{Left: yyS[yypt-3].valExpr, Operator: AST_NOT_LIKE, Right: yyS[yypt-0].valExpr}
+			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_LIKE, Right: yyDollar[4].valExpr}
 		}
 	case 96:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:575
 		{
-			yyVAL.boolExpr = &RangeCond{Left: yyS[yypt-4].valExpr, Operator: AST_BETWEEN, From: yyS[yypt-2].valExpr, To: yyS[yypt-0].valExpr}
+			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_BETWEEN, From: yyDollar[3].valExpr, To: yyDollar[5].valExpr}
 		}
 	case 97:
+		yyDollar = yyS[yypt-6 : yypt+1]
 		//line sql.y:579
 		{
-			yyVAL.boolExpr = &RangeCond{Left: yyS[yypt-5].valExpr, Operator: AST_NOT_BETWEEN, From: yyS[yypt-2].valExpr, To: yyS[yypt-0].valExpr}
+			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_NOT_BETWEEN, From: yyDollar[4].valExpr, To: yyDollar[6].valExpr}
 		}
 	case 98:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:583
 		{
-			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NULL, Expr: yyS[yypt-2].valExpr}
+			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 99:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:587
 		{
-			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NOT_NULL, Expr: yyS[yypt-3].valExpr}
+			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NOT_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 100:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:591
 		{
-			yyVAL.boolExpr = &ExistsExpr{Subquery: yyS[yypt-0].subquery}
+			yyVAL.boolExpr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 101:
+		yyDollar = yyS[yypt-6 : yypt+1]
 		//line sql.y:595
 		{
-			yyVAL.boolExpr = &KeyrangeExpr{Start: yyS[yypt-3].valExpr, End: yyS[yypt-1].valExpr}
+			yyVAL.boolExpr = &KeyrangeExpr{Start: yyDollar[3].valExpr, End: yyDollar[5].valExpr}
 		}
 	case 102:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:601
 		{
 			yyVAL.str = AST_EQ
 		}
 	case 103:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:605
 		{
 			yyVAL.str = AST_LT
 		}
 	case 104:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:609
 		{
 			yyVAL.str = AST_GT
 		}
 	case 105:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:613
 		{
 			yyVAL.str = AST_LE
 		}
 	case 106:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:617
 		{
 			yyVAL.str = AST_GE
 		}
 	case 107:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:621
 		{
 			yyVAL.str = AST_NE
 		}
 	case 108:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:625
 		{
 			yyVAL.str = AST_NSE
 		}
 	case 109:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:631
 		{
-			yyVAL.colTuple = ValTuple(yyS[yypt-1].valExprs)
+			yyVAL.colTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 110:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:635
 		{
-			yyVAL.colTuple = yyS[yypt-0].subquery
+			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 111:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:639
 		{
-			yyVAL.colTuple = ListArg(yyS[yypt-0].bytes)
+			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 112:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:645
 		{
-			yyVAL.subquery = &Subquery{yyS[yypt-1].selStmt}
+			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 113:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:651
 		{
-			yyVAL.valExprs = ValExprs{yyS[yypt-0].valExpr}
+			yyVAL.valExprs = ValExprs{yyDollar[1].valExpr}
 		}
 	case 114:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:655
 		{
-			yyVAL.valExprs = append(yyS[yypt-2].valExprs, yyS[yypt-0].valExpr)
+			yyVAL.valExprs = append(yyDollar[1].valExprs, yyDollar[3].valExpr)
 		}
 	case 115:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:661
 		{
-			yyVAL.valExpr = yyS[yypt-0].valExpr
+			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 116:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:665
 		{
-			yyVAL.valExpr = yyS[yypt-0].colName
+			yyVAL.valExpr = yyDollar[1].colName
 		}
 	case 117:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:669
 		{
-			yyVAL.valExpr = yyS[yypt-0].rowTuple
+			yyVAL.valExpr = yyDollar[1].rowTuple
 		}
 	case 118:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:673
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_BITAND, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITAND, Right: yyDollar[3].valExpr}
 		}
 	case 119:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:677
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_BITOR, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITOR, Right: yyDollar[3].valExpr}
 		}
 	case 120:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:681
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_BITXOR, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITXOR, Right: yyDollar[3].valExpr}
 		}
 	case 121:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:685
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_PLUS, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_PLUS, Right: yyDollar[3].valExpr}
 		}
 	case 122:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:689
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_MINUS, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MINUS, Right: yyDollar[3].valExpr}
 		}
 	case 123:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:693
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_MULT, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MULT, Right: yyDollar[3].valExpr}
 		}
 	case 124:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:697
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_DIV, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_DIV, Right: yyDollar[3].valExpr}
 		}
 	case 125:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:701
 		{
-			yyVAL.valExpr = &BinaryExpr{Left: yyS[yypt-2].valExpr, Operator: AST_MOD, Right: yyS[yypt-0].valExpr}
+			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MOD, Right: yyDollar[3].valExpr}
 		}
 	case 126:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:705
 		{
-			if num, ok := yyS[yypt-0].valExpr.(NumVal); ok {
-				switch yyS[yypt-1].byt {
+			if num, ok := yyDollar[2].valExpr.(NumVal); ok {
+				switch yyDollar[1].byt {
 				case '-':
 					yyVAL.valExpr = append(NumVal("-"), num...)
 				case '+':
 					yyVAL.valExpr = num
 				default:
-					yyVAL.valExpr = &UnaryExpr{Operator: yyS[yypt-1].byt, Expr: yyS[yypt-0].valExpr}
+					yyVAL.valExpr = &UnaryExpr{Operator: yyDollar[1].byt, Expr: yyDollar[2].valExpr}
 				}
 			} else {
-				yyVAL.valExpr = &UnaryExpr{Operator: yyS[yypt-1].byt, Expr: yyS[yypt-0].valExpr}
+				yyVAL.valExpr = &UnaryExpr{Operator: yyDollar[1].byt, Expr: yyDollar[2].valExpr}
 			}
 		}
 	case 127:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:720
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyS[yypt-2].bytes}
+			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes}
 		}
 	case 128:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:724
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyS[yypt-3].bytes, Exprs: yyS[yypt-1].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Exprs: yyDollar[3].selectExprs}
 		}
 	case 129:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:728
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyS[yypt-4].bytes, Distinct: true, Exprs: yyS[yypt-1].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 130:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:732
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyS[yypt-3].bytes, Exprs: yyS[yypt-1].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Exprs: yyDollar[3].selectExprs}
 		}
 	case 131:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:736
 		{
-			yyVAL.valExpr = yyS[yypt-0].caseExpr
+			yyVAL.valExpr = yyDollar[1].caseExpr
 		}
 	case 132:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:742
 		{
 			yyVAL.bytes = IF_BYTES
 		}
 	case 133:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:746
 		{
 			yyVAL.bytes = VALUES_BYTES
 		}
 	case 134:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:752
 		{
 			yyVAL.byt = AST_UPLUS
 		}
 	case 135:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:756
 		{
 			yyVAL.byt = AST_UMINUS
 		}
 	case 136:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:760
 		{
 			yyVAL.byt = AST_TILDA
 		}
 	case 137:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:766
 		{
-			yyVAL.caseExpr = &CaseExpr{Expr: yyS[yypt-3].valExpr, Whens: yyS[yypt-2].whens, Else: yyS[yypt-1].valExpr}
+			yyVAL.caseExpr = &CaseExpr{Expr: yyDollar[2].valExpr, Whens: yyDollar[3].whens, Else: yyDollar[4].valExpr}
 		}
 	case 138:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:771
 		{
 			yyVAL.valExpr = nil
 		}
 	case 139:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:775
 		{
-			yyVAL.valExpr = yyS[yypt-0].valExpr
+			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 140:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:781
 		{
-			yyVAL.whens = []*When{yyS[yypt-0].when}
+			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 141:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:785
 		{
-			yyVAL.whens = append(yyS[yypt-1].whens, yyS[yypt-0].when)
+			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 142:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:791
 		{
-			yyVAL.when = &When{Cond: yyS[yypt-2].boolExpr, Val: yyS[yypt-0].valExpr}
+			yyVAL.when = &When{Cond: yyDollar[2].boolExpr, Val: yyDollar[4].valExpr}
 		}
 	case 143:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:796
 		{
 			yyVAL.valExpr = nil
 		}
 	case 144:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:800
 		{
-			yyVAL.valExpr = yyS[yypt-0].valExpr
+			yyVAL.valExpr = yyDollar[2].valExpr
 		}
 	case 145:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:806
 		{
-			yyVAL.colName = &ColName{Name: yyS[yypt-0].bytes}
+			yyVAL.colName = &ColName{Name: yyDollar[1].bytes}
 		}
 	case 146:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:810
 		{
-			yyVAL.colName = &ColName{Qualifier: yyS[yypt-2].bytes, Name: yyS[yypt-0].bytes}
+			yyVAL.colName = &ColName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
 		}
 	case 147:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:816
 		{
-			yyVAL.valExpr = StrVal(yyS[yypt-0].bytes)
+			yyVAL.valExpr = StrVal(yyDollar[1].bytes)
 		}
 	case 148:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:820
 		{
-			yyVAL.valExpr = NumVal(yyS[yypt-0].bytes)
+			yyVAL.valExpr = NumVal(yyDollar[1].bytes)
 		}
 	case 149:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:824
 		{
-			yyVAL.valExpr = ValArg(yyS[yypt-0].bytes)
+			yyVAL.valExpr = ValArg(yyDollar[1].bytes)
 		}
 	case 150:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:828
 		{
 			yyVAL.valExpr = &NullVal{}
 		}
 	case 151:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:833
 		{
 			yyVAL.valExprs = nil
 		}
 	case 152:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:837
 		{
-			yyVAL.valExprs = yyS[yypt-0].valExprs
+			yyVAL.valExprs = yyDollar[3].valExprs
 		}
 	case 153:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:842
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 154:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:846
 		{
-			yyVAL.boolExpr = yyS[yypt-0].boolExpr
+			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
 	case 155:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:851
 		{
 			yyVAL.orderBy = nil
 		}
 	case 156:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:855
 		{
-			yyVAL.orderBy = yyS[yypt-0].orderBy
+			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 157:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:861
 		{
-			yyVAL.orderBy = OrderBy{yyS[yypt-0].order}
+			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 158:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:865
 		{
-			yyVAL.orderBy = append(yyS[yypt-2].orderBy, yyS[yypt-0].order)
+			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 159:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:871
 		{
-			yyVAL.order = &Order{Expr: yyS[yypt-1].valExpr, Direction: yyS[yypt-0].str}
+			yyVAL.order = &Order{Expr: yyDollar[1].valExpr, Direction: yyDollar[2].str}
 		}
 	case 160:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:876
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 161:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:880
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 162:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:884
 		{
 			yyVAL.str = AST_DESC
 		}
 	case 163:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:889
 		{
 			yyVAL.limit = nil
 		}
 	case 164:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:893
 		{
-			yyVAL.limit = &Limit{Rowcount: yyS[yypt-0].valExpr}
+			yyVAL.limit = &Limit{Rowcount: yyDollar[2].valExpr}
 		}
 	case 165:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:897
 		{
-			yyVAL.limit = &Limit{Offset: yyS[yypt-2].valExpr, Rowcount: yyS[yypt-0].valExpr}
+			yyVAL.limit = &Limit{Offset: yyDollar[2].valExpr, Rowcount: yyDollar[4].valExpr}
 		}
 	case 166:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:902
 		{
 			yyVAL.str = ""
 		}
 	case 167:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:906
 		{
 			yyVAL.str = AST_FOR_UPDATE
 		}
 	case 168:
+		yyDollar = yyS[yypt-4 : yypt+1]
 		//line sql.y:910
 		{
-			if !bytes.Equal(yyS[yypt-1].bytes, SHARE) {
+			if !bytes.Equal(yyDollar[3].bytes, SHARE) {
 				yylex.Error("expecting share")
 				return 1
 			}
-			if !bytes.Equal(yyS[yypt-0].bytes, MODE) {
+			if !bytes.Equal(yyDollar[4].bytes, MODE) {
 				yylex.Error("expecting mode")
 				return 1
 			}
 			yyVAL.str = AST_SHARE_MODE
 		}
 	case 169:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:923
 		{
 			yyVAL.columns = nil
 		}
 	case 170:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:927
 		{
-			yyVAL.columns = yyS[yypt-1].columns
+			yyVAL.columns = yyDollar[2].columns
 		}
 	case 171:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:933
 		{
-			yyVAL.columns = Columns{&NonStarExpr{Expr: yyS[yypt-0].colName}}
+			yyVAL.columns = Columns{&NonStarExpr{Expr: yyDollar[1].colName}}
 		}
 	case 172:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:937
 		{
-			yyVAL.columns = append(yyVAL.columns, &NonStarExpr{Expr: yyS[yypt-0].colName})
+			yyVAL.columns = append(yyVAL.columns, &NonStarExpr{Expr: yyDollar[3].colName})
 		}
 	case 173:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:942
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 174:
+		yyDollar = yyS[yypt-5 : yypt+1]
 		//line sql.y:946
 		{
-			yyVAL.updateExprs = yyS[yypt-0].updateExprs
+			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 175:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:952
 		{
-			yyVAL.insRows = yyS[yypt-0].values
+			yyVAL.insRows = yyDollar[2].values
 		}
 	case 176:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:956
 		{
-			yyVAL.insRows = yyS[yypt-0].selStmt
+			yyVAL.insRows = yyDollar[1].selStmt
 		}
 	case 177:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:962
 		{
-			yyVAL.values = Values{yyS[yypt-0].rowTuple}
+			yyVAL.values = Values{yyDollar[1].rowTuple}
 		}
 	case 178:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:966
 		{
-			yyVAL.values = append(yyS[yypt-2].values, yyS[yypt-0].rowTuple)
+			yyVAL.values = append(yyDollar[1].values, yyDollar[3].rowTuple)
 		}
 	case 179:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:972
 		{
-			yyVAL.rowTuple = ValTuple(yyS[yypt-1].valExprs)
+			yyVAL.rowTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 180:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:976
 		{
-			yyVAL.rowTuple = yyS[yypt-0].subquery
+			yyVAL.rowTuple = yyDollar[1].subquery
 		}
 	case 181:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:982
 		{
-			yyVAL.updateExprs = UpdateExprs{yyS[yypt-0].updateExpr}
+			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 182:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:986
 		{
-			yyVAL.updateExprs = append(yyS[yypt-2].updateExprs, yyS[yypt-0].updateExpr)
+			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 183:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:992
 		{
-			yyVAL.updateExpr = &UpdateExpr{Name: yyS[yypt-2].colName, Expr: yyS[yypt-0].valExpr}
+			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].valExpr}
 		}
 	case 184:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:997
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 185:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:999
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 186:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1002
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 187:
+		yyDollar = yyS[yypt-3 : yypt+1]
 		//line sql.y:1004
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 188:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1007
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 189:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1009
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 190:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1013
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 191:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1015
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 192:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1017
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 193:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1019
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 194:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1021
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 195:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1024
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 196:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1026
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 197:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1029
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 198:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1031
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 199:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1034
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 200:
+		yyDollar = yyS[yypt-2 : yypt+1]
 		//line sql.y:1036
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 201:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1040
 		{
-			yyVAL.bytes = bytes.ToLower(yyS[yypt-0].bytes)
+			yyVAL.bytes = bytes.ToLower(yyDollar[1].bytes)
 		}
 	case 202:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1046
 		{
 			if incNesting(yylex) {
@@ -1796,11 +2083,13 @@ yydefault:
 			}
 		}
 	case 203:
+		yyDollar = yyS[yypt-1 : yypt+1]
 		//line sql.y:1055
 		{
 			decNesting(yylex)
 		}
 	case 204:
+		yyDollar = yyS[yypt-0 : yypt+1]
 		//line sql.y:1060
 		{
 			forceEOF(yylex)

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -68,7 +68,6 @@ type yySymType struct {
 	updateExpr  *UpdateExpr
 	sqlID       SQLName
 	sqlIDs      []SQLName
-	tableID     TableID
 }
 
 const LEX_ERROR = 57346
@@ -910,37 +909,37 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:159
+		//line sql.y:158
 		{
 			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:165
+		//line sql.y:164
 		{
 			yyVAL.statement = yyDollar[1].selStmt
 		}
 	case 13:
 		yyDollar = yyS[yypt-12 : yypt+1]
-		//line sql.y:181
+		//line sql.y:180
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Distinct: yyDollar[3].str, SelectExprs: yyDollar[4].selectExprs, From: yyDollar[6].tableExprs, Where: NewWhere(AST_WHERE, yyDollar[7].boolExpr), GroupBy: GroupBy(yyDollar[8].valExprs), Having: NewWhere(AST_HAVING, yyDollar[9].boolExpr), OrderBy: yyDollar[10].orderBy, Limit: yyDollar[11].limit, Lock: yyDollar[12].str}
 		}
 	case 14:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:185
+		//line sql.y:184
 		{
 			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt}
 		}
 	case 15:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:191
+		//line sql.y:190
 		{
 			yyVAL.statement = &Insert{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Columns: yyDollar[5].columns, Rows: yyDollar[6].insRows, OnDup: OnDup(yyDollar[7].updateExprs)}
 		}
 	case 16:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:195
+		//line sql.y:194
 		{
 			cols := make(Columns, 0, len(yyDollar[6].updateExprs))
 			vals := make(ValTuple, 0, len(yyDollar[6].updateExprs))
@@ -952,659 +951,659 @@ yydefault:
 		}
 	case 17:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:207
+		//line sql.y:206
 		{
 			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[3].tableName, Exprs: yyDollar[5].updateExprs, Where: NewWhere(AST_WHERE, yyDollar[6].boolExpr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 18:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:213
+		//line sql.y:212
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Where: NewWhere(AST_WHERE, yyDollar[5].boolExpr), OrderBy: yyDollar[6].orderBy, Limit: yyDollar[7].limit}
 		}
 	case 19:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:219
+		//line sql.y:218
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].updateExprs}
 		}
 	case 20:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:225
+		//line sql.y:224
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[4].tableID}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[4].sqlID}
 		}
 	case 21:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:229
+		//line sql.y:228
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[7].tableID, NewName: yyDollar[7].tableID}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[7].sqlID, NewName: yyDollar[7].sqlID}
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:234
+		//line sql.y:233
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: TableID(yyDollar[3].sqlID)}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: SQLName(yyDollar[3].sqlID)}
 		}
 	case 23:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:240
+		//line sql.y:239
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[4].tableID, NewName: yyDollar[4].tableID}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[4].sqlID, NewName: yyDollar[4].sqlID}
 		}
 	case 24:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:244
+		//line sql.y:243
 		{
 			// Change this to a rename statement
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[4].tableID, NewName: yyDollar[7].tableID}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[4].sqlID, NewName: yyDollar[7].sqlID}
 		}
 	case 25:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:249
+		//line sql.y:248
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: TableID(yyDollar[3].sqlID), NewName: TableID(yyDollar[3].sqlID)}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: SQLName(yyDollar[3].sqlID), NewName: SQLName(yyDollar[3].sqlID)}
 		}
 	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:255
+		//line sql.y:254
 		{
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[3].tableID, NewName: yyDollar[5].tableID}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[3].sqlID, NewName: yyDollar[5].sqlID}
 		}
 	case 27:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:261
+		//line sql.y:260
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].tableID}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].sqlID}
 		}
 	case 28:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:265
+		//line sql.y:264
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[5].tableID, NewName: yyDollar[5].tableID}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[5].sqlID, NewName: yyDollar[5].sqlID}
 		}
 	case 29:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:270
+		//line sql.y:269
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: TableID(yyDollar[4].sqlID)}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: SQLName(yyDollar[4].sqlID)}
 		}
 	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:276
+		//line sql.y:275
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].tableID, NewName: yyDollar[3].tableID}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].sqlID, NewName: yyDollar[3].sqlID}
 		}
 	case 31:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:282
+		//line sql.y:281
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 32:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:286
+		//line sql.y:285
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 33:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:290
+		//line sql.y:289
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 34:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:295
+		//line sql.y:294
 		{
 			setAllowComments(yylex, true)
 		}
 	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:299
+		//line sql.y:298
 		{
 			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 36:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:305
+		//line sql.y:304
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:309
+		//line sql.y:308
 		{
 			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 38:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:315
+		//line sql.y:314
 		{
 			yyVAL.str = AST_UNION
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:319
+		//line sql.y:318
 		{
 			yyVAL.str = AST_UNION_ALL
 		}
 	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:323
+		//line sql.y:322
 		{
 			yyVAL.str = AST_SET_MINUS
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:327
+		//line sql.y:326
 		{
 			yyVAL.str = AST_EXCEPT
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:331
+		//line sql.y:330
 		{
 			yyVAL.str = AST_INTERSECT
 		}
 	case 43:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:336
+		//line sql.y:335
 		{
 			yyVAL.str = ""
 		}
 	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:340
+		//line sql.y:339
 		{
 			yyVAL.str = AST_DISTINCT
 		}
 	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:346
+		//line sql.y:345
 		{
 			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:350
+		//line sql.y:349
 		{
 			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:356
+		//line sql.y:355
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 48:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:360
+		//line sql.y:359
 		{
 			yyVAL.selectExpr = &NonStarExpr{Expr: yyDollar[1].expr, As: yyDollar[2].sqlID}
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:364
+		//line sql.y:363
 		{
-			yyVAL.selectExpr = &StarExpr{TableName: yyDollar[1].tableID}
+			yyVAL.selectExpr = &StarExpr{TableName: yyDollar[1].sqlID}
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:370
+		//line sql.y:369
 		{
 			yyVAL.expr = yyDollar[1].boolExpr
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:374
+		//line sql.y:373
 		{
 			yyVAL.expr = yyDollar[1].valExpr
 		}
 	case 52:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:379
+		//line sql.y:378
 		{
 			yyVAL.sqlID = ""
 		}
 	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:383
+		//line sql.y:382
 		{
 			yyVAL.sqlID = yyDollar[1].sqlID
 		}
 	case 54:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:387
+		//line sql.y:386
 		{
 			yyVAL.sqlID = yyDollar[2].sqlID
 		}
 	case 55:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:393
+		//line sql.y:392
 		{
 			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:397
+		//line sql.y:396
 		{
 			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:403
+		//line sql.y:402
 		{
-			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].smTableExpr, As: yyDollar[2].tableID, Hints: yyDollar[3].indexHints}
+			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].smTableExpr, As: yyDollar[2].sqlID, Hints: yyDollar[3].indexHints}
 		}
 	case 58:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:407
+		//line sql.y:406
 		{
 			yyVAL.tableExpr = &ParenTableExpr{Expr: yyDollar[2].tableExpr}
 		}
 	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:411
+		//line sql.y:410
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 60:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:415
+		//line sql.y:414
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, On: yyDollar[5].boolExpr}
 		}
 	case 61:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:420
+		//line sql.y:419
 		{
-			yyVAL.tableID = ""
+			yyVAL.sqlID = ""
 		}
 	case 62:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:424
+		//line sql.y:423
 		{
-			yyVAL.tableID = yyDollar[1].tableID
+			yyVAL.sqlID = yyDollar[1].sqlID
 		}
 	case 63:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:428
+		//line sql.y:427
 		{
-			yyVAL.tableID = yyDollar[2].tableID
+			yyVAL.sqlID = yyDollar[2].sqlID
 		}
 	case 64:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:434
+		//line sql.y:433
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 65:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:438
+		//line sql.y:437
 		{
 			yyVAL.str = AST_STRAIGHT_JOIN
 		}
 	case 66:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:442
+		//line sql.y:441
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 67:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:446
+		//line sql.y:445
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:450
+		//line sql.y:449
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:454
+		//line sql.y:453
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 70:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:458
+		//line sql.y:457
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 71:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:462
+		//line sql.y:461
 		{
 			yyVAL.str = AST_CROSS_JOIN
 		}
 	case 72:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:466
+		//line sql.y:465
 		{
 			yyVAL.str = AST_NATURAL_JOIN
 		}
 	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:472
+		//line sql.y:471
 		{
-			yyVAL.smTableExpr = &TableName{Name: yyDollar[1].tableID}
+			yyVAL.smTableExpr = &TableName{Name: yyDollar[1].sqlID}
 		}
 	case 74:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:476
+		//line sql.y:475
 		{
-			yyVAL.smTableExpr = &TableName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].tableID}
+			yyVAL.smTableExpr = &TableName{Qualifier: yyDollar[1].sqlID, Name: yyDollar[3].sqlID}
 		}
 	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:480
+		//line sql.y:479
 		{
 			yyVAL.smTableExpr = yyDollar[1].subquery
 		}
 	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:486
+		//line sql.y:485
 		{
-			yyVAL.tableName = &TableName{Name: yyDollar[1].tableID}
+			yyVAL.tableName = &TableName{Name: yyDollar[1].sqlID}
 		}
 	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:490
+		//line sql.y:489
 		{
-			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].tableID}
+			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].sqlID, Name: yyDollar[3].sqlID}
 		}
 	case 78:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:495
+		//line sql.y:494
 		{
 			yyVAL.indexHints = nil
 		}
 	case 79:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:499
+		//line sql.y:498
 		{
 			yyVAL.indexHints = &IndexHints{Type: AST_USE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 80:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:503
+		//line sql.y:502
 		{
 			yyVAL.indexHints = &IndexHints{Type: AST_IGNORE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 81:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:507
+		//line sql.y:506
 		{
 			yyVAL.indexHints = &IndexHints{Type: AST_FORCE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 82:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:513
+		//line sql.y:512
 		{
 			yyVAL.sqlIDs = []SQLName{yyDollar[1].sqlID}
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:517
+		//line sql.y:516
 		{
 			yyVAL.sqlIDs = append(yyDollar[1].sqlIDs, yyDollar[3].sqlID)
 		}
 	case 84:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:522
+		//line sql.y:521
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:526
+		//line sql.y:525
 		{
 			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
 	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:533
+		//line sql.y:532
 		{
 			yyVAL.boolExpr = &AndExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:537
+		//line sql.y:536
 		{
 			yyVAL.boolExpr = &OrExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 89:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:541
+		//line sql.y:540
 		{
 			yyVAL.boolExpr = &NotExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:545
+		//line sql.y:544
 		{
 			yyVAL.boolExpr = &ParenBoolExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:551
+		//line sql.y:550
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: yyDollar[2].str, Right: yyDollar[3].valExpr}
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:555
+		//line sql.y:554
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_IN, Right: yyDollar[3].colTuple}
 		}
 	case 93:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:559
+		//line sql.y:558
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_IN, Right: yyDollar[4].colTuple}
 		}
 	case 94:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:563
+		//line sql.y:562
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_LIKE, Right: yyDollar[3].valExpr}
 		}
 	case 95:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:567
+		//line sql.y:566
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_LIKE, Right: yyDollar[4].valExpr}
 		}
 	case 96:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:571
+		//line sql.y:570
 		{
 			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_BETWEEN, From: yyDollar[3].valExpr, To: yyDollar[5].valExpr}
 		}
 	case 97:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:575
+		//line sql.y:574
 		{
 			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_NOT_BETWEEN, From: yyDollar[4].valExpr, To: yyDollar[6].valExpr}
 		}
 	case 98:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:579
+		//line sql.y:578
 		{
 			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 99:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:583
+		//line sql.y:582
 		{
 			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NOT_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 100:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:587
+		//line sql.y:586
 		{
 			yyVAL.boolExpr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 101:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:591
+		//line sql.y:590
 		{
 			yyVAL.boolExpr = &KeyrangeExpr{Start: yyDollar[3].valExpr, End: yyDollar[5].valExpr}
 		}
 	case 102:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:597
+		//line sql.y:596
 		{
 			yyVAL.str = AST_EQ
 		}
 	case 103:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:601
+		//line sql.y:600
 		{
 			yyVAL.str = AST_LT
 		}
 	case 104:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:605
+		//line sql.y:604
 		{
 			yyVAL.str = AST_GT
 		}
 	case 105:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:609
+		//line sql.y:608
 		{
 			yyVAL.str = AST_LE
 		}
 	case 106:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:613
+		//line sql.y:612
 		{
 			yyVAL.str = AST_GE
 		}
 	case 107:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:617
+		//line sql.y:616
 		{
 			yyVAL.str = AST_NE
 		}
 	case 108:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:621
+		//line sql.y:620
 		{
 			yyVAL.str = AST_NSE
 		}
 	case 109:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:627
+		//line sql.y:626
 		{
 			yyVAL.colTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 110:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:631
+		//line sql.y:630
 		{
 			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 111:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:635
+		//line sql.y:634
 		{
 			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 112:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:641
+		//line sql.y:640
 		{
 			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 113:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:647
+		//line sql.y:646
 		{
 			yyVAL.valExprs = ValExprs{yyDollar[1].valExpr}
 		}
 	case 114:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:651
+		//line sql.y:650
 		{
 			yyVAL.valExprs = append(yyDollar[1].valExprs, yyDollar[3].valExpr)
 		}
 	case 115:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:657
+		//line sql.y:656
 		{
 			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 116:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:661
+		//line sql.y:660
 		{
 			yyVAL.valExpr = yyDollar[1].colName
 		}
 	case 117:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:665
+		//line sql.y:664
 		{
 			yyVAL.valExpr = yyDollar[1].rowTuple
 		}
 	case 118:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:669
+		//line sql.y:668
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITAND, Right: yyDollar[3].valExpr}
 		}
 	case 119:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:673
+		//line sql.y:672
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITOR, Right: yyDollar[3].valExpr}
 		}
 	case 120:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:677
+		//line sql.y:676
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITXOR, Right: yyDollar[3].valExpr}
 		}
 	case 121:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:681
+		//line sql.y:680
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_PLUS, Right: yyDollar[3].valExpr}
 		}
 	case 122:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:685
+		//line sql.y:684
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MINUS, Right: yyDollar[3].valExpr}
 		}
 	case 123:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:689
+		//line sql.y:688
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MULT, Right: yyDollar[3].valExpr}
 		}
 	case 124:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:693
+		//line sql.y:692
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_DIV, Right: yyDollar[3].valExpr}
 		}
 	case 125:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:697
+		//line sql.y:696
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MOD, Right: yyDollar[3].valExpr}
 		}
 	case 126:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:701
+		//line sql.y:700
 		{
 			if num, ok := yyDollar[2].valExpr.(NumVal); ok {
 				switch yyDollar[1].byt {
@@ -1621,253 +1620,253 @@ yydefault:
 		}
 	case 127:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:716
+		//line sql.y:715
 		{
 			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID)}
 		}
 	case 128:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:720
+		//line sql.y:719
 		{
 			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID), Exprs: yyDollar[3].selectExprs}
 		}
 	case 129:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:724
+		//line sql.y:723
 		{
 			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID), Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 130:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:728
+		//line sql.y:727
 		{
 			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].str, Exprs: yyDollar[3].selectExprs}
 		}
 	case 131:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:732
+		//line sql.y:731
 		{
 			yyVAL.valExpr = yyDollar[1].caseExpr
 		}
 	case 132:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:738
+		//line sql.y:737
 		{
 			yyVAL.str = "if"
 		}
 	case 133:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:742
+		//line sql.y:741
 		{
 			yyVAL.str = "values"
 		}
 	case 134:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:748
+		//line sql.y:747
 		{
 			yyVAL.byt = AST_UPLUS
 		}
 	case 135:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:752
+		//line sql.y:751
 		{
 			yyVAL.byt = AST_UMINUS
 		}
 	case 136:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:756
+		//line sql.y:755
 		{
 			yyVAL.byt = AST_TILDA
 		}
 	case 137:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:762
+		//line sql.y:761
 		{
 			yyVAL.caseExpr = &CaseExpr{Expr: yyDollar[2].valExpr, Whens: yyDollar[3].whens, Else: yyDollar[4].valExpr}
 		}
 	case 138:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:767
+		//line sql.y:766
 		{
 			yyVAL.valExpr = nil
 		}
 	case 139:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:771
+		//line sql.y:770
 		{
 			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 140:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:777
+		//line sql.y:776
 		{
 			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 141:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:781
+		//line sql.y:780
 		{
 			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 142:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:787
+		//line sql.y:786
 		{
 			yyVAL.when = &When{Cond: yyDollar[2].boolExpr, Val: yyDollar[4].valExpr}
 		}
 	case 143:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:792
+		//line sql.y:791
 		{
 			yyVAL.valExpr = nil
 		}
 	case 144:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:796
+		//line sql.y:795
 		{
 			yyVAL.valExpr = yyDollar[2].valExpr
 		}
 	case 145:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:802
+		//line sql.y:801
 		{
 			yyVAL.colName = &ColName{Name: yyDollar[1].sqlID}
 		}
 	case 146:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:806
+		//line sql.y:805
 		{
-			yyVAL.colName = &ColName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].sqlID}
+			yyVAL.colName = &ColName{Qualifier: yyDollar[1].sqlID, Name: yyDollar[3].sqlID}
 		}
 	case 147:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:812
+		//line sql.y:811
 		{
 			yyVAL.valExpr = StrVal(yyDollar[1].bytes)
 		}
 	case 148:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:816
+		//line sql.y:815
 		{
 			yyVAL.valExpr = NumVal(yyDollar[1].bytes)
 		}
 	case 149:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:820
+		//line sql.y:819
 		{
 			yyVAL.valExpr = ValArg(yyDollar[1].bytes)
 		}
 	case 150:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:824
+		//line sql.y:823
 		{
 			yyVAL.valExpr = &NullVal{}
 		}
 	case 151:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:829
+		//line sql.y:828
 		{
 			yyVAL.valExprs = nil
 		}
 	case 152:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:833
+		//line sql.y:832
 		{
 			yyVAL.valExprs = yyDollar[3].valExprs
 		}
 	case 153:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:838
+		//line sql.y:837
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 154:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:842
+		//line sql.y:841
 		{
 			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
 	case 155:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:847
+		//line sql.y:846
 		{
 			yyVAL.orderBy = nil
 		}
 	case 156:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:851
+		//line sql.y:850
 		{
 			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 157:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:857
+		//line sql.y:856
 		{
 			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 158:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:861
+		//line sql.y:860
 		{
 			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 159:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:867
+		//line sql.y:866
 		{
 			yyVAL.order = &Order{Expr: yyDollar[1].valExpr, Direction: yyDollar[2].str}
 		}
 	case 160:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:872
+		//line sql.y:871
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 161:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:876
+		//line sql.y:875
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 162:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:880
+		//line sql.y:879
 		{
 			yyVAL.str = AST_DESC
 		}
 	case 163:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:885
+		//line sql.y:884
 		{
 			yyVAL.limit = nil
 		}
 	case 164:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:889
+		//line sql.y:888
 		{
 			yyVAL.limit = &Limit{Rowcount: yyDollar[2].valExpr}
 		}
 	case 165:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:893
+		//line sql.y:892
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[2].valExpr, Rowcount: yyDollar[4].valExpr}
 		}
 	case 166:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:898
+		//line sql.y:897
 		{
 			yyVAL.str = ""
 		}
 	case 167:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:902
+		//line sql.y:901
 		{
 			yyVAL.str = AST_FOR_UPDATE
 		}
 	case 168:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:906
+		//line sql.y:905
 		{
 			if yyDollar[3].sqlID != "share" {
 				yylex.Error("expecting share")
@@ -1881,211 +1880,211 @@ yydefault:
 		}
 	case 169:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:919
+		//line sql.y:918
 		{
 			yyVAL.columns = nil
 		}
 	case 170:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:923
+		//line sql.y:922
 		{
 			yyVAL.columns = yyDollar[2].columns
 		}
 	case 171:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:929
+		//line sql.y:928
 		{
 			yyVAL.columns = Columns{&NonStarExpr{Expr: yyDollar[1].colName}}
 		}
 	case 172:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:933
+		//line sql.y:932
 		{
 			yyVAL.columns = append(yyVAL.columns, &NonStarExpr{Expr: yyDollar[3].colName})
 		}
 	case 173:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:938
+		//line sql.y:937
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 174:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:942
+		//line sql.y:941
 		{
 			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 175:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:948
+		//line sql.y:947
 		{
 			yyVAL.insRows = yyDollar[2].values
 		}
 	case 176:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:952
+		//line sql.y:951
 		{
 			yyVAL.insRows = yyDollar[1].selStmt
 		}
 	case 177:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:958
+		//line sql.y:957
 		{
 			yyVAL.values = Values{yyDollar[1].rowTuple}
 		}
 	case 178:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:962
+		//line sql.y:961
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].rowTuple)
 		}
 	case 179:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:968
+		//line sql.y:967
 		{
 			yyVAL.rowTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 180:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:972
+		//line sql.y:971
 		{
 			yyVAL.rowTuple = yyDollar[1].subquery
 		}
 	case 181:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:978
+		//line sql.y:977
 		{
 			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 182:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:982
+		//line sql.y:981
 		{
 			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 183:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:988
+		//line sql.y:987
 		{
 			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].valExpr}
 		}
 	case 184:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:993
+		//line sql.y:992
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 185:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:995
+		//line sql.y:994
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 186:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:998
+		//line sql.y:997
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 187:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1000
+		//line sql.y:999
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 188:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1003
+		//line sql.y:1002
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 189:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1005
+		//line sql.y:1004
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 190:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1009
+		//line sql.y:1008
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 191:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1011
+		//line sql.y:1010
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 192:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1013
+		//line sql.y:1012
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 193:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1015
+		//line sql.y:1014
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 194:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1017
+		//line sql.y:1016
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 195:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1020
+		//line sql.y:1019
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 196:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1022
+		//line sql.y:1021
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 197:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1025
+		//line sql.y:1024
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 198:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1027
+		//line sql.y:1026
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 199:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1030
+		//line sql.y:1029
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 200:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1032
+		//line sql.y:1031
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 201:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1036
+		//line sql.y:1035
 		{
 			yyVAL.sqlID = SQLName(strings.ToLower(string(yyDollar[1].bytes)))
 		}
 	case 202:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1042
+		//line sql.y:1041
 		{
-			yyVAL.tableID = TableID(yyDollar[1].bytes)
+			yyVAL.sqlID = SQLName(yyDollar[1].bytes)
 		}
 	case 203:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1048
+		//line sql.y:1047
 		{
 			if incNesting(yylex) {
 				yylex.Error("max nesting level reached")
@@ -2094,13 +2093,13 @@ yydefault:
 		}
 	case 204:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1057
+		//line sql.y:1056
 		{
 			decNesting(yylex)
 		}
 	case 205:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1062
+		//line sql.y:1061
 		{
 			forceEOF(yylex)
 		}

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -4,7 +4,7 @@ package sqlparser
 import __yyfmt__ "fmt"
 
 //line sql.y:6
-import "bytes"
+import "strings"
 
 func setParseTree(yylex interface{}, stmt Statement) {
 	yylex.(*Tokenizer).ParseTree = stmt
@@ -30,14 +30,7 @@ func forceEOF(yylex interface{}) {
 	yylex.(*Tokenizer).ForceEOF = true
 }
 
-var (
-	SHARE        = []byte("share")
-	MODE         = []byte("mode")
-	IF_BYTES     = []byte("if")
-	VALUES_BYTES = []byte("values")
-)
-
-//line sql.y:43
+//line sql.y:36
 type yySymType struct {
 	yys         int
 	empty       struct{}
@@ -73,6 +66,9 @@ type yySymType struct {
 	insRows     InsertRows
 	updateExprs UpdateExprs
 	updateExpr  *UpdateExpr
+	sqlID       SQLName
+	sqlIDs      []SQLName
+	tableID     TableID
 }
 
 const LEX_ERROR = 57346
@@ -272,158 +268,166 @@ var yyExca = [...]int{
 	-1, 1,
 	1, -1,
 	-2, 0,
+	-1, 68,
+	78, 202,
+	-2, 201,
 }
 
-const yyNprod = 205
+const yyNprod = 206
 const yyPrivate = 57344
 
 var yyTokenNames []string
 var yyStates []string
 
-const yyLast = 625
+const yyLast = 680
 
 var yyAct = [...]int{
 
-	94, 163, 160, 366, 229, 333, 90, 91, 250, 62,
-	199, 296, 241, 288, 92, 63, 210, 179, 28, 29,
-	30, 31, 162, 3, 104, 80, 50, 81, 137, 136,
-	375, 131, 230, 261, 262, 263, 264, 265, 65, 266,
-	267, 70, 232, 294, 73, 64, 187, 76, 77, 85,
-	53, 68, 51, 52, 237, 43, 97, 44, 86, 257,
-	344, 103, 230, 38, 109, 40, 324, 125, 230, 41,
-	121, 98, 84, 100, 101, 102, 230, 230, 230, 129,
-	343, 342, 99, 69, 133, 72, 107, 49, 230, 230,
-	45, 242, 164, 46, 47, 48, 165, 122, 313, 315,
-	124, 242, 272, 286, 135, 88, 193, 118, 114, 105,
-	106, 82, 120, 173, 65, 136, 110, 65, 339, 183,
-	182, 64, 169, 177, 64, 191, 71, 289, 314, 194,
-	219, 108, 181, 253, 86, 205, 183, 230, 159, 161,
-	128, 209, 137, 136, 217, 218, 184, 221, 222, 223,
-	224, 225, 226, 227, 228, 203, 197, 326, 307, 204,
-	149, 150, 151, 308, 212, 206, 166, 231, 233, 234,
-	86, 86, 235, 341, 220, 340, 65, 65, 239, 190,
-	192, 189, 311, 64, 248, 246, 207, 208, 254, 137,
-	136, 310, 309, 236, 238, 249, 103, 245, 116, 109,
-	147, 148, 149, 150, 151, 75, 305, 66, 100, 101,
-	102, 306, 271, 273, 234, 255, 258, 99, 275, 276,
-	232, 107, 89, 116, 180, 351, 203, 180, 130, 59,
-	252, 274, 328, 283, 289, 279, 14, 175, 117, 212,
-	86, 280, 99, 282, 105, 106, 28, 29, 30, 31,
-	99, 110, 293, 285, 78, 89, 89, 111, 295, 291,
-	292, 167, 168, 281, 170, 171, 108, 202, 71, 259,
-	303, 304, 116, 202, 131, 213, 317, 99, 319, 176,
-	321, 99, 270, 99, 203, 203, 322, 66, 112, 325,
-	323, 115, 287, 350, 318, 65, 316, 201, 89, 269,
-	331, 334, 329, 89, 89, 134, 211, 330, 144, 145,
-	146, 147, 148, 149, 150, 151, 300, 299, 14, 15,
-	16, 17, 71, 345, 103, 196, 335, 195, 346, 347,
-	178, 126, 123, 119, 89, 89, 100, 101, 102, 60,
-	357, 234, 79, 349, 74, 355, 18, 89, 372, 113,
-	348, 327, 14, 363, 334, 58, 214, 364, 215, 216,
-	367, 367, 367, 65, 368, 369, 373, 365, 201, 278,
-	64, 374, 370, 376, 377, 244, 380, 379, 185, 127,
-	381, 211, 382, 56, 54, 297, 338, 356, 320, 358,
-	144, 145, 146, 147, 148, 149, 150, 151, 19, 20,
-	22, 21, 23, 298, 89, 251, 302, 353, 354, 89,
-	337, 24, 25, 26, 97, 180, 61, 378, 362, 103,
-	14, 33, 109, 186, 39, 256, 201, 201, 188, 98,
-	84, 100, 101, 102, 42, 261, 262, 263, 264, 265,
-	99, 266, 267, 32, 107, 67, 247, 174, 371, 352,
-	14, 144, 145, 146, 147, 148, 149, 150, 151, 34,
-	35, 36, 37, 88, 332, 97, 336, 105, 106, 82,
-	103, 301, 284, 109, 110, 172, 240, 96, 93, 95,
-	98, 66, 100, 101, 102, 290, 243, 138, 87, 108,
-	312, 99, 200, 260, 277, 107, 144, 145, 146, 147,
-	148, 149, 150, 151, 89, 198, 89, 83, 268, 359,
-	360, 361, 97, 14, 88, 132, 55, 103, 105, 106,
-	109, 27, 57, 13, 12, 110, 11, 98, 66, 100,
-	101, 102, 10, 103, 9, 8, 109, 7, 99, 6,
-	108, 5, 107, 4, 66, 100, 101, 102, 2, 1,
-	0, 0, 0, 0, 99, 0, 0, 0, 107, 0,
-	0, 88, 0, 0, 0, 105, 106, 0, 139, 143,
-	141, 142, 110, 144, 145, 146, 147, 148, 149, 150,
-	151, 105, 106, 0, 0, 0, 0, 108, 110, 155,
-	156, 157, 158, 0, 152, 153, 154, 0, 0, 0,
-	0, 0, 0, 108, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 140, 144, 145, 146,
-	147, 148, 149, 150, 151,
+	96, 165, 162, 368, 231, 335, 92, 93, 252, 63,
+	201, 298, 243, 290, 94, 64, 212, 181, 28, 29,
+	30, 31, 164, 3, 232, 82, 50, 83, 189, 263,
+	264, 265, 266, 267, 78, 268, 269, 377, 66, 133,
+	70, 72, 139, 138, 75, 65, 234, 296, 259, 87,
+	53, 127, 51, 52, 99, 38, 74, 40, 88, 105,
+	346, 41, 111, 345, 49, 315, 317, 344, 232, 100,
+	68, 102, 103, 104, 232, 43, 232, 44, 71, 45,
+	101, 131, 326, 232, 109, 232, 135, 46, 47, 48,
+	139, 138, 232, 232, 166, 316, 244, 274, 167, 124,
+	137, 221, 126, 90, 120, 328, 116, 107, 108, 84,
+	244, 122, 288, 138, 112, 175, 66, 341, 73, 66,
+	291, 185, 184, 65, 118, 179, 65, 139, 138, 110,
+	151, 152, 153, 255, 183, 291, 88, 207, 185, 130,
+	161, 163, 343, 211, 342, 222, 219, 220, 186, 223,
+	224, 225, 226, 227, 228, 229, 230, 208, 199, 309,
+	307, 206, 313, 312, 310, 308, 168, 311, 182, 233,
+	235, 236, 88, 88, 237, 59, 118, 106, 66, 66,
+	241, 28, 29, 30, 31, 65, 250, 248, 209, 210,
+	256, 182, 234, 132, 353, 238, 240, 251, 105, 247,
+	330, 111, 149, 150, 151, 152, 153, 285, 119, 68,
+	102, 103, 104, 261, 273, 275, 236, 257, 260, 101,
+	277, 278, 91, 109, 146, 147, 148, 149, 150, 151,
+	152, 153, 254, 276, 114, 215, 118, 281, 117, 133,
+	61, 101, 88, 282, 77, 284, 107, 108, 101, 113,
+	101, 73, 68, 112, 295, 287, 177, 91, 91, 115,
+	297, 293, 294, 169, 170, 283, 172, 173, 110, 101,
+	14, 61, 305, 306, 123, 79, 67, 171, 319, 272,
+	321, 178, 323, 263, 264, 265, 266, 267, 324, 268,
+	269, 327, 325, 80, 289, 350, 61, 66, 136, 203,
+	91, 61, 333, 336, 331, 91, 91, 329, 213, 332,
+	205, 101, 60, 58, 280, 73, 374, 14, 216, 214,
+	217, 218, 76, 381, 187, 347, 81, 129, 337, 56,
+	348, 349, 86, 54, 375, 60, 91, 91, 299, 60,
+	246, 340, 359, 236, 300, 351, 121, 357, 253, 91,
+	339, 125, 304, 182, 128, 365, 336, 62, 380, 366,
+	364, 14, 369, 369, 369, 66, 370, 371, 33, 367,
+	203, 270, 65, 376, 372, 378, 379, 134, 382, 188,
+	39, 205, 383, 213, 384, 258, 190, 42, 69, 358,
+	249, 360, 176, 180, 214, 373, 354, 334, 239, 338,
+	99, 303, 286, 174, 197, 105, 91, 198, 111, 204,
+	86, 91, 195, 242, 98, 100, 68, 102, 103, 104,
+	95, 355, 356, 97, 292, 32, 101, 245, 203, 203,
+	109, 193, 140, 89, 314, 196, 202, 262, 105, 205,
+	205, 34, 35, 36, 37, 200, 86, 86, 85, 90,
+	102, 103, 104, 107, 108, 84, 55, 27, 57, 13,
+	112, 14, 15, 16, 17, 146, 147, 148, 149, 150,
+	151, 152, 153, 12, 11, 110, 10, 9, 8, 271,
+	204, 232, 352, 7, 6, 192, 194, 191, 5, 18,
+	4, 2, 1, 0, 0, 14, 0, 146, 147, 148,
+	149, 150, 151, 152, 153, 0, 91, 0, 91, 0,
+	99, 361, 362, 363, 0, 105, 86, 0, 111, 0,
+	0, 0, 0, 0, 0, 100, 68, 102, 103, 104,
+	0, 0, 301, 0, 0, 302, 101, 0, 204, 204,
+	109, 19, 20, 22, 21, 23, 0, 0, 0, 318,
+	0, 320, 0, 0, 24, 25, 26, 99, 14, 90,
+	0, 0, 105, 107, 108, 111, 0, 0, 0, 0,
+	112, 0, 100, 68, 102, 103, 104, 0, 105, 0,
+	0, 111, 0, 101, 0, 110, 0, 109, 0, 68,
+	102, 103, 104, 0, 0, 0, 0, 0, 0, 101,
+	0, 0, 0, 109, 0, 0, 90, 0, 0, 0,
+	107, 108, 0, 141, 145, 143, 144, 112, 0, 0,
+	0, 0, 0, 0, 0, 0, 107, 108, 0, 0,
+	0, 0, 110, 112, 157, 158, 159, 160, 0, 154,
+	155, 156, 0, 0, 0, 0, 0, 322, 110, 146,
+	147, 148, 149, 150, 151, 152, 153, 0, 0, 0,
+	0, 142, 146, 147, 148, 149, 150, 151, 152, 153,
+	279, 0, 146, 147, 148, 149, 150, 151, 152, 153,
 }
 var yyPact = [...]int{
 
-	313, -1000, -1000, 195, -1000, -1000, -1000, -1000, -1000, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -27,
-	-37, 0, 3, -3, -1000, -1000, -1000, 415, 367, -1000,
-	-1000, -1000, 365, -1000, 326, 303, 407, 251, -44, -8,
-	232, -1000, -5, 232, -1000, 308, -48, 232, -48, 306,
-	-1000, -1000, -1000, -1000, -1000, 394, -1000, 216, 303, 316,
-	30, 303, 143, -1000, 191, -1000, 29, 297, 43, 232,
-	-1000, -1000, 296, -1000, -26, 295, 359, 74, 232, -1000,
-	219, -1000, -1000, 286, 26, 122, 547, -1000, 492, 445,
-	-1000, -1000, -1000, 171, 196, 196, -1000, 196, 196, -1000,
-	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	171, -1000, 204, 251, 294, 405, 251, 171, 232, -1000,
-	358, -51, -1000, 93, -1000, 291, -1000, -1000, 289, -1000,
-	237, 394, -1000, -1000, 232, 90, 492, 492, 171, 235,
-	335, 171, 171, 105, 171, 171, 171, 171, 171, 171,
-	171, 171, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
-	547, -39, -33, -13, 547, -1000, 508, 36, 394, -1000,
-	415, 299, 10, 503, 347, 251, 251, 217, -1000, 392,
-	492, -1000, 503, -1000, -1000, -1000, 67, 232, -1000, -34,
-	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, 214, 379,
-	263, 231, 24, -1000, -1000, -1000, -1000, -1000, 47, 503,
-	-1000, 508, -1000, -1000, 235, 171, 171, 503, 426, -1000,
-	344, 127, 127, 127, 85, 85, -1000, -1000, -1000, -1000,
-	-1000, -1000, 171, -1000, 503, -1000, -24, 394, -24, 178,
-	20, -1000, 492, 61, 196, 195, 168, -12, -1000, 392,
-	370, 389, 122, 281, -1000, -1000, 280, -1000, 395, 237,
-	237, -1000, -1000, 150, 102, 136, 135, 126, 34, -1000,
-	260, -23, 258, -13, -1000, 503, 320, 171, -1000, 503,
-	-1000, -24, -1000, 299, -18, -1000, 171, 75, -1000, 321,
-	177, -1000, -1000, -1000, 251, 370, -1000, 171, 171, -1000,
-	-1000, 398, 372, 379, 52, -1000, 119, -1000, 117, -1000,
-	-1000, -1000, -1000, -10, -11, -31, -1000, -1000, -1000, -1000,
-	171, 503, -1000, -69, -1000, 503, 171, 319, 196, -1000,
-	-1000, 238, 170, -1000, 381, -1000, 392, 492, 171, 492,
-	-1000, -1000, 196, 196, 196, 503, -1000, 503, 411, -1000,
-	171, 171, -1000, -1000, -1000, 370, 122, 165, 122, 232,
-	232, 232, 251, 503, -1000, 332, -25, -1000, -25, -25,
-	143, -1000, 410, 356, -1000, 232, -1000, -1000, -1000, 232,
-	-1000, 232, -1000,
+	456, -1000, -1000, 130, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -35,
+	-17, -11, -3, -26, -1000, -1000, -1000, 356, 316, -1000,
+	-1000, -1000, 311, -1000, 284, 235, 348, 216, -55, -13,
+	215, -1000, -34, 215, -1000, 235, -61, 239, -61, 235,
+	-1000, -1000, -1000, -1000, -1000, 34, -1000, 208, 235, 226,
+	28, -1000, 235, 121, -1000, 161, -1000, 26, -1000, 235,
+	42, 238, -1000, -1000, 235, -1000, -42, 235, 307, 73,
+	215, -1000, 184, -1000, -1000, 279, 22, 60, 592, -1000,
+	537, 490, -1000, -1000, -1000, 173, 202, 202, -1000, 202,
+	202, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, 173, -1000, 223, 216, 235, 343, 216, 173,
+	215, -1000, 304, -69, -1000, 399, -1000, 235, -1000, -1000,
+	235, -1000, 204, 34, -1000, -1000, 215, 82, 537, 537,
+	173, 195, 297, 173, 173, 76, 173, 173, 173, 173,
+	173, 173, 173, 173, -1000, -1000, -1000, -1000, -1000, -1000,
+	-1000, -1000, 592, -25, -33, -9, 592, -1000, 553, 380,
+	34, -1000, 356, 413, 15, 154, 312, 216, 216, 181,
+	-1000, 335, 537, -1000, 154, -1000, -1000, -1000, 67, 215,
+	-1000, -45, -1000, -1000, -1000, -1000, -1000, -1000, -1000, -1000,
+	158, 227, 260, 265, 19, -1000, -1000, -1000, -1000, -1000,
+	45, 154, -1000, 553, -1000, -1000, 195, 173, 173, 154,
+	602, -1000, 289, 129, 129, 129, 55, 55, -1000, -1000,
+	-1000, -1000, -1000, -1000, 173, -1000, 154, -1000, -16, 34,
+	-16, 152, 29, -1000, 537, 54, 202, 130, 69, -8,
+	-1000, 335, 323, 330, 60, 235, -1000, -1000, 235, -1000,
+	341, 204, 204, -1000, -1000, 104, 103, 111, 107, 106,
+	1, -1000, 235, -27, 235, -9, -1000, 154, 579, 173,
+	-1000, 154, -1000, -16, -1000, 413, -2, -1000, 173, 23,
+	-1000, 277, 145, -1000, -1000, -1000, 216, 323, -1000, 173,
+	173, -1000, -1000, 338, 327, 227, 51, -1000, 88, -1000,
+	86, -1000, -1000, -1000, -1000, -24, -28, -31, -1000, -1000,
+	-1000, -1000, 173, 154, -1000, -77, -1000, 154, 173, 264,
+	202, -1000, -1000, 427, 139, -1000, 395, -1000, 335, 537,
+	173, 537, -1000, -1000, 202, 202, 202, 154, -1000, 154,
+	353, -1000, 173, 173, -1000, -1000, -1000, 323, 60, 137,
+	60, 215, 215, 215, 216, 154, -1000, 300, -18, -1000,
+	-18, -18, 121, -1000, 351, 302, -1000, 215, -1000, -1000,
+	-1000, 215, -1000, 215, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 549, 548, 22, 543, 541, 539, 537, 535, 534,
-	532, 526, 524, 523, 443, 522, 521, 516, 25, 27,
-	515, 508, 507, 505, 10, 493, 492, 229, 490, 3,
-	17, 49, 488, 487, 486, 6, 2, 16, 1, 485,
-	14, 479, 24, 478, 7, 477, 476, 12, 475, 472,
-	471, 466, 8, 464, 5, 449, 11, 448, 447, 446,
-	13, 9, 15, 205, 445, 434, 428, 425, 424, 423,
-	0, 26, 421, 166, 4,
+	0, 492, 491, 22, 490, 488, 484, 483, 478, 477,
+	476, 474, 473, 459, 425, 458, 457, 456, 25, 27,
+	448, 445, 10, 437, 436, 175, 434, 3, 17, 49,
+	433, 432, 427, 6, 2, 16, 1, 424, 14, 423,
+	177, 420, 7, 414, 413, 12, 403, 402, 401, 399,
+	8, 397, 5, 396, 11, 395, 392, 390, 13, 9,
+	15, 244, 388, 387, 386, 385, 380, 379, 0, 377,
+	276, 371, 26, 368, 166, 4,
 }
 var yyR1 = [...]int{
 
 	0, 1, 2, 2, 2, 2, 2, 2, 2, 2,
 	2, 2, 2, 3, 3, 4, 4, 5, 6, 7,
 	8, 8, 8, 9, 9, 9, 10, 11, 11, 11,
-	12, 13, 13, 13, 72, 14, 15, 15, 16, 16,
+	12, 13, 13, 13, 73, 14, 15, 15, 16, 16,
 	16, 16, 16, 17, 17, 18, 18, 19, 19, 19,
-	22, 22, 20, 20, 20, 23, 23, 24, 24, 24,
-	24, 21, 21, 21, 25, 25, 25, 25, 25, 25,
-	25, 25, 25, 26, 26, 26, 27, 27, 28, 28,
-	28, 28, 29, 29, 30, 30, 31, 31, 31, 31,
-	31, 32, 32, 32, 32, 32, 32, 32, 32, 32,
-	32, 32, 33, 33, 33, 33, 33, 33, 33, 37,
-	37, 37, 42, 38, 38, 36, 36, 36, 36, 36,
-	36, 36, 36, 36, 36, 36, 36, 36, 36, 36,
-	36, 36, 41, 41, 43, 43, 43, 45, 48, 48,
-	46, 46, 47, 49, 49, 44, 44, 35, 35, 35,
-	35, 50, 50, 51, 51, 52, 52, 53, 53, 54,
-	55, 55, 55, 56, 56, 56, 57, 57, 57, 58,
-	58, 59, 59, 60, 60, 34, 34, 39, 39, 40,
-	40, 61, 61, 62, 63, 63, 64, 64, 65, 65,
-	66, 66, 66, 66, 66, 67, 67, 68, 68, 69,
-	69, 70, 73, 74, 71,
+	20, 20, 69, 69, 69, 21, 21, 22, 22, 22,
+	22, 71, 71, 71, 23, 23, 23, 23, 23, 23,
+	23, 23, 23, 24, 24, 24, 25, 25, 26, 26,
+	26, 26, 27, 27, 28, 28, 29, 29, 29, 29,
+	29, 30, 30, 30, 30, 30, 30, 30, 30, 30,
+	30, 30, 31, 31, 31, 31, 31, 31, 31, 35,
+	35, 35, 40, 36, 36, 34, 34, 34, 34, 34,
+	34, 34, 34, 34, 34, 34, 34, 34, 34, 34,
+	34, 34, 39, 39, 41, 41, 41, 43, 46, 46,
+	44, 44, 45, 47, 47, 42, 42, 33, 33, 33,
+	33, 48, 48, 49, 49, 50, 50, 51, 51, 52,
+	53, 53, 53, 54, 54, 54, 55, 55, 55, 56,
+	56, 57, 57, 58, 58, 32, 32, 37, 37, 38,
+	38, 59, 59, 60, 61, 61, 62, 62, 63, 63,
+	64, 64, 64, 64, 64, 65, 65, 66, 66, 67,
+	67, 68, 70, 74, 75, 72,
 }
 var yyR2 = [...]int{
 
@@ -447,91 +451,91 @@ var yyR2 = [...]int{
 	3, 1, 3, 0, 5, 2, 1, 1, 3, 3,
 	1, 1, 3, 3, 0, 2, 0, 3, 0, 1,
 	1, 1, 1, 1, 1, 0, 1, 0, 1, 0,
-	2, 1, 1, 1, 0,
+	2, 1, 1, 1, 1, 0,
 }
 var yyChk = [...]int{
 
 	-1000, -1, -2, -3, -4, -5, -6, -7, -8, -9,
 	-10, -11, -12, -13, 5, 6, 7, 8, 33, 85,
 	86, 88, 87, 89, 98, 99, 100, -16, 51, 52,
-	53, 54, -14, -72, -14, -14, -14, -14, 90, -68,
-	92, 96, -65, 92, 94, 90, 90, 91, 92, 90,
-	-71, -71, -71, -3, 17, -17, 18, -15, 29, -27,
-	36, 9, -61, -62, -44, -70, 36, -64, 95, 91,
-	-70, 36, 90, -70, 36, -63, 95, -70, -63, 36,
-	-18, -19, 75, -22, 36, -31, -36, -32, 69, -73,
-	-35, -44, -40, -43, -70, -41, -45, 20, 35, 46,
-	37, 38, 39, 25, -42, 73, 74, 50, 95, 28,
-	80, 41, -27, 33, 78, -27, 55, 47, 78, 36,
-	69, -70, -71, 36, -71, 93, 36, 20, 66, -70,
-	9, 55, -20, -70, 19, 78, 68, 67, -33, 21,
-	69, 23, 24, 22, 70, 71, 72, 73, 74, 75,
-	76, 77, 47, 48, 49, 42, 43, 44, 45, -31,
-	-36, -31, -3, -38, -36, -36, -73, -73, -73, -42,
-	-73, -73, -48, -36, -58, 33, -73, -61, 36, -30,
-	10, -62, -36, -70, -71, 20, -69, 97, -66, 88,
-	86, 32, 87, 13, 36, 36, 36, -71, -23, -24,
-	-26, -73, 36, -42, -19, -70, 75, -31, -31, -36,
-	-37, -73, -42, 40, 21, 23, 24, -36, -36, 25,
-	69, -36, -36, -36, -36, -36, -36, -36, -36, -74,
-	101, -74, 55, -74, -36, -74, -18, 18, -18, -35,
-	-46, -47, 81, -34, 28, -3, -61, -59, -44, -30,
-	-52, 13, -31, 66, -70, -71, -67, 93, -30, 55,
-	-25, 56, 57, 58, 59, 60, 62, 63, -21, 36,
-	19, -24, 78, -38, -37, -36, -36, 68, 25, -36,
-	-74, -18, -74, 55, -49, -47, 83, -31, -60, 66,
-	-39, -40, -60, -74, 55, -52, -56, 15, 14, 36,
-	36, -50, 11, -24, -24, 56, 61, 56, 61, 56,
-	56, 56, -28, 64, 94, 65, 36, -74, 36, -74,
-	68, -36, -74, -35, 84, -36, 82, 30, 55, -44,
-	-56, -36, -53, -54, -36, -71, -51, 12, 14, 66,
-	56, 56, 91, 91, 91, -36, -74, -36, 31, -40,
-	55, 55, -55, 26, 27, -52, -31, -38, -31, -73,
-	-73, -73, 7, -36, -54, -56, -29, -70, -29, -29,
-	-61, -57, 16, 34, -74, 55, -74, -74, 7, 21,
-	-70, -70, -70,
+	53, 54, -14, -73, -14, -14, -14, -14, 90, -66,
+	92, 96, -63, 92, 94, 90, 90, 91, 92, 90,
+	-72, -72, -72, -3, 17, -17, 18, -15, 29, -25,
+	-70, 36, 9, -59, -60, -42, -68, -70, 36, -62,
+	95, 91, -68, 36, 90, -68, -70, -61, 95, 36,
+	-61, -70, -18, -19, 75, -20, -70, -29, -34, -30,
+	69, -74, -33, -42, -38, -41, -68, -39, -43, 20,
+	35, 46, 37, 38, 39, 25, -40, 73, 74, 50,
+	95, 28, 80, 41, -25, 33, 78, -25, 55, 47,
+	78, -70, 69, 36, -72, -70, -72, 93, -70, 20,
+	66, -68, 9, 55, -69, -68, 19, 78, 68, 67,
+	-31, 21, 69, 23, 24, 22, 70, 71, 72, 73,
+	74, 75, 76, 77, 47, 48, 49, 42, 43, 44,
+	45, -29, -34, -29, -3, -36, -34, -34, -74, -74,
+	-74, -40, -74, -74, -46, -34, -56, 33, -74, -59,
+	-70, -28, 10, -60, -34, -68, -72, 20, -67, 97,
+	-64, 88, 86, 32, 87, 13, 36, -70, -70, -72,
+	-21, -22, -24, -74, -70, -40, -19, -68, 75, -29,
+	-29, -34, -35, -74, -40, 40, 21, 23, 24, -34,
+	-34, 25, 69, -34, -34, -34, -34, -34, -34, -34,
+	-34, -75, 101, -75, 55, -75, -34, -75, -18, 18,
+	-18, -33, -44, -45, 81, -32, 28, -3, -59, -57,
+	-42, -28, -50, 13, -29, 66, -68, -72, -65, 93,
+	-28, 55, -23, 56, 57, 58, 59, 60, 62, 63,
+	-71, -70, 19, -22, 78, -36, -35, -34, -34, 68,
+	25, -34, -75, -18, -75, 55, -47, -45, 83, -29,
+	-58, 66, -37, -38, -58, -75, 55, -50, -54, 15,
+	14, -70, -70, -48, 11, -22, -22, 56, 61, 56,
+	61, 56, 56, 56, -26, 64, 94, 65, -70, -75,
+	-70, -75, 68, -34, -75, -33, 84, -34, 82, 30,
+	55, -42, -54, -34, -51, -52, -34, -72, -49, 12,
+	14, 66, 56, 56, 91, 91, 91, -34, -75, -34,
+	31, -38, 55, 55, -53, 26, 27, -50, -29, -36,
+	-29, -74, -74, -74, 7, -34, -52, -54, -27, -68,
+	-27, -27, -59, -55, 16, 34, -75, 55, -75, -75,
+	7, 21, -68, -68, -68,
 }
 var yyDef = [...]int{
 
 	0, -2, 1, 2, 3, 4, 5, 6, 7, 8,
 	9, 10, 11, 12, 34, 34, 34, 34, 34, 197,
-	188, 0, 0, 0, 204, 204, 204, 0, 38, 40,
+	188, 0, 0, 0, 205, 205, 205, 0, 38, 40,
 	41, 42, 43, 36, 0, 0, 0, 0, 186, 0,
 	0, 198, 0, 0, 189, 0, 184, 0, 184, 0,
 	31, 32, 33, 14, 39, 0, 44, 35, 0, 0,
-	76, 0, 19, 181, 0, 145, 201, 0, 0, 0,
-	204, 201, 0, 204, 0, 0, 0, 0, 0, 30,
-	0, 45, 47, 52, 201, 50, 51, 86, 0, 0,
-	115, 116, 117, 0, 145, 0, 131, 0, 0, 202,
-	147, 148, 149, 150, 180, 134, 135, 136, 132, 133,
-	138, 37, 169, 0, 0, 84, 0, 0, 0, 204,
-	0, 199, 22, 0, 25, 0, 27, 185, 0, 204,
-	0, 0, 48, 53, 0, 0, 0, 0, 0, 0,
+	76, 202, 0, 19, 181, 0, 145, 0, -2, 0,
+	0, 0, 205, 201, 0, 205, 0, 0, 0, 0,
+	0, 30, 0, 45, 47, 52, 0, 50, 51, 86,
+	0, 0, 115, 116, 117, 0, 145, 0, 131, 0,
+	0, 203, 147, 148, 149, 150, 180, 134, 135, 136,
+	132, 133, 138, 37, 169, 0, 0, 84, 0, 0,
+	0, 205, 0, 199, 22, 0, 25, 0, 27, 185,
+	0, 205, 0, 0, 48, 53, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 102, 103, 104, 105, 106, 107, 108, 89,
-	0, 0, 0, 0, 113, 126, 0, 0, 0, 100,
-	0, 0, 0, 139, 0, 0, 0, 84, 77, 155,
-	0, 182, 183, 146, 20, 187, 0, 0, 204, 195,
-	190, 191, 192, 193, 194, 26, 28, 29, 84, 55,
-	61, 0, 73, 75, 46, 54, 49, 87, 88, 91,
-	92, 0, 110, 111, 0, 0, 0, 94, 0, 98,
-	0, 118, 119, 120, 121, 122, 123, 124, 125, 90,
-	203, 112, 0, 179, 113, 127, 0, 0, 0, 0,
-	143, 140, 0, 173, 0, 176, 173, 0, 171, 155,
-	163, 0, 85, 0, 200, 23, 0, 196, 151, 0,
-	0, 64, 65, 0, 0, 0, 0, 0, 78, 62,
-	0, 0, 0, 0, 93, 95, 0, 0, 99, 114,
-	128, 0, 130, 0, 0, 141, 0, 0, 15, 0,
-	175, 177, 16, 170, 0, 163, 18, 0, 0, 204,
-	24, 153, 0, 56, 59, 66, 0, 68, 0, 70,
-	71, 72, 57, 0, 0, 0, 63, 58, 74, 109,
-	0, 96, 129, 0, 137, 144, 0, 0, 0, 172,
-	17, 164, 156, 157, 160, 21, 155, 0, 0, 0,
-	67, 69, 0, 0, 0, 97, 101, 142, 0, 178,
-	0, 0, 159, 161, 162, 163, 154, 152, 60, 0,
-	0, 0, 0, 165, 158, 166, 0, 82, 0, 0,
-	174, 13, 0, 0, 79, 0, 80, 81, 167, 0,
-	83, 0, 168,
+	0, 0, 0, 0, 102, 103, 104, 105, 106, 107,
+	108, 89, 0, 0, 0, 0, 113, 126, 0, 0,
+	0, 100, 0, 0, 0, 139, 0, 0, 0, 84,
+	77, 155, 0, 182, 183, 146, 20, 187, 0, 0,
+	205, 195, 190, 191, 192, 193, 194, 26, 28, 29,
+	84, 55, 61, 0, 73, 75, 46, 54, 49, 87,
+	88, 91, 92, 0, 110, 111, 0, 0, 0, 94,
+	0, 98, 0, 118, 119, 120, 121, 122, 123, 124,
+	125, 90, 204, 112, 0, 179, 113, 127, 0, 0,
+	0, 0, 143, 140, 0, 173, 0, 176, 173, 0,
+	171, 155, 163, 0, 85, 0, 200, 23, 0, 196,
+	151, 0, 0, 64, 65, 0, 0, 0, 0, 0,
+	78, 62, 0, 0, 0, 0, 93, 95, 0, 0,
+	99, 114, 128, 0, 130, 0, 0, 141, 0, 0,
+	15, 0, 175, 177, 16, 170, 0, 163, 18, 0,
+	0, 205, 24, 153, 0, 56, 59, 66, 0, 68,
+	0, 70, 71, 72, 57, 0, 0, 0, 63, 58,
+	74, 109, 0, 96, 129, 0, 137, 144, 0, 0,
+	0, 172, 17, 164, 156, 157, 160, 21, 155, 0,
+	0, 0, 67, 69, 0, 0, 0, 97, 101, 142,
+	0, 178, 0, 0, 159, 161, 162, 163, 154, 152,
+	60, 0, 0, 0, 0, 165, 158, 166, 0, 82,
+	0, 0, 174, 13, 0, 0, 79, 0, 80, 81,
+	167, 0, 83, 0, 168,
 }
 var yyTok1 = [...]int{
 
@@ -906,37 +910,37 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:163
+		//line sql.y:159
 		{
 			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:169
+		//line sql.y:165
 		{
 			yyVAL.statement = yyDollar[1].selStmt
 		}
 	case 13:
 		yyDollar = yyS[yypt-12 : yypt+1]
-		//line sql.y:185
+		//line sql.y:181
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Distinct: yyDollar[3].str, SelectExprs: yyDollar[4].selectExprs, From: yyDollar[6].tableExprs, Where: NewWhere(AST_WHERE, yyDollar[7].boolExpr), GroupBy: GroupBy(yyDollar[8].valExprs), Having: NewWhere(AST_HAVING, yyDollar[9].boolExpr), OrderBy: yyDollar[10].orderBy, Limit: yyDollar[11].limit, Lock: yyDollar[12].str}
 		}
 	case 14:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:189
+		//line sql.y:185
 		{
 			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt}
 		}
 	case 15:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:195
+		//line sql.y:191
 		{
 			yyVAL.statement = &Insert{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Columns: yyDollar[5].columns, Rows: yyDollar[6].insRows, OnDup: OnDup(yyDollar[7].updateExprs)}
 		}
 	case 16:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:199
+		//line sql.y:195
 		{
 			cols := make(Columns, 0, len(yyDollar[6].updateExprs))
 			vals := make(ValTuple, 0, len(yyDollar[6].updateExprs))
@@ -948,659 +952,659 @@ yydefault:
 		}
 	case 17:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:211
+		//line sql.y:207
 		{
 			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[3].tableName, Exprs: yyDollar[5].updateExprs, Where: NewWhere(AST_WHERE, yyDollar[6].boolExpr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 18:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:217
+		//line sql.y:213
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Table: yyDollar[4].tableName, Where: NewWhere(AST_WHERE, yyDollar[5].boolExpr), OrderBy: yyDollar[6].orderBy, Limit: yyDollar[7].limit}
 		}
 	case 19:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:223
+		//line sql.y:219
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].updateExprs}
 		}
 	case 20:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:229
+		//line sql.y:225
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[4].bytes}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[4].tableID}
 		}
 	case 21:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line sql.y:233
+		//line sql.y:229
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[7].bytes, NewName: yyDollar[7].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[7].tableID, NewName: yyDollar[7].tableID}
 		}
 	case 22:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:238
+		//line sql.y:234
 		{
-			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: yyDollar[3].bytes}
+			yyVAL.statement = &DDL{Action: AST_CREATE, NewName: TableID(yyDollar[3].sqlID)}
 		}
 	case 23:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:244
+		//line sql.y:240
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[4].bytes, NewName: yyDollar[4].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[4].tableID, NewName: yyDollar[4].tableID}
 		}
 	case 24:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line sql.y:248
+		//line sql.y:244
 		{
 			// Change this to a rename statement
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[4].bytes, NewName: yyDollar[7].bytes}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[4].tableID, NewName: yyDollar[7].tableID}
 		}
 	case 25:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:253
+		//line sql.y:249
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].bytes, NewName: yyDollar[3].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: TableID(yyDollar[3].sqlID), NewName: TableID(yyDollar[3].sqlID)}
 		}
 	case 26:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:259
+		//line sql.y:255
 		{
-			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[3].bytes, NewName: yyDollar[5].bytes}
+			yyVAL.statement = &DDL{Action: AST_RENAME, Table: yyDollar[3].tableID, NewName: yyDollar[5].tableID}
 		}
 	case 27:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:265
+		//line sql.y:261
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].bytes}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].tableID}
 		}
 	case 28:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:269
+		//line sql.y:265
 		{
 			// Change this to an alter statement
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[5].bytes, NewName: yyDollar[5].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[5].tableID, NewName: yyDollar[5].tableID}
 		}
 	case 29:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:274
+		//line sql.y:270
 		{
-			yyVAL.statement = &DDL{Action: AST_DROP, Table: yyDollar[4].bytes}
+			yyVAL.statement = &DDL{Action: AST_DROP, Table: TableID(yyDollar[4].sqlID)}
 		}
 	case 30:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:280
+		//line sql.y:276
 		{
-			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].bytes, NewName: yyDollar[3].bytes}
+			yyVAL.statement = &DDL{Action: AST_ALTER, Table: yyDollar[3].tableID, NewName: yyDollar[3].tableID}
 		}
 	case 31:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:286
+		//line sql.y:282
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 32:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:290
+		//line sql.y:286
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 33:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:294
+		//line sql.y:290
 		{
 			yyVAL.statement = &Other{}
 		}
 	case 34:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:299
+		//line sql.y:295
 		{
 			setAllowComments(yylex, true)
 		}
 	case 35:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:303
+		//line sql.y:299
 		{
 			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 36:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:309
+		//line sql.y:305
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:313
+		//line sql.y:309
 		{
 			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 38:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:319
+		//line sql.y:315
 		{
 			yyVAL.str = AST_UNION
 		}
 	case 39:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:323
+		//line sql.y:319
 		{
 			yyVAL.str = AST_UNION_ALL
 		}
 	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:327
+		//line sql.y:323
 		{
 			yyVAL.str = AST_SET_MINUS
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:331
+		//line sql.y:327
 		{
 			yyVAL.str = AST_EXCEPT
 		}
 	case 42:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:335
+		//line sql.y:331
 		{
 			yyVAL.str = AST_INTERSECT
 		}
 	case 43:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:340
+		//line sql.y:336
 		{
 			yyVAL.str = ""
 		}
 	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:344
+		//line sql.y:340
 		{
 			yyVAL.str = AST_DISTINCT
 		}
 	case 45:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:350
+		//line sql.y:346
 		{
 			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 46:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:354
+		//line sql.y:350
 		{
 			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:360
+		//line sql.y:356
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 48:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:364
+		//line sql.y:360
 		{
-			yyVAL.selectExpr = &NonStarExpr{Expr: yyDollar[1].expr, As: yyDollar[2].bytes}
+			yyVAL.selectExpr = &NonStarExpr{Expr: yyDollar[1].expr, As: yyDollar[2].sqlID}
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:368
+		//line sql.y:364
 		{
-			yyVAL.selectExpr = &StarExpr{TableName: yyDollar[1].bytes}
+			yyVAL.selectExpr = &StarExpr{TableName: yyDollar[1].tableID}
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:374
+		//line sql.y:370
 		{
 			yyVAL.expr = yyDollar[1].boolExpr
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:378
+		//line sql.y:374
 		{
 			yyVAL.expr = yyDollar[1].valExpr
 		}
 	case 52:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:383
+		//line sql.y:379
 		{
-			yyVAL.bytes = nil
+			yyVAL.sqlID = ""
 		}
 	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:387
+		//line sql.y:383
 		{
-			yyVAL.bytes = yyDollar[1].bytes
+			yyVAL.sqlID = yyDollar[1].sqlID
 		}
 	case 54:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:391
+		//line sql.y:387
 		{
-			yyVAL.bytes = yyDollar[2].bytes
+			yyVAL.sqlID = yyDollar[2].sqlID
 		}
 	case 55:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:397
+		//line sql.y:393
 		{
 			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 56:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:401
+		//line sql.y:397
 		{
 			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:407
+		//line sql.y:403
 		{
-			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].smTableExpr, As: yyDollar[2].bytes, Hints: yyDollar[3].indexHints}
+			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].smTableExpr, As: yyDollar[2].tableID, Hints: yyDollar[3].indexHints}
 		}
 	case 58:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:411
+		//line sql.y:407
 		{
 			yyVAL.tableExpr = &ParenTableExpr{Expr: yyDollar[2].tableExpr}
 		}
 	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:415
+		//line sql.y:411
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 60:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:419
+		//line sql.y:415
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, On: yyDollar[5].boolExpr}
 		}
 	case 61:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:424
+		//line sql.y:420
 		{
-			yyVAL.bytes = nil
+			yyVAL.tableID = ""
 		}
 	case 62:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:428
+		//line sql.y:424
 		{
-			yyVAL.bytes = yyDollar[1].bytes
+			yyVAL.tableID = yyDollar[1].tableID
 		}
 	case 63:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:432
+		//line sql.y:428
 		{
-			yyVAL.bytes = yyDollar[2].bytes
+			yyVAL.tableID = yyDollar[2].tableID
 		}
 	case 64:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:438
+		//line sql.y:434
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 65:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:442
+		//line sql.y:438
 		{
 			yyVAL.str = AST_STRAIGHT_JOIN
 		}
 	case 66:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:446
+		//line sql.y:442
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 67:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:450
+		//line sql.y:446
 		{
 			yyVAL.str = AST_LEFT_JOIN
 		}
 	case 68:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:454
+		//line sql.y:450
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 69:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:458
+		//line sql.y:454
 		{
 			yyVAL.str = AST_RIGHT_JOIN
 		}
 	case 70:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:462
+		//line sql.y:458
 		{
 			yyVAL.str = AST_JOIN
 		}
 	case 71:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:466
+		//line sql.y:462
 		{
 			yyVAL.str = AST_CROSS_JOIN
 		}
 	case 72:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:470
+		//line sql.y:466
 		{
 			yyVAL.str = AST_NATURAL_JOIN
 		}
 	case 73:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:476
+		//line sql.y:472
 		{
-			yyVAL.smTableExpr = &TableName{Name: yyDollar[1].bytes}
+			yyVAL.smTableExpr = &TableName{Name: yyDollar[1].tableID}
 		}
 	case 74:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:480
+		//line sql.y:476
 		{
-			yyVAL.smTableExpr = &TableName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
+			yyVAL.smTableExpr = &TableName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].tableID}
 		}
 	case 75:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:484
+		//line sql.y:480
 		{
 			yyVAL.smTableExpr = yyDollar[1].subquery
 		}
 	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:490
+		//line sql.y:486
 		{
-			yyVAL.tableName = &TableName{Name: yyDollar[1].bytes}
+			yyVAL.tableName = &TableName{Name: yyDollar[1].tableID}
 		}
 	case 77:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:494
+		//line sql.y:490
 		{
-			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
+			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].tableID}
 		}
 	case 78:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:499
+		//line sql.y:495
 		{
 			yyVAL.indexHints = nil
 		}
 	case 79:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:503
+		//line sql.y:499
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_USE, Indexes: yyDollar[4].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_USE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 80:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:507
+		//line sql.y:503
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_IGNORE, Indexes: yyDollar[4].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_IGNORE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 81:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:511
+		//line sql.y:507
 		{
-			yyVAL.indexHints = &IndexHints{Type: AST_FORCE, Indexes: yyDollar[4].bytes2}
+			yyVAL.indexHints = &IndexHints{Type: AST_FORCE, Indexes: yyDollar[4].sqlIDs}
 		}
 	case 82:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:517
+		//line sql.y:513
 		{
-			yyVAL.bytes2 = [][]byte{yyDollar[1].bytes}
+			yyVAL.sqlIDs = []SQLName{yyDollar[1].sqlID}
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:521
+		//line sql.y:517
 		{
-			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[3].bytes)
+			yyVAL.sqlIDs = append(yyDollar[1].sqlIDs, yyDollar[3].sqlID)
 		}
 	case 84:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:526
+		//line sql.y:522
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:530
+		//line sql.y:526
 		{
 			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
 	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:537
+		//line sql.y:533
 		{
 			yyVAL.boolExpr = &AndExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:541
+		//line sql.y:537
 		{
 			yyVAL.boolExpr = &OrExpr{Left: yyDollar[1].boolExpr, Right: yyDollar[3].boolExpr}
 		}
 	case 89:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:545
+		//line sql.y:541
 		{
 			yyVAL.boolExpr = &NotExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 90:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:549
+		//line sql.y:545
 		{
 			yyVAL.boolExpr = &ParenBoolExpr{Expr: yyDollar[2].boolExpr}
 		}
 	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:555
+		//line sql.y:551
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: yyDollar[2].str, Right: yyDollar[3].valExpr}
 		}
 	case 92:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:559
+		//line sql.y:555
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_IN, Right: yyDollar[3].colTuple}
 		}
 	case 93:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:563
+		//line sql.y:559
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_IN, Right: yyDollar[4].colTuple}
 		}
 	case 94:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:567
+		//line sql.y:563
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_LIKE, Right: yyDollar[3].valExpr}
 		}
 	case 95:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:571
+		//line sql.y:567
 		{
 			yyVAL.boolExpr = &ComparisonExpr{Left: yyDollar[1].valExpr, Operator: AST_NOT_LIKE, Right: yyDollar[4].valExpr}
 		}
 	case 96:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:575
+		//line sql.y:571
 		{
 			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_BETWEEN, From: yyDollar[3].valExpr, To: yyDollar[5].valExpr}
 		}
 	case 97:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:579
+		//line sql.y:575
 		{
 			yyVAL.boolExpr = &RangeCond{Left: yyDollar[1].valExpr, Operator: AST_NOT_BETWEEN, From: yyDollar[4].valExpr, To: yyDollar[6].valExpr}
 		}
 	case 98:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:583
+		//line sql.y:579
 		{
 			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 99:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:587
+		//line sql.y:583
 		{
 			yyVAL.boolExpr = &NullCheck{Operator: AST_IS_NOT_NULL, Expr: yyDollar[1].valExpr}
 		}
 	case 100:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:591
+		//line sql.y:587
 		{
 			yyVAL.boolExpr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 101:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line sql.y:595
+		//line sql.y:591
 		{
 			yyVAL.boolExpr = &KeyrangeExpr{Start: yyDollar[3].valExpr, End: yyDollar[5].valExpr}
 		}
 	case 102:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:601
+		//line sql.y:597
 		{
 			yyVAL.str = AST_EQ
 		}
 	case 103:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:605
+		//line sql.y:601
 		{
 			yyVAL.str = AST_LT
 		}
 	case 104:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:609
+		//line sql.y:605
 		{
 			yyVAL.str = AST_GT
 		}
 	case 105:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:613
+		//line sql.y:609
 		{
 			yyVAL.str = AST_LE
 		}
 	case 106:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:617
+		//line sql.y:613
 		{
 			yyVAL.str = AST_GE
 		}
 	case 107:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:621
+		//line sql.y:617
 		{
 			yyVAL.str = AST_NE
 		}
 	case 108:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:625
+		//line sql.y:621
 		{
 			yyVAL.str = AST_NSE
 		}
 	case 109:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:631
+		//line sql.y:627
 		{
 			yyVAL.colTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 110:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:635
+		//line sql.y:631
 		{
 			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 111:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:639
+		//line sql.y:635
 		{
 			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 112:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:645
+		//line sql.y:641
 		{
 			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 113:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:651
+		//line sql.y:647
 		{
 			yyVAL.valExprs = ValExprs{yyDollar[1].valExpr}
 		}
 	case 114:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:655
+		//line sql.y:651
 		{
 			yyVAL.valExprs = append(yyDollar[1].valExprs, yyDollar[3].valExpr)
 		}
 	case 115:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:661
+		//line sql.y:657
 		{
 			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 116:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:665
+		//line sql.y:661
 		{
 			yyVAL.valExpr = yyDollar[1].colName
 		}
 	case 117:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:669
+		//line sql.y:665
 		{
 			yyVAL.valExpr = yyDollar[1].rowTuple
 		}
 	case 118:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:673
+		//line sql.y:669
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITAND, Right: yyDollar[3].valExpr}
 		}
 	case 119:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:677
+		//line sql.y:673
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITOR, Right: yyDollar[3].valExpr}
 		}
 	case 120:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:681
+		//line sql.y:677
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_BITXOR, Right: yyDollar[3].valExpr}
 		}
 	case 121:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:685
+		//line sql.y:681
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_PLUS, Right: yyDollar[3].valExpr}
 		}
 	case 122:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:689
+		//line sql.y:685
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MINUS, Right: yyDollar[3].valExpr}
 		}
 	case 123:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:693
+		//line sql.y:689
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MULT, Right: yyDollar[3].valExpr}
 		}
 	case 124:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:697
+		//line sql.y:693
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_DIV, Right: yyDollar[3].valExpr}
 		}
 	case 125:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:701
+		//line sql.y:697
 		{
 			yyVAL.valExpr = &BinaryExpr{Left: yyDollar[1].valExpr, Operator: AST_MOD, Right: yyDollar[3].valExpr}
 		}
 	case 126:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:705
+		//line sql.y:701
 		{
 			if num, ok := yyDollar[2].valExpr.(NumVal); ok {
 				switch yyDollar[1].byt {
@@ -1617,259 +1621,259 @@ yydefault:
 		}
 	case 127:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:720
+		//line sql.y:716
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes}
+			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID)}
 		}
 	case 128:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:724
+		//line sql.y:720
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Exprs: yyDollar[3].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID), Exprs: yyDollar[3].selectExprs}
 		}
 	case 129:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:728
+		//line sql.y:724
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Distinct: true, Exprs: yyDollar[4].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: string(yyDollar[1].sqlID), Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 130:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:732
+		//line sql.y:728
 		{
-			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].bytes, Exprs: yyDollar[3].selectExprs}
+			yyVAL.valExpr = &FuncExpr{Name: yyDollar[1].str, Exprs: yyDollar[3].selectExprs}
 		}
 	case 131:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:736
+		//line sql.y:732
 		{
 			yyVAL.valExpr = yyDollar[1].caseExpr
 		}
 	case 132:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:742
+		//line sql.y:738
 		{
-			yyVAL.bytes = IF_BYTES
+			yyVAL.str = "if"
 		}
 	case 133:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:746
+		//line sql.y:742
 		{
-			yyVAL.bytes = VALUES_BYTES
+			yyVAL.str = "values"
 		}
 	case 134:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:752
+		//line sql.y:748
 		{
 			yyVAL.byt = AST_UPLUS
 		}
 	case 135:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:756
+		//line sql.y:752
 		{
 			yyVAL.byt = AST_UMINUS
 		}
 	case 136:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:760
+		//line sql.y:756
 		{
 			yyVAL.byt = AST_TILDA
 		}
 	case 137:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:766
+		//line sql.y:762
 		{
 			yyVAL.caseExpr = &CaseExpr{Expr: yyDollar[2].valExpr, Whens: yyDollar[3].whens, Else: yyDollar[4].valExpr}
 		}
 	case 138:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:771
+		//line sql.y:767
 		{
 			yyVAL.valExpr = nil
 		}
 	case 139:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:775
+		//line sql.y:771
 		{
 			yyVAL.valExpr = yyDollar[1].valExpr
 		}
 	case 140:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:781
+		//line sql.y:777
 		{
 			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 141:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:785
+		//line sql.y:781
 		{
 			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 142:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:791
+		//line sql.y:787
 		{
 			yyVAL.when = &When{Cond: yyDollar[2].boolExpr, Val: yyDollar[4].valExpr}
 		}
 	case 143:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:796
+		//line sql.y:792
 		{
 			yyVAL.valExpr = nil
 		}
 	case 144:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:800
+		//line sql.y:796
 		{
 			yyVAL.valExpr = yyDollar[2].valExpr
 		}
 	case 145:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:806
+		//line sql.y:802
 		{
-			yyVAL.colName = &ColName{Name: yyDollar[1].bytes}
+			yyVAL.colName = &ColName{Name: yyDollar[1].sqlID}
 		}
 	case 146:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:810
+		//line sql.y:806
 		{
-			yyVAL.colName = &ColName{Qualifier: yyDollar[1].bytes, Name: yyDollar[3].bytes}
+			yyVAL.colName = &ColName{Qualifier: yyDollar[1].tableID, Name: yyDollar[3].sqlID}
 		}
 	case 147:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:816
+		//line sql.y:812
 		{
 			yyVAL.valExpr = StrVal(yyDollar[1].bytes)
 		}
 	case 148:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:820
+		//line sql.y:816
 		{
 			yyVAL.valExpr = NumVal(yyDollar[1].bytes)
 		}
 	case 149:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:824
+		//line sql.y:820
 		{
 			yyVAL.valExpr = ValArg(yyDollar[1].bytes)
 		}
 	case 150:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:828
+		//line sql.y:824
 		{
 			yyVAL.valExpr = &NullVal{}
 		}
 	case 151:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:833
+		//line sql.y:829
 		{
 			yyVAL.valExprs = nil
 		}
 	case 152:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:837
+		//line sql.y:833
 		{
 			yyVAL.valExprs = yyDollar[3].valExprs
 		}
 	case 153:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:842
+		//line sql.y:838
 		{
 			yyVAL.boolExpr = nil
 		}
 	case 154:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:846
+		//line sql.y:842
 		{
 			yyVAL.boolExpr = yyDollar[2].boolExpr
 		}
 	case 155:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:851
+		//line sql.y:847
 		{
 			yyVAL.orderBy = nil
 		}
 	case 156:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:855
+		//line sql.y:851
 		{
 			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 157:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:861
+		//line sql.y:857
 		{
 			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 158:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:865
+		//line sql.y:861
 		{
 			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 159:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:871
+		//line sql.y:867
 		{
 			yyVAL.order = &Order{Expr: yyDollar[1].valExpr, Direction: yyDollar[2].str}
 		}
 	case 160:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:876
+		//line sql.y:872
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 161:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:880
+		//line sql.y:876
 		{
 			yyVAL.str = AST_ASC
 		}
 	case 162:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:884
+		//line sql.y:880
 		{
 			yyVAL.str = AST_DESC
 		}
 	case 163:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:889
+		//line sql.y:885
 		{
 			yyVAL.limit = nil
 		}
 	case 164:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:893
+		//line sql.y:889
 		{
 			yyVAL.limit = &Limit{Rowcount: yyDollar[2].valExpr}
 		}
 	case 165:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:897
+		//line sql.y:893
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[2].valExpr, Rowcount: yyDollar[4].valExpr}
 		}
 	case 166:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:902
+		//line sql.y:898
 		{
 			yyVAL.str = ""
 		}
 	case 167:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:906
+		//line sql.y:902
 		{
 			yyVAL.str = AST_FOR_UPDATE
 		}
 	case 168:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line sql.y:910
+		//line sql.y:906
 		{
-			if !bytes.Equal(yyDollar[3].bytes, SHARE) {
+			if yyDollar[3].sqlID != "share" {
 				yylex.Error("expecting share")
 				return 1
 			}
-			if !bytes.Equal(yyDollar[4].bytes, MODE) {
+			if yyDollar[4].sqlID != "mode" {
 				yylex.Error("expecting mode")
 				return 1
 			}
@@ -1877,220 +1881,226 @@ yydefault:
 		}
 	case 169:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:923
+		//line sql.y:919
 		{
 			yyVAL.columns = nil
 		}
 	case 170:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:927
+		//line sql.y:923
 		{
 			yyVAL.columns = yyDollar[2].columns
 		}
 	case 171:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:933
+		//line sql.y:929
 		{
 			yyVAL.columns = Columns{&NonStarExpr{Expr: yyDollar[1].colName}}
 		}
 	case 172:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:937
+		//line sql.y:933
 		{
 			yyVAL.columns = append(yyVAL.columns, &NonStarExpr{Expr: yyDollar[3].colName})
 		}
 	case 173:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:942
+		//line sql.y:938
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 174:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line sql.y:946
+		//line sql.y:942
 		{
 			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 175:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:952
+		//line sql.y:948
 		{
 			yyVAL.insRows = yyDollar[2].values
 		}
 	case 176:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:956
+		//line sql.y:952
 		{
 			yyVAL.insRows = yyDollar[1].selStmt
 		}
 	case 177:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:962
+		//line sql.y:958
 		{
 			yyVAL.values = Values{yyDollar[1].rowTuple}
 		}
 	case 178:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:966
+		//line sql.y:962
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].rowTuple)
 		}
 	case 179:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:972
+		//line sql.y:968
 		{
 			yyVAL.rowTuple = ValTuple(yyDollar[2].valExprs)
 		}
 	case 180:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:976
+		//line sql.y:972
 		{
 			yyVAL.rowTuple = yyDollar[1].subquery
 		}
 	case 181:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:982
+		//line sql.y:978
 		{
 			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 182:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:986
+		//line sql.y:982
 		{
 			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 183:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:992
+		//line sql.y:988
 		{
 			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].valExpr}
 		}
 	case 184:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:997
+		//line sql.y:993
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 185:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:999
+		//line sql.y:995
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 186:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1002
+		//line sql.y:998
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 187:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line sql.y:1004
+		//line sql.y:1000
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 188:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1007
+		//line sql.y:1003
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 189:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1009
+		//line sql.y:1005
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 190:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1013
+		//line sql.y:1009
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 191:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1015
+		//line sql.y:1011
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 192:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1017
+		//line sql.y:1013
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 193:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1019
+		//line sql.y:1015
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 194:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1021
+		//line sql.y:1017
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 195:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1024
+		//line sql.y:1020
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 196:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1026
+		//line sql.y:1022
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 197:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1029
+		//line sql.y:1025
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 198:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1031
+		//line sql.y:1027
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 199:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1034
+		//line sql.y:1030
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 200:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line sql.y:1036
+		//line sql.y:1032
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 201:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1040
+		//line sql.y:1036
 		{
-			yyVAL.bytes = bytes.ToLower(yyDollar[1].bytes)
+			yyVAL.sqlID = SQLName(strings.ToLower(string(yyDollar[1].bytes)))
 		}
 	case 202:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1046
+		//line sql.y:1042
+		{
+			yyVAL.tableID = TableID(yyDollar[1].bytes)
+		}
+	case 203:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		//line sql.y:1048
 		{
 			if incNesting(yylex) {
 				yylex.Error("max nesting level reached")
 				return 1
 			}
 		}
-	case 203:
+	case 204:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line sql.y:1055
+		//line sql.y:1057
 		{
 			decNesting(yylex)
 		}
-	case 204:
+	case 205:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line sql.y:1060
+		//line sql.y:1062
 		{
 			forceEOF(yylex)
 		}

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -69,7 +69,6 @@ func forceEOF(yylex interface{}) {
   updateExpr  *UpdateExpr
   sqlID       SQLName
   sqlIDs      []SQLName
-  tableID     TableID
 }
 
 %token LEX_ERROR
@@ -149,7 +148,7 @@ func forceEOF(yylex interface{}) {
 %type <updateExpr> update_expression
 %type <empty> exists_opt not_exists_opt ignore_opt non_rename_operation to_opt constraint_opt using_opt
 %type <sqlID> sql_id as_lower_opt
-%type <tableID> table_id as_opt
+%type <sqlID> table_id as_opt
 %type <empty> force_eof
 
 %%
@@ -232,7 +231,7 @@ create_statement:
   }
 | CREATE VIEW sql_id force_eof
   {
-    $$ = &DDL{Action: AST_CREATE, NewName: TableID($3)}
+    $$ = &DDL{Action: AST_CREATE, NewName: SQLName($3)}
   }
 
 alter_statement:
@@ -247,7 +246,7 @@ alter_statement:
   }
 | ALTER VIEW sql_id force_eof
   {
-    $$ = &DDL{Action: AST_ALTER, Table: TableID($3), NewName: TableID($3)}
+    $$ = &DDL{Action: AST_ALTER, Table: SQLName($3), NewName: SQLName($3)}
   }
 
 rename_statement:
@@ -268,7 +267,7 @@ drop_statement:
   }
 | DROP VIEW exists_opt sql_id force_eof
   {
-    $$ = &DDL{Action: AST_DROP, Table: TableID($4)}
+    $$ = &DDL{Action: AST_DROP, Table: SQLName($4)}
   }
 
 analyze_statement:
@@ -1040,7 +1039,7 @@ sql_id:
 table_id:
   ID
   {
-    $$ = TableID($1)
+    $$ = SQLName($1)
   }
 
 openb:

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -5,7 +5,7 @@
 %{
 package sqlparser
 
-import "bytes"
+import "strings"
 
 func setParseTree(yylex interface{}, stmt Statement) {
   yylex.(*Tokenizer).ParseTree = stmt
@@ -30,13 +30,6 @@ func decNesting(yylex interface{}) {
 func forceEOF(yylex interface{}) {
   yylex.(*Tokenizer).ForceEOF = true
 }
-
-var (
-  SHARE =        []byte("share")
-  MODE  =        []byte("mode")
-  IF_BYTES =     []byte("if")
-  VALUES_BYTES = []byte("values")
-)
 
 %}
 
@@ -74,6 +67,9 @@ var (
   insRows     InsertRows
   updateExprs UpdateExprs
   updateExpr  *UpdateExpr
+  sqlID       SQLName
+  sqlIDs      []SQLName
+  tableID     TableID
 }
 
 %token LEX_ERROR
@@ -115,7 +111,6 @@ var (
 %type <str> distinct_opt
 %type <selectExprs> select_expression_list
 %type <selectExpr> select_expression
-%type <bytes> as_lower_opt as_opt
 %type <expr> expression
 %type <tableExprs> table_expression_list
 %type <tableExpr> table_expression
@@ -123,7 +118,7 @@ var (
 %type <smTableExpr> simple_table_expression
 %type <tableName> dml_table_expression
 %type <indexHints> index_hint_list
-%type <bytes2> index_list
+%type <sqlIDs> index_list
 %type <boolExpr> where_expression_opt
 %type <boolExpr> boolean_expression condition
 %type <str> compare
@@ -133,7 +128,7 @@ var (
 %type <valExprs> value_expression_list
 %type <values> tuple_list
 %type <rowTuple> row_tuple
-%type <bytes> keyword_as_func
+%type <str> keyword_as_func
 %type <subquery> subquery
 %type <byt> unary_operator
 %type <colName> column_name
@@ -153,7 +148,8 @@ var (
 %type <updateExprs> update_list
 %type <updateExpr> update_expression
 %type <empty> exists_opt not_exists_opt ignore_opt non_rename_operation to_opt constraint_opt using_opt
-%type <bytes> sql_id
+%type <sqlID> sql_id as_lower_opt
+%type <tableID> table_id as_opt
 %type <empty> force_eof
 
 %%
@@ -225,58 +221,58 @@ set_statement:
   }
 
 create_statement:
-  CREATE TABLE not_exists_opt ID force_eof
+  CREATE TABLE not_exists_opt table_id force_eof
   {
     $$ = &DDL{Action: AST_CREATE, NewName: $4}
   }
-| CREATE constraint_opt INDEX sql_id using_opt ON ID force_eof
+| CREATE constraint_opt INDEX ID using_opt ON table_id force_eof
   {
     // Change this to an alter statement
     $$ = &DDL{Action: AST_ALTER, Table: $7, NewName: $7}
   }
 | CREATE VIEW sql_id force_eof
   {
-    $$ = &DDL{Action: AST_CREATE, NewName: $3}
+    $$ = &DDL{Action: AST_CREATE, NewName: TableID($3)}
   }
 
 alter_statement:
-  ALTER ignore_opt TABLE ID non_rename_operation force_eof
+  ALTER ignore_opt TABLE table_id non_rename_operation force_eof
   {
     $$ = &DDL{Action: AST_ALTER, Table: $4, NewName: $4}
   }
-| ALTER ignore_opt TABLE ID RENAME to_opt ID
+| ALTER ignore_opt TABLE table_id RENAME to_opt table_id
   {
     // Change this to a rename statement
     $$ = &DDL{Action: AST_RENAME, Table: $4, NewName: $7}
   }
 | ALTER VIEW sql_id force_eof
   {
-    $$ = &DDL{Action: AST_ALTER, Table: $3, NewName: $3}
+    $$ = &DDL{Action: AST_ALTER, Table: TableID($3), NewName: TableID($3)}
   }
 
 rename_statement:
-  RENAME TABLE ID TO ID
+  RENAME TABLE table_id TO table_id
   {
     $$ = &DDL{Action: AST_RENAME, Table: $3, NewName: $5}
   }
 
 drop_statement:
-  DROP TABLE exists_opt ID
+  DROP TABLE exists_opt table_id
   {
     $$ = &DDL{Action: AST_DROP, Table: $4}
   }
-| DROP INDEX sql_id ON ID
+| DROP INDEX ID ON table_id
   {
     // Change this to an alter statement
     $$ = &DDL{Action: AST_ALTER, Table: $5, NewName: $5}
   }
 | DROP VIEW exists_opt sql_id force_eof
   {
-    $$ = &DDL{Action: AST_DROP, Table: $4}
+    $$ = &DDL{Action: AST_DROP, Table: TableID($4)}
   }
 
 analyze_statement:
-  ANALYZE TABLE ID
+  ANALYZE TABLE table_id
   {
     $$ = &DDL{Action: AST_ALTER, Table: $3, NewName: $3}
   }
@@ -364,7 +360,7 @@ select_expression:
   {
     $$ = &NonStarExpr{Expr: $1, As: $2}
   }
-| ID '.' '*'
+| table_id '.' '*'
   {
     $$ = &StarExpr{TableName: $1}
   }
@@ -381,7 +377,7 @@ expression:
 
 as_lower_opt:
   {
-    $$ = nil
+    $$ = ""
   }
 | sql_id
   {
@@ -422,13 +418,13 @@ table_expression:
 
 as_opt:
   {
-    $$ = nil
+    $$ = ""
   }
-| ID
+| table_id
   {
     $$ = $1
   }
-| AS ID
+| AS table_id
   {
     $$ = $2
   }
@@ -472,11 +468,11 @@ join_type:
   }
 
 simple_table_expression:
-ID
+  table_id
   {
     $$ = &TableName{Name: $1}
   }
-| ID '.' ID
+| table_id '.' table_id
   {
     $$ = &TableName{Qualifier: $1, Name: $3}
   }
@@ -486,11 +482,11 @@ ID
   }
 
 dml_table_expression:
-ID
+  table_id
   {
     $$ = &TableName{Name: $1}
   }
-| ID '.' ID
+| table_id '.' table_id
   {
     $$ = &TableName{Qualifier: $1, Name: $3}
   }
@@ -515,7 +511,7 @@ index_hint_list:
 index_list:
   sql_id
   {
-    $$ = [][]byte{$1}
+    $$ = []SQLName{$1}
   }
 | index_list ',' sql_id
   {
@@ -718,15 +714,15 @@ value_expression:
   }
 | sql_id openb closeb
   {
-    $$ = &FuncExpr{Name: $1}
+    $$ = &FuncExpr{Name: string($1)}
   }
 | sql_id openb select_expression_list closeb
   {
-    $$ = &FuncExpr{Name: $1, Exprs: $3}
+    $$ = &FuncExpr{Name: string($1), Exprs: $3}
   }
 | sql_id openb DISTINCT select_expression_list closeb
   {
-    $$ = &FuncExpr{Name: $1, Distinct: true, Exprs: $4}
+    $$ = &FuncExpr{Name: string($1), Distinct: true, Exprs: $4}
   }
 | keyword_as_func openb select_expression_list closeb
   {
@@ -740,11 +736,11 @@ value_expression:
 keyword_as_func:
   IF
   {
-    $$ = IF_BYTES
+    $$ = "if"
   }
 | VALUES
   {
-    $$ = VALUES_BYTES
+    $$ = "values"
   }
 
 unary_operator:
@@ -806,7 +802,7 @@ column_name:
   {
     $$ = &ColName{Name: $1}
   }
-| ID '.' sql_id
+| table_id '.' sql_id
   {
     $$ = &ColName{Qualifier: $1, Name: $3}
   }
@@ -908,11 +904,11 @@ lock_opt:
   }
 | LOCK IN sql_id sql_id
   {
-    if !bytes.Equal($3, SHARE) {
+    if $3 != "share" {
       yylex.Error("expecting share")
       return 1
     }
-    if !bytes.Equal($4, MODE) {
+    if $4 != "mode" {
       yylex.Error("expecting mode")
       return 1
     }
@@ -1038,7 +1034,13 @@ using_opt:
 sql_id:
   ID
   {
-    $$ = bytes.ToLower($1)
+    $$ = SQLName(strings.ToLower(string($1)))
+  }
+
+table_id:
+  ID
+  {
+    $$ = TableID($1)
   }
 
 openb:

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -22,7 +22,7 @@ type Tokenizer struct {
 	ForceEOF      bool
 	lastChar      uint16
 	Position      int
-	errorToken    []byte
+	lastToken     []byte
 	LastError     string
 	posVarIndex   int
 	ParseTree     Statement
@@ -122,15 +122,15 @@ func (tkn *Tokenizer) Lex(lval *yySymType) int {
 	case ID, STRING, NUMBER, VALUE_ARG, LIST_ARG, COMMENT:
 		lval.bytes = val
 	}
-	tkn.errorToken = val
+	tkn.lastToken = val
 	return typ
 }
 
 // Error is called by go yacc if there's a parsing error.
 func (tkn *Tokenizer) Error(err string) {
 	buf := bytes.NewBuffer(make([]byte, 0, 32))
-	if tkn.errorToken != nil {
-		fmt.Fprintf(buf, "%s at position %v near %s", err, tkn.Position, tkn.errorToken)
+	if tkn.lastToken != nil {
+		fmt.Fprintf(buf, "%s at position %v near %s", err, tkn.Position, tkn.lastToken)
 	} else {
 		fmt.Fprintf(buf, "%s at position %v", err, tkn.Position)
 	}

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -22,6 +22,7 @@ type TrackedBuffer struct {
 	nodeFormatter func(buf *TrackedBuffer, node SQLNode)
 }
 
+// NewTrackedBuffer creates a new TrackedBuffer.
 func NewTrackedBuffer(nodeFormatter func(buf *TrackedBuffer, node SQLNode)) *TrackedBuffer {
 	buf := &TrackedBuffer{
 		Buffer:        bytes.NewBuffer(make([]byte, 0, 128)),
@@ -88,8 +89,9 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 	}
 }
 
-// WriteArg writes a value argument into the buffer. arg should not contain
-// the ':' prefix. It also adds tracking info for future substitutions.
+// WriteArg writes a value argument into the buffer along with
+// tracking information for future substitutions. arg must contain
+// the ":" or "::" prefix.
 func (buf *TrackedBuffer) WriteArg(arg string) {
 	buf.bindLocations = append(buf.bindLocations, bindLocation{
 		offset: buf.Len(),
@@ -98,10 +100,13 @@ func (buf *TrackedBuffer) WriteArg(arg string) {
 	buf.WriteString(arg)
 }
 
+// ParsedQuery returns a ParsedQuery that contains bind
+// locations for easy substitution.
 func (buf *TrackedBuffer) ParsedQuery() *ParsedQuery {
 	return &ParsedQuery{Query: buf.String(), bindLocations: buf.bindLocations}
 }
 
+// HasBindVars returns true if the parsed query uses bind vars.
 func (buf *TrackedBuffer) HasBindVars() bool {
 	return len(buf.bindLocations) != 0
 }

--- a/go/vt/tabletserver/planbuilder/query_gen.go
+++ b/go/vt/tabletserver/planbuilder/query_gen.go
@@ -11,12 +11,15 @@ import (
 	"github.com/youtube/vitess/go/vt/sqlparser"
 )
 
+// GenerateFullQuery generates the full query from the ast.
 func GenerateFullQuery(statement sqlparser.Statement) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	statement.Format(buf)
 	return buf.ParsedQuery()
 }
 
+// GenerateFieldQuery generates a query to just fetch the field info
+// by adding impossible where clauses as needed.
 func GenerateFieldQuery(statement sqlparser.Statement) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(FormatImpossible)
 	buf.Myprintf("%v", statement)
@@ -46,6 +49,7 @@ func FormatImpossible(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
 	}
 }
 
+// GenerateSelectLimitQuery generates a select query with a limit clause.
 func GenerateSelectLimitQuery(selStmt sqlparser.SelectStatement) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	sel, ok := selStmt.(*sqlparser.Select)
@@ -62,6 +66,7 @@ func GenerateSelectLimitQuery(selStmt sqlparser.SelectStatement) *sqlparser.Pars
 	return buf.ParsedQuery()
 }
 
+// GenerateSelectOuterQuery generates the outer query for dmls.
 func GenerateSelectOuterQuery(sel *sqlparser.Select, tableInfo *schema.Table) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	fmt.Fprintf(buf, "select ")
@@ -70,6 +75,7 @@ func GenerateSelectOuterQuery(sel *sqlparser.Select, tableInfo *schema.Table) *s
 	return buf.ParsedQuery()
 }
 
+// GenerateInsertOuterQuery generates the outer query for inserts.
 func GenerateInsertOuterQuery(ins *sqlparser.Insert) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.Myprintf("insert %vinto %v%v values %a%v",
@@ -82,29 +88,32 @@ func GenerateInsertOuterQuery(ins *sqlparser.Insert) *sqlparser.ParsedQuery {
 	return buf.ParsedQuery()
 }
 
+// GenerateUpdateOuterQuery generates the outer query for updates.
 func GenerateUpdateOuterQuery(upd *sqlparser.Update) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.Myprintf("update %v%v set %v where %a", upd.Comments, upd.Table, upd.Exprs, ":#pk")
 	return buf.ParsedQuery()
 }
 
+// GenerateDeleteOuterQuery generates the outer query for deletes.
 func GenerateDeleteOuterQuery(del *sqlparser.Delete) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.Myprintf("delete %vfrom %v where %a", del.Comments, del.Table, ":#pk")
 	return buf.ParsedQuery()
 }
 
+// GenerateSelectSubquery generates the subquery for selects.
 func GenerateSelectSubquery(sel *sqlparser.Select, tableInfo *schema.Table, index string) *sqlparser.ParsedQuery {
-	hint := &sqlparser.IndexHints{Type: sqlparser.AST_USE, Indexes: [][]byte{[]byte(index)}}
-	table_expr := sel.From[0].(*sqlparser.AliasedTableExpr)
-	savedHint := table_expr.Hints
-	table_expr.Hints = hint
+	hint := &sqlparser.IndexHints{Type: sqlparser.AST_USE, Indexes: []sqlparser.SQLName{sqlparser.SQLName(index)}}
+	tableExpr := sel.From[0].(*sqlparser.AliasedTableExpr)
+	savedHint := tableExpr.Hints
+	tableExpr.Hints = hint
 	defer func() {
-		table_expr.Hints = savedHint
+		tableExpr.Hints = savedHint
 	}()
 	return GenerateSubquery(
 		tableInfo.Indexes[0].Columns,
-		table_expr,
+		tableExpr,
 		sel.Where,
 		sel.OrderBy,
 		sel.Limit,
@@ -112,6 +121,7 @@ func GenerateSelectSubquery(sel *sqlparser.Select, tableInfo *schema.Table, inde
 	)
 }
 
+// GenerateUpdateSubquery generates the subquery for updats.
 func GenerateUpdateSubquery(upd *sqlparser.Update, tableInfo *schema.Table) *sqlparser.ParsedQuery {
 	return GenerateSubquery(
 		tableInfo.Indexes[0].Columns,
@@ -123,6 +133,7 @@ func GenerateUpdateSubquery(upd *sqlparser.Update, tableInfo *schema.Table) *sql
 	)
 }
 
+// GenerateDeleteSubquery generates the subquery for deletes.
 func GenerateDeleteSubquery(del *sqlparser.Delete, tableInfo *schema.Table) *sqlparser.ParsedQuery {
 	return GenerateSubquery(
 		tableInfo.Indexes[0].Columns,
@@ -134,7 +145,8 @@ func GenerateDeleteSubquery(del *sqlparser.Delete, tableInfo *schema.Table) *sql
 	)
 }
 
-func GenerateSubquery(columns []string, table *sqlparser.AliasedTableExpr, where *sqlparser.Where, order sqlparser.OrderBy, limit *sqlparser.Limit, for_update bool) *sqlparser.ParsedQuery {
+// GenerateSubquery generates a subquery based on the input parameters.
+func GenerateSubquery(columns []string, table *sqlparser.AliasedTableExpr, where *sqlparser.Where, order sqlparser.OrderBy, limit *sqlparser.Limit, forUpdate bool) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	if limit == nil {
 		limit = execLimit
@@ -146,7 +158,7 @@ func GenerateSubquery(columns []string, table *sqlparser.AliasedTableExpr, where
 	}
 	fmt.Fprintf(buf, "%s", columns[i])
 	buf.Myprintf(" from %v%v%v%v", table, where, order, limit)
-	if for_update {
+	if forUpdate {
 		buf.Myprintf(sqlparser.AST_FOR_UPDATE)
 	}
 	return buf.ParsedQuery()

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -468,7 +468,7 @@ func TestQueryExecutorPlanPKIn(t *testing.T) {
 func TestQueryExecutorPlanSelectSubQuery(t *testing.T) {
 	db := setUpQueryExecutorTest()
 	query := "select * from test_table where name = 1 limit 1000"
-	expandedQuery := "select pk from test_table use index (INDEX) where name = 1 limit 1000"
+	expandedQuery := "select pk from test_table use index (`index`) where name = 1 limit 1000"
 	want := &mproto.QueryResult{
 		Fields: getTestTableFields(),
 	}
@@ -1055,7 +1055,7 @@ func TestQueryExecutorTableAclExemptACL(t *testing.T) {
 func TestQueryExecutorBlacklistQRFail(t *testing.T) {
 	db := setUpQueryExecutorTest()
 	query := "select * from test_table where name = 1 limit 1000"
-	expandedQuery := "select pk from test_table use index (INDEX) where name = 1 limit 1000"
+	expandedQuery := "select pk from test_table use index (`index`) where name = 1 limit 1000"
 	expected := &mproto.QueryResult{
 		Fields: getTestTableFields(),
 	}
@@ -1114,7 +1114,7 @@ func TestQueryExecutorBlacklistQRFail(t *testing.T) {
 func TestQueryExecutorBlacklistQRRetry(t *testing.T) {
 	db := setUpQueryExecutorTest()
 	query := "select * from test_table where name = 1 limit 1000"
-	expandedQuery := "select pk from test_table use index (INDEX) where name = 1 limit 1000"
+	expandedQuery := "select pk from test_table use index (`index`) where name = 1 limit 1000"
 	expected := &mproto.QueryResult{
 		Fields: getTestTableFields(),
 	}
@@ -1377,7 +1377,7 @@ func getQueryExecutorSupportedQueries() map[string]*mproto.QueryResult {
 				[]sqltypes.Value{
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte{}),
-					sqltypes.MakeString([]byte("INDEX")),
+					sqltypes.MakeString([]byte("index")),
 					sqltypes.MakeString([]byte{}),
 					sqltypes.MakeString([]byte("name")),
 					sqltypes.MakeString([]byte{}),

--- a/go/vt/tabletserver/query_splitter.go
+++ b/go/vt/tabletserver/query_splitter.go
@@ -145,7 +145,7 @@ func (qs *QuerySplitter) getWhereClause(start, end sqltypes.Value) *sqlparser.Wh
 		return qs.sel.Where
 	}
 	pk := &sqlparser.ColName{
-		Name: []byte(qs.splitColumn),
+		Name: sqlparser.SQLName(qs.splitColumn),
 	}
 	// splitColumn >= start
 	if !start.IsNull() {

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -228,7 +228,7 @@ func (rci *RowcacheInvalidator) handleUnrecognizedEvent(sql string) {
 	}
 
 	// Ignore cross-db statements.
-	if table.Qualifier != nil && string(table.Qualifier) != rci.qe.dbconfigs.App.DbName {
+	if table.Qualifier != "" && string(table.Qualifier) != rci.qe.dbconfigs.App.DbName {
 		return
 	}
 

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -77,7 +77,7 @@ func buildIndexPlan(ins *sqlparser.Insert, tablename string, colVindex *ColVinde
 	}
 	if pos == -1 {
 		pos = len(ins.Columns)
-		ins.Columns = append(ins.Columns, &sqlparser.NonStarExpr{Expr: &sqlparser.ColName{Name: []byte(colVindex.Col)}})
+		ins.Columns = append(ins.Columns, &sqlparser.NonStarExpr{Expr: &sqlparser.ColName{Name: sqlparser.SQLName(colVindex.Col)}})
 		ins.Rows.(sqlparser.Values)[0] = append(ins.Rows.(sqlparser.Values)[0].(sqlparser.ValTuple), &sqlparser.NullVal{})
 	}
 	row := ins.Rows.(sqlparser.Values)[0].(sqlparser.ValTuple)


### PR DESCRIPTION
Fix for issue #797.
Names that used keywords were not always getting back-quoted
correctly during codegen. This is a comprehensive fix that
covers all such possible cases.