### PR TITLE
vterrors: Truncate gRPC errors which are larger than ~8 KiB.

### DIFF
--- a/go/vt/tabletmanager/grpctmserver/server.go
+++ b/go/vt/tabletmanager/grpctmserver/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/tabletmanager"
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
 	tabletmanagerservicepb "github.com/youtube/vitess/go/vt/proto/tabletmanagerservice"
@@ -182,7 +183,7 @@ func (s *server) ExecuteFetchAsDba(ctx context.Context, request *tabletmanagerda
 	return response, s.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsDba, request, response, func() error {
 		qr, err := s.agent.ExecuteFetchAsDba(ctx, request.Query, request.DbName, int(request.MaxRows), request.WantFields, request.DisableBinlogs, request.ReloadSchema)
 		if err != nil {
-			return err
+			return vterrors.ToGRPCError(err)
 		}
 		response.Result = sqltypes.ResultToProto3(qr)
 		return nil
@@ -195,7 +196,7 @@ func (s *server) ExecuteFetchAsApp(ctx context.Context, request *tabletmanagerda
 	return response, s.agent.RPCWrap(ctx, actionnode.TabletActionExecuteFetchAsApp, request, response, func() error {
 		qr, err := s.agent.ExecuteFetchAsApp(ctx, request.Query, int(request.MaxRows), request.WantFields)
 		if err != nil {
-			return err
+			return vterrors.ToGRPCError(err)
 		}
 		response.Result = sqltypes.ResultToProto3(qr)
 		return nil

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -162,9 +162,9 @@ func WithSuffix(in error, suffix string) error {
 	}
 }
 
-// This is the string that we prefix gRPC server errors with. This is necessary
-// because there is currently no good way, in gRPC, to differentiate between an
-// error from a server vs the client.
+// GRPCServerErrPrefix is the string we prefix gRPC server errors with. This is
+// necessary because there is currently no good way, in gRPC, to differentiate
+// between an error from a server vs the client.
 // See: https://github.com/grpc/grpc-go/issues/319
 const GRPCServerErrPrefix = "gRPCServerError:"
 

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -248,12 +248,27 @@ func toGRPCCode(err error) codes.Code {
 	return grpc.Code(err)
 }
 
+// truncateError shortens errors because gRPC has a size restriction on them.
+func truncateError(err error) error {
+	// For more details see: https://github.com/grpc/grpc-go/issues/443
+	// The gRPC spec says "Clients may limit the size of Response-Headers,
+	// Trailers, and Trailers-Only, with a default of 8 KiB each suggested."
+	// Therefore, we assume 8 KiB minus some headroom.
+	GRPCErrorLimit := 8*1024 - 512
+	if len(err.Error()) <= GRPCErrorLimit {
+		return err
+	}
+	truncateInfo := "[...] [remainder of the error is truncated because gRPC has a size limit on errors.]"
+	truncatedErr := err.Error()[:GRPCErrorLimit]
+	return fmt.Errorf("%v %v", truncatedErr, truncateInfo)
+}
+
 // ToGRPCError returns an error as a grpc error, with the appropriate error code
 func ToGRPCError(err error) error {
 	if err == nil {
 		return nil
 	}
-	return grpc.Errorf(toGRPCCode(err), "%v %v", GRPCServerErrPrefix, err)
+	return grpc.Errorf(toGRPCCode(err), "%v %v", GRPCServerErrPrefix, truncateError(err))
 }
 
 // FromGRPCError return a grpc error as a VitessError, translating between error codes


### PR DESCRIPTION
Use vterrors.ToGRPCError() for the tabletmanager gRPC server implementation.

This fixes issues with the vtworker.py test where a reparent is executed during a SplitClone. Since the full SQL query is returned in the error, the error size during SplitClone usually exceeds 20 KiB.

In addition, this will also fix all other places where we send too large errors via gRPC.

In practice, we saw that gRPC behaves undefined for messages larger than ~16 KiB. The spec assumes 8 KiB though. See grpc/grpc-go#443 for a discussion of the issue.

@aaijazi 