### PR TITLE
vtworker: Use shorter context with timeout of "--remote_actions_timeo…

### DIFF
--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -36,7 +36,9 @@ type QueryResultReader struct {
 // NewQueryResultReaderForTablet creates a new QueryResultReader for
 // the provided tablet / sql query
 func NewQueryResultReaderForTablet(ctx context.Context, ts topo.Server, tabletAlias *pb.TabletAlias, sql string) (*QueryResultReader, error) {
-	tablet, err := ts.GetTablet(ctx, tabletAlias)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	tablet, err := ts.GetTablet(shortCtx, tabletAlias)
+	cancel()
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -433,13 +433,13 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 	mu := sync.Mutex{}
 	var firstError error
 
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancelCopy := context.WithCancel(ctx)
 	processError := func(format string, args ...interface{}) {
 		scw.wr.Logger().Errorf(format, args...)
 		mu.Lock()
 		if firstError == nil {
 			firstError = fmt.Errorf(format, args...)
-			cancel()
+			cancelCopy()
 		}
 		mu.Unlock()
 	}

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -219,13 +219,17 @@ func (scw *SplitCloneWorker) init(ctx context.Context) error {
 	var err error
 
 	// read the keyspace and validate it
-	scw.keyspaceInfo, err = scw.wr.TopoServer().GetKeyspace(ctx, scw.keyspace)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	scw.keyspaceInfo, err = scw.wr.TopoServer().GetKeyspace(shortCtx, scw.keyspace)
+	cancel()
 	if err != nil {
 		return fmt.Errorf("cannot read keyspace %v: %v", scw.keyspace, err)
 	}
 
 	// find the OverlappingShards in the keyspace
-	osList, err := topotools.FindOverlappingShards(ctx, scw.wr.TopoServer(), scw.keyspace)
+	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
+	osList, err := topotools.FindOverlappingShards(shortCtx, scw.wr.TopoServer(), scw.keyspace)
+	cancel()
 	if err != nil {
 		return fmt.Errorf("cannot FindOverlappingShards in %v: %v", scw.keyspace, err)
 	}
@@ -286,12 +290,14 @@ func (scw *SplitCloneWorker) findTargets(ctx context.Context) error {
 	// get the tablet info for them, and stop their replication
 	scw.sourceTablets = make([]*topo.TabletInfo, len(scw.sourceAliases))
 	for i, alias := range scw.sourceAliases {
-		scw.sourceTablets[i], err = scw.wr.TopoServer().GetTablet(ctx, alias)
+		shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+		scw.sourceTablets[i], err = scw.wr.TopoServer().GetTablet(shortCtx, alias)
+		cancel()
 		if err != nil {
 			return fmt.Errorf("cannot read tablet %v: %v", topoproto.TabletAliasString(alias), err)
 		}
 
-		shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+		shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
 		err := scw.wr.TabletManagerClient().StopSlave(shortCtx, scw.sourceTablets[i])
 		cancel()
 		if err != nil {

--- a/go/vt/worker/split_clone_cmd.go
+++ b/go/vt/worker/split_clone_cmd.go
@@ -111,7 +111,9 @@ func commandSplitClone(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagS
 }
 
 func keyspacesWithOverlappingShards(ctx context.Context, wr *wrangler.Wrangler) ([]map[string]string, error) {
-	keyspaces, err := wr.TopoServer().GetKeyspaces(ctx)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	keyspaces, err := wr.TopoServer().GetKeyspaces(shortCtx)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +126,9 @@ func keyspacesWithOverlappingShards(ctx context.Context, wr *wrangler.Wrangler) 
 		wg.Add(1)
 		go func(keyspace string) {
 			defer wg.Done()
-			osList, err := topotools.FindOverlappingShards(ctx, wr.TopoServer(), keyspace)
+			shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
+			osList, err := topotools.FindOverlappingShards(shortCtx, wr.TopoServer(), keyspace)
+			cancel()
 			if err != nil {
 				rec.RecordError(err)
 				return

--- a/go/vt/worker/split_diff_cmd.go
+++ b/go/vt/worker/split_diff_cmd.go
@@ -80,7 +80,9 @@ func commandSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSe
 // shardsWithSources returns all the shards that have SourceShards set
 // with no Tables list.
 func shardsWithSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[string]string, error) {
-	keyspaces, err := wr.TopoServer().GetKeyspaces(ctx)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	keyspaces, err := wr.TopoServer().GetKeyspaces(shortCtx)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +95,9 @@ func shardsWithSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[string
 		wg.Add(1)
 		go func(keyspace string) {
 			defer wg.Done()
-			shards, err := wr.TopoServer().GetShardNames(ctx, keyspace)
+			shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+			shards, err := wr.TopoServer().GetShardNames(shortCtx, keyspace)
+			cancel()
 			if err != nil {
 				rec.RecordError(err)
 				return
@@ -102,7 +106,9 @@ func shardsWithSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[string
 				wg.Add(1)
 				go func(keyspace, shard string) {
 					defer wg.Done()
-					si, err := wr.TopoServer().GetShard(ctx, keyspace, shard)
+					shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+					si, err := wr.TopoServer().GetShard(shortCtx, keyspace, shard)
+					cancel()
 					if err != nil {
 						rec.RecordError(err)
 						return

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -372,13 +372,13 @@ func (vscw *VerticalSplitCloneWorker) copy(ctx context.Context) error {
 	mu := sync.Mutex{}
 	var firstError error
 
-	ctx, cancel = context.WithCancel(ctx)
+	ctx, cancelCopy := context.WithCancel(ctx)
 	processError := func(format string, args ...interface{}) {
 		vscw.wr.Logger().Errorf(format, args...)
 		mu.Lock()
 		if firstError == nil {
 			firstError = fmt.Errorf(format, args...)
-			cancel()
+			cancelCopy()
 		}
 		mu.Unlock()
 	}

--- a/go/vt/worker/vertical_split_clone_cmd.go
+++ b/go/vt/worker/vertical_split_clone_cmd.go
@@ -111,7 +111,9 @@ func commandVerticalSplitClone(wi *Instance, wr *wrangler.Wrangler, subFlags *fl
 // keyspacesWithServedFrom returns all the keyspaces that have ServedFrom set
 // to one value.
 func keyspacesWithServedFrom(ctx context.Context, wr *wrangler.Wrangler) ([]string, error) {
-	keyspaces, err := wr.TopoServer().GetKeyspaces(ctx)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	keyspaces, err := wr.TopoServer().GetKeyspaces(shortCtx)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +126,9 @@ func keyspacesWithServedFrom(ctx context.Context, wr *wrangler.Wrangler) ([]stri
 		wg.Add(1)
 		go func(keyspace string) {
 			defer wg.Done()
-			ki, err := wr.TopoServer().GetKeyspace(ctx, keyspace)
+			shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+			ki, err := wr.TopoServer().GetKeyspace(shortCtx, keyspace)
+			cancel()
 			if err != nil {
 				rec.RecordError(err)
 				return

--- a/go/vt/worker/vertical_split_diff_cmd.go
+++ b/go/vt/worker/vertical_split_diff_cmd.go
@@ -79,7 +79,9 @@ func commandVerticalSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *fla
 // shardsWithTablesSources returns all the shards that have SourceShards set
 // to one value, with an array of Tables.
 func shardsWithTablesSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[string]string, error) {
-	keyspaces, err := wr.TopoServer().GetKeyspaces(ctx)
+	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+	keyspaces, err := wr.TopoServer().GetKeyspaces(shortCtx)
+	cancel()
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +94,9 @@ func shardsWithTablesSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[
 		wg.Add(1)
 		go func(keyspace string) {
 			defer wg.Done()
-			shards, err := wr.TopoServer().GetShardNames(ctx, keyspace)
+			shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+			shards, err := wr.TopoServer().GetShardNames(shortCtx, keyspace)
+			cancel()
 			if err != nil {
 				rec.RecordError(err)
 				return
@@ -101,7 +105,9 @@ func shardsWithTablesSources(ctx context.Context, wr *wrangler.Wrangler) ([]map[
 				wg.Add(1)
 				go func(keyspace, shard string) {
 					defer wg.Done()
-					si, err := wr.TopoServer().GetShard(ctx, keyspace, shard)
+					shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
+					si, err := wr.TopoServer().GetShard(shortCtx, keyspace, shard)
+					cancel()
 					if err != nil {
 						rec.RecordError(err)
 						return


### PR DESCRIPTION
…ut" for all remote calls (e.g. topology calls).

This makes the code more consistent because some calls already used a shorter timeout, but mainly topology calls not.

In general, this should tighten debugging any hanging worker.py tests. (Note that by default context.Background() is used which is not bounded.)

@alainjobart @aaijazi 