### PR TITLE
misc: Fail precommits if GOPATH is not set.

### DIFF
--- a/misc/git/hooks/golint
+++ b/misc/git/hooks/golint
@@ -7,14 +7,18 @@
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
-#
-# This script does not handle file names that contain spaces.
+
+if [ -z "$GOPATH" ]; then
+  echo "ERROR: pre-commit hook for golint: \$GOPATH is empty. Please run 'source dev.env' to set the correct \$GOPATH."
+  exit 1
+fi
 
 if [ -z "$(which golint)" ]; then
   echo "golint not found, please run: go get github.com/golang/lint/golint"
   exit 1
 fi
 
+# This script does not handle file names that contain spaces.
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 
 errors=

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -7,7 +7,12 @@
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
-#
+
+if [ -z "$GOPATH" ]; then
+  echo "ERROR: pre-commit hook for go vet: \$GOPATH is empty. Please run 'source dev.env' to set the correct \$GOPATH."
+  exit 1
+fi
+
 # This script does not handle file names that contain spaces.
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 


### PR DESCRIPTION
Some precommits (go vet, golint) require a working Go environment
because they not only look at the file under inspection itself, but they
also try to load the imported packages.

Unfortunately, they don't fail if they cannot load the imports. Instead,
you see subsequent errors due to the missing imports.

For example:

Go vet error: "composite literal uses unkeyed fields"

This occurs when we use a struct initializer
without keyed fields where the struct is defined in another Go package.
In that case, the tools cannot find out how many/which fields the struct
has and if it's actually okay to use unkeyed fields because we specify
all fields.