### PR TITLE
Kubernetes updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 Godeps/_workspace/pkg
 Godeps/_workspace/bin
 _test
+java/*/target
+java/*/bin
+php/vendor
+

--- a/Dockerfile.mariadb
+++ b/Dockerfile.mariadb
@@ -1,4 +1,4 @@
-FROM vitess/bootstrap:mysql56
+FROM vitess/bootstrap:mariadb
 
 # Clear out old tree from bootstrap image.
 USER root

--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -711,22 +711,16 @@ You'll also need to adjust the same certificate path settings in the
 ### Status pages for vttablets
 
 Each `vttablet` serves a set of HTML status pages on its primary port.
-The `vtctld` interface provides a **STATUS** link for each tablet, but the
-links are actually to internal, per-pod IPs that can only be accessed from
-within Kubernetes.
+The `vtctld` interface provides a **STATUS** link for each tablet.
 
-As a workaround, you can access tablet status pages through the
-[apiserver proxy](http://kubernetes.io/v1.0/docs/user-guide/accessing-the-cluster.html#accessing-services-running-on-the-cluster),
-provided by the Kubernetes master. For example, to see the status
-page for the tablet with ID 100 (recall that our Kubernetes master is assumed to
-be on public IP 1.2.3.4), you could navigate to:
+If you access the vtctld web UI through the kubectl proxy as described above,
+it will automatically link to the vttablets through that same proxy,
+giving you access from outside the cluster.
 
-```
-https://1.2.3.4/api/v1/proxy/namespaces/default/pods/vttablet-100:15002/debug/status
-```
+You can also use the proxy to go directly to a tablet. For example,
+to see the status page for the tablet with ID `100`, you could navigate to:
 
-In the future, we plan to have vtctld directly link through this proxy from
-the **STATUS** link.
+http://localhost:8001/api/v1/proxy/namespaces/default/pods/vttablet-100:15002/debug/status
 
 ### Direct connection to mysqld
 

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -67,7 +67,12 @@ ENV CGO_LDFLAGS -L$VTROOT/dist/vt-zookeeper-3.3.5/lib
 ENV LD_LIBRARY_PATH $VTROOT/dist/vt-zookeeper-3.3.5/lib
 
 # Copy files needed for bootstrap
-COPY . /vt/src/github.com/youtube/vitess
+COPY bootstrap.sh dev.env /vt/src/github.com/youtube/vitess/
+COPY config /vt/src/github.com/youtube/vitess/config
+COPY third_party /vt/src/github.com/youtube/vitess/third_party
+COPY tools /vt/src/github.com/youtube/vitess/tools
+COPY travis /vt/src/github.com/youtube/vitess/travis
+COPY php/composer.* /vt/src/github.com/youtube/vitess/php/
 
 # Install gRPC and protobuf as root
 RUN $VTTOP/travis/install_protobuf.sh
@@ -89,3 +94,4 @@ VOLUME /vt/vtdataroot
 
 # If the user doesn't specify a command, load a shell.
 CMD ["/bin/bash"]
+

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -32,8 +32,6 @@ RUN mkdir -p /vt/bin && \
     curl -sL https://phar.phpunit.de/phpunit-4.8.9.phar > /vt/bin/phpunit && \
     chmod +x /vt/bin/phpunit && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/vt/bin --filename=composer && \
-    pecl install mongo && \
-    echo 'extension=mongo.so' > /etc/php5/cli/conf.d/20-mongo.ini && \
     pecl install xdebug && \
     echo "zend_extension=$(pecl config-get ext_dir default)/xdebug.so" > /etc/php5/cli/conf.d/20-xdebug.ini
 

--- a/docker/etcd-lite/Dockerfile
+++ b/docker/etcd-lite/Dockerfile
@@ -2,4 +2,4 @@
 FROM debian:jessie
 
 # Copy binaries (placed by build.sh)
-COPY base/etcd base/etcdctl /usr/bin/
+COPY base/* /usr/bin/

--- a/docker/etcd-lite/build.sh
+++ b/docker/etcd-lite/build.sh
@@ -12,7 +12,7 @@ set -e
 
 # Extract files from vitess/etcd image
 mkdir base
-sudo docker run -ti --rm -v $PWD/base:/base -u root vitess/etcd:$version bash -c 'cp -R /go/bin/etcd /go/bin/etcdctl /base/'
+sudo docker run -ti --rm -v $PWD/base:/base -u root vitess/etcd:$version bash -c 'cp -R /go/bin/* /base/'
 
 # Build vitess/etcd-lite image
 sudo docker build -t vitess/etcd:$version-lite .

--- a/docker/etcd/Dockerfile
+++ b/docker/etcd/Dockerfile
@@ -6,6 +6,9 @@
 # etcd Docker image on quay.io doesn't have any shell in it.
 FROM golang:1.5
 
+ADD getsrv.go /go/
+RUN GOBIN=/go/bin go install /go/getsrv.go
+
 RUN mkdir -p src/github.com/coreos && \
     cd src/github.com/coreos && \
     curl -sL https://github.com/coreos/etcd/archive/v2.0.13.tar.gz | tar -xz && \

--- a/docker/etcd/getsrv.go
+++ b/docker/etcd/getsrv.go
@@ -1,0 +1,21 @@
+// getsrv is a tiny utility that just calls net.LookupSRV().
+// It's used in the etcd pod for the Vitess on Kubernetes example,
+// to avoid having to install extra packages in etcd-lite.
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	_, addrs, err := net.LookupSRV(os.Args[1], os.Args[2], os.Args[3])
+	if err != nil {
+		return
+	}
+
+	for _, addr := range addrs {
+		fmt.Printf("%v:%v\n", addr.Target, addr.Port)
+	}
+}

--- a/docker/lite/Dockerfile.mariadb
+++ b/docker/lite/Dockerfile.mariadb
@@ -2,16 +2,13 @@
 FROM debian:jessie
 
 # Install dependencies
-RUN apt-key adv --recv-keys --keyserver pgp.mit.edu 5072E1F5 \
- && echo 'deb http://repo.mysql.com/apt/debian/ jessie mysql-5.6' > /etc/apt/sources.list.d/mysql.list \
+RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db \
+ && echo 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.0/debian jessie main' > /etc/apt/sources.list.d/mariadb.list \
  && apt-get update \
- && DEBIAN_FRONTEND=noninteractive \
-    apt-get install -y --no-install-recommends \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       bzip2 \
       memcached \
-      libmysqlclient18 \
-      mysql-client \
-      mysql-server \
+      mariadb-server \
  && rm -rf /var/lib/apt/lists/*
 
 # Set up Vitess environment (just enough to run pre-built Go binaries)

--- a/examples/kubernetes/etcd-controller-template.yaml
+++ b/examples/kubernetes/etcd-controller-template.yaml
@@ -45,16 +45,9 @@ spec:
             - >-
               ipaddr=$(hostname -i)
 
-              global_etcd=$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
-
-              cell="{{cell}}" &&
-              local_etcd_host_var="ETCD_${cell^^}_SERVICE_HOST" &&
-              local_etcd_port_var="ETCD_${cell^^}_SERVICE_PORT" &&
-              local_etcd=${!local_etcd_host_var}:${!local_etcd_port_var}
-
               if [ "{{cell}}" != "global" ]; then
-              until etcdctl -C "http://$global_etcd"
-              set "/vt/cells/{{cell}}" "http://$local_etcd"; do
+              until etcdctl -C "http://etcd-global:4001"
+              set "/vt/cells/{{cell}}" "http://etcd-{{cell}}:4001"; do
               echo "[$(date)] waiting for global etcd to register cell '{{cell}}'";
               sleep 1;
               done;

--- a/examples/kubernetes/etcd-controller-template.yaml
+++ b/examples/kubernetes/etcd-controller-template.yaml
@@ -23,6 +23,12 @@ spec:
       containers:
         - name: etcd
           image: vitess/etcd:v2.0.13-lite
+          livenessProbe:
+            httpGet:
+              path: /v2/keys/
+              port: 4001
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: certs
               readOnly: true

--- a/examples/kubernetes/etcd-controller-template.yaml
+++ b/examples/kubernetes/etcd-controller-template.yaml
@@ -23,12 +23,6 @@ spec:
       containers:
         - name: etcd
           image: vitess/etcd:v2.0.13-lite
-          livenessProbe:
-            httpGet:
-              path: /v2/keys/
-              port: 4001
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
           volumeMounts:
             - name: certs
               readOnly: true
@@ -42,20 +36,75 @@ spec:
           command:
             - bash
             - "-c"
-            - >-
+            - |
               ipaddr=$(hostname -i)
+              peer_url="http://$ipaddr:7001"
+              client_url="http://$ipaddr:4001"
 
-              if [ "{{cell}}" != "global" ]; then
-              until etcdctl -C "http://etcd-global:4001"
-              set "/vt/cells/{{cell}}" "http://etcd-{{cell}}:4001"; do
-              echo "[$(date)] waiting for global etcd to register cell '{{cell}}'";
-              sleep 1;
-              done;
+              export ETCD_NAME=$HOSTNAME
+              export ETCD_DATA_DIR=/vt/vtdataroot/etcd-$ETCD_NAME
+              export ETCD_STRICT_RECONFIG_CHECK=true
+              export ETCD_ADVERTISE_CLIENT_URLS=$client_url
+              export ETCD_INITIAL_ADVERTISE_PEER_URLS=$peer_url
+              export ETCD_LISTEN_CLIENT_URLS=$client_url
+              export ETCD_LISTEN_PEER_URLS=$peer_url
+
+              if [ -d $ETCD_DATA_DIR ]; then
+                # We've been restarted with an intact datadir.
+                # Just run without trying to do any bootstrapping.
+                echo "Resuming with existing data dir: $ETCD_DATA_DIR"
+              else
+                # This is the first run for this member.
+
+                # If there's already a functioning cluster, join it.
+                echo "Checking for existing cluster by trying to join..."
+                if result=$(etcdctl -C http://etcd-{{cell}}:4001 member add $ETCD_NAME $peer_url); then
+                  [[ "$result" =~ ETCD_INITIAL_CLUSTER=\"([^\"]*)\" ]] && \
+                  export ETCD_INITIAL_CLUSTER="${BASH_REMATCH[1]}"
+                  export ETCD_INITIAL_CLUSTER_STATE=existing
+                  echo "Joining existing cluster: $ETCD_INITIAL_CLUSTER"
+                else
+                  # Join failed. Assume we're trying to bootstrap.
+
+                  # First register with global topo, if we aren't global.
+                  if [ "{{cell}}" != "global" ]; then
+                    echo "Registering cell "{{cell}}" with global etcd..."
+                    until etcdctl -C "http://etcd-global:4001" \
+                        set "/vt/cells/{{cell}}" "http://etcd-{{cell}}:4001"; do
+                      echo "[$(date)] waiting for global etcd to register cell '{{cell}}'"
+                      sleep 1
+                    done
+                  fi
+
+                  # Use DNS to bootstrap.
+
+                  # First wait for the desired number of replicas to show up.
+                  echo "Waiting for {{replicas}} replicas in SRV record for etcd-{{cell}}-srv..."
+                  until [ $(getsrv etcd-server tcp etcd-{{cell}}-srv | wc -l) -eq {{replicas}} ]; do
+                    echo "[$(date)] waiting for {{replicas}} entries in SRV record for etcd-{{cell}}-srv"
+                    sleep 1
+                  done
+
+                  export ETCD_DISCOVERY_SRV=etcd-{{cell}}-srv
+                  echo "Bootstrapping with DNS discovery:"
+                  getsrv etcd-server tcp etcd-{{cell}}-srv
+                fi
               fi
 
-              etcd -name $HOSTNAME -discovery {{discovery}}
-              -advertise-client-urls http://$ipaddr:4001
-              -initial-advertise-peer-urls http://$ipaddr:7001
-              -listen-client-urls http://$ipaddr:4001
-              -listen-peer-urls http://$ipaddr:7001
+              # We've set up the env as we want it. Now run.
+              etcd
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - bash
+                  - "-c"
+                  - |
+                    # Find our member ID.
+                    members=$(etcdctl -C http://etcd-{{cell}}:4001 member list)
+                    if [[ "$members" =~ ^([0-9a-f]+):\ name=$HOSTNAME ]]; then
+                      member_id=${BASH_REMATCH[1]}
+                      echo "Removing $HOSTNAME ($member_id) from etcd-{{cell}} cluster..."
+                      etcdctl -C http://etcd-{{cell}}:4001 member remove $member_id
+                    fi
 

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -18,5 +18,6 @@ for cell in 'global' $cells; do
 
   echo "Deleting etcd service for $cell cell..."
   $KUBECTL delete service etcd-$cell
+  $KUBECTL delete service etcd-$cell-srv
 done
 

--- a/examples/kubernetes/etcd-service-template.yaml
+++ b/examples/kubernetes/etcd-service-template.yaml
@@ -1,3 +1,5 @@
+---
+# Regular service for load balancing client connections.
 kind: Service
 apiVersion: v1
 metadata:
@@ -13,3 +15,23 @@ spec:
     component: etcd
     cell: {{cell}}
     app: vitess
+---
+# Headless service for etcd cluster bootstrap.
+kind: Service
+apiVersion: v1
+metadata:
+  name: etcd-{{cell}}-srv
+  labels:
+    component: etcd
+    cell: {{cell}}
+    app: vitess
+spec:
+  clusterIP: None
+  ports:
+    - name: etcd-server
+      port: 7001
+  selector:
+    component: etcd
+    cell: {{cell}}
+    app: vitess
+

--- a/examples/kubernetes/etcd-up.sh
+++ b/examples/kubernetes/etcd-up.sh
@@ -19,10 +19,6 @@ CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 
 for cell in 'global' $cells; do
-  # Generate a discovery token.
-  echo "Generating discovery token for $cell cell..."
-  discovery=$(curl -sL https://discovery.etcd.io/new?size=$replicas)
-
   # Create the client service, which will load-balance across all replicas.
   echo "Creating etcd service for $cell cell..."
   cat etcd-service-template.yaml | \
@@ -31,7 +27,7 @@ for cell in 'global' $cells; do
 
   # Expand template variables
   sed_script=""
-  for var in cell discovery replicas; do
+  for var in cell replicas; do
     sed_script+="s,{{$var}},${!var},g;"
   done
 

--- a/examples/kubernetes/guestbook-controller.yaml
+++ b/examples/kubernetes/guestbook-controller.yaml
@@ -13,6 +13,12 @@ spec:
       containers:
         - name: guestbook
           image: vitess/guestbook
+          livenessProbe:
+            httpGet:
+              path: /env
+              port: 8080
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           ports:
             - name: http-server
               containerPort: 8080

--- a/examples/kubernetes/guestbook/main.py
+++ b/examples/kubernetes/guestbook/main.py
@@ -98,8 +98,8 @@ def env():
 if __name__ == "__main__":
   timeout = 10 # connect timeout in seconds
 
-  # Get vtgate service address from Kubernetes environment.
-  addr = '%s:%s' % (os.environ['VTGATE_SERVICE_HOST'], os.environ['VTGATE_SERVICE_PORT'])
+  # Get vtgate service address from Kubernetes DNS.
+  addr = 'vtgate:15001'
 
   # Connect to vtgate.
   conn = vtgatev2.connect({'vt': [addr]}, timeout)

--- a/examples/kubernetes/kvtctl.sh
+++ b/examples/kubernetes/kvtctl.sh
@@ -8,13 +8,9 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-echo "Getting vtctld address from kubectl..."
-get_vtctld_addr
-if [[ -z "$VTCTLD_ADDR" ]]; then
-  echo "Can't find VTCTLD_ADDR."
-  exit 1
-fi
+echo "Starting port forwarding to vtctld..."
+start_vtctld_forward
+trap stop_vtctld_forward EXIT
 
-echo "Using $VTCTLD_ADDR"
-vtctlclient -server $VTCTLD_ADDR "$@"
+vtctlclient -server localhost:$vtctld_forward_port "$@"
 

--- a/examples/kubernetes/vitess-up.sh
+++ b/examples/kubernetes/vitess-up.sh
@@ -118,7 +118,7 @@ wait_for_running_tasks vtgate $vtgate_count
 echo Creating firewall rule for vtctld...
 vtctld_port=30001
 gcloud compute firewall-rules create ${GKE_CLUSTER_NAME}-vtctld --allow tcp:$vtctld_port
-vtctld_ip=`kubectl get -o yaml nodes | grep 'type: ExternalIP' -B 1 | head -1 | awk '{print $NF}'`
+vtctld_ip=`$KUBECTL get -o yaml nodes | grep 'type: ExternalIP' -B 1 | head -1 | awk '{print $NF}'`
 vtctl_server="$vtctld_ip:$vtctld_port"
 kvtctl="$GOPATH/bin/vtctlclient -server $vtctl_server"
 

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -51,7 +51,7 @@ spec:
               -topo_implementation etcd
               -tablet_protocol grpc
               -tablet_manager_protocol grpc
-              -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+              -etcd_global_addrs http://etcd-global:4001
               {{backup_flags}}" vitess
       volumes:
         - name: syslog

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -46,7 +46,7 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000
-              -grpc_port 15001
+              -grpc_port 15999
               -service_map 'grpc-vtctl'
               -topo_implementation etcd
               -tablet_protocol grpc

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -13,6 +13,12 @@ spec:
       containers:
         - name: vtctld
           image: vitess/lite
+          livenessProbe:
+            httpGet:
+              path: /debug/vars
+              port: 15000
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: syslog
               mountPath: /dev/log

--- a/examples/kubernetes/vtctld-service.yaml
+++ b/examples/kubernetes/vtctld-service.yaml
@@ -7,16 +7,11 @@ metadata:
     app: vitess
 spec:
   ports:
-    - port: 15000
-      name: web
-      targetPort: 15000
-      nodePort: 30000
-    - port: 15001
-      name: grpc
-      targetPort: 15001
-      nodePort: 30001
+    - name: web
+      port: 15000
+    - name: grpc
+      port: 15999
   selector:
     component: vtctld
     app: vitess
-  type: NodePort
 

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -20,8 +20,8 @@ done
 # Instantiate template and send to kubectl.
 cat vtctld-controller-template.yaml | sed -e "$sed_script" | $KUBECTL create -f -
 
-get_vtctld_addr
 echo
-echo "vtctld RPC address: $VTCTLD_ADDR"
-echo "vtctld web address: http://$VTCTLD_HOST:30000"
+echo "To access vtctld web UI, start kubectl proxy in another terminal:"
+echo "  kubectl proxy --port=8001"
+echo "Then visit http://localhost:8001/api/v1/proxy/namespaces/default/services/vtctld:web/"
 

--- a/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
+++ b/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
@@ -30,7 +30,7 @@ spec:
               chown -R vitess /vt &&
               su -p -c "/vt/bin/vtgate
               -topo_implementation etcd
-              -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+              -etcd_global_addrs http://etcd-global:4001
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15001

--- a/examples/kubernetes/vtgate-controller-template.yaml
+++ b/examples/kubernetes/vtgate-controller-template.yaml
@@ -13,6 +13,12 @@ spec:
       containers:
         - name: vtgate
           image: vitess/lite
+          livenessProbe:
+            httpGet:
+              path: /debug/vars
+              port: 15001
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: syslog
               mountPath: /dev/log

--- a/examples/kubernetes/vtgate-controller-template.yaml
+++ b/examples/kubernetes/vtgate-controller-template.yaml
@@ -36,7 +36,7 @@ spec:
               chown -R vitess /vt &&
               su -p -c "/vt/bin/vtgate
               -topo_implementation etcd
-              -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+              -etcd_global_addrs http://etcd-global:4001
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15001

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -8,7 +8,10 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-get_vtctld_addr
+echo "Starting port forwarding to vtctld..."
+start_vtctld_forward
+trap stop_vtctld_forward EXIT
+VTCTLD_ADDR="localhost:$vtctld_forward_port"
 
 # Delete the pods for all shards
 CELLS=${CELLS:-'test'}

--- a/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
+++ b/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
@@ -112,10 +112,10 @@ spec:
           -db-config-filtered-uname vt_filtered
           -db-config-filtered-dbname vt_{{keyspace}}
           -db-config-filtered-charset utf8
-          -bootstrap_archive mysql-db-dir_10.0.13-MariaDB.tbz" vitess
+          -bootstrap_archive mysql-db-dir_5.6.24.tbz" vitess
       env:
         - name: EXTRA_MY_CNF
-          value: /vt/config/mycnf/benchmark.cnf:/vt/config/mycnf/master_mariadb.cnf
+          value: /vt/config/mycnf/benchmark.cnf:/vt/config/mycnf/master_mysql56.cnf
   volumes:
     - name: syslog
       hostPath: {path: /dev/log}

--- a/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
+++ b/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
@@ -43,7 +43,7 @@ spec:
 
           su -p -s /bin/bash -c "/vt/bin/vttablet
           -topo_implementation etcd
-          -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+          -etcd_global_addrs http://etcd-global:4001
           -log_dir $VTDATAROOT/tmp
           -alsologtostderr
           -port {{port}}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -32,6 +32,11 @@ spec:
         limits:
           memory: "1Gi"
           cpu: "500m"
+      ports:
+        - name: web
+          containerPort: {{port}}
+        - name: grpc
+          containerPort: {{grpc_port}}
       command:
         - bash
         - "-c"

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -44,7 +44,7 @@ spec:
 
           su -p -s /bin/bash -c "/vt/bin/vttablet
           -topo_implementation etcd
-          -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+          -etcd_global_addrs http://etcd-global:4001
           -log_dir $VTDATAROOT/tmp
           -alsologtostderr
           -port {{port}}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -109,10 +109,10 @@ spec:
           -db-config-filtered-uname vt_filtered
           -db-config-filtered-dbname vt_{{keyspace}}
           -db-config-filtered-charset utf8
-          -bootstrap_archive mysql-db-dir_10.0.13-MariaDB.tbz" vitess
+          -bootstrap_archive mysql-db-dir_5.6.24.tbz" vitess
       env:
         - name: EXTRA_MY_CNF
-          value: /vt/config/mycnf/master_mariadb.cnf
+          value: /vt/config/mycnf/master_mysql56.cnf
   volumes:
     - name: syslog
       hostPath: {path: /dev/log}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -12,6 +12,12 @@ spec:
   containers:
     - name: vttablet
       image: vitess/lite
+      livenessProbe:
+        httpGet:
+          path: /debug/vars
+          port: {{port}}
+        initialDelaySeconds: 30
+        timeoutSeconds: 5
       volumeMounts:
         - name: syslog
           mountPath: /dev/log

--- a/examples/kubernetes/vtworker-pod-template.yaml
+++ b/examples/kubernetes/vtworker-pod-template.yaml
@@ -25,7 +25,7 @@ spec:
           -alsologtostderr
           -port {{port}}
           -topo_implementation etcd
-          -etcd_global_addrs http://$ETCD_GLOBAL_SERVICE_HOST:$ETCD_GLOBAL_SERVICE_PORT
+          -etcd_global_addrs http://etcd-global:4001
           -min_healthy_rdonly_endpoints 1
           -cell {{cell}}
           -tablet_protocol grpc

--- a/test.go
+++ b/test.go
@@ -63,7 +63,7 @@ For example:
 
 // Flags
 var (
-	flavor   = flag.String("flavor", "mariadb", "bootstrap flavor to run against")
+	flavor   = flag.String("flavor", "mysql56", "bootstrap flavor to run against")
 	runCount = flag.Int("runs", 1, "run each test this many times")
 	retryMax = flag.Int("retry", 3, "max number of retries, to detect flaky tests")
 	logPass  = flag.Bool("log-pass", false, "log test output even if it passes")

--- a/travis/php_init.sh
+++ b/travis/php_init.sh
@@ -35,20 +35,6 @@ else
 	curl -sS https://getcomposer.org/installer | php -- --install-dir=$HOME/.phpenv/bin/ --filename=composer
 fi
 
-if [ -f $HOME/.phpenv/lib/mongo.so ]; then
-	echo "Using cached mongo.so"
-else
-	mkdir -p $HOME/mongo
-	git clone https://github.com/mongodb/mongo-php-driver.git $HOME/mongo
-	cd $HOME/mongo
-	phpize
-	./configure
-	make
-	mkdir -p $HOME/.phpenv/lib
-	mv modules/mongo.so $HOME/.phpenv/lib/
-	echo "extension=$HOME/.phpenv/lib/mongo.so" > ~/.phpenv/versions/$version/etc/conf.d/mongo.ini
-fi
-
 if [ ! -f $HOME/.phpenv/lib/grpc.so ]; then
 	echo "Forcing rebuild of gRPC so we can build PHP extension"
 	rm -rf $HOME/gopath/dist

--- a/web/vtctld/config.js
+++ b/web/vtctld/config.js
@@ -1,11 +1,20 @@
 // This file contains config that may need to be changed
 // on a site-local basis.
 vtconfig = {
+  k8s_proxy_re: /(\/api\/v1\/proxy\/.*)\/services\/vtctld/,
   tabletLinks: function(tablet) {
+    status_href = 'http://'+tablet.hostname+':'+tablet.port_map.vt+'/debug/status'
+
+    // If we're in Kubernetes, route through the proxy.
+    var match = window.location.pathname.match(vtconfig.k8s_proxy_re);
+    if (match) {
+      status_href = match[1] + '/pods/vttablet-' + tablet.alias.uid + ':' + tablet.port_map.vt + '/debug/status';
+    }
+
     return [
       {
         title: 'Status',
-        href: 'http://'+tablet.hostname+':'+tablet.port_map.vt+'/debug/status'
+        href: status_href
       }
     ];
   }


### PR DESCRIPTION
@alainjobart 

* Set up kubelet healthcheck (nullz)
* Use `kubectl exec` to avoid direct SSH
* Use k8s built-in DNS for service discovery
  * No longer dependent on startup order
* Use k8s built-in DNS for etcd bootstrap
  * No longer dependent on external discovery service
* Switch default flavor to MySQL56
  * User request
* Use `kubectl port-forward` for vtctld
  * Avoids needing to expose ports through firewall
* Write links to vttablet through k8s proxy