### PR TITLE
vtcombo fix: errors were not handled properly. To fix this, on the fake

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -176,7 +176,7 @@ func (itc *internalTabletConn) Execute(ctx context.Context, query string, bindVa
 		BindVariables: bindVars,
 		TransactionId: transactionID,
 	}, reply); err != nil {
-		return nil, err
+		return nil, tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
 	}
 	return reply, nil
 }
@@ -193,7 +193,7 @@ func (itc *internalTabletConn) ExecuteBatch(ctx context.Context, queries []tprot
 		AsTransaction: asTransaction,
 		TransactionId: transactionID,
 	}, reply); err != nil {
-		return nil, err
+		return nil, tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
 	}
 	return reply, nil
 }
@@ -223,7 +223,7 @@ func (itc *internalTabletConn) StreamExecute(ctx context.Context, query string, 
 	}()
 
 	return result, func() error {
-		return finalErr
+		return tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(finalErr))
 	}, nil
 }
 
@@ -235,31 +235,37 @@ func (itc *internalTabletConn) Begin(ctx context.Context) (transactionID int64, 
 		Shard:      itc.tablet.shard,
 		TabletType: itc.tablet.tabletType,
 	}, &tproto.Session{}, result); err != nil {
-		return 0, err
+		return 0, tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
 	}
 	return result.TransactionId, nil
 }
 
 // Commit is part of tabletconn.TabletConn
 func (itc *internalTabletConn) Commit(ctx context.Context, transactionID int64) error {
-	return itc.tablet.qsc.QueryService().Commit(ctx, &pbq.Target{
+	if err := itc.tablet.qsc.QueryService().Commit(ctx, &pbq.Target{
 		Keyspace:   itc.tablet.keyspace,
 		Shard:      itc.tablet.shard,
 		TabletType: itc.tablet.tabletType,
 	}, &tproto.Session{
 		TransactionId: transactionID,
-	})
+	}); err != nil {
+		return tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
+	}
+	return nil
 }
 
 // Rollback is part of tabletconn.TabletConn
 func (itc *internalTabletConn) Rollback(ctx context.Context, transactionID int64) error {
-	return itc.tablet.qsc.QueryService().Rollback(ctx, &pbq.Target{
+	if err := itc.tablet.qsc.QueryService().Rollback(ctx, &pbq.Target{
 		Keyspace:   itc.tablet.keyspace,
 		Shard:      itc.tablet.shard,
 		TabletType: itc.tablet.tabletType,
 	}, &tproto.Session{
 		TransactionId: transactionID,
-	})
+	}); err != nil {
+		return tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
+	}
+	return nil
 }
 
 // Execute2 is part of tabletconn.TabletConn
@@ -318,7 +324,7 @@ func (itc *internalTabletConn) SplitQuery(ctx context.Context, query tproto.Boun
 		SplitColumn: splitColumn,
 		SplitCount:  splitCount,
 	}, reply); err != nil {
-		return nil, err
+		return nil, tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
 	}
 	return reply.Queries, nil
 }
@@ -343,6 +349,6 @@ func (itc *internalTabletConn) StreamHealth(ctx context.Context) (<-chan *pbq.St
 	}()
 
 	return result, func() error {
-		return finalErr
+		return tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(finalErr))
 	}, nil
 }

--- a/go/vt/tabletserver/tabletconn/grpc_error.go
+++ b/go/vt/tabletserver/tabletconn/grpc_error.go
@@ -1,0 +1,41 @@
+package tabletconn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/youtube/vitess/go/vt/vterrors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// TabletErrorFromGRPC returns a ServerError or a
+// OperationalError from the gRPC error.
+func TabletErrorFromGRPC(err error) error {
+	// TODO(aaijazi): Unfortunately, there's no better way to check for a gRPC server
+	// error (vs a client error).
+	// See: https://github.com/grpc/grpc-go/issues/319
+	if !strings.Contains(err.Error(), vterrors.GRPCServerErrPrefix) {
+		return OperationalError(fmt.Sprintf("vttablet: %v", err))
+	}
+	// server side error, convert it
+	var code int
+	switch grpc.Code(err) {
+	case codes.Internal:
+		code = ERR_FATAL
+	case codes.FailedPrecondition:
+		code = ERR_RETRY
+	case codes.ResourceExhausted:
+		code = ERR_TX_POOL_FULL
+	case codes.Aborted:
+		code = ERR_NOT_IN_TX
+	default:
+		code = ERR_NORMAL
+	}
+
+	return &ServerError{
+		Code:       code,
+		Err:        fmt.Sprintf("vttablet: %v", err),
+		ServerCode: vterrors.GRPCCodeToErrorCode(grpc.Code(err)),
+	}
+}


### PR DESCRIPTION
vtgate -> vttablet link, I now convert the errors to gRPC errors,
and back. That way I use the RPC code, and no need to implement
anything specific.

@aaijazi without this fix, vtcombo breaks stuff inside google3, as error codes don't come back right.