### PR TITLE
vtdb.tablet client uses error codes instead of string parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
   - $MYSQL_ROOT
   # Cache bootstrapped dependencies (e.g. protobuf and gRPC).
   - $HOME/gopath/dist/grpc/.build_finished
-  - $HOME/gopath/dist/grpc/lib/python2.7/site-packages
+  - $HOME/gopath/dist/grpc/lib
   - $HOME/gopath/dist/protobuf/.build_finished
   - $HOME/gopath/dist/protobuf/lib
   - $HOME/gopath/dist/py-cbson/lib/python2.7/site-packages

--- a/dev.env
+++ b/dev.env
@@ -98,8 +98,11 @@ export CGO_CFLAGS="$CGO_CFLAGS -I$VTROOT/dist/vt-zookeeper-3.3.5/include/c-clien
 export CGO_LDFLAGS="$CGO_LDFLAGS -L$VTROOT/dist/vt-zookeeper-3.3.5/lib"
 export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $VTROOT/dist/vt-zookeeper-3.3.5/lib)
 
-# needed to correctly import grpc for python
-export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $VTROOT/dist/grpc/lib)
+# needed to correctly import grpc if it's not installed globally
+grpc_dist=$VTROOT/dist/grpc
+if [ -f $grpc_dist/.build_finished ]; then
+  export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $grpc_dist/lib)
+fi
 
 export GOPATH=$(prepend_path $GOPATH $VTROOT)
 

--- a/dev.env
+++ b/dev.env
@@ -69,7 +69,7 @@ if [[ "$VT_MYSQL_ROOT" == "" ]]; then
   else
     export VT_MYSQL_ROOT=$(dirname $(dirname $(which mysql_config)))
   fi
-fi 
+fi
 
 # restore MYSQL_FLAVOR, saved by bootstrap.sh
 if [ -r $VTROOT/dist/MYSQL_FLAVOR ]; then
@@ -97,6 +97,9 @@ export PKG_CONFIG_PATH=$(prepend_path $PKG_CONFIG_PATH $VTROOT/lib)
 export CGO_CFLAGS="$CGO_CFLAGS -I$VTROOT/dist/vt-zookeeper-3.3.5/include/c-client-src"
 export CGO_LDFLAGS="$CGO_LDFLAGS -L$VTROOT/dist/vt-zookeeper-3.3.5/lib"
 export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $VTROOT/dist/vt-zookeeper-3.3.5/lib)
+
+# needed to correctly import grpc for python
+export LD_LIBRARY_PATH=$(prepend_path $LD_LIBRARY_PATH $VTROOT/dist/grpc/lib)
 
 export GOPATH=$(prepend_path $GOPATH $VTROOT)
 

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -367,10 +367,7 @@ func (conn *vtgateConn) Commit(ctx context.Context, session interface{}) error {
 		Session:  session.(*pb.Session),
 	}
 	_, err := conn.c.Commit(ctx, request)
-	if err != nil {
-		return vterrors.FromGRPCError(err)
-	}
-	return nil
+	return vterrors.FromGRPCError(err)
 }
 
 func (conn *vtgateConn) Rollback(ctx context.Context, session interface{}) error {
@@ -379,10 +376,7 @@ func (conn *vtgateConn) Rollback(ctx context.Context, session interface{}) error
 		Session:  session.(*pb.Session),
 	}
 	_, err := conn.c.Rollback(ctx, request)
-	if err != nil {
-		return vterrors.FromGRPCError(err)
-	}
-	return nil
+	return vterrors.FromGRPCError(err)
 }
 
 func (conn *vtgateConn) Begin2(ctx context.Context) (interface{}, error) {

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -293,7 +293,6 @@ func (vtg *VTGate) Begin(ctx context.Context, request *pb.BeginRequest) (respons
 		callerid.NewImmediateCallerID("grpc client"))
 	outSession := new(proto.Session)
 	vtgErr := vtg.server.Begin(ctx, outSession)
-	// TODO(aaijazi): remove Error field from vtgateservice's non-Execute* methods
 	response = &pb.BeginResponse{}
 	if vtgErr == nil {
 		response.Session = proto.SessionToProto(outSession)


### PR DESCRIPTION
@alainjobart @dumbunny 

Some clean-up here. I think I'll use a similar structure for the VTGate clients, this was mostly testing my ideas out.

Before making the VTGate client changes, I'll be sure to add test cases to vtgateclientest.