### PR TITLE
travis: Cache missing files for make proto.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ cache:
   - $HOME/gopath/dist/protobuf/lib
   # Required by make proto and subsequently check_make_proto.sh.
   - $HOME/gopath/dist/protobuf/bin/protoc
+  # Required by make proto and subsequently check_make_proto.sh.
+  - $HOME/gopath/dist/grpc/bin/grpc_python_plugin
   - $HOME/gopath/dist/py-mock-1.0.1/.build_finished
   - $HOME/gopath/dist/py-mock-1.0.1/lib/python2.7/site-packages
   - $HOME/gopath/dist/py-vt-bson-0.3.2/lib/python2.7/site-packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,13 @@ cache:
   - $MYSQL_ROOT
   # Cache bootstrapped dependencies (e.g. protobuf and gRPC).
   - $HOME/gopath/dist/grpc/.build_finished
+  # Required by make proto and subsequently check_make_proto.sh.
+  - $HOME/gopath/dist/grpc/bin/grpc_python_plugin
   - $HOME/gopath/dist/grpc/lib
   - $HOME/gopath/dist/protobuf/.build_finished
   - $HOME/gopath/dist/protobuf/lib
   # Required by make proto and subsequently check_make_proto.sh.
   - $HOME/gopath/dist/protobuf/bin/protoc
-  # Required by make proto and subsequently check_make_proto.sh.
-  - $HOME/gopath/dist/grpc/bin/grpc_python_plugin
   - $HOME/gopath/dist/py-mock-1.0.1/.build_finished
   - $HOME/gopath/dist/py-mock-1.0.1/lib/python2.7/site-packages
   - $HOME/gopath/dist/py-vt-bson-0.3.2/lib/python2.7/site-packages


### PR DESCRIPTION
@enisoc 

Tests are currently failing because the file is not included in the cache.