### PR TITLE
backup: Fix GCS backup plugin for refactored client API.

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -192,6 +192,7 @@ func Backup(ctx context.Context, mysqld MysqlDaemon, logger logutil.Logger, dir,
 	if err != nil {
 		return err
 	}
+	defer bs.Close()
 	bh, err := bs.StartBackup(dir, name)
 	if err != nil {
 		return fmt.Errorf("StartBackup failed: %v", err)
@@ -572,6 +573,7 @@ func Restore(ctx context.Context, mysqld MysqlDaemon, dir string, restoreConcurr
 	if err != nil {
 		return replication.Position{}, err
 	}
+	defer bs.Close()
 	bhs, err := bs.ListBackups(dir)
 	if err != nil {
 		return replication.Position{}, fmt.Errorf("ListBackups failed: %v", err)

--- a/go/vt/mysqlctl/backupstorage/interface.go
+++ b/go/vt/mysqlctl/backupstorage/interface.go
@@ -69,6 +69,11 @@ type BackupStorage interface {
 	// RemoveBackup removes all the data associated with a backup.
 	// It will not appear in ListBackups after RemoveBackup succeeds.
 	RemoveBackup(dir, name string) error
+
+	// Close frees resources associated with an active backup session,
+	// such as closing connections. Implementations of BackupStorage must support
+	// being reused after Close() is called.
+	Close() error
 }
 
 // BackupStorageMap contains the registered implementations for BackupStorage
@@ -76,6 +81,7 @@ var BackupStorageMap = make(map[string]BackupStorage)
 
 // GetBackupStorage returns the current BackupStorage implementation.
 // Should be called after flags have been initialized.
+// When all operations are done, call BackupStorage.Close() to free resources.
 func GetBackupStorage() (BackupStorage, error) {
 	bs, ok := BackupStorageMap[*BackupStorageImplementation]
 	if !ok {

--- a/go/vt/mysqlctl/filebackupstorage/file.go
+++ b/go/vt/mysqlctl/filebackupstorage/file.go
@@ -136,6 +136,11 @@ func (fbs *FileBackupStorage) RemoveBackup(dir, name string) error {
 	return os.RemoveAll(p)
 }
 
+// Close implements BackupStorage.
+func (fbs *FileBackupStorage) Close() error {
+	return nil
+}
+
 func init() {
 	backupstorage.BackupStorageMap["file"] = &FileBackupStorage{}
 }


### PR DESCRIPTION
@michael-berlin 

This addresses the issues remaining after the first pass at fixing it in #1348.

* Add Close() method. This is not technically needed yet for HTTP-based GCS, but they plan to switch to gRPC later, which will require calling Close().
* Add auth info back to the context passed to NewClient().
* FYI, I renamed the getter method to just client() as recommended in the Go style guide.
* I tested GCS backups in k8s manually. Once we have a CI framework for k8s, we can automate this.