### PR TITLE
callerid: Move test suite out of the "callerid" package.

### DIFF
--- a/go/vt/callerid/gorpccallerid/gorpccallerid_test.go
+++ b/go/vt/callerid/gorpccallerid/gorpccallerid_test.go
@@ -3,17 +3,17 @@ package gorpccallerid
 import (
 	"testing"
 
-	"github.com/youtube/vitess/go/vt/callerid"
+	"github.com/youtube/vitess/go/vt/callerid/testsuite"
 )
 
 func TestGoRPCCallerID(t *testing.T) {
 	im := VTGateCallerID{
-		Username: callerid.FakeUsername,
+		Username: testsuite.FakeUsername,
 	}
 	ef := CallerID{
-		Principal:    callerid.FakePrincipal,
-		Component:    callerid.FakeComponent,
-		Subcomponent: callerid.FakeSubcomponent,
+		Principal:    testsuite.FakePrincipal,
+		Component:    testsuite.FakeComponent,
+		Subcomponent: testsuite.FakeSubcomponent,
 	}
 	// Test nil cases
 	if n := GoRPCImmediateCallerID(nil); n != nil {
@@ -22,5 +22,5 @@ func TestGoRPCCallerID(t *testing.T) {
 	if n := GoRPCEffectiveCallerID(nil); n != nil {
 		t.Errorf("Expect nil from GoRPCEffectiveCallerID(nil), but got %v", n)
 	}
-	callerid.Tests(t, GoRPCImmediateCallerID(&im), GoRPCEffectiveCallerID(&ef))
+	testsuite.RunTests(t, GoRPCImmediateCallerID(&im), GoRPCEffectiveCallerID(&ef))
 }

--- a/go/vt/callerid/testsuite/callerid_test.go
+++ b/go/vt/callerid/testsuite/callerid_test.go
@@ -1,4 +1,4 @@
-package callerid
+package testsuite
 
 import (
 	"testing"
@@ -16,5 +16,5 @@ func TestFakeCallerID(t *testing.T) {
 		Component:    FakeComponent,
 		Subcomponent: FakeSubcomponent,
 	}
-	Tests(t, &im, &ef)
+	RunTests(t, &im, &ef)
 }

--- a/go/vt/callerid/testsuite/testsuite.go
+++ b/go/vt/callerid/testsuite/testsuite.go
@@ -1,4 +1,4 @@
-package callerid
+package testsuite
 
 import (
 	"reflect"
@@ -6,6 +6,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/callerid"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
@@ -21,68 +22,68 @@ const (
 	FakeUsername = "TestUsername"
 )
 
-// Tests performs the necessary testsuite for CallerID operations
-func Tests(t *testing.T, im *querypb.VTGateCallerID, ef *vtrpcpb.CallerID) {
+// RunTests performs the necessary testsuite for CallerID operations
+func RunTests(t *testing.T, im *querypb.VTGateCallerID, ef *vtrpcpb.CallerID) {
 	ctx := context.TODO()
-	ctxim := ImmediateCallerIDFromContext(ctx)
+	ctxim := callerid.ImmediateCallerIDFromContext(ctx)
 	// For Contexts without immediate CallerID, ImmediateCallerIDFromContext should fail
 	if ctxim != nil {
 		t.Errorf("Expect nil from ImmediateCallerIDFromContext, but got %v", ctxim)
 	}
 	// For Contexts without effective CallerID, EffectiveCallerIDFromContext should fail
-	ctxef := EffectiveCallerIDFromContext(ctx)
+	ctxef := callerid.EffectiveCallerIDFromContext(ctx)
 	if ctxef != nil {
 		t.Errorf("Expect nil from EffectiveCallerIDFromContext, but got %v", ctxef)
 	}
 
-	ctx = NewContext(ctx, nil, nil)
-	ctxim = ImmediateCallerIDFromContext(ctx)
+	ctx = callerid.NewContext(ctx, nil, nil)
+	ctxim = callerid.ImmediateCallerIDFromContext(ctx)
 	// For Contexts with nil immediate CallerID, ImmediateCallerIDFromContext should fail
 	if ctxim != nil {
 		t.Errorf("Expect nil from ImmediateCallerIDFromContext, but got %v", ctxim)
 	}
 	// For Contexts with nil effective CallerID, EffectiveCallerIDFromContext should fail
-	ctxef = EffectiveCallerIDFromContext(ctx)
+	ctxef = callerid.EffectiveCallerIDFromContext(ctx)
 	if ctxef != nil {
 		t.Errorf("Expect nil from EffectiveCallerIDFromContext, but got %v", ctxef)
 	}
 
 	// Test GetXxx on nil receivers, should get all empty strings
-	if u := GetUsername(ctxim); u != "" {
+	if u := callerid.GetUsername(ctxim); u != "" {
 		t.Errorf("Expect empty string from GetUsername(nil), but got %v", u)
 	}
-	if p := GetPrincipal(ctxef); p != "" {
+	if p := callerid.GetPrincipal(ctxef); p != "" {
 		t.Errorf("Expect empty string from GetPrincipal(nil), but got %v", p)
 	}
-	if c := GetComponent(ctxef); c != "" {
+	if c := callerid.GetComponent(ctxef); c != "" {
 		t.Errorf("Expect empty string from GetComponent(nil), but got %v", c)
 	}
-	if s := GetSubcomponent(ctxef); s != "" {
+	if s := callerid.GetSubcomponent(ctxef); s != "" {
 		t.Errorf("Expect empty string from GetSubcomponent(nil), but got %v", s)
 	}
 
-	ctx = NewContext(ctx, ef, im)
-	ctxim = ImmediateCallerIDFromContext(ctx)
+	ctx = callerid.NewContext(ctx, ef, im)
+	ctxim = callerid.ImmediateCallerIDFromContext(ctx)
 	// retrieved immediate CallerID should be equal to the one we put into Context
 	if !reflect.DeepEqual(ctxim, im) {
 		t.Errorf("Expect %v from ImmediateCallerIDFromContext, but got %v", im, ctxim)
 	}
-	if u := GetUsername(im); u != FakeUsername {
+	if u := callerid.GetUsername(im); u != FakeUsername {
 		t.Errorf("Expect %v from GetUsername(im), but got %v", FakeUsername, u)
 	}
 
-	ctxef = EffectiveCallerIDFromContext(ctx)
+	ctxef = callerid.EffectiveCallerIDFromContext(ctx)
 	// retrieved effective CallerID should be equal to the one we put into Context
 	if !reflect.DeepEqual(ctxef, ef) {
 		t.Errorf("Expect %v from EffectiveCallerIDFromContext, but got %v", ef, ctxef)
 	}
-	if p := GetPrincipal(ef); p != FakePrincipal {
+	if p := callerid.GetPrincipal(ef); p != FakePrincipal {
 		t.Errorf("Expect %v from GetPrincipal(ef), but got %v", FakePrincipal, p)
 	}
-	if c := GetComponent(ef); c != FakeComponent {
+	if c := callerid.GetComponent(ef); c != FakeComponent {
 		t.Errorf("Expect %v from GetComponent(ef), but got %v", FakeComponent, c)
 	}
-	if s := GetSubcomponent(ef); s != FakeSubcomponent {
+	if s := callerid.GetSubcomponent(ef); s != FakeSubcomponent {
 		t.Errorf("Expect %v from GetSubcomponent(ef), but got %v", FakeSubcomponent, s)
 	}
 }


### PR DESCRIPTION
@guokeno0 

Before this change, importing the "callerid" package resulted into
including the Go "testing" package as well because the testsuite uses
it.

One of the biggest downsides of an included "testing" package is that
all our binaries (which include "callerid") will also show the test.*
flags from the "testing" package in the usage output.

By moving the testsuite into a separate package, the dependency chain is
broken up and the usage output is cleaner now.

Note that I had to move the "callerid_test.go" into the new package as
well to avoid a cyclic dependency (callerid -> testsuite -> callerid).