### PR TITLE
vtworker: Log output of vtworker commands executed via RPC.

### DIFF
--- a/go/vt/worker/grpcvtworkerserver/server.go
+++ b/go/vt/worker/grpcvtworkerserver/server.go
@@ -38,9 +38,12 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *vtworkerdatapb.ExecuteVtwo
 	// (started in Instance.setAndStartWorker()) which has its own panic handler.
 	defer servenv.HandlePanic("vtworker", &err)
 
-	// create a logger, send the result back to the caller
+	// Stream everything back what the Wrangler is logging.
 	logstream := logutil.NewChannelLogger(10)
-	logger := logutil.NewTeeLogger(logstream, logutil.NewMemoryLogger())
+	// Let the Wrangler also log everything to the console (and thereby
+	// effectively to a logfile) to make sure that any information or errors
+	// is preserved in the logs in case the RPC or vtworker crashes.
+	logger := logutil.NewTeeLogger(logstream, logutil.NewConsoleLogger())
 
 	// send logs to the caller
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
@aaijazi @alainjobart 

One vtworker command may be very long running (on the order of days). If the command is executed via an RPC, the output of the command is currently only stored in memory. There are several situations where this output may get lost halfway:
- if vtworker crashes
- if the consumer crashes and vtworker gets reset

From an operations perspective, we want avoid this and preserve the output instead.

Therefore, the output of each RPC will be logged to the console (and consequently, depending on the flags of the Go log package, to a file as well).

NOTE: The previous code also set a NewMemoryLogger() for the Wrangler. But this wasn't actually necessary.