### PR TITLE
Fail integration tests after a 5 minute timeout.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ small_integration_test_files = \
 	initial_sharding_bytes.py \
 	initial_sharding.py
 
-# TODO(mberlin): Remove -v option to worker.py when we found out what causes 10 minute Travis timeouts.
 medium_integration_test_files = \
 	tabletmanager.py \
 	reparent.py \
@@ -119,7 +118,7 @@ medium_integration_test_files = \
 	client_test.py \
 	vtgate_utils_test.py \
 	rowcache_invalidator.py \
-	"worker.py -v" \
+	worker.py \
 	automation_horizontal_resharding.py
 
 large_integration_test_files = \
@@ -146,19 +145,12 @@ SHELL = /bin/bash
 
 # function to execute a list of integration test files
 # exits on first failure
-# TODO(mberlin): Remove special handling for worker.py when we found out what causes 10 minute Travis timeouts.
 define run_integration_tests
 	cd test ; \
 	for t in $1 ; do \
 		echo $$(date): Running test/$$t... ; \
-		if [[ $$t == *worker.py* ]]; then \
-			time ./$$t $$VT_TEST_FLAGS 2>&1 ; \
-			rc=$$? ; \
-		else \
-			output=$$(time ./$$t $$VT_TEST_FLAGS 2>&1) ; \
-			rc=$$? ; \
-		fi ; \
-		if [[ $$rc != 0 ]]; then \
+		output=$$(time ./$$t $$VT_TEST_FLAGS 2>&1) ; \
+		if [[ $$? != 0 ]]; then \
 			echo "$$output" >&2 ; \
 			exit 1 ; \
 		fi ; \

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ define run_integration_tests
 	cd test ; \
 	for t in $1 ; do \
 		echo $$(date): Running test/$$t... ; \
-		output=$$(time ./$$t $$VT_TEST_FLAGS 2>&1) ; \
+		output=$$(time timeout 5m ./$$t $$VT_TEST_FLAGS 2>&1) ; \
 		if [[ $$? != 0 ]]; then \
 			echo "$$output" >&2 ; \
 			exit 1 ; \


### PR DESCRIPTION
See commit messages. This helps to free up Travis resources sooner.