### PR TITLE
healthcheck: Always update lastHealthMapCount.

### DIFF
--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -172,6 +172,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType pbt.TabletType) {
 			health[topo.ReplicationLag] = topo.ReplicationLagHigh
 		}
 	}
+	agent.lastHealthMapCount.Set(int64(len(health)))
 
 	// Figure out if we should be running QueryService, see if we are,
 	// and reconcile.
@@ -307,7 +308,6 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType pbt.TabletType) {
 
 		// we need to update our state
 		log.Infof("Updating tablet record as healthy type %v -> %v with health details %v -> %v", tablet.Type, newTabletType, tablet.HealthMap, health)
-		agent.lastHealthMapCount.Set(int64(len(health)))
 	}
 
 	// Change the Type, update the health. Note we pass in a map


### PR DESCRIPTION
@alainjobart 

If a topo update failed at the right time, it was possible to enter a
situation where lastHealthMapCount is wrong, and it never gets updated
because of short-circuit return statements.

The lastHealthMapCount stats var is intended to be a ground truth
indicator of whether the tablet is degraded. It should be updated every
time the health map is computed, regardless of anything else.

Note that previously the value of this var would be unpredictable on an
unhealthy tablet - it could be 0 or 1 depending on the state just before
going unhealthy. With this change, the var will always be 0 on an
unhealthy tablet. This is consistent with the definition: an unhealthy
tablet is NOT degraded, so lastHealthMapCount=0.