### PR TITLE
Change default tablet_manager_protocol to grpc.

### DIFF
--- a/go/vt/tabletmanager/tmclient/rpc_client_api.go
+++ b/go/vt/tabletmanager/tmclient/rpc_client_api.go
@@ -23,7 +23,7 @@ import (
 
 // TabletManagerProtocol is the implementation to use for tablet
 // manager protocol. It is exported for tests only.
-var TabletManagerProtocol = flag.String("tablet_manager_protocol", "bson", "the protocol to use to talk to vttablet")
+var TabletManagerProtocol = flag.String("tablet_manager_protocol", "grpc", "the protocol to use to talk to vttablet")
 
 // ErrFunc is used by streaming RPCs that don't return a specific result
 type ErrFunc func() error


### PR DESCRIPTION
@alainjobart 

All our examples use grpc-tabletmanager service. We should set grpc
as the default on the client side, or else user-typed commands like
vtctl or vtworker will have to be polluted with extra flags.