### PR TITLE
Use error codes in VtGate

### DIFF
--- a/go/vt/tabletserver/gorpctabletconn/conn.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn.go
@@ -622,7 +622,11 @@ func tabletError(err error) error {
 		default:
 			code = tabletconn.ERR_NORMAL
 		}
-		return &tabletconn.ServerError{Code: code, Err: fmt.Sprintf("vttablet: %v", err)}
+		return &tabletconn.ServerError{
+			Code:       code,
+			Err:        fmt.Sprintf("vttablet: %v", err),
+			ServerCode: vtrpc.ErrorCode_UNKNOWN_ERROR,
+		}
 	}
 
 	if err == context.Canceled {
@@ -647,5 +651,9 @@ func tabletErrorFromVitessError(ve *vterrors.VitessError) error {
 		code = tabletconn.ERR_NORMAL
 	}
 
-	return &tabletconn.ServerError{Code: code, Err: fmt.Sprintf("vttablet: %v", ve.Error())}
+	return &tabletconn.ServerError{
+		Code:       code,
+		Err:        fmt.Sprintf("vttablet: %v", ve.Error()),
+		ServerCode: ve.Code,
+	}
 }

--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -385,5 +385,10 @@ func tabletErrorFromGRPC(err error) error {
 	default:
 		code = tabletconn.ERR_NORMAL
 	}
-	return &tabletconn.ServerError{Code: code, Err: fmt.Sprintf("vttablet: %v", err)}
+
+	return &tabletconn.ServerError{
+		Code:       code,
+		Err:        fmt.Sprintf("vttablet: %v", err),
+		ServerCode: vterrors.GRPCCodeToErrorCode(grpc.Code(err)),
+	}
 }

--- a/go/vt/tabletserver/tablet_error.go
+++ b/go/vt/tabletserver/tablet_error.go
@@ -177,6 +177,11 @@ func (te *TabletError) Error() string {
 	return te.Prefix() + te.Message
 }
 
+// VtErrorCode returns the underlying Vitess error code
+func (te *TabletError) VtErrorCode() vtrpc.ErrorCode {
+	return te.ErrorCode
+}
+
 // Prefix returns the prefix for the error, like error, fatal, etc.
 func (te *TabletError) Prefix() string {
 	prefix := "error: "

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -49,13 +49,8 @@ type ServerError struct {
 
 func (e *ServerError) Error() string { return e.Err }
 
-// RecoverServerCode attempts to recover an error code from a ServerError
-func RecoverServerCode(err error) vtrpc.ErrorCode {
-	if se, ok := err.(*ServerError); ok {
-		return se.ServerCode
-	}
-	return vtrpc.ErrorCode_UNKNOWN_ERROR
-}
+// VtErrorCode returns the underlying Vitess error code
+func (e *ServerError) VtErrorCode() vtrpc.ErrorCode { return e.ServerCode }
 
 // OperationalError represents an error due to a failure to
 // communicate with vttablet.

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -15,6 +15,7 @@ import (
 
 	pb "github.com/youtube/vitess/go/vt/proto/query"
 	pbt "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -42,6 +43,8 @@ var (
 type ServerError struct {
 	Code int
 	Err  string
+	// ServerCode is the error code that we got from the server.
+	ServerCode vtrpc.ErrorCode
 }
 
 func (e *ServerError) Error() string { return e.Err }

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -49,6 +49,14 @@ type ServerError struct {
 
 func (e *ServerError) Error() string { return e.Err }
 
+// RecoverServerCode attempts to recover an error code from a ServerError
+func RecoverServerCode(err error) vtrpc.ErrorCode {
+	if se, ok := err.(*ServerError); ok {
+		return se.ServerCode
+	}
+	return vtrpc.ErrorCode_UNKNOWN_ERROR
+}
+
 // OperationalError represents an error due to a failure to
 // communicate with vttablet.
 type OperationalError string

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -8,6 +8,7 @@ package vterrors
 
 import (
 	"fmt"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -15,6 +16,15 @@ import (
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
+
+// ConcatenateErrors aggregates an array of errors into a single error by string concatenation
+func ConcatenateErrors(errors []error) error {
+	errStrs := make([]string, 0, len(errors))
+	for _, e := range errors {
+		errStrs = append(errStrs, fmt.Sprintf("%v", e))
+	}
+	return fmt.Errorf("%v", strings.Join(errStrs, "\n"))
+}
 
 // VitessError is the error type that we use internally for passing structured errors
 type VitessError struct {
@@ -57,9 +67,6 @@ func NewVitessError(code vtrpc.ErrorCode, err error, format string, args ...inte
 		err:     err,
 	}
 }
-
-// TODO(aaijazi): add FromErrorWithCode which tries to recover the error code
-// from the error that we're wrapping. we'll need an ErrorCode interface for it to work.
 
 // FromError returns a VitessError with the supplied error code by wrapping an
 // existing error.

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -95,6 +95,40 @@ func WithPrefix(prefix string, in error) error {
 // See: https://github.com/grpc/grpc-go/issues/319
 const GRPCServerErrPrefix = "gRPCServerError: "
 
+// GRPCCodeToErrorCode maps a gRPC codes.Code to a vtrpc.ErrorCode
+func GRPCCodeToErrorCode(code codes.Code) vtrpc.ErrorCode {
+	switch code {
+	case codes.OK:
+		return vtrpc.ErrorCode_SUCCESS
+	case codes.Canceled:
+		return vtrpc.ErrorCode_CANCELLED
+	case codes.Unknown:
+		return vtrpc.ErrorCode_UNKNOWN_ERROR
+	case codes.InvalidArgument:
+		return vtrpc.ErrorCode_BAD_INPUT
+	case codes.DeadlineExceeded:
+		return vtrpc.ErrorCode_DEADLINE_EXCEEDED
+	case codes.AlreadyExists:
+		return vtrpc.ErrorCode_INTEGRITY_ERROR
+	case codes.PermissionDenied:
+		return vtrpc.ErrorCode_PERMISSION_DENIED
+	case codes.ResourceExhausted:
+		return vtrpc.ErrorCode_RESOURCE_EXHAUSTED
+	case codes.FailedPrecondition:
+		return vtrpc.ErrorCode_QUERY_NOT_SERVED
+	case codes.Aborted:
+		return vtrpc.ErrorCode_NOT_IN_TX
+	case codes.Internal:
+		return vtrpc.ErrorCode_INTERNAL_ERROR
+	case codes.Unavailable:
+		return vtrpc.ErrorCode_TRANSIENT_ERROR
+	case codes.Unauthenticated:
+		return vtrpc.ErrorCode_UNAUTHENTICATED
+	default:
+		return vtrpc.ErrorCode_UNKNOWN_ERROR
+	}
+}
+
 // ErrorCodeToGRPCCode maps a vtrpc.ErrorCode to a gRPC codes.Code
 func ErrorCodeToGRPCCode(code vtrpc.ErrorCode) codes.Code {
 	switch code {

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -43,6 +43,18 @@ func (e *VitessError) AsString() string {
 	return fmt.Sprintf("Code: %v, err: %v", e.Code, e.err)
 }
 
+// NewVitessError returs a VitessError backed error with the given arguments.
+// Usually, this is not what you want to use. It's only useful if you want to
+// create a VitessError that wraps an existing error, but has a completely
+// different error string.
+func NewVitessError(code vtrpc.ErrorCode, msg string, err error) error {
+	return &VitessError{
+		Code:    code,
+		Message: msg,
+		err:     err,
+	}
+}
+
 // FromError returns a VitessError with the supplied error code and wrapped error.
 func FromError(code vtrpc.ErrorCode, err error) error {
 	return &VitessError{

--- a/go/vt/vtgate/balancer.go
+++ b/go/vt/vtgate/balancer.go
@@ -15,6 +15,8 @@ import (
 	log "github.com/golang/glog"
 
 	pb "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/proto/vtrpc"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 var resetDownConnDelay = flag.Duration("reset-down-conn-delay", 10*time.Minute, "delay to reset a marked down tabletconn")
@@ -129,7 +131,10 @@ func (blc *Balancer) refresh() error {
 		i++
 	}
 	if len(blc.addressNodes) == 0 {
-		return fmt.Errorf("no available addresses")
+		return vterrors.FromError(
+			vtrpc.ErrorCode_INTERNAL_ERROR,
+			fmt.Errorf("no available addresses"),
+		)
 	}
 	// Sort endpoints by timeRetry (from ZERO to largest)
 	sort.Sort(AddressList(blc.addressNodes))

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -519,15 +519,18 @@ func (stc *ScatterConn) Close() error {
 // ScatterConnError is the ScatterConn specific error.
 type ScatterConnError struct {
 	Code int
-	// ServerCode is the error code to use for all the server errors in aggregate
-	ServerCode vtrpc.ErrorCode
 	// Preserve the original errors, so that we don't need to parse the error string.
 	Errs []error
+	// serverCode is the error code to use for all the server errors in aggregate
+	serverCode vtrpc.ErrorCode
 }
 
 func (e *ScatterConnError) Error() string {
 	return fmt.Sprintf("%v", vterrors.ConcatenateErrors(e.Errs))
 }
+
+// VtErrorCode returns the underlying Vitess error code
+func (e *ScatterConnError) VtErrorCode() vtrpc.ErrorCode { return e.serverCode }
 
 func (stc *ScatterConn) aggregateErrors(errors []error) error {
 	if len(errors) == 0 {
@@ -551,7 +554,7 @@ func (stc *ScatterConn) aggregateErrors(errors []error) error {
 	return &ScatterConnError{
 		Code:       code,
 		Errs:       errors,
-		ServerCode: aggregateVtGateErrorCodes(errors),
+		serverCode: aggregateVtGateErrorCodes(errors),
 	}
 }
 

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -17,9 +17,11 @@ import (
 	"github.com/youtube/vitess/go/vt/concurrency"
 	kproto "github.com/youtube/vitess/go/vt/key"
 	pb "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/proto/vtrpc"
 	tproto "github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vtgate/proto"
 )
 
@@ -235,6 +237,7 @@ func (stc *ScatterConn) ExecuteBatch(
 				allErrors.RecordError(err)
 				// Don't increment the error counter for duplicate keys, as those errors
 				// are caused by client queries and are not VTGate's fault.
+				// TODO(aaijazi): get rid of this string parsing, and handle all cases of invalid input
 				if !strings.Contains(err.Error(), errDupKey) && !strings.Contains(err.Error(), errOutOfRange) {
 					stc.tabletCallErrorCount.Add(statsKey, 1)
 				}
@@ -257,6 +260,7 @@ func (stc *ScatterConn) ExecuteBatch(
 		if session.InTransaction() {
 			errstr := allErrors.Error().Error()
 			// We cannot recover from these errors
+			// TODO(aaijazi): get rid of this string parsing
 			if strings.Contains(errstr, "tx_pool_full") || strings.Contains(errstr, "not_in_tx") {
 				stc.Rollback(ctx, session)
 			}
@@ -372,10 +376,16 @@ func (stc *ScatterConn) StreamExecuteMulti(
 // Commit commits the current transaction. There are no retries on this operation.
 func (stc *ScatterConn) Commit(ctx context.Context, session *SafeSession) (err error) {
 	if session == nil {
-		return fmt.Errorf("cannot commit: empty session")
+		return vterrors.FromError(
+			vtrpc.ErrorCode_BAD_INPUT,
+			fmt.Errorf("cannot commit: empty session"),
+		)
 	}
 	if !session.InTransaction() {
-		return fmt.Errorf("cannot commit: not in transaction")
+		return vterrors.FromError(
+			vtrpc.ErrorCode_NOT_IN_TX,
+			fmt.Errorf("cannot commit: not in transaction"),
+		)
 	}
 	committing := true
 	for _, shardSession := range session.ShardSessions {
@@ -588,6 +598,7 @@ func (stc *ScatterConn) multiGo(
 				allErrors.RecordError(err)
 				// Don't increment the error counter for duplicate keys, as those errors
 				// are caused by client queries and are not VTGate's fault.
+				// TODO(aaijazi): get rid of this string parsing, and handle all cases of invalid input
 				if !strings.Contains(err.Error(), errDupKey) && !strings.Contains(err.Error(), errOutOfRange) {
 					stc.tabletCallErrorCount.Add(statsKey, 1)
 				}
@@ -603,6 +614,8 @@ func (stc *ScatterConn) multiGo(
 			if session.InTransaction() {
 				errstr := allErrors.Error().Error()
 				// We cannot recover from these errors
+				// TODO(aaijazi): get rid of this string parsing. Might want a function that searches
+				// through a deeply nested error chain a particular error.
 				if strings.Contains(errstr, "tx_pool_full") || strings.Contains(errstr, "not_in_tx") {
 					stc.Rollback(ctx, session)
 				}

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -339,7 +339,7 @@ func (sdc *ShardConn) getNewConn(ctx context.Context) (conn tabletconn.TabletCon
 			)
 			allErrors.RecordError(err)
 			// TODO(aaijazi): use a custom aggregation for this, not just concatenation.
-			return nil, nil, true, allErrors.Error()
+			return nil, nil, true, allErrors.AggrError(aggregateVtGateErrors)
 		}
 	}
 	return nil, nil, false, allErrors.Error()

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -100,6 +100,8 @@ type ShardConnError struct {
 	InTransaction   bool
 	// Preserve the original error, so that we don't need to parse the error string.
 	Err error
+	// EndpointCode is the error code to use for all the endpoint errors in aggregate
+	EndpointCode vtrpc.ErrorCode
 }
 
 func (e *ShardConnError) Error() string {

--- a/go/vt/vtgate/shardgateway.go
+++ b/go/vt/vtgate/shardgateway.go
@@ -98,6 +98,9 @@ func (sg *shardGateway) InitializeConnections(ctx context.Context) error {
 	}
 	wg.Wait()
 	if errRecorder.HasErrors() {
+		// TODO(aaijazi): how to aggregate and return these errors with an error code?
+		// Probably okay to stick with UNKNOWN for now...
+		// Maybe have an interface for things that implement ErrorCode()?
 		return errRecorder.Error()
 	}
 	return nil

--- a/go/vt/vtgate/shardgateway.go
+++ b/go/vt/vtgate/shardgateway.go
@@ -98,10 +98,7 @@ func (sg *shardGateway) InitializeConnections(ctx context.Context) error {
 	}
 	wg.Wait()
 	if errRecorder.HasErrors() {
-		// TODO(aaijazi): how to aggregate and return these errors with an error code?
-		// Probably okay to stick with UNKNOWN for now...
-		// Maybe have an interface for things that implement ErrorCode()?
-		return errRecorder.Error()
+		return errRecorder.AggrError(aggregateVtGateErrors)
 	}
 	return nil
 }

--- a/go/vt/vtgate/vtgate_error.go
+++ b/go/vt/vtgate/vtgate_error.go
@@ -75,10 +75,12 @@ func rpcErrFromVtGateError(err error) *mproto.RPCError {
 // aggregateVtGateErrorCodes aggregates a list of errors into a single error code.
 // It does so by finding the highest priority error code in the list.
 func aggregateVtGateErrorCodes(errors []error) vtrpc.ErrorCode {
-	var highCode vtrpc.ErrorCode
+	highCode := vtrpc.ErrorCode_SUCCESS
 	for _, e := range errors {
-		var code vtrpc.ErrorCode
-		// get the type of error, and recover the error code
+		code := vtrpc.ErrorCode_UNKNOWN_ERROR
+		if vtErr, ok := e.(vterrors.VtError); ok {
+			code = vtErr.VtErrorCode()
+		}
 		if errorPriorities[code] > errorPriorities[highCode] {
 			highCode = code
 		}

--- a/go/vt/vtgate/vtgate_error.go
+++ b/go/vt/vtgate/vtgate_error.go
@@ -11,6 +11,44 @@ import (
 	"github.com/youtube/vitess/go/vt/vtgate/proto"
 )
 
+// A list of all vtrpc.ErrorCodes, ordered by priority. These priorities are
+// used when aggregating multiple errors in VtGate.
+// Higher priority error codes are more urgent for users to see. They are
+// prioritized based on the following question: assuming a scatter query produced multiple
+// errors, which of the errors is the most likely to give the user useful information
+// about why the query failed and how they should proceed?
+const (
+	PrioritySuccess = iota
+	PriorityTransientError
+	PriorityQueryNotServed
+	PriorityDeadlineExceeded
+	PriorityCancelled
+	PriorityIntegrityError
+	PriorityNotInTx
+	PriorityUnknownError
+	PriorityInternalError
+	PriorityResourceExhausted
+	PriorityUnauthenticated
+	PriorityPermissionDenied
+	PriorityBadInput
+)
+
+var errorPriorities = map[vtrpc.ErrorCode]int{
+	vtrpc.ErrorCode_SUCCESS:            PrioritySuccess,
+	vtrpc.ErrorCode_CANCELLED:          PriorityCancelled,
+	vtrpc.ErrorCode_UNKNOWN_ERROR:      PriorityUnknownError,
+	vtrpc.ErrorCode_BAD_INPUT:          PriorityBadInput,
+	vtrpc.ErrorCode_DEADLINE_EXCEEDED:  PriorityDeadlineExceeded,
+	vtrpc.ErrorCode_INTEGRITY_ERROR:    PriorityIntegrityError,
+	vtrpc.ErrorCode_PERMISSION_DENIED:  PriorityPermissionDenied,
+	vtrpc.ErrorCode_RESOURCE_EXHAUSTED: PriorityResourceExhausted,
+	vtrpc.ErrorCode_QUERY_NOT_SERVED:   PriorityQueryNotServed,
+	vtrpc.ErrorCode_NOT_IN_TX:          PriorityNotInTx,
+	vtrpc.ErrorCode_INTERNAL_ERROR:     PriorityInternalError,
+	vtrpc.ErrorCode_TRANSIENT_ERROR:    PriorityTransientError,
+	vtrpc.ErrorCode_UNAUTHENTICATED:    PriorityUnauthenticated,
+}
+
 // rpcErrFromTabletError translate an error from VTGate to an *mproto.RPCError
 func rpcErrFromVtGateError(err error) *mproto.RPCError {
 	if err == nil {
@@ -32,6 +70,30 @@ func rpcErrFromVtGateError(err error) *mproto.RPCError {
 		Code:    int64(vtrpc.ErrorCode_UNKNOWN_ERROR),
 		Message: err.Error(),
 	}
+}
+
+// aggregateVtGateErrorCodes aggregates a list of errors into a single error code.
+// It does so by finding the highest priority error code in the list.
+func aggregateVtGateErrorCodes(errors []error) vtrpc.ErrorCode {
+	var highCode vtrpc.ErrorCode
+	for _, e := range errors {
+		var code vtrpc.ErrorCode
+		// get the type of error, and recover the error code
+		if errorPriorities[code] > errorPriorities[highCode] {
+			highCode = code
+		}
+	}
+	return highCode
+}
+
+func aggregateVtGateErrors(errors []error) error {
+	if len(errors) == 0 {
+		return nil
+	}
+	return vterrors.FromError(
+		aggregateVtGateErrorCodes(errors),
+		vterrors.ConcatenateErrors(errors),
+	)
 }
 
 // AddVtGateErrorToQueryResult will mutate a QueryResult struct to fill in the Err


### PR DESCRIPTION
@alainjobart @guoliang100 

Sorry for the messy PR, I wasn't quite sure where this was going at first. Probably isn't helpful to look at this commit-by-commit.

I basically do three things in this PR:

1. Classify all the errors that VtGate itself produces with an error code
2. Make sure that all the layers of VtGate are passing errors through without losing information. This means adding error codes to a lot more errors, to the point where it was getting quite unwieldy, so I added an interface.
3. I needed to be able to aggregate error codes, because there are many parts of VtGate that try multiple concurrent things, and we need to be able to return a coherent error code from that. I took an attempt at sorting error codes by priority, and my aggregation just pulls out the highest priority code from the list.

Let me know if the above doesn't make sense, we can talk in person too. Also am open to suggestions for how to do this cleaner, it feels like Go error handling and the number of VtGate layers don't play nicely together :)

This isn't totally complete, I want to do some more testing etc. before merging. Unfortunately, we don't have good VtGate client error tests right now, so I'll take a stab at adding some tomorrow.