### PR TITLE
Demote or suppress some errors in logs

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -50,6 +50,9 @@ const (
 	// ErrOptionPreventsStatement is C.ER_OPTION_PREVENTS_STATEMENT
 	ErrOptionPreventsStatement = C.ER_OPTION_PREVENTS_STATEMENT
 
+	// ErrDataTooLong is C.ER_DATA_TOO_LONG
+	ErrDataTooLong = C.ER_DATA_TOO_LONG
+
 	// ErrServerLost is C.CR_SERVER_LOST.
 	// It's hard-coded for now because it causes problems on import.
 	ErrServerLost = 2013


### PR DESCRIPTION
@sougou 

Quick change to suppress some of the errors that we've seen as being too spammy.

I'm unsure about 1406/ER_DATA_TOO_LONG, @nurblieh can confirm that we want to suppress that one too.