### PR TITLE
Travis: Prevent .lastUpdated file in Maven directory from always

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,10 @@ cache:
 before_cache:
   # Travis CI caching doesn't work with this symlink. Just delete it.
   - rm $HOME/gopath/bin/zksrv.sh
-  # Delete this file because it keeps changing (having the latest timestamp of an update)
-  # and triggers a lengthy update of the cache (~19 seconds).
+  # Delete these files because they keep changing (having the latest timestamp
+  # of an update) and trigger a lengthy update of the cache (~25 seconds).
   - rm $HOME/.m2/repository/com/youtube/vitess/*/*-SNAPSHOT/resolver-status.properties
+  - rm $HOME/.m2/repository/io/grpc/protoc-gen-grpc-java/*/protoc-gen-grpc-java-*.pom.lastUpdated
   # Don't cache unnecessary PHP files.
   - rm $HOME/.phpenv/versions/*/sbin/*
   - rm $HOME/.phpenv/versions/*/bin/php-cgi


### PR DESCRIPTION
updating the Travis cache.

This will cut down the test duration of shard 2 by ~25 seconds.

The Java test time doesn't seem to increase when the file is no longer
cached.

@enisoc 