### PR TITLE
tabletmanager: Fix recognizing deadline exceeded as timeout error.

### DIFF
--- a/go/vt/tabletmanager/grpctmclient/client.go
+++ b/go/vt/tabletmanager/grpctmclient/client.go
@@ -48,7 +48,7 @@ func (client *Client) dial(ctx context.Context, tablet *topo.TabletInfo) (*grpc.
 	deadline, ok := ctx.Deadline()
 	if ok {
 		connectTimeout = deadline.Sub(time.Now())
-		if connectTimeout < 0 {
+		if connectTimeout <= 0 {
 			return nil, nil, timeoutError{fmt.Errorf("timeout connecting to TabletManager on %v", tablet.Alias)}
 		}
 	}

--- a/go/vt/tabletmanager/grpctmclient/client.go
+++ b/go/vt/tabletmanager/grpctmclient/client.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -668,6 +669,9 @@ func (client *Client) Backup(ctx context.Context, tablet *topo.TabletInfo, concu
 
 // IsTimeoutError is part of the tmclient.TabletManagerClient interface
 func (client *Client) IsTimeoutError(err error) bool {
+	if grpc.Code(err) == codes.DeadlineExceeded {
+		return true
+	}
 	switch err.(type) {
 	case timeoutError:
 		return true

--- a/go/vt/tabletmanager/grpctmserver/server_test.go
+++ b/go/vt/tabletmanager/grpctmserver/server_test.go
@@ -17,9 +17,9 @@ import (
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
-// the test here creates a fake server implementation, a fake client
+// TestGRPCTMServer creates a fake server implementation, a fake client
 // implementation, and runs the test suite against the setup.
-func TestGoRPCTMServer(t *testing.T) {
+func TestGRPCTMServer(t *testing.T) {
 	// Listen on a random port
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -28,13 +28,13 @@ func TestGoRPCTMServer(t *testing.T) {
 	host := listener.Addr().(*net.TCPAddr).IP.String()
 	port := int32(listener.Addr().(*net.TCPAddr).Port)
 
-	// Create a gRPC server and listen on the port
+	// Create a gRPC server and listen on the port.
 	s := grpc.NewServer()
 	fakeAgent := agentrpctest.NewFakeRPCAgent(t)
 	tabletmanagerservicepb.RegisterTabletManagerServer(s, &server{agent: fakeAgent})
 	go s.Serve(listener)
 
-	// Create a gRPG client to talk to the fake tablet
+	// Create a gRPC client to talk to the fake tablet.
 	client := &grpctmclient.Client{}
 	ti := topo.NewTabletInfo(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{


### PR DESCRIPTION
Before this fix vtworker for example didn't retry on an expired timeout.

@aaijazi 