### PR TITLE
automation wrapper for vtctl and vtworkerclient: Log output and error…

### DIFF
--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -29,6 +29,7 @@ func ExecuteVtctl(ctx context.Context, server string, args []string) (string, er
 		30*time.Second, // dialTimeout
 		time.Hour,      // actionTimeout
 		CreateLoggerEventToBufferFunction(&output))
+	log.Infof("Executed remote vtctl command: %v server: %v err: %v output (starting on next line):\n%v", args, server, err, output.String())
 
 	return output.String(), err
 }

--- a/go/vt/automation/vtworkerclient_wrapper.go
+++ b/go/vt/automation/vtworkerclient_wrapper.go
@@ -21,6 +21,7 @@ func ExecuteVtworker(ctx context.Context, server string, args []string) (string,
 	err := vtworkerclient.RunCommandAndWait(
 		ctx, server, args,
 		CreateLoggerEventToBufferFunction(&output))
+	log.Infof("Executed remote vtworker command: %v server: %v err: %v output (starting on next line):\n%v", args, server, err, output.String())
 
 	return output.String(), err
 }

--- a/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
+++ b/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
@@ -18,7 +18,7 @@ import (
 // The fake can be used to return a specific result for a given command.
 // If the command is not registered, an error will be thrown.
 type FakeVtctlClient struct {
-	FakeLoggerEventStreamingClient
+	*FakeLoggerEventStreamingClient
 }
 
 // NewFakeVtctlClient creates a FakeVtctlClient struct.

--- a/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
+++ b/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
@@ -20,7 +20,7 @@ import (
 // The fake can be used to return a specific result for a given command.
 // If the command is not registered, an error will be thrown.
 type FakeVtworkerClient struct {
-	fakevtctlclient.FakeLoggerEventStreamingClient
+	*fakevtctlclient.FakeLoggerEventStreamingClient
 }
 
 // NewFakeVtworkerClient creates a FakeVtworkerClient struct.


### PR DESCRIPTION
… of commands such that we have the information available in the log file.

Added new method RegisteredCommands() in the base class "FakeLoggerEventStreamingClient" to verify in unit tests that all registered fake results were consumed.

NOTE: This is an automated export. Changes were already LGTM'd internally.