### PR TITLE
Move files around. Now have a proper library, and the unit tests

### DIFF
--- a/go/cmd/vtgateclienttest/goclienttest/main.go
+++ b/go/cmd/vtgateclienttest/goclienttest/main.go
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package goclienttest
 
 import (
 	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
@@ -36,7 +37,7 @@ func testCallerID(t *testing.T, conn *vtgateconn.VTGateConn) {
 		t.Errorf("failed to marshal callerid: %v", err)
 		return
 	}
-	query := callerIDPrefix + string(data)
+	query := services.CallerIDPrefix + string(data)
 
 	// test Execute forwards the callerID
 	if _, err := conn.Execute(ctx, query, nil, topo.TYPE_MASTER); err != nil {
@@ -46,7 +47,8 @@ func testCallerID(t *testing.T, conn *vtgateconn.VTGateConn) {
 	// FIXME(alainjobart) add all function calls
 }
 
-func testGoClient(t *testing.T, protocol, addr string) {
+// TestGoClient runs the test suite for the provided client
+func TestGoClient(t *testing.T, protocol, addr string) {
 	// Create a client connecting to the server
 	ctx := context.Background()
 	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second)

--- a/go/cmd/vtgateclienttest/gorpcclienttest/gorpc_goclient_test.go
+++ b/go/cmd/vtgateclienttest/gorpcclienttest/gorpc_goclient_test.go
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package gorpcclienttest
 
 import (
 	"net"
 	"net/http"
 	"testing"
 
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/goclienttest"
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
 	"github.com/youtube/vitess/go/vt/vtgate/gorpcvtgateservice"
@@ -19,7 +21,7 @@ import (
 
 // TestGoRPCGoClient tests the go client using goRPC
 func TestGoRPCGoClient(t *testing.T) {
-	service := createService()
+	service := services.CreateServices()
 
 	// listen on a random port
 	listener, err := net.Listen("tcp", ":0")
@@ -41,5 +43,5 @@ func TestGoRPCGoClient(t *testing.T) {
 	go httpServer.Serve(listener)
 
 	// and run the test suite
-	testGoClient(t, "gorpc", listener.Addr().String())
+	goclienttest.TestGoClient(t, "gorpc", listener.Addr().String())
 }

--- a/go/cmd/vtgateclienttest/grpcclienttest/grpc_goclient_test.go
+++ b/go/cmd/vtgateclienttest/grpcclienttest/grpc_goclient_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package grpcclienttest
 
 import (
 	"net"
@@ -10,6 +10,8 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/goclienttest"
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 
 	// import the grpc client, it will register itself
@@ -18,7 +20,7 @@ import (
 
 // TestGRPCGoClient tests the go client using gRPC
 func TestGRPCGoClient(t *testing.T) {
-	service := createService()
+	service := services.CreateServices()
 
 	// listen on a random port
 	listener, err := net.Listen("tcp", ":0")
@@ -33,5 +35,5 @@ func TestGRPCGoClient(t *testing.T) {
 	go server.Serve(listener)
 
 	// and run the test suite
-	testGoClient(t, "grpc", listener.Addr().String())
+	goclienttest.TestGoClient(t, "grpc", listener.Addr().String())
 }

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -10,24 +10,14 @@ package main
 import (
 	"flag"
 
+	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vtgate"
-	"github.com/youtube/vitess/go/vt/vtgate/vtgateservice"
 )
 
 func init() {
 	servenv.RegisterDefaultFlags()
-}
-
-// createService creates the implementation chain of all the test cases
-func createService() vtgateservice.VTGateService {
-	var s vtgateservice.VTGateService
-	s = newTerminalClient()
-	s = newSuccessClient(s)
-	s = newErrorClient(s)
-	s = newCallerIDClient(s)
-	return s
 }
 
 func main() {
@@ -37,7 +27,7 @@ func main() {
 	servenv.Init()
 
 	// The implementation chain.
-	s := createService()
+	s := services.CreateServices()
 	for _, f := range vtgate.RegisterVTGates {
 		f(s)
 	}

--- a/go/cmd/vtgateclienttest/services/callerid.go
+++ b/go/cmd/vtgateclienttest/services/callerid.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package services
 
 import (
 	"encoding/json"
@@ -22,7 +22,9 @@ import (
 	pb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
-const callerIDPrefix = "callerid "
+// CallerIDPrefix is the prefix to send with queries to they go
+// through this test suite.
+const CallerIDPrefix = "callerid "
 
 // callerIDClient implements vtgateservice.VTGateService, and checks
 // the received callerid matches the one passed out of band by the client.
@@ -42,11 +44,11 @@ func newCallerIDClient(fallback vtgateservice.VTGateService) *callerIDClient {
 // Returns true and the the error to return with the call
 // if this module is handling the request.
 func (c *callerIDClient) checkCallerID(ctx context.Context, received string) (bool, error) {
-	if !strings.HasPrefix(received, callerIDPrefix) {
+	if !strings.HasPrefix(received, CallerIDPrefix) {
 		return false, nil
 	}
 
-	jsonCallerID := []byte(received[len(callerIDPrefix):])
+	jsonCallerID := []byte(received[len(CallerIDPrefix):])
 	expectedCallerID := &pb.CallerID{}
 	if err := json.Unmarshal(jsonCallerID, expectedCallerID); err != nil {
 		return true, fmt.Errorf("cannot unmarshal provided callerid: %v", err)

--- a/go/cmd/vtgateclienttest/services/errors.go
+++ b/go/cmd/vtgateclienttest/services/errors.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package services
 
 import (
 	"fmt"

--- a/go/cmd/vtgateclienttest/services/services.go
+++ b/go/cmd/vtgateclienttest/services/services.go
@@ -1,0 +1,18 @@
+// Copyright 2015 Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package services exposes all the services for the vtgateclienttest binary.
+package services
+
+import "github.com/youtube/vitess/go/vt/vtgate/vtgateservice"
+
+// CreateServices creates the implementation chain of all the test cases
+func CreateServices() vtgateservice.VTGateService {
+	var s vtgateservice.VTGateService
+	s = newTerminalClient()
+	s = newSuccessClient(s)
+	s = newErrorClient(s)
+	s = newCallerIDClient(s)
+	return s
+}

--- a/go/cmd/vtgateclienttest/services/success.go
+++ b/go/cmd/vtgateclienttest/services/success.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package services
 
 import (
 	"fmt"

--- a/go/cmd/vtgateclienttest/services/terminal.go
+++ b/go/cmd/vtgateclienttest/services/terminal.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package services
 
 import (
 	"errors"


### PR DESCRIPTION
are in sub-libraries.

@aaijazi @enisoc Needed for my import, otherwise build files are all messed up.
