### PR TITLE
Fix Java example test and update MariaDB download URLs.

### DIFF
--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -72,7 +72,7 @@ echo "Run Java client script..."
 # We have to install the "example" module first because Maven cannot resolve
 # them when we run "exec:java". See also: http://stackoverflow.com/questions/11091311/maven-execjava-goal-on-a-multi-module-project
 # Install only "example". See also: http://stackoverflow.com/questions/1114026/maven-modules-building-a-single-specific-module
-mvn -f ../../java/pom.xml -pl example -am install -Dmaven.test.skip=true
+mvn -f ../../java/pom.xml -pl example -am install -DskipTests
 mvn -f ../../java/example/pom.xml exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass="com.youtube.vitess.example.VitessClientExample" -Dexec.args="localhost:15991" || teardown
 
 exitcode=0

--- a/travis/download_mariadb.sh
+++ b/travis/download_mariadb.sh
@@ -5,15 +5,15 @@ set -e
 
 # As of 07/2015, this mirror is the fastest for the Travis CI workers.
 DEB_PACKAGES="
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.22+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.22+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.22+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.22+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.23+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.23+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.23+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.23+maria-1~precise_amd64.deb
 "
 
 mkdir -p $MYSQL_ROOT


### PR DESCRIPTION
I dropped the Travis caches to debug the issue why the Java test didn't build on master.

I think the problem was that the cache of my pull request had binaries built which the final version didn't have anymore. This fix should fix it.