### PR TITLE
Passing the right protocol flavor to vtctld for tablet connections.

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -921,6 +921,7 @@ class Vtctld(object):
             '-tablet_manager_protocol',
             protocols_flavor().tablet_manager_protocol(),
             '-vtgate_protocol', protocols_flavor().vtgate_protocol(),
+            '-tablet_protocol', protocols_flavor().tabletconn_protocol(),
             ] + \
             environment.topo_server().flags()
     if protocols_flavor().service_map():


### PR DESCRIPTION
required in google3... now that gRPC is default ;)