### PR TITLE
misc: Allow Git pre-commit hook to be run from any working directory.

### DIFF
--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -5,8 +5,9 @@ set -e
 
 # This is necessary because the Emacs extensions don't set GIT_DIR.
 if [ -z "$GIT_DIR" ]; then
- GIT_DIR="$(pwd)/.git"
+  DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+  GIT_DIR="${DIR}/.."
 fi
 for hook in $GIT_DIR/../misc/git/hooks/*; do
-    $hook
+  $hook
 done


### PR DESCRIPTION
@enisoc 

I have an alias to the pre-commit script which I sometimes run manually e.g. to go over all lint errors.

Before this fix, pre-commit could only be run from $VTTOP.