### PR TITLE
Clean up vtgatev2.py after merging entity_ids in.

### DIFF
--- a/py/vtdb/sql_builder.py
+++ b/py/vtdb/sql_builder.py
@@ -796,10 +796,6 @@ class OrExprs(SQLOperator):
     return or_clause, bind_vars
 
 
-class Like(SQLOperator):
-  op = 'LIKE'
-
-
 class Greater(SQLOperator):
   op = '>'
 
@@ -814,6 +810,14 @@ class Less(SQLOperator):
 
 class LessEqual(SQLOperator):
   op = '<='
+
+
+class Like(SQLOperator):
+  op = 'LIKE'
+
+
+class NotLike(SQLOperator):
+  op = 'NOT LIKE'
 
 
 class ModuloEquals(SQLOperator):

--- a/test/sql_builder_test.py
+++ b/test/sql_builder_test.py
@@ -579,11 +579,6 @@ class TestSqlWhereExprs(BaseTestCase):
         dict(x_5=3, y_4=5, z_3=7),
         column_name=None)
 
-  def test_like(self):
-    self._check_build_where_sql(
-        sql_builder.Like('FOO%'),
-        'col_a LIKE %(col_a_3)s', dict(col_a_3='FOO%'))
-
   def test_greater_than(self):
     self._check_build_where_sql(
         sql_builder.Greater(5),
@@ -604,11 +599,21 @@ class TestSqlWhereExprs(BaseTestCase):
         sql_builder.LessEqual(5),
         'col_a <= %(col_a_3)s', dict(col_a_3=5))
 
+  def test_like(self):
+    self._check_build_where_sql(
+        sql_builder.Like('FOO%'),
+        'col_a LIKE %(col_a_3)s', dict(col_a_3='FOO%'))
+
   def test_modulo_equals(self):
     self._check_build_where_sql(
         sql_builder.ModuloEquals(modulus=5, value=3),
         '(col_a %% %(modulus_3)s) = %(col_a_4)s',
         dict(modulus_3=5, col_a_4=3))
+
+  def test_not_like(self):
+    self._check_build_where_sql(
+        sql_builder.NotLike('FOO%'),
+        'col_a NOT LIKE %(col_a_3)s', dict(col_a_3='FOO%'))
 
   def test_expression(self):
     self._check_build_where_sql(

--- a/test/sql_builder_test.py
+++ b/test/sql_builder_test.py
@@ -11,8 +11,8 @@ import utils
 
 
 class BaseTestCase(unittest.TestCase):
-
   pass
+
 
 class TestBuildValuesClause(BaseTestCase):
   """Test sql_builder.build_values_clause."""

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -19,8 +19,8 @@ from vtdb import dbexceptions
 from vtdb import keyrange
 from vtdb import keyrange_constants
 from vtdb import vtdb_logger
-from vtdb import vtgate_cursor
 from vtdb import vtgate_client
+from vtdb import vtgate_cursor
 
 shard_0_master = tablet.Tablet()
 shard_0_replica1 = tablet.Tablet()
@@ -239,6 +239,7 @@ class BaseTestCase(unittest.TestCase):
   def setUp(self):
     super(BaseTestCase, self).setUp()
     logging.info('Start: %s.', '.'.join(self.id().split('.')[-2:]))
+
 
 class TestCoreVTGateFunctions(BaseTestCase):
 
@@ -682,7 +683,7 @@ class TestCoreVTGateFunctions(BaseTestCase):
     query = 'select * from vt_field_types where str_val in %(str_val_1)s'
     rowcount = cursor.execute(query, {'str_val_1': str_val_list})
     self.assertEqual(rowcount, len(str_val_list), "rowcount doesn't match")
-    for i, r in enumerate(cursor.results):
+    for r in cursor.results:
       row = DBRow(field_names, r)
       self.assertIsInstance(row.str_val, str)
 
@@ -692,7 +693,7 @@ class TestCoreVTGateFunctions(BaseTestCase):
     rowcount = cursor.execute(query, {'unicode_val_1': unicode_val_list})
     self.assertEqual(
         rowcount, len(unicode_val_list), "rowcount doesn't match")
-    for i, r in enumerate(cursor.results):
+    for r in cursor.results:
       row = DBRow(field_names, r)
       self.assertIsInstance(row.unicode_val, basestring)
 
@@ -727,9 +728,9 @@ class TestFailures(BaseTestCase):
     utils.vtgate.kill()
     utils.VtGate(port=port).start()
 
-  def tablet_start(self, tablet, tablet_type, lameduck_period='0.5s'):
+  def tablet_start(self, tablet_obj, tablet_type, lameduck_period='0.5s'):
     _ = tablet_type
-    return tablet.start_vttablet(lameduck_period=lameduck_period)
+    return tablet_obj.start_vttablet(lameduck_period=lameduck_period)
 
   def test_status_with_error(self):
     """Tests that the status page loads correctly after a VTGate error."""


### PR DESCRIPTION
Make vtgatev2._execute prefer entity_keyspace_ids_map if both entity_keyspace_ids_map and other routing parameters are use. Fix some pylint errors. Add sql_builder.NotLike.

@alainjobart 