### PR TITLE
stop table ACL check for query without a table name.

### DIFF
--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -230,6 +230,12 @@ func (qre *QueryExecutor) checkPermissions() error {
 		qre.qe.tableaclExemptCount.Add(1)
 		return nil
 	}
+
+	// empty table name, do not need a table ACL check.
+	if qre.plan.TableName == "" {
+		return nil
+	}
+
 	if qre.plan.Authorized == nil {
 		return NewTabletError(ErrFail, vtrpc.ErrorCode_PERMISSION_DENIED, "table acl error: nil acl")
 	}


### PR DESCRIPTION
Vitess supports non table queries like "set flag=true"; therefore, table
ACL should be ignored for these queries.