### PR TITLE
UI updates -- sticky left and right nav, better responsive layouts

### DIFF
--- a/doc/BackupAndRestore.md
+++ b/doc/BackupAndRestore.md
@@ -4,10 +4,6 @@ Vitess. Vitess uses backups for two purposes:
 * Provide a point-in-time backup of the data on a tablet
 * Bootstrap new tablets in an existing shard
 
-**Contents:**
-
-<div id="toc"></div>
-
 ## Prerequisites
 
 Vitess stores data backups on a Backup Storage service. Currently,

--- a/doc/ClientLibraries.md
+++ b/doc/ClientLibraries.md
@@ -1,9 +1,3 @@
-**Contents:**
-
-<div id="toc"></div>
-
-## Overview
-
 You can access your Vitess cluster using a variety of clients and
 programming languages. Vitess client libraries help your client
 application to more easily talk to your storage system to query data.

--- a/doc/Concepts.md
+++ b/doc/Concepts.md
@@ -1,6 +1,4 @@
-Vitess uses the following concepts and terms:
-
-<div id="toc"></div>
+This document defines common Vitess concepts and terminology.
 
 ## Keyspace
 
@@ -40,9 +38,9 @@ A keyspace ID can be an unsigned number or a binary character column
 (<code>unsigned bigint</code> or <code>varbinary</code> in MySQL tables).
 Other data types are not allowed due to ambiguous equality or inequality rules.
 
-<!--
+<div style="display:none">
 TODO: keyspace ID rules must be solidified once VTGate features are finalized.
--->
+</div>
 
 ## Shard
 
@@ -79,9 +77,9 @@ There are several other tablet types that each serve a specific purpose, includi
 
 Only <code>master</code>, <code>replica</code>, and <code>rdonly</code> tablets are included in the [serving graph](#serving-graph).
 
-<!--
+<div style="display:none">
 TODO: Add pointer to complete list of types and explain how to update type?
--->
+</div>
 
 ## Shard graph
 
@@ -132,11 +130,11 @@ A Vitess implementation has one global instance of the topology service and one 
   Each local instance contains information about information specific to the cell where it is located. Specifically, it contains data about tablets in the cell, the serving graph for that cell, and the master-slave map for MySQL instances in that cell.<br><br>
   The local topology server must be available for Vitess to serve data.
 
-<!--
+<div style="display:none">
   To ensure reliability, the topology service has multiple server processes running on different servers. Those servers elect a master and perform chorum writes. In ZooKeeper, for a write to succeed, more than half of the servers must acknowledge it. Thus, a typical ZooKeeper configuration consists of either three or five servers, where two (out of three) or three (out of five) servers must agree for a write operation to succeed.
 The instance is the set of servers providing topology services. So, in a Vitess implementation using ZooKeeper, the global and local instances likely consist of three or five servers apiece.
   To be reliable, the global instance needs to have server processes spread across all regions and cells. Read-only replicas of the global instance can be maintained in each data center (cell).
--->
+</div>
 
 ## Cell (Data Center)
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -4,8 +4,6 @@ You can build Vitess using either [Docker](#docker-build) or a
 If you run into issues or have questions, please post on our
 [forum](https://groups.google.com/forum/#!forum/vitess).
 
-<div id="toc"></div>
-
 ## Docker Build
 
 To run Vitess in Docker, use an
@@ -247,7 +245,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     step since the environment variables will already be set.
 
     Navigate to the directory where you built Vitess
-    (**$WORKSPACE/src/github.com/youtube/vitess**) and run the
+    (**$WORKSPACE/src/<wbr>github.com/<wbr>youtube/vitess**) and run the
     following command:
 
     ``` sh

--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -7,10 +7,6 @@ If you already have Kubernetes v0.19+ running in one of the other
 you can skip the <code>gcloud</code> steps.
 The <code>kubectl</code> steps will apply to any Kubernetes cluster.
 
-**Contents:**
-
-<div id="toc"></div>
-
 ## Prerequisites
 
 To complete the exercise in this guide, you must locally install Go 1.3+,

--- a/doc/HorizontalReshardingGuide.md
+++ b/doc/HorizontalReshardingGuide.md
@@ -2,10 +2,6 @@ This step-by-step guide explains how to split an unsharded keyspace into two sha
 
 You can use the same general instructions to reshard a sharded keyspace.
 
-**Contents:**
-
-<div id="toc"></div>
-
 ## Prerequisites
 
 To complete these steps, you must have:

--- a/doc/Reparenting.md
+++ b/doc/Reparenting.md
@@ -1,9 +1,3 @@
-**Contents:**
-
-<div id="toc"></div>
-
-## Overview
-
 **Reparenting** is the process of changing a shard's master tablet
 from one host to another or changing a slave tablet to have a
 different master. Reparenting can be initiated manually

--- a/doc/SchemaManagement.md
+++ b/doc/SchemaManagement.md
@@ -7,10 +7,6 @@ This document describes the <code>[vtctl](/reference/vtctl.html)</code>
 commands that you can use to [review](#reviewing-your-schema) or
 [update](#changing-your-schema) your schema in Vitess. 
 
-**Contents:**
-
-<div id="toc"></div>
-
 ## Reviewing your schema
 
 This section describes the following <code>vtctl</code> commands, which let you look at the schema and validate its consistency across tablets or shards:

--- a/doc/Sharding.md
+++ b/doc/Sharding.md
@@ -2,10 +2,6 @@ Sharding is a method of horizontally partitioning a database to store
 data across two or more database servers. This document explains how
 sharding works in Vitess and the types of sharding that Vitess supports.
 
-**Contents:**
-
-<div id="toc"></div>
-
 ## Overview
 
 In Vitess, a shard is a partition of a keyspace. In turn, the keyspace

--- a/doc/ShardingKubernetes.md
+++ b/doc/ShardingKubernetes.md
@@ -1,9 +1,6 @@
 This guide walks you through the process of sharding an existing unsharded
 Vitess [keyspace](http://vitess.io/overview/concepts.html#keyspace) in Kubernetes.
 
-**Contents:**
-<div id="toc"></div>
-
 ## Prerequisites
 
 We begin by assuming you've completed the

--- a/doc/UserGuideIntroduction.md
+++ b/doc/UserGuideIntroduction.md
@@ -1,7 +1,3 @@
-**Contents:**
-
-<div id="toc"></div>
-
 ## Platform support
 
 Vitess runs on either Ubuntu 14.04 (Trusty) or Debian 7.0 (Wheezy).

--- a/doc/VitessOverview.md
+++ b/doc/VitessOverview.md
@@ -1,24 +1,14 @@
-**Contents:**
-
-<div id="toc"></div>
-
-## Overview
-
 Vitess is a database solution for scaling MySQL. It's architected to run as
 effectively in a public or private cloud architecture as it does on dedicated
 hardware. It combines and extends many important MySQL features with the
 scalability of a NoSQL database. Vitess has been serving all YouTube database
 traffic since 2011.
 
-### Vitess on Kubernetes
+## Vitess on Kubernetes
 
 Kubernetes is an open-source orchestration system for Docker containers, and Vitess is the logical storage engine choice for Kubernetes users.
 
 Kubernetes handles scheduling onto nodes in a compute cluster, actively manages workloads on those nodes, and groups containers comprising an application for easy management and discovery. Using Kubernetes, you can easily create and manage a Vitess cluster, out of the box.
-
-<!--
-### Vitess on Local Hardware
--->
 
 ## Comparisons to other storage options
 
@@ -131,7 +121,9 @@ Vitess tools and servers are designed to help you whether you start with a compl
 
 The diagram below illustrates Vitess' components:
 
-![Diagram showing Vitess implementation](https://raw.githubusercontent.com/youtube/vitess/master/doc/VitessOverview.png)
+<div style="overflow-x: scroll">
+<img src="https://raw.githubusercontent.com/youtube/vitess/master/doc/VitessOverview.png" alt="Diagram showing Vitess implementation" width="509" height="322"/>
+</div>
 
 ### Topology
 
@@ -150,10 +142,6 @@ To route queries, vtgate considers the sharding scheme, required latency, and th
 **vttablet** is a proxy server that sits in front of a MySQL database. A Vitess implementation has one vttablet for each MySQL instance.
 
 vttablet performs tasks that attempt to maximize throughput as well as protect MySQL from harmful queries. Its features include connection pooling, query rewriting, and query de-duping. In addition, vttablet executes management tasks that vtctl initiates, and it provides streaming services that are used for [filtered replication](/user-guide/sharding.html#filtered-replication) and data exports.
-
-<!--
-It is a newer version of and provides all of the same benefits as vtocc, including connection pooling, query rewriting, and query de-duping. In addition, vttablet executes management tasks that vtctl initiates. It also provides streaming services that are used for [filtered replication](http://vitess.io/user-guide/sharding.html#resharding) and data export.
--->
 
 A lightweight Vitess implementation uses vttablet as a smart connection proxy that serves queries for a single MySQL database. By running vttablet in front of your MySQL database and changing your app to use the Vitess client instead of your MySQL driver, your app benefits from vttablet's connection pooling, query rewriting, and query de-duping features.
 

--- a/vitess.io/_includes/end-of-page-styles.liquid
+++ b/vitess.io/_includes/end-of-page-styles.liquid
@@ -1,7 +1,9 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+<!--    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>   -->
     <!-- Include all compiled plugins (below), or include individual files as needed -->
+<!--
     <script src="/libs/bootstrap/js/bootstrap.min.js"></script>
+-->
     <!-- Include the common site javascript -->
     <script src="/js/common.js" type="text/javascript" charset="utf-8"></script>
 

--- a/vitess.io/_includes/left-nav-menu.html
+++ b/vitess.io/_includes/left-nav-menu.html
@@ -1,0 +1,43 @@
+        <li class="submenu">
+          <h4 class="arrow-r no-top-margin">Overview</h4>
+          <ul style="display: none">
+            <li><a href="/overview/">What is Vitess</a></li>
+            <li><a href="/overview/concepts.html">Key Concepts</a></li>
+          </ul>
+        </li>
+        <li class="submenu">
+          <h4 class="arrow-r">Getting Started</h4>
+          <ul style="display: none">
+            <li><a href="/getting-started/">Run Vitess on Kubernetes</a></li>
+            <li><a href="/getting-started/local-instance.html">Run Vitess Locally</a></li>
+          </ul>
+        </li>
+        <li class="submenu">
+          <h4 class="arrow-r">User Guide</h4>
+          <ul style="display: none">
+            <li><a href="/user-guide/introduction.html">Introduction</a>
+            <li><a href="/user-guide/client-libraries.html">Client Libraries</a>
+            <li><a href="/user-guide/backup-and-restore.html">Backing Up Data</a>
+            <li><a href="/user-guide/reparenting.html">Reparenting</a></li>
+            <li><a href="/user-guide/schema-management.html">Schema Management</a></li>
+            <li style="padding-bottom: 0"><a href="/user-guide/sharding.html">Sharding</a>
+              <ul style="list-style-type: none">
+                <li><a href="/user-guide/horizontal-sharding.html">Horizontal Sharding (Codelab)</a></li>
+                <li style="padding-bottom: 0"><a href="/user-guide/sharding-kubernetes.html">Sharding in Kubernetes (Codelab)</a></li>
+              </ul>
+            </li>
+          </ul>
+        </li>
+        <li class="submenu">
+          <h4 class="arrow-r">Reference Guides</h4>
+          <ul style="display: none">
+            <li><a href="/reference/vitess-api.html">Vitess API</a>
+            <li><a href="/reference/vtctl.html">vtctl Commands</a>
+          </ul>
+        </li>
+        <li class="submenu">
+          <h4 class="arrow-r">Other Resources</h4>
+          <ul style="display: none">
+            <li><a href="/resources/presentations.html">Presentations</a>
+          </ul>
+        </li>

--- a/vitess.io/_includes/nav.html
+++ b/vitess.io/_includes/nav.html
@@ -1,4 +1,4 @@
-<nav id="common-nav" class="navbar navbar-static-top inverse">
+<nav id="common-nav" class="navbar navbar-fixed-top inverse">
   <div class="container">
     <!-- Brand and toggle get grouped for better mobile display -->
     <div class="navbar-header">
@@ -15,12 +15,16 @@
 
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="navbar-collapse-1">
-      <ul class="nav navbar-nav navbar-right">
+      <ul class="nav navbar-nav navbar-right" id="standard-menu-links">
         <li><a href="/overview/">Guides</a></li>
         <li><a href="/reference/vitess-api.html">Reference</a></li>
         <li><a href="https://github.com/youtube/vitess"><i class="fa fa-github"></i> GitHub</a></li>
         <!-- Hide link to blog unless we have actual posts -->
         <!-- <li><a href="/blog/" title="">Blog</a></li> -->
+      </ul>
+      <ul class="nav nav-stacked mobile-left-nav-menu" id="collapsed-left-menu">
+        {% include left-nav-menu.html %}
+        <li><a href="https://github.com/youtube/vitess" style="font-size: 18px; margin-left: 0.25em;"><i class="fa fa-github"></i> GitHub</a></li>
       </ul>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->

--- a/vitess.io/_includes/styles.liquid
+++ b/vitess.io/_includes/styles.liquid
@@ -23,5 +23,7 @@
     
     <!-- Less clientside js script after all less stylesheets. -->
     <script src="/libs/less/less.min.js" type="text/javascript"></script>
-
-
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="/libs/bootstrap/js/bootstrap.min.js"></script>

--- a/vitess.io/_layouts/new_base.html
+++ b/vitess.io/_layouts/new_base.html
@@ -13,7 +13,12 @@
     <meta name="og:image" content="{{ site.baseurl }}/images/{{ site.logo }}"/>
     <meta name="og:description" content="{{ site.description }}"/>
   </head>
-  <body class="{{ page.bodyclass }}">
+  <body class="{{ page.bodyclass }}" id="top_of_page">
+{% if page.tocDepth %}
+    <span id="toc-depth" data-toc-depth="{{ page.tocDepth }}"></span>
+{% else %}
+    <span id="toc-depth" data-toc-depth="h2,h3"></span>
+{% endif %}
 
   	{{ content }}
 

--- a/vitess.io/_layouts/new_default.html
+++ b/vitess.io/_layouts/new_default.html
@@ -5,9 +5,13 @@ layout: new_base
 {% include nav.html %}
 
 {% if page.title %}
-<div class="page-title-bar">
+<div id="masthead">
   <div class="container">
-    <h1>{{ page.title }}</h1>
+    <div class="row">
+      <div class="col-md-7">
+        <h1>{{ page.title }}</h1>
+      </div>
+    </div>
   </div>
 </div>
 {% endif %}
@@ -15,5 +19,3 @@ layout: new_base
 <div class="container">
   {{ content }}
 </div>
-
-<div class="page-spacer"></div>

--- a/vitess.io/_layouts/new_docs.html
+++ b/vitess.io/_layouts/new_docs.html
@@ -3,37 +3,20 @@ layout: new_default
 bodyclass: docs
 ---
 
-<div class="row">
-  <div class="col-sm-3">
-    <div id="left-nav">
-    <ul class="list-unstyled docs-side-nav">
-      <li><h4 class="no-top-margin">Overview</h4></li>
-      <li><a href="/overview/">What is Vitess</a></li>
-      <li><a href="/overview/concepts.html">Key Concepts</a></li>
-      <li><h4>Getting Started</h4></li>
-      <li><a href="/getting-started/">Run Vitess on Kubernetes</a></li>
-      <li><a href="/getting-started/local-instance.html">Run Vitess Locally</a></li>
-      <li><h4>User Guide</h4></li>
-      <li><a href="/user-guide/introduction.html">Introduction</a>
-      <li><a href="/user-guide/client-libraries.html">Client Libraries</a>
-      <li><a href="/user-guide/backup-and-restore.html">Backing Up Data</a>
-      <li><a href="/user-guide/reparenting.html">Reparenting</a></li>
-      <li><a href="/user-guide/schema-management.html">Schema Management</a></li>
-      <li><a href="/user-guide/sharding.html">Sharding</a>
-        <ul style="list-style-type: none">
-          <li><a href="/user-guide/horizontal-sharding.html">Horizontal Sharding (Codelab)</a></li>
-          <li><a href="/user-guide/sharding-kubernetes.html">Sharding in Kubernetes (Codelab)</a></li>
-        </ul>
-      </li>
-      <li><h4>Reference Guides</h4></li>
-      <li><a href="/reference/vitess-api.html">Vitess API</a>
-      <li><a href="/reference/vtctl.html">vtctl Commands</a>
-      <li><h4>Other Resources</h4></li>
-      <li><a href="/resources/presentations.html">Presentations</a>
-    </ul>
+  <div class="row scroll-margin" id="toc-content-row">
+    <div class="col-md-3" id="leftCol">
+      <ul class="nav nav-stacked mobile-left-nav-menu" id="sidebar">
+        {% include left-nav-menu.html %}
+      </ul>
+    </div>
+    <div class="col-md-2" id="rightCol">
+      <div class="nav nav-stacked" id="tocSidebar">
+        <div id="toc"></div>
+      </div>
+    </div>
+    <div class="col-md-7" id="centerCol">
+      <div id="centerTextCol">
+        {{ content }}
+      </div>
+    </div>
   </div>
-  </div>
-  <div class="col-sm-9">
-      {{ content }}
-  </div>
-</div>

--- a/vitess.io/css/style.less
+++ b/vitess.io/css/style.less
@@ -210,3 +210,21 @@ body.post {
         padding-bottom: 0;
     }
 }
+
+// collapsible menus
+h4.arrow-d, h4.arrow-r {
+  cursor: pointer;
+  &::before{
+    font-family: monospace;
+    font-weight: bold;
+  }
+}
+
+// Expandy nav items
+h4.arrow-r::before {
+    content: "+ ";
+}
+
+h4.arrow-d::before {
+    content: "- ";
+}

--- a/vitess.io/css/vitess.css
+++ b/vitess.io/css/vitess.css
@@ -5,6 +5,10 @@
 
 @import url("https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.3/themes/smoothness/jquery-ui.css");
 
+body {
+  padding-top: 50px;
+}
+
 p {
   margin: 0 0 1em;
 }
@@ -17,6 +21,7 @@ table {
   border-spacing:0;
   text-align:left;
   width:100%;
+  margin-bottom: 2.125em;
 }
 
 table thead {
@@ -89,11 +94,26 @@ br.bigbreak {
 div.indent-details {
   padding-left: 1.6250em;
 }
+#toc {
+  border-left: solid 3px #4E5A92;
+  padding-left: 12px;
+}
 #toc ol, #toc ul {
+  font-size: 13px;
+  list-style: none;
   margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
+#toc ol ol, #toc ol ul, #toc ul ol, #toc ul ul {
+  padding-left: 25px;
+  list-style: circle;
 }
 #toc li {
   margin-bottom: 0;
+}
+#toc-contents-header {
+  font-size: 13px;
 }
 ol ol, ol ul, ul ol, ul ul {
   margin: 0.8em 0em;
@@ -101,45 +121,155 @@ ol ol, ol ul, ul ol, ul ul {
 ol ol li, ol ul li, ul ol li, ul ul li {
   margin: 0;
 }
-li, .docs-side-nav ol li, .docs-side-nav ul li {
+li {
   margin-bottom: 0.5em;
 }
 /*
  * Left nav
  */
-.docs-side-nav {
-  margin-top: 0;
+#left-nav {
+  overflow-x: hidden;
+  overflow-y: auto;
 }
-.docs-side-nav ol, .docs-side-nav ul {
-  padding-left: 1.625em;
+
+#masthead {
+  background-color: #E8F4FF;
+  margin-bottom: 40px;
+  min-height: 105px;
 }
-.docs-side-nav li h4 {
-  margin-top: 1.2em;
+
+#masthead h1 {
+  color: #4E5A92;
+  font-size: 36px;
+  padding: 18px;
 }
-.docs-side-nav li h4.no-top-margin {
-  margin-top: 0;
+.icon-bar {
+  background-color:#fff;
 }
-.docs-side-nav li a {
-  padding-left: 8px;
+
+@media screen and (min-width: 768px) {
+  #masthead h1 {
+    font-size: 36px;
+  }
 }
-.docs-side-nav li.active-item {
-  border-left: solid 3px #4E5A92;
+
+.navbar-brand {
+  padding: 7px 15px;
+}
+
+.nav > li {
+  margin-bottom: 0;
+}
+.nav li.active-item {
   font-weight: bold;
-  margin-left: -3px;
   text-decoration: none;
 }
-.docs-side-nav li.active-item ul, .docs-side-nav li.active-item ol {
-  border-left: solid 3px #fff;
-  font-weight: normal;
-  margin-left: -3px;
+#sidebar > li > h4 {
+  font-size: 16px;
+  margin-top: 0.8em;
+}
+.nav > li > h4.no-top-margin {
   margin-top: 0;
+}
+#sidebar > li > a {
+  padding: 6px 15px 6px 0px;
+}
+#sidebar li a {
+  font-size: 13px;
+}
+#sidebar li ul li, #sidebar li ol li {
+  padding-bottom: 5px;
+}
+.nav li.active-item ul, .nav li.active-item ol {
+  font-weight: normal;
   padding-top: 0.8em;
+}
+.nav-stacked > li+li {
+  margin-top: 0;
+}
+.nav ol, .nav ul {
+  list-style: none;
+  padding-left: 1.5em;
+}
+#rightCol li.active > a {
+  color: #730073;
+  font-weight: bold;
+}
+#centerTextCol h2, #centerTextCol h3, #centerTextCol h4,
+                   #centerTextCol h5, #centerTextCol h6 {
+  padding-top: 50px;
+  margin-top: -50px;
+}
+
+.affix-top,.affix{
+  position: static;
+}
+#sidebar.affix-top,#sidebar.affix{
+  max-width: 170px;
+}
+
+@media (min-width: 1200px) {
+  #tocSidebar.affix, #tocSidebar.affix-top {
+    min-width: 170px;
+  }
+  #rightCol #tocSidebar.affix, #rightCol #tocSidebar.affix-top {
+    max-width: 210px;
+  }
+  #toc > ul > li > a {
+    display: inline-block;
+    padding-left: 10px;
+    text-indent: -10px;
+  }
+
+  #sidebar.affix, #tocSidebar.affix {
+    position: fixed;
+    top: 70px;
+    bottom: 0px;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}
+@media (min-width: 992px) {
+  #sidebar.affix, #sidebar.affix-top {
+    width: 228px;
+  }
+
+  #tocSidebar.affix, #tocSidebar.affix-top {
+  }
+
+  #sidebar.affix-top, #tocSidebar.affix-top {
+    position: static;
+  }
+  
+  #sidebar.affix, #tocSidebar.affix {
+    position: fixed;
+    top: 70px;
+    bottom: 0px;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}
+@media (min-width: 768px) {
+  #sidebar.affix {
+    position: fixed;
+    top: 70px;
+    bottom: 0px;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+}
+
+/*
+ * Left nav highlighting title of selected document
+ */
+
+.main-site-content {
+  max-width: 1512px;
+  padding: 0 80px;
 }
 
 /*
  * Responsive tables
-  background: rgba(255, 255, 255, .95);
-  background: rgba(255, 255, 255, .87);
  */
 table.responsive tr:not(.alt) td td:first-child,
 table.responsive td tr:not(.alt) td:first-child {
@@ -167,29 +297,7 @@ table.responsive td td:first-child {
 table.responsive th:not(:first-child) {
   display: none;
 }
-@media screen and (max-width: 1000px) {
-  /*
-   * Force responsive tables to lay out completely vertically. The "responsive"
-   * class should only be applied to tables that are composed like a definition
-   * list, with a "term" (say, a property name) in the first column and any
-   * "definitions" (say, type, description, and a sample value) stacked on top
-   * of each other in the second column. This makes it possible to lay out the
-   * table vertically and keep it readable on smaller screens without horizontal
-   * scrolling. This structure and behavior is documented.
-   */
-  table.responsive,
-  table.responsive thead,
-  table.responsive tbody,
-  table.responsive tr,
-  table.responsive th,
-  table.responsive td {
-    display: block;
-  }
-}
 
-/*
- * App bar changing color when scrolled
- */
 /*** main layout ***/
 
 #home-page-logo {
@@ -199,7 +307,9 @@ table.responsive th:not(:first-child) {
   height: 228px;
 }
 .page-title-bar {
-  margin: 60px 0px;
+  margin: 50px 0px 0px;
+  padding-bottom: 10px;
+  padding-top: 15px;
 }
 
 .app-bar {
@@ -255,6 +365,25 @@ table.responsive th:not(:first-child) {
   background-size: 24px 24px;
 }
 
+#leftCol {
+  float: left;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+#rightCol {
+  float: right;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-right: 0px;
+  position: static;
+  z-index: 10000;
+}
+
+.scrolled {
+  margin-bottom: 80px;
+  z-index: 20000;
+}
+
 .scrolled .app-bar {
   color: #000000;
   background: #FFFFFF;
@@ -291,54 +420,90 @@ main .fa {
   padding-left: 0;
   padding-right: 0;
 }
+#mobile-left-nav-menu-button {
+  display: none;
+  background-color: transparent;
+  background-image: url('/images/left-nav-menu-expander.svg');
+  border: 0;
+  height: 24px;
+  margin-left: 10px;
+  min-width: 24px;
+}
+#collapsed-left-menu {
+  display: none;
+}
+#collapsed-left-menu h4 {
+  color: #E8F4FF;
+}
 
-@media screen and (min-width: 768px) {
-  .navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 60px;
-    -webkit-transition: background-color 0.2s ease-out;
-            transition: background-color 0.2s ease-out;
+@media screen and (max-width: 1199px) {
+  #rightCol {
+    margin: 0;
   }
-  .navbar-brand {
-    padding: 13px 0px;
+  #centerCol {
+    z-index: 1;
   }
-
-  .navbar .container,
-  .navdrawer-container ul {
-    float: right;
-    display: inline;
+  #toc-content-row {
+    position: relative;
+    z-index: 1;
   }
-  .navbar .container,
-  .navdrawer-container ul li {
-    display: inline;
+}
+@media screen and (max-width: 991px) {
+  #rightCol {
+    float: none;
+    margin: 12px 0 30px calc(25% + 15px);
+    max-width: 255px;
   }
-  .navbar .container,
-  .navdrawer-container ul li a {
-    display: inline-block;
-    padding: 0 20px;
-    font-size: 17px;
-    line-height: 60px;
-    font-weight: 300;
-    text-transform: uppercase;
+  #centerCol {
+    margin-left: calc(25% + 15px);
+    z-index: 1;
   }
-
-  .scrolled .navdrawer-container ul li a {
-    color: #000000;
-  }
-  .scrolled .navdrawer-container ul li a:hover {
-    background-color: rgba(78,90,146, 0.2);
-  }
-  .scrolled .navdrawer-container ul li a:focus {
-    background-color: rgba(78,90,146, 0.3);
-  }
-  .scrolled .navdrawer-container ul li a:active {
-    background-color: rgba(78,90,146, 0.4);
+  #leftCol {
+    max-width: 200px;
   }
 
-  #nav .index {
+  /*
+   * Force responsive tables to lay out completely vertically. The "responsive"
+   * class should only be applied to tables that are composed like a definition
+   * list, with a "term" (say, a property name) in the first column and any
+   * "definitions" (say, type, description, and a sample value) stacked on top
+   * of each other in the second column. This makes it possible to lay out the
+   * table vertically and keep it readable on smaller screens without horizontal
+   * scrolling. This structure and behavior is documented.
+   */
+  table.responsive,
+  table.responsive thead,
+  table.responsive tbody,
+  table.responsive tr,
+  table.responsive th,
+  table.responsive td {
+    display: block;
+  }
+
+  .main-site-content {
+    padding: 0 24px;
+  }
+}
+@media screen and (max-width: 767px) {
+  #mobile-left-nav-menu-button {
+    display: block;
+  }
+  #rightCol {
+    margin: 12px 0 30px;
+  }
+  #leftCol {
+    display: none;
+  }
+  #centerCol {
+    margin-left: 0;
+  }
+  .main-site-content {
+    padding: 0 16px;
+  }
+  #collapsed-left-menu {
+    display: block;
+  }
+  #standard-menu-links {
     display: none;
   }
 }

--- a/vitess.io/images/left-nav-menu-expander.svg
+++ b/vitess.io/images/left-nav-menu-expander.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+<path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="#757575"/>
+</svg>

--- a/vitess.io/js/common.js
+++ b/vitess.io/js/common.js
@@ -30,11 +30,38 @@ $(document).ready(function() {
     return this.href == url;
   }).parent('li').addClass('active-item');
   //$('#left-nav').fixLeftNav();
+
+  $('#sidebar').affix({
+    offset: {
+      top: 110
+    }
+  });
+  $('#tocSidebar').affix({
+    offset: {
+      top: 110
+    }
+  });
+
+  var $body = $(document.body);
+  var navHeight = $('.navbar').outerHeight(true) + 20;
+
+  $body.scrollspy({
+    target: '#rightCol',
+    offset: navHeight
+  });
+
 });
+
+
 
 // Prettyprint
 $('pre').addClass("prettyprint");
 $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js", function(){
+});
+
+$.getScript("/js/jquery.collapsible.js", function() {
+  highlightActive();
+  $('.submenu').collapsible();
 });
 
   var previous = -1;
@@ -46,18 +73,24 @@ $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prett
       document.body.className = document.body.className.replace(' scrolled', '');
     }
     previous = current;
-    console.log('new scroll is ' + previous);
+    var activeTocLinks = $('.active');
+    if (activeTocLinks.length > 1) {
+      for (var i = 0; i < (activeTocLinks.length - 1); i++) {
+        activeTocLinks[i].className = '';
+      }
+    }
   }
 
 // TOC script
 // https://github.com/ghiculescu/jekyll-table-of-contents
 (function($){
   $.fn.toc = function(options) {
+    var tocDepth = $('#toc-depth').attr('data-toc-depth') || ''
     var defaults = {
       noBackToTopLinks: false,
-      title: '',
+      title: '<b>Contents</b>',
       minimumHeaders: 3,
-      headers: 'h1, h2, h3, h4, h5, h6',
+      headers: tocDepth || 'h1, h2, h3, h4, h5, h6',
       listType: 'ol', // values: [ol|ul]
       showEffect: 'show', // values: [show|slideDown|fadeIn|none]
       showSpeed: 'slow' // set to 0 to deactivate effect
@@ -72,9 +105,9 @@ $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prett
 
     var headers = $(settings.headers).filter(function() {
       // get all headers with an ID
-      var previousSiblingName = $(this).prev().attr( "name" );
+      var previousSiblingName = $(this).prev().attr( 'name' );
       if (!this.id && previousSiblingName) {
-        this.id = $(this).attr( "id", previousSiblingName.replace(/\./g, "-") );
+        this.id = $(this).attr( 'id', previousSiblingName.replace(/\./g, '-') );
       }
       return this.id;
     }), output = $(this);
@@ -93,13 +126,14 @@ $.getScript("https://cdn.rawgit.com/google/code-prettify/master/loader/run_prett
       none: function() { output.html(html); }
     };
 
-    var get_level = function(ele) { return parseInt(ele.nodeName.replace("H", ""), 10); }
+    var get_level = function(ele) { return parseInt(ele.nodeName.replace('H', ''), 10); }
     var highest_level = headers.map(function(_, ele) { return get_level(ele); }).get().sort()[0];
     var return_to_top = '<i class="icon-arrow-up back-to-top"> </i>';
 
     var level = get_level(headers[0]),
       this_level,
-      html = settings.title + " <"+settings.listType+">";
+      html = ('<a href="#top_of_page" id="toc-contents-header" data-title="' +
+              settings.title + '">' + settings.title + '</a><'+settings.listType+'>');
     headers.on('click', function() {
       if (!settings.noBackToTopLinks) {
         window.location.hash = this.id;

--- a/vitess.io/js/jquery.collapsible.js
+++ b/vitess.io/js/jquery.collapsible.js
@@ -1,0 +1,93 @@
+/*!
+* Adapted from collapsible.js 1.0.0
+* https://github.com/jordnkr/collapsible
+*/
+
+    function highlightActive() {
+      function stringEndsWith(str, endsWithString) {
+        var index = str.indexOf(endsWithString);
+        if (index >= 0 && str.length == endsWithString.length + index) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+      // First have to invalidate old active item.
+      $('#sidebar a.active').removeClass('active');
+      var currentLocation = window.location.hostname + window.location.pathname;
+      $('#sidebar li a[href]').each(function(index, element) {
+        if (stringEndsWith(currentLocation, element.href.replace(/^.*\/\//,"").replace(/\:\d+/, ""))) {
+          $(element).addClass('active');
+        }
+      });
+    };
+
+
+(function($, undefined) {
+    $.fn.collapsible = function(effect, options) {
+        var defaults = {
+            accordionUpSpeed: 400,
+            accordionDownSpeed: 400,
+            collapseSpeed: 400,
+            contentOpen: 0,
+            arrowRclass: 'arrow-r',
+            arrowDclass: 'arrow-d',
+            animate: true
+        };
+
+        if (typeof effect === "object") {
+            var settings = $.extend(defaults, effect);
+        } else {
+            var settings = $.extend(defaults, options);
+        }
+
+        return this.each(function() {
+            if (settings.animate === false) {
+                settings.accordionUpSpeed = 0;
+                settings.accordionDownSpeed = 0;
+                settings.collapseSpeed = 0;
+            }
+
+            var $thisEven = $(this).children(':even');
+            var $thisOdd = $(this).children(':odd');
+            var accord = 'accordion-active';
+            
+
+            switch (effect) {
+              case 'accordion-open':
+              /* FALLTHROUGH */
+              case 'accordion':
+                if (effect === 'accordion-open') {
+                    $($thisEven[settings.contentOpen]).children(':first-child').toggleClass(settings.arrowRclass + ' ' + settings.arrowDclass);
+                    $($thisOdd[settings.contentOpen]).show().addClass(accord);
+                 }
+                 $($thisEven).click(function() {
+                   if ($(this).next().attr('class') === accord) {
+                            $(this).next().slideUp(settings.accordionUpSpeed).removeClass(accord);
+                            $(this).children(':first-child').toggleClass(settings.arrowRclass + ' ' + settings.arrowDclass);
+                   } else {
+                            $($thisEven).children().removeClass(settings.arrowDclass).addClass(settings.arrowRclass); 
+                            $($thisOdd).slideUp(settings.accordionUpSpeed).removeClass(accord);
+                            $(this).next().slideDown(settings.accordionDownSpeed).addClass(accord); 
+                            $(this).children(':first-child').toggleClass(settings.arrowRclass + ' ' + settings.arrowDclass);              
+                   }
+                   });
+                 break;
+               case 'default-open':
+               /* FALLTHROUGH */
+               default:
+                 // is everything open by default or do I have an active child?
+                 if (effect === 'default-open'|| $(this).find("a.active").length) {
+                   $($thisEven[settings.contentOpen]).toggleClass(settings.arrowRclass + ' ' + settings.arrowDclass);
+                   $($thisOdd[settings.contentOpen]).show();
+                 }
+                 $($thisEven).click(function() {
+                   $(this).toggleClass(settings.arrowRclass + ' ' + settings.arrowDclass);
+                   $(this).next().slideToggle(settings.collapseSpeed);
+                  });
+                 break;
+            }
+        });
+    };
+})(jQuery);


### PR DESCRIPTION
These changes update the UI so that on documentation pages, the Bootstrap 12-column layout is divided into three sections. The left section is three columns and contains a list of available documents grouped by sections, where the current section's document is expanded and the rest are collapsed. The center section is seven columns and contains the main page content. The right section is two columns and contains an automatically generated table of contents.

It also modifies the CSS so that documentation renders better on mobile phones and tablets, switching as appropriate, to either a two-section or one-section layout based on screen size. CSS identifies different layout rules at 768, 992, 1200px. Below 992px, the TOC appears above the main page content, and the list of documents still appears to the left. Below 768px, the list of documents is moved to an expandable menu in the header.

And it makes the left and right sections anchor below the top nav bar when you scroll so that they remain visible no matter where you are on the page. The TOC highlights the section you are currently looking at.