### PR TITLE
sqltypes: backward compatibilty tweaks

### DIFF
--- a/go/sqltypes/proto3.go
+++ b/go/sqltypes/proto3.go
@@ -45,7 +45,9 @@ func RowsToProto3(rows [][]Value) []*querypb.Row {
 // because it uses the trusted API.
 func proto3ToRows(fields []*querypb.Field, rows []*querypb.Row) [][]Value {
 	if len(rows) == 0 {
-		return nil
+		// TODO(sougou): This is needed for backward compatibility.
+		// Remove when it's not needed any more.
+		return [][]Value{}
 	}
 
 	result := make([][]Value, len(rows))

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -52,7 +52,7 @@ type Value struct {
 // Every place this function is called, a comment is needed that explains
 // why it's justified.
 func MakeTrusted(typ querypb.Type, val []byte) Value {
-	if typ == Null || val == nil {
+	if typ == Null {
 		return NULL
 	}
 	return Value{typ: typ, val: val}

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -19,10 +19,6 @@ func TestMake(t *testing.T) {
 	if !reflect.DeepEqual(v, NULL) {
 		t.Errorf("MakeTrusted(Null...) = %v, want null", makePretty(v))
 	}
-	v = MakeTrusted(Int64, nil)
-	if !reflect.DeepEqual(v, NULL) {
-		t.Errorf("MakeTrusted(..., nil) = %v, want null", makePretty(v))
-	}
 	v = MakeTrusted(Int64, []byte("1"))
 	want := testVal(Int64, "1")
 	if !reflect.DeepEqual(v, want) {

--- a/test/rowcache_invalidator.py
+++ b/test/rowcache_invalidator.py
@@ -200,7 +200,7 @@ class RowCacheInvalidator(unittest.TestCase):
                             'vt_test_keyspace',
                             'delete from vt_insert_test where id = 1000000')
     self._wait_for_replica()
-    self._wait_for_value(None)
+    self._wait_for_value([])
     end2 = self.replica_vars()['InternalErrors'].get('Invalidation', 0)
     self.assertEqual(end1, end2)
 


### PR DESCRIPTION
Some changes of sqltypes were not backward compatible:
- Sometimes we get nil bytes for valid string types.
- bsonrpc and grpc were different for Result.Rows.