### PR TITLE
Clean vtdb/py/__init__.py.

### DIFF
--- a/py/vtdb/__init__.py
+++ b/py/vtdb/__init__.py
@@ -9,9 +9,7 @@ apilevel = '2.0'
 threadsafety = 0
 paramstyle = 'named'
 
-from vtdb.cursorv3 import *
-from vtdb.dbexceptions import *
-from vtdb.field_types import STRING, BINARY, NUMBER, DATETIME, ROWID
-from vtdb.times import Date, Time, Timestamp, DateFromTicks, TimeFromTicks, TimestampFromTicks
-from vtdb.vtgatev2 import *
-from vtdb.vtgatev3 import *
+# DEPRECATED: Callers should use dbexceptions.%(ErrorClass)s directly.
+from google3.third_party.golang.vitess.py.vtdb.dbexceptions import DatabaseError
+from google3.third_party.golang.vitess.py.vtdb.dbexceptions import IntegrityError
+from google3.third_party.golang.vitess.py.vtdb.dbexceptions import OperationalError


### PR DESCRIPTION
Import * statements make code analysis difficult.