### PR TITLE
Fix races in etcdtopo test

### DIFF
--- a/go/vt/etcdtopo/serving_graph.go
+++ b/go/vt/etcdtopo/serving_graph.go
@@ -286,7 +286,7 @@ func (s *Server) WatchEndPoints(ctx context.Context, cellName, keyspace, shard s
 		}
 
 		for {
-			if _, err := cell.Client.Watch(filePath, uint64(modifiedVersion), false /* recursive */, watch, stop); err != nil {
+			if _, err := cell.Client.Watch(filePath, uint64(modifiedVersion+1), false /* recursive */, watch, stop); err != nil {
 				log.Errorf("Watch on %v failed, waiting for %v to retry: %v", filePath, WatchSleepDuration, err)
 				timer := time.After(WatchSleepDuration)
 				select {


### PR DESCRIPTION
@michael-berlin 

After fixing the first race, the test started succeeding often enough to encounter another, much more rare, deadlock condition. It turned out to be because our fake etcd was doing the wrong thing. It shouldn't be a problem with real etcd.