### PR TITLE
Use InetSocketAddress as function param in RpcClientFactory

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/RpcClientFactory.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/RpcClientFactory.java
@@ -1,10 +1,10 @@
 package com.youtube.vitess.client;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 
 /**
  * RpcClientFactory creates a concrete RpcClient.
  */
 public interface RpcClientFactory {
-  RpcClient create(Context ctx, SocketAddress address);
+  RpcClient create(Context ctx, InetSocketAddress address);
 }

--- a/java/grpc-client/src/main/java/com/youtube/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/com/youtube/vitess/client/grpc/GrpcClientFactory.java
@@ -7,14 +7,14 @@ import com.youtube.vitess.client.RpcClientFactory;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 
-import java.net.SocketAddress;
+import java.net.InetSocketAddress;
 
 /**
  * GrpcClientFactory creates RpcClients with the gRPC implemenation.
  */
 public class GrpcClientFactory implements RpcClientFactory {
   @Override
-  public RpcClient create(Context ctx, SocketAddress address) {
+  public RpcClient create(Context ctx, InetSocketAddress address) {
     return new GrpcClient(
         NettyChannelBuilder.forAddress(address).negotiationType(NegotiationType.PLAINTEXT).build());
   }


### PR DESCRIPTION
SocketAddress represents a socket address with no protocol attachment.
It is too general to be useful as often the subclass needs to know the
hostname and port info.