### PR TITLE
Error codes for BsonP3

### DIFF
--- a/go/vt/vterrors/vterrors_test.go
+++ b/go/vt/vterrors/vterrors_test.go
@@ -1,0 +1,93 @@
+// Copyright 2012, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package vterrors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+func TestToJSONError(t *testing.T) {
+	var testcases = []struct {
+		input    error
+		expected error
+	}{
+		{
+			input:    nil,
+			expected: nil,
+		},
+		{
+			// valid VtError
+			input: &VitessError{
+				Code: vtrpc.ErrorCode_BAD_INPUT,
+				err:  fmt.Errorf("test vtgate error"),
+			},
+			expected: fmt.Errorf(`{"code":3,"message":"test vtgate error"}`),
+		},
+		{
+			// error doesn't implement VtError
+			input: fmt.Errorf("regular error"),
+			// code UNKNOWN_ERROR
+			expected: fmt.Errorf(`{"code":2,"message":"regular error"}`),
+		},
+		// TODO(aaijazi): add a test for something that causes json.Marshal to return an error.
+	}
+	for _, tc := range testcases {
+		out := ToJSONError(tc.input)
+		if !reflect.DeepEqual(out, tc.expected) {
+			t.Errorf("ToJSONError(%+v) = %+v \nwant: %+v",
+				tc.input, out, tc.expected)
+		}
+	}
+}
+
+func TestFromJSONError(t *testing.T) {
+	invalidJSON := fmt.Errorf("error: invalid json")
+
+	var testcases = []struct {
+		input    error
+		expected error
+	}{
+		{
+			input:    nil,
+			expected: nil,
+		},
+		{
+			// valid JSON
+			input: fmt.Errorf(`{"code":3,"message":"test vtgate error"}`),
+			expected: &VitessError{
+				Code: vtrpc.ErrorCode_BAD_INPUT,
+				err:  fmt.Errorf("test vtgate error"),
+			},
+		},
+		{
+			// valid JSON, but doesn't match the JSON fields we expect
+			input: fmt.Errorf(`{"ErrCode":3,"ErrorMessage":"test vtgate error"}`),
+			expected: &VitessError{
+				Code: vtrpc.ErrorCode_INTERNAL_ERROR,
+				err:  fmt.Errorf(`unexpected fields in JSONError: {"ErrCode":3,"ErrorMessage":"test vtgate error"}`),
+			},
+		},
+		{
+			// invalid JSON
+			input: invalidJSON,
+			expected: &VitessError{
+				Code:    vtrpc.ErrorCode_UNKNOWN_ERROR,
+				Message: "can't unmarshal JSON: error: invalid json",
+				err:     invalidJSON,
+			},
+		},
+	}
+	for _, tc := range testcases {
+		out := FromJSONError(tc.input)
+		if !reflect.DeepEqual(out, tc.expected) {
+			t.Errorf("FromJSONError(%+v) = %+v \nwant: %+v",
+				tc.input, out, tc.expected)
+		}
+	}
+}

--- a/go/vt/vtgate/bsonp3vtgateconn/conn.go
+++ b/go/vt/vtgate/bsonp3vtgateconn/conn.go
@@ -23,7 +23,6 @@ import (
 	qpb "github.com/youtube/vitess/go/vt/proto/query"
 	topopb "github.com/youtube/vitess/go/vt/proto/topodata"
 	pb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func init() {
@@ -53,17 +52,17 @@ func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[
 	}
 	request := &pb.ExecuteRequest{
 		CallerId:         callerid.EffectiveCallerIDFromContext(ctx),
+		Session:          s,
 		Query:            tproto.BoundQueryToProto3(query, bindVars),
 		TabletType:       tabletType,
-		Session:          s,
 		NotInTransaction: notInTransaction,
 	}
 	response := &pb.ExecuteResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.Execute", request, response); err != nil {
-		return nil, response.Session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResult(response.Result), response.Session, nil
 }
@@ -75,19 +74,19 @@ func (conn *vtgateConn) ExecuteShards(ctx context.Context, query string, keyspac
 	}
 	request := &pb.ExecuteShardsRequest{
 		CallerId:         callerid.EffectiveCallerIDFromContext(ctx),
+		Session:          s,
 		Query:            tproto.BoundQueryToProto3(query, bindVars),
 		Keyspace:         keyspace,
 		Shards:           shards,
 		TabletType:       tabletType,
-		Session:          s,
 		NotInTransaction: notInTransaction,
 	}
 	response := &pb.ExecuteShardsResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteShards", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResult(response.Result), response.Session, nil
 }
@@ -99,19 +98,19 @@ func (conn *vtgateConn) ExecuteKeyspaceIds(ctx context.Context, query string, ke
 	}
 	request := &pb.ExecuteKeyspaceIdsRequest{
 		CallerId:         callerid.EffectiveCallerIDFromContext(ctx),
+		Session:          s,
 		Query:            tproto.BoundQueryToProto3(query, bindVars),
 		Keyspace:         keyspace,
 		KeyspaceIds:      keyspaceIds,
 		TabletType:       tabletType,
-		Session:          s,
 		NotInTransaction: notInTransaction,
 	}
 	response := &pb.ExecuteKeyspaceIdsResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteKeyspaceIds", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResult(response.Result), response.Session, nil
 }
@@ -123,19 +122,19 @@ func (conn *vtgateConn) ExecuteKeyRanges(ctx context.Context, query string, keys
 	}
 	request := &pb.ExecuteKeyRangesRequest{
 		CallerId:         callerid.EffectiveCallerIDFromContext(ctx),
+		Session:          s,
 		Query:            tproto.BoundQueryToProto3(query, bindVars),
 		Keyspace:         keyspace,
 		KeyRanges:        keyRanges,
 		TabletType:       tabletType,
-		Session:          s,
 		NotInTransaction: notInTransaction,
 	}
 	response := &pb.ExecuteKeyRangesResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteKeyRanges", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResult(response.Result), response.Session, nil
 }
@@ -147,20 +146,20 @@ func (conn *vtgateConn) ExecuteEntityIds(ctx context.Context, query string, keys
 	}
 	request := &pb.ExecuteEntityIdsRequest{
 		CallerId:          callerid.EffectiveCallerIDFromContext(ctx),
+		Session:           s,
 		Query:             tproto.BoundQueryToProto3(query, bindVars),
 		Keyspace:          keyspace,
 		EntityColumnName:  entityColumnName,
 		EntityKeyspaceIds: entityKeyspaceIDs,
 		TabletType:        tabletType,
-		Session:           s,
 		NotInTransaction:  notInTransaction,
 	}
 	response := &pb.ExecuteEntityIdsResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteEntityIds", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResult(response.Result), response.Session, nil
 }
@@ -172,17 +171,17 @@ func (conn *vtgateConn) ExecuteBatchShards(ctx context.Context, queries []proto.
 	}
 	request := &pb.ExecuteBatchShardsRequest{
 		CallerId:      callerid.EffectiveCallerIDFromContext(ctx),
+		Session:       s,
 		Queries:       proto.BoundShardQueriesToProto(queries),
 		TabletType:    tabletType,
 		AsTransaction: asTransaction,
-		Session:       s,
 	}
 	response := &pb.ExecuteBatchShardsResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteBatchShards", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResults(response.Results), response.Session, nil
 }
@@ -194,17 +193,17 @@ func (conn *vtgateConn) ExecuteBatchKeyspaceIds(ctx context.Context, queries []p
 	}
 	request := &pb.ExecuteBatchKeyspaceIdsRequest{
 		CallerId:      callerid.EffectiveCallerIDFromContext(ctx),
+		Session:       s,
 		Queries:       proto.BoundKeyspaceIdQueriesToProto(queries),
 		TabletType:    tabletType,
 		AsTransaction: asTransaction,
-		Session:       s,
 	}
 	response := &pb.ExecuteBatchKeyspaceIdsResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.ExecuteBatchKeyspaceIds", request, response); err != nil {
-		return nil, session, err
+		return nil, session, vterrors.FromJSONError(err)
 	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, response.Session, err
+	if response.Error != nil {
+		return nil, response.Session, vterrors.FromVtRPCError(response.Error)
 	}
 	return mproto.Proto3ToQueryResults(response.Results), response.Session, nil
 }
@@ -220,11 +219,11 @@ func (conn *vtgateConn) StreamExecute2(ctx context.Context, query string, bindVa
 		TabletType: tabletType,
 	}
 	sr := make(chan *pb.StreamExecuteResponse, 10)
-	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecute2", req, sr)
-	srr := make(chan streamResult)
+	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecute", req, sr)
+	srr := make(chan *qpb.QueryResult)
 	go func() {
 		for v := range sr {
-			srr <- streamResult{qr: v.Result, err: v.Error}
+			srr <- v.Result
 		}
 		close(srr)
 	}()
@@ -244,11 +243,11 @@ func (conn *vtgateConn) StreamExecuteShards2(ctx context.Context, query string, 
 		TabletType: tabletType,
 	}
 	sr := make(chan *pb.StreamExecuteShardsResponse, 10)
-	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteShards2", req, sr)
-	srr := make(chan streamResult)
+	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteShards", req, sr)
+	srr := make(chan *qpb.QueryResult)
 	go func() {
 		for v := range sr {
-			srr <- streamResult{qr: v.Result, err: v.Error}
+			srr <- v.Result
 		}
 		close(srr)
 	}()
@@ -268,11 +267,11 @@ func (conn *vtgateConn) StreamExecuteKeyRanges2(ctx context.Context, query strin
 		TabletType: tabletType,
 	}
 	sr := make(chan *pb.StreamExecuteKeyRangesResponse, 10)
-	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteKeyRanges2", req, sr)
-	srr := make(chan streamResult)
+	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteKeyRanges", req, sr)
+	srr := make(chan *qpb.QueryResult)
 	go func() {
 		for v := range sr {
-			srr <- streamResult{qr: v.Result, err: v.Error}
+			srr <- v.Result
 		}
 		close(srr)
 	}()
@@ -292,48 +291,27 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query str
 		TabletType:  tabletType,
 	}
 	sr := make(chan *pb.StreamExecuteKeyspaceIdsResponse, 10)
-	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteKeyspaceIds2", req, sr)
-	srr := make(chan streamResult)
+	c := conn.rpcConn.StreamGo("VTGateP3.StreamExecuteKeyspaceIds", req, sr)
+	srr := make(chan *qpb.QueryResult)
 	go func() {
 		for v := range sr {
-			srr <- streamResult{qr: v.Result, err: v.Error}
+			srr <- v.Result
 		}
 		close(srr)
 	}()
 	return sendStreamResults(c, srr)
 }
 
-type streamResult struct {
-	qr  *qpb.QueryResult
-	err *vtpb.RPCError
-}
-
-func sendStreamResults(c *rpcplus.Call, sr chan streamResult) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
+func sendStreamResults(c *rpcplus.Call, sr chan *qpb.QueryResult) (<-chan *mproto.QueryResult, vtgateconn.ErrFunc, error) {
 	srout := make(chan *mproto.QueryResult, 1)
-	var err error
 	go func() {
 		defer close(srout)
 		for r := range sr {
-			// nil != nil
-			vtErr := vterrors.FromVtRPCError(r.err)
-			if vtErr != nil {
-				err = vtErr
-				continue
-			}
-			// If we get a QueryResult with an RPCError, that was an extra QueryResult sent by
-			// the server specifically to indicate an error, and we shouldn't surface it to clients.
-			srout <- mproto.Proto3ToQueryResult(r.qr)
+			srout <- mproto.Proto3ToQueryResult(r)
 		}
 	}()
-	// errFunc will return either an RPC-layer error or an application error, if one exists.
-	// It will only return the most recent application error (i.e, from the QueryResult that
-	// most recently contained an error). It will prioritize an RPC-layer error over an apperror,
-	// if both exist.
 	errFunc := func() error {
-		if c.Error != nil {
-			return c.Error
-		}
-		return err
+		return vterrors.FromJSONError(c.Error)
 	}
 	return srout, errFunc, nil
 }
@@ -355,11 +333,8 @@ func (conn *vtgateConn) Begin2(ctx context.Context) (interface{}, error) {
 		CallerId: callerid.EffectiveCallerIDFromContext(ctx),
 	}
 	response := &pb.BeginResponse{}
-	if err := conn.rpcConn.Call(ctx, "VTGateP3.Begin2", request, response); err != nil {
-		return nil, err
-	}
-	if err := vterrors.FromVtRPCError(response.Error); err != nil {
-		return nil, err
+	if err := conn.rpcConn.Call(ctx, "VTGateP3.Begin", request, response); err != nil {
+		return nil, vterrors.FromJSONError(err)
 	}
 	// Return a non-nil pointer
 	session := &pb.Session{}
@@ -376,12 +351,8 @@ func (conn *vtgateConn) Commit2(ctx context.Context, session interface{}) error 
 		Session:  s,
 	}
 	response := &pb.CommitResponse{}
-	if err := conn.rpcConn.Call(ctx, "VTGateP3.Commit2", request, response); err != nil {
-		return err
-	}
-	// nil != nil
-	if vtErr := vterrors.FromVtRPCError(response.Error); vtErr != nil {
-		return vtErr
+	if err := conn.rpcConn.Call(ctx, "VTGateP3.Commit", request, response); err != nil {
+		return vterrors.FromJSONError(err)
 	}
 	return nil
 }
@@ -393,11 +364,8 @@ func (conn *vtgateConn) Rollback2(ctx context.Context, session interface{}) erro
 		Session:  s,
 	}
 	response := &pb.RollbackResponse{}
-	if err := conn.rpcConn.Call(ctx, "VTGateP3.Rollback2", request, response); err != nil {
-		return err
-	}
-	if vtErr := vterrors.FromVtRPCError(response.Error); vtErr != nil {
-		return vtErr
+	if err := conn.rpcConn.Call(ctx, "VTGateP3.Rollback", request, response); err != nil {
+		return vterrors.FromJSONError(err)
 	}
 	return nil
 }
@@ -412,7 +380,7 @@ func (conn *vtgateConn) SplitQuery(ctx context.Context, keyspace string, query s
 	}
 	response := &pb.SplitQueryResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.SplitQuery", request, response); err != nil {
-		return nil, err
+		return nil, vterrors.FromJSONError(err)
 	}
 	return proto.ProtoToSplitQueryParts(response), nil
 }
@@ -423,7 +391,7 @@ func (conn *vtgateConn) GetSrvKeyspace(ctx context.Context, keyspace string) (*t
 	}
 	response := &pb.GetSrvKeyspaceResponse{}
 	if err := conn.rpcConn.Call(ctx, "VTGateP3.GetSrvKeyspace", request, response); err != nil {
-		return nil, err
+		return nil, vterrors.FromJSONError(err)
 	}
 	return response.SrvKeyspace, nil
 }

--- a/go/vt/vtgate/bsonp3vtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/bsonp3vtgateconn/conn_rpc_test.go
@@ -12,14 +12,13 @@ import (
 
 	"github.com/youtube/vitess/go/rpcplus"
 	"github.com/youtube/vitess/go/rpcwrap/bsonrpc"
-	"github.com/youtube/vitess/go/vt/vtgate"
 	"github.com/youtube/vitess/go/vt/vtgate/bsonp3vtgateservice"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconntest"
 	"golang.org/x/net/context"
 )
 
-// This test makes sure the go rpc service works
-func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
+// TestBsonP3VTGateConn makes sure the BsonP3RPC service works
+func TestBsonP3VTGateConn(t *testing.T) {
 	// fake service
 	service := vtgateconntest.CreateFakeServer(t)
 
@@ -32,7 +31,6 @@ func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 	// Create a Go Rpc server and listen on the port
 	server := rpcplus.NewServer()
 	server.Register(bsonp3vtgateservice.New(service))
-	*vtgate.RPCErrorOnlyInReply = rpcOnlyInReply
 
 	// create the HTTP server, serve the server from it
 	handler := http.NewServeMux()
@@ -48,18 +46,12 @@ func testGoRPCVTGateConn(t *testing.T, rpcOnlyInReply bool) {
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}
+	vtgateconntest.RegisterTestDialProtocol(client)
 
 	// run the test suite
-	vtgateconntest.TestSuite(t, client, service)
+	// vtgateconntest.TestSuite(t, client, service)
+	vtgateconntest.TestErrorSuite(t, service)
 
 	// and clean up
 	client.Close()
-}
-
-func TestGoRPCVTGateConn(t *testing.T) {
-	testGoRPCVTGateConn(t, false)
-}
-
-func TestGoRPCVTGateConnWithErrorOnlyInRPCReply(t *testing.T) {
-	testGoRPCVTGateConn(t, true)
 }

--- a/go/vt/vtgate/bsonp3vtgateservice/server.go
+++ b/go/vt/vtgate/bsonp3vtgateservice/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vtgate"
 	"github.com/youtube/vitess/go/vt/vtgate/proto"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateservice"
@@ -38,22 +39,15 @@ func (vtg *VTGateP3) Execute(ctx context.Context, request *pb.ExecuteRequest, re
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResult{}
-	vtgErr := vtg.server.Execute(ctx,
-		string(request.Query.Sql),
-		tproto.Proto3ToBindVariables(request.Query.BindVariables),
-		request.TabletType,
-		proto.ProtoToSession(request.Session),
-		request.NotInTransaction,
-		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Result = mproto.QueryResultToProto3(reply.Result)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResult)
+	executeErr := vtg.server.Execute(ctx, string(request.Query.Sql), tproto.Proto3ToBindVariables(request.Query.BindVariables), request.TabletType, proto.ProtoToSession(request.Session), request.NotInTransaction, reply)
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Result = mproto.QueryResultToProto3(reply.Result)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteShards is the RPC version of vtgateservice.VTGateService method
@@ -63,9 +57,9 @@ func (vtg *VTGateP3) ExecuteShards(ctx context.Context, request *pb.ExecuteShard
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResult{}
-	vtgErr := vtg.server.ExecuteShards(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResult)
+	executeErr := vtg.server.ExecuteShards(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -74,13 +68,12 @@ func (vtg *VTGateP3) ExecuteShards(ctx context.Context, request *pb.ExecuteShard
 		proto.ProtoToSession(request.Session),
 		request.NotInTransaction,
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Result = mproto.QueryResultToProto3(reply.Result)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Result = mproto.QueryResultToProto3(reply.Result)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteKeyspaceIds is the RPC version of vtgateservice.VTGateService method
@@ -90,9 +83,9 @@ func (vtg *VTGateP3) ExecuteKeyspaceIds(ctx context.Context, request *pb.Execute
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResult{}
-	vtgErr := vtg.server.ExecuteKeyspaceIds(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResult)
+	executeErr := vtg.server.ExecuteKeyspaceIds(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -101,13 +94,12 @@ func (vtg *VTGateP3) ExecuteKeyspaceIds(ctx context.Context, request *pb.Execute
 		proto.ProtoToSession(request.Session),
 		request.NotInTransaction,
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Result = mproto.QueryResultToProto3(reply.Result)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Result = mproto.QueryResultToProto3(reply.Result)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteKeyRanges is the RPC version of vtgateservice.VTGateService method
@@ -117,9 +109,9 @@ func (vtg *VTGateP3) ExecuteKeyRanges(ctx context.Context, request *pb.ExecuteKe
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResult{}
-	vtgErr := vtg.server.ExecuteKeyRanges(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResult)
+	executeErr := vtg.server.ExecuteKeyRanges(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -128,13 +120,12 @@ func (vtg *VTGateP3) ExecuteKeyRanges(ctx context.Context, request *pb.ExecuteKe
 		proto.ProtoToSession(request.Session),
 		request.NotInTransaction,
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Result = mproto.QueryResultToProto3(reply.Result)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Result = mproto.QueryResultToProto3(reply.Result)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteEntityIds is the RPC version of vtgateservice.VTGateService method
@@ -144,9 +135,9 @@ func (vtg *VTGateP3) ExecuteEntityIds(ctx context.Context, request *pb.ExecuteEn
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResult{}
-	vtgErr := vtg.server.ExecuteEntityIds(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResult)
+	executeErr := vtg.server.ExecuteEntityIds(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
@@ -156,13 +147,12 @@ func (vtg *VTGateP3) ExecuteEntityIds(ctx context.Context, request *pb.ExecuteEn
 		proto.ProtoToSession(request.Session),
 		request.NotInTransaction,
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Result = mproto.QueryResultToProto3(reply.Result)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Result = mproto.QueryResultToProto3(reply.Result)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteBatchShards is the RPC version of vtgateservice.VTGateService method
@@ -172,21 +162,20 @@ func (vtg *VTGateP3) ExecuteBatchShards(ctx context.Context, request *pb.Execute
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResultList{}
-	vtgErr := vtg.server.ExecuteBatchShards(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResultList)
+	executeErr := vtg.server.ExecuteBatchShards(ctx,
 		proto.ProtoToBoundShardQueries(request.Queries),
 		request.TabletType,
 		request.AsTransaction,
 		proto.ProtoToSession(request.Session),
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Results = tproto.QueryResultListToProto3(reply.List)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Results = tproto.QueryResultListToProto3(reply.List)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
 // ExecuteBatchKeyspaceIds is the RPC version of
@@ -197,212 +186,141 @@ func (vtg *VTGateP3) ExecuteBatchKeyspaceIds(ctx context.Context, request *pb.Ex
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	reply := &proto.QueryResultList{}
-	vtgErr := vtg.server.ExecuteBatchKeyspaceIds(ctx,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	reply := new(proto.QueryResultList)
+	executeErr := vtg.server.ExecuteBatchKeyspaceIds(ctx,
 		proto.ProtoToBoundKeyspaceIdQueries(request.Queries),
 		request.TabletType,
 		request.AsTransaction,
 		proto.ProtoToSession(request.Session),
 		reply)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, reply.Error)
-	response.Results = tproto.QueryResultListToProto3(reply.List)
-	response.Session = proto.SessionToProto(reply.Session)
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
+	if executeErr == nil {
+		response.Error = vtgate.RPCErrorToVtRPCError(reply.Err)
+		response.Results = tproto.QueryResultListToProto3(reply.List)
+		response.Session = proto.SessionToProto(reply.Session)
 	}
-	return vtgErr
+	return vterrors.ToJSONError(executeErr)
 }
 
-// StreamExecute2 is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGateP3) StreamExecute2(ctx context.Context, request *pb.StreamExecuteRequest, sendReply func(interface{}) error) (err error) {
+// StreamExecute is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGateP3) StreamExecute(ctx context.Context, request *pb.StreamExecuteRequest, sendReply func(interface{}) error) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.StreamExecute(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.TabletType,
 		func(reply *proto.QueryResult) error {
 			return sendReply(&pb.StreamExecuteResponse{
-				Error:  vtgate.VtGateErrorToVtRPCError(nil, reply.Error),
 				Result: mproto.QueryResultToProto3(reply.Result),
 			})
 		})
-	if vtgErr == nil {
-		return nil
-	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(&pb.StreamExecuteResponse{
-			Error: vtgate.VtGateErrorToVtRPCError(vtgErr, ""),
-		})
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
-// StreamExecuteShards2 is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGateP3) StreamExecuteShards2(ctx context.Context, request *pb.StreamExecuteShardsRequest, sendReply func(interface{}) error) (err error) {
+// StreamExecuteShards is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGateP3) StreamExecuteShards(ctx context.Context, request *pb.StreamExecuteShardsRequest, sendReply func(interface{}) error) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.StreamExecuteShards(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
 		request.Shards,
 		request.TabletType,
-		func(reply *proto.QueryResult) error {
+		func(value *proto.QueryResult) error {
 			return sendReply(&pb.StreamExecuteShardsResponse{
-				Error:  vtgate.VtGateErrorToVtRPCError(nil, reply.Error),
-				Result: mproto.QueryResultToProto3(reply.Result),
+				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
-	if vtgErr == nil {
-		return nil
-	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(&pb.StreamExecuteShardsResponse{
-			Error: vtgate.VtGateErrorToVtRPCError(vtgErr, ""),
-		})
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
-// StreamExecuteKeyspaceIds2 is the RPC version of
+// StreamExecuteKeyspaceIds is the RPC version of
 // vtgateservice.VTGateService method
-func (vtg *VTGateP3) StreamExecuteKeyspaceIds2(ctx context.Context, request *pb.StreamExecuteKeyspaceIdsRequest, sendReply func(interface{}) error) (err error) {
+func (vtg *VTGateP3) StreamExecuteKeyspaceIds(ctx context.Context, request *pb.StreamExecuteKeyspaceIdsRequest, sendReply func(interface{}) error) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.StreamExecuteKeyspaceIds(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
 		request.KeyspaceIds,
 		request.TabletType,
-		func(reply *proto.QueryResult) error {
+		func(value *proto.QueryResult) error {
 			return sendReply(&pb.StreamExecuteKeyspaceIdsResponse{
-				Error:  vtgate.VtGateErrorToVtRPCError(nil, reply.Error),
-				Result: mproto.QueryResultToProto3(reply.Result),
+				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
-	if vtgErr == nil {
-		return nil
-	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(&pb.StreamExecuteKeyspaceIdsResponse{
-			Error: vtgate.VtGateErrorToVtRPCError(vtgErr, ""),
-		})
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
-// StreamExecuteKeyRanges2 is the RPC version of
+// StreamExecuteKeyRanges is the RPC version of
 // vtgateservice.VTGateService method
-func (vtg *VTGateP3) StreamExecuteKeyRanges2(ctx context.Context, request *pb.StreamExecuteKeyRangesRequest, sendReply func(interface{}) error) (err error) {
+func (vtg *VTGateP3) StreamExecuteKeyRanges(ctx context.Context, request *pb.StreamExecuteKeyRangesRequest, sendReply func(interface{}) error) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.StreamExecuteKeyRanges(ctx,
 		string(request.Query.Sql),
 		tproto.Proto3ToBindVariables(request.Query.BindVariables),
 		request.Keyspace,
 		request.KeyRanges,
 		request.TabletType,
-		func(reply *proto.QueryResult) error {
+		func(value *proto.QueryResult) error {
 			return sendReply(&pb.StreamExecuteKeyRangesResponse{
-				Error:  vtgate.VtGateErrorToVtRPCError(nil, reply.Error),
-				Result: mproto.QueryResultToProto3(reply.Result),
+				Result: mproto.QueryResultToProto3(value.Result),
 			})
 		})
+	return vterrors.ToJSONError(vtgErr)
+}
+
+// Begin is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGateP3) Begin(ctx context.Context, request *pb.BeginRequest, response *pb.BeginResponse) (err error) {
+	defer vtg.server.HandlePanic(&err)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
+	defer cancel()
+	ctx = callerid.NewContext(ctx,
+		request.CallerId,
+		callerid.NewImmediateCallerID("bsonp3 client"))
+	outSession := new(proto.Session)
+	vtgErr := vtg.server.Begin(ctx, outSession)
 	if vtgErr == nil {
+		response.Session = proto.SessionToProto(outSession)
 		return nil
 	}
-	if *vtgate.RPCErrorOnlyInReply {
-		// If there was an app error, send a QueryResult back with it.
-		// Sending back errors this way is not backwards compatible. If a (new) server sends an additional
-		// QueryResult with an error, and the (old) client doesn't know how to read it, it will cause
-		// problems where the client will get out of sync with the number of QueryResults sent.
-		// That's why this the error is only sent this way when the --rpc_errors_only_in_reply flag is set
-		// (signalling that all clients are able to handle new-style errors).
-		return sendReply(&pb.StreamExecuteKeyRangesResponse{
-			Error: vtgate.VtGateErrorToVtRPCError(vtgErr, ""),
-		})
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
-// Begin2 is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGateP3) Begin2(ctx context.Context, request *pb.BeginRequest, response *pb.BeginResponse) (err error) {
+// Commit is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGateP3) Commit(ctx context.Context, request *pb.CommitRequest, response *pb.CommitResponse) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
-	// Don't pass in a nil pointer
-	session := &proto.Session{}
-	vtgErr := vtg.server.Begin(ctx, session)
-	response.Session = proto.SessionToProto(session)
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, "")
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
-}
-
-// Commit2 is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGateP3) Commit2(ctx context.Context, request *pb.CommitRequest, response *pb.CommitResponse) (err error) {
-	defer vtg.server.HandlePanic(&err)
-	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
-	defer cancel()
-	ctx = callerid.NewContext(ctx,
-		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.Commit(ctx, proto.ProtoToSession(request.Session))
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, "")
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
-// Rollback2 is the RPC version of vtgateservice.VTGateService method
-func (vtg *VTGateP3) Rollback2(ctx context.Context, request *pb.RollbackRequest, response *pb.RollbackResponse) (err error) {
+// Rollback is the RPC version of vtgateservice.VTGateService method
+func (vtg *VTGateP3) Rollback(ctx context.Context, request *pb.RollbackRequest, response *pb.RollbackResponse) (err error) {
 	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	vtgErr := vtg.server.Rollback(ctx, proto.ProtoToSession(request.Session))
-	response.Error = vtgate.VtGateErrorToVtRPCError(vtgErr, "")
-	if *vtgate.RPCErrorOnlyInReply {
-		return nil
-	}
-	return vtgErr
+	return vterrors.ToJSONError(vtgErr)
 }
 
 // SplitQuery is the RPC version of vtgateservice.VTGateService method
@@ -412,7 +330,7 @@ func (vtg *VTGateP3) SplitQuery(ctx context.Context, request *pb.SplitQueryReque
 	defer cancel()
 	ctx = callerid.NewContext(ctx,
 		request.CallerId,
-		callerid.NewImmediateCallerID("gorpc client"))
+		callerid.NewImmediateCallerID("bsonp3 client"))
 	reply := &proto.SplitQueryResult{}
 	vtgErr := vtg.server.SplitQuery(ctx,
 		request.Keyspace,
@@ -422,7 +340,7 @@ func (vtg *VTGateP3) SplitQuery(ctx context.Context, request *pb.SplitQueryReque
 		int(request.SplitCount),
 		reply)
 	if vtgErr != nil {
-		return vtgErr
+		return vterrors.ToJSONError(vtgErr)
 	}
 	*response = *proto.SplitQueryPartsToProto(reply.Splits)
 	return nil
@@ -433,11 +351,11 @@ func (vtg *VTGateP3) GetSrvKeyspace(ctx context.Context, request *pb.GetSrvKeysp
 	defer vtg.server.HandlePanic(&err)
 	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(*rpcTimeout))
 	defer cancel()
-	ks, err := vtg.server.GetSrvKeyspace(ctx, request.Keyspace)
-	if err != nil {
-		return err
+	sk, vtgErr := vtg.server.GetSrvKeyspace(ctx, request.Keyspace)
+	if vtgErr != nil {
+		return vterrors.ToJSONError(vtgErr)
 	}
-	response.SrvKeyspace = ks
+	response.SrvKeyspace = sk
 	return nil
 }
 

--- a/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/gorpcvtgateconn/conn_rpc_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// This test makes sure the go rpc service works
+// TestGoRPCVTGateConn makes sure the gorpc (BsonRPC) service works
 func TestGoRPCVTGateConn(t *testing.T) {
 	// fake service
 	service := vtgateconntest.CreateFakeServer(t)

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -16,8 +16,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// This test makes sure the go rpc service works
-func testGRPCVTGateConn(t *testing.T) {
+// TestGRPCVTGateConn makes sure the grpc service works
+func TestGRPCVTGateConn(t *testing.T) {
 	// fake service
 	service := vtgateconntest.CreateFakeServer(t)
 
@@ -46,8 +46,4 @@ func testGRPCVTGateConn(t *testing.T) {
 
 	// and clean up
 	client.Close()
-}
-
-func TestGRPCVTGateConn(t *testing.T) {
-	testGRPCVTGateConn(t)
 }

--- a/php/src/VTGateConn.php
+++ b/php/src/VTGateConn.php
@@ -22,7 +22,7 @@ class VTGateTx {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, $method, $req)->reply;
 		if (array_key_exists('Session', $resp) && $resp['Session']) {
 			$this->session = $resp['Session'];
@@ -30,7 +30,7 @@ class VTGateTx {
 			$this->session = NULL;
 		}
 		VTProto::checkError($resp);
-		
+
 		return VTQueryResult::fromBsonP3($resp['Result']);
 	}
 
@@ -45,7 +45,7 @@ class VTGateTx {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, $method, $req)->reply;
 		if (array_key_exists('Session', $resp) && $resp['Session']) {
 			$this->session = $resp['Session'];
@@ -53,7 +53,7 @@ class VTGateTx {
 			$this->session = NULL;
 		}
 		VTProto::checkError($resp);
-		
+
 		$results = array();
 		foreach ($resp['Results'] as $result) {
 			$results[] = VTQueryResult::fromBsonP3($result);
@@ -68,21 +68,21 @@ class VTGateTx {
 	public function executeShards(VTContext $ctx, $query, $keyspace, array $shards, array $bind_vars, $tablet_type = VTTabletType::MASTER, $not_in_transaction = FALSE) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, $not_in_transaction, 'VTGateP3.ExecuteShards', array(
 				'Keyspace' => $keyspace,
-				'Shards' => $shards 
+				'Shards' => $shards
 		));
 	}
 
 	public function executeKeyspaceIds(VTContext $ctx, $query, $keyspace, array $keyspace_ids, array $bind_vars, $tablet_type = VTTabletType::MASTER, $not_in_transaction = FALSE) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, $not_in_transaction, 'VTGateP3.ExecuteKeyspaceIds', array(
 				'Keyspace' => $keyspace,
-				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids) 
+				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids)
 		));
 	}
 
 	public function executeKeyRanges(VTContext $ctx, $query, $keyspace, array $key_ranges, array $bind_vars, $tablet_type = VTTabletType::MASTER, $not_in_transaction = FALSE) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, $not_in_transaction, 'VTGateP3.ExecuteKeyRanges', array(
 				'Keyspace' => $keyspace,
-				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges) 
+				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges)
 		));
 	}
 
@@ -90,7 +90,7 @@ class VTGateTx {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, $not_in_transaction, 'VTGateP3.ExecuteEntityIds', array(
 				'Keyspace' => $keyspace,
 				'EntityColumnName' => $entity_column_name,
-				'EntityKeyspaceIds' => VTEntityId::buildBsonP3Array($entity_keyspace_ids) 
+				'EntityKeyspaceIds' => VTEntityId::buildBsonP3Array($entity_keyspace_ids)
 		));
 	}
 
@@ -107,13 +107,13 @@ class VTGateTx {
 			throw new Exception('commit called while not in transaction.');
 		}
 		$req = array(
-				'Session' => $this->session 
+				'Session' => $this->session
 		);
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
-		$resp = $this->client->call($ctx, 'VTGateP3.Commit2', $req)->reply;
+
+		$resp = $this->client->call($ctx, 'VTGateP3.Commit', $req)->reply;
 		$this->session = NULL;
 	}
 
@@ -122,13 +122,13 @@ class VTGateTx {
 			throw new Exception('rollback called while not in transaction.');
 		}
 		$req = array(
-				'Session' => $this->session 
+				'Session' => $this->session
 		);
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
-		$resp = $this->client->call($ctx, 'VTGateP3.Rollback2', $req)->reply;
+
+		$resp = $this->client->call($ctx, 'VTGateP3.Rollback', $req)->reply;
 		$this->session = NULL;
 	}
 }
@@ -146,10 +146,10 @@ class VTGateConn {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, $method, $req)->reply;
 		VTProto::checkError($resp);
-		
+
 		return VTQueryResult::fromBsonP3($resp['Result']);
 	}
 
@@ -160,10 +160,10 @@ class VTGateConn {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, $method, $req)->reply;
 		VTProto::checkError($resp);
-		
+
 		$results = array();
 		if (array_key_exists('Results', $resp)) {
 			foreach ($resp['Results'] as $result) {
@@ -179,9 +179,9 @@ class VTGateConn {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$this->client->streamCall($ctx, $method, $req);
-		
+
 		return new VTStreamResults($ctx, $this->client);
 	}
 
@@ -192,21 +192,21 @@ class VTGateConn {
 	public function executeShards(VTContext $ctx, $query, $keyspace, array $shards, array $bind_vars, $tablet_type) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.ExecuteShards', array(
 				'Keyspace' => $keyspace,
-				'Shards' => $shards 
+				'Shards' => $shards
 		));
 	}
 
 	public function executeKeyspaceIds(VTContext $ctx, $query, $keyspace, array $keyspace_ids, array $bind_vars, $tablet_type) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.ExecuteKeyspaceIds', array(
 				'Keyspace' => $keyspace,
-				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids) 
+				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids)
 		));
 	}
 
 	public function executeKeyRanges(VTContext $ctx, $query, $keyspace, array $key_ranges, array $bind_vars, $tablet_type) {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.ExecuteKeyRanges', array(
 				'Keyspace' => $keyspace,
-				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges) 
+				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges)
 		));
 	}
 
@@ -214,7 +214,7 @@ class VTGateConn {
 		return $this->callExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.ExecuteEntityIds', array(
 				'Keyspace' => $keyspace,
 				'EntityColumnName' => $entity_column_name,
-				'EntityKeyspaceIds' => VTEntityId::buildBsonP3Array($entity_keyspace_ids) 
+				'EntityKeyspaceIds' => VTEntityId::buildBsonP3Array($entity_keyspace_ids)
 		));
 	}
 
@@ -227,27 +227,27 @@ class VTGateConn {
 	}
 
 	public function streamExecute(VTContext $ctx, $query, array $bind_vars, $tablet_type) {
-		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecute2');
+		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecute');
 	}
 
 	public function streamExecuteShards(VTContext $ctx, $query, $keyspace, array $shards, array $bind_vars, $tablet_type) {
-		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteShards2', array(
+		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteShards', array(
 				'Keyspace' => $keyspace,
-				'Shards' => $shards 
+				'Shards' => $shards
 		));
 	}
 
 	public function streamExecuteKeyspaceIds(VTContext $ctx, $query, $keyspace, array $keyspace_ids, array $bind_vars, $tablet_type) {
-		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteKeyspaceIds2', array(
+		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteKeyspaceIds', array(
 				'Keyspace' => $keyspace,
-				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids) 
+				'KeyspaceIds' => VTKeyspaceId::buildBsonP3Array($keyspace_ids)
 		));
 	}
 
 	public function streamExecuteKeyRanges(VTContext $ctx, $query, $keyspace, array $key_ranges, array $bind_vars, $tablet_type) {
-		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteKeyRanges2', array(
+		return $this->callStreamExecute($ctx, $query, $bind_vars, $tablet_type, 'VTGateP3.StreamExecuteKeyRanges', array(
 				'Keyspace' => $keyspace,
-				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges) 
+				'KeyRanges' => VTKeyRange::buildBsonP3Array($key_ranges)
 		));
 	}
 
@@ -256,9 +256,9 @@ class VTGateConn {
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
-		$resp = $this->client->call($ctx, 'VTGateP3.Begin2', $req)->reply;
-		
+
+		$resp = $this->client->call($ctx, 'VTGateP3.Begin', $req)->reply;
+
 		return new VTGateTx($this->client, $resp['Session']);
 	}
 
@@ -267,14 +267,14 @@ class VTGateConn {
 				'Keyspace' => $keyspace,
 				'Query' => VTBoundQuery::buildBsonP3($query, $bind_vars),
 				'SplitColumn' => $split_column,
-				'SplitCount' => $split_count 
+				'SplitCount' => $split_count
 		);
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, 'VTGateP3.SplitQuery', $req)->reply;
-		
+
 		$results = array();
 		if (array_key_exists('Splits', $resp)) {
 			foreach ($resp['Splits'] as $split) {
@@ -286,12 +286,12 @@ class VTGateConn {
 
 	public function getSrvKeyspace(VTContext $ctx, $keyspace) {
 		$req = array(
-				'Keyspace' => $keyspace 
+				'Keyspace' => $keyspace
 		);
 		if ($ctx->getCallerId()) {
 			$req['CallerId'] = $ctx->getCallerId()->toBsonP3();
 		}
-		
+
 		$resp = $this->client->call($ctx, 'VTGateP3.GetSrvKeyspace', $req)->reply;
 		return VTSrvKeyspace::fromBsonP3($resp['SrvKeyspace']);
 	}


### PR DESCRIPTION
@alainjobart 

Large clean-up of BsonP3, it now matches grpc almost exactly. As discussed, went the route of doing error codes serialized in the error string, so that we can keep our proto3 clean and take out the error  where it's not needed.

I'm doing a simple JSON serialization for the error string.