### PR TITLE
Fix copy in KeyRangesOverlap

### DIFF
--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -22,16 +22,14 @@ import (
 type Uint64Key uint64
 
 func (i Uint64Key) String() string {
-	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, uint64(i))
-	return buf.String()
+	return string(i.Bytes())
 }
 
 // Bytes returns the keyspace id (as bytes) associated with a Uint64Key.
 func (i Uint64Key) Bytes() []byte {
-	buf := new(bytes.Buffer)
-	binary.Write(buf, binary.BigEndian, uint64(i))
-	return buf.Bytes()
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(i))
+	return buf
 }
 
 //
@@ -59,8 +57,8 @@ func KeyRangeContains(kr *topodatapb.KeyRange, id []byte) bool {
 	if kr == nil {
 		return true
 	}
-	return string(kr.Start) <= string(id) &&
-		(len(kr.End) == 0 || string(id) < string(kr.End))
+	return bytes.Compare(kr.Start, id) <= 0 &&
+		(len(kr.End) == 0 || bytes.Compare(id, kr.End) < 0)
 }
 
 // ParseKeyRangeParts parses a start and end hex values and build a proto KeyRange
@@ -100,8 +98,8 @@ func KeyRangeEqual(left, right *topodatapb.KeyRange) bool {
 	if right == nil {
 		return len(left.Start) == 0 && len(left.End) == 0
 	}
-	return string(left.Start) == string(right.Start) &&
-		string(left.End) == string(right.End)
+	return bytes.Compare(left.Start, right.Start) == 0 &&
+		bytes.Compare(left.End, right.End) == 0
 }
 
 // KeyRangeStartEqual returns true if both key ranges have the same start
@@ -112,7 +110,7 @@ func KeyRangeStartEqual(left, right *topodatapb.KeyRange) bool {
 	if right == nil {
 		return len(left.Start) == 0
 	}
-	return string(left.Start) == string(right.Start)
+	return bytes.Compare(left.Start, right.Start) == 0
 }
 
 // KeyRangeEndEqual returns true if both key ranges have the same end
@@ -123,7 +121,7 @@ func KeyRangeEndEqual(left, right *topodatapb.KeyRange) bool {
 	if right == nil {
 		return len(left.End) == 0
 	}
-	return string(left.End) == string(right.End)
+	return bytes.Compare(left.End, right.End) == 0
 }
 
 // For more info on the following functions, see:
@@ -137,8 +135,8 @@ func KeyRangesIntersect(first, second *topodatapb.KeyRange) bool {
 	if first == nil || second == nil {
 		return true
 	}
-	return (len(first.End) == 0 || string(second.Start) < string(first.End)) &&
-		(len(second.End) == 0 || string(first.Start) < string(second.End))
+	return (len(first.End) == 0 || bytes.Compare(second.Start, first.End) < 0) &&
+		(len(second.End) == 0 || bytes.Compare(first.Start, second.End) < 0)
 }
 
 // KeyRangesOverlap returns the overlap between two KeyRanges.
@@ -155,19 +153,19 @@ func KeyRangesOverlap(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange,
 	}
 	// compute max(c,a) and min(b,d)
 	// start with (a,b)
-	result := &(*first)
+	result := *first
 	// if c > a, then use c
-	if string(second.Start) > string(first.Start) {
+	if bytes.Compare(second.Start, first.Start) > 0 {
 		result.Start = second.Start
 	}
 	// if b is maxed out, or
 	// (d is not maxed out and d < b)
 	//                           ^ valid test as neither b nor d are max
 	// then use d
-	if len(first.End) == 0 || (len(second.End) != 0 && string(second.End) < string(first.End)) {
+	if len(first.End) == 0 || (len(second.End) != 0 && bytes.Compare(second.End, first.End) < 0) {
 		result.End = second.End
 	}
-	return result, nil
+	return &result, nil
 }
 
 // ParseShardingSpec parses a string that describes a sharding

--- a/go/vt/key/key_test.go
+++ b/go/vt/key/key_test.go
@@ -177,3 +177,77 @@ func TestIntersectOverlap(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkUint64KeyBytes(b *testing.B) {
+	keys := []Uint64Key{
+		0, 1, 0x7FFFFFFFFFFFFFFF, 0x8000000000000000, 0xFFFFFFFFFFFFFFFF,
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			key.Bytes()
+		}
+	}
+}
+
+func BenchmarkUint64KeyString(b *testing.B) {
+	keys := []Uint64Key{
+		0, 1, 0x7FFFFFFFFFFFFFFF, 0x8000000000000000, 0xFFFFFFFFFFFFFFFF,
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			key.String()
+		}
+	}
+}
+
+func BenchmarkKeyRangeContains(b *testing.B) {
+	kr := &topodatapb.KeyRange{
+		Start: []byte{0x40, 0, 0, 0, 0, 0, 0, 0},
+		End:   []byte{0x80, 0, 0, 0, 0, 0, 0, 0},
+	}
+	keys := [][]byte{
+		{0x30, 0, 0, 0, 0, 0, 0, 0},
+		{0x40, 0, 0, 0, 0, 0, 0, 0},
+		{0x50, 0, 0, 0, 0, 0, 0, 0},
+		{0x80, 0, 0, 0, 0, 0, 0, 0},
+		{0x90, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	for i := 0; i < b.N; i++ {
+		for _, key := range keys {
+			KeyRangeContains(kr, key)
+		}
+	}
+}
+
+func BenchmarkKeyRangesIntersect(b *testing.B) {
+	kr1 := &topodatapb.KeyRange{
+		Start: []byte{0x40, 0, 0, 0, 0, 0, 0, 0},
+		End:   []byte{0x80, 0, 0, 0, 0, 0, 0, 0},
+	}
+	kr2 := &topodatapb.KeyRange{
+		Start: []byte{0x30, 0, 0, 0, 0, 0, 0, 0},
+		End:   []byte{0x50, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	for i := 0; i < b.N; i++ {
+		KeyRangesIntersect(kr1, kr2)
+	}
+}
+
+func BenchmarkKeyRangesOverlap(b *testing.B) {
+	kr1 := &topodatapb.KeyRange{
+		Start: []byte{0x40, 0, 0, 0, 0, 0, 0, 0},
+		End:   []byte{0x80, 0, 0, 0, 0, 0, 0, 0},
+	}
+	kr2 := &topodatapb.KeyRange{
+		Start: []byte{0x30, 0, 0, 0, 0, 0, 0, 0},
+		End:   []byte{0x50, 0, 0, 0, 0, 0, 0, 0},
+	}
+
+	for i := 0; i < b.N; i++ {
+		KeyRangesOverlap(kr1, kr2)
+	}
+}

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -131,7 +131,7 @@ func (tkn *Tokenizer) Lex(lval *yySymType) int {
 
 // Error is called by go yacc if there's a parsing error.
 func (tkn *Tokenizer) Error(err string) {
-	buf := bytes.NewBuffer(make([]byte, 0, 32))
+	buf := &bytes.Buffer{}
 	if tkn.lastToken != nil {
 		fmt.Fprintf(buf, "%s at position %v near '%s'", err, tkn.Position, tkn.lastToken)
 	} else {
@@ -248,7 +248,7 @@ func (tkn *Tokenizer) skipBlank() {
 }
 
 func (tkn *Tokenizer) scanIdentifier() (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	buffer.WriteByte(byte(tkn.lastChar))
 	for tkn.next(); isLetter(tkn.lastChar) || isDigit(tkn.lastChar); tkn.next() {
 		buffer.WriteByte(byte(tkn.lastChar))
@@ -266,7 +266,7 @@ func (tkn *Tokenizer) scanIdentifier() (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanLiteralIdentifier() (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	buffer.WriteByte(byte(tkn.lastChar))
 	if !isLetter(tkn.lastChar) {
 		return LEX_ERROR, buffer.Bytes()
@@ -282,7 +282,7 @@ func (tkn *Tokenizer) scanLiteralIdentifier() (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanBindVar() (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	buffer.WriteByte(byte(tkn.lastChar))
 	token := VALUE_ARG
 	tkn.next()
@@ -308,7 +308,7 @@ func (tkn *Tokenizer) scanMantissa(base int, buffer *bytes.Buffer) {
 }
 
 func (tkn *Tokenizer) scanNumber(seenDecimalPoint bool) (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	if seenDecimalPoint {
 		buffer.WriteByte('.')
 		tkn.scanMantissa(10, buffer)
@@ -365,7 +365,7 @@ exit:
 }
 
 func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	for {
 		ch := tkn.lastChar
 		tkn.next()
@@ -395,7 +395,7 @@ func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanCommentType1(prefix string) (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	buffer.WriteString(prefix)
 	for tkn.lastChar != eofChar {
 		if tkn.lastChar == '\n' {
@@ -408,7 +408,7 @@ func (tkn *Tokenizer) scanCommentType1(prefix string) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanCommentType2() (int, []byte) {
-	buffer := bytes.NewBuffer(make([]byte, 0, 8))
+	buffer := &bytes.Buffer{}
 	buffer.WriteString("/*")
 	for {
 		if tkn.lastChar == '*' {

--- a/go/vt/tabletserver/codex.go
+++ b/go/vt/tabletserver/codex.go
@@ -217,7 +217,7 @@ func getLimit(limit interface{}, bv map[string]interface{}) (int64, error) {
 }
 
 func buildKey(row []sqltypes.Value) (key string) {
-	buf := bytes.NewBuffer(make([]byte, 0, 32))
+	buf := &bytes.Buffer{}
 	for i, pkValue := range row {
 		if pkValue.IsNull() {
 			return ""


### PR DESCRIPTION
@sougou @guoliang100 

I happened to notice the line `result := &(*first)` and thought, "wait, does that make a copy or not?". It turns out it doesn't make a copy, but it seems clear the author was expecting it to so I fixed it.

I also noticed some unnecessary []byte-to-string conversions and wondered how much those extra copies were costing. I added some microbenchmarks related to reducing allocations in per-query code paths. See the commit messages for results.