### PR TITLE
Github front page: Remove coverage button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vitess <p align="right">[![Build Status](https://travis-ci.org/youtube/vitess.svg?branch=master)](https://travis-ci.org/youtube/vitess/builds) [![Coverage Status](https://coveralls.io/repos/youtube/vitess/badge.png)](https://coveralls.io/r/youtube/vitess)</p>
+# Vitess <p align="right">[![Build Status](https://travis-ci.org/youtube/vitess.svg?branch=master)](https://travis-ci.org/youtube/vitess/builds)</p>
 
 Vitess is a storage platform for scaling MySQL.
 It is optimized to run as effectively in cloud architectures as it does on dedicated hardware.


### PR DESCRIPTION
The coverage button currently shows 56% coverage for our Go code in a red color.
Unfortunately, this is incorrect because coverage is only tested and
added up for code within the same package. However, our true
coverage is much higher because we have dedicated integration test
packages which cover a lot of other packages.

Therefore, we'll remove the coverage button for now. Once we fixed
calculating the true coverage, we can re-add it.