### PR TITLE
k8s: -t for --template is deprecated since v1.1.1

### DIFF
--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -11,7 +11,7 @@ VTCTLD_PORT=${VTCTLD_PORT:-30001}
 
 # Get the ExternalIP of any node.
 get_node_ip() {
-  $KUBECTL get -o template -t '{{range (index .items 0).status.addresses}}{{if eq .type "ExternalIP" "LegacyHostIP"}}{{.address}}{{end}}{{end}}' nodes
+  $KUBECTL get -o template --template '{{range (index .items 0).status.addresses}}{{if eq .type "ExternalIP" "LegacyHostIP"}}{{.address}}{{end}}{{end}}' nodes
 }
 
 # Try to find vtctld address if not provided.
@@ -26,7 +26,7 @@ get_vtctld_addr() {
 
 # Find the name of a vtctld pod.
 get_vtctld_pod() {
-  $KUBECTL get -o template -t "{{if ge (len .items) 1 }}{{(index .items 0).metadata.name}}{{end}}" -l 'app=vitess,component=vtctld' pods
+  $KUBECTL get -o template --template "{{if ge (len .items) 1 }}{{(index .items 0).metadata.name}}{{end}}" -l 'app=vitess,component=vtctld' pods
 }
 
 start_vtctld_forward() {

--- a/examples/kubernetes/sharded-vtworker.sh
+++ b/examples/kubernetes/sharded-vtworker.sh
@@ -24,7 +24,7 @@ cat vtworker-pod-template.yaml | sed -e "$sed_script" | $KUBECTL create -f -
 set +e
 
 # Wait for vtworker pod to show up.
-until [ $($KUBECTL get pod -o template -t '{{.status.phase}}' vtworker 2> /dev/null) = "Running" ]; do
+until [ $($KUBECTL get pod -o template --template '{{.status.phase}}' vtworker 2> /dev/null) = "Running" ]; do
   echo "Waiting for vtworker pod to be created..."
 	sleep 1
 done
@@ -34,11 +34,11 @@ $KUBECTL logs -f vtworker
 
 # Get vtworker exit code. Wait for complete shutdown.
 # (Although logs -f exited, the pod isn't fully shutdown yet and the exit code is not available yet.)
-until [ $($KUBECTL get pod -o template -t '{{.status.phase}}' vtworker 2> /dev/null) != "Running" ]; do
+until [ $($KUBECTL get pod -o template --template '{{.status.phase}}' vtworker 2> /dev/null) != "Running" ]; do
   echo "Waiting for vtworker pod to shutdown completely..."
   sleep 1
 done
-exit_code=$($KUBECTL get -o template -t '{{(index .status.containerStatuses 0).state.terminated.exitCode}}' pods vtworker)
+exit_code=$($KUBECTL get -o template --template '{{(index .status.containerStatuses 0).state.terminated.exitCode}}' pods vtworker)
 
 echo "Deleting vtworker pod..."
 $KUBECTL delete pod vtworker


### PR DESCRIPTION
This shouldn't affect backwards compatibility for the Kubernetes example.

-t for --template has been deprecated to make it --tty (https://github.com/kubernetes/kubernetes/pull/12813)

https://github.com/kubernetes/kubernetes/releases/tag/v1.1.1