### PR TITLE
Go driver: Add per-shard vtgate v2 fallback mode.

### DIFF
--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -34,6 +34,8 @@ in the form of :v1, :v2, etc.
 	timeout       = flag.Duration("timeout", 30*time.Second, "timeout for queries")
 	streaming     = flag.Bool("streaming", false, "use a streaming query")
 	bindVariables = newBindvars("bind_variables", "bind variables as a json list")
+	keyspace      = flag.String("keyspace", "", "Keyspace of a specific keyspace/shard to target. Disables vtgate v3.")
+	shard         = flag.String("shard", "", "Shard of a specific keyspace/shard to target. Disables vtgate v3.")
 )
 
 func init() {
@@ -104,7 +106,7 @@ func main() {
 		exit.Return(1)
 	}
 
-	connStr := fmt.Sprintf(`{"address": "%s", "tablet_type": "%s", "streaming": %v, "timeout": %d}`, *server, *tabletType, *streaming, int64(30*(*timeout)))
+	connStr := fmt.Sprintf(`{"address": "%s", "keyspace": "%s", "shard": "%s", "tablet_type": "%s", "streaming": %v, "timeout": %d}`, *server, *keyspace, *shard, *tabletType, *streaming, int64(30*(*timeout)))
 	db, err := sql.Open("vitess", connStr)
 	if err != nil {
 		log.Errorf("client error: %v", err)

--- a/go/vt/client/client.go
+++ b/go/vt/client/client.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
@@ -24,22 +25,41 @@ func init() {
 	sql.Register("vitess", drv{})
 }
 
+// TODO(mberlin): Add helper methods.
+
 type drv struct {
 }
 
 // Open must be called with a JSON string that looks like this:
-// {"protocol": "gorpc", "address": "localhost:1111", "tablet_type": "master", "timeout": 1000000000}
+//
+//   {"protocol": "gorpc", "address": "localhost:1111", "tablet_type": "master", "timeout": 1000000000}
+//
 // protocol specifies the rpc protocol to use.
 // address specifies the address for the VTGate to connect to.
 // tablet_type represents the consistency level of your operations.
 // For example "replica" means eventually consistent reads, while
 // "master" supports transactions and gives you read-after-write consistency.
 // timeout is specified in nanoseconds. It applies for all operations.
+//
+// If you want to execute queries which are not supported by vtgate v3, you can
+// run queries against a specific keyspace and shard.
+// Therefore, add the fields "keyspace" and "shard" to the JSON string. Example:
+//
+//   {"protocol": "gorpc", "address": "localhost:1111", "keyspace": "ks1", "shard": "0", "tablet_type": "master", "timeout": 1000000000}
+//
+// Note that this function will always create a connection to vtgate i.e. there
+// is no need to call DB.Ping() to verify the connection.
 func (d drv) Open(name string) (driver.Conn, error) {
 	c := &conn{TabletType: "master"}
 	err := json.Unmarshal([]byte(name), c)
 	if err != nil {
 		return nil, err
+	}
+	if (c.Keyspace != "" && c.Shard == "") || (c.Keyspace == "" && c.Shard != "") {
+		return nil, fmt.Errorf("Always set both keyspace and shard or leave both empty. keyspace: %v shard: %v", c.Keyspace, c.Shard)
+	}
+	if c.useExecuteShards() {
+		log.Infof("Sending queries only to keyspace/shard: %v/%v", c.Keyspace, c.Shard)
 	}
 	c.tabletType, err = topoproto.ParseTabletType(c.TabletType)
 	if err != nil {
@@ -53,8 +73,15 @@ func (d drv) Open(name string) (driver.Conn, error) {
 }
 
 type conn struct {
-	Protocol   string
-	Address    string
+	Protocol string
+	Address  string
+	// Keyspace of a specific keyspace/shard to target. Disables vtgate v3.
+	// If Keyspace and Shard are not empty, vtgate v2 instead of v3 will be used
+	// and all requests will be sent only to that particular shard.
+	// This functionality is meant for initial migrations from MySQL/MariaDB to Vitess.
+	Keyspace string
+	// Shard of a specific keyspace/shard to target. Disables vtgate v3.
+	Shard      string
 	TabletType string `json:"tablet_type"`
 	Streaming  bool
 	Timeout    time.Duration
@@ -72,6 +99,10 @@ func (c *conn) dial() error {
 		c.vtgateConn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address, c.Timeout)
 	}
 	return err
+}
+
+func (c *conn) useExecuteShards() bool {
+	return c.Keyspace != "" && c.Shard != ""
 }
 
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
@@ -137,16 +168,12 @@ func (s *stmt) NumInput() int {
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.c.Timeout)
 	defer cancel()
+
 	if s.c.Streaming {
 		return nil, errors.New("Exec not allowed for streaming connections")
 	}
-	var qr *sqltypes.Result
-	var err error
-	if s.c.tx == nil {
-		qr, err = s.c.vtgateConn.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType)
-	} else {
-		qr, err = s.c.tx.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType, false)
-	}
+
+	qr, err := s.executeVitess(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -155,25 +182,44 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.c.Timeout)
+
 	if s.c.Streaming {
-		qrc, errFunc, err := s.c.vtgateConn.StreamExecute(ctx, s.query, makeBindVars(args), s.c.tabletType)
+		var qrc <-chan *sqltypes.Result
+		var errFunc vtgateconn.ErrFunc
+		var err error
+		if s.c.useExecuteShards() {
+			qrc, errFunc, err = s.c.vtgateConn.StreamExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletType)
+		} else {
+			qrc, errFunc, err = s.c.vtgateConn.StreamExecute(ctx, s.query, makeBindVars(args), s.c.tabletType)
+		}
 		if err != nil {
 			return nil, err
 		}
 		return newStreamingRows(qrc, errFunc, cancel), nil
 	}
+	// Do not cancel in case of a streaming query. It will do it itself.
 	defer cancel()
-	var qr *sqltypes.Result
-	var err error
-	if s.c.tx == nil {
-		qr, err = s.c.vtgateConn.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType)
-	} else {
-		qr, err = s.c.tx.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType, false)
-	}
+
+	qr, err := s.executeVitess(ctx, args)
 	if err != nil {
 		return nil, err
 	}
 	return newRows(qr), nil
+}
+
+func (s *stmt) executeVitess(ctx context.Context, args []driver.Value) (*sqltypes.Result, error) {
+	if s.c.tx != nil {
+		if s.c.useExecuteShards() {
+			return s.c.tx.ExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletType, false /* notInTransaction */)
+		}
+		return s.c.tx.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType, false /* notInTransaction */)
+	}
+
+	// Non-transactional case.
+	if s.c.useExecuteShards() {
+		return s.c.vtgateConn.ExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletType)
+	}
+	return s.c.vtgateConn.Execute(ctx, s.query, makeBindVars(args), s.c.tabletType)
 }
 
 func makeBindVars(args []driver.Value) map[string]interface{} {

--- a/go/vt/client/client_test.go
+++ b/go/vt/client/client_test.go
@@ -101,185 +101,255 @@ func TestDial(t *testing.T) {
 }
 
 func TestExec(t *testing.T) {
-	connStr := fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "timeout": %d}`, testAddress, int64(30*time.Second))
+	var testcases = []struct {
+		dataSourceName string
+		requestName    string
+	}{
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1",
+		},
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "keyspace": "ks1", "shard": "0", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1SpecificShard",
+		},
+	}
+
+	for _, tc := range testcases {
+		connStr := fmt.Sprintf(tc.dataSourceName, testAddress, int64(30*time.Second))
+		c, err := drv{}.Open(connStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s, _ := c.Prepare(tc.requestName)
+		if ni := s.NumInput(); ni != -1 {
+			t.Errorf("got %d, want -1", ni)
+		}
+		r, err := s.Exec([]driver.Value{int64(0)})
+		if err != nil {
+			t.Error(err)
+		}
+		if v, _ := r.LastInsertId(); v != 72 {
+			t.Errorf("insert id: %d, want 72", v)
+		}
+		if v, _ := r.RowsAffected(); v != 123 {
+			t.Errorf("rows affected: %d, want 123", v)
+		}
+		_ = s.Close()
+
+		s, _ = c.Prepare("none")
+		_, err = s.Exec(nil)
+		want := "no match for: none"
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("err: %v, does not contain %s", err, want)
+		}
+		_ = c.Close()
+	}
+}
+
+func TestExecStreamingNotAllowed(t *testing.T) {
+	connStr := fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "streaming": true, "timeout": %d}`, testAddress, int64(30*time.Second))
 	c, err := drv{}.Open(connStr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	s, _ := c.Prepare("request1")
-	if ni := s.NumInput(); ni != -1 {
-		t.Errorf("got %d, want -1", ni)
-	}
-	r, err := s.Exec([]driver.Value{int64(0)})
-	if err != nil {
-		t.Error(err)
-	}
-	if v, _ := r.LastInsertId(); v != 72 {
-		t.Errorf("insert id: %d, want 72", v)
-	}
-	if v, _ := r.RowsAffected(); v != 123 {
-		t.Errorf("rows affected: %d, want 123", v)
-	}
-	_ = s.Close()
-
-	s, _ = c.Prepare("none")
-	_, err = s.Exec(nil)
-	want := "no match for: none"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("err: %v, does not contain %s", err, want)
-	}
-	_ = c.Close()
-
-	connStr = fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "streaming": true, "timeout": %d}`, testAddress, int64(30*time.Second))
-	c, err = drv{}.Open(connStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s, _ = c.Prepare("request1")
-	r, err = s.Exec([]driver.Value{int64(0)})
-	want = "Exec not allowed for streaming connections"
+	_, err = s.Exec([]driver.Value{int64(0)})
+	want := "Exec not allowed for streaming connections"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("err: %v, does not contain %s", err, want)
 	}
 }
 
 func TestQuery(t *testing.T) {
-	connStr := fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "timeout": %d}`, testAddress, int64(30*time.Second))
-	c, err := drv{}.Open(connStr)
-	if err != nil {
-		t.Fatal(err)
+	var testcases = []struct {
+		dataSourceName string
+		requestName    string
+	}{
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1",
+		},
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "keyspace": "ks1", "shard": "0", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1SpecificShard",
+		},
 	}
-	s, _ := c.Prepare("request1")
-	r, err := s.Query([]driver.Value{int64(0)})
-	if err != nil {
-		t.Error(err)
-	}
-	cols := r.Columns()
-	wantCols := []string{
-		"field1",
-		"field2",
-	}
-	if !reflect.DeepEqual(cols, wantCols) {
-		t.Errorf("cols: %v, want %v", cols, wantCols)
-	}
-	row := make([]driver.Value, 2)
-	count := 0
-	for {
-		err = r.Next(row)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			t.Error(err)
-		}
-		count++
-	}
-	if count != 2 {
-		t.Errorf("count: %d, want 2", count)
-	}
-	_ = s.Close()
 
-	s, _ = c.Prepare("none")
-	_, err = s.Query(nil)
-	want := "no match for: none"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("err: %v, does not contain %s", err, want)
-	}
-	_ = c.Close()
-
-	connStr = fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "streaming": true, "timeout": %d}`, testAddress, int64(30*time.Second))
-	c, err = drv{}.Open(connStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	s, _ = c.Prepare("request1")
-	r, err = s.Query([]driver.Value{int64(0)})
-	if err != nil {
-		t.Error(err)
-	}
-	cols = r.Columns()
-	wantCols = []string{
-		"field1",
-		"field2",
-	}
-	if !reflect.DeepEqual(cols, wantCols) {
-		t.Errorf("cols: %v, want %v", cols, wantCols)
-	}
-	row = make([]driver.Value, 2)
-	count = 0
-	for {
-		err = r.Next(row)
+	for _, tc := range testcases {
+		connStr := fmt.Sprintf(tc.dataSourceName, testAddress, int64(30*time.Second))
+		c, err := drv{}.Open(connStr)
 		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			t.Error(err)
+			t.Fatal(err)
 		}
-		count++
+		s, _ := c.Prepare(tc.requestName)
+		r, err := s.Query([]driver.Value{int64(0)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		cols := r.Columns()
+		wantCols := []string{
+			"field1",
+			"field2",
+		}
+		if !reflect.DeepEqual(cols, wantCols) {
+			t.Fatalf("cols: %v, want %v", cols, wantCols)
+		}
+		row := make([]driver.Value, 2)
+		count := 0
+		for {
+			err = r.Next(row)
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Error(err)
+			}
+			count++
+		}
+		if count != 2 {
+			t.Errorf("count: %d, want 2", count)
+		}
+		_ = s.Close()
+
+		s, _ = c.Prepare("none")
+		_, err = s.Query(nil)
+		want := "no match for: none"
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("err: %v, does not contain %s", err, want)
+		}
+		_ = c.Close()
 	}
-	if count != 2 {
-		t.Errorf("count: %d, want 2", count)
+}
+
+func TestQueryStreaming(t *testing.T) {
+	var testcases = []struct {
+		dataSourceName string
+		requestName    string
+	}{
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1",
+		},
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "keyspace": "ks1", "shard": "0", "tablet_type": "rdonly", "timeout": %d}`,
+			requestName:    "request1SpecificShard",
+		},
 	}
-	_ = s.Close()
-	_ = c.Close()
+
+	for _, tc := range testcases {
+		connStr := fmt.Sprintf(tc.dataSourceName, testAddress, int64(30*time.Second))
+		c, err := drv{}.Open(connStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s, _ := c.Prepare(tc.requestName)
+		r, err := s.Query([]driver.Value{int64(0)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		cols := r.Columns()
+		wantCols := []string{
+			"field1",
+			"field2",
+		}
+		if !reflect.DeepEqual(cols, wantCols) {
+			t.Fatalf("cols: %v, want %v", cols, wantCols)
+		}
+		row := make([]driver.Value, 2)
+		count := 0
+		for {
+			err = r.Next(row)
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Fatal(err)
+			}
+			count++
+		}
+		if count != 2 {
+			t.Errorf("count: %d, want 2", count)
+		}
+		_ = s.Close()
+		_ = c.Close()
+	}
 }
 
 func TestTx(t *testing.T) {
-	connStr := fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "master", "timeout": %d}`, testAddress, int64(30*time.Second))
+	var testcases = []struct {
+		dataSourceName string
+		requestName    string
+	}{
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "tablet_type": "master", "timeout": %d}`,
+			requestName:    "txRequest",
+		},
+		{
+			dataSourceName: `{"protocol": "grpc", "address": "%s", "keyspace": "ks1", "shard": "0", "tablet_type": "master", "timeout": %d}`,
+			requestName:    "txRequestSpecificShard",
+		},
+	}
+
+	for _, tc := range testcases {
+		connStr := fmt.Sprintf(tc.dataSourceName, testAddress, int64(30*time.Second))
+		c, err := drv{}.Open(connStr)
+		if err != nil {
+			t.Fatalf("%v: %v", tc.requestName, err)
+		}
+		tx, err := c.Begin()
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		s, _ := c.Prepare(tc.requestName)
+		_, err = s.Exec([]driver.Value{int64(0)})
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		err = tx.Commit()
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		err = tx.Commit()
+		want := "commit: not in transaction"
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("case: %v err: %v, does not contain %s", tc.requestName, err, want)
+		}
+		_ = c.Close()
+
+		c, err = drv{}.Open(connStr)
+		if err != nil {
+			t.Fatalf("%v: %v", tc.requestName, err)
+		}
+		tx, err = c.Begin()
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		s, _ = c.Prepare(tc.requestName)
+		_, err = s.Query([]driver.Value{int64(0)})
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		err = tx.Rollback()
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		err = tx.Rollback()
+		if err != nil {
+			t.Errorf("%v: %v", tc.requestName, err)
+		}
+		_ = c.Close()
+	}
+}
+
+func TestTxExecStreamingNotAllowed(t *testing.T) {
+	connStr := fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "streaming": true, "timeout": %d}`, testAddress, int64(30*time.Second))
 	c, err := drv{}.Open(connStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tx, err := c.Begin()
-	if err != nil {
-		t.Error(err)
-	}
-	s, _ := c.Prepare("txRequest")
-	_, err = s.Exec([]driver.Value{int64(0)})
-	if err != nil {
-		t.Error(err)
-	}
-	err = tx.Commit()
-	if err != nil {
-		t.Error(err)
-	}
-	err = tx.Commit()
-	want := "commit: not in transaction"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("err: %v, does not contain %s", err, want)
-	}
-	_ = c.Close()
-
-	c, err = drv{}.Open(connStr)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tx, err = c.Begin()
-	if err != nil {
-		t.Error(err)
-	}
-	s, _ = c.Prepare("txRequest")
-	_, err = s.Query([]driver.Value{int64(0)})
-	if err != nil {
-		t.Error(err)
-	}
-	err = tx.Rollback()
-	if err != nil {
-		t.Error(err)
-	}
-	err = tx.Rollback()
-	if err != nil {
-		t.Error(err)
-	}
-	_ = c.Close()
-
-	connStr = fmt.Sprintf(`{"protocol": "grpc", "address": "%s", "tablet_type": "rdonly", "streaming": true, "timeout": %d}`, testAddress, int64(30*time.Second))
-	c, err = drv{}.Open(connStr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = c.Begin()
-	want = "transaction not allowed for streaming connection"
+	want := "transaction not allowed for streaming connection"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("err: %v, does not contain %s", err, want)
 	}

--- a/go/vt/client/fakeserver_test.go
+++ b/go/vt/client/fakeserver_test.go
@@ -27,6 +27,14 @@ type queryExecute struct {
 	NotInTransaction bool
 }
 
+// queryExecuteSpecificShard contains all the fields we use to test the
+// vtgate v2 fallback mode which uses vtgateconn.ExecuteShards internally.
+type queryExecuteSpecificShard struct {
+	queryExecute
+	Keyspace string
+	Shard    string
+}
+
 // Execute is part of the VTGateService interface
 func (f *fakeVTGateService) Execute(ctx context.Context, sql string, bindVariables map[string]interface{}, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool) (*sqltypes.Result, error) {
 	execCase, ok := execMap[sql]
@@ -41,7 +49,7 @@ func (f *fakeVTGateService) Execute(ctx context.Context, sql string, bindVariabl
 		NotInTransaction: notInTransaction,
 	}
 	if !reflect.DeepEqual(query, execCase.execQuery) {
-		return nil, fmt.Errorf("request mismatch: got %+v, want %+v", query, execCase.execQuery)
+		return nil, fmt.Errorf("Execute request mismatch: got %+v, want %+v", query, execCase.execQuery)
 	}
 	if execCase.session != nil {
 		*session = *execCase.session
@@ -51,7 +59,28 @@ func (f *fakeVTGateService) Execute(ctx context.Context, sql string, bindVariabl
 
 // ExecuteShards is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteShards(ctx context.Context, sql string, bindVariables map[string]interface{}, keyspace string, shards []string, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool) (*sqltypes.Result, error) {
-	return nil, nil
+	execCase, ok := execSpecificShardMap[sql]
+	if !ok {
+		return nil, fmt.Errorf("no match for: %s", sql)
+	}
+	query := &queryExecuteSpecificShard{
+		queryExecute: queryExecute{
+			SQL:              sql,
+			BindVariables:    bindVariables,
+			TabletType:       tabletType,
+			Session:          session,
+			NotInTransaction: notInTransaction,
+		},
+		Keyspace: keyspace,
+		Shard:    shards[0],
+	}
+	if !reflect.DeepEqual(query, execCase.execQuery) {
+		return nil, fmt.Errorf("ExecuteShards request mismatch: got %+v, want %+v", query, execCase.execQuery)
+	}
+	if execCase.session != nil {
+		*session = *execCase.session
+	}
+	return execCase.result, nil
 }
 
 // ExecuteKeyspaceIds is part of the VTGateService interface
@@ -201,6 +230,49 @@ var execMap = map[string]struct {
 			},
 			TabletType: topodatapb.TabletType_MASTER,
 			Session:    session1,
+		},
+		result:  &sqltypes.Result{},
+		session: session2,
+	},
+}
+
+// execSpecificShardMap is used to test the vtgate v2 fallback behavior where
+// sql.Open() was called for a specific keyspace/shard and
+// vtgateconn.ExecuteShards is used internally by the driver.
+var execSpecificShardMap = map[string]struct {
+	execQuery *queryExecuteSpecificShard
+	result    *sqltypes.Result
+	session   *vtgatepb.Session
+	err       error
+}{
+	"request1SpecificShard": {
+		execQuery: &queryExecuteSpecificShard{
+			queryExecute: queryExecute{
+				SQL: "request1SpecificShard",
+				BindVariables: map[string]interface{}{
+					"v1": int64(0),
+				},
+				TabletType: topodatapb.TabletType_RDONLY,
+				Session:    nil,
+			},
+			Keyspace: "ks1",
+			Shard:    "0",
+		},
+		result:  &result1,
+		session: nil,
+	},
+	"txRequestSpecificShard": {
+		execQuery: &queryExecuteSpecificShard{
+			queryExecute: queryExecute{
+				SQL: "txRequestSpecificShard",
+				BindVariables: map[string]interface{}{
+					"v1": int64(0),
+				},
+				TabletType: topodatapb.TabletType_MASTER,
+				Session:    session1,
+			},
+			Keyspace: "ks1",
+			Shard:    "0",
 		},
 		result:  &sqltypes.Result{},
 		session: session2,

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -11,6 +11,8 @@ import environment
 import tablet
 import utils
 
+from vtproto import topodata_pb2
+
 # shards
 shard_0_master = tablet.Tablet()
 shard_0_rdonly = tablet.Tablet()
@@ -108,9 +110,7 @@ class TestCustomSharding(unittest.TestCase):
                      shard_0_master.tablet_alias], auto_log=True)
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
-    ks = utils.run_vtctl_json(['GetSrvKeyspace', 'test_nj', 'test_keyspace'])
-    self.assertEqual(len(ks['partitions'][0]['shard_references']), 1)
-    self.assertEqual(len(ks['partitions'][0]['shard_references']), 1)
+    self._check_shards_count_in_srv_keyspace(1)
     s = utils.run_vtctl_json(['GetShard', 'test_keyspace/0'])
     self.assertEqual(len(s['served_types']), 3)
 
@@ -176,9 +176,7 @@ primary key (id)
     self._check_data('1', 400, 10, table='data2')
 
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-    ks = utils.run_vtctl_json(['GetSrvKeyspace', 'test_nj', 'test_keyspace'])
-    self.assertEqual(len(ks['partitions'][0]['shard_references']), 2)
-    self.assertEqual(len(ks['partitions'][0]['shard_references']), 2)
+    self._check_shards_count_in_srv_keyspace(2)
 
     # Now test SplitQuery API works (used in MapReduce usually, but bringing
     # up a full MR-capable cluster is too much for this test environment)
@@ -216,6 +214,19 @@ primary key (id)
     self.assertEqual(rows, expected)
 
     self._test_vtclient_execute_shards_fallback()
+
+  def _check_shards_count_in_srv_keyspace(self, shard_count):
+    ks = utils.run_vtctl_json(['GetSrvKeyspace', 'test_nj', 'test_keyspace'])
+    check_types = set([topodata_pb2.MASTER, topodata_pb2.RDONLY])
+    for p in ks['partitions']:
+      if p['served_type'] in check_types:
+        self.assertEqual(len(p['shard_references']), shard_count)
+        check_types.remove(p['served_type'])
+
+    self.assertEqual(len(check_types), 0,
+                     'The number of expected shard_references in GetSrvKeyspace'
+                     ' was not equal %d for all expected tablet types.'
+                     % shard_count)
 
   def _test_vtclient_execute_shards_fallback(self):
     """Test per-shard mode of Go SQL driver (through vtclient)."""

--- a/test/utils.py
+++ b/test/utils.py
@@ -598,13 +598,18 @@ class VtGate(object):
     """Returns the vars for this process."""
     return get_vars(self.port)
 
-  def vtclient(self, sql, tablet_type='master', bindvars=None,
-               streaming=False, verbose=False, raise_on_error=False):
+  def vtclient(self, sql, keyspace=None, shard=None, tablet_type='master',
+               bindvars=None, streaming=False,
+               verbose=False, raise_on_error=True):
     """Uses the vtclient binary to send a query to vtgate."""
     args = environment.binary_args('vtclient') + [
         '-server', self.rpc_endpoint(),
         '-tablet_type', tablet_type,
         '-vtgate_protocol', protocols_flavor().vtgate_protocol()]
+    if keyspace:
+      args.extend(['-keyspace', keyspace])
+    if shard:
+      args.extend(['-shard', shard])
     if bindvars:
       args.extend(['-bind_variables', json.dumps(bindvars)])
     if streaming:


### PR DESCRIPTION
@alainjobart @sougou 

When a "keyspace" and a "shard" is defined, use ExecuteShards() instead of Execute().

After this, I'll make more changes:
- add helper methods for sql.Open(), e.g. provide client.Open(address, "master", ...) to free the user from passing a JSON
- add a first minimal package godoc
- use the Golang sql interface where possible e.g. in vtclient instead of relying on details of the driver implementation