### PR TITLE
tabletserver endtoend tests WIP

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -38,6 +38,99 @@ func init() {
 }
 
 const (
+	// TypeDecimal specifies a DECIMAL type.
+	// Value is 0.
+	TypeDecimal = C.FIELD_TYPE_DECIMAL
+	// TypeTiny specifies a TINY type.
+	// Value is 1.
+	TypeTiny = C.FIELD_TYPE_TINY
+	// TypeShort specifies a SHORT type.
+	// Value is 2.
+	TypeShort = C.FIELD_TYPE_SHORT
+	// TypeLong specifies a LONG type.
+	// Value is 3.
+	TypeLong = C.FIELD_TYPE_LONG
+	// TypeFloat specifies a FLOAT type.
+	// Value is 4.
+	TypeFloat = C.FIELD_TYPE_FLOAT
+	// TypeDouble specifies a DOUBLE type.
+	// Value is 5.
+	TypeDouble = C.FIELD_TYPE_DOUBLE
+	// TypeNull specifies a NULL type.
+	// Value is 6.
+	TypeNull = C.FIELD_TYPE_NULL
+	// TypeTimestamp specifies a TIMESTAMP type.
+	// Value is 7.
+	TypeTimestamp = C.FIELD_TYPE_TIMESTAMP
+	// TypeLonglong specifies a LONGLONG type.
+	// Value is 8.
+	TypeLonglong = C.FIELD_TYPE_LONGLONG
+	// TypeInt24 specifies an INT24 type.
+	// Value is 9.
+	TypeInt24 = C.FIELD_TYPE_INT24
+	// TypeDate specifies a DATE type.
+	// Value is 10.
+	TypeDate = C.FIELD_TYPE_DATE
+	// TypeTime specifies a TIME type.
+	// Value is 11.
+	TypeTime = C.FIELD_TYPE_TIME
+	// TypeDatetime specifies a DATETIME type.
+	// Value is 12.
+	TypeDatetime = C.FIELD_TYPE_DATETIME
+	// TypeYear specifies a YEAR type.
+	// Value is 13.
+	TypeYear = C.FIELD_TYPE_YEAR
+	// TypeNewdate specifies a NEWDATE type.
+	// Value is 14.
+	TypeNewdate = C.FIELD_TYPE_NEWDATE
+	// TypeEnum specifies an ENUM type.
+	// Value is 247.
+	TypeEnum = C.FIELD_TYPE_ENUM
+	// TypeSet specifies a SET type.
+	// Value is 248.
+	TypeSet = C.FIELD_TYPE_SET
+	// TypeTinyBlob specifies a TINY BLOB type.
+	// Value is 249.
+	TypeTinyBlob = C.FIELD_TYPE_TINY_BLOB
+	// TypeMediumBlob specifies a MEDIUM BLOB type.
+	// Value is 250.
+	TypeMediumBlob = C.FIELD_TYPE_MEDIUM_BLOB
+	// TypeLongBlob specifies a LONG BLOB type.
+	// Value is 251.
+	TypeLongBlob = C.FIELD_TYPE_LONG_BLOB
+	// TypeBlob specifies a BLOB type.
+	// Value is 252.
+	TypeBlob = C.FIELD_TYPE_BLOB
+	// TypeVarString specifies a VARCHAR or VARBINARY type.
+	// Value is 253.
+	TypeVarString = C.FIELD_TYPE_VAR_STRING
+	// TypeString specifies a CHAR or BINARY type.
+	// Value is 254.
+	TypeString = C.FIELD_TYPE_STRING
+)
+
+const (
+	// FlagUnsigned specifies if the value is an unsigned.
+	// Value is 32 (0x20).
+	FlagUnsigned = C.UNSIGNED_FLAG
+	// FlagBinary specifies if the data is binary.
+	// Value is 128 (0x80).
+	FlagBinary = C.BINARY_FLAG
+	// FlagEnum specifies if the value is an enum.
+	// Value is 256 (0x100).
+	FlagEnum = C.ENUM_FLAG
+	// FlagSet specifies if the value is a set.
+	// Value is 2048 (0x800).
+	FlagSet = C.SET_FLAG
+
+	// RelevantFlags is used to mask out irrelevant flags.
+	RelevantFlags = FlagUnsigned |
+		FlagBinary |
+		FlagEnum |
+		FlagSet
+)
+
+const (
 	// ErrDupEntry is C.ER_DUP_ENTRY
 	ErrDupEntry = C.ER_DUP_ENTRY
 
@@ -206,7 +299,7 @@ func (conn *Connection) Fields() (fields []proto.Field) {
 		fname := (*[maxSize]byte)(unsafe.Pointer(cfields[i].name))[:length]
 		fields[i].Name = string(fname)
 		fields[i].Type = int64(cfields[i]._type)
-		fields[i].Flags = int64(cfields[i].flags)
+		fields[i].Flags = int64(cfields[i].flags) & RelevantFlags
 	}
 	return fields
 }

--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -38,9 +38,6 @@ func init() {
 }
 
 const (
-	// TypeDecimal specifies a DECIMAL or NUMERIC type.
-	// Value is 0.
-	TypeDecimal = C.FIELD_TYPE_DECIMAL
 	// TypeTiny specifies a TINYINT type.
 	// Value is 1.
 	TypeTiny = C.FIELD_TYPE_TINY
@@ -60,7 +57,7 @@ const (
 	// Value is 6.
 	TypeNull = C.FIELD_TYPE_NULL
 	// TypeTimestamp specifies a TIMESTAMP type.
-	// Value is 7.
+	// Value is 7. NOT SUPPORTED.
 	TypeTimestamp = C.FIELD_TYPE_TIMESTAMP
 	// TypeLonglong specifies a BIGINT type.
 	// Value is 8.
@@ -83,24 +80,9 @@ const (
 	// TypeBit specifies a BIT type.
 	// Value is 16.
 	TypeBit = C.MYSQL_TYPE_BIT
-	// TypeNewDecimal specifies a precision math DECIMAL or NUMERIC type.
+	// TypeNewDecimal specifies a DECIMAL or NUMERIC type.
 	// Value is 246.
 	TypeNewDecimal = C.MYSQL_TYPE_NEWDECIMAL
-	// TypeEnum specifies an ENUM type.
-	// Value is 247.
-	TypeEnum = C.FIELD_TYPE_ENUM
-	// TypeSet specifies a SET type.
-	// Value is 248.
-	TypeSet = C.FIELD_TYPE_SET
-	// TypeTinyBlob specifies a TINY BLOB type.
-	// Value is 249.
-	TypeTinyBlob = C.FIELD_TYPE_TINY_BLOB
-	// TypeMediumBlob specifies a MEDIUM BLOB type.
-	// Value is 250.
-	TypeMediumBlob = C.FIELD_TYPE_MEDIUM_BLOB
-	// TypeLongBlob specifies a LONG BLOB type.
-	// Value is 251.
-	TypeLongBlob = C.FIELD_TYPE_LONG_BLOB
 	// TypeBlob specifies a BLOB or TEXT type.
 	// Value is 252.
 	TypeBlob = C.FIELD_TYPE_BLOB
@@ -111,7 +93,7 @@ const (
 	// Value is 254.
 	TypeString = C.FIELD_TYPE_STRING
 	// TypeGeometry specifies a Spatial field.
-	// Value is 255.
+	// Value is 255. NOT SUPPORTED.
 	TypeGeometry = C.MYSQL_TYPE_GEOMETRY
 )
 

--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -38,22 +38,22 @@ func init() {
 }
 
 const (
-	// TypeDecimal specifies a DECIMAL type.
+	// TypeDecimal specifies a DECIMAL or NUMERIC type.
 	// Value is 0.
 	TypeDecimal = C.FIELD_TYPE_DECIMAL
-	// TypeTiny specifies a TINY type.
+	// TypeTiny specifies a TINYINT type.
 	// Value is 1.
 	TypeTiny = C.FIELD_TYPE_TINY
-	// TypeShort specifies a SHORT type.
+	// TypeShort specifies a SMALLINT type.
 	// Value is 2.
 	TypeShort = C.FIELD_TYPE_SHORT
-	// TypeLong specifies a LONG type.
+	// TypeLong specifies a INTEGER type.
 	// Value is 3.
 	TypeLong = C.FIELD_TYPE_LONG
 	// TypeFloat specifies a FLOAT type.
 	// Value is 4.
 	TypeFloat = C.FIELD_TYPE_FLOAT
-	// TypeDouble specifies a DOUBLE type.
+	// TypeDouble specifies a DOUBLE or REAL type.
 	// Value is 5.
 	TypeDouble = C.FIELD_TYPE_DOUBLE
 	// TypeNull specifies a NULL type.
@@ -62,10 +62,10 @@ const (
 	// TypeTimestamp specifies a TIMESTAMP type.
 	// Value is 7.
 	TypeTimestamp = C.FIELD_TYPE_TIMESTAMP
-	// TypeLonglong specifies a LONGLONG type.
+	// TypeLonglong specifies a BIGINT type.
 	// Value is 8.
 	TypeLonglong = C.FIELD_TYPE_LONGLONG
-	// TypeInt24 specifies an INT24 type.
+	// TypeInt24 specifies a MEDIUMINT type.
 	// Value is 9.
 	TypeInt24 = C.FIELD_TYPE_INT24
 	// TypeDate specifies a DATE type.
@@ -80,9 +80,12 @@ const (
 	// TypeYear specifies a YEAR type.
 	// Value is 13.
 	TypeYear = C.FIELD_TYPE_YEAR
-	// TypeNewdate specifies a NEWDATE type.
-	// Value is 14.
-	TypeNewdate = C.FIELD_TYPE_NEWDATE
+	// TypeBit specifies a BIT type.
+	// Value is 16.
+	TypeBit = C.MYSQL_TYPE_BIT
+	// TypeNewDecimal specifies a precision math DECIMAL or NUMERIC type.
+	// Value is 246.
+	TypeNewDecimal = C.MYSQL_TYPE_NEWDECIMAL
 	// TypeEnum specifies an ENUM type.
 	// Value is 247.
 	TypeEnum = C.FIELD_TYPE_ENUM
@@ -98,7 +101,7 @@ const (
 	// TypeLongBlob specifies a LONG BLOB type.
 	// Value is 251.
 	TypeLongBlob = C.FIELD_TYPE_LONG_BLOB
-	// TypeBlob specifies a BLOB type.
+	// TypeBlob specifies a BLOB or TEXT type.
 	// Value is 252.
 	TypeBlob = C.FIELD_TYPE_BLOB
 	// TypeVarString specifies a VARCHAR or VARBINARY type.
@@ -107,6 +110,9 @@ const (
 	// TypeString specifies a CHAR or BINARY type.
 	// Value is 254.
 	TypeString = C.FIELD_TYPE_STRING
+	// TypeGeometry specifies a Spatial field.
+	// Value is 255.
+	TypeGeometry = C.MYSQL_TYPE_GEOMETRY
 )
 
 const (

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCharaterSet(t *testing.T) {
-	qr, err := newQueryClient().Execute("select * from vtocc_test limit 2", nil)
+	qr, err := newClient(defaultServer).Execute("select * from vtocc_test where intval=1", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -39,19 +39,13 @@ func TestCharaterSet(t *testing.T) {
 				Flags: mysql.FlagBinary,
 			},
 		},
-		RowsAffected: 2,
+		RowsAffected: 1,
 		Rows: [][]sqltypes.Value{
 			[]sqltypes.Value{
 				sqltypes.Value{Inner: sqltypes.Numeric("1")},
 				sqltypes.Value{Inner: sqltypes.Fractional("1.12345")},
 				sqltypes.Value{Inner: sqltypes.String("\xc2\xa2")},
 				sqltypes.Value{Inner: sqltypes.String("\x00\xff")},
-			},
-			[]sqltypes.Value{
-				sqltypes.Value{Inner: sqltypes.Numeric("2")},
-				sqltypes.Value{},
-				sqltypes.Value{Inner: sqltypes.String("")},
-				sqltypes.Value{},
 			},
 		},
 	}
@@ -61,7 +55,7 @@ func TestCharaterSet(t *testing.T) {
 }
 
 func TestInts(t *testing.T) {
-	client := newQueryClient()
+	client := newClient(defaultServer)
 	_, err := client.Execute(
 		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+
 			":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
@@ -159,7 +153,7 @@ func TestInts(t *testing.T) {
 }
 
 func TestFractionals(t *testing.T) {
-	client := newQueryClient()
+	client := newClient(defaultServer)
 	_, err := client.Execute(
 		"insert into vtocc_fracts values(:id, :deci, :num, :f, :d)",
 		map[string]interface{}{
@@ -220,7 +214,7 @@ func TestFractionals(t *testing.T) {
 }
 
 func TestStrings(t *testing.T) {
-	client := newQueryClient()
+	client := newClient(defaultServer)
 	_, err := client.Execute(
 		"insert into vtocc_strings values "+
 			"(:vb, :c, :vc, :b, :tb, :bl, :ttx, :tx, :en, :s)",
@@ -312,7 +306,7 @@ func TestStrings(t *testing.T) {
 }
 
 func TestMiscTypes(t *testing.T) {
-	client := newQueryClient()
+	client := newClient(defaultServer)
 	_, err := client.Execute(
 		"insert into vtocc_misc values(:id, :b, :d, :dt, :t)",
 		map[string]interface{}{
@@ -373,7 +367,7 @@ func TestMiscTypes(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	client := newQueryClient()
+	client := newClient(defaultServer)
 	qr, err := client.Execute("select null from dual", nil)
 	if err != nil {
 		t.Error(err)

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/tabletserver/endtoend/framework"
 )
 
 func TestCharaterSet(t *testing.T) {
-	qr, err := newClient(defaultServer).Execute("select * from vtocc_test where intval=1", nil)
+	qr, err := framework.NewDefaultClient().Execute("select * from vtocc_test where intval=1", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -55,7 +56,7 @@ func TestCharaterSet(t *testing.T) {
 }
 
 func TestInts(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	defer client.Execute("delete from vtocc_ints", nil)
 
 	_, err := client.Execute(
@@ -155,7 +156,7 @@ func TestInts(t *testing.T) {
 }
 
 func TestFractionals(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	defer client.Execute("delete from vtocc_fracts", nil)
 
 	_, err := client.Execute(
@@ -218,7 +219,7 @@ func TestFractionals(t *testing.T) {
 }
 
 func TestStrings(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	defer client.Execute("delete from vtocc_strings", nil)
 
 	_, err := client.Execute(
@@ -312,7 +313,7 @@ func TestStrings(t *testing.T) {
 }
 
 func TestMiscTypes(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	defer client.Execute("delete from vtocc_misc", nil)
 
 	_, err := client.Execute(
@@ -375,7 +376,7 @@ func TestMiscTypes(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	qr, err := client.Execute("select null from dual", nil)
 	if err != nil {
 		t.Error(err)

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -63,7 +63,8 @@ func TestCharaterSet(t *testing.T) {
 func TestInts(t *testing.T) {
 	client := newQueryClient()
 	qr, err := client.Execute(
-		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
+		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+
+			":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
 		map[string]interface{}{
 			"tiny":    int32(-128),
 			"tinyu":   uint32(255),
@@ -149,6 +150,220 @@ func TestInts(t *testing.T) {
 				sqltypes.Value{Inner: sqltypes.Numeric("-9223372036854775808")},
 				sqltypes.Value{Inner: sqltypes.Numeric("18446744073709551615")},
 				sqltypes.Value{Inner: sqltypes.Numeric("2012")},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}
+
+func TestFractionals(t *testing.T) {
+	client := newQueryClient()
+	qr, err := client.Execute(
+		"insert into vtocc_fracts values(:id, :deci, :num, :f, :d)",
+		map[string]interface{}{
+			"id":   1,
+			"deci": "1.99",
+			"num":  "2.99",
+			"f":    3.99,
+			"d":    4.99,
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err = client.Execute("select * from vtocc_fracts where id = 1", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "id",
+				Type:  mysql.TypeLong,
+				Flags: 0,
+			}, {
+				Name:  "deci",
+				Type:  mysql.TypeNewDecimal,
+				Flags: 0,
+			}, {
+				Name:  "num",
+				Type:  mysql.TypeNewDecimal,
+				Flags: 0,
+			}, {
+				Name:  "f",
+				Type:  mysql.TypeFloat,
+				Flags: 0,
+			}, {
+				Name:  "d",
+				Type:  mysql.TypeDouble,
+				Flags: 0,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.Numeric("1")},
+				sqltypes.Value{Inner: sqltypes.Fractional("1.99")},
+				sqltypes.Value{Inner: sqltypes.Fractional("2.99")},
+				sqltypes.Value{Inner: sqltypes.Fractional("3.99")},
+				sqltypes.Value{Inner: sqltypes.Fractional("4.99")},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}
+
+func TestStrings(t *testing.T) {
+	client := newQueryClient()
+	qr, err := client.Execute(
+		"insert into vtocc_strings values "+
+			"(:vb, :c, :vc, :b, :tb, :bl, :ttx, :tx, :en, :s)",
+		map[string]interface{}{
+			"vb":  "a",
+			"c":   "b",
+			"vc":  "c",
+			"b":   "d",
+			"tb":  "e",
+			"bl":  "f",
+			"ttx": "g",
+			"tx":  "h",
+			"en":  "a",
+			"s":   "a,b",
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err = client.Execute("select * from vtocc_strings where vb = 'a'", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "vb",
+				Type:  mysql.TypeVarString,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "c",
+				Type:  mysql.TypeString,
+				Flags: 0,
+			}, {
+				Name:  "vc",
+				Type:  mysql.TypeVarString,
+				Flags: 0,
+			}, {
+				Name:  "b",
+				Type:  mysql.TypeString,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "tb",
+				Type:  mysql.TypeBlob,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "bl",
+				Type:  mysql.TypeBlob,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "ttx",
+				Type:  mysql.TypeBlob,
+				Flags: 0,
+			}, {
+				Name:  "tx",
+				Type:  mysql.TypeBlob,
+				Flags: 0,
+			}, {
+				Name:  "en",
+				Type:  mysql.TypeString,
+				Flags: mysql.FlagEnum,
+			}, {
+				Name:  "s",
+				Type:  mysql.TypeString,
+				Flags: mysql.FlagSet,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.String("a")},
+				sqltypes.Value{Inner: sqltypes.String("b")},
+				sqltypes.Value{Inner: sqltypes.String("c")},
+				sqltypes.Value{Inner: sqltypes.String("d\x00\x00\x00")},
+				sqltypes.Value{Inner: sqltypes.String("e")},
+				sqltypes.Value{Inner: sqltypes.String("f")},
+				sqltypes.Value{Inner: sqltypes.String("g")},
+				sqltypes.Value{Inner: sqltypes.String("h")},
+				sqltypes.Value{Inner: sqltypes.String("a")},
+				sqltypes.Value{Inner: sqltypes.String("a,b")},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}
+
+func TestMiscTypes(t *testing.T) {
+	client := newQueryClient()
+	qr, err := client.Execute(
+		"insert into vtocc_misc values(:id, :b, :d, :dt, :t)",
+		map[string]interface{}{
+			"id": 1,
+			"b":  "\x01",
+			"d":  "2012-01-01",
+			"dt": "2012-01-01 15:45:45",
+			"t":  "15:45:45",
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err = client.Execute("select * from vtocc_misc where id = 1", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "id",
+				Type:  mysql.TypeLong,
+				Flags: 0,
+			}, {
+				Name:  "b",
+				Type:  mysql.TypeBit,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "d",
+				Type:  mysql.TypeDate,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "dt",
+				Type:  mysql.TypeDatetime,
+				Flags: mysql.FlagBinary,
+			}, {
+				Name:  "t",
+				Type:  mysql.TypeTime,
+				Flags: mysql.FlagBinary,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.Numeric("1")},
+				sqltypes.Value{Inner: sqltypes.String("\x01")},
+				sqltypes.Value{Inner: sqltypes.String("2012-01-01")},
+				sqltypes.Value{Inner: sqltypes.String("2012-01-01 15:45:45")},
+				sqltypes.Value{Inner: sqltypes.String("15:45:45")},
 			},
 		},
 	}

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -56,6 +56,8 @@ func TestCharaterSet(t *testing.T) {
 
 func TestInts(t *testing.T) {
 	client := newClient(defaultServer)
+	defer client.Execute("delete from vtocc_ints", nil)
+
 	_, err := client.Execute(
 		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+
 			":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
@@ -154,6 +156,8 @@ func TestInts(t *testing.T) {
 
 func TestFractionals(t *testing.T) {
 	client := newClient(defaultServer)
+	defer client.Execute("delete from vtocc_fracts", nil)
+
 	_, err := client.Execute(
 		"insert into vtocc_fracts values(:id, :deci, :num, :f, :d)",
 		map[string]interface{}{
@@ -215,6 +219,8 @@ func TestFractionals(t *testing.T) {
 
 func TestStrings(t *testing.T) {
 	client := newClient(defaultServer)
+	defer client.Execute("delete from vtocc_strings", nil)
+
 	_, err := client.Execute(
 		"insert into vtocc_strings values "+
 			"(:vb, :c, :vc, :b, :tb, :bl, :ttx, :tx, :en, :s)",
@@ -307,6 +313,8 @@ func TestStrings(t *testing.T) {
 
 func TestMiscTypes(t *testing.T) {
 	client := newClient(defaultServer)
+	defer client.Execute("delete from vtocc_misc", nil)
+
 	_, err := client.Execute(
 		"insert into vtocc_misc values(:id, :b, :d, :dt, :t)",
 		map[string]interface{}{

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -1,0 +1,158 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package endtoend
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/mysql"
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestCharaterSet(t *testing.T) {
+	qr, err := newQueryClient().Execute("select * from vtocc_test limit 2", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "intval",
+				Type:  3,
+				Flags: 0,
+			}, {
+				Name:  "floatval",
+				Type:  4,
+				Flags: 0,
+			}, {
+				Name:  "charval",
+				Type:  253,
+				Flags: 0,
+			}, {
+				Name:  "binval",
+				Type:  253,
+				Flags: mysql.FlagBinary,
+			},
+		},
+		RowsAffected: 2,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.Numeric("1")},
+				sqltypes.Value{Inner: sqltypes.Fractional("1.12345")},
+				sqltypes.Value{Inner: sqltypes.String("\xc2\xa2")},
+				sqltypes.Value{Inner: sqltypes.String("\x00\xff")},
+			},
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.Numeric("2")},
+				sqltypes.Value{},
+				sqltypes.Value{Inner: sqltypes.String("")},
+				sqltypes.Value{},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}
+
+func TestInts(t *testing.T) {
+	client := newQueryClient()
+	qr, err := client.Execute(
+		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
+		map[string]interface{}{
+			"tiny":    int32(-128),
+			"tinyu":   uint32(255),
+			"small":   int32(-32768),
+			"smallu":  uint32(65535),
+			"medium":  int32(-8388608),
+			"mediumu": uint32(16777215),
+			"normal":  int64(-2147483648),
+			"normalu": uint64(4294967295),
+			"big":     int64(-9223372036854775808),
+			"bigu":    uint64(18446744073709551615),
+			"year":    2012,
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err = client.Execute("select * from vtocc_ints where tiny = -128", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "tiny",
+				Type:  mysql.TypeTiny,
+				Flags: 0,
+			}, {
+				Name:  "tinyu",
+				Type:  mysql.TypeTiny,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "small",
+				Type:  mysql.TypeShort,
+				Flags: 0,
+			}, {
+				Name:  "smallu",
+				Type:  mysql.TypeShort,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "medium",
+				Type:  mysql.TypeInt24,
+				Flags: 0,
+			}, {
+				Name:  "mediumu",
+				Type:  mysql.TypeInt24,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "normal",
+				Type:  mysql.TypeLong,
+				Flags: 0,
+			}, {
+				Name:  "normalu",
+				Type:  mysql.TypeLong,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "big",
+				Type:  mysql.TypeLonglong,
+				Flags: 0,
+			}, {
+				Name:  "bigu",
+				Type:  mysql.TypeLonglong,
+				Flags: mysql.FlagUnsigned,
+			}, {
+				Name:  "y",
+				Type:  mysql.TypeYear,
+				Flags: mysql.FlagUnsigned,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.Numeric("-128")},
+				sqltypes.Value{Inner: sqltypes.Numeric("255")},
+				sqltypes.Value{Inner: sqltypes.Numeric("-32768")},
+				sqltypes.Value{Inner: sqltypes.Numeric("65535")},
+				sqltypes.Value{Inner: sqltypes.Numeric("-8388608")},
+				sqltypes.Value{Inner: sqltypes.Numeric("16777215")},
+				sqltypes.Value{Inner: sqltypes.Numeric("-2147483648")},
+				sqltypes.Value{Inner: sqltypes.Numeric("4294967295")},
+				sqltypes.Value{Inner: sqltypes.Numeric("-9223372036854775808")},
+				sqltypes.Value{Inner: sqltypes.Numeric("18446744073709551615")},
+				sqltypes.Value{Inner: sqltypes.Numeric("2012")},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -62,7 +62,7 @@ func TestCharaterSet(t *testing.T) {
 
 func TestInts(t *testing.T) {
 	client := newQueryClient()
-	qr, err := client.Execute(
+	_, err := client.Execute(
 		"insert into vtocc_ints values(:tiny, :tinyu, :small, "+
 			":smallu, :medium, :mediumu, :normal, :normalu, :big, :bigu, :year)",
 		map[string]interface{}{
@@ -83,7 +83,7 @@ func TestInts(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	qr, err = client.Execute("select * from vtocc_ints where tiny = -128", nil)
+	qr, err := client.Execute("select * from vtocc_ints where tiny = -128", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -160,7 +160,7 @@ func TestInts(t *testing.T) {
 
 func TestFractionals(t *testing.T) {
 	client := newQueryClient()
-	qr, err := client.Execute(
+	_, err := client.Execute(
 		"insert into vtocc_fracts values(:id, :deci, :num, :f, :d)",
 		map[string]interface{}{
 			"id":   1,
@@ -174,7 +174,7 @@ func TestFractionals(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	qr, err = client.Execute("select * from vtocc_fracts where id = 1", nil)
+	qr, err := client.Execute("select * from vtocc_fracts where id = 1", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -221,7 +221,7 @@ func TestFractionals(t *testing.T) {
 
 func TestStrings(t *testing.T) {
 	client := newQueryClient()
-	qr, err := client.Execute(
+	_, err := client.Execute(
 		"insert into vtocc_strings values "+
 			"(:vb, :c, :vc, :b, :tb, :bl, :ttx, :tx, :en, :s)",
 		map[string]interface{}{
@@ -241,7 +241,7 @@ func TestStrings(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	qr, err = client.Execute("select * from vtocc_strings where vb = 'a'", nil)
+	qr, err := client.Execute("select * from vtocc_strings where vb = 'a'", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -313,7 +313,7 @@ func TestStrings(t *testing.T) {
 
 func TestMiscTypes(t *testing.T) {
 	client := newQueryClient()
-	qr, err := client.Execute(
+	_, err := client.Execute(
 		"insert into vtocc_misc values(:id, :b, :d, :dt, :t)",
 		map[string]interface{}{
 			"id": 1,
@@ -327,7 +327,7 @@ func TestMiscTypes(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	qr, err = client.Execute("select * from vtocc_misc where id = 1", nil)
+	qr, err := client.Execute("select * from vtocc_misc where id = 1", nil)
 	if err != nil {
 		t.Error(err)
 		return
@@ -364,6 +364,33 @@ func TestMiscTypes(t *testing.T) {
 				sqltypes.Value{Inner: sqltypes.String("2012-01-01")},
 				sqltypes.Value{Inner: sqltypes.String("2012-01-01 15:45:45")},
 				sqltypes.Value{Inner: sqltypes.String("15:45:45")},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}
+
+func TestNull(t *testing.T) {
+	client := newQueryClient()
+	qr, err := client.Execute("select null from dual", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "NULL",
+				Type:  mysql.TypeNull,
+				Flags: mysql.FlagBinary,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{},
 			},
 		},
 	}

--- a/go/vt/tabletserver/endtoend/framework/client.go
+++ b/go/vt/tabletserver/endtoend/framework/client.go
@@ -1,0 +1,82 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package framework
+
+import (
+	"errors"
+
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/vt/proto/query"
+	"github.com/youtube/vitess/go/vt/tabletserver"
+	"github.com/youtube/vitess/go/vt/tabletserver/proto"
+	"golang.org/x/net/context"
+)
+
+// QueryClient provides a convenient wrapper for TabletServer's query service.
+// It's not thread safe, but you can create multiple clients that point to the
+// same server.
+type QueryClient struct {
+	target        query.Target
+	server        *tabletserver.TabletServer
+	transactionID int64
+}
+
+// NewDefaultClient creates a new client for the default server.
+func NewDefaultClient() *QueryClient {
+	return &QueryClient{
+		target: Target,
+		server: DefaultServer,
+	}
+}
+
+// NewClient creates a new client for the specified server.
+func NewClient(server *tabletserver.TabletServer) *QueryClient {
+	return &QueryClient{
+		target: Target,
+		server: server,
+	}
+}
+
+// Begin begins a transaction.
+func (client *QueryClient) Begin() error {
+	if client.transactionID != 0 {
+		return errors.New("already in transaction")
+	}
+	var txinfo proto.TransactionInfo
+	err := client.server.Begin(context.Background(), &client.target, nil, &txinfo)
+	if err != nil {
+		return err
+	}
+	client.transactionID = txinfo.TransactionId
+	return nil
+}
+
+// Commit commits the current transaction.
+func (client *QueryClient) Commit() error {
+	defer func() { client.transactionID = 0 }()
+	return client.server.Commit(context.Background(), &client.target, nil)
+}
+
+// Rollback rolls back the current transaction.
+func (client *QueryClient) Rollback() error {
+	defer func() { client.transactionID = 0 }()
+	return client.server.Rollback(context.Background(), &client.target, nil)
+}
+
+// Execute executes a query.
+func (client *QueryClient) Execute(query string, bindvars map[string]interface{}) (*mproto.QueryResult, error) {
+	var qr = &mproto.QueryResult{}
+	err := client.server.Execute(
+		context.Background(),
+		&client.target,
+		&proto.Query{
+			Sql:           query,
+			BindVariables: bindvars,
+			TransactionId: client.transactionID,
+		},
+		qr,
+	)
+	return qr, err
+}

--- a/go/vt/tabletserver/endtoend/framework/debugvars.go
+++ b/go/vt/tabletserver/endtoend/framework/debugvars.go
@@ -1,0 +1,53 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package framework
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// DebugVars parses /debug/vars and returns a map. The function returns
+// an empty map on error.
+func DebugVars() map[string]interface{} {
+	out := map[string]interface{}{}
+	response, err := http.Get(fmt.Sprintf("%s/debug/vars", ServerAddress))
+	if err != nil {
+		return out
+	}
+	defer response.Body.Close()
+	_ = json.NewDecoder(response.Body).Decode(&out)
+	return out
+}
+
+// FetchInt fetches the specified dot-separated tag and returns the
+// value as an int. It returns 0 on error, or if not found.
+func FetchInt(vars map[string]interface{}, tags string) int {
+	val, _ := FetchVal(vars, tags).(float64)
+	return int(val)
+}
+
+// FetchVal fetches the specified dot-separated tag and returns the
+// value as an interface. It returns nil on error, or if not found.
+func FetchVal(vars map[string]interface{}, tags string) interface{} {
+	splitTags := strings.Split(tags, ".")
+	if len(tags) == 0 {
+		return nil
+	}
+	current := vars
+	for _, tag := range splitTags[:len(splitTags)-1] {
+		icur, ok := current[tag]
+		if !ok {
+			return nil
+		}
+		current, ok = icur.(map[string]interface{})
+		if !ok {
+			return nil
+		}
+	}
+	return current[splitTags[len(splitTags)-1]]
+}

--- a/go/vt/tabletserver/endtoend/framework/server.go
+++ b/go/vt/tabletserver/endtoend/framework/server.go
@@ -1,0 +1,131 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package framework
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/mysqlctl"
+	"github.com/youtube/vitess/go/vt/proto/query"
+	"github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/tabletserver"
+	"github.com/youtube/vitess/go/vt/vttest"
+)
+
+var (
+	// BaseConfig is the base config of the default server.
+	BaseConfig tabletserver.Config
+	// Target is the target info for the default server.
+	Target query.Target
+	// DefaultServer is the default server.
+	DefaultServer *tabletserver.TabletServer
+	// ServerAddress is the http URL for the default server.
+	ServerAddress string
+)
+
+// StartDefaultServer starts the default server and initializes
+// all the global variables. This function should only be called
+// once at the beginning of the test.
+func StartDefaultServer(connParams sqldb.ConnParams) error {
+	dbcfgs := dbconfigs.DBConfigs{
+		App: dbconfigs.DBConfig{
+			ConnParams:        connParams,
+			Keyspace:          "vttest",
+			Shard:             "0",
+			EnableRowcache:    true,
+			EnableInvalidator: false,
+		},
+	}
+
+	mysqld := mysqlctl.NewMysqld(
+		"Dba",
+		"App",
+		&mysqlctl.Mycnf{},
+		&dbcfgs.Dba,
+		&dbcfgs.App.ConnParams,
+		&dbcfgs.Repl)
+
+	BaseConfig = tabletserver.DefaultQsConfig
+	BaseConfig.RowCache.Binary = vttest.MemcachedPath()
+	BaseConfig.RowCache.Socket = path.Join(os.TempDir(), "memcache.sock")
+	BaseConfig.EnableAutoCommit = true
+
+	Target = query.Target{
+		Keyspace:   "vttest",
+		Shard:      "0",
+		TabletType: topodata.TabletType_MASTER,
+	}
+
+	DefaultServer = tabletserver.NewTabletServer(BaseConfig)
+	DefaultServer.Register()
+	err := DefaultServer.StartService(&Target, &dbcfgs, nil, mysqld)
+	if err != nil {
+		return fmt.Errorf("could not start service: %v\n", err)
+	}
+
+	// Start http service.
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return fmt.Errorf("could not start listener: %v\n", err)
+	}
+	ServerAddress = fmt.Sprintf("http://%s", ln.Addr().String())
+	go http.Serve(ln, nil)
+	for {
+		time.Sleep(10 * time.Millisecond)
+		response, err := http.Get(fmt.Sprintf("%s/debug/vars", ServerAddress))
+		if err == nil {
+			response.Body.Close()
+			break
+		}
+	}
+	return nil
+}
+
+// StopDefaultServer must be called once all the tests are done.
+func StopDefaultServer() {
+	DefaultServer.StopService()
+}
+
+// NewServer starts a new unregistered TabletServer.
+// You have to end it with StopService once testing is done.
+func NewServer(config tabletserver.Config, connParams sqldb.ConnParams, enableRowcache bool) (*tabletserver.TabletServer, error) {
+	dbcfgs := dbconfigs.DBConfigs{
+		App: dbconfigs.DBConfig{
+			ConnParams:        connParams,
+			Keyspace:          "vttest",
+			Shard:             "0",
+			EnableRowcache:    enableRowcache,
+			EnableInvalidator: false,
+		},
+	}
+
+	mysqld := mysqlctl.NewMysqld(
+		"Dba",
+		"App",
+		&mysqlctl.Mycnf{},
+		&dbcfgs.Dba,
+		&dbcfgs.App.ConnParams,
+		&dbcfgs.Repl)
+
+	Target = query.Target{
+		Keyspace:   "vttest",
+		Shard:      "0",
+		TabletType: topodata.TabletType_MASTER,
+	}
+
+	server := tabletserver.NewTabletServer(config)
+	err := server.StartService(&Target, &dbcfgs, nil, mysqld)
+	if err != nil {
+		return nil, err
+	}
+	return server, nil
+}

--- a/go/vt/tabletserver/endtoend/main_test.go
+++ b/go/vt/tabletserver/endtoend/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	tabletserver.Init()
 
 	exitCode := func() int {
-		hdl, err := vttest.LauncMySQL("vttest", schema, testing.Verbose())
+		hdl, err := vttest.LaunchMySQL("vttest", schema, testing.Verbose())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not launch mysql: %v\n", err)
 			return 1

--- a/go/vt/tabletserver/endtoend/nocache_test.go
+++ b/go/vt/tabletserver/endtoend/nocache_test.go
@@ -1,0 +1,92 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package endtoend
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/mysql"
+	mproto "github.com/youtube/vitess/go/mysql/proto"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestSimpleRead(t *testing.T) {
+	vstart := debugVars()
+	_, err := newClient(defaultServer).Execute("select * from vtocc_test where intval=1", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	vend := debugVars()
+	v1 := fetchInt(vstart, "Queries.TotalCount")
+	v2 := fetchInt(vend, "Queries.TotalCount")
+	if v1+1 != v2 {
+		t.Errorf("Queries.TotalCount: %d, want %d", v1+1, v2)
+	}
+	v1 = fetchInt(vstart, "Queries.Histograms.PASS_SELECT.Count")
+	v2 = fetchInt(vend, "Queries.Histograms.PASS_SELECT.Count")
+	if v1+1 != v2 {
+		t.Errorf("Queries...Count: %d, want %d", v1+1, v2)
+	}
+}
+
+func TestBinary(t *testing.T) {
+	client := newClient(defaultServer)
+	defer client.Execute("delete from vtocc_test where intval in (4,5)", nil)
+
+	binaryData := "\x00'\"\b\n\r\t\x1a\\\x00\x0f\xf0\xff"
+	// Test without bindvars.
+	_, err := client.Execute(
+		"insert into vtocc_test values "+
+			"(4, null, null, '\\0\\'\\\"\\b\\n\\r\\t\\Z\\\\\x00\x0f\xf0\xff')",
+		nil,
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err := client.Execute("select binval from vtocc_test where intval=4", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want := mproto.QueryResult{
+		Fields: []mproto.Field{
+			{
+				Name:  "binval",
+				Type:  mysql.TypeVarString,
+				Flags: mysql.FlagBinary,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			[]sqltypes.Value{
+				sqltypes.Value{Inner: sqltypes.String(binaryData)},
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+
+	// Test with bindvars.
+	_, err = client.Execute(
+		"insert into vtocc_test values(5, null, null, :bindata)",
+		map[string]interface{}{"bindata": binaryData},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	qr, err = client.Execute("select binval from vtocc_test where intval=5", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
+}

--- a/go/vt/tabletserver/endtoend/nocache_test.go
+++ b/go/vt/tabletserver/endtoend/nocache_test.go
@@ -11,30 +11,31 @@ import (
 	"github.com/youtube/vitess/go/mysql"
 	mproto "github.com/youtube/vitess/go/mysql/proto"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/tabletserver/endtoend/framework"
 )
 
 func TestSimpleRead(t *testing.T) {
-	vstart := debugVars()
-	_, err := newClient(defaultServer).Execute("select * from vtocc_test where intval=1", nil)
+	vstart := framework.DebugVars()
+	_, err := framework.NewDefaultClient().Execute("select * from vtocc_test where intval=1", nil)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	vend := debugVars()
-	v1 := fetchInt(vstart, "Queries.TotalCount")
-	v2 := fetchInt(vend, "Queries.TotalCount")
+	vend := framework.DebugVars()
+	v1 := framework.FetchInt(vstart, "Queries.TotalCount")
+	v2 := framework.FetchInt(vend, "Queries.TotalCount")
 	if v1+1 != v2 {
 		t.Errorf("Queries.TotalCount: %d, want %d", v1+1, v2)
 	}
-	v1 = fetchInt(vstart, "Queries.Histograms.PASS_SELECT.Count")
-	v2 = fetchInt(vend, "Queries.Histograms.PASS_SELECT.Count")
+	v1 = framework.FetchInt(vstart, "Queries.Histograms.PASS_SELECT.Count")
+	v2 = framework.FetchInt(vend, "Queries.Histograms.PASS_SELECT.Count")
 	if v1+1 != v2 {
 		t.Errorf("Queries...Count: %d, want %d", v1+1, v2)
 	}
 }
 
 func TestBinary(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	defer client.Execute("delete from vtocc_test where intval in (4,5)", nil)
 
 	binaryData := "\x00'\"\b\n\r\t\x1a\\\x00\x0f\xf0\xff"
@@ -92,7 +93,7 @@ func TestBinary(t *testing.T) {
 }
 
 func TestNocacheListArgs(t *testing.T) {
-	client := newClient(defaultServer)
+	client := framework.NewDefaultClient()
 	query := "select * from vtocc_test where intval in ::list"
 
 	qr, err := client.Execute(

--- a/go/vt/tabletserver/endtoend/nocache_test.go
+++ b/go/vt/tabletserver/endtoend/nocache_test.go
@@ -90,3 +90,63 @@ func TestBinary(t *testing.T) {
 		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
 	}
 }
+
+func TestNocacheListArgs(t *testing.T) {
+	client := newClient(defaultServer)
+	query := "select * from vtocc_test where intval in ::list"
+
+	qr, err := client.Execute(
+		query,
+		map[string]interface{}{
+			"list": []interface{}{2, 3, 4},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if qr.RowsAffected != 2 {
+		t.Errorf("rows affected: %d, want 2", qr.RowsAffected)
+	}
+
+	qr, err = client.Execute(
+		query,
+		map[string]interface{}{
+			"list": []interface{}{3, 4},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if qr.RowsAffected != 1 {
+		t.Errorf("rows affected: %d, want 1", qr.RowsAffected)
+	}
+
+	qr, err = client.Execute(
+		query,
+		map[string]interface{}{
+			"list": []interface{}{3},
+		},
+	)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if qr.RowsAffected != 1 {
+		t.Errorf("rows affected: %d, want 1", qr.RowsAffected)
+	}
+
+	// Error case
+	_, err = client.Execute(
+		query,
+		map[string]interface{}{
+			"list": []interface{}{},
+		},
+	)
+	want := "error: empty list supplied for list"
+	if err == nil || err.Error() != want {
+		t.Errorf("error returned: %v, want %s", err, want)
+		return
+	}
+}

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -43,9 +43,9 @@ func LaunchVitess(topo, schemaDir string, verbose bool) (hdl *Handle, err error)
 	return hdl, nil
 }
 
-// LauncMySQL launches just a MySQL instance with the specified db name. The schema
+// LaunchMySQL launches just a MySQL instance with the specified db name. The schema
 // is specified as a string instead of a file.
-func LauncMySQL(dbName, schema string, verbose bool) (hdl *Handle, err error) {
+func LaunchMySQL(dbName, schema string, verbose bool) (hdl *Handle, err error) {
 	hdl = &Handle{
 		dbname: dbName,
 	}

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -57,7 +57,7 @@ func TestVitess(t *testing.T) {
 }
 
 func TestMySQL(t *testing.T) {
-	hdl, err := LauncMySQL("vttest", "create table a(id int, name varchar(128), primary key(id))", false)
+	hdl, err := LaunchMySQL("vttest", "create table a(id int, name varchar(128), primary key(id))", false)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Making progress on endtoend tests while also building the necessary support framework.
Client developers: @enisoc, @dumbunny, @erzel, @yaoshengzhe can look at the mysql.go changes. I've now made official the list of types and flags we're supporting. I'm actually masking off irrelevant flags so that the behavior is more deterministic. I've added an explicit NOT SUPPORTED comment to unsupported types. The mysql API also has a bunch of deprecated types, which I've not listed.
The clients will eventually have to support the rest of the types and also interpret the flags correctly.