### PR TITLE
netutil: Temporarily remove LookupCNAME to fix builds for Go 1.5.

### DIFF
--- a/go/netutil/netutil.go
+++ b/go/netutil/netutil.go
@@ -110,11 +110,7 @@ func FullyQualifiedHostname() (string, error) {
 		return "", err
 	}
 
-	cname, err := net.LookupCNAME(hostname)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(cname, "."), nil
+	return strings.TrimRight(hostname, "."), nil
 }
 
 // FullyQualifiedHostnameOrPanic is the same as FullyQualifiedHostname


### PR DESCRIPTION
I'll readd the functionality later in a separate commit.