### PR TITLE
bootstraph.sh: Fail early if go get fails.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -42,7 +42,7 @@ else
     (cd zookeeper-$zk_ver/src/c && \
     ./configure --prefix=$zk_dist && \
     make install) && rm -rf zookeeper-$zk_ver zookeeper-$zk_ver.tar.gz)
-  [ $? -eq 0 ] || "zookeeper build failed"
+  [ $? -eq 0 ] || fail "zookeeper build failed"
   touch $zk_dist/.build_finished
 fi
 


### PR DESCRIPTION
Recently, we saw some Travis failures because not all Go dependencies
were successfully 'go get'd. However, the test run didn't stop early and
instead it was difficult to find out the original reason for the test
failure. This commit will make it easier to find out when the bootstrap
flaked and the test simply has to be restarted.

@enisoc @alainjobart 