### PR TITLE
Fix golint pre commit hook for non-interactive shell.

### DIFF
--- a/misc/git/hooks/golint
+++ b/misc/git/hooks/golint
@@ -35,28 +35,37 @@ done
 
 [ -z "$errors" ] && exit 0
 
-# git doesn't give us access to user input, so let's steal it.
-exec < /dev/tty
+if [[ $- == *i* ]]; then
+  # interactive shell. Prompt the user.
+  # git doesn't give us access to user input, so let's steal it.
+  exec < /dev/tty
 
-echo
-echo "Lint suggestions were found. They're not enforced, but we're pausing"
-echo "to let you know before they get clobbered in the scrollback buffer."
-echo
-read -r -p 'Press enter to cancel, "s" to step through the warnings or type "ack" to continue: '
-if [ "$REPLY" = "ack" ]; then
-  exit 0
-fi
-if [ "$REPLY" = "s" ]; then
-  first_file="true"
+  echo
+  echo "Lint suggestions were found. They're not enforced, but we're pausing"
+  echo "to let you know before they get clobbered in the scrollback buffer."
+  echo
+  read -r -p 'Press enter to cancel, "s" to step through the warnings or type "ack" to continue: '
+  if [ "$REPLY" = "ack" ]; then
+    exit 0
+  fi
+  if [ "$REPLY" = "s" ]; then
+    first_file="true"
+    for gofile in "${gofiles_with_warnings[@]}"
+    do
+      echo
+      if [ "$first_file" != "true" ]; then
+	echo "Press enter to show the warnings for the next file."
+	read
+      fi
+      golint $gofile
+      first_file="false"
+    done
+  fi
+else
+  # non-interactive shell (e.g. called from Eclipse). Just display the errors.
   for gofile in "${gofiles_with_warnings[@]}"
   do
-    echo
-    if [ "$first_file" != "true" ]; then
-      echo "Press enter to show the warnings for the next file."
-      read
-    fi
     golint $gofile
-    first_file="false"
   done
 fi
 exit 1


### PR DESCRIPTION
When running the precommit commands from Eclipse, such a shell is used.

@enisoc 