### PR TITLE
automation: Add task for vtctl RebuildKeyspaceGraph.

### DIFF
--- a/go/vt/automation/copy_schema_shard_task_test.go
+++ b/go/vt/automation/copy_schema_shard_task_test.go
@@ -29,11 +29,11 @@ func TestCopySchemaShardTask(t *testing.T) {
 		"vtctld_endpoint": "localhost:15000",
 		"exclude_tables":  "",
 	}
-	testTask(t, "CopySchemaShard", task, parameters)
+	testTask(t, "CopySchemaShard", task, parameters, fake)
 
 	fake.RegisterResult([]string{"CopySchemaShard", "--exclude_tables=excluded_table1", "test_keyspace/0", "test_keyspace/2"},
 		"",  // No output.
 		nil) // No error.
 	parameters["exclude_tables"] = "excluded_table1"
-	testTask(t, "CopySchemaShard", task, parameters)
+	testTask(t, "CopySchemaShard", task, parameters, fake)
 }

--- a/go/vt/automation/migrate_served_types_task.go
+++ b/go/vt/automation/migrate_served_types_task.go
@@ -21,8 +21,8 @@ func (t *MigrateServedTypesTask) Run(parameters map[string]string) ([]*automatio
 	keyspaceAndShard := fmt.Sprintf("%v/%v", parameters["keyspace"], parameters["source_shard"])
 
 	args := []string{"MigrateServedTypes"}
-	if cell := parameters["cell"]; cell != "" {
-		args = append(args, "--cells="+cell)
+	if cells := parameters["cells"]; cells != "" {
+		args = append(args, "--cells="+cells)
 	}
 	if reverse := parameters["reverse"]; reverse != "" {
 		args = append(args, "--reverse="+reverse)
@@ -39,5 +39,5 @@ func (t *MigrateServedTypesTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *MigrateServedTypesTask) OptionalParameters() []string {
-	return []string{"cell", "reverse"}
+	return []string{"cells", "reverse"}
 }

--- a/go/vt/automation/rebuild_keyspace_graph_task.go
+++ b/go/vt/automation/rebuild_keyspace_graph_task.go
@@ -1,0 +1,36 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package automation
+
+import (
+	automationpb "github.com/youtube/vitess/go/vt/proto/automation"
+	"golang.org/x/net/context"
+)
+
+// RebuildKeyspaceGraphTask runs vtctl RebuildKeyspaceGraph to migrate a serving
+// type from the source shard to the shards that it replicates to.
+type RebuildKeyspaceGraphTask struct {
+}
+
+// Run is part of the Task interface.
+func (t *RebuildKeyspaceGraphTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
+	args := []string{"RebuildKeyspaceGraph"}
+	if cells := parameters["cells"]; cells != "" {
+		args = append(args, "--cells="+cells)
+	}
+	args = append(args, parameters["keyspace"])
+	output, err := ExecuteVtctl(context.TODO(), parameters["vtctld_endpoint"], args)
+	return nil, output, err
+}
+
+// RequiredParameters is part of the Task interface.
+func (t *RebuildKeyspaceGraphTask) RequiredParameters() []string {
+	return []string{"keyspace", "vtctld_endpoint"}
+}
+
+// OptionalParameters is part of the Task interface.
+func (t *RebuildKeyspaceGraphTask) OptionalParameters() []string {
+	return []string{"cells"}
+}

--- a/go/vt/automation/rebuild_keyspace_graph_task_test.go
+++ b/go/vt/automation/rebuild_keyspace_graph_task_test.go
@@ -12,28 +12,25 @@ import (
 	"github.com/youtube/vitess/go/vt/vtctl/vtctlclient"
 )
 
-func TestMigrateServedTypesTask(t *testing.T) {
+func TestRebuildKeyspaceGraphTask(t *testing.T) {
 	fake := fakevtctlclient.NewFakeVtctlClient()
 	vtctlclient.RegisterFactory("fake", fake.FakeVtctlClientFactory)
 	defer vtctlclient.UnregisterFactoryForTest("fake")
 	flag.Set("vtctl_client_protocol", "fake")
-	task := &MigrateServedTypesTask{}
+	task := &RebuildKeyspaceGraphTask{}
 
-	fake.RegisterResult([]string{"MigrateServedTypes", "test_keyspace/0", "rdonly"},
+	fake.RegisterResult([]string{"RebuildKeyspaceGraph", "test_keyspace"},
 		"",  // No output.
 		nil) // No error.
 	parameters := map[string]string{
 		"keyspace":        "test_keyspace",
-		"source_shard":    "0",
-		"type":            "rdonly",
 		"vtctld_endpoint": "localhost:15000",
 	}
-	testTask(t, "MigrateServedTypes", task, parameters, fake)
+	testTask(t, "RebuildKeyspaceGraph", task, parameters, fake)
 
-	fake.RegisterResult([]string{"MigrateServedTypes", "--cells=cell1", "--reverse=true", "test_keyspace/0", "rdonly"},
+	fake.RegisterResult([]string{"RebuildKeyspaceGraph", "--cells=cell1", "test_keyspace"},
 		"",  // No output.
 		nil) // No error.
 	parameters["cells"] = "cell1"
-	parameters["reverse"] = "true"
-	testTask(t, "MigrateServedTypes", task, parameters, fake)
+	testTask(t, "RebuildKeyspaceGraph", task, parameters, fake)
 }

--- a/go/vt/automation/scheduler.go
+++ b/go/vt/automation/scheduler.go
@@ -209,12 +209,14 @@ func defaultTaskCreator(taskName string) Task {
 		return &CopySchemaShardTask{}
 	case "MigrateServedTypesTask":
 		return &MigrateServedTypesTask{}
-	case "WaitForFilteredReplicationTask":
-		return &WaitForFilteredReplicationTask{}
+	case "RebuildKeyspaceGraph":
+		return &RebuildKeyspaceGraphTask{}
 	case "SplitCloneTask":
 		return &SplitCloneTask{}
 	case "SplitDiffTask":
 		return &SplitDiffTask{}
+	case "WaitForFilteredReplicationTask":
+		return &WaitForFilteredReplicationTask{}
 	default:
 		return nil
 	}

--- a/go/vt/automation/testutils_test.go
+++ b/go/vt/automation/testutils_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	automationpb "github.com/youtube/vitess/go/vt/proto/automation"
+	"github.com/youtube/vitess/go/vt/vtctl/fakevtctlclient"
 )
 
 func testingTaskCreator(taskName string) Task {
@@ -105,7 +106,7 @@ func (t *TestingEmitEchoFailEchoTask) OptionalParameters() []string {
 // testTask runs the given tasks and checks if it succeeds.
 // To make the task succeed you have to register the result with a fake first
 // e.g. see migrate_served_types_task_test.go for an example.
-func testTask(t *testing.T, test string, task Task, parameters map[string]string) {
+func testTask(t *testing.T, test string, task Task, parameters map[string]string, vtctlClientFake *fakevtctlclient.FakeVtctlClient) {
 	err := validateParameters(task, parameters)
 	if err != nil {
 		t.Fatalf("%s: Not all required parameters were specified: %v", test, err)
@@ -117,5 +118,9 @@ func testTask(t *testing.T, test string, task Task, parameters map[string]string
 	}
 	if err != nil {
 		t.Errorf("%s: Task should not fail: %v", err, test)
+	}
+
+	if c := vtctlClientFake.RegisteredCommands(); len(c) != 0 {
+		t.Errorf("Not all registered results were consumed from the fake. Commands left: %v", c)
 	}
 }

--- a/go/vt/vtctl/fakevtctlclient/fake_loggerevent_streamingclient.go
+++ b/go/vt/vtctl/fakevtctlclient/fake_loggerevent_streamingclient.go
@@ -18,14 +18,14 @@ import (
 // FakeLoggerEventStreamingClient is the base for the fakes for the vtctlclient and vtworkerclient.
 // It allows to register a (multi-)line string for a given command and return the result as channel which streams it back.
 type FakeLoggerEventStreamingClient struct {
-	results map[string]result
+	results map[string]*result
 	// mu guards all fields of the structs.
 	mu sync.Mutex
 }
 
 // NewFakeLoggerEventStreamingClient creates a new fake.
 func NewFakeLoggerEventStreamingClient() *FakeLoggerEventStreamingClient {
-	return &FakeLoggerEventStreamingClient{results: make(map[string]result)}
+	return &FakeLoggerEventStreamingClient{results: make(map[string]*result)}
 }
 
 // generateKey returns a map key for a []string.
@@ -38,6 +38,15 @@ func generateKey(args []string) string {
 type result struct {
 	output string
 	err    error
+	// count is the number of times this result is registered for the same
+	// command. With each stream of this result, count will be decreased by one.
+	count int
+}
+
+func (r1 result) Equals(r2 result) bool {
+	return r1.output == r2.output &&
+		((r1.err == nil && r2.err == nil) ||
+			(r1.err != nil && r2.err != nil && r1.err.Error() == r2.err.Error()))
 }
 
 // RegisterResult registers for a given command (args) the result which the fake should return.
@@ -47,10 +56,15 @@ func (f *FakeLoggerEventStreamingClient) RegisterResult(args []string, output st
 	defer f.mu.Unlock()
 
 	k := generateKey(args)
+	v := result{output, err, 1}
 	if result, ok := f.results[k]; ok {
-		return fmt.Errorf("Result is already registered as: %v", result)
+		if result.Equals(v) {
+			result.count++
+			return nil
+		}
+		return fmt.Errorf("A different result (%v) is already registered for command: %v", result, args)
 	}
-	f.results[k] = result{output, err}
+	f.results[k] = &v
 	return nil
 }
 
@@ -77,7 +91,10 @@ func (f *FakeLoggerEventStreamingClient) StreamResult(args []string) (<-chan *lo
 	if !ok {
 		return nil, nil, fmt.Errorf("No response was registered for args: %v", args)
 	}
-	delete(f.results, k)
+	result.count--
+	if result.count == 0 {
+		delete(f.results, k)
+	}
 
 	stream := make(chan *logutilpb.Event)
 	go func() {

--- a/go/vt/vtctl/fakevtctlclient/fake_loggerevent_streamingclient_test.go
+++ b/go/vt/vtctl/fakevtctlclient/fake_loggerevent_streamingclient_test.go
@@ -6,30 +6,44 @@ package fakevtctlclient
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func TestStreamOutputAndError(t *testing.T) {
-	verifyStreamOutputAndError(t, errors.New("something went wrong"))
-}
-
-func TestStreamOutput(t *testing.T) {
-	verifyStreamOutputAndError(t, nil)
-}
-
-func verifyStreamOutputAndError(t *testing.T, wantErr error) {
 	fake := NewFakeLoggerEventStreamingClient()
 	args := []string{"CopySchemaShard", "test_keyspace/0", "test_keyspace/2"}
 	output := []string{"event1", "event2"}
-	err := fake.RegisterResult(args,
-		strings.Join(output, "\n"),
-		wantErr)
+	wantErr := errors.New("something went wrong")
+
+	err := fake.RegisterResult(args, strings.Join(output, "\n"), wantErr)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to register fake result for: %v err: %v", args, err)
 	}
 
+	verifyStreamOutputAndError(t, fake, args, output, wantErr)
+}
+
+func TestStreamOutput(t *testing.T) {
+	fake := NewFakeLoggerEventStreamingClient()
+	args := []string{"CopySchemaShard", "test_keyspace/0", "test_keyspace/2"}
+	output := []string{"event1", "event2"}
+	var wantErr error
+
+	err := fake.RegisterResult(args, strings.Join(output, "\n"), wantErr)
+	if err != nil {
+		t.Fatalf("Failed to register fake result for: %v err: %v", args, err)
+	}
+
+	verifyStreamOutputAndError(t, fake, args, output, wantErr)
+}
+
+func verifyStreamOutputAndError(t *testing.T, fake *FakeLoggerEventStreamingClient, args, output []string, wantErr error) {
 	stream, errFunc, err := fake.StreamResult(args)
+	if err != nil {
+		t.Fatalf("Failed to stream result: %v", err)
+	}
 
 	// Verify output and error.
 	i := 0
@@ -73,12 +87,52 @@ func TestResultAlreadyRegistered(t *testing.T) {
 		t.Fatalf("Registering the result should have been successful. Error: %v", errFirst)
 	}
 
-	errSecond := fake.RegisterResult([]string{"ListShardTablets", "test_keyspace/0"}, "output1", nil)
+	errSecond := fake.RegisterResult([]string{"ListShardTablets", "test_keyspace/0"}, "output2", nil)
 	if errSecond == nil {
-		t.Fatal("Registering a duplicate result should not have been successful.")
+		t.Fatal("Registering a duplicate, different result should not have been successful.")
 	}
-	want := "Result is already registered as: {output1 <nil>}"
-	if errSecond.Error() != want {
+	want := ") is already registered for command: "
+	if !strings.Contains(errSecond.Error(), want) {
 		t.Fatalf("Wrong error message: got: '%v' want: '%v'", errSecond, want)
+	}
+}
+
+func TestRegisterMultipleResultsForSameCommand(t *testing.T) {
+	fake := NewFakeLoggerEventStreamingClient()
+	args := []string{"CopySchemaShard", "test_keyspace/0", "test_keyspace/2"}
+	output := []string{"event1", "event2"}
+	var wantErr error
+
+	// Register first result.
+	err := fake.RegisterResult(args, strings.Join(output, "\n"), wantErr)
+	if err != nil {
+		t.Fatalf("Failed to register fake result for: %v err: %v", args, err)
+	}
+	registeredCommands := []string{strings.Join(args, " ")}
+	verifyListOfRegisteredCommands(t, fake, registeredCommands)
+
+	// Register second result.
+	err = fake.RegisterResult(args, strings.Join(output, "\n"), wantErr)
+	if err != nil {
+		t.Fatalf("Failed to register fake result for: %v err: %v", args, err)
+	}
+	verifyListOfRegisteredCommands(t, fake, registeredCommands)
+
+	// Consume first result.
+	verifyStreamOutputAndError(t, fake, args, output, wantErr)
+	verifyListOfRegisteredCommands(t, fake, registeredCommands)
+
+	// Consume second result.
+	verifyStreamOutputAndError(t, fake, args, output, wantErr)
+	verifyListOfRegisteredCommands(t, fake, []string{})
+}
+
+func verifyListOfRegisteredCommands(t *testing.T, fake *FakeLoggerEventStreamingClient, want []string) {
+	got := fake.RegisteredCommands()
+	if len(got) == 0 && len(want) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fake.RegisteredCommands() = %v, want: %v", got, want)
 	}
 }


### PR DESCRIPTION
Fix issues in MigrateServedTypes actuator/task ("cell" -> "cells",
reordered parameters such that the vtctld address is the last one).

automation unit tests: Check that all fake results were consumed.

fake vtctl client: Added support for registering the same result for the
same command multiple times. The reference count is decreased every time
the result is streamed.

NOTE: This is an automated export. Changes were already LGTM'd internally.