### PR TITLE
tabletserver & v3: fix case sensitivity bugs

### DIFF
--- a/go/vt/schema/schema.go
+++ b/go/vt/schema/schema.go
@@ -8,6 +8,8 @@ package schema
 // It contains a data structure that's shared between sqlparser & tabletserver
 
 import (
+	"strings"
+
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/sync2"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -55,7 +57,7 @@ func NewTable(name string) *Table {
 // AddColumn adds a column to the Table.
 func (ta *Table) AddColumn(name string, columnType querypb.Type, defval sqltypes.Value, extra string) {
 	index := len(ta.Columns)
-	ta.Columns = append(ta.Columns, TableColumn{Name: name})
+	ta.Columns = append(ta.Columns, TableColumn{Name: strings.ToLower(name)})
 	ta.Columns[index].Type = columnType
 	if extra == "auto_increment" {
 		ta.Columns[index].IsAuto = true
@@ -119,7 +121,7 @@ func NewIndex(name string) *Index {
 
 // AddColumn adds a column to the index.
 func (idx *Index) AddColumn(name string, cardinality uint64) {
-	idx.Columns = append(idx.Columns, name)
+	idx.Columns = append(idx.Columns, strings.ToLower(name))
 	if cardinality == 0 {
 		cardinality = uint64(len(idx.Cardinality) + 1)
 	}

--- a/go/vt/tabletserver/endtoend/main_test.go
+++ b/go/vt/tabletserver/endtoend/main_test.go
@@ -106,6 +106,7 @@ create unique index id2_idx on upsert_test(id2);
 insert into vitess_a(eid, id, name, foo) values(1, 1, 'abcd', 'efgh'), (1, 2, 'bcde', 'fghi');
 insert into vitess_b(eid, id) values(1, 1), (1, 2);
 insert into vitess_c(eid, name, foo) values(10, 'abcd', '20'), (11, 'bcde', '30');
+create table vitess_mixed_case(Col1 int, COL2 int, primary key(col1)) comment 'vitess_nocache';
 
 create table vitess_cached1(eid bigint, name varchar(128), foo varbinary(128), primary key(eid));
 create index aname1 on vitess_cached1(name);
@@ -178,7 +179,7 @@ var tableACLConfig = `{
     },
     {
       "name": "vitess",
-      "table_names_or_prefixes": ["vitess_a", "vitess_b", "vitess_c", "dual", "vitess_d", "vitess_temp", "vitess_e", "vitess_f", "upsert_test", "vitess_strings", "vitess_fracts", "vitess_ints", "vitess_misc", "vitess_big", "vitess_view"],
+      "table_names_or_prefixes": ["vitess_a", "vitess_b", "vitess_c", "dual", "vitess_d", "vitess_temp", "vitess_e", "vitess_f", "vitess_mixed_case", "upsert_test", "vitess_strings", "vitess_fracts", "vitess_ints", "vitess_misc", "vitess_big", "vitess_view"],
       "readers": ["dev"],
       "writers": ["dev"],
       "admins": ["dev"]

--- a/go/vt/tabletserver/endtoend/nocache_case_test.go
+++ b/go/vt/tabletserver/endtoend/nocache_case_test.go
@@ -571,6 +571,29 @@ func TestNocacheCases(t *testing.T) {
 			},
 		},
 		&framework.MultiCase{
+			Name: "insert with mixed case column names",
+			Cases: []framework.Testable{
+				framework.TestQuery("begin"),
+				&framework.TestCase{
+					Query: "insert into vitess_mixed_case(col1, col2) values(1, 2)",
+					Rewritten: []string{
+						"insert into vitess_mixed_case(col1, col2) values (1, 2) /* _stream vitess_mixed_case (col1 ) (1 )",
+					},
+					RowsAffected: 1,
+				},
+				framework.TestQuery("commit"),
+				&framework.TestCase{
+					Query: "select COL1, COL2 from vitess_mixed_case",
+					Result: [][]string{
+						{"1", "2"},
+					},
+				},
+				framework.TestQuery("begin"),
+				framework.TestQuery("delete from vitess_mixed_case"),
+				framework.TestQuery("commit"),
+			},
+		},
+		&framework.MultiCase{
 			Name: "insert auto_increment",
 			Cases: []framework.Testable{
 				framework.TestQuery("alter table vitess_e auto_increment = 1"),

--- a/go/vt/vtgate/planbuilder/schema.go
+++ b/go/vt/vtgate/planbuilder/schema.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"sort"
+	"strings"
 )
 
 // Schema represents the denormalized version of SchemaFormal,
@@ -85,7 +86,7 @@ func BuildSchema(source *SchemaFormal) (schema *Schema, err error) {
 					return nil, fmt.Errorf("vindex %s not found for class %s", ind.Name, cname)
 				}
 				columnVindex := &ColVindex{
-					Col:    ind.Col,
+					Col:    strings.ToLower(ind.Col),
 					Type:   vindexInfo.Type,
 					Name:   ind.Name,
 					Owned:  vindexInfo.Owner == tname,


### PR DESCRIPTION
Since column names are not case sensitive, we have to normalize them when we read them in.