### PR TITLE
Fix potential vtgatev2 stream cursor bug.

### DIFF
--- a/py/vtdb/base_cursor.py
+++ b/py/vtdb/base_cursor.py
@@ -68,7 +68,8 @@ class BasePEP0249Cursor(object):
   def _clear_common_state(self):
     self.index = 0
 
-  def _get_conn(self):
+  @property
+  def connection(self):
     if not self._conn:
       raise dbexceptions.ProgrammingError(
           'Cannot use closed cursor %s.' % self.__class__)
@@ -100,13 +101,13 @@ class BaseListCursor(BasePEP0249Cursor):
     self.effective_caller_id = effective_caller_id
 
   def begin(self):
-    return self._get_conn().begin(self.effective_caller_id)
+    return self.connection.begin(self.effective_caller_id)
 
   def commit(self):
-    return self._get_conn().commit()
+    return self.connection.commit()
 
   def rollback(self):
-    return self._get_conn().rollback()
+    return self.connection.rollback()
 
   def _check_fetch(self):
     if self.results is None:

--- a/py/vtdb/cursor.py
+++ b/py/vtdb/cursor.py
@@ -18,7 +18,7 @@ class BaseCursor(base_cursor.BaseListCursor):
     if self._handle_transaction_sql(sql):
       return
     self.results, self.rowcount, self.lastrowid, self.description = (
-        self._get_conn()._execute(sql, bind_variables, **kargs))
+        self.connection._execute(sql, bind_variables, **kargs))
     return self.rowcount
 
 
@@ -43,7 +43,7 @@ class BatchCursor(BaseCursor):
     self.bind_vars_list.append(bind_variables)
 
   def flush(self, as_transaction=False):
-    self.rowsets = self._get_conn()._execute_batch(
+    self.rowsets = self.connection._execute_batch(
         self.query_list, self.bind_vars_list, as_transaction)
     self.query_list = []
     self.bind_vars_list = []
@@ -69,6 +69,6 @@ class StreamCursor(base_cursor.BaseStreamCursor):
   # for instance, a key value for shard mapping
   def execute(self, sql, bind_variables, **kargs):
     self._clear_stream_state()
-    self.generator, self.description = self._get_conn()._stream_execute(
+    self.generator, self.description = self.connection._stream_execute(
         sql, bind_variables, **kargs)
     return 0

--- a/py/vtdb/cursorv3.py
+++ b/py/vtdb/cursorv3.py
@@ -17,7 +17,7 @@ class Cursor(base_cursor.BaseListCursor):
     if self._handle_transaction_sql(sql):
       return
     self.results, self.rowcount, self.lastrowid, self.description = (
-        self._get_conn()._execute(sql, bind_variables, self.tablet_type))
+        self.connection._execute(sql, bind_variables, self.tablet_type))
     return self.rowcount
 
 
@@ -30,6 +30,6 @@ class StreamCursor(base_cursor.BaseStreamCursor):
 
   def execute(self, sql, bind_variables, **kargs):
     self._clear_stream_state()
-    self.generator, self.description = self._get_conn()._stream_execute(
+    self.generator, self.description = self.connection._stream_execute(
         sql, bind_variables, self.tablet_type)
     return 0

--- a/py/vtdb/vtgate_cursor.py
+++ b/py/vtdb/vtgate_cursor.py
@@ -65,7 +65,7 @@ class VTGateCursor(base_cursor.BaseListCursor, VTGateCursorMixin):
         raise dbexceptions.DatabaseError('DML on a non-writable cursor', sql)
 
     self.results, self.rowcount, self.lastrowid, self.description = (
-        self._get_conn()._execute(
+        self.connection._execute(
             sql,
             bind_variables,
             self.keyspace,
@@ -86,7 +86,7 @@ class VTGateCursor(base_cursor.BaseListCursor, VTGateCursorMixin):
       raise dbexceptions.DatabaseError(
           'execute_entity_ids is not allowed for write queries')
     self.results, self.rowcount, self.lastrowid, self.description = (
-        self._get_conn()._execute_entity_ids(
+        self.connection._execute_entity_ids(
             sql,
             bind_variables,
             self.keyspace,
@@ -149,7 +149,7 @@ class BatchVTGateCursor(VTGateCursor):
     self.keyspace_ids_list.append(keyspace_ids)
 
   def flush(self, as_transaction=False):
-    self.rowsets = self._get_conn()._execute_batch(
+    self.rowsets = self.connection._execute_batch(
         self.query_list,
         self.bind_vars_list,
         self.keyspace_list,
@@ -190,7 +190,7 @@ class StreamVTGateCursor(base_cursor.BaseStreamCursor, VTGateCursorMixin):
     if self._writable:
       raise dbexceptions.ProgrammingError('Streaming query cannot be writable')
     self._clear_stream_state()
-    self.generator, self.description = self._get_conn()._stream_execute(
+    self.generator, self.description = self.connection._stream_execute(
         sql,
         bind_variables,
         self.keyspace,

--- a/test/python_client_test.py
+++ b/test/python_client_test.py
@@ -6,6 +6,7 @@
 """This test uses vtgateclienttest to test the vtdb python vtgate client.
 """
 
+import logging
 import struct
 import unittest
 
@@ -66,6 +67,9 @@ class TestPythonClient(unittest.TestCase):
     addr = 'localhost:%d' % vtgateclienttest_port
     protocol = protocols_flavor().vtgate_python_protocol()
     self.conn = vtgate_client.connect(protocol, addr, 30.0)
+    logging.info(
+        'Start: %s, protocol %s.',
+        '.'.join(self.id().split('.')[-2:]), protocol)
 
   def tearDown(self):
     self.conn.close()


### PR DESCRIPTION
Always open a new connection for every stream_execute. Reusing an
existing connection may cause problems if you are in a transaction; this
logic is simpler.

Also, change the cursor._get_conn() method into a cursor.connection property.