### PR TITLE
etcd: Require strong consistency (quorum reads).

### DIFF
--- a/go/vt/etcdtopo/client.go
+++ b/go/vt/etcdtopo/client.go
@@ -9,7 +9,12 @@ import (
 )
 
 func newEtcdClient(machines []string) Client {
-	return etcd.NewClient(machines)
+	c := etcd.NewClient(machines)
+	// Vitess requires strong consistency mode for etcd.
+	if err := c.SetConsistency(etcd.STRONG_CONSISTENCY); err != nil {
+		panic("failed to set consistency on etcd client: " + err.Error())
+	}
+	return c
 }
 
 // Client contains the parts of etcd.Client that are needed.


### PR DESCRIPTION
@michael-berlin 

This makes etcdtopo match the consistency expectations of Vitess.