### PR TITLE
VtGate streaming endpoint errors in BsonRPC

### DIFF
--- a/go/mysql/proto/proto3.go
+++ b/go/mysql/proto/proto3.go
@@ -90,7 +90,7 @@ func RowsToProto3(rows [][]sqltypes.Value) []*pbq.Row {
 // Proto3ToRows converts a proto3 []Row to an internal data structure.
 func Proto3ToRows(rows []*pbq.Row) [][]sqltypes.Value {
 	if len(rows) == 0 {
-		return nil
+		return [][]sqltypes.Value{}
 	}
 
 	result := make([][]sqltypes.Value, len(rows))

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -225,13 +225,28 @@ func (conn *FakeVTGateConn) StreamExecuteShard(ctx context.Context, query string
 	panic("not implemented")
 }
 
+// StreamExecuteShard2 please see vtgateconn.Impl.StreamExecuteShard2
+func (conn *FakeVTGateConn) StreamExecuteShard2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	panic("not implemented")
+}
+
 // StreamExecuteKeyRanges please see vtgateconn.Impl.StreamExecuteKeyRanges
 func (conn *FakeVTGateConn) StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	panic("not implemented")
 }
 
+// StreamExecuteKeyRanges2 please see vtgateconn.Impl.StreamExecuteKeyRanges2
+func (conn *FakeVTGateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	panic("not implemented")
+}
+
 // StreamExecuteKeyspaceIds please see vtgateconn.Impl.StreamExecuteKeyspaceIds
 func (conn *FakeVTGateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	panic("not implemented")
+}
+
+// StreamExecuteKeyspaceIds2 please see vtgateconn.Impl.StreamExecuteKeyspaceIds2
+func (conn *FakeVTGateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	panic("not implemented")
 }
 

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -215,6 +215,11 @@ func (conn *FakeVTGateConn) StreamExecute(ctx context.Context, query string, bin
 	return resultChan, func() error { return nil }, nil
 }
 
+// StreamExecute2 please see vtgateconn.Impl.StreamExecute2
+func (conn *FakeVTGateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	panic("not implemented")
+}
+
 // StreamExecuteShard please see vtgateconn.Impl.StreamExecuteShard
 func (conn *FakeVTGateConn) StreamExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	panic("not implemented")

--- a/go/vt/vtgate/gorpcvtgateconn/conn.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn.go
@@ -285,6 +285,21 @@ func (conn *vtgateConn) StreamExecuteShard(ctx context.Context, query string, ke
 	return sendStreamResults(c, sr)
 }
 
+func (conn *vtgateConn) StreamExecuteShard2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	req := &proto.QueryShard{
+		CallerID:      getEffectiveCallerID(ctx),
+		Sql:           query,
+		BindVariables: bindVars,
+		Keyspace:      keyspace,
+		Shards:        shards,
+		TabletType:    tabletType,
+		Session:       nil,
+	}
+	sr := make(chan *proto.QueryResult, 10)
+	c := conn.rpcConn.StreamGo("VTGate.StreamExecuteShard2", req, sr)
+	return sendStreamResults(c, sr)
+}
+
 func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &proto.KeyRangeQuery{
 		CallerID:      getEffectiveCallerID(ctx),
@@ -300,6 +315,21 @@ func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	return sendStreamResults(c, sr)
 }
 
+func (conn *vtgateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	req := &proto.KeyRangeQuery{
+		CallerID:      getEffectiveCallerID(ctx),
+		Sql:           query,
+		BindVariables: bindVars,
+		Keyspace:      keyspace,
+		KeyRanges:     keyRanges,
+		TabletType:    tabletType,
+		Session:       nil,
+	}
+	sr := make(chan *proto.QueryResult, 10)
+	c := conn.rpcConn.StreamGo("VTGate.StreamExecuteKeyRanges2", req, sr)
+	return sendStreamResults(c, sr)
+}
+
 func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &proto.KeyspaceIdQuery{
 		CallerID:      getEffectiveCallerID(ctx),
@@ -312,6 +342,21 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query stri
 	}
 	sr := make(chan *proto.QueryResult, 10)
 	c := conn.rpcConn.StreamGo("VTGate.StreamExecuteKeyspaceIds", req, sr)
+	return sendStreamResults(c, sr)
+}
+
+func (conn *vtgateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	req := &proto.KeyspaceIdQuery{
+		CallerID:      getEffectiveCallerID(ctx),
+		Sql:           query,
+		BindVariables: bindVars,
+		Keyspace:      keyspace,
+		KeyspaceIds:   keyspaceIds,
+		TabletType:    tabletType,
+		Session:       nil,
+	}
+	sr := make(chan *proto.QueryResult, 10)
+	c := conn.rpcConn.StreamGo("VTGate.StreamExecuteKeyspaceIds2", req, sr)
 	return sendStreamResults(c, sr)
 }
 

--- a/go/vt/vtgate/gorpcvtgateconn/conn.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn.go
@@ -257,6 +257,19 @@ func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVar
 	return sendStreamResults(c, sr)
 }
 
+func (conn *vtgateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	req := &proto.Query{
+		CallerID:      getEffectiveCallerID(ctx),
+		Sql:           query,
+		BindVariables: bindVars,
+		TabletType:    tabletType,
+		Session:       nil,
+	}
+	sr := make(chan *proto.QueryResult, 10)
+	c := conn.rpcConn.StreamGo("VTGate.StreamExecute2", req, sr)
+	return sendStreamResults(c, sr)
+}
+
 func (conn *vtgateConn) StreamExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &proto.QueryShard{
 		CallerID:      getEffectiveCallerID(ctx),
@@ -304,13 +317,29 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query stri
 
 func sendStreamResults(c *rpcplus.Call, sr chan *proto.QueryResult) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	srout := make(chan *mproto.QueryResult, 1)
+	var vtErr error
 	go func() {
 		defer close(srout)
 		for r := range sr {
-			srout <- r.Result
+			vtErr = vterrors.FromRPCError(r.Err)
+			// If we get a QueryResult with an RPCError, that was an extra QueryResult sent by
+			// the server specifically to indicate an error, and we shouldn't surface it to clients.
+			if vtErr == nil {
+				srout <- r.Result
+			}
 		}
 	}()
-	return srout, func() error { return c.Error }, nil
+	// errFunc will return either an RPC-layer error or an application error, if one exists.
+	// It will only return the most recent application error (i.e, from the QueryResult that
+	// most recently contained an error). It will prioritize an RPC-layer error over an apperror,
+	// if both exist.
+	errFunc := func() error {
+		if c.Error != nil {
+			return c.Error
+		}
+		return vtErr
+	}
+	return srout, errFunc, nil
 }
 
 func (conn *vtgateConn) Begin(ctx context.Context) (interface{}, error) {

--- a/go/vt/vtgate/gorpcvtgateservice/server.go
+++ b/go/vt/vtgate/gorpcvtgateservice/server.go
@@ -189,6 +189,32 @@ func (vtg *VTGate) StreamExecuteShard(ctx context.Context, request *proto.QueryS
 	})
 }
 
+// StreamExecuteShard2 is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGate) StreamExecuteShard2(ctx context.Context, request *proto.QueryShard, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
+	ctx = callerid.NewContext(ctx,
+		callerid.GoRPCEffectiveCallerID(request.CallerID),
+		callerid.NewImmediateCallerID("gorpc client"))
+	vtgErr := vtg.server.StreamExecuteShard(ctx, request, func(value *proto.QueryResult) error {
+		return sendReply(value)
+	})
+	if vtgErr == nil {
+		return nil
+	}
+	if *vtgate.RPCErrorOnlyInReply {
+		// If there was an app error, send a QueryResult back with it.
+		qr := new(proto.QueryResult)
+		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
+		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
+		// problems where the client will get out of sync with the number of QueryResults sent.
+		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
+		// (signalling that all clients are able to handle new-style errors).
+		return sendReply(qr)
+	}
+	return vtgErr
+}
+
 // StreamExecuteKeyRanges is the RPC version of
 // vtgateservice.VTGateService method
 func (vtg *VTGate) StreamExecuteKeyRanges(ctx context.Context, request *proto.KeyRangeQuery, sendReply func(interface{}) error) (err error) {
@@ -201,6 +227,33 @@ func (vtg *VTGate) StreamExecuteKeyRanges(ctx context.Context, request *proto.Ke
 	})
 }
 
+// StreamExecuteKeyRanges2 is the RPC version of
+// vtgateservice.VTGateService method
+func (vtg *VTGate) StreamExecuteKeyRanges2(ctx context.Context, request *proto.KeyRangeQuery, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
+	ctx = callerid.NewContext(ctx,
+		callerid.GoRPCEffectiveCallerID(request.CallerID),
+		callerid.NewImmediateCallerID("gorpc client"))
+	vtgErr := vtg.server.StreamExecuteKeyRanges(ctx, request, func(value *proto.QueryResult) error {
+		return sendReply(value)
+	})
+	if vtgErr == nil {
+		return nil
+	}
+	if *vtgate.RPCErrorOnlyInReply {
+		// If there was an app error, send a QueryResult back with it.
+		qr := new(proto.QueryResult)
+		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
+		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
+		// problems where the client will get out of sync with the number of QueryResults sent.
+		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
+		// (signalling that all clients are able to handle new-style errors).
+		return sendReply(qr)
+	}
+	return vtgErr
+}
+
 // StreamExecuteKeyspaceIds is the RPC version of
 // vtgateservice.VTGateService method
 func (vtg *VTGate) StreamExecuteKeyspaceIds(ctx context.Context, request *proto.KeyspaceIdQuery, sendReply func(interface{}) error) (err error) {
@@ -211,6 +264,33 @@ func (vtg *VTGate) StreamExecuteKeyspaceIds(ctx context.Context, request *proto.
 	return vtg.server.StreamExecuteKeyspaceIds(ctx, request, func(value *proto.QueryResult) error {
 		return sendReply(value)
 	})
+}
+
+// StreamExecuteKeyspaceIds2 is the RPC version of
+// vtgateservice.VTGateService method
+func (vtg *VTGate) StreamExecuteKeyspaceIds2(ctx context.Context, request *proto.KeyspaceIdQuery, sendReply func(interface{}) error) (err error) {
+	defer vtg.server.HandlePanic(&err)
+	ctx = callerid.NewContext(ctx,
+		callerid.GoRPCEffectiveCallerID(request.CallerID),
+		callerid.NewImmediateCallerID("gorpc client"))
+	vtgErr := vtg.server.StreamExecuteKeyspaceIds(ctx, request, func(value *proto.QueryResult) error {
+		return sendReply(value)
+	})
+	if vtgErr == nil {
+		return nil
+	}
+	if *vtgate.RPCErrorOnlyInReply {
+		// If there was an app error, send a QueryResult back with it.
+		qr := new(proto.QueryResult)
+		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
+		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
+		// problems where the client will get out of sync with the number of QueryResults sent.
+		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
+		// (signalling that all clients are able to handle new-style errors).
+		return sendReply(qr)
+	}
+	return vtgErr
 }
 
 // Begin is the RPC version of vtgateservice.VTGateService method

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -285,6 +285,10 @@ func (conn *vtgateConn) StreamExecuteShard(ctx context.Context, query string, ke
 	}, nil
 }
 
+func (conn *vtgateConn) StreamExecuteShard2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	return conn.StreamExecuteShard(ctx, query, keyspace, shards, bindVars, tabletType)
+}
+
 func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &pb.StreamExecuteKeyRangesRequest{
 		CallerId:   callerid.EffectiveCallerIDFromContext(ctx),
@@ -322,6 +326,10 @@ func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	}, nil
 }
 
+func (conn *vtgateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	return conn.StreamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
+}
+
 func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &pb.StreamExecuteKeyspaceIdsRequest{
 		CallerId:    callerid.EffectiveCallerIDFromContext(ctx),
@@ -357,6 +365,10 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query stri
 	return sr, func() error {
 		return finalError
 	}, nil
+}
+
+func (conn *vtgateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	return conn.StreamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
 }
 
 func (conn *vtgateConn) Begin(ctx context.Context) (interface{}, error) {

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -244,6 +244,10 @@ func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVar
 	}, nil
 }
 
+func (conn *vtgateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+	return conn.StreamExecute(ctx, query, bindVars, tabletType)
+}
+
 func (conn *vtgateConn) StreamExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	req := &pb.StreamExecuteShardsRequest{
 		CallerId:   callerid.EffectiveCallerIDFromContext(ctx),

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -101,6 +101,15 @@ func (conn *VTGateConn) StreamExecute(ctx context.Context, query string, bindVar
 	return conn.impl.StreamExecute(ctx, query, bindVars, tabletType)
 }
 
+// StreamExecute2 executes a streaming query on vtgate. It returns a
+// channel, an ErrFunc, and error. First check the error. Then you can
+// pull values from the channel till it's closed. Following this, you
+// can call ErrFunc to see if the stream ended normally or due to a
+// failure.
+func (conn *VTGateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error) {
+	return conn.impl.StreamExecute2(ctx, query, bindVars, tabletType)
+}
+
 // StreamExecuteShard executes a streaming query on vtgate, on a set
 // of shards.  It returns a channel, an ErrFunc, and error. First
 // check the error. Then you can pull values from the channel till
@@ -321,6 +330,9 @@ type Impl interface {
 
 	// StreamExecute executes a streaming query on vtgate.
 	StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
+
+	// StreamExecute2 executes a streaming query on vtgate.
+	StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
 
 	// StreamExecuteShard executes a streaming query on vtgate, on a set of shards.
 	StreamExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -119,6 +119,15 @@ func (conn *VTGateConn) StreamExecuteShard(ctx context.Context, query string, ke
 	return conn.impl.StreamExecuteShard(ctx, query, keyspace, shards, bindVars, tabletType)
 }
 
+// StreamExecuteShard2 executes a streaming query on vtgate, on a set
+// of shards.  It returns a channel, an ErrFunc, and error. First
+// check the error. Then you can pull values from the channel till
+// it's closed. Following this, you can call ErrFunc to see if the
+// stream ended normally or due to a failure.
+func (conn *VTGateConn) StreamExecuteShard2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error) {
+	return conn.impl.StreamExecuteShard2(ctx, query, keyspace, shards, bindVars, tabletType)
+}
+
 // StreamExecuteKeyRanges executes a streaming query on vtgate, on a
 // set of keyranges.  It returns a channel, an ErrFunc, and
 // error. First check the error. Then you can pull values from the
@@ -128,6 +137,15 @@ func (conn *VTGateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	return conn.impl.StreamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
 }
 
+// StreamExecuteKeyRanges2 executes a streaming query on vtgate, on a
+// set of keyranges.  It returns a channel, an ErrFunc, and
+// error. First check the error. Then you can pull values from the
+// channel till it's closed. Following this, you can call ErrFunc to
+// see if the stream ended normally or due to a failure.
+func (conn *VTGateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error) {
+	return conn.impl.StreamExecuteKeyRanges2(ctx, query, keyspace, keyRanges, bindVars, tabletType)
+}
+
 // StreamExecuteKeyspaceIds executes a streaming query on vtgate, for
 // the given keyspaceIds.  It returns a channel, an ErrFunc, and
 // error. First check the error. Then you can pull values from the
@@ -135,6 +153,15 @@ func (conn *VTGateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 // see if the stream ended normally or due to a failure.
 func (conn *VTGateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error) {
 	return conn.impl.StreamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+}
+
+// StreamExecuteKeyspaceIds2 executes a streaming query on vtgate, for
+// the given keyspaceIds.  It returns a channel, an ErrFunc, and
+// error. First check the error. Then you can pull values from the
+// channel till it's closed. Following this, you can call ErrFunc to
+// see if the stream ended normally or due to a failure.
+func (conn *VTGateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error) {
+	return conn.impl.StreamExecuteKeyspaceIds2(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
 }
 
 // Begin starts a transaction and returns a VTGateTX.
@@ -337,11 +364,20 @@ type Impl interface {
 	// StreamExecuteShard executes a streaming query on vtgate, on a set of shards.
 	StreamExecuteShard(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
 
+	// StreamExecuteShard2 executes a streaming query on vtgate, on a set of shards.
+	StreamExecuteShard2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
+
 	// StreamExecuteKeyRanges executes a streaming query on vtgate, on a set of keyranges.
 	StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
 
+	// StreamExecuteKeyRanges2 executes a streaming query on vtgate, on a set of keyranges.
+	StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []key.KeyRange, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
+
 	// StreamExecuteKeyspaceIds executes a streaming query on vtgate, for the given keyspaceIds.
 	StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
+
+	// StreamExecuteKeyspaceIds2 executes a streaming query on vtgate, for the given keyspaceIds.
+	StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds []key.KeyspaceId, bindVars map[string]interface{}, tabletType topo.TabletType) (<-chan *mproto.QueryResult, ErrFunc, error)
 
 	// Begin starts a transaction and returns a VTGateTX.
 	Begin(ctx context.Context) (interface{}, error)

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -543,8 +543,11 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	testStreamExecuteError(t, conn, fs)
 	testStreamExecute2Error(t, conn, fs)
 	testStreamExecuteShardError(t, conn, fs)
+	testStreamExecuteShard2Error(t, conn, fs)
 	testStreamExecuteKeyRangesError(t, conn, fs)
+	testStreamExecuteKeyRanges2Error(t, conn, fs)
 	testStreamExecuteKeyspaceIdsError(t, conn, fs)
+	testStreamExecuteKeyspaceIds2Error(t, conn, fs)
 	testSplitQueryError(t, conn)
 	testGetSrvKeyspaceError(t, conn)
 	fs.hasError = false
@@ -1070,6 +1073,32 @@ func testStreamExecuteShardError(t *testing.T, conn *vtgateconn.VTGateConn, fake
 	verifyError(t, err, "StreamExecuteShard")
 }
 
+func testStreamExecuteShard2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteShard2(ctx, execCase.shardQuery.Sql, execCase.shardQuery.Keyspace, execCase.shardQuery.Shards, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteShard2 failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteShard2 failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteShard2: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteShard2 channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteShard2")
+}
+
 func testStreamExecuteShardPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -1164,6 +1193,32 @@ func testStreamExecuteKeyRangesError(t *testing.T, conn *vtgateconn.VTGateConn, 
 	verifyError(t, err, "StreamExecuteKeyRanges")
 }
 
+func testStreamExecuteKeyRanges2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteKeyRanges2(ctx, execCase.keyRangeQuery.Sql, execCase.keyRangeQuery.Keyspace, execCase.keyRangeQuery.KeyRanges, execCase.keyRangeQuery.BindVariables, execCase.keyRangeQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteKeyRanges2 failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteKeyRanges2 failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteKeyRanges2: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteKeyRanges2 channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteKeyRanges2")
+}
+
 func testStreamExecuteKeyRangesPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -1256,6 +1311,32 @@ func testStreamExecuteKeyspaceIdsError(t *testing.T, conn *vtgateconn.VTGateConn
 	}
 	err = errFunc()
 	verifyError(t, err, "StreamExecuteKeyspaceIds")
+}
+
+func testStreamExecuteKeyspaceIds2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteKeyspaceIds2(ctx, execCase.keyspaceIdQuery.Sql, execCase.keyspaceIdQuery.Keyspace, execCase.keyspaceIdQuery.KeyspaceIds, execCase.keyspaceIdQuery.BindVariables, execCase.keyspaceIdQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteKeyspaceIds2 failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteKeyspaceIds2 failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteKeyspaceIds2: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteKeyspaceIds2 channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteKeyspaceIds2")
 }
 
 func testStreamExecuteKeyspaceIdsPanic(t *testing.T, conn *vtgateconn.VTGateConn) {

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -38,6 +38,7 @@ type fakeVTGateService struct {
 	// we can test subsequent calls in the transaction (e.g., Commit, Rollback).
 	forceBeginSuccess bool
 	hasCallerID       bool
+	errorWait         chan struct{}
 }
 
 var errTestVtGateError = errors.New("test vtgate error")
@@ -245,6 +246,13 @@ func (f *fakeVTGateService) StreamExecute(ctx context.Context, query *proto.Quer
 		if err := sendReply(&result); err != nil {
 			return err
 		}
+		if f.hasError {
+			// wait until the client has the response, since all streaming implementation may not
+			// send previous messages if an error has been triggered.
+			<-f.errorWait
+			f.errorWait = make(chan struct{}) // for next test
+			return errTestVtGateError
+		}
 		for _, row := range execCase.reply.Result.Rows {
 			result := proto.QueryResult{Result: &mproto.QueryResult{}}
 			result.Result.Rows = [][]sqltypes.Value{row}
@@ -279,6 +287,13 @@ func (f *fakeVTGateService) StreamExecuteShard(ctx context.Context, query *proto
 		result.Result.Fields = execCase.reply.Result.Fields
 		if err := sendReply(&result); err != nil {
 			return err
+		}
+		if f.hasError {
+			// wait until the client has the response, since all streaming implementation may not
+			// send previous messages if an error has been triggered.
+			<-f.errorWait
+			f.errorWait = make(chan struct{}) // for next test
+			return errTestVtGateError
 		}
 		for _, row := range execCase.reply.Result.Rows {
 			result := proto.QueryResult{Result: &mproto.QueryResult{}}
@@ -315,6 +330,13 @@ func (f *fakeVTGateService) StreamExecuteKeyRanges(ctx context.Context, query *p
 		if err := sendReply(&result); err != nil {
 			return err
 		}
+		if f.hasError {
+			// wait until the client has the response, since all streaming implementation may not
+			// send previous messages if an error has been triggered.
+			<-f.errorWait
+			f.errorWait = make(chan struct{}) // for next test
+			return errTestVtGateError
+		}
 		for _, row := range execCase.reply.Result.Rows {
 			result := proto.QueryResult{Result: &mproto.QueryResult{}}
 			result.Result.Rows = [][]sqltypes.Value{row}
@@ -349,6 +371,13 @@ func (f *fakeVTGateService) StreamExecuteKeyspaceIds(ctx context.Context, query 
 		result.Result.Fields = execCase.reply.Result.Fields
 		if err := sendReply(&result); err != nil {
 			return err
+		}
+		if f.hasError {
+			// wait until the client has the response, since all streaming implementation may not
+			// send previous messages if an error has been triggered.
+			<-f.errorWait
+			f.errorWait = make(chan struct{}) // for next test
+			return errTestVtGateError
 		}
 		for _, row := range execCase.reply.Result.Rows {
 			result := proto.QueryResult{Result: &mproto.QueryResult{}}
@@ -446,6 +475,7 @@ func CreateFakeServer(t *testing.T) vtgateservice.VTGateService {
 		t:           t,
 		panics:      false,
 		hasCallerID: true,
+		errorWait:   make(chan struct{}),
 	}
 }
 
@@ -466,6 +496,8 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
 	}
 
+	fs := fakeServer.(*fakeVTGateService)
+
 	testExecute(t, conn)
 	testExecuteShard(t, conn)
 	testExecuteKeyspaceIds(t, conn)
@@ -477,11 +509,11 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	testStreamExecuteShard(t, conn)
 	testStreamExecuteKeyRanges(t, conn)
 	testStreamExecuteKeyspaceIds(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = false
+	fs.hasCallerID = false
 	testTxPass(t, conn)
 	testTxPassNotInTransaction(t, conn)
 	testTxFail(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = true
+	fs.hasCallerID = true
 	testTx2Pass(t, conn)
 	testTx2PassNotInTransaction(t, conn)
 	testTx2Fail(t, conn)
@@ -489,16 +521,17 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	testGetSrvKeyspace(t, conn)
 
 	// return an error for every call, make sure they're handled properly
-	fakeServer.(*fakeVTGateService).hasError = true
+	fs.hasError = true
 
-	// First test errors in Begin, and then force it to succeed so we can test
-	// subsequent calls in the transaction.
-	fakeServer.(*fakeVTGateService).forceBeginSuccess = false
-	fakeServer.(*fakeVTGateService).hasCallerID = false
+	fs.hasCallerID = false
 	testBeginError(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = true
+	testCommitError(t, conn, fs)
+	testRollbackError(t, conn, fs)
+
+	fs.hasCallerID = true
 	testBegin2Error(t, conn)
-	fakeServer.(*fakeVTGateService).forceBeginSuccess = true
+	testCommit2Error(t, conn, fs)
+	testRollback2Error(t, conn, fs)
 
 	testExecuteError(t, conn)
 	testExecuteShardError(t, conn)
@@ -507,31 +540,26 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	testExecuteEntityIdsError(t, conn)
 	testExecuteBatchShardError(t, conn)
 	testExecuteBatchKeyspaceIdsError(t, conn)
-	// testStreamExecuteError(t, conn)
-	// testStreamExecuteShardError(t, conn)
-	// testStreamExecuteKeyRangesError(t, conn)
-	// testStreamExecuteKeyspaceIdsError(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = false
-	testCommitError(t, conn)
-	testRollbackError(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = true
-	testCommit2Error(t, conn)
-	testRollback2Error(t, conn)
+	testStreamExecuteError(t, conn, fs)
+	testStreamExecuteShardError(t, conn, fs)
+	testStreamExecuteKeyRangesError(t, conn, fs)
+	testStreamExecuteKeyspaceIdsError(t, conn, fs)
 	testSplitQueryError(t, conn)
 	testGetSrvKeyspaceError(t, conn)
-	fakeServer.(*fakeVTGateService).hasError = false
+	fs.hasError = false
 
 	// force a panic at every call, then test that works
-	fakeServer.(*fakeVTGateService).panics = true
+	fs.panics = true
 
-	// First test errors in Begin, and then force it to succeed so we can test
-	// subsequent calls in the transaction.
-	fakeServer.(*fakeVTGateService).forceBeginSuccess = false
-	fakeServer.(*fakeVTGateService).hasCallerID = false
+	fs.hasCallerID = false
 	testBeginPanic(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = true
+	testCommitPanic(t, conn, fs)
+	testRollbackPanic(t, conn, fs)
+
+	fs.hasCallerID = true
 	testBegin2Panic(t, conn)
-	fakeServer.(*fakeVTGateService).forceBeginSuccess = true
+	testCommit2Panic(t, conn, fs)
+	testRollback2Panic(t, conn, fs)
 
 	testExecutePanic(t, conn)
 	testExecuteShardPanic(t, conn)
@@ -544,15 +572,9 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	testStreamExecuteShardPanic(t, conn)
 	testStreamExecuteKeyRangesPanic(t, conn)
 	testStreamExecuteKeyspaceIdsPanic(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = false
-	testCommitPanic(t, conn)
-	testRollbackPanic(t, conn)
-	fakeServer.(*fakeVTGateService).hasCallerID = true
-	testCommit2Panic(t, conn)
-	testRollback2Panic(t, conn)
 	testSplitQueryPanic(t, conn)
 	testGetSrvKeyspacePanic(t, conn)
-	fakeServer.(*fakeVTGateService).panics = false
+	fs.panics = false
 }
 
 func expectPanic(t *testing.T, err error) {
@@ -901,6 +923,32 @@ func testStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 	}
 }
 
+func testStreamExecuteError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecute(ctx, execCase.execQuery.Sql, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecute failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecute failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecute: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecute channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecute")
+}
+
 func testStreamExecutePanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -967,6 +1015,32 @@ func testStreamExecuteShard(t *testing.T, conn *vtgateconn.VTGateConn) {
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("errorRequst: %v, want %v", err, want)
 	}
+}
+
+func testStreamExecuteShardError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteShard(ctx, execCase.shardQuery.Sql, execCase.shardQuery.Keyspace, execCase.shardQuery.Shards, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteShard failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteShard failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteShard: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteShard channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteShard")
 }
 
 func testStreamExecuteShardPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -1037,6 +1111,32 @@ func testStreamExecuteKeyRanges(t *testing.T, conn *vtgateconn.VTGateConn) {
 	}
 }
 
+func testStreamExecuteKeyRangesError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteKeyRanges(ctx, execCase.keyRangeQuery.Sql, execCase.keyRangeQuery.Keyspace, execCase.keyRangeQuery.KeyRanges, execCase.keyRangeQuery.BindVariables, execCase.keyRangeQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteKeyRanges failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteKeyRanges failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteKeyRanges: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteKeyRanges channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteKeyRanges")
+}
+
 func testStreamExecuteKeyRangesPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -1103,6 +1203,32 @@ func testStreamExecuteKeyspaceIds(t *testing.T, conn *vtgateconn.VTGateConn) {
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("errorRequst: %v, want %v", err, want)
 	}
+}
+
+func testStreamExecuteKeyspaceIdsError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
+	ctx := newContext()
+	execCase := execMap["request1"]
+	stream, errFunc, err := conn.StreamExecuteKeyspaceIds(ctx, execCase.keyspaceIdQuery.Sql, execCase.keyspaceIdQuery.Keyspace, execCase.keyspaceIdQuery.KeyspaceIds, execCase.keyspaceIdQuery.BindVariables, execCase.keyspaceIdQuery.TabletType)
+	if err != nil {
+		t.Fatalf("StreamExecuteKeyspaceIds failed: %v", err)
+	}
+	qr, ok := <-stream
+	if !ok {
+		t.Fatalf("StreamExecuteKeyspaceIds failed: cannot read result1")
+	}
+
+	if !reflect.DeepEqual(qr, &streamResult1) {
+		t.Errorf("Unexpected result from StreamExecuteKeyspaceIds: got %#v want %#v", qr, &streamResult1)
+	}
+	// signal to the server that the first result has been received
+	close(fake.errorWait)
+	// After 1 result, we expect to get an error (no more results).
+	qr, ok = <-stream
+	if ok {
+		t.Fatalf("StreamExecuteKeyspaceIds channel wasn't closed")
+	}
+	err = errFunc()
+	verifyError(t, err, "StreamExecuteKeyspaceIds")
 }
 
 func testStreamExecuteKeyspaceIdsPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -1411,9 +1537,13 @@ func testBeginError(t *testing.T, conn *vtgateconn.VTGateConn) {
 	verifyError(t, err, "Begin")
 }
 
-func testCommitError(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testCommitError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1421,9 +1551,13 @@ func testCommitError(t *testing.T, conn *vtgateconn.VTGateConn) {
 	verifyError(t, err, "Commit")
 }
 
-func testRollbackError(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testRollbackError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1437,9 +1571,13 @@ func testBegin2Error(t *testing.T, conn *vtgateconn.VTGateConn) {
 	verifyError(t, err, "Begin2")
 }
 
-func testCommit2Error(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testCommit2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin2(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1447,9 +1585,13 @@ func testCommit2Error(t *testing.T, conn *vtgateconn.VTGateConn) {
 	verifyError(t, err, "Commit2")
 }
 
-func testRollback2Error(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testRollback2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin2(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1463,9 +1605,13 @@ func testBeginPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	expectPanic(t, err)
 }
 
-func testCommitPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testCommitPanic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1473,9 +1619,13 @@ func testCommitPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	expectPanic(t, err)
 }
 
-func testRollbackPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testRollbackPanic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1489,9 +1639,13 @@ func testBegin2Panic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	expectPanic(t, err)
 }
 
-func testCommit2Panic(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testCommit2Panic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin2(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -1499,9 +1653,13 @@ func testCommit2Panic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	expectPanic(t, err)
 }
 
-func testRollback2Panic(t *testing.T, conn *vtgateconn.VTGateConn) {
+func testRollback2Panic(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
 	ctx := newContext()
+
+	fake.forceBeginSuccess = true
 	tx, err := conn.Begin2(ctx)
+	fake.forceBeginSuccess = false
+
 	if err != nil {
 		t.Error(err)
 	}
@@ -2156,6 +2314,22 @@ var result1 = mproto.QueryResult{
 			sqltypes.MakeString([]byte("row2 value2")),
 		},
 	},
+}
+
+var streamResult1 = mproto.QueryResult{
+	Fields: []mproto.Field{
+		mproto.Field{
+			Name: "field1",
+			Type: 42,
+		},
+		mproto.Field{
+			Name: "field2",
+			Type: 73,
+		},
+	},
+	RowsAffected: 0,
+	InsertId:     0,
+	Rows:         [][]sqltypes.Value{},
 }
 
 var session1 = &proto.Session{


### PR DESCRIPTION
@alainjobart 

Finishing off the server side work that we need for returning structured errors everywhere in BsonRPC.

I didn't convert the StreamExecute*2 endpoints to have StreamExecuteRequest/StreamExecuteResponse. I thought it might be too much work for something that's deprecated, but let me know if you think otherwise. 