### PR TITLE
gofmt -s is now enforced.

### DIFF
--- a/misc/git/hooks/gofmt
+++ b/misc/git/hooks/gofmt
@@ -15,9 +15,9 @@ gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 unformatted=$(gofmt -s -l $gofiles 2>&1)
 [ -z "$unformatted" ] && exit 0
 
-# Some files are not goimports'd. Print message and fail.
+# Some files are not gofmt'd. Print message and fail.
 
-echo >&2 "Go files must be formatted with goimports. Please run:"
+echo >&2 "Go files must be formatted with gofmt. Please run:"
 echo >&2
 echo -n >&2 "  gofmt -s -w"
 for fn in $unformatted; do

--- a/misc/git/hooks/goimports
+++ b/misc/git/hooks/goimports
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-# git gofmt pre-commit hook
+# git goimports pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
@@ -12,14 +12,14 @@
 gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 
 [ -z "$gofiles" ] && exit 0
-unformatted=$(gofmt -s -l $gofiles 2>&1)
+unformatted=$(goimports -l=true $gofiles 2>&1 | awk -F: '{print $1}')
 [ -z "$unformatted" ] && exit 0
 
 # Some files are not goimports'd. Print message and fail.
 
 echo >&2 "Go files must be formatted with goimports. Please run:"
 echo >&2
-echo -n >&2 "  gofmt -s -w"
+echo -n >&2 "  goimports -w"
 for fn in $unformatted; do
     echo -n >&2 " $PWD/$fn"
 done

--- a/misc/gofmt-all
+++ b/misc/gofmt-all
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-find . -name '*.go' -exec gofmt -w {} \;
+find . -name '*.go' -exec gofmt -s -w {} \;


### PR DESCRIPTION
Renaming the goimports hook to goimports.

@michael-berlin @sougou 