### PR TITLE
vtworkerclient: Move client test suite into its own package.

### DIFF
--- a/go/vt/vtctl/vtctlclienttest/client.go
+++ b/go/vt/vtctl/vtctlclienttest/client.go
@@ -2,9 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package vtctlclienttest provides testing library for vtctl
-// implementations to use in their tests.
+// Package vtctlclienttest contains the testsuite against which each
+// RPC implementation of the vtctlclient interface must be tested.
 package vtctlclienttest
+
+// NOTE: This file is not test-only code because it is referenced by tests in
+//			 other packages and therefore it has to be regularly visible.
+
+// NOTE: This code is in its own package such that its dependencies (e.g.
+//       zookeeper) won't be drawn into production binaries as well.
 
 import (
 	"strings"

--- a/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
+++ b/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
@@ -29,7 +29,7 @@ func NewFakeVtworkerClient() *FakeVtworkerClient {
 }
 
 // FakeVtworkerClientFactory always returns the current instance.
-func (f *FakeVtworkerClient) FakeVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.VtworkerClient, error) {
+func (f *FakeVtworkerClient) FakeVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.Client, error) {
 	return f, nil
 }
 

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -23,7 +23,7 @@ type gRPCVtworkerClient struct {
 	c  vtworkerservicepb.VtworkerClient
 }
 
-func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.VtworkerClient, error) {
+func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.Client, error) {
 	// create the RPC client
 	cc, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {

--- a/go/vt/worker/grpcvtworkerclient/client_test.go
+++ b/go/vt/worker/grpcvtworkerclient/client_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/vt/worker/grpcvtworkerserver"
-	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
+	"github.com/youtube/vitess/go/vt/worker/vtworkerclienttest"
 	"google.golang.org/grpc"
 
 	vtworkerservicepb "github.com/youtube/vitess/go/vt/proto/vtworkerservice"
@@ -19,7 +19,7 @@ import (
 
 // Test gRPC interface using a vtworker and vtworkerclient.
 func TestVtworkerServer(t *testing.T) {
-	wi := vtworkerclient.CreateWorkerInstance(t)
+	wi := vtworkerclienttest.CreateWorkerInstance(t)
 
 	// Listen on a random port.
 	listener, err := net.Listen("tcp", ":0")
@@ -40,5 +40,5 @@ func TestVtworkerServer(t *testing.T) {
 	}
 	defer client.Close()
 
-	vtworkerclient.TestSuite(t, wi, client)
+	vtworkerclienttest.TestSuite(t, wi, client)
 }

--- a/go/vt/worker/vtworkerclient/interface.go
+++ b/go/vt/worker/vtworkerclient/interface.go
@@ -16,8 +16,8 @@ import (
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 )
 
-// VtworkerClientProtocol specifices which RPC client implementation should be used.
-var VtworkerClientProtocol = flag.String("vtworker_client_protocol", "grpc", "the protocol to use to talk to the vtworker server")
+// protocol specifices which RPC client implementation should be used.
+var protocol = flag.String("vtworker_client_protocol", "grpc", "the protocol to use to talk to the vtworker server")
 
 // ErrFunc is returned by streaming queries to get the error
 type ErrFunc func() error
@@ -48,9 +48,9 @@ func RegisterFactory(name string, factory Factory) {
 
 // New allows a user of the client library to get its implementation.
 func New(addr string, connectTimeout time.Duration) (VtworkerClient, error) {
-	factory, ok := factories[*VtworkerClientProtocol]
+	factory, ok := factories[*protocol]
 	if !ok {
-		return nil, fmt.Errorf("unknown vtworker client protocol: %v", *VtworkerClientProtocol)
+		return nil, fmt.Errorf("unknown vtworker client protocol: %v", *protocol)
 	}
 	return factory(addr, connectTimeout)
 }

--- a/go/vt/worker/vtworkerclient/interface.go
+++ b/go/vt/worker/vtworkerclient/interface.go
@@ -22,8 +22,8 @@ var protocol = flag.String("vtworker_client_protocol", "grpc", "the protocol to 
 // ErrFunc is returned by streaming queries to get the error
 type ErrFunc func() error
 
-// VtworkerClient defines the interface used to send remote vtworker commands
-type VtworkerClient interface {
+// Client defines the interface used to send remote vtworker commands
+type Client interface {
 	// ExecuteVtworkerCommand will execute the command remotely.
 	// NOTE: ErrFunc should only be checked after the returned channel was closed to avoid races.
 	ExecuteVtworkerCommand(ctx context.Context, args []string) (<-chan *logutilpb.Event, ErrFunc, error)
@@ -34,7 +34,7 @@ type VtworkerClient interface {
 }
 
 // Factory functions are registered by client implementations.
-type Factory func(addr string, connectTimeout time.Duration) (VtworkerClient, error)
+type Factory func(addr string, connectTimeout time.Duration) (Client, error)
 
 var factories = make(map[string]Factory)
 
@@ -47,7 +47,7 @@ func RegisterFactory(name string, factory Factory) {
 }
 
 // New allows a user of the client library to get its implementation.
-func New(addr string, connectTimeout time.Duration) (VtworkerClient, error) {
+func New(addr string, connectTimeout time.Duration) (Client, error) {
 	factory, ok := factories[*protocol]
 	if !ok {
 		return nil, fmt.Errorf("unknown vtworker client protocol: %v", *protocol)

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package vtworkerclient
+// Package vtworkerclienttest contains the testsuite against which each
+// RPC implementation of the vtworkerclient interface must be tested.
+package vtworkerclienttest
 
 // NOTE: This file is not test-only code because it is referenced by tests in
 //			 other packages and therefore it has to be regularly visible.
+
+// NOTE: This code is in its own package such that its dependencies (e.g.
+//       zookeeper) won't be drawn into production binaries as well.
 
 import (
 	"strings"
@@ -15,6 +20,8 @@ import (
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/worker"
+	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
+
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"golang.org/x/net/context"
 
@@ -35,7 +42,7 @@ func CreateWorkerInstance(t *testing.T) *worker.Instance {
 }
 
 // TestSuite runs the test suite on the given vtworker and vtworkerclient
-func TestSuite(t *testing.T, wi *worker.Instance, c VtworkerClient) {
+func TestSuite(t *testing.T, wi *worker.Instance, c vtworkerclient.Client) {
 	commandSucceeds(t, c)
 
 	commandErrors(t, c)
@@ -43,7 +50,7 @@ func TestSuite(t *testing.T, wi *worker.Instance, c VtworkerClient) {
 	commandPanics(t, c)
 }
 
-func commandSucceeds(t *testing.T, client VtworkerClient) {
+func commandSucceeds(t *testing.T, client vtworkerclient.Client) {
 	logs, errFunc, err := client.ExecuteVtworkerCommand(context.Background(), []string{"Ping", "pong"})
 	if err != nil {
 		t.Fatalf("Cannot execute remote command: %v", err)
@@ -76,7 +83,7 @@ func commandSucceeds(t *testing.T, client VtworkerClient) {
 	}
 }
 
-func commandErrors(t *testing.T, client VtworkerClient) {
+func commandErrors(t *testing.T, client vtworkerclient.Client) {
 	logs, errFunc, err := client.ExecuteVtworkerCommand(context.Background(), []string{"NonexistingCommand"})
 	// The expected error could already be seen now or after the output channel is closed.
 	// To avoid checking for the same error twice, we don't check it here yet.
@@ -100,7 +107,7 @@ func commandErrors(t *testing.T, client VtworkerClient) {
 	}
 }
 
-func commandPanics(t *testing.T, client VtworkerClient) {
+func commandPanics(t *testing.T, client vtworkerclient.Client) {
 	logs, errFunc, err := client.ExecuteVtworkerCommand(context.Background(), []string{"Panic"})
 	// The expected error could already be seen now or after the output channel is closed.
 	// To avoid checking for the same error twice, we don't check it here yet.


### PR DESCRIPTION
Before this change production binaries, which included vtworkerclient, unnecessarily also included all dependencies (e.g. the go/zk package) of the test suite.

vtctlclient has a similar structure. There we had already a separate package only for the client test suite. I've added comments in its package as well to document why we have a separate package.