### PR TITLE
Return a TabletError even when TerseErrors are enabled

### DIFF
--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -154,7 +154,7 @@ var DefaultQsConfig = Config{
 	SpotCheckRatio:       0,
 	StrictMode:           true,
 	StrictTableAcl:       false,
-	TerseErrors:          false,
+	TerseErrors:          true,
 	EnablePublishStats:   true,
 	EnableAutoCommit:     false,
 	EnableTableAclDryRun: false,

--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -154,7 +154,7 @@ var DefaultQsConfig = Config{
 	SpotCheckRatio:       0,
 	StrictMode:           true,
 	StrictTableAcl:       false,
-	TerseErrors:          true,
+	TerseErrors:          false,
 	EnablePublishStats:   true,
 	EnableAutoCommit:     false,
 	EnableTableAclDryRun: false,

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -600,7 +600,12 @@ func (tsv *TabletServer) handleExecErrorNoPanic(query *proto.Query, err interfac
 	}
 	var myError error
 	if tsv.config.TerseErrors && terr.SQLError != 0 && len(query.BindVariables) != 0 {
-		myError = fmt.Errorf("%s(errno %d) during query: %s", terr.Prefix(), terr.SQLError, query.Sql)
+		myError = &TabletError{
+			ErrorType: terr.ErrorType,
+			SQLError:  terr.SQLError,
+			ErrorCode: terr.ErrorCode,
+			Message:   fmt.Sprintf("(errno %d) during query: %s", terr.SQLError, query.Sql),
+		}
 	} else {
 		myError = terr
 	}


### PR DESCRIPTION
@sougou @alainjobart 

I'm enabling TerseErrors by default, since I believe this is what we expect people to run it like in production, and I want our test environments to match production.