### PR TITLE
Properly freeing up the healthcheck resources in binlog player.

### DIFF
--- a/go/vt/tabletmanager/binlog.go
+++ b/go/vt/tabletmanager/binlog.go
@@ -442,6 +442,7 @@ func (blm *BinlogPlayerMap) StopAllPlayersAndReset() {
 		if blm.state == BpmStateRunning {
 			bpc.Stop()
 		}
+		bpc.healthCheck.Close()
 		hadPlayers = true
 	}
 	blm.players = make(map[uint32]*BinlogPlayerController)
@@ -482,6 +483,7 @@ func (blm *BinlogPlayerMap) RefreshMap(ctx context.Context, tablet *topodatapb.T
 	// remove all entries from toRemove
 	for source := range toRemove {
 		blm.players[source].Stop()
+		blm.players[source].healthCheck.Close()
 		delete(blm.players, source)
 	}
 


### PR DESCRIPTION
@guoliang100 this is the fix I was supposed to make after your change.