### PR TITLE
Now vtcombo fake vtgate -> vttablet connection copies the bind variab…

### DIFF
--- a/go/vt/tabletserver/endtoend/main_test.go
+++ b/go/vt/tabletserver/endtoend/main_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	flag.Parse()
+	flag.Parse() // Do not remove this comment, import into google3 depends on it
 	tabletserver.Init()
 
 	exitCode := func() int {


### PR DESCRIPTION
…les, as tabletserver will change them, and that messes up vtgate.

@enisoc this is breaking test migration to vtcombo in google3 (that are not enabled yet because of this).