### PR TITLE
healthcheck: Don't update tablet record if it's been taken over.

### DIFF
--- a/go/vt/tabletmanager/agent.go
+++ b/go/vt/tabletmanager/agent.go
@@ -103,6 +103,11 @@ type ActionAgent struct {
 	// replication.  It is protected by actionMutex.
 	initReplication bool
 
+	// initialTablet remembers the state of the tablet record at startup.
+	// It can be used to notice, for example, if another tablet has taken over
+	// the record.
+	initialTablet *topodatapb.Tablet
+
 	// mutex protects the following fields, only hold the mutex
 	// to update the fields, nothing else.
 	mutex            sync.Mutex
@@ -462,6 +467,9 @@ func (agent *ActionAgent) Start(ctx context.Context, mysqlPort, vtPort, gRPCPort
 	if err != nil {
 		return err
 	}
+
+	// Save the original tablet record as it is now (at startup).
+	agent.initialTablet = tablet.Tablet
 
 	if err = agent.verifyTopology(ctx); err != nil {
 		return err

--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -1152,7 +1152,7 @@ func Run(t *testing.T, client tmclient.TabletManagerClient, ti *topo.TabletInfo,
 	ctx := context.Background()
 
 	// Test RPC specific methods of the interface.
-    agentRPCTestIsTimeoutErrorDialExpiredContext(ctx, t, client, ti)
+	agentRPCTestIsTimeoutErrorDialExpiredContext(ctx, t, client, ti)
 	agentRPCTestIsTimeoutErrorDialTimeout(ctx, t, client, ti)
 	agentRPCTestIsTimeoutErrorRPC(ctx, t, client, ti, fakeAgent.(*fakeRPCAgent))
 

--- a/go/vt/topotools/tablet_test.go
+++ b/go/vt/topotools/tablet_test.go
@@ -1,0 +1,87 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package topotools
+
+import (
+	"testing"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+func TestCheckOwnership(t *testing.T) {
+	type testCase struct {
+		oldTablet, newTablet *topodatapb.Tablet
+		wantError            bool
+	}
+	table := []testCase{
+		{
+			oldTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123, "mysql": 555},
+			},
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123, "mysql": 222},
+			},
+			wantError: false,
+		},
+		{
+			oldTablet: &topodatapb.Tablet{
+				Ip:      "4.3.2.1",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			wantError: true,
+		},
+		{
+			oldTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 321},
+			},
+			wantError: true,
+		},
+		{
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			wantError: true,
+		},
+		{
+			oldTablet: &topodatapb.Tablet{
+				PortMap: map[string]int32{"vt": 123},
+			},
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			wantError: true,
+		},
+		{
+			oldTablet: &topodatapb.Tablet{
+				Ip: "1.2.3.4",
+			},
+			newTablet: &topodatapb.Tablet{
+				Ip:      "1.2.3.4",
+				PortMap: map[string]int32{"vt": 123},
+			},
+			wantError: true,
+		},
+	}
+
+	for i, tc := range table {
+		gotError := CheckOwnership(tc.oldTablet, tc.newTablet) != nil
+		if gotError != tc.wantError {
+			t.Errorf("[%v]: got error = %v, want error = %v", i, gotError, tc.wantError)
+		}
+	}
+}


### PR DESCRIPTION
@alainjobart 

If the machine a tablet is on loses contact with the cluster, a human or
automated cluster manager may launch a replacement tablet on another
machine. If the original tablet later regains contact, we need to
prevent its healthcheck from modifying the tablet record, which is now
owned by a new instance.

To do this, we rely on the fact that each tablet will set its IP and
primary port in topology on startup. The IP:port should never change for
the life of a process, and any new process that runs simultaneously with
the old one should always have a different IP:port tuple.

Thus, we say that whichever tablet has its IP:port in the tablet record
is the true owner of that record. The healthcheck of any other tablet is
not allowed to modify the record. Note that this check for ownership
applies ONLY to the healthcheck (which includes going SPARE on
shutdown). All other updates to tablet records are unaffected.