### PR TITLE
travis: Do no longer cache the gRPC virtual env directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ cache:
   - $MYSQL_ROOT
   # Cache bootstrapped dependencies (e.g. protobuf and gRPC).
   - $HOME/gopath/dist/grpc/.build_finished
-  - $HOME/gopath/dist/grpc/grpc/python2.7_virtual_environment
   - $HOME/gopath/dist/grpc/lib/python2.7/site-packages
   - $HOME/gopath/dist/protobuf/.build_finished
   - $HOME/gopath/dist/protobuf/lib


### PR DESCRIPTION
After the switch to gRPC beta in
https://github.com/youtube/vitess/pull/1086, the directory no longer exists. Because
of that, creating the cache currently fails.