### PR TITLE
Go unit tests: Determine coverage for outside packages as well.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ env:
     - PHP_FLAGS="-d extension=$HOME/php/mongo.so"
     - PATH="$HOME/php:$PATH"
     # Add -follow to TEST_FLAGS below to print as the test runs, to diagnose stuck tests.
-    - TEST_FLAGS="-docker=false -timeout=5m -print-log -remote-stats=http://enisoc.com:15123/travis/stats"
+    - TEST_FLAGS="-docker=false -timeout=10m -print-log -remote-stats=http://enisoc.com:15123/travis/stats"
   matrix:
     # NOTE: Travis CI schedules up to 5 tests simultaneously.
     #       All our tests should be spread out as evenly as possible across these 5 slots.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,8 @@ repos="github.com/golang/glog \
 "
 
 # Packages for uploading code coverage to coveralls.io (used by Travis CI).
-repos+=" github.com/modocache/gover github.com/mattn/goveralls"
+# TODO(mberlin): Replace "deplist" fork with the original repo "github.com/cespare/deplist" when our changes are merged there.
+repos+=" github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/michael-berlin/deplist"
 # The cover tool needs to be installed into the Go toolchain, so it will fail
 # if Go is installed somewhere that requires root access.
 source tools/shell_functions.inc

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,7 +107,7 @@ repos="github.com/golang/glog \
 
 # Packages for uploading code coverage to coveralls.io (used by Travis CI).
 # TODO(mberlin): Replace "deplist" fork with the original repo "github.com/cespare/deplist" when our changes are merged there.
-repos+=" github.com/axw/gocov/gocov github.com/mattn/goveralls github.com/michael-berlin/deplist"
+repos+=" github.com/wadey/gocovmerge github.com/mattn/goveralls github.com/michael-berlin/deplist"
 # The cover tool needs to be installed into the Go toolchain, so it will fail
 # if Go is installed somewhere that requires root access.
 source tools/shell_functions.inc

--- a/test/config.json
+++ b/test/config.json
@@ -39,10 +39,12 @@
 			"File": "",
 			"Args": [],
 			"Command": [
-				"travis/goveralls.sh"
+				"travis/goveralls.sh",
+				"--full"
 			],
 			"Manual": true,
-			"Shard": 0
+			"Shard": 0,
+			"RetryMax": 1
 		},
 		"initial_sharding": {
 			"File": "initial_sharding.py",

--- a/travis/goveralls.sh
+++ b/travis/goveralls.sh
@@ -51,14 +51,8 @@ else
 fi
 [ -f unit_test_goveralls.txt ] && rm unit_test_goveralls.txt
 
-# Merge all .coverprofile files. The output is a JSON file which is only
-# supported by gocov and goveralls, but not by the default Go tools.
-# NOTE: In the past, we used github.com/modocache/gover to concatenate all
-# .coverprofile files. That approach worked because the packages covered by
-# each file were disjoint. With a custom -coverpkg this approach of simple
-# concatenation no longer works, because goveralls or (?) coveralls.io itself
-# does not properly merge the information. Therefore, we're using gocov now.
-find -name .coverprofile | xargs gocov convert > gocov.json
+# Merge all .coverprofile files.
+find -name .coverprofile | xargs gocovmerge > all.coverprofile
 # -shallow ensures that goveralls does not return with a failure \
 # if Coveralls returns a 500 http error or higher (e.g. when the site is in read-only mode). \
-goveralls -shallow -gocovdata=gocov.json -service=travis-ci
+goveralls -shallow -coverprofile=all.coverprofile -service=travis-ci

--- a/travis/goveralls.sh
+++ b/travis/goveralls.sh
@@ -5,12 +5,60 @@
 
 set -e
 
-go list -f '{{if len .TestGoFiles}}godep go test $(VT_GO_PARALLEL) -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}{{end    }}' ./go/... | xargs -i sh -c {} | tee unit_test_goveralls.txt
-gover ./go/
-# -shallow ensures that goveralls does not return with a failure \
-# if Coveralls returns a 500 http error or higher (e.g. when the site is in read-only mode). \
-goveralls -shallow -coverprofile=gover.coverprofile -service=travis-ci
+# Required for packages which link the MySQL C library.
+export CGO_LDFLAGS="-L${VT_MYSQL_ROOT}/lib"
+
+if [ -n "$VT_GO_PARALLEL" ]; then
+  GO_PARALLEL="-p $VT_GO_PARALLEL"
+fi
+
+# Faster default coverage test: No instrumentation outside the package under test.
+per_package_coverage='{{if len .TestGoFiles}}godep go test $GO_PARALLEL -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}{{end}}'
+# For each Go package with test files, generate a line like this:
+#   godep go test -coverpkg "$(deplist ... <pkg>)" -coverprofile=... <pkg>
+# When run by the shell, $(deplist ... <pkg>) will generate the list of
+# dependent packages (including <pkg>) and add them to the -coverpkg option.
+# This way, these packages will get instrumented for coverage as well.
+full_coverage='{{if len .TestGoFiles}}godep go test $GO_PARALLEL -coverpkg "$(deplist -oneline -include_input_pkg -p github.com/youtube/vitess -t {{.ImportPath}})" -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}{{end}}'
+
+if [ "$1" == "--full" ]; then
+  generate_shell_commands="$full_coverage"
+else
+  generate_shell_commands="$per_package_coverage"
+fi
+
+# Remove any output from a previous incomplete run.
+[ -f unit_test_goveralls.txt ] && rm unit_test_goveralls.txt
+
+go list -f "$generate_shell_commands" ./go/... | while read line; do
+  # Allow tests to fail e.g. due to flakiness.
+  # The impact on coverage due to failed tests should be minimal.
+  set +e
+  # Filter out go test complaints that test imports are not required to be
+  # instrumented. That's wrong because it would result in less coverage.
+  time sh -c "$line" 2>&1 | grep -v "warning: no packages being tested depend on " | tee --append unit_test_goveralls.txt
+  set -e
+done
+
 echo
 echo "Top 10 of Go packages with worst coverage:"
 sort -n -k 5 unit_test_goveralls.txt | head -n10
+echo
+if [ "$1" == "--full" ]; then
+  echo "NOTE: Coverage may be low because it is counted across *all* dependent packages."
+else
+  echo "NOTE: Coverage may be low because coverage is not counted across *all* dependent packages. Use --full to run such a coverage analysis."
+fi
 [ -f unit_test_goveralls.txt ] && rm unit_test_goveralls.txt
+
+# Merge all .coverprofile files. The output is a JSON file which is only
+# supported by gocov and goveralls, but not by the default Go tools.
+# NOTE: In the past, we used github.com/modocache/gover to concatenate all
+# .coverprofile files. That approach worked because the packages covered by
+# each file were disjoint. With a custom -coverpkg this approach of simple
+# concatenation no longer works, because goveralls or (?) coveralls.io itself
+# does not properly merge the information. Therefore, we're using gocov now.
+find -name .coverprofile | xargs gocov convert > gocov.json
+# -shallow ensures that goveralls does not return with a failure \
+# if Coveralls returns a 500 http error or higher (e.g. when the site is in read-only mode). \
+goveralls -shallow -gocovdata=gocov.json -service=travis-ci


### PR DESCRIPTION
@enisoc @alainjobart 

**TL;DR: 6% higher coverage at the expense of 4 minute extra test time.**

By default, go test -cover only instruments code within the same package. Therefore, code which is only tested by integration tests (located in different/outside packages) isn't counted at all.

To solve this problem, the go test -coverpkg flag can be used to increase the scope of instrumentation. I've changed the goveralls script such that for each package under test, all dependent packages will be instrumented.

For each package, this results in a cover profile. All cover profiles have to be merged and then uploaded to coveralls.io.

There are two ways to merge the profiles:
a) use gocov which uses its own JSON format as output
b) use gocovmerge which produces a cover profile that can be used by other Go tools (e.g. the HTML visualization)

## Summary of Results
(each merge approach considered separately):

### Example runs on coveralls.io:
old per-package coverage: https://coveralls.io/builds/3459978
full coverage, gocov JSON merge: https://coveralls.io/builds/3461277
full coverage, gocovmerge: https://coveralls.io/builds/3461299

### total coverage:
```
old per-package: ~56%
JSON merge:      ~82%
gocovmerge:      ~62%
```

### relevant lines:
```
old per-package: ~47k
JSON merge:      ~71k
gocovmerge:      ~62k
```

### runtime increase:
```
old per-package: ~2m42s
new dep-package: ~6m48s
```


The downside of merge approach a) is that it drastically changes the way coverage is counted. For example, all whitespace is now counted as relevant lines and therefore the coverage increases with the ratio between whitespace/total lines ;-) Therefore, I suggest to go with approach b).

Merge approach b) also increases the number of relevant lines because: The old coverage only counted packages with *_test.go files. Now, also packages without *_test.go files are counted if they are dependency of a package with tests. Examples are: go/vt/schema/schema.go or go/vt/topo/test/vschema.go

Also note that we cannot instrument all our code (which would give us the maximum number of relevant lines) because for example the go/cmd/* packages have flags with the same name defined as global variables and that let's make the compiler stutter. In addition to that, it would be much slower because the result of the instrumentation doesn't get cached.

If we plan to go forward with this pull request, we'll need to rebalance the test shards on Travis.