### PR TITLE
Include document explaining schema management to vitess.io User Guide.

### DIFF
--- a/vitess.io/_layouts/base.liquid
+++ b/vitess.io/_layouts/base.liquid
@@ -91,17 +91,19 @@
                      </ul>
                      <div class="aside-nav-header">User Guide</div>
                      <ul>
+                        {% if page.showIntro %}
+                        <li><a href="/user-guide/introduction.html">Introduction</a>
+                        <li><a href="/user-guide/client-libraries.html">Client Libraries</a>
+                        {% endif %}
                         <li><a href="/user-guide/backup-and-restore.html">Backing Up Data</a>
+                        <li><a href="/user-guide/reparenting.html">Reparenting</a></li>
+                        <li><a href="/user-guide/schema-management.html">Schema Management</a></li>
                         <li><a href="/user-guide/sharding.html">Sharding</a>
                           <ul>
                             <li><a href="/user-guide/horizontal-sharding.html">Horizontal Sharding (Codelab)</a></li>
                             <li><a href="/user-guide/sharding-kubernetes.html">Sharding in Kubernetes (Codelab)</a></li>
                           </ul>
                         </li>
-<!--
-                        <li><a href="/user-guide/schema-management.html">Schema Management</a></li>
--->
-                        <li><a href="/user-guide/reparenting.html">Reparenting</a></li>
 <!--
                         <li><a href="/user-guide/storage.html">Storage</a></li>
                         <li><a href="/user-guide/api.html">Using the API</a></li>

--- a/vitess.io/css/responsee.css
+++ b/vitess.io/css/responsee.css
@@ -18,6 +18,21 @@ body {
   font-family:"Open Sans",Arial,sans-serif;
   color:#444;
   }
+.base,p,ul,ol {
+  font-size:16px;
+  line-height:1.6250em;
+  padding-top:0.8em;
+  padding-bottom:0
+}
+.table-of-contents li {
+  margin-bottom: 0;
+}
+.table-of-contents li ul {
+  padding-top: 0;
+}
+table tr {
+  border-bottom: inherit;
+}
 h1, h2, h3, h4, h5, h6 {
   color:#444;
   font-weight: normal;
@@ -170,6 +185,7 @@ ul.chevron .submenu > a:after, ul.chevron .sub-submenu > a:after,ul.chevron .asi
   margin-left: -20px;
 }
 @media screen and (min-width:801px) {
+  .xxlarge {font-size: 54px;}
   .aside-nav .count-number {
 	 margin-left:-1.25em;	
 	 float:right;	
@@ -203,7 +219,7 @@ a.categories-toggle:before {
 .aside-nav ul li a.categories-toggle {
   padding-left: 0;
 }
-.aside-nav ul li a { font-size: 16px; padding-left: 20px; }
+.aside-nav ul li a { font-size: 14px; padding-left: 20px; }
 .aside-nav ul li.last a { border-bottom: 0; }
 .aside-nav li li a, .aside-nav li li.active-item a, .aside-nav li li.aside-sub-submenu li a, 
 .aside-nav > ul > li > a, .aside-nav > ul > li.active-item > a:link, .aside-nav > ul > li.active-item > a:visited, .aside-nav li > ul,
@@ -224,7 +240,7 @@ a.categories-toggle:before {
 }
 .aside-nav li a {
   display:block;
-  padding:0.5em;
+  padding:0.3em;
   border-bottom:1px solid #d2d2d2; 
 }
 .aside-nav > ul > li:last-child a {border-bottom:0 none;}

--- a/vitess.io/user-guide/schema-management.md
+++ b/vitess.io/user-guide/schema-management.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: "Schema Management"
+description:
+modified:
+excerpt:
+tags: []
+image:
+  feature:
+  teaser:
+  thumb:
+toc: true
+share: false
+---
+
+{% include doc/SchemaManagement.md %}


### PR DESCRIPTION
This change adds the Schema Management doc to the User Guide on vitess.io. It also plays with the font sizes a bit on the site to try to make the font not quite so big and reduce spacing between lines.