### PR TITLE
Use standard Python unit test runner for pure unit tests to drop dependency on "units" module.

### DIFF
--- a/go/cmd/automation_server/plugin_grpcvtctlclient.go
+++ b/go/cmd/automation_server/plugin_grpcvtctlclient.go
@@ -1,0 +1,11 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+// Imports and register the gRPC vtctl client.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/vtctl/grpcvtctlclient"
+)

--- a/go/cmd/vtctlclient/plugin_grpcvtctlclient.go
+++ b/go/cmd/vtctlclient/plugin_grpcvtctlclient.go
@@ -4,7 +4,7 @@
 
 package main
 
-// Imports and register the gRPC vtctl client
+// Imports and register the gRPC vtctl client.
 
 import (
 	_ "github.com/youtube/vitess/go/vt/vtctl/grpcvtctlclient"

--- a/test/config.json
+++ b/test/config.json
@@ -86,7 +86,9 @@
 		"keyrange": {
 			"File": "keyrange_test.py",
 			"Args": [],
-			"Command": [],
+			"Command": [
+				"test/keyrange_test.py"
+			],
 			"Manual": false,
 			"Shard": 3,
 			"RetryMax": 0,
@@ -218,7 +220,9 @@
 		"sql_builder": {
 			"File": "sql_builder_test.py",
 			"Args": [],
-			"Command": [],
+			"Command": [
+				"test/sql_builder_test.py"
+			],
 			"Manual": false,
 			"Shard": 2,
 			"RetryMax": 0,

--- a/test/keyrange_test.py
+++ b/test/keyrange_test.py
@@ -2,7 +2,6 @@
 
 import struct
 import unittest
-import utils
 
 from vtdb import dbexceptions
 from vtdb import keyrange
@@ -157,4 +156,4 @@ class TestKeyRange(unittest.TestCase):
     self.assertEqual(bind_vars, {})
 
 if __name__ == '__main__':
-  utils.main()
+  unittest.main()

--- a/test/keyrange_test.py
+++ b/test/keyrange_test.py
@@ -68,10 +68,10 @@ class TestKeyRange(unittest.TestCase):
     self.assertEqual(str(kr), keyrange_constants.NON_PARTIAL_KEYRANGE)
 
     for kr_str in int_shard_kid_map:
-      Start_raw, End_raw = kr_str.split('-')
+      start_raw, end_raw = kr_str.split('-')
       kr = keyrange.KeyRange(kr_str)
-      self.assertEqual(kr.Start, Start_raw.strip().decode('hex'))
-      self.assertEqual(kr.End, End_raw.strip().decode('hex'))
+      self.assertEqual(kr.Start, start_raw.strip().decode('hex'))
+      self.assertEqual(kr.End, end_raw.strip().decode('hex'))
       self.assertEqual(str(kr), kr_str)
 
   def test_incorrect_tasks(self):
@@ -94,10 +94,10 @@ class TestKeyRange(unittest.TestCase):
       kr_parts = kr.split('-')
       where_clause, bind_vars = vtrouting._create_where_clause_for_keyrange(kr)
       if len(bind_vars.keys()) == 1:
-        if kr_parts[0] == '':
-          self.assertNotEqual(where_clause.find('<'), -1)
-        else:
+        if kr_parts[0]:
           self.assertNotEqual(where_clause.find('>='), -1)
+        else:
+          self.assertNotEqual(where_clause.find('<'), -1)
       else:
         self.assertNotEqual(where_clause.find('>='), -1)
         self.assertNotEqual(where_clause.find('>='), -1)
@@ -105,10 +105,10 @@ class TestKeyRange(unittest.TestCase):
       kid_list = int_shard_kid_map[kr]
       for keyspace_id in kid_list:
         if len(bind_vars.keys()) == 1:
-          if kr_parts[0] == '':
-            self.assertLess(keyspace_id, bind_vars['keyspace_id0'])
-          else:
+          if kr_parts[0]:
             self.assertGreaterEqual(keyspace_id, bind_vars['keyspace_id0'])
+          else:
+            self.assertLess(keyspace_id, bind_vars['keyspace_id0'])
         else:
           self.assertGreaterEqual(keyspace_id, bind_vars['keyspace_id0'])
           self.assertLess(keyspace_id, bind_vars['keyspace_id1'])
@@ -125,10 +125,10 @@ class TestKeyRange(unittest.TestCase):
       where_clause, bind_vars = vtrouting._create_where_clause_for_keyrange(
           kr, keyspace_col_type=keyrange_constants.KIT_BYTES)
       if len(bind_vars.keys()) == 1:
-        if kr_parts[0] == '':
-          self.assertNotEqual(where_clause.find('<'), -1)
-        else:
+        if kr_parts[0]:
           self.assertNotEqual(where_clause.find('>='), -1)
+        else:
+          self.assertNotEqual(where_clause.find('<'), -1)
       else:
         self.assertNotEqual(where_clause.find('>='), -1)
         self.assertNotEqual(where_clause.find('>='), -1)
@@ -136,11 +136,11 @@ class TestKeyRange(unittest.TestCase):
       kid_list = str_shard_kid_map[kr]
       for keyspace_id in kid_list:
         if len(bind_vars.keys()) == 1:
-          if kr_parts[0] == '':
-            self.assertLess(
+          if kr_parts[0]:
+            self.assertGreaterEqual(
                 keyspace_id.encode('hex'), bind_vars['keyspace_id0'])
           else:
-            self.assertGreaterEqual(
+            self.assertLess(
                 keyspace_id.encode('hex'), bind_vars['keyspace_id0'])
         else:
           self.assertGreaterEqual(

--- a/test/sql_builder_test.py
+++ b/test/sql_builder_test.py
@@ -7,8 +7,6 @@ import unittest
 from vtdb import sql_builder
 from vtdb import vtrouting
 
-import utils
-
 
 class BaseTestCase(unittest.TestCase):
   pass
@@ -685,4 +683,4 @@ class TestUpdateColumnsQuery(BaseTestCase):
         update_column_value_pairs=[('col_c', 3)])
 
 if __name__ == '__main__':
-  utils.main()
+  unittest.main()


### PR DESCRIPTION
NOTE: This is an automated export. Changes were already LGTM'd internally.

I also fixed the pylint issues in test/keyrange_test.py.