### PR TITLE
proto 3 Rows benchmark

### DIFF
--- a/go/vt/proto/bench/bench_test.go
+++ b/go/vt/proto/bench/bench_test.go
@@ -213,7 +213,7 @@ func BenchmarkUnmarshal3(b *testing.B) {
 		return
 	}
 	for i := 0; i < b.N; i++ {
-		res := &query.Result2{}
+		res := &query.Result3{}
 		err = proto.Unmarshal(bytes, res)
 		if err != nil {
 			b.Error(err)

--- a/go/vt/proto/bench/bench_test.go
+++ b/go/vt/proto/bench/bench_test.go
@@ -1,0 +1,223 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/youtube/vitess/go/vt/proto/query"
+)
+
+var cellval = []byte("1234567890123456789012345")
+
+func BenchmarkRow1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vals := make([]byte, 1000, 1000)
+		pcells := make([]*query.Cell, 40, 40)
+		cells := make([]query.Cell, 40, 40)
+		for j := 0; j < 40; j++ {
+			copy(vals[j*25:(j+1)*25], cellval)
+			cells[j].Value = vals[j*25 : (j+1)*25]
+			pcells[j] = &cells[j]
+		}
+		prow := make([]*query.Row1, 1, 1)
+		row := make([]query.Row1, 1, 1)
+		row[0].Values = pcells
+		prow[0] = &row[0]
+		result1 := &query.Result1{Rows: prow}
+		process1(result1)
+	}
+}
+
+func process1(r *query.Result1) *query.Result1 {
+	return r
+}
+
+func BenchmarkMarshal1(b *testing.B) {
+	vals := make([]byte, 1000, 1000)
+	pcells := make([]*query.Cell, 40, 40)
+	cells := make([]query.Cell, 40, 40)
+	for j := 0; j < 40; j++ {
+		copy(vals[j*25:(j+1)*25], cellval)
+		cells[j].Value = vals[j*25 : (j+1)*25]
+		pcells[j] = &cells[j]
+	}
+	prow := make([]*query.Row1, 1, 1)
+	row := make([]query.Row1, 1, 1)
+	row[0].Values = pcells
+	prow[0] = &row[0]
+	result1 := &query.Result1{Rows: prow}
+	for i := 0; i < b.N; i++ {
+		proto.Marshal(result1)
+	}
+}
+
+func BenchmarkUnmarshal1(b *testing.B) {
+	vals := make([]byte, 1000, 1000)
+	pcells := make([]*query.Cell, 40, 40)
+	cells := make([]query.Cell, 40, 40)
+	for j := 0; j < 40; j++ {
+		copy(vals[j*25:(j+1)*25], cellval)
+		cells[j].Value = vals[j*25 : (j+1)*25]
+		pcells[j] = &cells[j]
+	}
+	prow := make([]*query.Row1, 1, 1)
+	row := make([]query.Row1, 1, 1)
+	row[0].Values = pcells
+	prow[0] = &row[0]
+	result1 := &query.Result1{Rows: prow}
+	bytes, err := proto.Marshal(result1)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		res := &query.Result1{}
+		err = proto.Unmarshal(bytes, res)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+	}
+}
+
+func BenchmarkRow2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vals := make([]byte, 1000, 1000)
+		nulls := make([]bool, 40)
+		cells := make([][]byte, 40, 40)
+		for j := 0; j < 40; j++ {
+			copy(vals[j*25:(j+1)*25], cellval)
+			cells[j] = vals[j*25 : (j+1)*25]
+			nulls[j] = true
+		}
+		prow := make([]*query.Row2, 1, 1)
+		row := make([]query.Row2, 1, 1)
+		row[0].IsNull = nulls
+		row[0].Values = cells
+		prow[0] = &row[0]
+		result2 := &query.Result2{Rows: prow}
+		process2(result2)
+	}
+}
+
+func process2(r *query.Result2) *query.Result2 {
+	return r
+}
+
+func BenchmarkMarshal2(b *testing.B) {
+	vals := make([]byte, 1000, 1000)
+	nulls := make([]bool, 40)
+	cells := make([][]byte, 40, 40)
+	for j := 0; j < 40; j++ {
+		copy(vals[j*25:(j+1)*25], cellval)
+		cells[j] = vals[j*25 : (j+1)*25]
+		nulls[j] = true
+	}
+	prow := make([]*query.Row2, 1, 1)
+	row := make([]query.Row2, 1, 1)
+	row[0].IsNull = nulls
+	row[0].Values = cells
+	prow[0] = &row[0]
+	result2 := &query.Result2{Rows: prow}
+	for i := 0; i < b.N; i++ {
+		proto.Marshal(result2)
+	}
+}
+
+func BenchmarkUnmarshal2(b *testing.B) {
+	vals := make([]byte, 1000, 1000)
+	nulls := make([]bool, 40)
+	cells := make([][]byte, 40, 40)
+	for j := 0; j < 40; j++ {
+		copy(vals[j*25:(j+1)*25], cellval)
+		cells[j] = vals[j*25 : (j+1)*25]
+		nulls[j] = true
+	}
+	prow := make([]*query.Row2, 1, 1)
+	row := make([]query.Row2, 1, 1)
+	row[0].IsNull = nulls
+	row[0].Values = cells
+	prow[0] = &row[0]
+	result2 := &query.Result2{Rows: prow}
+	bytes, err := proto.Marshal(result2)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		res := &query.Result2{}
+		err = proto.Unmarshal(bytes, res)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+	}
+}
+
+func BenchmarkRow3(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		vals := make([]byte, 0, 1000)
+		indexes := make([]int64, 40)
+		for j := 0; j < 40; j++ {
+			vals = append(vals, cellval...)
+			indexes[j] = 25
+		}
+		prow := make([]*query.Row3, 1, 1)
+		row := make([]query.Row3, 1, 1)
+		row[0].Indexes = indexes
+		row[0].Values = vals
+		prow[0] = &row[0]
+		result3 := &query.Result3{Rows: prow}
+		process3(result3)
+	}
+}
+
+func process3(r *query.Result3) *query.Result3 {
+	return r
+}
+
+func BenchmarkMarshal3(b *testing.B) {
+	vals := make([]byte, 0, 1000)
+	indexes := make([]int64, 40)
+	for j := 0; j < 40; j++ {
+		vals = append(vals, cellval...)
+		indexes[j] = 25
+	}
+	prow := make([]*query.Row3, 1, 1)
+	row := make([]query.Row3, 1, 1)
+	row[0].Indexes = indexes
+	row[0].Values = vals
+	prow[0] = &row[0]
+	result3 := &query.Result3{Rows: prow}
+	for i := 0; i < b.N; i++ {
+		proto.Marshal(result3)
+	}
+}
+
+func BenchmarkUnmarshal3(b *testing.B) {
+	vals := make([]byte, 0, 1000)
+	indexes := make([]int64, 40)
+	for j := 0; j < 40; j++ {
+		vals = append(vals, cellval...)
+		indexes[j] = 25
+	}
+	prow := make([]*query.Row3, 1, 1)
+	row := make([]query.Row3, 1, 1)
+	row[0].Indexes = indexes
+	row[0].Values = vals
+	prow[0] = &row[0]
+	result3 := &query.Result3{Rows: prow}
+	bytes, err := proto.Marshal(result3)
+	if err != nil {
+		b.Error(err)
+		return
+	}
+	for i := 0; i < b.N; i++ {
+		res := &query.Result2{}
+		err = proto.Unmarshal(bytes, res)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+	}
+}

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -15,6 +15,13 @@ It has these top-level messages:
 	BoundQuery
 	Field
 	Row
+	Cell
+	Row1
+	Result1
+	Row2
+	Result2
+	Row3
+	Result3
 	QueryResult
 	GetSessionIdRequest
 	GetSessionIdResponse
@@ -341,6 +348,92 @@ type Row struct {
 func (m *Row) Reset()         { *m = Row{} }
 func (m *Row) String() string { return proto.CompactTextString(m) }
 func (*Row) ProtoMessage()    {}
+
+type Cell struct {
+	Value []byte `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (m *Cell) Reset()         { *m = Cell{} }
+func (m *Cell) String() string { return proto.CompactTextString(m) }
+func (*Cell) ProtoMessage()    {}
+
+type Row1 struct {
+	Values []*Cell `protobuf:"bytes,1,rep,name=values" json:"values,omitempty"`
+}
+
+func (m *Row1) Reset()         { *m = Row1{} }
+func (m *Row1) String() string { return proto.CompactTextString(m) }
+func (*Row1) ProtoMessage()    {}
+
+func (m *Row1) GetValues() []*Cell {
+	if m != nil {
+		return m.Values
+	}
+	return nil
+}
+
+type Result1 struct {
+	Rows []*Row1 `protobuf:"bytes,1,rep,name=rows" json:"rows,omitempty"`
+}
+
+func (m *Result1) Reset()         { *m = Result1{} }
+func (m *Result1) String() string { return proto.CompactTextString(m) }
+func (*Result1) ProtoMessage()    {}
+
+func (m *Result1) GetRows() []*Row1 {
+	if m != nil {
+		return m.Rows
+	}
+	return nil
+}
+
+type Row2 struct {
+	IsNull []bool   `protobuf:"varint,1,rep,name=is_null" json:"is_null,omitempty"`
+	Values [][]byte `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty"`
+}
+
+func (m *Row2) Reset()         { *m = Row2{} }
+func (m *Row2) String() string { return proto.CompactTextString(m) }
+func (*Row2) ProtoMessage()    {}
+
+type Result2 struct {
+	Rows []*Row2 `protobuf:"bytes,1,rep,name=rows" json:"rows,omitempty"`
+}
+
+func (m *Result2) Reset()         { *m = Result2{} }
+func (m *Result2) String() string { return proto.CompactTextString(m) }
+func (*Result2) ProtoMessage()    {}
+
+func (m *Result2) GetRows() []*Row2 {
+	if m != nil {
+		return m.Rows
+	}
+	return nil
+}
+
+type Row3 struct {
+	Indexes []int64 `protobuf:"varint,1,rep,name=indexes" json:"indexes,omitempty"`
+	Values  []byte  `protobuf:"bytes,2,opt,name=values,proto3" json:"values,omitempty"`
+}
+
+func (m *Row3) Reset()         { *m = Row3{} }
+func (m *Row3) String() string { return proto.CompactTextString(m) }
+func (*Row3) ProtoMessage()    {}
+
+type Result3 struct {
+	Rows []*Row3 `protobuf:"bytes,1,rep,name=rows" json:"rows,omitempty"`
+}
+
+func (m *Result3) Reset()         { *m = Result3{} }
+func (m *Result3) String() string { return proto.CompactTextString(m) }
+func (*Result3) ProtoMessage()    {}
+
+func (m *Result3) GetRows() []*Row3 {
+	if m != nil {
+		return m.Rows
+	}
+	return nil
+}
 
 // QueryResult is returned by Execute and ExecuteStream.
 //

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -136,6 +136,36 @@ message Row {
   repeated bytes values = 1;
 }
 
+message Cell {
+  bytes value = 1;
+}
+
+message Row1 {
+  repeated Cell values = 1;
+}
+
+message Result1 {
+  repeated Row1 rows = 1;
+}
+
+message Row2 {
+  repeated bool is_null = 1;
+  repeated bytes values = 2;
+}
+
+message Result2 {
+  repeated Row2 rows = 1;
+}
+
+message Row3 {
+  repeated int64 indexes = 1;
+  bytes values = 2;
+}
+
+message Result3 {
+  repeated Row3 rows = 1;
+}
+
 // QueryResult is returned by Execute and ExecuteStream.
 //
 // As returned by Execute, len(fields) is always equal to len(row)

--- a/py/vtproto/query_pb2.py
+++ b/py/vtproto/query_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='query.proto',
   package='query',
   syntax='proto3',
-  serialized_pb=b'\n\x0bquery.proto\x12\x05query\x1a\x0etopodata.proto\x1a\x0bvtrpc.proto\"T\n\x06Target\x12\x10\n\x08keyspace\x18\x01 \x01(\t\x12\r\n\x05shard\x18\x02 \x01(\t\x12)\n\x0btablet_type\x18\x03 \x01(\x0e\x32\x14.topodata.TabletType\"\"\n\x0eVTGateCallerID\x12\x10\n\x08username\x18\x01 \x01(\t\"\x92\x03\n\x0c\x42indVariable\x12&\n\x04type\x18\x01 \x01(\x0e\x32\x18.query.BindVariable.Type\x12\x13\n\x0bvalue_bytes\x18\x02 \x01(\x0c\x12\x11\n\tvalue_int\x18\x03 \x01(\x03\x12\x12\n\nvalue_uint\x18\x04 \x01(\x04\x12\x13\n\x0bvalue_float\x18\x05 \x01(\x01\x12\x18\n\x10value_bytes_list\x18\x06 \x03(\x0c\x12\x16\n\x0evalue_int_list\x18\x07 \x03(\x03\x12\x17\n\x0fvalue_uint_list\x18\x08 \x03(\x04\x12\x18\n\x10value_float_list\x18\t \x03(\x01\"\xa3\x01\n\x04Type\x12\r\n\tTYPE_NULL\x10\x00\x12\x0e\n\nTYPE_BYTES\x10\x01\x12\x0c\n\x08TYPE_INT\x10\x02\x12\r\n\tTYPE_UINT\x10\x03\x12\x0e\n\nTYPE_FLOAT\x10\x04\x12\x13\n\x0fTYPE_BYTES_LIST\x10\x05\x12\x11\n\rTYPE_INT_LIST\x10\x06\x12\x12\n\x0eTYPE_UINT_LIST\x10\x07\x12\x13\n\x0fTYPE_FLOAT_LIST\x10\x08\"\xa2\x01\n\nBoundQuery\x12\x0b\n\x03sql\x18\x01 \x01(\t\x12<\n\x0e\x62ind_variables\x18\x02 \x03(\x0b\x32$.query.BoundQuery.BindVariablesEntry\x1aI\n\x12\x42indVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.query.BindVariable:\x02\x38\x01\"\xa1\x07\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x04type\x18\x02 \x01(\x0e\x32\x11.query.Field.Type\x12\r\n\x05\x66lags\x18\x03 \x01(\x03\"\xe1\x03\n\x04Type\x12\x10\n\x0cTYPE_DECIMAL\x10\x00\x12\r\n\tTYPE_TINY\x10\x01\x12\x0e\n\nTYPE_SHORT\x10\x02\x12\r\n\tTYPE_LONG\x10\x03\x12\x0e\n\nTYPE_FLOAT\x10\x04\x12\x0f\n\x0bTYPE_DOUBLE\x10\x05\x12\r\n\tTYPE_NULL\x10\x06\x12\x12\n\x0eTYPE_TIMESTAMP\x10\x07\x12\x11\n\rTYPE_LONGLONG\x10\x08\x12\x0e\n\nTYPE_INT24\x10\t\x12\r\n\tTYPE_DATE\x10\n\x12\r\n\tTYPE_TIME\x10\x0b\x12\x11\n\rTYPE_DATETIME\x10\x0c\x12\r\n\tTYPE_YEAR\x10\r\x12\x10\n\x0cTYPE_NEWDATE\x10\x0e\x12\x10\n\x0cTYPE_VARCHAR\x10\x0f\x12\x0c\n\x08TYPE_BIT\x10\x10\x12\x14\n\x0fTYPE_NEWDECIMAL\x10\xf6\x01\x12\x0e\n\tTYPE_ENUM\x10\xf7\x01\x12\r\n\x08TYPE_SET\x10\xf8\x01\x12\x13\n\x0eTYPE_TINY_BLOB\x10\xf9\x01\x12\x15\n\x10TYPE_MEDIUM_BLOB\x10\xfa\x01\x12\x13\n\x0eTYPE_LONG_BLOB\x10\xfb\x01\x12\x0e\n\tTYPE_BLOB\x10\xfc\x01\x12\x14\n\x0fTYPE_VAR_STRING\x10\xfd\x01\x12\x10\n\x0bTYPE_STRING\x10\xfe\x01\x12\x12\n\rTYPE_GEOMETRY\x10\xff\x01\"\xf5\x02\n\x04\x46lag\x12\x15\n\x11VT_ZEROVALUE_FLAG\x10\x00\x12\x14\n\x10VT_NOT_NULL_FLAG\x10\x01\x12\x13\n\x0fVT_PRI_KEY_FLAG\x10\x02\x12\x16\n\x12VT_UNIQUE_KEY_FLAG\x10\x04\x12\x18\n\x14VT_MULTIPLE_KEY_FLAG\x10\x08\x12\x10\n\x0cVT_BLOB_FLAG\x10\x10\x12\x14\n\x10VT_UNSIGNED_FLAG\x10 \x12\x14\n\x10VT_ZEROFILL_FLAG\x10@\x12\x13\n\x0eVT_BINARY_FLAG\x10\x80\x01\x12\x11\n\x0cVT_ENUM_FLAG\x10\x80\x02\x12\x1b\n\x16VT_AUTO_INCREMENT_FLAG\x10\x80\x04\x12\x16\n\x11VT_TIMESTAMP_FLAG\x10\x80\x08\x12\x10\n\x0bVT_SET_FLAG\x10\x80\x10\x12\x1d\n\x18VT_NO_DEFAULT_VALUE_FLAG\x10\x80 \x12\x1a\n\x15VT_ON_UPDATE_NOW_FLAG\x10\x80@\x12\x11\n\x0bVT_NUM_FLAG\x10\x80\x80\x02\"\x15\n\x03Row\x12\x0e\n\x06values\x18\x01 \x03(\x0c\"o\n\x0bQueryResult\x12\x1c\n\x06\x66ields\x18\x01 \x03(\x0b\x32\x0c.query.Field\x12\x15\n\rrows_affected\x18\x02 \x01(\x04\x12\x11\n\tinsert_id\x18\x03 \x01(\x04\x12\x18\n\x04rows\x18\x04 \x03(\x0b\x32\n.query.Row\"\x98\x01\n\x13GetSessionIdRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x10\n\x08keyspace\x18\x03 \x01(\t\x12\r\n\x05shard\x18\x04 \x01(\t\"*\n\x14GetSessionIdResponse\x12\x12\n\nsession_id\x18\x01 \x01(\x03\"\xdf\x01\n\x0e\x45xecuteRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x16\n\x0etransaction_id\x18\x05 \x01(\x03\x12\x12\n\nsession_id\x18\x06 \x01(\x03\"5\n\x0f\x45xecuteResponse\x12\"\n\x06result\x18\x01 \x01(\x0b\x32\x12.query.QueryResult\"\xfe\x01\n\x13\x45xecuteBatchRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\"\n\x07queries\x18\x04 \x03(\x0b\x32\x11.query.BoundQuery\x12\x16\n\x0e\x61s_transaction\x18\x05 \x01(\x08\x12\x16\n\x0etransaction_id\x18\x06 \x01(\x03\x12\x12\n\nsession_id\x18\x07 \x01(\x03\";\n\x14\x45xecuteBatchResponse\x12#\n\x07results\x18\x01 \x03(\x0b\x32\x12.query.QueryResult\"\xcd\x01\n\x14StreamExecuteRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x12\n\nsession_id\x18\x05 \x01(\x03\";\n\x15StreamExecuteResponse\x12\"\n\x06result\x18\x01 \x01(\x0b\x32\x12.query.QueryResult\"\xa3\x01\n\x0c\x42\x65ginRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x12\n\nsession_id\x18\x04 \x01(\x03\"\'\n\rBeginResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\x03\"\xbc\x01\n\rCommitRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x16\n\x0etransaction_id\x18\x04 \x01(\x03\x12\x12\n\nsession_id\x18\x05 \x01(\x03\"\x10\n\x0e\x43ommitResponse\"\xbe\x01\n\x0fRollbackRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x16\n\x0etransaction_id\x18\x04 \x01(\x03\x12\x12\n\nsession_id\x18\x05 \x01(\x03\"\x12\n\x10RollbackResponse\"\xf5\x01\n\x11SplitQueryRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x14\n\x0csplit_column\x18\x05 \x01(\t\x12\x13\n\x0bsplit_count\x18\x06 \x01(\x03\x12\x12\n\nsession_id\x18\x07 \x01(\x03\"A\n\nQuerySplit\x12 \n\x05query\x18\x01 \x01(\x0b\x32\x11.query.BoundQuery\x12\x11\n\trow_count\x18\x02 \x01(\x03\"8\n\x12SplitQueryResponse\x12\"\n\x07queries\x18\x01 \x03(\x0b\x32\x11.query.QuerySplit\"\x15\n\x13StreamHealthRequest\"\xa9\x01\n\rRealtimeStats\x12\x14\n\x0chealth_error\x18\x01 \x01(\t\x12\x1d\n\x15seconds_behind_master\x18\x02 \x01(\r\x12\x1c\n\x14\x62inlog_players_count\x18\x03 \x01(\x05\x12\x32\n*seconds_behind_master_filtered_replication\x18\x04 \x01(\x03\x12\x11\n\tcpu_usage\x18\x05 \x01(\x01\"\xa4\x01\n\x14StreamHealthResponse\x12\x1d\n\x06target\x18\x01 \x01(\x0b\x32\r.query.Target\x12\x0f\n\x07serving\x18\x02 \x01(\x08\x12.\n&tablet_externally_reparented_timestamp\x18\x03 \x01(\x03\x12,\n\x0erealtime_stats\x18\x04 \x01(\x0b\x32\x14.query.RealtimeStatsB\x1a\n\x18\x63om.youtube.vitess.protob\x06proto3'
+  serialized_pb=b'\n\x0bquery.proto\x12\x05query\x1a\x0etopodata.proto\x1a\x0bvtrpc.proto\"T\n\x06Target\x12\x10\n\x08keyspace\x18\x01 \x01(\t\x12\r\n\x05shard\x18\x02 \x01(\t\x12)\n\x0btablet_type\x18\x03 \x01(\x0e\x32\x14.topodata.TabletType\"\"\n\x0eVTGateCallerID\x12\x10\n\x08username\x18\x01 \x01(\t\"\x92\x03\n\x0c\x42indVariable\x12&\n\x04type\x18\x01 \x01(\x0e\x32\x18.query.BindVariable.Type\x12\x13\n\x0bvalue_bytes\x18\x02 \x01(\x0c\x12\x11\n\tvalue_int\x18\x03 \x01(\x03\x12\x12\n\nvalue_uint\x18\x04 \x01(\x04\x12\x13\n\x0bvalue_float\x18\x05 \x01(\x01\x12\x18\n\x10value_bytes_list\x18\x06 \x03(\x0c\x12\x16\n\x0evalue_int_list\x18\x07 \x03(\x03\x12\x17\n\x0fvalue_uint_list\x18\x08 \x03(\x04\x12\x18\n\x10value_float_list\x18\t \x03(\x01\"\xa3\x01\n\x04Type\x12\r\n\tTYPE_NULL\x10\x00\x12\x0e\n\nTYPE_BYTES\x10\x01\x12\x0c\n\x08TYPE_INT\x10\x02\x12\r\n\tTYPE_UINT\x10\x03\x12\x0e\n\nTYPE_FLOAT\x10\x04\x12\x13\n\x0fTYPE_BYTES_LIST\x10\x05\x12\x11\n\rTYPE_INT_LIST\x10\x06\x12\x12\n\x0eTYPE_UINT_LIST\x10\x07\x12\x13\n\x0fTYPE_FLOAT_LIST\x10\x08\"\xa2\x01\n\nBoundQuery\x12\x0b\n\x03sql\x18\x01 \x01(\t\x12<\n\x0e\x62ind_variables\x18\x02 \x03(\x0b\x32$.query.BoundQuery.BindVariablesEntry\x1aI\n\x12\x42indVariablesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\"\n\x05value\x18\x02 \x01(\x0b\x32\x13.query.BindVariable:\x02\x38\x01\"\xa1\x07\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1f\n\x04type\x18\x02 \x01(\x0e\x32\x11.query.Field.Type\x12\r\n\x05\x66lags\x18\x03 \x01(\x03\"\xe1\x03\n\x04Type\x12\x10\n\x0cTYPE_DECIMAL\x10\x00\x12\r\n\tTYPE_TINY\x10\x01\x12\x0e\n\nTYPE_SHORT\x10\x02\x12\r\n\tTYPE_LONG\x10\x03\x12\x0e\n\nTYPE_FLOAT\x10\x04\x12\x0f\n\x0bTYPE_DOUBLE\x10\x05\x12\r\n\tTYPE_NULL\x10\x06\x12\x12\n\x0eTYPE_TIMESTAMP\x10\x07\x12\x11\n\rTYPE_LONGLONG\x10\x08\x12\x0e\n\nTYPE_INT24\x10\t\x12\r\n\tTYPE_DATE\x10\n\x12\r\n\tTYPE_TIME\x10\x0b\x12\x11\n\rTYPE_DATETIME\x10\x0c\x12\r\n\tTYPE_YEAR\x10\r\x12\x10\n\x0cTYPE_NEWDATE\x10\x0e\x12\x10\n\x0cTYPE_VARCHAR\x10\x0f\x12\x0c\n\x08TYPE_BIT\x10\x10\x12\x14\n\x0fTYPE_NEWDECIMAL\x10\xf6\x01\x12\x0e\n\tTYPE_ENUM\x10\xf7\x01\x12\r\n\x08TYPE_SET\x10\xf8\x01\x12\x13\n\x0eTYPE_TINY_BLOB\x10\xf9\x01\x12\x15\n\x10TYPE_MEDIUM_BLOB\x10\xfa\x01\x12\x13\n\x0eTYPE_LONG_BLOB\x10\xfb\x01\x12\x0e\n\tTYPE_BLOB\x10\xfc\x01\x12\x14\n\x0fTYPE_VAR_STRING\x10\xfd\x01\x12\x10\n\x0bTYPE_STRING\x10\xfe\x01\x12\x12\n\rTYPE_GEOMETRY\x10\xff\x01\"\xf5\x02\n\x04\x46lag\x12\x15\n\x11VT_ZEROVALUE_FLAG\x10\x00\x12\x14\n\x10VT_NOT_NULL_FLAG\x10\x01\x12\x13\n\x0fVT_PRI_KEY_FLAG\x10\x02\x12\x16\n\x12VT_UNIQUE_KEY_FLAG\x10\x04\x12\x18\n\x14VT_MULTIPLE_KEY_FLAG\x10\x08\x12\x10\n\x0cVT_BLOB_FLAG\x10\x10\x12\x14\n\x10VT_UNSIGNED_FLAG\x10 \x12\x14\n\x10VT_ZEROFILL_FLAG\x10@\x12\x13\n\x0eVT_BINARY_FLAG\x10\x80\x01\x12\x11\n\x0cVT_ENUM_FLAG\x10\x80\x02\x12\x1b\n\x16VT_AUTO_INCREMENT_FLAG\x10\x80\x04\x12\x16\n\x11VT_TIMESTAMP_FLAG\x10\x80\x08\x12\x10\n\x0bVT_SET_FLAG\x10\x80\x10\x12\x1d\n\x18VT_NO_DEFAULT_VALUE_FLAG\x10\x80 \x12\x1a\n\x15VT_ON_UPDATE_NOW_FLAG\x10\x80@\x12\x11\n\x0bVT_NUM_FLAG\x10\x80\x80\x02\"\x15\n\x03Row\x12\x0e\n\x06values\x18\x01 \x03(\x0c\"\x15\n\x04\x43\x65ll\x12\r\n\x05value\x18\x01 \x01(\x0c\"#\n\x04Row1\x12\x1b\n\x06values\x18\x01 \x03(\x0b\x32\x0b.query.Cell\"$\n\x07Result1\x12\x19\n\x04rows\x18\x01 \x03(\x0b\x32\x0b.query.Row1\"\'\n\x04Row2\x12\x0f\n\x07is_null\x18\x01 \x03(\x08\x12\x0e\n\x06values\x18\x02 \x03(\x0c\"$\n\x07Result2\x12\x19\n\x04rows\x18\x01 \x03(\x0b\x32\x0b.query.Row2\"\'\n\x04Row3\x12\x0f\n\x07indexes\x18\x01 \x03(\x03\x12\x0e\n\x06values\x18\x02 \x01(\x0c\"$\n\x07Result3\x12\x19\n\x04rows\x18\x01 \x03(\x0b\x32\x0b.query.Row3\"o\n\x0bQueryResult\x12\x1c\n\x06\x66ields\x18\x01 \x03(\x0b\x32\x0c.query.Field\x12\x15\n\rrows_affected\x18\x02 \x01(\x04\x12\x11\n\tinsert_id\x18\x03 \x01(\x04\x12\x18\n\x04rows\x18\x04 \x03(\x0b\x32\n.query.Row\"\x98\x01\n\x13GetSessionIdRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x10\n\x08keyspace\x18\x03 \x01(\t\x12\r\n\x05shard\x18\x04 \x01(\t\"*\n\x14GetSessionIdResponse\x12\x12\n\nsession_id\x18\x01 \x01(\x03\"\xdf\x01\n\x0e\x45xecuteRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x16\n\x0etransaction_id\x18\x05 \x01(\x03\x12\x12\n\nsession_id\x18\x06 \x01(\x03\"5\n\x0f\x45xecuteResponse\x12\"\n\x06result\x18\x01 \x01(\x0b\x32\x12.query.QueryResult\"\xfe\x01\n\x13\x45xecuteBatchRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\"\n\x07queries\x18\x04 \x03(\x0b\x32\x11.query.BoundQuery\x12\x16\n\x0e\x61s_transaction\x18\x05 \x01(\x08\x12\x16\n\x0etransaction_id\x18\x06 \x01(\x03\x12\x12\n\nsession_id\x18\x07 \x01(\x03\";\n\x14\x45xecuteBatchResponse\x12#\n\x07results\x18\x01 \x03(\x0b\x32\x12.query.QueryResult\"\xcd\x01\n\x14StreamExecuteRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x12\n\nsession_id\x18\x05 \x01(\x03\";\n\x15StreamExecuteResponse\x12\"\n\x06result\x18\x01 \x01(\x0b\x32\x12.query.QueryResult\"\xa3\x01\n\x0c\x42\x65ginRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x12\n\nsession_id\x18\x04 \x01(\x03\"\'\n\rBeginResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\x03\"\xbc\x01\n\rCommitRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x16\n\x0etransaction_id\x18\x04 \x01(\x03\x12\x12\n\nsession_id\x18\x05 \x01(\x03\"\x10\n\x0e\x43ommitResponse\"\xbe\x01\n\x0fRollbackRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12\x16\n\x0etransaction_id\x18\x04 \x01(\x03\x12\x12\n\nsession_id\x18\x05 \x01(\x03\"\x12\n\x10RollbackResponse\"\xf5\x01\n\x11SplitQueryRequest\x12,\n\x13\x65\x66\x66\x65\x63tive_caller_id\x18\x01 \x01(\x0b\x32\x0f.vtrpc.CallerID\x12\x32\n\x13immediate_caller_id\x18\x02 \x01(\x0b\x32\x15.query.VTGateCallerID\x12\x1d\n\x06target\x18\x03 \x01(\x0b\x32\r.query.Target\x12 \n\x05query\x18\x04 \x01(\x0b\x32\x11.query.BoundQuery\x12\x14\n\x0csplit_column\x18\x05 \x01(\t\x12\x13\n\x0bsplit_count\x18\x06 \x01(\x03\x12\x12\n\nsession_id\x18\x07 \x01(\x03\"A\n\nQuerySplit\x12 \n\x05query\x18\x01 \x01(\x0b\x32\x11.query.BoundQuery\x12\x11\n\trow_count\x18\x02 \x01(\x03\"8\n\x12SplitQueryResponse\x12\"\n\x07queries\x18\x01 \x03(\x0b\x32\x11.query.QuerySplit\"\x15\n\x13StreamHealthRequest\"\xa9\x01\n\rRealtimeStats\x12\x14\n\x0chealth_error\x18\x01 \x01(\t\x12\x1d\n\x15seconds_behind_master\x18\x02 \x01(\r\x12\x1c\n\x14\x62inlog_players_count\x18\x03 \x01(\x05\x12\x32\n*seconds_behind_master_filtered_replication\x18\x04 \x01(\x03\x12\x11\n\tcpu_usage\x18\x05 \x01(\x01\"\xa4\x01\n\x14StreamHealthResponse\x12\x1d\n\x06target\x18\x01 \x01(\x0b\x32\r.query.Target\x12\x0f\n\x07serving\x18\x02 \x01(\x08\x12.\n&tablet_externally_reparented_timestamp\x18\x03 \x01(\x03\x12,\n\x0erealtime_stats\x18\x04 \x01(\x0b\x32\x14.query.RealtimeStatsB\x1a\n\x18\x63om.youtube.vitess.protob\x06proto3'
   ,
   dependencies=[topodata__pb2.DESCRIPTOR,vtrpc__pb2.DESCRIPTOR,])
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
@@ -594,6 +594,237 @@ _ROW = _descriptor.Descriptor(
 )
 
 
+_CELL = _descriptor.Descriptor(
+  name='Cell',
+  full_name='query.Cell',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='value', full_name='query.Cell.value', index=0,
+      number=1, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1698,
+  serialized_end=1719,
+)
+
+
+_ROW1 = _descriptor.Descriptor(
+  name='Row1',
+  full_name='query.Row1',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='values', full_name='query.Row1.values', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1721,
+  serialized_end=1756,
+)
+
+
+_RESULT1 = _descriptor.Descriptor(
+  name='Result1',
+  full_name='query.Result1',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='rows', full_name='query.Result1.rows', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1758,
+  serialized_end=1794,
+)
+
+
+_ROW2 = _descriptor.Descriptor(
+  name='Row2',
+  full_name='query.Row2',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='is_null', full_name='query.Row2.is_null', index=0,
+      number=1, type=8, cpp_type=7, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='values', full_name='query.Row2.values', index=1,
+      number=2, type=12, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1796,
+  serialized_end=1835,
+)
+
+
+_RESULT2 = _descriptor.Descriptor(
+  name='Result2',
+  full_name='query.Result2',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='rows', full_name='query.Result2.rows', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1837,
+  serialized_end=1873,
+)
+
+
+_ROW3 = _descriptor.Descriptor(
+  name='Row3',
+  full_name='query.Row3',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='indexes', full_name='query.Row3.indexes', index=0,
+      number=1, type=3, cpp_type=2, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='values', full_name='query.Row3.values', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"",
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1875,
+  serialized_end=1914,
+)
+
+
+_RESULT3 = _descriptor.Descriptor(
+  name='Result3',
+  full_name='query.Result3',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='rows', full_name='query.Result3.rows', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1916,
+  serialized_end=1952,
+)
+
+
 _QUERYRESULT = _descriptor.Descriptor(
   name='QueryResult',
   full_name='query.QueryResult',
@@ -641,8 +872,8 @@ _QUERYRESULT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1698,
-  serialized_end=1809,
+  serialized_start=1954,
+  serialized_end=2065,
 )
 
 
@@ -693,8 +924,8 @@ _GETSESSIONIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1812,
-  serialized_end=1964,
+  serialized_start=2068,
+  serialized_end=2220,
 )
 
 
@@ -724,8 +955,8 @@ _GETSESSIONIDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1966,
-  serialized_end=2008,
+  serialized_start=2222,
+  serialized_end=2264,
 )
 
 
@@ -790,8 +1021,8 @@ _EXECUTEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2011,
-  serialized_end=2234,
+  serialized_start=2267,
+  serialized_end=2490,
 )
 
 
@@ -821,8 +1052,8 @@ _EXECUTERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2236,
-  serialized_end=2289,
+  serialized_start=2492,
+  serialized_end=2545,
 )
 
 
@@ -894,8 +1125,8 @@ _EXECUTEBATCHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2292,
-  serialized_end=2546,
+  serialized_start=2548,
+  serialized_end=2802,
 )
 
 
@@ -925,8 +1156,8 @@ _EXECUTEBATCHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2548,
-  serialized_end=2607,
+  serialized_start=2804,
+  serialized_end=2863,
 )
 
 
@@ -984,8 +1215,8 @@ _STREAMEXECUTEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2610,
-  serialized_end=2815,
+  serialized_start=2866,
+  serialized_end=3071,
 )
 
 
@@ -1015,8 +1246,8 @@ _STREAMEXECUTERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2817,
-  serialized_end=2876,
+  serialized_start=3073,
+  serialized_end=3132,
 )
 
 
@@ -1067,8 +1298,8 @@ _BEGINREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2879,
-  serialized_end=3042,
+  serialized_start=3135,
+  serialized_end=3298,
 )
 
 
@@ -1098,8 +1329,8 @@ _BEGINRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3044,
-  serialized_end=3083,
+  serialized_start=3300,
+  serialized_end=3339,
 )
 
 
@@ -1157,8 +1388,8 @@ _COMMITREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3086,
-  serialized_end=3274,
+  serialized_start=3342,
+  serialized_end=3530,
 )
 
 
@@ -1181,8 +1412,8 @@ _COMMITRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3276,
-  serialized_end=3292,
+  serialized_start=3532,
+  serialized_end=3548,
 )
 
 
@@ -1240,8 +1471,8 @@ _ROLLBACKREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3295,
-  serialized_end=3485,
+  serialized_start=3551,
+  serialized_end=3741,
 )
 
 
@@ -1264,8 +1495,8 @@ _ROLLBACKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3487,
-  serialized_end=3505,
+  serialized_start=3743,
+  serialized_end=3761,
 )
 
 
@@ -1337,8 +1568,8 @@ _SPLITQUERYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3508,
-  serialized_end=3753,
+  serialized_start=3764,
+  serialized_end=4009,
 )
 
 
@@ -1375,8 +1606,8 @@ _QUERYSPLIT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3755,
-  serialized_end=3820,
+  serialized_start=4011,
+  serialized_end=4076,
 )
 
 
@@ -1406,8 +1637,8 @@ _SPLITQUERYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3822,
-  serialized_end=3878,
+  serialized_start=4078,
+  serialized_end=4134,
 )
 
 
@@ -1430,8 +1661,8 @@ _STREAMHEALTHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3880,
-  serialized_end=3901,
+  serialized_start=4136,
+  serialized_end=4157,
 )
 
 
@@ -1489,8 +1720,8 @@ _REALTIMESTATS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3904,
-  serialized_end=4073,
+  serialized_start=4160,
+  serialized_end=4329,
 )
 
 
@@ -1541,8 +1772,8 @@ _STREAMHEALTHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4076,
-  serialized_end=4240,
+  serialized_start=4332,
+  serialized_end=4496,
 )
 
 _TARGET.fields_by_name['tablet_type'].enum_type = topodata__pb2._TABLETTYPE
@@ -1554,6 +1785,10 @@ _BOUNDQUERY.fields_by_name['bind_variables'].message_type = _BOUNDQUERY_BINDVARI
 _FIELD.fields_by_name['type'].enum_type = _FIELD_TYPE
 _FIELD_TYPE.containing_type = _FIELD
 _FIELD_FLAG.containing_type = _FIELD
+_ROW1.fields_by_name['values'].message_type = _CELL
+_RESULT1.fields_by_name['rows'].message_type = _ROW1
+_RESULT2.fields_by_name['rows'].message_type = _ROW2
+_RESULT3.fields_by_name['rows'].message_type = _ROW3
 _QUERYRESULT.fields_by_name['fields'].message_type = _FIELD
 _QUERYRESULT.fields_by_name['rows'].message_type = _ROW
 _GETSESSIONIDREQUEST.fields_by_name['effective_caller_id'].message_type = vtrpc__pb2._CALLERID
@@ -1596,6 +1831,13 @@ DESCRIPTOR.message_types_by_name['BindVariable'] = _BINDVARIABLE
 DESCRIPTOR.message_types_by_name['BoundQuery'] = _BOUNDQUERY
 DESCRIPTOR.message_types_by_name['Field'] = _FIELD
 DESCRIPTOR.message_types_by_name['Row'] = _ROW
+DESCRIPTOR.message_types_by_name['Cell'] = _CELL
+DESCRIPTOR.message_types_by_name['Row1'] = _ROW1
+DESCRIPTOR.message_types_by_name['Result1'] = _RESULT1
+DESCRIPTOR.message_types_by_name['Row2'] = _ROW2
+DESCRIPTOR.message_types_by_name['Result2'] = _RESULT2
+DESCRIPTOR.message_types_by_name['Row3'] = _ROW3
+DESCRIPTOR.message_types_by_name['Result3'] = _RESULT3
 DESCRIPTOR.message_types_by_name['QueryResult'] = _QUERYRESULT
 DESCRIPTOR.message_types_by_name['GetSessionIdRequest'] = _GETSESSIONIDREQUEST
 DESCRIPTOR.message_types_by_name['GetSessionIdResponse'] = _GETSESSIONIDRESPONSE
@@ -1667,6 +1909,55 @@ Row = _reflection.GeneratedProtocolMessageType('Row', (_message.Message,), dict(
   # @@protoc_insertion_point(class_scope:query.Row)
   ))
 _sym_db.RegisterMessage(Row)
+
+Cell = _reflection.GeneratedProtocolMessageType('Cell', (_message.Message,), dict(
+  DESCRIPTOR = _CELL,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Cell)
+  ))
+_sym_db.RegisterMessage(Cell)
+
+Row1 = _reflection.GeneratedProtocolMessageType('Row1', (_message.Message,), dict(
+  DESCRIPTOR = _ROW1,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Row1)
+  ))
+_sym_db.RegisterMessage(Row1)
+
+Result1 = _reflection.GeneratedProtocolMessageType('Result1', (_message.Message,), dict(
+  DESCRIPTOR = _RESULT1,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Result1)
+  ))
+_sym_db.RegisterMessage(Result1)
+
+Row2 = _reflection.GeneratedProtocolMessageType('Row2', (_message.Message,), dict(
+  DESCRIPTOR = _ROW2,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Row2)
+  ))
+_sym_db.RegisterMessage(Row2)
+
+Result2 = _reflection.GeneratedProtocolMessageType('Result2', (_message.Message,), dict(
+  DESCRIPTOR = _RESULT2,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Result2)
+  ))
+_sym_db.RegisterMessage(Result2)
+
+Row3 = _reflection.GeneratedProtocolMessageType('Row3', (_message.Message,), dict(
+  DESCRIPTOR = _ROW3,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Row3)
+  ))
+_sym_db.RegisterMessage(Row3)
+
+Result3 = _reflection.GeneratedProtocolMessageType('Result3', (_message.Message,), dict(
+  DESCRIPTOR = _RESULT3,
+  __module__ = 'query_pb2'
+  # @@protoc_insertion_point(class_scope:query.Result3)
+  ))
+_sym_db.RegisterMessage(Result3)
 
 QueryResult = _reflection.GeneratedProtocolMessageType('QueryResult', (_message.Message,), dict(
   DESCRIPTOR = _QUERYRESULT,


### PR DESCRIPTION
TL;DR: The cost of manipulating and converting data structures
in go code is negligible. However the cost of decoding pointers
or multidimensional slices is very high.

This is only an experimental benchmark. I'll not be submitting
this. So, we either have to use the complicated Rows3 format,
or fix the root cause of the performance in proto3.

BenchmarkRow1-12          500000              2967 ns/op
BenchmarkMarshal1-12      200000              8587 ns/op
BenchmarkUnmarshal1-12    100000             17030 ns/op
BenchmarkRow2-12          500000              2158 ns/op
BenchmarkMarshal2-12      300000              6654 ns/op
BenchmarkUnmarshal2-12    100000             12778 ns/op
BenchmarkRow3-12         1000000              1323 ns/op
BenchmarkMarshal3-12      500000              3182 ns/op
BenchmarkUnmarshal3-12    300000              4623 ns/op