### PR TITLE
Add gRPC port to vtctld.

### DIFF
--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -301,7 +301,7 @@ $ export KUBECTL=/example/path/to/google-cloud-sdk/bin/kubectl
     # Creating vtctld pod...
     # pods/vtctld
     #
-    # vtctld address: http://2.3.4.5:30000
+    # vtctld web address: http://2.3.4.5:30000
     ```
 
     To let you access vtctld from outside Kubernetes, the
@@ -320,7 +320,7 @@ $ export KUBECTL=/example/path/to/google-cloud-sdk/bin/kubectl
 1.  **Access vtctld**
 
     To access the `vtctld` service from outside
-    Kubernetes, you need to open port `30000` in your platform's firewall.
+    Kubernetes, you need to open ports `30000-30001` in your platform's firewall.
     (If you don't complete this step, the only way to issue commands
     to `vtctld` would be to SSH into a Kubernetes node
     and install and run `vtctlclient` there.)
@@ -328,7 +328,7 @@ $ export KUBECTL=/example/path/to/google-cloud-sdk/bin/kubectl
     On Compute Engine, you can open the port like this:
 
     ``` sh
-    $ gcloud compute firewall-rules create vtctld --allow tcp:30000
+    $ gcloud compute firewall-rules create vtctld --allow tcp:30000-30001
     ```
 
     You can then access the vtctld web interface at the address printed
@@ -342,6 +342,9 @@ $ export KUBECTL=/example/path/to/google-cloud-sdk/bin/kubectl
 
     When you call `vtctlclient`, the command requires
     the IP address and port for your `vtctld` service.
+    Note that the RPC service is on a different port than the web UI.
+    In this example, we've set the RPC port to `30001`.
+
     To avoid having to enter that for each command, you can use the
     provided `kvtctl.sh` script, which uses `kubectl` to discover the
     proper address.

--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -7,7 +7,7 @@
 KUBECTL=${KUBECTL:-kubectl}
 
 # This should match the nodePort in vtctld-service.yaml
-VTCTLD_PORT=${VTCTLD_PORT:-30000}
+VTCTLD_PORT=${VTCTLD_PORT:-30001}
 
 # Get the ExternalIP of any node.
 get_node_ip() {
@@ -17,12 +17,11 @@ get_node_ip() {
 # Try to find vtctld address if not provided.
 get_vtctld_addr() {
   if [ -z "$VTCTLD_ADDR" ]; then
-    node_ip=$(get_node_ip)
-    if [ -n "$node_ip" ]; then
-      VTCTLD_ADDR="$node_ip:$VTCTLD_PORT"
+    VTCTLD_HOST=$(get_node_ip)
+    if [ -n "$VTCTLD_HOST" ]; then
+      VTCTLD_ADDR="$VTCTLD_HOST:$VTCTLD_PORT"
     fi
   fi
-  echo "$VTCTLD_ADDR"
 }
 
 config_file=`dirname "${BASH_SOURCE}"`/config.sh

--- a/examples/kubernetes/guestbook/Dockerfile
+++ b/examples/kubernetes/guestbook/Dockerfile
@@ -1,5 +1,25 @@
 # This Dockerfile should be built from within the accompanying build.sh script.
-FROM google/python-runtime
+FROM debian:jessie
+
+RUN apt-get update -y \
+ && apt-get install --no-install-recommends -y -q \
+    build-essential \
+    python2.7 \
+    python2.7-dev \
+    python-pip \
+    git \
+ && pip install -U pip \
+ && pip install virtualenv
+
+WORKDIR /app
+RUN virtualenv /env
+ADD requirements.txt /app/requirements.txt
+RUN /env/bin/pip install -r /app/requirements.txt
+ADD . /app
+
+EXPOSE 8080
+CMD []
+ENTRYPOINT ["/env/bin/python", "main.py"]
 
 ADD tmp/pkg /app/site-packages
 ADD tmp/lib/* /app/lib/

--- a/examples/kubernetes/kvtctl.sh
+++ b/examples/kubernetes/kvtctl.sh
@@ -9,12 +9,12 @@ script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
 echo "Getting vtctld address from kubectl..."
-server=$(get_vtctld_addr)
-if [[ -z "$server" ]]; then
+get_vtctld_addr
+if [[ -z "$VTCTLD_ADDR" ]]; then
   echo "Can't find VTCTLD_ADDR."
   exit 1
 fi
 
-echo "Using $server"
-vtctlclient -server $server "$@"
+echo "Using $VTCTLD_ADDR"
+vtctlclient -server $VTCTLD_ADDR "$@"
 

--- a/examples/kubernetes/vitess-up.sh
+++ b/examples/kubernetes/vitess-up.sh
@@ -116,7 +116,7 @@ wait_for_running_tasks vttablet $total_tablet_count
 wait_for_running_tasks vtgate $vtgate_count
 
 echo Creating firewall rule for vtctld...
-vtctld_port=30000
+vtctld_port=30001
 gcloud compute firewall-rules create ${GKE_CLUSTER_NAME}-vtctld --allow tcp:$vtctld_port
 vtctld_ip=`kubectl get -o yaml nodes | grep 'type: ExternalIP' -B 1 | head -1 | awk '{print $NF}'`
 vtctl_server="$vtctld_ip:$vtctld_port"

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -40,6 +40,7 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000
+              -grpc_port 15001
               -service_map 'grpc-vtctl'
               -topo_implementation etcd
               -tablet_protocol grpc

--- a/examples/kubernetes/vtctld-service.yaml
+++ b/examples/kubernetes/vtctld-service.yaml
@@ -8,8 +8,13 @@ metadata:
 spec:
   ports:
     - port: 15000
+      name: web
       targetPort: 15000
       nodePort: 30000
+    - port: 15001
+      name: grpc
+      targetPort: 15001
+      nodePort: 30001
   selector:
     component: vtctld
     app: vitess

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -20,7 +20,8 @@ done
 # Instantiate template and send to kubectl.
 cat vtctld-controller-template.yaml | sed -e "$sed_script" | $KUBECTL create -f -
 
-server=$(get_vtctld_addr)
+get_vtctld_addr
 echo
-echo "vtctld address: http://$server"
+echo "vtctld RPC address: $VTCTLD_ADDR"
+echo "vtctld web address: http://$VTCTLD_HOST:30000"
 

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -8,7 +8,7 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-server=$(get_vtctld_addr)
+get_vtctld_addr
 
 # Delete the pods for all shards
 CELLS=${CELLS:-'test'}
@@ -27,10 +27,10 @@ for shard in `seq 1 $num_shards`; do
       uid=$[$uid_base + $uid_index + $cell_index]
       printf -v alias '%s-%010d' $cell $uid
 
-      if [ -n "$server" ]; then
+      if [ -n "$VTCTLD_ADDR" ]; then
         set +e
         echo "Removing tablet $alias from Vitess topology..."
-        vtctlclient -server $server DeleteTablet -allow_master -skip_rebuild $alias
+        vtctlclient -server $VTCTLD_ADDR DeleteTablet -allow_master -skip_rebuild $alias
         set -e
       fi
 


### PR DESCRIPTION
@michael-berlin 

Now that we use gRPC for vtctlclient, we need to add a -grpc_port flag.
Since gRPC can't coexist on the same port as HTTP/1, we now need two
ports for vtctld.