### PR TITLE
SchemaManager should be able to handle nil ShardInfo.MasterAlias.

### DIFF
--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -269,6 +269,7 @@ func (client *fakeTabletManagerClient) ExecuteFetchAsDba(ctx context.Context, ta
 
 type fakeTopo struct {
 	faketopo.FakeTopo
+	WithEmptyMasterAlias bool
 }
 
 func newFakeTopo() *fakeTopo {
@@ -284,11 +285,15 @@ func (topoServer *fakeTopo) GetShardNames(ctx context.Context, keyspace string) 
 }
 
 func (topoServer *fakeTopo) GetShard(ctx context.Context, keyspace string, shard string) (*topo.ShardInfo, error) {
-	value := &pb.Shard{
-		MasterAlias: &pb.TabletAlias{
+	var masterAlias *pb.TabletAlias
+	if !topoServer.WithEmptyMasterAlias {
+		masterAlias = &pb.TabletAlias{
 			Cell: "test_cell",
 			Uid:  0,
-		},
+		}
+	}
+	value := &pb.Shard{
+		MasterAlias: masterAlias,
 	}
 	return topo.NewShardInfo(keyspace, shard, value, 0), nil
 }

--- a/go/vt/schemamanager/tablet_executor.go
+++ b/go/vt/schemamanager/tablet_executor.go
@@ -54,6 +54,10 @@ func (exec *TabletExecutor) Open(ctx context.Context, keyspace string) error {
 		if err != nil {
 			return fmt.Errorf("unable to get shard info, keyspace: %s, shard: %s, error: %v", keyspace, shardName, err)
 		}
+		if !shardInfo.HasMaster() {
+			log.Errorf("shard: %s does not have a master", shardName)
+			return fmt.Errorf("shard: %s does not have a master", shardName)
+		}
 		tabletInfo, err := exec.topoServer.GetTablet(ctx, shardInfo.MasterAlias)
 		if err != nil {
 			return fmt.Errorf("unable to get master tablet info, keyspace: %s, shard: %s, error: %v", keyspace, shardName, err)

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -26,6 +26,20 @@ func TestTabletExecutorOpen(t *testing.T) {
 	}
 }
 
+func TestTabletExecutorOpenWithEmptyMasterAlias(t *testing.T) {
+	fakeTopo := newFakeTopo()
+	fakeTopo.WithEmptyMasterAlias = true
+	executor := NewTabletExecutor(
+		newFakeTabletManagerClient(),
+		fakeTopo)
+	ctx := context.Background()
+
+	if err := executor.Open(ctx, "test_keyspace"); err == nil {
+		t.Fatalf("executor.Open() = nil, want error")
+	}
+	executor.Close()
+}
+
 func TestTabletExecutorValidate(t *testing.T) {
 	fakeTmc := newFakeTabletManagerClient()
 


### PR DESCRIPTION
ShardInfo.GetShard may contain nil MasterAlias because when creating a shard,
or when scrapping the shard's master, the MasterAlias will be nil.

SchemaManager should return error in such case instead of throwing a panic.