### PR TITLE
vtcombo: Fix race condition in StreamExecute.

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -267,7 +267,9 @@ func (itc *internalTabletConn) StreamExecute(ctx context.Context, query string, 
 			BindVariables: bindVars,
 			TransactionId: transactionID,
 		}, func(reply *sqltypes.Result) error {
-			result <- reply
+			// We need to deep-copy the reply before returning,
+			// because the underlying buffers are reused.
+			result <- sqltypes.Proto3ToResult(sqltypes.ResultToProto3(reply))
 			return nil
 		})
 


### PR DESCRIPTION
@alainjobart @sougou 

While porting tests from java_vtgate_test_helper to vtcombo, I found
that streaming queries that fetched more than ~300 rows would indicate
success, but receive fewer rows than expected. The number of rows actually
returned was always in the same ballpark, but would fluctuate from run
to run.

It turned out that since vtcombo returns results in-memory from vttablet
to vtgate, we were returning a *Result once the rows filled up the
buffer size, and then concurrently modifying the already-returned struct
to fill in the next set of rows.