### PR TITLE
Deflake vtgatev2_test.

### DIFF
--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -743,7 +743,10 @@ class TestFailures(unittest.TestCase):
 
   def test_tablet_restart_read(self):
     try:
-      vtgate_conn = get_connection()
+      # Since we're going to kill the tablet, there will be a race between the
+      # client timeout here and the vtgate->vttablet connection timeout, so we
+      # increase it for this test.
+      vtgate_conn = get_connection(timeout=30)
     except Exception, e:
       self.fail('Connection to vtgate failed with error %s' % (str(e)))
     self.replica_tablet.kill_vttablet()
@@ -785,7 +788,10 @@ class TestFailures(unittest.TestCase):
 
   def test_tablet_restart_stream_execute(self):
     try:
-      vtgate_conn = get_connection()
+      # Since we're going to kill the tablet, there will be a race between the
+      # client timeout here and the vtgate->vttablet connection timeout, so we
+      # increase it for this test.
+      vtgate_conn = get_connection(timeout=30)
     except Exception, e:
       self.fail('Connection to vtgate failed with error %s' % (str(e)))
     stream_cursor = vtgate_conn.cursor(
@@ -862,7 +868,10 @@ class TestFailures(unittest.TestCase):
 
   def test_tablet_fail_write(self):
     try:
-      vtgate_conn = get_connection()
+      # Since we're going to kill the tablet, there will be a race between the
+      # client timeout here and the vtgate->vttablet connection timeout, so we
+      # increase it for this test.
+      vtgate_conn = get_connection(timeout=30)
     except Exception, e:
       self.fail('Connection to shard0 master failed with error %s' % str(e))
     with self.assertRaises(dbexceptions.DatabaseError):


### PR DESCRIPTION
@michael-berlin @alainjobart

Some of the tests connect to vtgate, then kill the tablet,
and execute a vtgate call that's expected to fail. Out of those,
some of them then go on to try to continue using the vtgate conn.

The problem is that depending on how long it takes to fail, the
first vtgate call might end up hitting a client-side timeout,
which closes the vtgate conn. In the case of gRPC, there is a
set of non-configurable reconnection attempts, which means the
calls can take a while to fail (based on the server-side timeout).

This change increases the client-side timeout for those tests,
to avoid racing with the server-side timeout.