### PR TITLE
tabletserver: fix race conditions in SchemaInfo

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -320,16 +320,14 @@ func (qe *QueryEngine) Commit(ctx context.Context, logStats *LogStats, transacti
 }
 
 // ClearRowcache invalidates all items in the rowcache.
-func (qe *QueryEngine) ClearRowcache() error {
+func (qe *QueryEngine) ClearRowcache(ctx context.Context) error {
 	if qe.cachePool.IsClosed() {
 		return NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "rowcache is not up")
 	}
-	ctx := context.Background()
 	conn := qe.cachePool.Get(ctx)
 	defer func() { qe.cachePool.Put(conn) }()
 
-	err := conn.FlushAll()
-	if err != nil {
+	if err := conn.FlushAll(); err != nil {
 		conn.Close()
 		conn = nil
 		return NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "%s", err)

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -91,7 +91,7 @@ func (rci *RowcacheInvalidator) Open(dbname string, mysqld mysqlctl.MysqlDaemon)
 	if mysqld.Cnf().BinLogPath == "" {
 		panic(NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "Rowcache invalidator aborting: binlog path not specified"))
 	}
-	err = rci.qe.ClearRowcache()
+	err = rci.qe.ClearRowcache(context.Background())
 	if err != nil {
 		panic(NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "Rowcahe is not reachable"))
 	}

--- a/go/vt/tabletserver/rowcache_invalidator.go
+++ b/go/vt/tabletserver/rowcache_invalidator.go
@@ -91,7 +91,7 @@ func (rci *RowcacheInvalidator) Open(dbname string, mysqld mysqlctl.MysqlDaemon)
 	if mysqld.Cnf().BinLogPath == "" {
 		panic(NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "Rowcache invalidator aborting: binlog path not specified"))
 	}
-	err = rci.qe.schemaInfo.ClearRowcache()
+	err = rci.qe.ClearRowcache()
 	if err != nil {
 		panic(NewTabletError(ErrFatal, vtrpc.ErrorCode_INTERNAL_ERROR, "Rowcahe is not reachable"))
 	}

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -30,18 +30,18 @@ func TestSchemaInfoStrictMode(t *testing.T) {
 		db.AddQuery(query, result)
 	}
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
+	t.Log(schemaInfo)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because of underlying "+
 			"connection cannot verify strict mode",
 		ErrFatal,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, true)
 }
 
 func TestSchemaInfoOpenFailedDueToMissMySQLTime(t *testing.T) {
@@ -57,15 +57,14 @@ func TestSchemaInfoOpenFailedDueToMissMySQLTime(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because of it could not get MySQL time",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, false)
 }
 
 func TestSchemaInfoOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
@@ -81,15 +80,14 @@ func TestSchemaInfoOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because of incorrect MySQL row number",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, false)
 }
 
 func TestSchemaInfoOpenFailedDueToInvalidTimeFormat(t *testing.T) {
@@ -105,15 +103,14 @@ func TestSchemaInfoOpenFailedDueToInvalidTimeFormat(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because it could not get MySQL time",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, false)
 }
 
 func TestSchemaInfoOpenFailedDueToExecErr(t *testing.T) {
@@ -129,15 +126,14 @@ func TestSchemaInfoOpenFailedDueToExecErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because conn.Exec failed",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, false)
 }
 
 func TestSchemaInfoOpenFailedDueToTableInfoErr(t *testing.T) {
@@ -159,15 +155,14 @@ func TestSchemaInfoOpenFailedDueToTableInfoErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because NewTableInfo failed",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, false)
 }
 
 func TestSchemaInfoOpenWithSchemaOverride(t *testing.T) {
@@ -179,19 +174,18 @@ func TestSchemaInfoOpenWithSchemaOverride(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
 	// test cache type RW
-	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, true)
 	testTableInfo := schemaInfo.GetTable("test_table_01")
 	if testTableInfo.Table.CacheType != schema.CACHE_RW {
 		t.Fatalf("test_table_01's cache type should be RW")
 	}
 	schemaInfo.Close()
 	// test cache type W
-	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, true)
 	testTableInfo = schemaInfo.GetTable("test_table_02")
 	if testTableInfo.Table.CacheType != schema.CACHE_W {
 		t.Fatalf("test_table_02's cache type should be W")
@@ -209,11 +203,10 @@ func TestSchemaInfoReload(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, idleTimeout, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	// test cache type RW
-	schemaInfo.Open(&appParams, &dbaParams, nil, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, nil, true)
 	defer schemaInfo.Close()
 	// this new table does not exist
 	newTable := "test_table_04"
@@ -293,15 +286,14 @@ func TestSchemaInfoCreateOrUpdateTableFailedDuetoExecErr(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	defer handleAndVerifyTabletError(
 		t,
 		"CreateOrUpdateTable should fail because it could not tables from MySQL",
 		ErrFail,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), cachePool, false)
+	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), false)
 	defer schemaInfo.Close()
 	schemaInfo.CreateOrUpdateTable(context.Background(), "test_table")
 }
@@ -323,10 +315,9 @@ func TestSchemaInfoCreateOrUpdateTable(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
-	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), cachePool, false)
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
+	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), false)
 	schemaInfo.CreateOrUpdateTable(context.Background(), "test_table_01")
 	schemaInfo.Close()
 }
@@ -348,10 +339,9 @@ func TestSchemaInfoDropTable(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
-	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), cachePool, false)
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
+	schemaInfo.Open(&appParams, &dbaParams, getSchemaInfoTestSchemaOverride(), false)
 	tableInfo := schemaInfo.GetTable(existingTable)
 	if tableInfo == nil {
 		t.Fatalf("table: %s should exist", existingTable)
@@ -373,12 +363,11 @@ func TestSchemaInfoGetPlanPanicDuetoEmptyQuery(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
 	// test cache type RW
-	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, true)
 	defer schemaInfo.Close()
 
 	ctx := context.Background()
@@ -400,12 +389,11 @@ func TestSchemaInfoQueryCacheFailDueToInvalidCacheSize(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
 	// test cache type RW
-	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, true)
 	defer schemaInfo.Close()
 	defer handleAndVerifyTabletError(
 		t,
@@ -430,12 +418,11 @@ func TestSchemaInfoQueryCache(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, true)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(true, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
 	schemaOverrides := getSchemaInfoTestSchemaOverride()
 	// test cache type RW
-	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, cachePool, true)
+	schemaInfo.Open(&appParams, &dbaParams, schemaOverrides, true)
 	defer schemaInfo.Close()
 
 	ctx := context.Background()
@@ -464,10 +451,9 @@ func TestSchemaInfoExportVars(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, true)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(true, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, true)
 	defer schemaInfo.Close()
 	expvar.Do(func(kv expvar.KeyValue) {
 		_ = kv.Value.String()
@@ -484,10 +470,9 @@ func TestUpdatedMysqlStats(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, idleTimeout, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(true, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
-	schemaInfo.Open(&appParams, &dbaParams, nil, cachePool, true)
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
+	schemaInfo.Open(&appParams, &dbaParams, nil, true)
 	defer schemaInfo.Close()
 	// Add new table
 	tableName := "mysql_stats_test_table"
@@ -554,10 +539,9 @@ func TestSchemaInfoStatsURL(t *testing.T) {
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	appParams := sqldb.ConnParams{}
 	dbaParams := sqldb.ConnParams{}
-	cachePool := newTestSchemaInfoCachePool(false, schemaInfo.queryServiceStats)
-	cachePool.Open()
-	defer cachePool.Close()
-	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, cachePool, true)
+	schemaInfo.cachePool.Open()
+	defer schemaInfo.cachePool.Close()
+	schemaInfo.Open(&appParams, &dbaParams, []SchemaOverride{}, true)
 	defer schemaInfo.Close()
 	// warm up cache
 	ctx := context.Background()

--- a/go/vt/tabletserver/schemaz.go
+++ b/go/vt/tabletserver/schemaz.go
@@ -33,10 +33,10 @@ var (
 			<td>{{range .Columns}}{{.Name}}: {{index $top.ColumnCategory .Category}}, {{if .IsAuto}}autoinc{{end}}, {{.Default}}<br>{{end}}</td>
 			<td>{{range .Indexes}}{{.Name}}: ({{range .Columns}}{{.}},{{end}}), ({{range .Cardinality}}{{.}},{{end}})<br>{{end}}</td>
 			<td>{{index $top.CacheType .CacheType}}</td>
-			<td>{{index $top.TableRows .TableRows}}</td>
-			<td>{{index $top.DataLength .DataLength}}</td>
-			<td>{{index $top.IndexLength .IndexLength}}</td>
-			<td>{{index $top.DataFree .DataFree}}</td>
+			<td>{{.TableRows.Get}}</td>
+			<td>{{.DataLength.Get}}</td>
+			<td>{{.IndexLength.Get}}</td>
+			<td>{{.DataFree.Get}}</td>
 		</tr>{{end}}
 	`))
 )

--- a/go/vt/tabletserver/table_info_test.go
+++ b/go/vt/tabletserver/table_info_test.go
@@ -282,8 +282,7 @@ func newTestTableInfo(cachePool *CachePool, tableType string, comment string) (*
 	defer conn.Recycle()
 
 	tableName := "test_table"
-	createTime := sqltypes.MakeString([]byte("1427325875"))
-	tableInfo, err := NewTableInfo(conn, tableName, tableType, createTime, comment, cachePool)
+	tableInfo, err := NewTableInfo(conn, tableName, tableType, comment, cachePool)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -147,16 +147,17 @@ func newTestSchemaInfo(
 	name := fmt.Sprintf("TestSchemaInfo-%d-", randID)
 	queryServiceStats := NewQueryServiceStats(name, enablePublishStats)
 	return NewSchemaInfo(
-		queryCacheSize,
 		name,
+		queryCacheSize,
+		reloadTime,
+		idleTimeout,
+		newTestSchemaInfoCachePool(enablePublishStats, queryServiceStats),
 		map[string]string{
 			debugQueryPlansKey: fmt.Sprintf("/debug/query_plans_%d", randID),
 			debugQueryStatsKey: fmt.Sprintf("/debug/query_stats_%d", randID),
 			debugTableStatsKey: fmt.Sprintf("/debug/table_stats_%d", randID),
 			debugSchemaKey:     fmt.Sprintf("/debug/schema_%d", randID),
 		},
-		reloadTime,
-		idleTimeout,
 		enablePublishStats,
 		queryServiceStats,
 	)


### PR DESCRIPTION
I found many race conditions in SchemaInfo due to poor documentation
and organic growth. All fixed now, with clear rules about when to use
the mutex.
There's still one complicated case where we hold a mutex while sending
a query to MySQL. A more elaborate scheme is needed to fix it. I've
added a note for it in the code.