### PR TITLE
travis: Don't cache unnecessary PHP files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,11 @@ before_cache:
   # Delete this file because it keeps changing (having the latest timestamp of an update)
   # and triggers a lengthy update of the cache (~19 seconds).
   - rm $HOME/.m2/repository/com/youtube/vitess/*/*-SNAPSHOT/resolver-status.properties
+  # Don't cache unnecessary PHP files.
+  - rm $HOME/.phpenv/versions/*/sbin/*
+  - rm $HOME/.phpenv/versions/*/bin/php-cgi
+  - find $HOME/.phpenv/vendor/grpc/grpc -mindepth 1 -maxdepth 1 ! -name src | xargs rm -rf
+  - find $HOME/.phpenv/vendor/grpc/grpc/src -mindepth 1 -maxdepth 1 ! -name php | xargs rm -rf
 env:
   global:
     - MYSQL_FLAVOR=MariaDB


### PR DESCRIPTION
@michael-berlin 

This fixes the unnecessary increase in travis cache size introduced in #1190.

That PR added `.phpenv` to the cache, containing these main large dirs:
```
75M	 ./.phpenv/versions/5.5.9/bin
33M	 ./.phpenv/versions/5.5.9/sbin
115M ./.phpenv/versions/5.5.9
115M ./.phpenv/versions
95M  ./.phpenv/vendor/grpc
112M ./.phpenv/vendor
235M ./.phpenv
```

I reduced the `bin` and `sbin` dirs by removing binaries we don't need. The `vendor/grpc` dir contained an entire clone of grpc's github repo (downloaded by composer). That folder only really needs the PHP source files, so I removed everything else.

summary | cache size
--- | ---
before PR1190 | 143MB
after PR1190 | 256MB
after this fix | 175MB