### PR TITLE
Go SQL driver: Rename package from "client" to "vitessdriver".

### DIFF
--- a/examples/local/client.go
+++ b/examples/local/client.go
@@ -1,4 +1,4 @@
-// client.go is a sample for using the Go Vitess client with an unsharded keyspace.
+// client.go is a sample for using the Vitess Go SQL driver with an unsharded keyspace.
 //
 // Before running this, start up a local example cluster as described in the
 // README.md file.
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	// import the 'vitess' sql driver
-	_ "github.com/youtube/vitess/go/vt/client"
+	_ "github.com/youtube/vitess/go/vt/vitessdriver"
 )
 
 var (

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -137,8 +137,8 @@ func main() {
 		}
 
 		rowsAffected, err := result.RowsAffected()
-		lastInsertId, err := result.LastInsertId()
-		log.Infof("Total time: %v / Row affected: %v / Last Insert Id: %v", time.Now().Sub(now), rowsAffected, lastInsertId)
+		lastInsertID, err := result.LastInsertId()
+		log.Infof("Total time: %v / Row affected: %v / Last Insert Id: %v", time.Now().Sub(now), rowsAffected, lastInsertID)
 	} else {
 
 		// launch the query

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -18,7 +18,7 @@ import (
 	"github.com/youtube/vitess/go/vt/logutil"
 
 	// import the 'vitess' sql driver
-	_ "github.com/youtube/vitess/go/vt/client"
+	_ "github.com/youtube/vitess/go/vt/vitessdriver"
 )
 
 var (

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
 import (
 	"database/sql"

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
 import (
 	"database/sql"

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -1,4 +1,4 @@
-package client
+package vitessdriver
 
 import (
 	"errors"

--- a/go/vt/vitessdriver/plugin_gorpcvtgateconn.go
+++ b/go/vt/vitessdriver/plugin_gorpcvtgateconn.go
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
-// Imports and register the gRPC vtgateconn client.
+// Imports and register the gorpc vtgateconn client.
 
 import (
-	// Import the gRPC vtgateconn client and make it part of the Vitess
+	// Import the gorpc vtgateconn client and make it part of the Vitess
 	// Go SQL driver. This way, users do not have to do this.
-	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
+	_ "github.com/youtube/vitess/go/vt/vtgate/gorpcvtgateconn"
 )

--- a/go/vt/vitessdriver/plugin_grpcvtgateconn.go
+++ b/go/vt/vitessdriver/plugin_grpcvtgateconn.go
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
-// Imports and register the gorpc vtgateconn client.
+// Imports and register the gRPC vtgateconn client.
 
 import (
-	// Import the gorpc vtgateconn client and make it part of the Vitess
+	// Import the gRPC vtgateconn client and make it part of the Vitess
 	// Go SQL driver. This way, users do not have to do this.
-	_ "github.com/youtube/vitess/go/vt/vtgate/gorpcvtgateconn"
+	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateconn"
 )

--- a/go/vt/vitessdriver/rows.go
+++ b/go/vt/vitessdriver/rows.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
 import (
 	"database/sql/driver"

--- a/go/vt/vitessdriver/rows_test.go
+++ b/go/vt/vitessdriver/rows_test.go
@@ -1,4 +1,4 @@
-package client
+package vitessdriver
 
 import (
 	"database/sql/driver"

--- a/go/vt/vitessdriver/streaming_rows.go
+++ b/go/vt/vitessdriver/streaming_rows.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
 import (
 	"database/sql/driver"

--- a/go/vt/vitessdriver/streaming_rows_test.go
+++ b/go/vt/vitessdriver/streaming_rows_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package client
+package vitessdriver
 
 import (
 	"database/sql/driver"


### PR DESCRIPTION
@alainjobart @sougou 

I feel that this name is more direct. The Go "sql" package also talks about "drivers": https://golang.org/pkg/database/sql/

To get a sense how other drivers are named, here's a list: https://github.com/golang/go/wiki/SQLDrivers

Instead of "driver", an even better package name would be "vitess". Once we provide helper functions for Open(), application code would read then as:

``` go
vitess.Open(address, "master", ...)
```

instead of:

``` go
driver.Open(address, "master", ...)
```

However, I think our current directory structure doesn't allow us to name a package as generic as "vitess". Therefore, I feel "driver" is better.

```go/vt/driver``` makes it clear that it's the Go Vitess driver.