### PR TITLE
GCS backup plugin: Adapt to new API of the GCS Go client.

### DIFF
--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -83,7 +83,7 @@ func (bh *GCSBackupHandle) ReadFile(filename string) (io.ReadCloser, error) {
 	return storage.NewReader(bh.authCtx, *bucket, objName(bh.dir, bh.name, filename))
 }
 
-// GCSBackupStorage implements BackupStorage for local file system.
+// GCSBackupStorage implements BackupStorage for Google Cloud Storage.
 type GCSBackupStorage struct {
 	authCtx context.Context
 }


### PR DESCRIPTION
@sougou 

This unbreaks our Go build.

In commit b467501b2a6e4998b369e3569864906a1261972c they changed their API from one-shot commands to a client.Bucket.Object pattern.

Where we previously stored only the "authCtx" in the global instance of the GSC backup plugin, we're now keeping the instance of the GSC Go client.

Note that we're supposed to call Close() on the GSC client instance eventually. However, our backup interface doesn't foresee a Close() yet. Therefore, for now, we keep the GSC Go Client instance around once it was actively used. The cost of this "leak" is therefore minimal.

NOTE: In their new API I didn't find a way to fill in the project id. We'll need to look into it.
NOTE: This code change is untested and may not work at all. However, it's good enough to merge and unbreak our build.