### PR TITLE
Update replication lag filter to return at least 2 items.

### DIFF
--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -53,7 +53,7 @@ var (
 <br>
 <table>
   <tr>
-    <th colspan="5">EndPoints Cache</th>
+    <th colspan="5">EndPoints Cache (NOT USED for new endpoint implementation)</th>
   </tr>
   <tr>
     <th>Cell</th>
@@ -72,7 +72,7 @@ var (
   </tr>
   {{end}}
 </table>
-<small>This is just a cache, so some data may not be visible here yet.</small>
+<small>This is just a cache, so some data may not be visible here yet. It is empty if using new endpoint implementation.</small>
 `
 
 	statsTemplate = `
@@ -219,8 +219,8 @@ google.setOnLoadCallback(function() {
     <th>Address</th>
     <th>Query Sent</th>
     <th>Query Error</th>
-    <th>QPS</th>
-    <th>Latency (ms)</th>
+    <th>QPS (avg 1m)</th>
+    <th>Latency (ms) (avg 1m)</th>
   </tr>
   {{range $i, $status := .}}
   <tr>

--- a/go/vt/discovery/replicationlag.go
+++ b/go/vt/discovery/replicationlag.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"flag"
 	"fmt"
+	"math"
 	"time"
 )
 
@@ -47,6 +48,26 @@ func FilterByReplicationLag(epsList []*EndPointStats) []*EndPointStats {
 		mi, _ := mean(list, i)
 		if float64(mi) > float64(m)*0.7 {
 			res = append(res, eps)
+		}
+	}
+	// return at least 2 endpoints to avoid over loading
+	if len(res) == 0 {
+		return list
+	}
+	if len(res) == 1 && len(list) > 1 {
+		minLag := uint32(math.MaxUint32)
+		idx := -1
+		for i, eps := range list {
+			if eps == res[0] {
+				continue
+			}
+			if eps.Stats.SecondsBehindMaster < minLag {
+				idx = i
+				minLag = eps.Stats.SecondsBehindMaster
+			}
+		}
+		if idx >= 0 {
+			res = append(res, list[idx])
 		}
 	}
 	return res

--- a/go/vt/discovery/replicationlag_test.go
+++ b/go/vt/discovery/replicationlag_test.go
@@ -107,4 +107,19 @@ func TestFilterByReplicationLag(t *testing.T) {
 	if len(got) != 4 || !reflect.DeepEqual(got[0], eps1) || !reflect.DeepEqual(got[1], eps2) || !reflect.DeepEqual(got[2], eps3) || !reflect.DeepEqual(got[3], eps4) {
 		t.Errorf("FilterByReplicationLag([30m, 35m, 40m, 45m]) = %+v, want all", got)
 	}
+	// lags of (1m, 100m) - always return at least 2 items to avoid overloading
+	eps1 = &EndPointStats{
+		EndPoint: &topodatapb.EndPoint{Uid: 1},
+		Serving:  true,
+		Stats:    &querypb.RealtimeStats{SecondsBehindMaster: 1 * 60},
+	}
+	eps2 = &EndPointStats{
+		EndPoint: &topodatapb.EndPoint{Uid: 2},
+		Serving:  true,
+		Stats:    &querypb.RealtimeStats{SecondsBehindMaster: 100 * 60},
+	}
+	got = FilterByReplicationLag([]*EndPointStats{eps1, eps2})
+	if len(got) != 2 || !reflect.DeepEqual(got[0], eps1) || !reflect.DeepEqual(got[1], eps2) {
+		t.Errorf("FilterByReplicationLag([1m, 100m]) = %+v, want all", got)
+	}
 }

--- a/go/vt/discovery/replicationlag_test.go
+++ b/go/vt/discovery/replicationlag_test.go
@@ -107,7 +107,7 @@ func TestFilterByReplicationLag(t *testing.T) {
 	if len(got) != 4 || !reflect.DeepEqual(got[0], eps1) || !reflect.DeepEqual(got[1], eps2) || !reflect.DeepEqual(got[2], eps3) || !reflect.DeepEqual(got[3], eps4) {
 		t.Errorf("FilterByReplicationLag([30m, 35m, 40m, 45m]) = %+v, want all", got)
 	}
-	// lags of (1m, 100m) - always return at least 2 items to avoid overloading
+	// lags of (1m, 100m) - return at least 2 items to avoid overloading if the 2nd one is not delayed too much
 	eps1 = &EndPointStats{
 		EndPoint: &topodatapb.EndPoint{Uid: 1},
 		Serving:  true,
@@ -121,5 +121,20 @@ func TestFilterByReplicationLag(t *testing.T) {
 	got = FilterByReplicationLag([]*EndPointStats{eps1, eps2})
 	if len(got) != 2 || !reflect.DeepEqual(got[0], eps1) || !reflect.DeepEqual(got[1], eps2) {
 		t.Errorf("FilterByReplicationLag([1m, 100m]) = %+v, want all", got)
+	}
+	// lags of (1m, 3h) - return 1 if the 2nd one is delayed too much
+	eps1 = &EndPointStats{
+		EndPoint: &topodatapb.EndPoint{Uid: 1},
+		Serving:  true,
+		Stats:    &querypb.RealtimeStats{SecondsBehindMaster: 1 * 60},
+	}
+	eps2 = &EndPointStats{
+		EndPoint: &topodatapb.EndPoint{Uid: 2},
+		Serving:  true,
+		Stats:    &querypb.RealtimeStats{SecondsBehindMaster: 3 * 60 * 60},
+	}
+	got = FilterByReplicationLag([]*EndPointStats{eps1, eps2})
+	if len(got) != 1 || !reflect.DeepEqual(got[0], eps1) {
+		t.Errorf("FilterByReplicationLag([1m, 3h]) = %+v, want [1m]", got)
 	}
 }


### PR DESCRIPTION
@alainjobart @sougou 

It is to avoid overloading 1 endpoint when other high replication lag ones are available.