### PR TITLE
bootstrap.sh: Restore Go 1.3 compability.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -109,7 +109,12 @@ repos="github.com/golang/glog \
 repos+=" github.com/modocache/gover github.com/mattn/goveralls"
 # The cover tool needs to be installed into the Go toolchain, so it will fail
 # if Go is installed somewhere that requires root access.
-repos+=" golang.org/x/tools/cmd/cover"
+source tools/shell_functions.inc
+if goversion_min 1.4; then
+  repos+=" golang.org/x/tools/cmd/cover"
+else
+  repos+=" code.google.com/p/go.tools/cmd/cover"
+fi
 
 go get -u $repos
 

--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 
-# goversion_min returns true if major.minor go version is at least some value.
-function goversion_min() {
-	[[ "$(go version)" =~ go([0-9]+)\.([0-9]+) ]]
-	gotmajor=${BASH_REMATCH[1]}
-	gotminor=${BASH_REMATCH[2]}
-	[[ "$1" =~ ([0-9]+)\.([0-9]+) ]]
-	wantmajor=${BASH_REMATCH[1]}
-	wantminor=${BASH_REMATCH[2]}
-	[ "$gotmajor" -lt "$wantmajor" ] && return 1
-	[ "$gotmajor" -gt "$wantmajor" ] && return 0
-	[ "$gotminor" -lt "$wantminor" ] && return 1
-	return 0
-}
+# Copyright 2015, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+source $DIR/shell_functions.inc
 
 # Starting with Go 1.5, the syntax for the -X flag changed.
 # Earlier Go versions don't support the new syntax.

--- a/tools/shell_functions.inc
+++ b/tools/shell_functions.inc
@@ -1,0 +1,19 @@
+# Copyright 2015, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+# Library of functions which are used by bootstrap.sh or the Makefile.
+
+# goversion_min returns true if major.minor go version is at least some value.
+function goversion_min() {
+  [[ "$(go version)" =~ go([0-9]+)\.([0-9]+) ]]
+  gotmajor=${BASH_REMATCH[1]}
+  gotminor=${BASH_REMATCH[2]}
+  [[ "$1" =~ ([0-9]+)\.([0-9]+) ]]
+  wantmajor=${BASH_REMATCH[1]}
+  wantminor=${BASH_REMATCH[2]}
+  [ "$gotmajor" -lt "$wantmajor" ] && return 1
+  [ "$gotmajor" -gt "$wantmajor" ] && return 0
+  [ "$gotminor" -lt "$wantminor" ] && return 1
+  return 0
+}


### PR DESCRIPTION
@enisoc I noticed that you re-added the goversion_min shell function :)

Having it back, it's easier to restore Go 1.3 compatibility which I dropped in https://github.com/youtube/vitess/commit/f476b03f2ba9192ca2505c129a23fed6888b30c0

This way we don't have to update the docs ;-)