### PR TITLE
tabletmanager: Add grace period for lameduck.

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -77,6 +77,7 @@ func main() {
 		log.Warning(err)
 	}
 	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl)
+	servenv.OnClose(mysqld.Close)
 
 	// tablets configuration and init
 	initTabletMap(ts, *topology, mysqld, dbcfgs, mycnf)
@@ -103,9 +104,7 @@ func main() {
 	vtgate.Init(healthCheck, ts, resilientSrvTopoServer, schema, cell, 1*time.Millisecond /*retryDelay*/, 2 /*retryCount*/, 30*time.Second /*connTimeoutTotal*/, 10*time.Second /*connTimeoutPerConn*/, 365*24*time.Hour /*connLife*/, tabletTypesToWait, 0 /*maxInFlight*/, "" /*testGateway*/)
 
 	servenv.OnTerm(func() {
-		// FIXME(alainjobart) stop vtgate, all tablets
-		//		qsc.DisallowQueries()
-		//		agent.Stop()
+		// FIXME(alainjobart): stop vtgate
 	})
 	servenv.OnClose(func() {
 		// We will still use the topo server during lameduck period

--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/youtube/vitess/go/vt/status"
 	"github.com/youtube/vitess/go/vt/tabletmanager"
 	"github.com/youtube/vitess/go/vt/tabletserver"
+	"github.com/youtube/vitess/go/vt/topo"
 )
 
 var (
@@ -172,7 +173,7 @@ var onStatusRegistered func()
 func addStatusParts(qsc tabletserver.Controller) {
 	servenv.AddStatusPart("Tablet", tabletTemplate, func() interface{} {
 		return map[string]interface{}{
-			"Tablet":              agent.Tablet(),
+			"Tablet":              topo.NewTabletInfo(agent.Tablet(), -1),
 			"BlacklistedTables":   agent.BlacklistedTables(),
 			"DisableQueryService": agent.DisableQueryService(),
 		}

--- a/go/vt/tabletmanager/after_action.go
+++ b/go/vt/tabletmanager/after_action.go
@@ -90,9 +90,7 @@ func (agent *ActionAgent) broadcastHealth() {
 	if !terTime.IsZero() {
 		ts = terTime.Unix()
 	}
-	go func() {
-		agent.QueryServiceControl.BroadcastHealth(ts, stats)
-	}()
+	go agent.QueryServiceControl.BroadcastHealth(ts, stats)
 }
 
 // refreshTablet needs to be run after an action may have changed the current

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"html/template"
 	"reflect"
+	"sync"
 	"time"
 
 	log "github.com/golang/glog"
@@ -167,11 +168,13 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 	if tablet.Type == topodatapb.TabletType_MASTER {
 		isSlaveType = false
 	}
-	replicationDelay, err := agent.HealthReporter.Report(isSlaveType, shouldBeServing)
+	// Remember the health error as healthErr to be sure we don't accidentally
+	// overwrite it with some other err.
+	replicationDelay, healthErr := agent.HealthReporter.Report(isSlaveType, shouldBeServing)
 	health := make(map[string]string)
-	if err == nil {
+	if healthErr == nil {
 		if replicationDelay > *unhealthyThreshold {
-			err = fmt.Errorf("reported replication lag: %v higher than unhealthy threshold: %v", replicationDelay.Seconds(), unhealthyThreshold.Seconds())
+			healthErr = fmt.Errorf("reported replication lag: %v higher than unhealthy threshold: %v", replicationDelay.Seconds(), unhealthyThreshold.Seconds())
 		} else if replicationDelay > *degradedThreshold {
 			health[topo.ReplicationLag] = topo.ReplicationLagHigh
 		}
@@ -180,7 +183,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 
 	// Figure out if we should be running QueryService, see if we are,
 	// and reconcile.
-	if err != nil {
+	if healthErr != nil {
 		if tablet.Type != topodatapb.TabletType_WORKER {
 			// We are not healthy and must shut down QueryService.
 			// At the moment, the only exception to this are "worker" tablets which
@@ -191,30 +194,38 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 	isServing := agent.QueryServiceControl.IsServing()
 	if shouldBeServing {
 		if !isServing {
-			// send the type we want to be, not the type we are
+			// It might be that we're ready to serve, but we just need to start
+			// queryservice. Send the type we want to be, not the type we are.
 			desiredType := tablet.Type
 			if desiredType == topodatapb.TabletType_SPARE {
 				desiredType = targetTabletType
 			}
 
-			// we remember this new possible error
-			err = agent.allowQueries(desiredType)
+			// If starting queryservice fails, that's our new reason for being unhealthy.
+			healthErr = agent.allowQueries(desiredType)
 		}
 	} else {
 		if isServing {
-			// We are not healthy or should not be running the
-			// query service, shut it down.
-			// Note this is possibly sending 'spare' as
-			// the tablet type, we will clean it up later.
+			// We are not healthy or should not be running the query service.
+			//
+			// We do NOT enter lameduck in this case, because we should only hit this
+			// in the following scenarios:
+			//
+			// * Healthcheck fails: We're probably serving errors anyway, so no point.
+			// * Replication lag exceeds unhealthy threshold: This is very rare, so it
+			//   isn't worth optimizing the potential 1s of errors away. It will also
+			//   go away when vtgate is the only one looking at lag.
+			// * We're in a special state where queryservice should be disabled
+			//   despite being non-SPARE: This is not a live serving instance anyway.
 			agent.disallowQueries(tablet.Type,
-				fmt.Sprintf("health-check failure(%v)", err),
+				fmt.Sprintf("health-check failure(%v)", healthErr),
 			)
 		}
 	}
 
 	// save the health record
 	record := &HealthRecord{
-		Error:            err,
+		Error:            healthErr,
 		ReplicationDelay: replicationDelay,
 		Time:             time.Now(),
 	}
@@ -234,29 +245,30 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 			agent.mutex.Unlock()
 		} else {
 			log.Infof("Updating tablet mysql port to %v", mysqlPort)
-			if _, err := agent.TopoServer.UpdateTabletFields(agent.batchCtx, tablet.Alias, func(tablet *topodatapb.Tablet) error {
-				if err := topotools.CheckOwnership(agent.initialTablet, tablet); err != nil {
-					return err
-				}
-				tablet.PortMap["mysql"] = mysqlPort
-				return nil
-			}); err != nil {
-				log.Infof("Error updating mysql port in tablet record, will try again: %v", err)
-				return
+			_, err := agent.TopoServer.UpdateTabletFields(agent.batchCtx, tablet.Alias,
+				func(tablet *topodatapb.Tablet) error {
+					if err := topotools.CheckOwnership(agent.initialTablet, tablet); err != nil {
+						return err
+					}
+					tablet.PortMap["mysql"] = mysqlPort
+					return nil
+				})
+			if err != nil {
+				log.Infof("Error updating mysql port in tablet record (will try again at healthcheck interval): %v", err)
+			} else {
+				// save the port so we don't update it again next time
+				// we do the health check.
+				agent.mutex.Lock()
+				agent._tablet.PortMap["mysql"] = mysqlPort
+				agent._waitingForMysql = false
+				agent.mutex.Unlock()
 			}
-
-			// save the port so we don't update it again next time
-			// we do the health check.
-			agent.mutex.Lock()
-			agent._tablet.PortMap["mysql"] = mysqlPort
-			agent._waitingForMysql = false
-			agent.mutex.Unlock()
 		}
 	}
 
 	// remember our health status
 	agent.mutex.Lock()
-	agent._healthy = err
+	agent._healthy = healthErr
 	agent._healthyTime = time.Now()
 	agent._replicationDelay = replicationDelay
 	agent.mutex.Unlock()
@@ -266,14 +278,14 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 
 	// Update our topo.Server state, start with no change
 	newTabletType := tablet.Type
-	if err != nil {
+	if healthErr != nil {
 		// The tablet is not healthy, let's see what we need to do
 		if tablet.Type != targetTabletType {
 			if tablet.Type != topodatapb.TabletType_SPARE {
 				// we only log if we're not in spare,
 				// as the spare state is normal for a
 				// failed health check.
-				log.Infof("Tablet not healthy and in state %v, not changing it: %v", tablet.Type, err)
+				log.Infof("Tablet not healthy and in state %v, not changing it: %v", tablet.Type, healthErr)
 			}
 			return
 		}
@@ -282,7 +294,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 		// need to stop it. The post-action callback will do
 		// it, and it will be done after we change our state,
 		// so it's the right order, let it do it.
-		log.Infof("Tablet not healthy, converting it from %v to spare: %v", targetTabletType, err)
+		log.Infof("Tablet not healthy, converting it from %v to spare: %v", targetTabletType, healthErr)
 		newTabletType = topodatapb.TabletType_SPARE
 	} else {
 		// We are healthy, maybe with health, see if we need
@@ -303,7 +315,7 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 
 	// Change the Type, update the health. Note we pass in a map
 	// that's not nil, meaning if it's empty, we will clear it.
-	tablet, err = topotools.ChangeOwnType(agent.batchCtx, agent.TopoServer, agent.initialTablet, newTabletType, health)
+	tablet, err := topotools.ChangeOwnType(agent.batchCtx, agent.TopoServer, agent.initialTablet, newTabletType, health)
 	if err != nil {
 		log.Infof("Error updating tablet record: %v", err)
 		return
@@ -315,7 +327,9 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 		log.Warningf("updateServingGraph failed (will still run post action callbacks, serving graph might be out of date): %v", err)
 	}
 
-	// run the post action callbacks, not much we can do with returned error
+	// Run the post action callbacks.
+	// Note that this is where we might block for *gracePeriod, depending on the
+	// type of state change. See changeCallback() for details.
 	if err := agent.refreshTablet(agent.batchCtx, "healthcheck"); err != nil {
 		log.Warningf("refreshTablet failed: %v", err)
 	}
@@ -332,33 +346,55 @@ func (agent *ActionAgent) terminateHealthChecks(targetTabletType topodatapb.Tabl
 
 	// read the current tablet record
 	tablet := agent.Tablet()
+
 	if tablet.Type != targetTabletType {
+		// If we're MASTER, SPARE, WORKER, etc. then the healthcheck shouldn't
+		// touch it. We also skip gracePeriod in that case.
 		log.Infof("Tablet in state %v, not changing it", tablet.Type)
 		return
 	}
 
-	// Change the Type to spare, update the health. Note we pass in a map
-	// that's not nil, meaning we will clear it.
-	tablet, err := topotools.ChangeOwnType(agent.batchCtx, agent.TopoServer, agent.initialTablet, topodatapb.TabletType_SPARE, make(map[string]string))
-	if err != nil {
-		log.Infof("Error updating tablet record: %v", err)
-		return
-	}
+	var wg sync.WaitGroup
 
-	// Update the serving graph in our cell, only if we're dealing with
-	// a serving type
-	if err := agent.updateServingGraph(tablet, targetTabletType); err != nil {
-		log.Warningf("updateServingGraph failed (will still run post action callbacks, serving graph might be out of date): %v", err)
-	}
-
-	// We've already rebuilt the shard, which is the only reason we registered
-	// ourself as OnTermSync (synchronous). The rest can be done asynchronously.
+	// Go lameduck for gracePeriod.
+	// We've already checked above that we're not MASTER.
+	wg.Add(1)
 	go func() {
-		// Run the post action callbacks (let them shutdown the query service)
-		if err := agent.refreshTablet(agent.batchCtx, "terminatehealthcheck"); err != nil {
-			log.Warningf("refreshTablet failed: %v", err)
+		defer wg.Done()
+
+		// Enter new lameduck mode for gracePeriod, then shut down queryservice.
+		// New lameduck mode means keep accepting queries, but advertise unhealthy.
+		// After we return from this synchronous OnTermSync hook, servenv may decide
+		// to wait even longer, for the rest of the time specified by its own
+		// "-lameduck-period" flag. During that extra period, queryservice will be
+		// in old lameduck mode, meaning stay alive but reject new queries.
+		agent.enterLameduck("terminating healthchecks")
+		agent.broadcastHealth()
+		time.Sleep(*gracePeriod)
+		agent.disallowQueries(tablet.Type, "terminating healthchecks")
+	}()
+
+	// Change Type to spare and clear HealthMap.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// We don't wait until after the lameduck period, because we want to make
+		// sure this gets done before servenv onTermTimeout.
+		tablet, err := topotools.ChangeOwnType(agent.batchCtx, agent.TopoServer, agent.initialTablet, topodatapb.TabletType_SPARE, topotools.ClearHealthMap)
+		if err != nil {
+			log.Infof("Error updating tablet record: %v", err)
+			return
+		}
+
+		// Update the serving graph in our cell, only if we're dealing with
+		// a serving type
+		if err := agent.updateServingGraph(tablet, targetTabletType); err != nil {
+			log.Warningf("updateServingGraph failed (will still run post action callbacks, serving graph might be out of date): %v", err)
 		}
 	}()
+
+	wg.Wait()
 }
 
 // updateServingGraph will update the serving graph if we need to.

--- a/go/vt/tabletmanager/healthcheck_test.go
+++ b/go/vt/tabletmanager/healthcheck_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
+	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletservermock"
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"golang.org/x/net/context"
@@ -170,10 +171,7 @@ func TestHealthCheckControlsQueryService(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd := <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 12 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 12)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_REPLICA {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -199,10 +197,7 @@ func TestHealthCheckControlsQueryService(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd = <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 13 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 13)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_SPARE {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -244,7 +239,7 @@ func TestQueryServiceNotStarting(t *testing.T) {
 }
 
 // TestQueryServiceStopped verifies that if a healthy tablet's query
-// service is shut down, the tablet does unhealthy
+// service is shut down, the tablet goes unhealthy
 func TestQueryServiceStopped(t *testing.T) {
 	ctx := context.Background()
 	agent := createTestAgent(ctx, t)
@@ -270,10 +265,7 @@ func TestQueryServiceStopped(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd := <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 14 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 14)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_REPLICA {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -304,10 +296,7 @@ func TestQueryServiceStopped(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd = <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 15 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	bd := waitForBroadcastData(t, agent.QueryServiceControl, 15)
 	if bd.RealtimeStats.HealthError != "test cannot start query service" {
 		t.Errorf("unexpected HealthError: %v", *bd)
 	}
@@ -343,10 +332,7 @@ func TestTabletControl(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd := <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 16 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 16)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_REPLICA {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -402,10 +388,7 @@ func TestTabletControl(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd = <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 17 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 17)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_REPLICA {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -431,10 +414,7 @@ func TestTabletControl(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd = <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 18 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 18)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_SPARE {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -460,10 +440,7 @@ func TestTabletControl(t *testing.T) {
 	if agent._healthyTime.Sub(before) < 0 {
 		t.Errorf("runHealthCheck did not update agent._healthyTime")
 	}
-	bd = <-agent.QueryServiceControl.(*tabletservermock.Controller).BroadcastData
-	if bd.RealtimeStats.SecondsBehindMaster != 19 {
-		t.Errorf("unexpected replicaton delay: %v", *bd)
-	}
+	waitForBroadcastData(t, agent.QueryServiceControl, 19)
 	if agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType != topodatapb.TabletType_REPLICA {
 		t.Errorf("invalid tabletserver target: %v", agent.QueryServiceControl.(*tabletservermock.Controller).CurrentTarget.TabletType)
 	}
@@ -493,5 +470,22 @@ func TestOldHealthCheck(t *testing.T) {
 	agent._healthyTime = time.Now().Add(-4 * *healthCheckInterval)
 	if _, healthy := agent.Healthy(); healthy == nil || !strings.Contains(healthy.Error(), "last health check is too old") {
 		t.Errorf("Healthy returned wrong error: %v", healthy)
+	}
+}
+
+// waitForBroadcastData is used by tests to get the first BroadcastData that's
+// recent enough, without relying on the precise number of times TabletManager
+// calls BroadcastHealth() in the meantime.
+func waitForBroadcastData(t *testing.T, qsc tabletserver.Controller, secondsBehindMaster uint32) *tabletservermock.BroadcastData {
+	timer := time.NewTimer(10 * time.Second)
+	for {
+		select {
+		case bd := <-qsc.(*tabletservermock.Controller).BroadcastData:
+			if bd.RealtimeStats.SecondsBehindMaster == secondsBehindMaster {
+				return bd
+			}
+		case <-timer.C:
+			t.Fatalf("Timed out waiting for SecondsBehindMaster = %v", secondsBehindMaster)
+		}
 	}
 }

--- a/go/vt/tabletmanager/init_tablet.go
+++ b/go/vt/tabletmanager/init_tablet.go
@@ -183,8 +183,7 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 		}
 
 	case topo.ErrNodeExists:
-		// The node already exists, will just try to update
-		// it. So we read it first.
+		// The node already exists, will just try to update it. So we read it first.
 		oldTablet, err := agent.TopoServer.GetTablet(ctx, tablet.Alias)
 		if err != nil {
 			return fmt.Errorf("InitTablet failed to read existing tablet record: %v", err)
@@ -195,9 +194,8 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 			return fmt.Errorf("InitTablet failed because existing tablet keyspace and shard %v/%v differ from the provided ones %v/%v", oldTablet.Keyspace, oldTablet.Shard, tablet.Keyspace, tablet.Shard)
 		}
 
-		// And overwrite the rest
-		*(oldTablet.Tablet) = *tablet
-		if err := agent.TopoServer.UpdateTablet(ctx, oldTablet); err != nil {
+		// Then overwrite everything, ignoring version mismatch.
+		if err := agent.TopoServer.UpdateTablet(ctx, topo.NewTabletInfo(tablet, -1)); err != nil {
 			return fmt.Errorf("UpdateTablet failed: %v", err)
 		}
 

--- a/go/vt/tabletmanager/init_tablet_test.go
+++ b/go/vt/tabletmanager/init_tablet_test.go
@@ -116,6 +116,23 @@ func TestInitTablet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTablet failed: %v", err)
 	}
+	// It should still be spare, because the tablet record doesn't agree.
+	if ti.Type != topodatapb.TabletType_SPARE {
+		t.Errorf("wrong tablet type: %v", ti.Type)
+	}
+
+	// Fix the tablet record to agree that we're master.
+	ti.Type = topodatapb.TabletType_MASTER
+	if err := ts.UpdateTablet(ctx, ti); err != nil {
+		t.Fatalf("UpdateTablet failed: %v", err)
+	}
+	if err := agent.InitTablet(port, gRPCPort); err != nil {
+		t.Fatalf("InitTablet(type, healthcheck) failed: %v", err)
+	}
+	ti, err = ts.GetTablet(ctx, tabletAlias)
+	if err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
 	if ti.Type != topodatapb.TabletType_MASTER {
 		t.Errorf("wrong tablet type: %v", ti.Type)
 	}

--- a/go/vt/tabletmanager/reparent.go
+++ b/go/vt/tabletmanager/reparent.go
@@ -69,6 +69,14 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 		return nil
 	}
 
+	// Remember when we were first told we're the master.
+	// If another tablet claims to be master and offers a more recent time,
+	// that tablet will be trusted over us.
+	agent.mutex.Lock()
+	agent._tabletExternallyReparentedTime = startTime
+	agent._replicationDelay = 0
+	agent.mutex.Unlock()
+
 	// Create a reusable Reparent event with available info.
 	ev := &events.Reparent{
 		ShardInfo: *si,
@@ -86,6 +94,9 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 	}()
 	event.DispatchUpdate(ev, "starting external from tablet (fast)")
 
+	var wg sync.WaitGroup
+	var errs concurrency.AllErrorRecorder
+
 	// Execute state change to master by force-updating only the local copy of the
 	// tablet record. The actual record in topo will be updated later.
 	log.Infof("fastTabletExternallyReparented: executing change callback for state change to MASTER")
@@ -93,35 +104,47 @@ func (agent *ActionAgent) TabletExternallyReparented(ctx context.Context, extern
 	tablet.Type = topodatapb.TabletType_MASTER
 	tablet.HealthMap = nil
 	agent.setTablet(tablet)
-	if err := agent.updateState(ctx, oldTablet, "fastTabletExternallyReparented"); err != nil {
-		return fmt.Errorf("fastTabletExternallyReparented: failed to change tablet state to MASTER: %v", err)
-	}
 
-	agent.mutex.Lock()
-	agent._tabletExternallyReparentedTime = time.Now()
-	agent._replicationDelay = 0
-	agent.mutex.Unlock()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 
-	// update the listeners in the background
-	event.DispatchUpdate(ev, "broadcasting to listeners")
-	agent.broadcastHealth()
+		// This is where updateState will block for gracePeriod, while it gives
+		// vtgate a chance to stop sending replica queries.
+		if err := agent.updateState(ctx, oldTablet, "fastTabletExternallyReparented"); err != nil {
+			errs.RecordError(fmt.Errorf("fastTabletExternallyReparented: failed to change tablet state to MASTER: %v", err))
+		}
+	}()
 
-	// Directly write the new master endpoint in the serving graph.
-	// We will do a true rebuild in the background soon, but in the meantime,
-	// this will be enough for clients to re-resolve the new master.
-	event.DispatchUpdate(ev, "writing new master endpoint")
-	log.Infof("fastTabletExternallyReparented: writing new master endpoint to serving graph")
-	ep, err := topo.TabletEndPoint(tablet)
-	if err != nil {
-		return fmt.Errorf("fastTabletExternallyReparented: failed to generate EndPoint for tablet %v: %v", tablet.Alias, err)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Directly write the new master endpoint in the serving graph.
+		// We will do a true rebuild in the background soon, but in the meantime,
+		// this will be enough for clients to re-resolve the new master.
+		event.DispatchUpdate(ev, "writing new master endpoint")
+		log.Infof("fastTabletExternallyReparented: writing new master endpoint to serving graph")
+		ep, err := topo.TabletEndPoint(tablet)
+		if err != nil {
+			errs.RecordError(fmt.Errorf("fastTabletExternallyReparented: failed to generate EndPoint for tablet %v: %v", tablet.Alias, err))
+			return
+		}
+		err = topo.UpdateEndPoints(ctx, agent.TopoServer, tablet.Alias.Cell,
+			si.Keyspace(), si.ShardName(), topodatapb.TabletType_MASTER,
+			&topodatapb.EndPoints{Entries: []*topodatapb.EndPoint{ep}}, -1)
+		if err != nil {
+			errs.RecordError(fmt.Errorf("fastTabletExternallyReparented: failed to update master endpoint: %v", err))
+			return
+		}
+		externalReparentStats.Record("NewMasterVisible", startTime)
+	}()
+
+	// Wait for serving state grace period and serving graph update.
+	wg.Wait()
+	if errs.HasErrors() {
+		return errs.Error()
 	}
-	err = topo.UpdateEndPoints(ctx, agent.TopoServer, tablet.Alias.Cell,
-		si.Keyspace(), si.ShardName(), topodatapb.TabletType_MASTER,
-		&topodatapb.EndPoints{Entries: []*topodatapb.EndPoint{ep}}, -1)
-	if err != nil {
-		return fmt.Errorf("fastTabletExternallyReparented: failed to update master endpoint: %v", err)
-	}
-	externalReparentStats.Record("NewMasterVisible", startTime)
 
 	// Start the finalize stage with a background context, but connect the trace.
 	bgCtx, cancel := context.WithTimeout(agent.batchCtx, *finalizeReparentTimeout)
@@ -178,7 +201,8 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 	if !topoproto.TabletAliasIsZero(oldMasterAlias) {
 		wg.Add(1)
 		go func() {
-			// Force the old master to spare.
+			// Forcibly demote the old master in topology, since we can't rely on the
+			// old master to be up to change its own record.
 			oldMasterTablet, err := agent.TopoServer.UpdateTabletFields(ctx, oldMasterAlias,
 				func(tablet *topodatapb.Tablet) error {
 					tablet.Type = topodatapb.TabletType_SPARE
@@ -190,19 +214,18 @@ func (agent *ActionAgent) finalizeTabletExternallyReparented(ctx context.Context
 				return
 			}
 
-			if oldMasterTablet != nil {
-				// We now know more about the old master, so add it to event data.
-				ev.OldMaster = *oldMasterTablet
+			// We now know more about the old master, so add it to event data.
+			ev.OldMaster = *oldMasterTablet
 
-				// Update the serving graph.
-				errs.RecordError(
-					topotools.UpdateTabletEndpoints(ctx, agent.TopoServer, oldMasterTablet))
-				wg.Done()
+			// Update the serving graph.
+			errs.RecordError(
+				topotools.UpdateTabletEndpoints(ctx, agent.TopoServer, oldMasterTablet))
+			wg.Done()
 
-				// Tell the old master to refresh its state. We don't need to wait for it.
-				tmc := tmclient.NewTabletManagerClient()
-				tmc.RefreshState(ctx, topo.NewTabletInfo(oldMasterTablet, -1))
-			}
+			// Tell the old master to re-read its tablet record and change its state.
+			// We don't need to wait for it.
+			tmc := tmclient.NewTabletManagerClient()
+			tmc.RefreshState(ctx, topo.NewTabletInfo(oldMasterTablet, -1))
 		}()
 	}
 

--- a/go/vt/tabletmanager/restore.go
+++ b/go/vt/tabletmanager/restore.go
@@ -36,7 +36,7 @@ func (agent *ActionAgent) RestoreFromBackup(ctx context.Context) error {
 	// always authorized)
 	tablet := agent.Tablet()
 	originalType := tablet.Type
-	if err := agent.TopoServer.UpdateTabletFields(ctx, tablet.Alias, func(tablet *topodatapb.Tablet) error {
+	if _, err := agent.TopoServer.UpdateTabletFields(ctx, tablet.Alias, func(tablet *topodatapb.Tablet) error {
 		tablet.Type = topodatapb.TabletType_RESTORE
 		return nil
 	}); err != nil {
@@ -63,7 +63,7 @@ func (agent *ActionAgent) RestoreFromBackup(ctx context.Context) error {
 	}
 
 	// Change type back to original type if we're ok to serve.
-	if err := agent.TopoServer.UpdateTabletFields(ctx, tablet.Alias, func(tablet *topodatapb.Tablet) error {
+	if _, err := agent.TopoServer.UpdateTabletFields(ctx, tablet.Alias, func(tablet *topodatapb.Tablet) error {
 		tablet.Type = originalType
 		return nil
 	}); err != nil {

--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -198,6 +198,9 @@ type Controller interface {
 	// SetServingType transitions the query service to the required serving type.
 	SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) error
 
+	// EnterLameduck causes tabletserver to enter the lameduck state.
+	EnterLameduck()
+
 	// IsServing returns true if the query service is running
 	IsServing() bool
 

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -400,7 +400,7 @@ func (tsv *TabletServer) gracefulStop() {
 // StopService shuts down the tabletserver to the uninitialized state.
 // It first transitions to StateShuttingDown, then waits for existing
 // transactions to complete. Once all transactions are resolved, it shuts
-// down the rest of the services nad transitions to StateNotConnected.
+// down the rest of the services and transitions to StateNotConnected.
 func (tsv *TabletServer) StopService() {
 	defer close(tsv.setTimeBomb())
 	defer logError(tsv.qe.queryServiceStats)

--- a/go/vt/tabletserver/tabletservermock/controller.go
+++ b/go/vt/tabletserver/tabletservermock/controller.go
@@ -131,3 +131,7 @@ func (tqsc *Controller) BroadcastHealth(terTimestamp int64, stats *querypb.Realt
 		RealtimeStats: *stats,
 	}
 }
+
+// EnterLameduck implements tabletserver.Controller.
+func (tqsc *Controller) EnterLameduck() {
+}

--- a/go/vt/topo/helpers/copy.go
+++ b/go/vt/topo/helpers/copy.go
@@ -154,7 +154,7 @@ func CopyTablets(ctx context.Context, fromTS, toTS topo.Impl) {
 						if err == topo.ErrNodeExists {
 							// update the destination tablet
 							log.Warningf("tablet %v already exists, updating it", tabletAlias)
-							err = tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
+							_, err = tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
 								*t = *tablet
 								return nil
 							})

--- a/go/vt/topo/test/tablet.go
+++ b/go/vt/topo/test/tablet.go
@@ -93,19 +93,26 @@ func CheckTablet(ctx context.Context, t *testing.T, ts topo.Impl) {
 	}
 
 	// test UpdateTabletFields works
-	if err := tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
+	updatedTablet, err := tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
 		t.Hostname = "anotherhost"
 		return nil
-	}); err != nil {
+	})
+	if err != nil {
 		t.Errorf("UpdateTabletFields: %v", err)
+	}
+	if got, want := updatedTablet.Hostname, "anotherhost"; got != want {
+		t.Errorf("updatedTablet.Hostname = %q, want %q", got, want)
 	}
 	nt, nv, err = ts.GetTablet(ctx, tablet.Alias)
 	if err != nil {
 		t.Errorf("GetTablet %v: %v", tablet.Alias, err)
 	}
+	if got, want := nt.Hostname, "anotherhost"; got != want {
+		t.Errorf("nt.Hostname = %q, want %q", got, want)
+	}
 
 	// test UpdateTabletFields that returns ErrNoUpdateNeeded works
-	if err := tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
+	if _, err := tts.UpdateTabletFields(ctx, tablet.Alias, func(t *topodatapb.Tablet) error {
 		return topo.ErrNoUpdateNeeded
 	}); err != nil {
 		t.Errorf("UpdateTabletFields: %v", err)

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -667,7 +667,7 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 	if err != nil {
 		return err
 	}
-	return wr.TopoServer().UpdateTabletFields(ctx, tabletAlias, func(tablet *topodatapb.Tablet) error {
+	_, err = wr.TopoServer().UpdateTabletFields(ctx, tabletAlias, func(tablet *topodatapb.Tablet) error {
 		if *hostname != "" {
 			tablet.Hostname = *hostname
 		}
@@ -690,6 +690,7 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 		}
 		return nil
 	})
+	return err
 }
 
 func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -102,7 +102,7 @@ func FindWorkerTablet(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrang
 	ourURL := servenv.ListeningURL.String()
 	wr.Logger().Infof("Adding tag[worker]=%v to tablet %v", ourURL, topoproto.TabletAliasString(tabletAlias))
 	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
-	err = wr.TopoServer().UpdateTabletFields(shortCtx, tabletAlias, func(tablet *topodatapb.Tablet) error {
+	_, err = wr.TopoServer().UpdateTabletFields(shortCtx, tabletAlias, func(tablet *topodatapb.Tablet) error {
 		if tablet.Tags == nil {
 			tablet.Tags = make(map[string]string)
 		}

--- a/go/vt/wrangler/cleaner.go
+++ b/go/vt/wrangler/cleaner.go
@@ -194,7 +194,7 @@ func RecordTabletTagAction(cleaner *Cleaner, tabletAlias *topodatapb.TabletAlias
 
 // CleanUp is part of CleanerAction interface.
 func (tta TabletTagAction) CleanUp(ctx context.Context, wr *Wrangler) error {
-	return wr.TopoServer().UpdateTabletFields(ctx, tta.TabletAlias, func(tablet *topodatapb.Tablet) error {
+	_, err := wr.TopoServer().UpdateTabletFields(ctx, tta.TabletAlias, func(tablet *topodatapb.Tablet) error {
 		if tablet.Tags == nil {
 			tablet.Tags = make(map[string]string)
 		}
@@ -205,6 +205,7 @@ func (tta TabletTagAction) CleanUp(ctx context.Context, wr *Wrangler) error {
 		}
 		return nil
 	})
+	return err
 }
 
 //

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -164,6 +164,10 @@ func (wr *Wrangler) ChangeSlaveType(ctx context.Context, tabletAlias *topodatapb
 		return err
 	}
 
+	if !topo.IsTrivialTypeChange(ti.Type, tabletType) {
+		return fmt.Errorf("tablet %v type change %v -> %v is not an allowed transition for ChangeSlaveType", tabletAlias, ti.Type, tabletType)
+	}
+
 	// ask the tablet to make the change
 	if err := wr.tmc.ChangeType(ctx, ti, tabletType); err != nil {
 		return err

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -174,7 +174,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 	// create a test agent on that port, and re-read the record
 	// (it has new ports and IP)
 	ft.Agent = tabletmanager.NewTestActionAgent(context.Background(), wr.TopoServer(), ft.Tablet.Alias, vtPort, gRPCPort, ft.FakeMysqlDaemon)
-	ft.Tablet = ft.Agent.Tablet().Tablet
+	ft.Tablet = ft.Agent.Tablet()
 
 	// create the gRPC server
 	ft.RPCServer = grpc.NewServer()
@@ -188,7 +188,7 @@ func (ft *FakeTablet) StartActionLoop(t *testing.T, wr *wrangler.Wrangler) {
 	c := tmclient.NewTabletManagerClient()
 	for timeout >= 0 {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		err := c.Ping(ctx, ft.Agent.Tablet())
+		err := c.Ping(ctx, topo.NewTabletInfo(ft.Agent.Tablet(), -1))
 		cancel()
 		if err == nil {
 			break

--- a/test/config.json
+++ b/test/config.json
@@ -311,6 +311,17 @@
 				"site_test"
 			]
 		},
+		"vtgatev2_discovery": {
+			"File": "vtgatev2_test.py",
+			"Args": ["--vtgate-gateway-flavor=discoverygateway"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 3,
+			"RetryMax": 0,
+			"Tags": [
+				"site_test"
+			]
+		},
 		"vtgatev3": {
 			"File": "vtgatev3_test.py",
 			"Args": [],


### PR DESCRIPTION
@alainjobart @guoliang100 

The tabletmanager grace period is the amount of time it pauses after broadcasting to vtgate that it's going to stop serving a particular target type (e.g. when going spare, or when being promoted to master). During this period, we expect vtgate to gracefully redirect traffic elsewhere, before the tablet actually starts rejecting queries for that target type.

The -serving_state_grace_period flag defaults to 0, which corresponds roughly to the old behavior, with an additional health broadcast.

However, after manually running the tests with value 0, I've set the default value in test/tablet.py to 1s. There are no branches in the code for the 0 value; it just means the Sleep() returns immediately. So it isn't worth running the entire test suite twice from now on.