### PR TITLE
Change protocol defaults to grpc.

### DIFF
--- a/examples/kubernetes/vtctld-controller.yaml
+++ b/examples/kubernetes/vtctld-controller.yaml
@@ -35,7 +35,7 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000
-              -service_map 'bsonrpc-vt-vtctl'
+              -service_map 'grpc-vtctl'
               -topo_implementation etcd
               -tablet_protocol grpc
               -tablet_manager_protocol grpc

--- a/examples/local/vtctld-up.sh
+++ b/examples/local/vtctld-up.sh
@@ -22,7 +22,7 @@ $VTROOT/bin/vtctld -debug -templates $VTTOP/go/cmd/vtctld/templates \
   -web_dir $VTTOP/web/vtctld \
   -tablet_protocol grpc \
   -tablet_manager_protocol grpc \
-  -service_map 'bsonrpc-vt-vtctl' \
+  -service_map 'grpc-vtctl' \
   -log_dir $VTDATAROOT/tmp -port $port > $VTDATAROOT/tmp/vtctld.out 2>&1 &
 disown -a
 

--- a/go/vt/binlog/binlogplayer/client.go
+++ b/go/vt/binlog/binlogplayer/client.go
@@ -22,7 +22,7 @@ import (
 This file contains the API and registration mechanism for binlog player client.
 */
 
-var binlogPlayerProtocol = flag.String("binlog_player_protocol", "gorpc", "the protocol to download binlogs from a vttablet")
+var binlogPlayerProtocol = flag.String("binlog_player_protocol", "grpc", "the protocol to download binlogs from a vttablet")
 var binlogPlayerConnTimeout = flag.Duration("binlog_player_conn_timeout", 5*time.Second, "binlog player connection timeout")
 
 // ErrFunc is a return value for streaming events

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -15,8 +15,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// VtctlClientProtocol specifices which RPC client implementation should be used.
-var VtctlClientProtocol = flag.String("vtctl_client_protocol", "grpc", "the protocol to use to talk to the vtctl server")
+// vtctlClientProtocol specifices which RPC client implementation should be used.
+var vtctlClientProtocol = flag.String("vtctl_client_protocol", "grpc", "the protocol to use to talk to the vtctl server")
 
 // ErrFunc is returned by streaming queries to get the error
 type ErrFunc func() error
@@ -58,9 +58,9 @@ func UnregisterFactoryForTest(name string) {
 
 // New allows a user of the client library to get its implementation.
 func New(addr string, connectTimeout time.Duration) (VtctlClient, error) {
-	factory, ok := factories[*VtctlClientProtocol]
+	factory, ok := factories[*vtctlClientProtocol]
 	if !ok {
-		return nil, fmt.Errorf("unknown vtctl client protocol: %v", *VtctlClientProtocol)
+		return nil, fmt.Errorf("unknown vtctl client protocol: %v", *vtctlClientProtocol)
 	}
 	return factory(addr, connectTimeout)
 }

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -16,7 +16,7 @@ import (
 )
 
 // VtctlClientProtocol specifices which RPC client implementation should be used.
-var VtctlClientProtocol = flag.String("vtctl_client_protocol", "gorpc", "the protocol to use to talk to the vtctl server")
+var VtctlClientProtocol = flag.String("vtctl_client_protocol", "grpc", "the protocol to use to talk to the vtctl server")
 
 // ErrFunc is returned by streaming queries to get the error
 type ErrFunc func() error

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -5,6 +5,7 @@
 package testlib
 
 import (
+	"flag"
 	"fmt"
 	"net"
 	"testing"
@@ -24,7 +25,7 @@ import (
 
 func init() {
 	// make sure we use the right protocol
-	*vtctlclient.VtctlClientProtocol = "grpc"
+	flag.Set("vtctl_client_protocol", "grpc")
 }
 
 // VtctlPipe is a vtctl server based on a topo server, and a client that

--- a/test/protocols_flavor.py
+++ b/test/protocols_flavor.py
@@ -12,7 +12,7 @@ class ProtocolsFlavor(object):
   """Base class for protocols flavor."""
 
   def binlog_player_protocol(self):
-    """Tdthe binlog player protocol between vttablets, in go."""
+    """The binlog player protocol between vttablets, in go."""
     raise NotImplementedError('Not implemented in the base class')
 
   def binlog_player_python_protocol(self):


### PR DESCRIPTION
Done:
- vtctl_client_protocol
- binlog_player_protocol

Left:
- vtgate_protocol (requiring the Python gRPC implementation)