### PR TITLE
doc: TestingOnARamDisk.md: Renamed env var for test dir to fix issue …

### DIFF
--- a/doc/TestingOnARamDisk.md
+++ b/doc/TestingOnARamDisk.md
@@ -7,13 +7,13 @@ The `integration_test` testsuite contains tests that may time-out if run against
 First, set up a normal vitess development environment by running `bootstrap.sh` and sourcing `dev.env` (see [GettingStarted](GettingStarted.md)). Then overwrite the testing temporary directories and make a 4GiB (smaller sizes may work, if you're constrained on RAM) ramdisk at the location of your choice (this example uses `/tmp/vt`):
 
 ```sh
-export TEST_TMPDIR=/tmp/vt
+export VT_TEST_TMPDIR=/tmp/vt
 
-mkdir ${TEST_TMPDIR}
-sudo mount -t tmpfs -o size=4g tmpfs ${TEST_TMPDIR}
+mkdir ${VT_TEST_TMPDIR}
+sudo mount -t tmpfs -o size=4g tmpfs ${VT_TEST_TMPDIR}
 
-export VTDATAROOT=${TEST_TMPDIR}
-export TEST_UNDECLARED_OUTPUTS_DIR=${TEST_TMPDIR}
+export VTDATAROOT=${VT_TEST_TMPDIR}
+export TEST_UNDECLARED_OUTPUTS_DIR=${VT_TEST_TMPDIR}
 ```
 
 You can now run tests (either individually or as part of `make test`) normally.
@@ -23,6 +23,6 @@ You can now run tests (either individually or as part of `make test`) normally.
 When you are done testing, you can remove the ramdisk by unmounting it and then removing the directory:
 
 ```sh
-sudo umount ${TEST_TMPDIR}
-rmdir ${TEST_TMPDIR}
+sudo umount ${VT_TEST_TMPDIR}
+rmdir ${VT_TEST_TMPDIR}
 ```


### PR DESCRIPTION
…with internal build tool.

Renamed TEST_TMPDIR to VT_TEST_TMPDIR because "TEST_TMPDIR" is a special environment variable recognized by our internal build tools.

If the variable is set, it prevents caching state of the build tool between consecutive runs. Therefore, we mustn't set it and use a different name.