### PR TITLE
make SplitQuery support string column.

### DIFF
--- a/go/sqltypes/sqltypes.go
+++ b/go/sqltypes/sqltypes.go
@@ -104,6 +104,18 @@ func (v Value) ParseUint64() (val uint64, err error) {
 	return strconv.ParseUint(string(n.raw()), 10, 64)
 }
 
+// ParseFloat64 will parse a Fractional value into an float64
+func (v Value) ParseFloat64() (val float64, err error) {
+	if v.Inner == nil {
+		return 0, fmt.Errorf("value is null")
+	}
+	n, ok := v.Inner.(Fractional)
+	if !ok {
+		return 0, fmt.Errorf("value is not Fractional")
+	}
+	return strconv.ParseFloat(string(n.raw()), 64)
+}
+
 // EncodeSql encodes the value into an SQL statement. Can be binary.
 func (v Value) EncodeSql(b BinWriter) {
 	if v.Inner == nil {

--- a/go/vt/tabletserver/query_splitter.go
+++ b/go/vt/tabletserver/query_splitter.go
@@ -1,6 +1,7 @@
 package tabletserver
 
 import (
+	"encoding/binary"
 	"fmt"
 	"strconv"
 
@@ -25,6 +26,11 @@ type QuerySplitter struct {
 	splitColumn string
 	rowCount    int64
 }
+
+const (
+	startBindVarName = ":_splitquery_start"
+	endBindVarName   = ":_splitquery_end"
+)
 
 // NewQuerySplitter creates a new QuerySplitter. query is the original query
 // to split and splitCount is the desired number of splits. splitCount must
@@ -95,8 +101,8 @@ func (qs *QuerySplitter) validateQuery() error {
 
 // split splits the query into multiple queries. validateQuery() must return
 // nil error before split() is called.
-func (qs *QuerySplitter) split(pkMinMax *mproto.QueryResult) ([]proto.QuerySplit, error) {
-	boundaries, err := qs.splitBoundaries(pkMinMax)
+func (qs *QuerySplitter) split(columnType int64, pkMinMax *mproto.QueryResult) ([]proto.QuerySplit, error) {
+	boundaries, err := qs.splitBoundaries(columnType, pkMinMax)
 	if err != nil {
 		return nil, err
 	}
@@ -108,51 +114,59 @@ func (qs *QuerySplitter) split(pkMinMax *mproto.QueryResult) ([]proto.QuerySplit
 		}
 		splits = append(splits, *split)
 	} else {
+		boundaries = append(boundaries, sqltypes.Value{})
+		whereClause := qs.sel.Where
 		// Loop through the boundaries and generated modified where clauses
 		start := sqltypes.Value{}
-		clauses := []*sqlparser.Where{}
 		for _, end := range boundaries {
-			clauses = append(clauses, qs.getWhereClause(start, end))
-			start.Inner = end.Inner
-		}
-		clauses = append(clauses, qs.getWhereClause(start, sqltypes.Value{}))
-		// Generate one split per clause
-		for _, clause := range clauses {
-			sel := qs.sel
-			sel.Where = clause
+			bindVars := make(map[string]interface{}, len(qs.query.BindVariables))
+			for k, v := range qs.query.BindVariables {
+				bindVars[k] = v
+			}
+			qs.sel.Where = qs.getWhereClause(whereClause, bindVars, start, end)
 			q := &proto.BoundQuery{
-				Sql:           sqlparser.String(sel),
-				BindVariables: qs.query.BindVariables,
+				Sql:           sqlparser.String(qs.sel),
+				BindVariables: bindVars,
 			}
 			split := &proto.QuerySplit{
 				Query:    *q,
 				RowCount: qs.rowCount,
 			}
 			splits = append(splits, *split)
+			start.Inner = end.Inner
 		}
+		qs.sel.Where = whereClause // reset where clause
 	}
 	return splits, err
 }
 
 // getWhereClause returns a whereClause based on desired upper and lower
 // bounds for primary key.
-func (qs *QuerySplitter) getWhereClause(start, end sqltypes.Value) *sqlparser.Where {
+func (qs *QuerySplitter) getWhereClause(whereClause *sqlparser.Where, bindVars map[string]interface{}, start, end sqltypes.Value) *sqlparser.Where {
 	var startClause *sqlparser.ComparisonExpr
 	var endClause *sqlparser.ComparisonExpr
 	var clauses sqlparser.BoolExpr
 	// No upper or lower bound, just return the where clause of original query
 	if start.IsNull() && end.IsNull() {
-		return qs.sel.Where
+		return whereClause
 	}
 	pk := &sqlparser.ColName{
 		Name: sqlparser.SQLName(qs.splitColumn),
 	}
-	// splitColumn >= start
 	if !start.IsNull() {
 		startClause = &sqlparser.ComparisonExpr{
 			Operator: sqlparser.AST_GE,
 			Left:     pk,
-			Right:    sqlparser.NumVal((start).Raw()),
+			Right:    sqlparser.ValArg([]byte(startBindVarName)),
+		}
+		if start.IsNumeric() {
+			v, _ := start.ParseInt64()
+			bindVars[startBindVarName] = v
+		} else if start.IsString() {
+			bindVars[startBindVarName] = start.Raw()
+		} else if start.IsFractional() {
+			v, _ := start.ParseFloat64()
+			bindVars[startBindVarName] = v
 		}
 	}
 	// splitColumn < end
@@ -160,7 +174,16 @@ func (qs *QuerySplitter) getWhereClause(start, end sqltypes.Value) *sqlparser.Wh
 		endClause = &sqlparser.ComparisonExpr{
 			Operator: sqlparser.AST_LT,
 			Left:     pk,
-			Right:    sqlparser.NumVal((end).Raw()),
+			Right:    sqlparser.ValArg([]byte(endBindVarName)),
+		}
+		if end.IsNumeric() {
+			v, _ := end.ParseInt64()
+			bindVars[endBindVarName] = v
+		} else if end.IsString() {
+			bindVars[endBindVarName] = end.Raw()
+		} else if end.IsFractional() {
+			v, _ := end.ParseFloat64()
+			bindVars[endBindVarName] = v
 		}
 	}
 	if startClause == nil {
@@ -176,9 +199,9 @@ func (qs *QuerySplitter) getWhereClause(start, end sqltypes.Value) *sqlparser.Wh
 			}
 		}
 	}
-	if qs.sel.Where != nil {
+	if whereClause != nil {
 		clauses = &sqlparser.AndExpr{
-			Left:  qs.sel.Where.Expr,
+			Left:  whereClause.Expr,
 			Right: clauses,
 		}
 	}
@@ -188,24 +211,23 @@ func (qs *QuerySplitter) getWhereClause(start, end sqltypes.Value) *sqlparser.Wh
 	}
 }
 
-func (qs *QuerySplitter) splitBoundaries(pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
-	boundaries := []sqltypes.Value{}
-	var err error
-	// If no min or max values were found, return empty list of boundaries
-	if len(pkMinMax.Rows) != 1 || pkMinMax.Rows[0][0].IsNull() || pkMinMax.Rows[0][1].IsNull() {
-		return boundaries, err
-	}
-	switch pkMinMax.Fields[0].Type {
+func (qs *QuerySplitter) splitBoundaries(columnType int64, pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
+	switch columnType {
 	case mproto.VT_TINY, mproto.VT_SHORT, mproto.VT_LONG, mproto.VT_LONGLONG, mproto.VT_INT24:
-		boundaries, err = qs.parseInt(pkMinMax)
+		return qs.splitBoundariesIntColumn(pkMinMax)
 	case mproto.VT_FLOAT, mproto.VT_DOUBLE:
-		boundaries, err = qs.parseFloat(pkMinMax)
+		return qs.splitBoundariesFloatColumn(pkMinMax)
+	case mproto.VT_VARCHAR, mproto.VT_BIT, mproto.VT_VAR_STRING, mproto.VT_STRING:
+		return qs.splitBoundariesStringColumn()
 	}
-	return boundaries, err
+	return []sqltypes.Value{}, nil
 }
 
-func (qs *QuerySplitter) parseInt(pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
+func (qs *QuerySplitter) splitBoundariesIntColumn(pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
 	boundaries := []sqltypes.Value{}
+	if pkMinMax == nil || len(pkMinMax.Rows) != 1 || pkMinMax.Rows[0][0].IsNull() || pkMinMax.Rows[0][1].IsNull() {
+		return boundaries, nil
+	}
 	minNumeric := sqltypes.MakeNumeric(pkMinMax.Rows[0][0].Raw())
 	maxNumeric := sqltypes.MakeNumeric(pkMinMax.Rows[0][1].Raw())
 	if pkMinMax.Rows[0][0].Raw()[0] == '-' {
@@ -256,8 +278,11 @@ func (qs *QuerySplitter) parseInt(pkMinMax *mproto.QueryResult) ([]sqltypes.Valu
 	return boundaries, nil
 }
 
-func (qs *QuerySplitter) parseFloat(pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
+func (qs *QuerySplitter) splitBoundariesFloatColumn(pkMinMax *mproto.QueryResult) ([]sqltypes.Value, error) {
 	boundaries := []sqltypes.Value{}
+	if pkMinMax == nil || len(pkMinMax.Rows) != 1 || pkMinMax.Rows[0][0].IsNull() || pkMinMax.Rows[0][1].IsNull() {
+		return boundaries, nil
+	}
 	min, err := strconv.ParseFloat(pkMinMax.Rows[0][0].String(), 64)
 	if err != nil {
 		return nil, err
@@ -278,6 +303,30 @@ func (qs *QuerySplitter) parseFloat(pkMinMax *mproto.QueryResult) ([]sqltypes.Va
 			return nil, err
 		}
 		boundaries = append(boundaries, v)
+	}
+	return boundaries, nil
+}
+
+// TODO(shengzhe): support split based on min, max from the string column.
+func (qs *QuerySplitter) splitBoundariesStringColumn() ([]sqltypes.Value, error) {
+	firstRow := int64(0x0)
+	lastRow := int64(0xFFFFFFFF)
+	splitRange := lastRow - firstRow + 1
+	splitSize := splitRange / int64(qs.splitCount)
+	qs.rowCount = splitSize
+	var boundaries []sqltypes.Value
+	for i := 1; i < qs.splitCount; i++ {
+		buf := make([]byte, 8)
+		// encode split point into binaries.
+		binary.BigEndian.PutUint64(buf, uint64(firstRow+splitSize*int64(i)))
+		// only converts the lower 4 bytes into hex because the upper 4 bytes are
+		// always 0x00000000 and mysql does byte comparison from the most significant
+		// bits.
+		val, err := sqltypes.BuildValue(buf[4:])
+		if err != nil {
+			return nil, err
+		}
+		boundaries = append(boundaries, val)
 	}
 	return boundaries, nil
 }

--- a/go/vt/tabletserver/query_splitter.go
+++ b/go/vt/tabletserver/query_splitter.go
@@ -28,8 +28,8 @@ type QuerySplitter struct {
 }
 
 const (
-	startBindVarName = ":_splitquery_start"
-	endBindVarName   = ":_splitquery_end"
+	startBindVarName = "_splitquery_start"
+	endBindVarName   = "_splitquery_end"
 )
 
 // NewQuerySplitter creates a new QuerySplitter. query is the original query
@@ -157,7 +157,7 @@ func (qs *QuerySplitter) getWhereClause(whereClause *sqlparser.Where, bindVars m
 		startClause = &sqlparser.ComparisonExpr{
 			Operator: sqlparser.AST_GE,
 			Left:     pk,
-			Right:    sqlparser.ValArg([]byte(startBindVarName)),
+			Right:    sqlparser.ValArg([]byte(":" + startBindVarName)),
 		}
 		if start.IsNumeric() {
 			v, _ := start.ParseInt64()
@@ -174,7 +174,7 @@ func (qs *QuerySplitter) getWhereClause(whereClause *sqlparser.Where, bindVars m
 		endClause = &sqlparser.ComparisonExpr{
 			Operator: sqlparser.AST_LT,
 			Left:     pk,
-			Right:    sqlparser.ValArg([]byte(endBindVarName)),
+			Right:    sqlparser.ValArg([]byte(":" + endBindVarName)),
 		}
 		if end.IsNumeric() {
 			v, _ := end.ParseInt64()

--- a/go/vt/tabletserver/query_splitter.go
+++ b/go/vt/tabletserver/query_splitter.go
@@ -201,8 +201,8 @@ func (qs *QuerySplitter) getWhereClause(whereClause *sqlparser.Where, bindVars m
 	}
 	if whereClause != nil {
 		clauses = &sqlparser.AndExpr{
-			Left:  whereClause.Expr,
-			Right: clauses,
+			Left:  &sqlparser.ParenBoolExpr{Expr: whereClause.Expr},
+			Right: &sqlparser.ParenBoolExpr{Expr: clauses},
 		}
 	}
 	return &sqlparser.Where{
@@ -310,7 +310,7 @@ func (qs *QuerySplitter) splitBoundariesFloatColumn(pkMinMax *mproto.QueryResult
 // TODO(shengzhe): support split based on min, max from the string column.
 func (qs *QuerySplitter) splitBoundariesStringColumn() ([]sqltypes.Value, error) {
 	firstRow := int64(0x0)
-	lastRow := int64(0xFFFFFFFF)
+	lastRow := int64(0xFFFFFFFFFFFFFF)
 	splitRange := lastRow - firstRow + 1
 	splitSize := splitRange / int64(qs.splitCount)
 	qs.rowCount = splitSize

--- a/go/vt/tabletserver/query_splitter_test.go
+++ b/go/vt/tabletserver/query_splitter_test.go
@@ -165,7 +165,7 @@ func TestGetWhereClause(t *testing.T) {
 	bindVars = make(map[string]interface{})
 	bindVars[":count"] = 300
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, start, nilValue)
-	want = " where count > :count and id >= " + startBindVarName
+	want = " where (count > :count) and (id >= " + startBindVarName + ")"
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -182,7 +182,7 @@ func TestGetWhereClause(t *testing.T) {
 	end, _ := sqltypes.BuildValue(endVal)
 	bindVars = make(map[string]interface{})
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, nilValue, end)
-	want = " where count > :count and id < " + endBindVarName
+	want = " where (count > :count) and (id < " + endBindVarName + ")"
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -198,7 +198,7 @@ func TestGetWhereClause(t *testing.T) {
 	// Set both bounds, should add two conditions to where clause
 	bindVars = make(map[string]interface{})
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, start, end)
-	want = fmt.Sprintf(" where count > :count and id >= %s and id < %s", startBindVarName, endBindVarName)
+	want = fmt.Sprintf(" where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName)
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -355,18 +355,18 @@ func TestSplitQuery(t *testing.T) {
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where count > :count and id < " + endBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: int64(100)},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where count > :count and id >= %s and id < %s", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: int64(100),
 				endBindVarName:   int64(200),
 			},
 		},
 		{
-			Sql:           "select * from test_table where count > :count and id >= " + startBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: int64(200)},
 		},
 	}
@@ -411,18 +411,18 @@ func TestSplitQueryFractionalColumn(t *testing.T) {
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where count > :count and id < " + endBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: 170.5},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where count > :count and id >= %s and id < %s", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: 170.5,
 				endBindVarName:   330.5,
 			},
 		},
 		{
-			Sql:           "select * from test_table where count > :count and id >= " + startBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: 330.5},
 		},
 	}
@@ -444,25 +444,25 @@ func TestSplitQueryStringColumn(t *testing.T) {
 	}
 	got := []proto.BoundQuery{}
 	for _, split := range splits {
-		if split.RowCount != 1431655765 {
+		if split.RowCount != 24019198012642645 {
 			t.Errorf("wrong RowCount, got: %v, want: %v", split.RowCount, 1431655765)
 		}
 		got = append(got, split.Query)
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where count > :count and id < " + endBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: hexToByteUInt64(0x55555555)[4:]},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where count > :count and id >= %s and id < %s", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: hexToByteUInt64(0x55555555)[4:],
 				endBindVarName:   hexToByteUInt64(0xAAAAAAAA)[4:],
 			},
 		},
 		{
-			Sql:           "select * from test_table where count > :count and id >= " + startBindVarName,
+			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: hexToByteUInt64(0xAAAAAAAA)[4:]},
 		},
 	}

--- a/go/vt/tabletserver/query_splitter_test.go
+++ b/go/vt/tabletserver/query_splitter_test.go
@@ -165,7 +165,7 @@ func TestGetWhereClause(t *testing.T) {
 	bindVars = make(map[string]interface{})
 	bindVars[":count"] = 300
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, start, nilValue)
-	want = " where (count > :count) and (id >= " + startBindVarName + ")"
+	want = " where (count > :count) and (id >= :" + startBindVarName + ")"
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -182,7 +182,7 @@ func TestGetWhereClause(t *testing.T) {
 	end, _ := sqltypes.BuildValue(endVal)
 	bindVars = make(map[string]interface{})
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, nilValue, end)
-	want = " where (count > :count) and (id < " + endBindVarName + ")"
+	want = " where (count > :count) and (id < :" + endBindVarName + ")"
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -198,7 +198,7 @@ func TestGetWhereClause(t *testing.T) {
 	// Set both bounds, should add two conditions to where clause
 	bindVars = make(map[string]interface{})
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, start, end)
-	want = fmt.Sprintf(" where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName)
+	want = fmt.Sprintf(" where (count > :count) and (id >= :%s and id < :%s)", startBindVarName, endBindVarName)
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -219,7 +219,7 @@ func TestGetWhereClause(t *testing.T) {
 	bindVars = make(map[string]interface{})
 	// Set both bounds, should add two conditions to where clause
 	clause = splitter.getWhereClause(splitter.sel.Where, bindVars, start, end)
-	want = fmt.Sprintf(" where id >= %s and id < %s", startBindVarName, endBindVarName)
+	want = fmt.Sprintf(" where id >= :%s and id < :%s", startBindVarName, endBindVarName)
 	got = sqlparser.String(clause)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("incorrect where clause, got:%v, want:%v", got, want)
@@ -355,18 +355,18 @@ func TestSplitQuery(t *testing.T) {
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id < :" + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: int64(100)},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= :%s and id < :%s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: int64(100),
 				endBindVarName:   int64(200),
 			},
 		},
 		{
-			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id >= :" + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: int64(200)},
 		},
 	}
@@ -411,18 +411,18 @@ func TestSplitQueryFractionalColumn(t *testing.T) {
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id < :" + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: 170.5},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= :%s and id < :%s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: 170.5,
 				endBindVarName:   330.5,
 			},
 		},
 		{
-			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id >= :" + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: 330.5},
 		},
 	}
@@ -451,18 +451,18 @@ func TestSplitQueryStringColumn(t *testing.T) {
 	}
 	want := []proto.BoundQuery{
 		{
-			Sql:           "select * from test_table where (count > :count) and (id < " + endBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id < :" + endBindVarName + ")",
 			BindVariables: map[string]interface{}{endBindVarName: hexToByteUInt64(0x55555555)[4:]},
 		},
 		{
-			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= %s and id < %s)", startBindVarName, endBindVarName),
+			Sql: fmt.Sprintf("select * from test_table where (count > :count) and (id >= :%s and id < :%s)", startBindVarName, endBindVarName),
 			BindVariables: map[string]interface{}{
 				startBindVarName: hexToByteUInt64(0x55555555)[4:],
 				endBindVarName:   hexToByteUInt64(0xAAAAAAAA)[4:],
 			},
 		},
 		{
-			Sql:           "select * from test_table where (count > :count) and (id >= " + startBindVarName + ")",
+			Sql:           "select * from test_table where (count > :count) and (id >= :" + startBindVarName + ")",
 			BindVariables: map[string]interface{}{startBindVarName: hexToByteUInt64(0xAAAAAAAA)[4:]},
 		},
 	}

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -679,7 +679,7 @@ func getColumnType(qre *QueryExecutor, columnName, tableName string) (int64, err
 		return mproto.VT_NULL, err
 	}
 	defer conn.Recycle()
-	query := fmt.Sprintf("SELECT %v FROM %v LIMIT 1", columnName, tableName)
+	query := fmt.Sprintf("SELECT %v FROM %v LIMIT 0", columnName, tableName)
 	result, err := qre.execSQL(conn, query, true)
 	if err != nil {
 		return mproto.VT_NULL, err

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -679,6 +679,9 @@ func getColumnType(qre *QueryExecutor, columnName, tableName string) (int64, err
 		return mproto.VT_NULL, err
 	}
 	defer conn.Recycle()
+	// TODO(shengzhe): use AST to represent the query to avoid sql injection.
+	// current code is safe because QuerySplitter.validateQuery is called before
+	// calling this.
 	query := fmt.Sprintf("SELECT %v FROM %v LIMIT 0", columnName, tableName)
 	result, err := qre.execSQL(conn, query, true)
 	if err != nil {
@@ -696,6 +699,9 @@ func getColumnMinMax(qre *QueryExecutor, columnName, tableName string) (*mproto.
 		return nil, err
 	}
 	defer conn.Recycle()
+	// TODO(shengzhe): use AST to represent the query to avoid sql injection.
+	// current code is safe because QuerySplitter.validateQuery is called before
+	// calling this.
 	minMaxSQL := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v", columnName, columnName, tableName)
 	return qre.execSQL(conn, minMaxSQL, true)
 }

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -539,20 +539,19 @@ func (sq *SqlQuery) SplitQuery(ctx context.Context, target *pb.Target, req *prot
 		logStats: logStats,
 		qe:       sq.qe,
 	}
-	conn, err := qre.getConn(sq.qe.connPool)
+	columnType, err := getColumnType(qre, splitter.splitColumn, splitter.tableName)
 	if err != nil {
 		return err
 	}
-	defer conn.Recycle()
-	// TODO: For fetching MinMax, include where clauses on the
-	// primary key, if any, in the original query which might give a narrower
-	// range of split column to work with.
-	minMaxSQL := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v", splitter.splitColumn, splitter.splitColumn, splitter.tableName)
-	splitColumnMinMax, err := qre.execSQL(conn, minMaxSQL, true)
-	if err != nil {
-		return err
+	var pkMinMax *mproto.QueryResult
+	switch columnType {
+	case mproto.VT_TINY, mproto.VT_SHORT, mproto.VT_LONG, mproto.VT_LONGLONG, mproto.VT_INT24, mproto.VT_FLOAT, mproto.VT_DOUBLE:
+		pkMinMax, err = getColumnMinMax(qre, splitter.splitColumn, splitter.tableName)
+		if err != nil {
+			return err
+		}
 	}
-	reply.Queries, err = splitter.split(splitColumnMinMax)
+	reply.Queries, err = splitter.split(columnType, pkMinMax)
 	if err != nil {
 		return NewTabletError(ErrFail, "splitQuery: query split error: %s, request: %#v", err, req)
 	}
@@ -672,4 +671,31 @@ func withTimeout(ctx context.Context, timeout time.Duration) (context.Context, c
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, timeout)
+}
+
+func getColumnType(qre *QueryExecutor, columnName, tableName string) (int64, error) {
+	conn, err := qre.getConn(qre.qe.connPool)
+	if err != nil {
+		return mproto.VT_NULL, err
+	}
+	defer conn.Recycle()
+	query := fmt.Sprintf("SELECT %v FROM %v LIMIT 1", columnName, tableName)
+	result, err := qre.execSQL(conn, query, true)
+	if err != nil {
+		return mproto.VT_NULL, err
+	}
+	if result == nil || len(result.Fields) != 1 {
+		return mproto.VT_NULL, NewTabletError(ErrFail, "failed to get column type for column: %v, invalid result: %v", columnName, result)
+	}
+	return result.Fields[0].Type, nil
+}
+
+func getColumnMinMax(qre *QueryExecutor, columnName, tableName string) (*mproto.QueryResult, error) {
+	conn, err := qre.getConn(qre.qe.connPool)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+	minMaxSQL := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v", columnName, columnName, tableName)
+	return qre.execSQL(conn, minMaxSQL, true)
 }

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -19,28 +19,28 @@ import (
 )
 
 func TestSqlQueryAllowQueriesFailBadConn(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	db.EnableConnFail()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
-	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	checkSQLQueryState(t, sqlQuery, "NOT_SERVING")
 	dbconfigs := testUtils.newDBConfigs()
 	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail")
 	}
-	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	checkSQLQueryState(t, sqlQuery, "NOT_SERVING")
 }
 
 func TestSqlQueryAllowQueriesFailStrictModeConflictWithRowCache(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	// disable strict mode
 	config.StrictMode = false
 	sqlQuery := NewSqlQuery(config)
-	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	checkSQLQueryState(t, sqlQuery, "NOT_SERVING")
 	dbconfigs := testUtils.newDBConfigs()
 	// enable rowcache
 	dbconfigs.App.EnableRowcache = true
@@ -48,15 +48,15 @@ func TestSqlQueryAllowQueriesFailStrictModeConflictWithRowCache(t *testing.T) {
 	if err == nil {
 		t.Fatalf("SqlQuery.allowQueries should fail because strict mode is disabled while rowcache is enabled.")
 	}
-	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	checkSQLQueryState(t, sqlQuery, "NOT_SERVING")
 }
 
 func TestSqlQueryAllowQueries(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
-	checkSqlQueryState(t, sqlQuery, "NOT_SERVING")
+	checkSQLQueryState(t, sqlQuery, "NOT_SERVING")
 	dbconfigs := testUtils.newDBConfigs()
 	sqlQuery.setState(StateServing)
 	err := sqlQuery.allowQueries(nil, &dbconfigs, []SchemaOverride{}, testUtils.newMysqld(&dbconfigs))
@@ -73,7 +73,7 @@ func TestSqlQueryAllowQueries(t *testing.T) {
 }
 
 func TestSqlQueryCheckMysql(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -89,7 +89,7 @@ func TestSqlQueryCheckMysql(t *testing.T) {
 }
 
 func TestSqlQueryCheckMysqlFailInvalidConn(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -107,7 +107,7 @@ func TestSqlQueryCheckMysqlFailInvalidConn(t *testing.T) {
 }
 
 func TestSqlQueryCheckMysqlFailUninitializedQueryEngine(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -126,7 +126,7 @@ func TestSqlQueryCheckMysqlFailUninitializedQueryEngine(t *testing.T) {
 }
 
 func TestSqlQueryCheckMysqlInNotServingState(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	config.EnablePublishStats = true
@@ -151,7 +151,7 @@ func TestSqlQueryCheckMysqlInNotServingState(t *testing.T) {
 }
 
 func TestSqlQueryGetSessionId(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -196,7 +196,7 @@ func TestSqlQueryGetSessionId(t *testing.T) {
 }
 
 func TestSqlQueryCommandFailUnMatchedSessionId(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -286,17 +286,17 @@ func TestSqlQueryCommandFailUnMatchedSessionId(t *testing.T) {
 }
 
 func TestSqlQueryCommitTransaciton(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table limit 1000"
-	executeSqlResult := &mproto.QueryResult{
+	executeSQL := "select * from test_table limit 1000"
+	executeSQLResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db.AddQuery(executeSql, executeSqlResult)
+	db.AddQuery(executeSQL, executeSQLResult)
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
@@ -316,7 +316,7 @@ func TestSqlQueryCommitTransaciton(t *testing.T) {
 	}
 	session.TransactionId = txInfo.TransactionId
 	query := proto.Query{
-		Sql:           executeSql,
+		Sql:           executeSQL,
 		BindVariables: nil,
 		SessionId:     session.SessionId,
 		TransactionId: session.TransactionId,
@@ -331,17 +331,17 @@ func TestSqlQueryCommitTransaciton(t *testing.T) {
 }
 
 func TestSqlQueryRollback(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table limit 1000"
-	executeSqlResult := &mproto.QueryResult{
+	executeSQL := "select * from test_table limit 1000"
+	executeSQLResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db.AddQuery(executeSql, executeSqlResult)
+	db.AddQuery(executeSQL, executeSQLResult)
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
@@ -361,7 +361,7 @@ func TestSqlQueryRollback(t *testing.T) {
 	}
 	session.TransactionId = txInfo.TransactionId
 	query := proto.Query{
-		Sql:           executeSql,
+		Sql:           executeSQL,
 		BindVariables: nil,
 		SessionId:     session.SessionId,
 		TransactionId: session.TransactionId,
@@ -376,17 +376,17 @@ func TestSqlQueryRollback(t *testing.T) {
 }
 
 func TestSqlQueryStreamExecute(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	// sql that will be executed in this test
-	executeSql := "select * from test_table limit 1000"
-	executeSqlResult := &mproto.QueryResult{
+	executeSQL := "select * from test_table limit 1000"
+	executeSQLResult := &mproto.QueryResult{
 		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 		},
 	}
-	db.AddQuery(executeSql, executeSqlResult)
+	db.AddQuery(executeSQL, executeSQLResult)
 
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -407,7 +407,7 @@ func TestSqlQueryStreamExecute(t *testing.T) {
 	}
 	session.TransactionId = txInfo.TransactionId
 	query := proto.Query{
-		Sql:           executeSql,
+		Sql:           executeSQL,
 		BindVariables: nil,
 		SessionId:     session.SessionId,
 		TransactionId: session.TransactionId,
@@ -427,14 +427,14 @@ func TestSqlQueryStreamExecute(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatch(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	sql := "insert into test_table values (1, 2)"
 	sqlResult := &mproto.QueryResult{}
-	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+	expanedSQL := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
 
 	db.AddQuery(sql, sqlResult)
-	db.AddQuery(expanedSql, sqlResult)
+	db.AddQuery(expanedSQL, sqlResult)
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
@@ -469,7 +469,7 @@ func TestSqlQueryExecuteBatch(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchFailEmptyQueryList(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -493,7 +493,7 @@ func TestSqlQueryExecuteBatchFailEmptyQueryList(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchFailAsTransaction(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -524,7 +524,7 @@ func TestSqlQueryExecuteBatchFailAsTransaction(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchBeginFail(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	// make "begin" query fail
 	db.AddRejectedQuery("begin")
@@ -558,7 +558,7 @@ func TestSqlQueryExecuteBatchBeginFail(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchCommitFail(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	// make "commit" query fail
 	db.AddRejectedQuery("commit")
@@ -597,18 +597,18 @@ func TestSqlQueryExecuteBatchCommitFail(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchSqlExecFailInTransaction(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	sql := "insert into test_table values (1, 2)"
 	sqlResult := &mproto.QueryResult{}
-	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+	expanedSQL := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
 
 	db.AddQuery(sql, sqlResult)
-	db.AddQuery(expanedSql, sqlResult)
+	db.AddQuery(expanedSQL, sqlResult)
 
 	// make this query fail
 	db.AddRejectedQuery(sql)
-	db.AddRejectedQuery(expanedSql)
+	db.AddRejectedQuery(expanedSQL)
 
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -652,14 +652,14 @@ func TestSqlQueryExecuteBatchSqlExecFailInTransaction(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchSqlSucceedInTransaction(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	sql := "insert into test_table values (1, 2)"
 	sqlResult := &mproto.QueryResult{}
-	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+	expanedSQL := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
 
 	db.AddQuery(sql, sqlResult)
-	db.AddQuery(expanedSql, sqlResult)
+	db.AddQuery(expanedSQL, sqlResult)
 
 	// cause execution error for this particular sql query
 	db.AddRejectedQuery(sql)
@@ -695,7 +695,7 @@ func TestSqlQueryExecuteBatchSqlSucceedInTransaction(t *testing.T) {
 }
 
 func TestSqlQueryExecuteBatchCallCommitWithoutABegin(t *testing.T) {
-	setUpSqlQueryTest()
+	setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -727,14 +727,14 @@ func TestSqlQueryExecuteBatchCallCommitWithoutABegin(t *testing.T) {
 }
 
 func TestExecuteBatchNestedTransaction(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	sql := "insert into test_table values (1, 2)"
 	sqlResult := &mproto.QueryResult{}
-	expanedSql := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
+	expanedSQL := "insert into test_table values (1, 2) /* _stream test_table (pk ) (1 ); */"
 
 	db.AddQuery(sql, sqlResult)
-	db.AddQuery(expanedSql, sqlResult)
+	db.AddQuery(expanedSQL, sqlResult)
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
 	dbconfigs := testUtils.newDBConfigs()
@@ -786,7 +786,7 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 }
 
 func TestSqlQuerySplitQuery(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	db.AddQuery("SELECT MIN(pk), MAX(pk) FROM test_table", &mproto.QueryResult{
 		Fields: []mproto.Field{
 			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
@@ -799,7 +799,7 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 			},
 		},
 	})
-	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+	db.AddQuery("SELECT pk FROM test_table LIMIT 0", &mproto.QueryResult{
 		Fields: []mproto.Field{
 			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
 		},
@@ -847,7 +847,7 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 }
 
 func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	db.AddQuery("SELECT MIN(pk), MAX(pk) FROM test_table", &mproto.QueryResult{
 		Fields: []mproto.Field{
 			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
@@ -860,7 +860,7 @@ func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
 			},
 		},
 	})
-	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+	db.AddQuery("SELECT pk FROM test_table LIMIT 0", &mproto.QueryResult{
 		Fields: []mproto.Field{
 			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
 		},
@@ -908,7 +908,7 @@ func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
 }
 
 func TestSqlQuerySplitQueryInvalidMinMax(t *testing.T) {
-	db := setUpSqlQueryTest()
+	db := setUpSQLQueryTest()
 	testUtils := newTestUtils()
 	pkMinMaxQuery := "SELECT MIN(pk), MAX(pk) FROM test_table"
 	pkMinMaxQueryResp := &mproto.QueryResult{
@@ -924,7 +924,7 @@ func TestSqlQuerySplitQueryInvalidMinMax(t *testing.T) {
 			},
 		},
 	}
-	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+	db.AddQuery("SELECT pk FROM test_table LIMIT 0", &mproto.QueryResult{
 		Fields: []mproto.Field{
 			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
 		},
@@ -1055,7 +1055,7 @@ func TestTerseErrors2(t *testing.T) {
 	})
 }
 
-func setUpSqlQueryTest() *fakesqldb.DB {
+func setUpSQLQueryTest() *fakesqldb.DB {
 	db := fakesqldb.Register()
 	for query, result := range getSupportedQueries() {
 		db.AddQuery(query, result)
@@ -1063,7 +1063,7 @@ func setUpSqlQueryTest() *fakesqldb.DB {
 	return db
 }
 
-func checkSqlQueryState(t *testing.T, sqlQuery *SqlQuery, expectState string) {
+func checkSQLQueryState(t *testing.T, sqlQuery *SqlQuery, expectState string) {
 	if sqlQuery.GetState() != expectState {
 		t.Fatalf("sqlquery should in state: %s, but get state: %s", expectState, sqlQuery.GetState())
 	}

--- a/go/vt/tabletserver/sqlquery_test.go
+++ b/go/vt/tabletserver/sqlquery_test.go
@@ -799,7 +799,17 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 			},
 		},
 	})
-
+	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.MakeNumeric([]byte("1")),
+			},
+		},
+	})
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -837,7 +847,30 @@ func TestSqlQuerySplitQuery(t *testing.T) {
 }
 
 func TestSqlQuerySplitQueryInvalidQuery(t *testing.T) {
-	setUpSqlQueryTest()
+	db := setUpSqlQueryTest()
+	db.AddQuery("SELECT MIN(pk), MAX(pk) FROM test_table", &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.MakeNumeric([]byte("1")),
+				sqltypes.MakeNumeric([]byte("100")),
+			},
+		},
+	})
+	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.MakeNumeric([]byte("1")),
+			},
+		},
+	})
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	sqlQuery := NewSqlQuery(config)
@@ -891,6 +924,17 @@ func TestSqlQuerySplitQueryInvalidMinMax(t *testing.T) {
 			},
 		},
 	}
+	db.AddQuery("SELECT pk FROM test_table LIMIT 1", &mproto.QueryResult{
+		Fields: []mproto.Field{
+			mproto.Field{Name: "pk", Type: mproto.VT_LONG},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.MakeNumeric([]byte("1")),
+			},
+		},
+	})
 	db.AddQuery(pkMinMaxQuery, pkMinMaxQueryResp)
 
 	config := testUtils.newQueryServiceConfig()

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -193,7 +193,8 @@ primary key (id)
     rows = {}
     for q in s:
       qr = utils.vtgate.execute_shard(q['QueryShard']['Sql'],
-                                      'test_keyspace', ",".join(q['QueryShard']['Shards']))
+                                      'test_keyspace', ",".join(q['QueryShard']['Shards']),
+                                      tablet_type='master', bindvars=q['QueryShard']['BindVariables'])
       for r in qr['Rows']:
         id = int(r[0])
         rows[id] = r[1]


### PR DESCRIPTION
1. SplitQuery will split a string column as a hex string. That is, it assumes
   the key range is [0x0000000, 0xFFFFFFF] and then divides the range into
   intervals based on split count.
2. Introduce splitBoundariesStringColumn to handle string column case.
3. Use MySQL's HEX function when constructing where clause.
4. Refactor existing SplitQuery in sqlquery.go: create two helper functions
   getColumnType and getColumnMinMax.