### PR TITLE
go: Unbreak Go tests.

### DIFF
--- a/go/cmd/automation_client/automation_client.go
+++ b/go/cmd/automation_client/automation_client.go
@@ -66,7 +66,7 @@ func main() {
 
 	fmt.Println("Connecting to Automation Server:", *automationServer)
 
-	conn, err := grpc.Dial(*automationServer)
+	conn, err := grpc.Dial(*automationServer, grpc.WithInsecure())
 	if err != nil {
 		fmt.Println("Cannot create connection:", err)
 		os.Exit(3)

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -32,7 +32,7 @@ type client struct {
 func (client *client) Dial(endPoint *pbt.EndPoint, connTimeout time.Duration) error {
 	addr := netutil.JoinHostPort(endPoint.Host, endPoint.PortMap["grpc"])
 	var err error
-	client.cc, err = grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(connTimeout))
+	client.cc, err = grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(connTimeout))
 	if err != nil {
 		return err
 	}

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -26,7 +26,7 @@ type client struct {
 
 func factory(network, addr string, dialTimeout time.Duration) (mysqlctlclient.MysqlctlClient, error) {
 	// create the RPC client
-	cc, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+	cc, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(network, addr, timeout)
 	}))
 	if err != nil {

--- a/go/vt/tabletmanager/grpctmclient/client.go
+++ b/go/vt/tabletmanager/grpctmclient/client.go
@@ -56,9 +56,9 @@ func (client *Client) dial(ctx context.Context, tablet *topo.TabletInfo) (*grpc.
 	var err error
 	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
 	if connectTimeout == 0 {
-		cc, err = grpc.Dial(addr, grpc.WithBlock())
+		cc, err = grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock())
 	} else {
-		cc, err = grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(connectTimeout))
+		cc, err = grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(connectTimeout))
 	}
 	if err != nil {
 		return nil, nil, err

--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -48,7 +48,7 @@ type gRPCQueryClient struct {
 func DialTablet(ctx context.Context, endPoint *pbt.EndPoint, keyspace, shard string, tabletType pbt.TabletType, timeout time.Duration) (tabletconn.TabletConn, error) {
 	// create the RPC client
 	addr := netutil.JoinHostPort(endPoint.Host, endPoint.PortMap["grpc"])
-	cc, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -25,7 +25,7 @@ type gRPCVtctlClient struct {
 
 func gRPCVtctlClientFactory(addr string, dialTimeout time.Duration) (vtctlclient.VtctlClient, error) {
 	// create the RPC client
-	cc, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
+	cc, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -35,7 +35,7 @@ type vtgateConn struct {
 }
 
 func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.Impl, error) {
-	cc, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -25,7 +25,7 @@ type gRPCVtworkerClient struct {
 
 func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.VtworkerClient, error) {
 	// create the RPC client
-	cc, err := grpc.Dial(addr)
+	cc, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tests were failing with error message: "grpc: no transport security set"

This is due to a recent change in grpc-go: https://github.com/grpc/grpc-go/issues/307