### PR TITLE
sqlparser: special handling for DUAL

### DIFF
--- a/data/test/sqlparser_test/parse_pass.sql
+++ b/data/test/sqlparser_test/parse_pass.sql
@@ -146,6 +146,9 @@ select /* limit a */ 1 from t limit a
 select /* limit a,b */ 1 from t limit a, b
 select /* binary unary */ a- -b from t#select /* binary unary */ a - -b from t
 select /* - - */ - -b from t
+select /* dual */ 1 from dual
+select /* Dual */ 1 from Dual#select /* Dual */ 1 from dual
+select /* DUAL */ 1 from Dual#select /* DUAL */ 1 from dual
 insert /* simple */ into a values (1)
 insert /* a.b */ into a.b values (1)
 insert /* multi-value */ into a values (1, 2)

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -977,9 +977,10 @@ func (node OnDup) Format(buf *TrackedBuffer) {
 type SQLName string
 
 func (node SQLName) Format(buf *TrackedBuffer) {
-	if _, ok := keywords[strings.ToLower(string(node))]; ok {
-		buf.Myprintf("`%s`", string(node))
+	name := string(node)
+	if _, ok := keywords[strings.ToLower(name)]; ok {
+		buf.Myprintf("`%s`", name)
 		return
 	}
-	buf.Myprintf("%s", string(node))
+	buf.Myprintf("%s", name)
 }

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -252,8 +252,13 @@ func (tkn *Tokenizer) scanIdentifier() (int, []byte) {
 		buffer.WriteByte(byte(tkn.lastChar))
 	}
 	lowered := bytes.ToLower(buffer.Bytes())
-	if keywordID, found := keywords[string(lowered)]; found {
+	loweredStr := string(lowered)
+	if keywordID, found := keywords[loweredStr]; found {
 		return keywordID, lowered
+	}
+	// dual must always be case-insensitive
+	if loweredStr == "dual" {
+		return ID, lowered
 	}
 	return ID, buffer.Bytes()
 }

--- a/go/vt/tabletserver/schema_info.go
+++ b/go/vt/tabletserver/schema_info.go
@@ -174,9 +174,7 @@ func (si *SchemaInfo) Open(appParams, dbaParams *sqldb.ConnParams, schemaOverrid
 	}
 
 	si.tables = make(map[string]*TableInfo, len(tables.Rows))
-	// TODO(sougou): Fix this in the parser.
 	si.tables["dual"] = &TableInfo{Table: schema.NewTable("dual")}
-	si.tables["DUAL"] = &TableInfo{Table: schema.NewTable("DUAL")}
 	for _, row := range tables.Rows {
 		tableName := row[0].String()
 		tableInfo, err := NewTableInfo(


### PR DESCRIPTION
@nurblieh @aaijazi 
MySQL table names are case-sensitive, but the fake
DUAL table is case-insensitive. So, I've changed the parser
to always lower case this id.
We don't want to treat this as a keyword because the AST
then tries to escape it with back-quotes. So, it's better
to just treat this as a case-insensitive ID.