### PR TITLE
tests: fix rowcache_invalidator flakyness

### DIFF
--- a/go/vt/tabletserver/cache_pool.go
+++ b/go/vt/tabletserver/cache_pool.go
@@ -153,7 +153,7 @@ func (cp *CachePool) startCacheService() {
 	for {
 		c, err := cacheservice.Connect(cacheservice.Config{
 			Address: cp.socket,
-			Timeout: 30 * time.Millisecond,
+			Timeout: 10 * time.Second,
 		})
 
 		if err != nil {


### PR DESCRIPTION
memcache seems to start up slow sometimes. Give the sanity check
a higher timeout to account for it.