### PR TITLE
Propagate error codes through VtGate.Execute* calls

### DIFF
--- a/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
+++ b/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
@@ -30,10 +30,7 @@ func (sq *SqlQuery) GetSessionId(sessionParams *proto.SessionParams, sessionInfo
 	defer sq.server.HandlePanic(&err)
 	tErr := sq.server.GetSessionId(sessionParams, sessionInfo)
 	tabletserver.AddTabletErrorToSessionInfo(tErr, sessionInfo)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // GetSessionId2 should not be used by anything other than tests.
@@ -43,10 +40,7 @@ func (sq *SqlQuery) GetSessionId2(sessionIdReq *proto.GetSessionIdRequest, sessi
 	defer sq.server.HandlePanic(&err)
 	tErr := sq.server.GetSessionId(&sessionIdReq.Params, sessionInfo)
 	tabletserver.AddTabletErrorToSessionInfo(tErr, sessionInfo)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Begin is exposing tabletserver.SqlQuery.Begin
@@ -54,10 +48,7 @@ func (sq *SqlQuery) Begin(ctx context.Context, session *proto.Session, txInfo *p
 	defer sq.server.HandlePanic(&err)
 	tErr := sq.server.Begin(callinfo.RPCWrapCallInfo(ctx), nil, session, txInfo)
 	tabletserver.AddTabletErrorToTransactionInfo(tErr, txInfo)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Begin2 should not be used by anything other than tests.
@@ -77,10 +68,7 @@ func (sq *SqlQuery) Begin2(ctx context.Context, beginRequest *proto.BeginRequest
 	// Convert from TxInfo => beginResponse for the output
 	beginResponse.TransactionId = txInfo.TransactionId
 	tabletserver.AddTabletErrorToBeginResponse(tErr, beginResponse)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Commit is exposing tabletserver.SqlQuery.Commit
@@ -104,10 +92,7 @@ func (sq *SqlQuery) Commit2(ctx context.Context, commitRequest *proto.CommitRequ
 	)
 	tErr := sq.server.Commit(callinfo.RPCWrapCallInfo(ctx), proto.TargetToProto3(commitRequest.Target), session)
 	tabletserver.AddTabletErrorToCommitResponse(tErr, commitResponse)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Rollback is exposing tabletserver.SqlQuery.Rollback
@@ -131,10 +116,7 @@ func (sq *SqlQuery) Rollback2(ctx context.Context, rollbackRequest *proto.Rollba
 	)
 	tErr := sq.server.Rollback(callinfo.RPCWrapCallInfo(ctx), proto.TargetToProto3(rollbackRequest.Target), session)
 	tabletserver.AddTabletErrorToRollbackResponse(tErr, rollbackResponse)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Execute is exposing tabletserver.SqlQuery.Execute
@@ -142,10 +124,7 @@ func (sq *SqlQuery) Execute(ctx context.Context, query *proto.Query, reply *mpro
 	defer sq.server.HandlePanic(&err)
 	tErr := sq.server.Execute(callinfo.RPCWrapCallInfo(ctx), nil, query, reply)
 	tabletserver.AddTabletErrorToQueryResult(tErr, reply)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // Execute2 should not be used by anything other than tests
@@ -159,10 +138,7 @@ func (sq *SqlQuery) Execute2(ctx context.Context, executeRequest *proto.ExecuteR
 	)
 	tErr := sq.server.Execute(callinfo.RPCWrapCallInfo(ctx), proto.TargetToProto3(executeRequest.Target), &executeRequest.QueryRequest, reply)
 	tabletserver.AddTabletErrorToQueryResult(tErr, reply)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // StreamExecute is exposing tabletserver.SqlQuery.StreamExecute
@@ -191,18 +167,15 @@ func (sq *SqlQuery) StreamExecute2(ctx context.Context, req *proto.StreamExecute
 	if tErr == nil {
 		return nil
 	}
-	if *tabletserver.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		qr := new(mproto.QueryResult)
-		tabletserver.AddTabletErrorToQueryResult(tErr, qr)
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(qr)
-	}
-	return tErr
+	// If there was an app error, send a QueryResult back with it.
+	qr := new(mproto.QueryResult)
+	tabletserver.AddTabletErrorToQueryResult(tErr, qr)
+	// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
+	// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
+	// problems where the client will get out of sync with the number of QueryResults sent.
+	// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
+	// (signalling that all clients are able to handle new-style errors).
+	return sendReply(qr)
 }
 
 // ExecuteBatch is exposing tabletserver.SqlQuery.ExecuteBatch
@@ -210,10 +183,7 @@ func (sq *SqlQuery) ExecuteBatch(ctx context.Context, queryList *proto.QueryList
 	defer sq.server.HandlePanic(&err)
 	tErr := sq.server.ExecuteBatch(callinfo.RPCWrapCallInfo(ctx), nil, queryList, reply)
 	tabletserver.AddTabletErrorToQueryResultList(tErr, reply)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // ExecuteBatch2 should not be used by anything other than tests
@@ -230,10 +200,7 @@ func (sq *SqlQuery) ExecuteBatch2(ctx context.Context, req *proto.ExecuteBatchRe
 	)
 	tErr := sq.server.ExecuteBatch(callinfo.RPCWrapCallInfo(ctx), proto.TargetToProto3(req.Target), &req.QueryBatch, reply)
 	tabletserver.AddTabletErrorToQueryResultList(tErr, reply)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // SplitQuery is exposing tabletserver.SqlQuery.SplitQuery
@@ -245,10 +212,7 @@ func (sq *SqlQuery) SplitQuery(ctx context.Context, req *proto.SplitQueryRequest
 	)
 	tErr := sq.server.SplitQuery(callinfo.RPCWrapCallInfo(ctx), proto.TargetToProto3(req.Target), req, reply)
 	tabletserver.AddTabletErrorToSplitQueryResult(tErr, reply)
-	if *tabletserver.RPCErrorOnlyInReply {
-		return nil
-	}
-	return tErr
+	return nil
 }
 
 // StreamHealth is exposing tabletserver.SqlQuery.StreamHealthRegister and

--- a/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
+++ b/go/vt/tabletserver/gorpcqueryservice/sqlquery.go
@@ -170,11 +170,6 @@ func (sq *SqlQuery) StreamExecute2(ctx context.Context, req *proto.StreamExecute
 	// If there was an app error, send a QueryResult back with it.
 	qr := new(mproto.QueryResult)
 	tabletserver.AddTabletErrorToQueryResult(tErr, qr)
-	// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-	// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-	// problems where the client will get out of sync with the number of QueryResults sent.
-	// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-	// (signalling that all clients are able to handle new-style errors).
 	return sendReply(qr)
 }
 

--- a/go/vt/tabletserver/gorpctabletconn/conn_test.go
+++ b/go/vt/tabletserver/gorpctabletconn/conn_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
-	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/gorpcqueryservice"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconntest"
 
@@ -19,7 +18,7 @@ import (
 )
 
 // This test makes sure the go rpc service works
-func testGoRPCTabletConn(t *testing.T, rpcOnlyInReply bool) {
+func testGoRPCTabletConn(t *testing.T) {
 	// fake service
 	service := tabletconntest.CreateFakeServer(t)
 
@@ -42,8 +41,6 @@ func testGoRPCTabletConn(t *testing.T, rpcOnlyInReply bool) {
 		Handler: handler,
 	}
 	go httpServer.Serve(listener)
-	// Handle errors appropriately
-	*tabletserver.RPCErrorOnlyInReply = rpcOnlyInReply
 
 	// run the test suite
 	tabletconntest.TestSuite(t, protocolName, &pb.EndPoint{
@@ -55,9 +52,5 @@ func testGoRPCTabletConn(t *testing.T, rpcOnlyInReply bool) {
 }
 
 func TestGoRPCTabletConn(t *testing.T) {
-	testGoRPCTabletConn(t, false)
-}
-
-func TestGoRPCTabletConnWithErrorOnlyInRPCReply(t *testing.T) {
-	testGoRPCTabletConn(t, true)
+	testGoRPCTabletConn(t)
 }

--- a/go/vt/tabletserver/sqlquery.go
+++ b/go/vt/tabletserver/sqlquery.go
@@ -59,7 +59,7 @@ var stateName = []string{
 
 var (
 	// RPCErrorOnlyInReply is the flag to control how errors will be sent over RPCs for all queryservice implementations.
-	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", false, "if true, supported RPC calls will only return errors as part of the RPC server response")
+	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", true, "if true, supported RPC calls will only return errors as part of the RPC server response")
 )
 
 // SqlQuery implements the RPC interface for the query service.

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -151,7 +151,7 @@ func WithSuffix(in error, suffix string) error {
 // because there is currently no good way, in gRPC, to differentiate between an
 // error from a server vs the client.
 // See: https://github.com/grpc/grpc-go/issues/319
-const GRPCServerErrPrefix = "gRPCServerError: "
+const GRPCServerErrPrefix = "gRPCServerError:"
 
 // GRPCCodeToErrorCode maps a gRPC codes.Code to a vtrpc.ErrorCode
 func GRPCCodeToErrorCode(code codes.Code) vtrpc.ErrorCode {

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -240,3 +240,14 @@ func ToGRPCError(err error) error {
 	}
 	return grpc.Errorf(toGRPCCode(err), "%v %v", GRPCServerErrPrefix, err)
 }
+
+// FromGRPCError return a grpc error as a VitessError, translating between error codes
+func FromGRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &VitessError{
+		Code: GRPCCodeToErrorCode(grpc.Code(err)),
+		err:  err,
+	}
+}

--- a/go/vt/vtgate/gorpcvtgateconn/conn.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn.go
@@ -6,7 +6,6 @@
 package gorpcvtgateconn
 
 import (
-	"errors"
 	"strings"
 	"time"
 
@@ -75,9 +74,6 @@ func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[
 	if err := conn.rpcConn.Call(ctx, "VTGate.Execute", request, &result); err != nil {
 		return nil, session, err
 	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
-	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
 	}
@@ -102,9 +98,6 @@ func (conn *vtgateConn) ExecuteShards(ctx context.Context, query string, keyspac
 	var result proto.QueryResult
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteShard", request, &result); err != nil {
 		return nil, session, err
-	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
 	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
@@ -131,9 +124,6 @@ func (conn *vtgateConn) ExecuteKeyspaceIds(ctx context.Context, query string, ke
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteKeyspaceIds", request, &result); err != nil {
 		return nil, session, err
 	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
-	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
 	}
@@ -158,9 +148,6 @@ func (conn *vtgateConn) ExecuteKeyRanges(ctx context.Context, query string, keys
 	var result proto.QueryResult
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteKeyRanges", request, &result); err != nil {
 		return nil, session, err
-	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
 	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
@@ -188,9 +175,6 @@ func (conn *vtgateConn) ExecuteEntityIds(ctx context.Context, query string, keys
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteEntityIds", request, &result); err != nil {
 		return nil, session, err
 	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
-	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
 	}
@@ -213,9 +197,6 @@ func (conn *vtgateConn) ExecuteBatchShards(ctx context.Context, queries []proto.
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteBatchShard", request, &result); err != nil {
 		return nil, session, err
 	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
-	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err
 	}
@@ -237,9 +218,6 @@ func (conn *vtgateConn) ExecuteBatchKeyspaceIds(ctx context.Context, queries []p
 	var result proto.QueryResultList
 	if err := conn.rpcConn.Call(ctx, "VTGate.ExecuteBatchKeyspaceIds", request, &result); err != nil {
 		return nil, session, err
-	}
-	if result.Error != "" {
-		return nil, result.Session, errors.New(result.Error)
 	}
 	if err := vterrors.FromRPCError(result.Err); err != nil {
 		return nil, result.Session, err

--- a/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
-	"github.com/youtube/vitess/go/vt/vtgate"
 	"github.com/youtube/vitess/go/vt/vtgate/gorpcvtgateservice"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconntest"
 	"golang.org/x/net/context"
 )
 
 // This test makes sure the go rpc service works
-func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
+func testGoRPCVTGateConn(t *testing.T) {
 	// fake service
 	service := vtgateconntest.CreateFakeServer(t)
 
@@ -32,7 +31,6 @@ func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 	// Create a Go Rpc server and listen on the port
 	server := rpcplus.NewServer()
 	server.Register(gorpcvtgateservice.New(service))
-	*vtgate.RPCErrorOnlyInReply = rpcOnlyInReply
 
 	// create the HTTP server, serve the server from it
 	handler := http.NewServeMux()
@@ -57,9 +55,5 @@ func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 }
 
 func TestGoRPCVTGateConn(t *testing.T) {
-	testGoRPCVTGateConn(t, false)
-}
-
-func TestGoRPCVTGateConnWithErrorOnlyInRPCReply(t *testing.T) {
-	testGoRPCVTGateConn(t, true)
+	testGoRPCVTGateConn(t)
 }

--- a/go/vt/vtgate/gorpcvtgateservice/server.go
+++ b/go/vt/vtgate/gorpcvtgateservice/server.go
@@ -45,10 +45,7 @@ func (vtg *VTGate) Execute(ctx context.Context, request *proto.Query, reply *pro
 		request.NotInTransaction,
 		reply)
 	vtgate.AddVtGateErrorToQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteShard is the RPC version of vtgateservice.VTGateService method
@@ -69,10 +66,7 @@ func (vtg *VTGate) ExecuteShard(ctx context.Context, request *proto.QueryShard, 
 		request.NotInTransaction,
 		reply)
 	vtgate.AddVtGateErrorToQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteKeyspaceIds is the RPC version of vtgateservice.VTGateService method
@@ -93,10 +87,7 @@ func (vtg *VTGate) ExecuteKeyspaceIds(ctx context.Context, request *proto.Keyspa
 		request.NotInTransaction,
 		reply)
 	vtgate.AddVtGateErrorToQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteKeyRanges is the RPC version of vtgateservice.VTGateService method
@@ -117,10 +108,7 @@ func (vtg *VTGate) ExecuteKeyRanges(ctx context.Context, request *proto.KeyRange
 		request.NotInTransaction,
 		reply)
 	vtgate.AddVtGateErrorToQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteEntityIds is the RPC version of vtgateservice.VTGateService method
@@ -142,10 +130,7 @@ func (vtg *VTGate) ExecuteEntityIds(ctx context.Context, request *proto.EntityId
 		request.NotInTransaction,
 		reply)
 	vtgate.AddVtGateErrorToQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteBatchShard is the RPC version of vtgateservice.VTGateService method
@@ -163,10 +148,7 @@ func (vtg *VTGate) ExecuteBatchShard(ctx context.Context, request *proto.BatchQu
 		request.Session,
 		reply)
 	vtgate.AddVtGateErrorToQueryResultList(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // ExecuteBatchKeyspaceIds is the RPC version of
@@ -185,10 +167,7 @@ func (vtg *VTGate) ExecuteBatchKeyspaceIds(ctx context.Context, request *proto.K
 		request.Session,
 		reply)
 	vtgate.AddVtGateErrorToQueryResultList(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // StreamExecute is the RPC version of vtgateservice.VTGateService method
@@ -222,18 +201,10 @@ func (vtg *VTGate) StreamExecute2(ctx context.Context, request *proto.Query, sen
 	if vtgErr == nil {
 		return nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		qr := new(proto.QueryResult)
-		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(qr)
-	}
-	return vtgErr
+	// If there was an app error, send a QueryResult back with it.
+	qr := new(proto.QueryResult)
+	vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+	return sendReply(qr)
 }
 
 // StreamExecuteShard is the RPC version of vtgateservice.VTGateService method
@@ -271,18 +242,10 @@ func (vtg *VTGate) StreamExecuteShard2(ctx context.Context, request *proto.Query
 	if vtgErr == nil {
 		return nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		qr := new(proto.QueryResult)
-		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(qr)
-	}
-	return vtgErr
+	// If there was an app error, send a QueryResult back with it.
+	qr := new(proto.QueryResult)
+	vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+	return sendReply(qr)
 }
 
 // StreamExecuteKeyspaceIds is the RPC version of
@@ -322,18 +285,10 @@ func (vtg *VTGate) StreamExecuteKeyspaceIds2(ctx context.Context, request *proto
 	if vtgErr == nil {
 		return nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		qr := new(proto.QueryResult)
-		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(qr)
-	}
-	return vtgErr
+	// If there was an app error, send a QueryResult back with it.
+	qr := new(proto.QueryResult)
+	vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+	return sendReply(qr)
 }
 
 // StreamExecuteKeyRanges is the RPC version of
@@ -373,18 +328,10 @@ func (vtg *VTGate) StreamExecuteKeyRanges2(ctx context.Context, request *proto.K
 	if vtgErr == nil {
 		return nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		qr := new(proto.QueryResult)
-		vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(qr)
-	}
-	return vtgErr
+	// If there was an app error, send a QueryResult back with it.
+	qr := new(proto.QueryResult)
+	vtgate.AddVtGateErrorToQueryResult(vtgErr, qr)
+	return sendReply(qr)
 }
 
 // Begin is the RPC version of vtgateservice.VTGateService method
@@ -423,10 +370,7 @@ func (vtg *VTGate) Begin2(ctx context.Context, request *proto.BeginRequest, repl
 	reply.Session = &proto.Session{}
 	vtgErr := vtg.server.Begin(ctx, reply.Session)
 	vtgate.AddVtGateErrorToBeginResponse(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // Commit2 is the RPC version of vtgateservice.VTGateService method
@@ -439,10 +383,7 @@ func (vtg *VTGate) Commit2(ctx context.Context, request *proto.CommitRequest, re
 		callerid.NewImmediateCallerID("gorpc client"))
 	vtgErr := vtg.server.Commit(ctx, request.Session)
 	vtgate.AddVtGateErrorToCommitResponse(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // Rollback2 is the RPC version of vtgateservice.VTGateService method
@@ -455,10 +396,7 @@ func (vtg *VTGate) Rollback2(ctx context.Context, request *proto.RollbackRequest
 		callerid.NewImmediateCallerID("gorpc client"))
 	vtgErr := vtg.server.Rollback(ctx, request.Session)
 	vtgate.AddVtGateErrorToRollbackResponse(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // SplitQuery is the RPC version of vtgateservice.VTGateService method
@@ -477,10 +415,7 @@ func (vtg *VTGate) SplitQuery(ctx context.Context, request *proto.SplitQueryRequ
 		request.SplitCount,
 		reply)
 	vtgate.AddVtGateErrorToSplitQueryResult(vtgErr, reply)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return nil
 }
 
 // GetSrvKeyspace is the RPC version of vtgateservice.VTGateService method

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -60,7 +60,7 @@ func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[
 	}
 	response, err := conn.c.Execute(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -84,7 +84,7 @@ func (conn *vtgateConn) ExecuteShards(ctx context.Context, query string, keyspac
 	}
 	response, err := conn.c.ExecuteShards(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -108,7 +108,7 @@ func (conn *vtgateConn) ExecuteKeyspaceIds(ctx context.Context, query string, ke
 	}
 	response, err := conn.c.ExecuteKeyspaceIds(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -132,7 +132,7 @@ func (conn *vtgateConn) ExecuteKeyRanges(ctx context.Context, query string, keys
 	}
 	response, err := conn.c.ExecuteKeyRanges(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -157,7 +157,7 @@ func (conn *vtgateConn) ExecuteEntityIds(ctx context.Context, query string, keys
 	}
 	response, err := conn.c.ExecuteEntityIds(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -179,7 +179,7 @@ func (conn *vtgateConn) ExecuteBatchShards(ctx context.Context, queries []proto.
 	}
 	response, err := conn.c.ExecuteBatchShards(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -201,7 +201,7 @@ func (conn *vtgateConn) ExecuteBatchKeyspaceIds(ctx context.Context, queries []p
 	}
 	response, err := conn.c.ExecuteBatchKeyspaceIds(ctx, request)
 	if err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromGRPCError(err)
 	}
 	if response.Error != nil {
 		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
@@ -217,9 +217,10 @@ func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVar
 	}
 	stream, err := conn.c.StreamExecute(ctx, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, vterrors.FromGRPCError(err)
 	}
 	sr := make(chan *mproto.QueryResult, 10)
+	// TODO(aaijazi): I'm pretty sure ther error handling going on down here is overkill now...
 	var finalError error
 	go func() {
 		for {
@@ -258,7 +259,7 @@ func (conn *vtgateConn) StreamExecuteShards(ctx context.Context, query string, k
 	}
 	stream, err := conn.c.StreamExecuteShards(ctx, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, vterrors.FromGRPCError(err)
 	}
 	sr := make(chan *mproto.QueryResult, 10)
 	var finalError error
@@ -299,7 +300,7 @@ func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	}
 	stream, err := conn.c.StreamExecuteKeyRanges(ctx, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, vterrors.FromGRPCError(err)
 	}
 	sr := make(chan *mproto.QueryResult, 10)
 	var finalError error
@@ -340,7 +341,7 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query stri
 	}
 	stream, err := conn.c.StreamExecuteKeyspaceIds(ctx, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, vterrors.FromGRPCError(err)
 	}
 	sr := make(chan *mproto.QueryResult, 10)
 	var finalError error
@@ -377,10 +378,7 @@ func (conn *vtgateConn) Begin(ctx context.Context) (interface{}, error) {
 	}
 	response, err := conn.c.Begin(ctx, request)
 	if err != nil {
-		return nil, err
-	}
-	if response.Error != nil {
-		return nil, vterrors.FromVtRPCError(response.Error)
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return response.Session, nil
 }
@@ -390,12 +388,9 @@ func (conn *vtgateConn) Commit(ctx context.Context, session interface{}) error {
 		CallerId: callerid.EffectiveCallerIDFromContext(ctx),
 		Session:  session.(*pb.Session),
 	}
-	response, err := conn.c.Commit(ctx, request)
+	_, err := conn.c.Commit(ctx, request)
 	if err != nil {
-		return err
-	}
-	if response.Error != nil {
-		return vterrors.FromVtRPCError(response.Error)
+		return vterrors.FromGRPCError(err)
 	}
 	return nil
 }
@@ -405,12 +400,9 @@ func (conn *vtgateConn) Rollback(ctx context.Context, session interface{}) error
 		CallerId: callerid.EffectiveCallerIDFromContext(ctx),
 		Session:  session.(*pb.Session),
 	}
-	response, err := conn.c.Rollback(ctx, request)
+	_, err := conn.c.Rollback(ctx, request)
 	if err != nil {
-		return err
-	}
-	if response.Error != nil {
-		return vterrors.FromVtRPCError(response.Error)
+		return vterrors.FromGRPCError(err)
 	}
 	return nil
 }
@@ -437,7 +429,7 @@ func (conn *vtgateConn) SplitQuery(ctx context.Context, keyspace string, query s
 	}
 	response, err := conn.c.SplitQuery(ctx, request)
 	if err != nil {
-		return nil, err
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return proto.ProtoToSplitQueryParts(response), nil
 }
@@ -448,7 +440,7 @@ func (conn *vtgateConn) GetSrvKeyspace(ctx context.Context, keyspace string) (*t
 	}
 	response, err := conn.c.GetSrvKeyspace(ctx, request)
 	if err != nil {
-		return nil, err
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return topo.ProtoToSrvKeyspace(response.SrvKeyspace), nil
 }

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -11,14 +11,13 @@ import (
 
 	"google.golang.org/grpc"
 
-	"github.com/youtube/vitess/go/vt/vtgate"
 	"github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconntest"
 	"golang.org/x/net/context"
 )
 
 // This test makes sure the go rpc service works
-func testGRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
+func testGRPCVTGateConn(t *testing.T) {
 	// fake service
 	service := vtgateconntest.CreateFakeServer(t)
 
@@ -31,7 +30,6 @@ func testGRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 	// Create a gRPC server and listen on the port
 	server := grpc.NewServer()
 	grpcvtgateservice.RegisterForTest(server, service)
-	*vtgate.RPCErrorOnlyInReply = rpcOnlyInReply
 	go server.Serve(listener)
 
 	// Create a Go RPC client connecting to the server
@@ -49,9 +47,5 @@ func testGRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 }
 
 func TestGRPCVTGateConn(t *testing.T) {
-	testGRPCVTGateConn(t, false)
-}
-
-func TestGRPCVTGateConnWithErrorOnlyInRPCReply(t *testing.T) {
-	testGRPCVTGateConn(t, true)
+	testGRPCVTGateConn(t)
 }

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 	tproto "github.com/youtube/vitess/go/vt/tabletserver/proto"
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vtgate"
 	"github.com/youtube/vitess/go/vt/vtgate/proto"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateservice"
@@ -37,17 +38,14 @@ func (vtg *VTGate) Execute(ctx context.Context, request *pb.ExecuteRequest) (res
 	reply := new(proto.QueryResult)
 	executeErr := vtg.server.Execute(ctx, string(request.Query.Sql), tproto.Proto3ToBindVariables(request.Query.BindVariables), request.TabletType, proto.ProtoToSession(request.Session), request.NotInTransaction, reply)
 	response = &pb.ExecuteResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Result = mproto.QueryResultToProto3(reply.Result)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteShards is the RPC version of vtgateservice.VTGateService method
@@ -67,17 +65,14 @@ func (vtg *VTGate) ExecuteShards(ctx context.Context, request *pb.ExecuteShardsR
 		request.NotInTransaction,
 		reply)
 	response = &pb.ExecuteShardsResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Result = mproto.QueryResultToProto3(reply.Result)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteKeyspaceIds is the RPC version of vtgateservice.VTGateService method
@@ -97,17 +92,14 @@ func (vtg *VTGate) ExecuteKeyspaceIds(ctx context.Context, request *pb.ExecuteKe
 		request.NotInTransaction,
 		reply)
 	response = &pb.ExecuteKeyspaceIdsResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Result = mproto.QueryResultToProto3(reply.Result)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteKeyRanges is the RPC version of vtgateservice.VTGateService method
@@ -127,17 +119,14 @@ func (vtg *VTGate) ExecuteKeyRanges(ctx context.Context, request *pb.ExecuteKeyR
 		request.NotInTransaction,
 		reply)
 	response = &pb.ExecuteKeyRangesResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Result = mproto.QueryResultToProto3(reply.Result)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteEntityIds is the RPC version of vtgateservice.VTGateService method
@@ -158,17 +147,14 @@ func (vtg *VTGate) ExecuteEntityIds(ctx context.Context, request *pb.ExecuteEnti
 		request.NotInTransaction,
 		reply)
 	response = &pb.ExecuteEntityIdsResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Result = mproto.QueryResultToProto3(reply.Result)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteBatchShards is the RPC version of vtgateservice.VTGateService method
@@ -185,17 +171,14 @@ func (vtg *VTGate) ExecuteBatchShards(ctx context.Context, request *pb.ExecuteBa
 		proto.ProtoToSession(request.Session),
 		reply)
 	response = &pb.ExecuteBatchShardsResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Results = tproto.QueryResultListToProto3(reply.List)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // ExecuteBatchKeyspaceIds is the RPC version of
@@ -213,17 +196,14 @@ func (vtg *VTGate) ExecuteBatchKeyspaceIds(ctx context.Context, request *pb.Exec
 		proto.ProtoToSession(request.Session),
 		reply)
 	response = &pb.ExecuteBatchKeyspaceIdsResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(executeErr, reply.Error),
+		Error: vtgate.RPCErrorToVtRPCError(reply.Err),
 	}
 	if executeErr == nil {
 		response.Results = tproto.QueryResultListToProto3(reply.List)
 		response.Session = proto.SessionToProto(reply.Session)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, executeErr
+	return nil, vterrors.ToGRPCError(executeErr)
 }
 
 // StreamExecute is the RPC version of vtgateservice.VTGateService method
@@ -232,7 +212,7 @@ func (vtg *VTGate) StreamExecute(request *pb.StreamExecuteRequest, stream pbs.Vi
 	ctx := callerid.NewContext(callinfo.GRPCCallInfo(stream.Context()),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	return vtg.server.StreamExecute(ctx,
+	vtgErr := vtg.server.StreamExecute(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.TabletType,
@@ -241,6 +221,7 @@ func (vtg *VTGate) StreamExecute(request *pb.StreamExecuteRequest, stream pbs.Vi
 				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
+	return vterrors.ToGRPCError(vtgErr)
 }
 
 // StreamExecuteShards is the RPC version of vtgateservice.VTGateService method
@@ -249,7 +230,7 @@ func (vtg *VTGate) StreamExecuteShards(request *pb.StreamExecuteShardsRequest, s
 	ctx := callerid.NewContext(callinfo.GRPCCallInfo(stream.Context()),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	return vtg.server.StreamExecuteShards(ctx,
+	vtgErr := vtg.server.StreamExecuteShards(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -260,6 +241,7 @@ func (vtg *VTGate) StreamExecuteShards(request *pb.StreamExecuteShardsRequest, s
 				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
+	return vterrors.ToGRPCError(vtgErr)
 }
 
 // StreamExecuteKeyspaceIds is the RPC version of
@@ -269,7 +251,7 @@ func (vtg *VTGate) StreamExecuteKeyspaceIds(request *pb.StreamExecuteKeyspaceIds
 	ctx := callerid.NewContext(callinfo.GRPCCallInfo(stream.Context()),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	return vtg.server.StreamExecuteKeyspaceIds(ctx,
+	vtgErr := vtg.server.StreamExecuteKeyspaceIds(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -280,6 +262,7 @@ func (vtg *VTGate) StreamExecuteKeyspaceIds(request *pb.StreamExecuteKeyspaceIds
 				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
+	return vterrors.ToGRPCError(vtgErr)
 }
 
 // StreamExecuteKeyRanges is the RPC version of
@@ -289,7 +272,7 @@ func (vtg *VTGate) StreamExecuteKeyRanges(request *pb.StreamExecuteKeyRangesRequ
 	ctx := callerid.NewContext(callinfo.GRPCCallInfo(stream.Context()),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	return vtg.server.StreamExecuteKeyRanges(ctx,
+	vtgErr := vtg.server.StreamExecuteKeyRanges(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -300,6 +283,7 @@ func (vtg *VTGate) StreamExecuteKeyRanges(request *pb.StreamExecuteKeyRangesRequ
 				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
+	return vterrors.ToGRPCError(vtgErr)
 }
 
 // Begin is the RPC version of vtgateservice.VTGateService method
@@ -309,18 +293,14 @@ func (vtg *VTGate) Begin(ctx context.Context, request *pb.BeginRequest) (respons
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
 	outSession := new(proto.Session)
-	beginErr := vtg.server.Begin(ctx, outSession)
-	response = &pb.BeginResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(beginErr, ""),
-	}
-	if beginErr == nil {
+	vtgErr := vtg.server.Begin(ctx, outSession)
+	// TODO(aaijazi): remove Error field from vtgateservice's non-Execute* methods
+	response = &pb.BeginResponse{}
+	if vtgErr == nil {
 		response.Session = proto.SessionToProto(outSession)
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, beginErr
+	return nil, vterrors.ToGRPCError(vtgErr)
 }
 
 // Commit is the RPC version of vtgateservice.VTGateService method
@@ -329,17 +309,12 @@ func (vtg *VTGate) Commit(ctx context.Context, request *pb.CommitRequest) (respo
 	ctx = callerid.NewContext(callinfo.GRPCCallInfo(ctx),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	commitErr := vtg.server.Commit(ctx, proto.ProtoToSession(request.Session))
-	response = &pb.CommitResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(commitErr, ""),
-	}
-	if commitErr == nil {
+	vtgErr := vtg.server.Commit(ctx, proto.ProtoToSession(request.Session))
+	response = &pb.CommitResponse{}
+	if vtgErr == nil {
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, commitErr
+	return nil, vterrors.ToGRPCError(vtgErr)
 }
 
 // Rollback is the RPC version of vtgateservice.VTGateService method
@@ -348,17 +323,12 @@ func (vtg *VTGate) Rollback(ctx context.Context, request *pb.RollbackRequest) (r
 	ctx = callerid.NewContext(callinfo.GRPCCallInfo(ctx),
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
-	rollbackErr := vtg.server.Rollback(ctx, proto.ProtoToSession(request.Session))
-	response = &pb.RollbackResponse{
-		Error: vtgate.VtGateErrorToVtRPCError(rollbackErr, ""),
-	}
-	if rollbackErr == nil {
+	vtgErr := vtg.server.Rollback(ctx, proto.ProtoToSession(request.Session))
+	response = &pb.RollbackResponse{}
+	if vtgErr == nil {
 		return response, nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		return response, nil
-	}
-	return nil, rollbackErr
+	return nil, vterrors.ToGRPCError(vtgErr)
 }
 
 // SplitQuery is the RPC version of vtgateservice.VTGateService method
@@ -369,14 +339,15 @@ func (vtg *VTGate) SplitQuery(ctx context.Context, request *pb.SplitQueryRequest
 		request.CallerId,
 		callerid.NewImmediateCallerID("grpc client"))
 	reply := new(proto.SplitQueryResult)
-	if err := vtg.server.SplitQuery(ctx,
+	vtgErr := vtg.server.SplitQuery(ctx,
 		request.Keyspace,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.SplitColumn,
 		int(request.SplitCount),
-		reply); err != nil {
-		return nil, err
+		reply)
+	if vtgErr != nil {
+		return nil, vterrors.ToGRPCError(vtgErr)
 	}
 	return proto.SplitQueryPartsToProto(reply.Splits), nil
 }
@@ -384,9 +355,9 @@ func (vtg *VTGate) SplitQuery(ctx context.Context, request *pb.SplitQueryRequest
 // GetSrvKeyspace is the RPC version of vtgateservice.VTGateService method
 func (vtg *VTGate) GetSrvKeyspace(ctx context.Context, request *pb.GetSrvKeyspaceRequest) (response *pb.GetSrvKeyspaceResponse, err error) {
 	defer vtg.server.HandlePanic(&err)
-	sk, err := vtg.server.GetSrvKeyspace(ctx, request.Keyspace)
-	if err != nil {
-		return nil, err
+	sk, vtgErr := vtg.server.GetSrvKeyspace(ctx, request.Keyspace)
+	if vtgErr != nil {
+		return nil, vterrors.ToGRPCError(vtgErr)
 	}
 	return &pb.GetSrvKeyspaceResponse{
 		SrvKeyspace: topo.SrvKeyspaceToProto(sk),

--- a/go/vt/vtgate/proto/vtgate_proto.go
+++ b/go/vt/vtgate/proto/vtgate_proto.go
@@ -125,8 +125,10 @@ type EntityIdsQuery struct {
 type QueryResult struct {
 	Result  *mproto.QueryResult
 	Session *Session
-	Error   string
-	Err     *mproto.RPCError
+	// Error field is deprecated, as it only returns a string. New users should use the
+	// Err field below, which contains a string and an error code.
+	Error string
+	Err   *mproto.RPCError
 }
 
 //go:generate bsongen -file $GOFILE -type QueryResult -o query_result_bson.go
@@ -181,8 +183,10 @@ type KeyspaceIdBatchQuery struct {
 type QueryResultList struct {
 	List    []mproto.QueryResult
 	Session *Session
-	Error   string
-	Err     *mproto.RPCError
+	// Error field is deprecated, as it only returns a string. New users should use the
+	// Err field below, which contains a string and an error code.
+	Error string
+	Err   *mproto.RPCError
 }
 
 // SplitQueryRequest is a request to split a query into multiple parts

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -338,7 +338,6 @@ func (sdc *ShardConn) getNewConn(ctx context.Context) (conn tabletconn.TabletCon
 				fmt.Errorf("timeout when connecting to %+v", endPoint),
 			)
 			allErrors.RecordError(err)
-			// TODO(aaijazi): use a custom aggregation for this, not just concatenation.
 			return nil, nil, true, allErrors.AggrError(aggregateVtGateErrors)
 		}
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -97,7 +97,7 @@ var RegisterVTGates []RegisterVTGate
 
 var (
 	// RPCErrorOnlyInReply informs vtgateservice(s) about how to return errors.
-	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", false, "if true, supported RPC calls from vtgateservice(s) will only return errors as part of the RPC server response")
+	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", true, "if true, supported RPC calls from vtgateservice(s) will only return errors as part of the RPC server response")
 )
 
 // Init initializes VTGate server.

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -97,7 +97,7 @@ var RegisterVTGates []RegisterVTGate
 
 var (
 	// RPCErrorOnlyInReply informs vtgateservice(s) about how to return errors.
-	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", true, "if true, supported RPC calls from vtgateservice(s) will only return errors as part of the RPC server response")
+	RPCErrorOnlyInReply = flag.Bool("rpc-error-only-in-reply", false, "if true, supported RPC calls from vtgateservice(s) will only return errors as part of the RPC server response")
 )
 
 // Init initializes VTGate server.

--- a/go/vt/vtgate/vtgate_error.go
+++ b/go/vt/vtgate/vtgate_error.go
@@ -142,6 +142,9 @@ func AddVtGateErrorToRollbackResponse(err error, reply *proto.RollbackResponse) 
 
 // RPCErrorToVtRPCError converts a VTGate error into a vtrpc error.
 func RPCErrorToVtRPCError(rpcErr *mproto.RPCError) *vtrpc.RPCError {
+	if rpcErr == nil {
+		return nil
+	}
 	return &vtrpc.RPCError{
 		Code:    vtrpc.ErrorCode(rpcErr.Code),
 		Message: rpcErr.Message,

--- a/go/vt/vtgate/vtgate_error.go
+++ b/go/vt/vtgate/vtgate_error.go
@@ -140,6 +140,14 @@ func AddVtGateErrorToRollbackResponse(err error, reply *proto.RollbackResponse) 
 	reply.Err = rpcErrFromVtGateError(err)
 }
 
+// RPCErrorToVtRPCError converts a VTGate error into a vtrpc error.
+func RPCErrorToVtRPCError(rpcErr *mproto.RPCError) *vtrpc.RPCError {
+	return &vtrpc.RPCError{
+		Code:    vtrpc.ErrorCode(rpcErr.Code),
+		Message: rpcErr.Message,
+	}
+}
+
 // VtGateErrorToVtRPCError converts a vtgate error into a vtrpc error.
 // TODO(aaijazi): rename this guy, and correct the usage of it everywhere. As it's currently used,
 // it will almost never return the correct error code, as it's only getting executeErr and reply.Error.

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -304,6 +304,7 @@ func (f *fakeVTGateService) ExecuteBatchShards(ctx context.Context, queries []pr
 		return nil
 	}
 	reply.Error = execCase.reply.Error
+	reply.Err = execCase.reply.Err
 	if reply.Error == "" && execCase.reply.Result != nil {
 		reply.List = []mproto.QueryResult{*execCase.reply.Result}
 	}
@@ -344,6 +345,7 @@ func (f *fakeVTGateService) ExecuteBatchKeyspaceIds(ctx context.Context, queries
 		return nil
 	}
 	reply.Error = execCase.reply.Error
+	reply.Err = execCase.reply.Err
 	if reply.Error == "" && execCase.reply.Result != nil {
 		reply.List = []mproto.QueryResult{*execCase.reply.Result}
 	}
@@ -2360,6 +2362,10 @@ var execMap = map[string]struct {
 			Result:  nil,
 			Session: nil,
 			Error:   "app error",
+			Err: &mproto.RPCError{
+				Code:    int64(pbv.ErrorCode_UNKNOWN_ERROR),
+				Message: "app error",
+			},
 		},
 	},
 	"txRequest": {

--- a/test/python_client_test.py
+++ b/test/python_client_test.py
@@ -30,22 +30,26 @@ def setUpModule():
   global vtgateclienttest_port
   global vtgateclienttest_grpc_port
 
-  environment.topo_server().setup()
+  try:
+    environment.topo_server().setup()
 
-  vtgateclienttest_port = environment.reserve_ports(1)
-  args = environment.binary_args('vtgateclienttest') + [
-      '-log_dir', environment.vtlogroot,
-      '-port', str(vtgateclienttest_port),
-      ]
+    vtgateclienttest_port = environment.reserve_ports(1)
+    args = environment.binary_args('vtgateclienttest') + [
+        '-log_dir', environment.vtlogroot,
+        '-port', str(vtgateclienttest_port),
+        ]
 
-  if protocols_flavor().vtgate_python_protocol() == 'grpc':
-    vtgateclienttest_grpc_port = environment.reserve_ports(1)
-    args.extend(['-grpc_port', str(vtgateclienttest_grpc_port)])
-  if protocols_flavor().service_map():
-    args.extend(['-service_map', ','.join(protocols_flavor().service_map())])
+    if protocols_flavor().vtgate_python_protocol() == 'grpc':
+      vtgateclienttest_grpc_port = environment.reserve_ports(1)
+      args.extend(['-grpc_port', str(vtgateclienttest_grpc_port)])
+    if protocols_flavor().service_map():
+      args.extend(['-service_map', ','.join(protocols_flavor().service_map())])
 
-  vtgateclienttest_process = utils.run_bg(args)
-  utils.wait_for_vars('vtgateclienttest', vtgateclienttest_port)
+    vtgateclienttest_process = utils.run_bg(args)
+    utils.wait_for_vars('vtgateclienttest', vtgateclienttest_port)
+  except:
+    tearDownModule()
+    raise
 
 
 def tearDownModule():


### PR DESCRIPTION
Fixed up grpc and gorpc vtgateconn to handle things correctly.

Next changes to come: delete proto3 fields that we shouldn't be using anymore (i'll make the internal changes to stop using those fields first), and then real e2e tests.

@alainjobart 