### PR TITLE
healthcheck: Re-read tablet after going SPARE when shutting down.

### DIFF
--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -353,6 +353,12 @@ func (agent *ActionAgent) terminateHealthChecks(targetTabletType pbt.TabletType)
 		log.Infof("Error updating tablet record: %v", err)
 		return
 	}
+	// The change above succeeded, so update our local copy.
+	tablet, err := agent.readTablet(agent.batchCtx)
+	if err != nil {
+		log.Infof("Error re-reading tablet record: %v", err)
+		return
+	}
 
 	// Update the serving graph in our cell, only if we're dealing with
 	// a serving type

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -488,6 +488,9 @@ class TestTabletManager(unittest.TestCase):
         ti['type'], tablet.Tablet.tablet_type_value['SPARE'],
         "tablet didn't go to spare while in lameduck mode: %s" % str(ti))
 
+    # Also the replica should be gone from the serving graph.
+    utils.run_vtctl(['GetEndPoints', 'test_nj', 'test_keyspace/0', 'replica'], expect_fail=True)
+
   def test_health_check_worker_state_does_not_shutdown_query_service(self):
     # This test is similar to test_health_check, but has the following
     # differences:


### PR DESCRIPTION
@alainjobart 

We were using ChangeType to go SPARE, but we were then using the
outdated tablet record to do a point update in the serving graph.