### PR TITLE
travis: Fix URLs to MariaDB packages.

### DIFF
--- a/travis/download_mariadb.sh
+++ b/travis/download_mariadb.sh
@@ -5,15 +5,15 @@ set -e
 
 # As of 07/2015, this mirror is the fastest for the Travis CI workers.
 DEB_PACKAGES="
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.20+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.20+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.20+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.20+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.21+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.21+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.21+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.21+maria-1~precise_amd64.deb
 "
 
 mkdir -p $MYSQL_ROOT


### PR DESCRIPTION
Version on mirror got bumped from 10.0.20 to 10.0.21.

We didn't notice this change before because download of the packages is
skipped when the Travis CI cache is present.