### PR TITLE
Excluding proto generated files from golint and pylint.

### DIFF
--- a/misc/git/hooks/golint
+++ b/misc/git/hooks/golint
@@ -19,7 +19,7 @@ if [ -z "$(which golint)" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/')
 
 errors=
 

--- a/misc/git/hooks/pylint
+++ b/misc/git/hooks/pylint
@@ -19,7 +19,7 @@ PYLINT=/usr/bin/gpylint
 PYARGS="--mode style --disable g-bad-file-header"
 
 # This script does not handle file names that contain spaces.
-pyfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.py$')
+pyfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.py$' | grep -v '^py/vtproto/')
 if [ -z "$pyfiles" ] ; then
   msg "No python files changed."
   exit 0


### PR DESCRIPTION
@dumbunny @enisoc @michael-berlin 