### PR TITLE
Fixing vttest for go / vitess.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,21 +48,22 @@ clean:
 clean_pkg:
 	rm -rf ../../../../pkg Godeps/_workspace/pkg
 
-unit_test:
+unit_test: build
+	echo $$(date): Running unit tests
 	godep go test $(VT_GO_PARALLEL) ./go/...
 
 # Run the code coverage tools, compute aggregate.
 # If you want to improve in a directory, run:
 #   go test -coverprofile=coverage.out && go tool cover -html=coverage.out
-unit_test_cover:
+unit_test_cover: build
 	godep go test $(VT_GO_PARALLEL) -cover ./go/... | misc/parse_cover.py
 
-unit_test_race:
+unit_test_race: build
 	godep go test $(VT_GO_PARALLEL) -race ./go/...
 
 # Run coverage and upload to coveralls.io.
 # Requires the secret COVERALLS_TOKEN env variable to be set.
-unit_test_goveralls:
+unit_test_goveralls: build
 	travis/goveralls.sh
 
 queryservice_test:

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -8,6 +8,9 @@ import (
 	"errors"
 	"os"
 	"path"
+
+	// we use gRPC everywhere, so import the vtgate client.
+	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
 )
 
 func launcherPath() (string, error) {
@@ -16,10 +19,6 @@ func launcherPath() (string, error) {
 		return "", errors.New("VTTOP not set")
 	}
 	return path.Join(vttop, "py/vttest/run_local_database.py"), nil
-}
-
-func topoFlags(topo string) []string {
-	return []string{"--topology", topo}
 }
 
 func vtgateProtocol() string {

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -152,8 +152,8 @@ func (hdl *Handle) run(port int, topo, schemaDir string, mysqlOnly, verbose bool
 	hdl.cmd = exec.Command(
 		launcher,
 		"--port", strconv.Itoa(port),
+		"--topology", topo,
 	)
-	hdl.cmd.Args = append(hdl.cmd.Args, topoFlags(topo)...)
 	if schemaDir != "" {
 		hdl.cmd.Args = append(hdl.cmd.Args, "--schema_dir", schemaDir)
 	}

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/proto/topodata"
-	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 )
 

--- a/py/vttest/local_database.py
+++ b/py/vttest/local_database.py
@@ -57,13 +57,7 @@ class LocalDatabase(object):
   def config(self):
     """Returns a dict with enough information to be able to connect."""
     if self.mysql_only:
-      return {
-          'username': self.mysql_db.username(),
-          'password': self.mysql_db.password(),
-          'host': '127.0.0.1',
-          'port': self.mysql_db.port(),
-          'socket': self.mysql_db.unix_socket(),
-          }
+      return self.mysql_db.config()
     else:
       result = {
           'port': vt_processes.vtgate_process.port,

--- a/py/vttest/local_database.py
+++ b/py/vttest/local_database.py
@@ -60,6 +60,7 @@ class LocalDatabase(object):
       return {
           'username': self.mysql_db.username(),
           'password': self.mysql_db.password(),
+          'host': '127.0.0.1',
           'port': self.mysql_db.port(),
           'socket': self.mysql_db.unix_socket(),
           }

--- a/py/vttest/mysql_db.py
+++ b/py/vttest/mysql_db.py
@@ -35,3 +35,7 @@ class MySqlDB(object):
 
   def unix_socket(self):
     raise NotImplementedError('MySqlDB is the base class.')
+
+  def config(self):
+    """Returns the json config to output."""
+    raise NotImplementedError('MySqlDB is the base class.')

--- a/py/vttest/mysql_db_mysqlctl.py
+++ b/py/vttest/mysql_db_mysqlctl.py
@@ -71,3 +71,10 @@ class MySqlDBMysqlctl(mysql_db.MySqlDB):
 
   def unix_socket(self):
     return os.path.join(self._directory, 'vt_0000000001', 'mysql.sock')
+
+  def config(self):
+    return {
+        'username': self.username(),
+        'password': self.password(),
+        'socket': self.unix_socket(),
+    }


### PR DESCRIPTION
@sougou 
Fixing a few things:
- moving import of gRPC client to environment.go, so we can do other protocols in other places.
- topoFlags are the same everywhere now, moving them out of environment.go
- adding host so local connections work without socket.