### PR TITLE
java: Don't require VTROOT in base RpcClientTest.

### DIFF
--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -16,7 +16,6 @@ import com.youtube.vitess.proto.Vtrpc.CallerID;
 import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -33,18 +32,9 @@ import java.util.Map;
  */
 public abstract class RpcClientTest {
   protected static RpcClient client;
-  protected static String vtRoot;
 
   private Context ctx;
   private VTGateConn conn;
-
-  @BeforeClass
-  public static void setUpBeforeSubclass() {
-    vtRoot = System.getenv("VTROOT");
-    if (vtRoot == null) {
-      throw new RuntimeException("cannot find env variable VTROOT; make sure to source dev.env");
-    }
-  }
 
   @Before
   public void setUp() {

--- a/java/grpc-client/src/test/java/com/youtube/vitess/client/grpc/GrpcClientTest.java
+++ b/java/grpc-client/src/test/java/com/youtube/vitess/client/grpc/GrpcClientTest.java
@@ -20,6 +20,11 @@ public class GrpcClientTest extends RpcClientTest {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    String vtRoot = System.getenv("VTROOT");
+    if (vtRoot == null) {
+      throw new RuntimeException("cannot find env variable VTROOT; make sure to source dev.env");
+    }
+
     ServerSocket socket = new ServerSocket(0);
     port = socket.getLocalPort();
     socket.close();


### PR DESCRIPTION
@alainjobart 

Some subclasses may not need VTROOT, so we shouldn't require it to be
found successfully at the base class level.