### PR TITLE
client: Move vtgateconn plugins into the Vitess Go SQL driver package.

### DIFF
--- a/go/vt/client/client_test.go
+++ b/go/vt/client/client_test.go
@@ -21,9 +21,6 @@ import (
 	"github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-
-	// load the gRPC vtgate conn driver
-	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
 )
 
 var (

--- a/go/vt/client/plugin_gorpcvtgateconn.go
+++ b/go/vt/client/plugin_gorpcvtgateconn.go
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package client
 
-// Imports and register the gorpc vtgateconn client
+// Imports and register the gorpc vtgateconn client.
 
 import (
+	// Import the gorpc vtgateconn client and make it part of the Vitess
+	// Go SQL driver. This way, users do not have to do this.
 	_ "github.com/youtube/vitess/go/vt/vtgate/gorpcvtgateconn"
 )

--- a/go/vt/client/plugin_grpcvtgateconn.go
+++ b/go/vt/client/plugin_grpcvtgateconn.go
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package client
 
-// Imports and register the gRPC vtgateconn client
+// Imports and register the gRPC vtgateconn client.
 
 import (
+	// Import the gRPC vtgateconn client and make it part of the Vitess
+	// Go SQL driver. This way, users do not have to do this.
 	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
 )


### PR DESCRIPTION
@alainjobart 

Before this change, users had to explicitly import their preferred vtgateconn implementation (in most cases gRPC).

With this change, this is no longer necessary because the driver will import all available implementations automatically.

This is also more consistent with the remaining code:
- we import different implementations at the binary level (in go/cmd/*)
- the Go SQL Driver is a library and therefore at the same level as a binary