### PR TITLE
tabletserver: fetch memcached path from vttest

### DIFF
--- a/go/vt/tabletserver/endtoend/main_test.go
+++ b/go/vt/tabletserver/endtoend/main_test.go
@@ -179,7 +179,7 @@ func TestMain(m *testing.M) {
 		}
 
 		tsConfig = tabletserver.DefaultQsConfig
-		tsConfig.RowCache.Binary = "memcached"
+		tsConfig.RowCache.Binary = vttest.MemcachedPath()
 		tsConfig.RowCache.Socket = path.Join(os.TempDir(), "memcache.sock")
 
 		mysqld := mysqlctl.NewMysqld(

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -21,6 +21,11 @@ func launcherPath() (string, error) {
 	return path.Join(vttop, "py/vttest/run_local_database.py"), nil
 }
 
+// MemcachedPath returns the path to the memcached binary.
+func MemcachedPath() string {
+	return "memcached"
+}
+
 func vtgateProtocol() string {
 	return "grpc"
 }


### PR DESCRIPTION
The path was previously hardcoded in a non-customizable file. It's
now moved to environment.go.