### PR TITLE
vtctl ApplySchema: Added flag -allow_long_unavailability.

### DIFF
--- a/go/vt/schemamanager/plain_controller.go
+++ b/go/vt/schemamanager/plain_controller.go
@@ -67,13 +67,13 @@ func (controller *PlainController) OnReadFail(ctx context.Context, err error) er
 
 // OnValidationSuccess is called when schemamanager successfully validates all sql statements.
 func (controller *PlainController) OnValidationSuccess(ctx context.Context) error {
-	log.Info("Successfully validate all sqls.")
+	log.Info("Successfully validated all SQL statements.")
 	return nil
 }
 
 // OnValidationFail is called when schemamanager fails to validate sql statements.
 func (controller *PlainController) OnValidationFail(ctx context.Context, err error) error {
-	log.Errorf("Failed to validate sqls, error: %v\n", err)
+	log.Errorf("Failed to validate SQL statements, error: %v\n", err)
 	return err
 }
 

--- a/go/vt/schemamanager/schemamanager.go
+++ b/go/vt/schemamanager/schemamanager.go
@@ -76,7 +76,7 @@ type ShardResult struct {
 	Result *querypb.QueryResult
 }
 
-// Run schema changes on Vitess through VtGate
+// Run applies schema changes on Vitess through VtGate.
 func Run(ctx context.Context, controller Controller, executor Executor) error {
 	if err := controller.Open(ctx); err != nil {
 		log.Errorf("failed to open data sourcer: %v", err)

--- a/go/vt/schemamanager/tablet_executor_test.go
+++ b/go/vt/schemamanager/tablet_executor_test.go
@@ -115,6 +115,21 @@ func TestTabletExecutorValidate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("executor.Validate should succeed, drop a table with more than 2,000,000 rows is allowed")
 	}
+
+	executor.AllowBigSchemaChange()
+	// alter a table with more than 100,000 rows
+	if err := executor.Validate(ctx, []string{
+		"ALTER TABLE test_table_03 ADD COLUMN new_id bigint(20)",
+	}); err != nil {
+		t.Fatalf("executor.Validate should succeed, big schema change is disabled")
+	}
+
+	executor.DisallowBigSchemaChange()
+	if err := executor.Validate(ctx, []string{
+		"ALTER TABLE test_table_03 ADD COLUMN new_id bigint(20)",
+	}); err == nil {
+		t.Fatalf("executor.Validate should fail, alter a table more than 100,000 rows")
+	}
 }
 
 func TestTabletExecutorExecute(t *testing.T) {

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1831,7 +1831,7 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 }
 
 func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	force := subFlags.Bool("force", false, "Applies the schema even if the preflight schema doesn't match")
+	force := subFlags.Bool("force", false, "Applies the schema even if it is big (alter too many rows)")
 	sql := subFlags.String("sql", "", "A list of semicolon-delimited SQL commands")
 	sqlFile := subFlags.String("sql-file", "", "Identifies the file that contains the SQL commands")
 	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "The amount of time to wait for slaves to catch up during reparenting. The default value is 30 seconds.")

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -308,8 +308,8 @@ var commands = []commandGroup{
 				"[-exclude_tables=''] [-include-views] <keyspace name>",
 				"Validates that the master schema from shard 0 matches the schema on all of the other tablets in the keyspace."},
 			{"ApplySchema", commandApplySchema,
-				"[-force] {-sql=<sql> || -sql-file=<filename>} <keyspace>",
-				"Applies the schema change to the specified keyspace on every master, running in parallel on all shards. The changes are then propagated to slaves via replication. If the force flag is set, then numerous checks will be ignored, so that option should be used very cautiously."},
+				"[-allow_long_unavailability] {-sql=<sql> || -sql-file=<filename>} <keyspace>",
+				"Applies the schema change to the specified keyspace on every master, running in parallel on all shards. The changes are then propagated to slaves via replication. If -allow_long_unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected."},
 			{"CopySchemaShard", commandCopySchemaShard,
 				"[-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] {<source keyspace/shard> || <source tablet alias>} <destination keyspace/shard>",
 				"Copies the schema from a source shard's master (or a specific tablet) to a destination shard. The schema is applied directly on the master of the destination shard, and it is propagated to the replicas through binlogs."},
@@ -1831,7 +1831,7 @@ func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, s
 }
 
 func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	force := subFlags.Bool("force", false, "Applies the schema even if it is big (alter too many rows)")
+	allowLongUnavailability := subFlags.Bool("allow_long_unavailability", false, "Allow large schema changes which incur a longer unavailability of the database.")
 	sql := subFlags.String("sql", "", "A list of semicolon-delimited SQL commands")
 	sqlFile := subFlags.String("sql-file", "", "Identifies the file that contains the SQL commands")
 	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "The amount of time to wait for slaves to catch up during reparenting. The default value is 30 seconds.")
@@ -1847,7 +1847,7 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	if err != nil {
 		return err
 	}
-	scr, err := wr.ApplySchemaKeyspace(ctx, keyspace, change, *force, *waitSlaveTimeout)
+	scr, err := wr.ApplySchemaKeyspace(ctx, keyspace, change, *allowLongUnavailability, *waitSlaveTimeout)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1847,11 +1847,10 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 	if err != nil {
 		return err
 	}
-	scr, err := wr.ApplySchemaKeyspace(ctx, keyspace, change, *allowLongUnavailability, *waitSlaveTimeout)
-	if err != nil {
+	if err := wr.ApplySchemaKeyspace(ctx, keyspace, change, *allowLongUnavailability, *waitSlaveTimeout); err != nil {
 		return err
 	}
-	return printJSON(wr, scr)
+	return nil
 }
 
 func commandCopySchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -326,11 +326,14 @@ func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace string, ch
 	if err != nil {
 		return nil, err
 	}
-
+	executor := schemamanager.NewTabletExecutor(wr.tmc, wr.ts)
+	if force {
+		executor.AllowBigSchemaChange()
+	}
 	err = schemamanager.Run(
 		ctx,
 		schemamanager.NewPlainController(change, keyspace),
-		schemamanager.NewTabletExecutor(wr.tmc, wr.ts),
+		executor,
 	)
 
 	return nil, wr.unlockKeyspace(ctx, keyspace, actionNode, lockPath, err)

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -320,11 +320,11 @@ func (wr *Wrangler) applySchemaShard(ctx context.Context, shardInfo *topo.ShardI
 // take a keyspace lock to do this.
 // first we will validate the Preflight works the same on all shard masters
 // and fail if not (unless force is specified)
-func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace, change string, allowLongUnavailability bool, waitSlaveTimeout time.Duration) (*tmutils.SchemaChangeResult, error) {
+func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace, change string, allowLongUnavailability bool, waitSlaveTimeout time.Duration) error {
 	actionNode := actionnode.ApplySchemaKeyspace(change)
 	lockPath, err := wr.lockKeyspace(ctx, keyspace, actionNode)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	executor := schemamanager.NewTabletExecutor(wr.tmc, wr.ts)
 	if allowLongUnavailability {
@@ -336,7 +336,7 @@ func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace, change st
 		executor,
 	)
 
-	return nil, wr.unlockKeyspace(ctx, keyspace, actionNode, lockPath, err)
+	return wr.unlockKeyspace(ctx, keyspace, actionNode, lockPath, err)
 }
 
 // CopySchemaShardFromShard copies the schema from a source shard to the specified destination shard.

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -320,14 +320,14 @@ func (wr *Wrangler) applySchemaShard(ctx context.Context, shardInfo *topo.ShardI
 // take a keyspace lock to do this.
 // first we will validate the Preflight works the same on all shard masters
 // and fail if not (unless force is specified)
-func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace string, change string, force bool, waitSlaveTimeout time.Duration) (*tmutils.SchemaChangeResult, error) {
+func (wr *Wrangler) ApplySchemaKeyspace(ctx context.Context, keyspace, change string, allowLongUnavailability bool, waitSlaveTimeout time.Duration) (*tmutils.SchemaChangeResult, error) {
 	actionNode := actionnode.ApplySchemaKeyspace(change)
 	lockPath, err := wr.lockKeyspace(ctx, keyspace, actionNode)
 	if err != nil {
 		return nil, err
 	}
 	executor := schemamanager.NewTabletExecutor(wr.tmc, wr.ts)
-	if force {
+	if allowLongUnavailability {
 		executor.AllowBigSchemaChange()
 	}
 	err = schemamanager.Run(

--- a/go/vt/wrangler/testlib/apply_schema_test.go
+++ b/go/vt/wrangler/testlib/apply_schema_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testlib
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
+	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
+	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
+	"github.com/youtube/vitess/go/vt/wrangler"
+	"github.com/youtube/vitess/go/vt/zktopo"
+
+	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// TestApplySchema_AllowLongUnavailability is an integration test for the
+// -allow_long_unavailability flag of vtctl ApplySchema.
+// Only if the flag is specified, potentially long running schema changes are
+// allowed.
+func TestApplySchema_AllowLongUnavailability(t *testing.T) {
+	cells := []string{"cell1"}
+	db := fakesqldb.Register()
+	ts := zktopo.NewTestServer(t, cells)
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+	vp := NewVtctlPipe(t, ts)
+	defer vp.Close()
+
+	if err := ts.CreateKeyspace(context.Background(), "ks", &topodatapb.Keyspace{
+		ShardingColumnName: "keyspace_id",
+		ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
+	}); err != nil {
+		t.Fatalf("CreateKeyspace failed: %v", err)
+	}
+
+	beforeSchema := &tabletmanagerdatapb.SchemaDefinition{
+		DatabaseSchema: "CREATE DATABASE `{{.DatabaseName}}` /*!40100 DEFAULT CHARACTER SET utf8 */",
+		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+			{
+				Name:     "table1",
+				Schema:   "CREATE TABLE `table1` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` varchar(64) DEFAULT NULL,\n  `keyspace_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `by_msg` (`msg`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8",
+				Type:     tmutils.TableBaseTable,
+				RowCount: 3000000,
+			},
+		},
+	}
+	afterSchema := &tabletmanagerdatapb.SchemaDefinition{
+		DatabaseSchema: "CREATE DATABASE `{{.DatabaseName}}` /*!40100 DEFAULT CHARACTER SET utf8 */",
+		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+			{
+				Name:     "table1",
+				Schema:   "CREATE TABLE `table1` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` varchar(64) DEFAULT NULL,\n  `keyspace_id` bigint(20) unsigned NOT NULL,\n  `id` bigint(20),\n  PRIMARY KEY (`id`),\n  KEY `by_msg` (`msg`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8",
+				Type:     tmutils.TableBaseTable,
+				RowCount: 3000000,
+			},
+		},
+	}
+	preflightSchemaChange := &tmutils.SchemaChangeResult{
+		BeforeSchema: beforeSchema,
+		AfterSchema:  afterSchema,
+	}
+
+	tShard1 := NewFakeTablet(t, wr, cells[0], 0,
+		topodatapb.TabletType_MASTER, db, TabletKeyspaceShard(t, "ks", "-80"))
+	tShard2 := NewFakeTablet(t, wr, cells[0], 1,
+		topodatapb.TabletType_MASTER, db, TabletKeyspaceShard(t, "ks", "80-"))
+	for _, ft := range []*FakeTablet{tShard1, tShard2} {
+		ft.StartActionLoop(t, wr)
+		defer ft.StopActionLoop(t)
+
+		ft.FakeMysqlDaemon.Schema = beforeSchema
+		ft.FakeMysqlDaemon.PreflightSchemaChangeResult = preflightSchemaChange
+	}
+
+	changeToDb := "USE vt_ks"
+	addColumn := "ALTER TABLE table1 ADD COLUMN new_id bigint(20)"
+	db.AddQuery(changeToDb, &sqltypes.Result{})
+	db.AddQuery(addColumn, &sqltypes.Result{})
+
+	// First ApplySchema fails because the table is very big and -allow_long_unavailability is missing.
+	if err := vp.Run([]string{"ApplySchema", "-sql", addColumn, "ks"}); err == nil {
+		t.Fatal("ApplySchema should have failed but did not.")
+	} else if !strings.Contains(err.Error(), "big schema change detected") {
+		t.Fatalf("ApplySchema failed with wrong error. got: %v", err)
+	}
+
+	// Second ApplySchema succeeds because -allow_long_unavailability is set.
+	if err := vp.Run([]string{"ApplySchema", "-allow_long_unavailability", "-sql", addColumn, "ks"}); err != nil {
+		t.Fatalf("ApplySchema failed: %v", err)
+	}
+	if count := db.GetQueryCalledNum(changeToDb); count != 2 {
+		t.Fatalf("ApplySchema: unexpected call count. Query: %v got: %v want: %v", changeToDb, count, 2)
+	}
+	if count := db.GetQueryCalledNum(addColumn); count != 2 {
+		t.Fatalf("ApplySchema: unexpected call count. Query: %v got: %v want: %v", addColumn, count, 2)
+	}
+}

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -62,7 +62,7 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 		TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
 			{
 				Name:   "table1",
-				Schema: "CREATE TABLE `resharding1` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` varchar(64) DEFAULT NULL,\n  `keyspace_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `by_msg` (`msg`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8",
+				Schema: "CREATE TABLE `table1` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `msg` varchar(64) DEFAULT NULL,\n  `keyspace_id` bigint(20) unsigned NOT NULL,\n  PRIMARY KEY (`id`),\n  KEY `by_msg` (`msg`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8",
 				Type:   tmutils.TableBaseTable,
 			},
 			{
@@ -76,7 +76,7 @@ func copySchema(t *testing.T, useShardAsSource bool) {
 	sourceRdonly.FakeMysqlDaemon.Schema = schema
 
 	createDb := "CREATE DATABASE `vt_ks` /*!40100 DEFAULT CHARACTER SET utf8 */"
-	createTable := "CREATE TABLE `vt_ks`.`resharding1` (\n" +
+	createTable := "CREATE TABLE `vt_ks`.`table1` (\n" +
 		"  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n" +
 		"  `msg` varchar(64) DEFAULT NULL,\n" +
 		"  `keyspace_id` bigint(20) unsigned NOT NULL,\n" +


### PR DESCRIPTION
By default, long running schema changes are rejected. With this new flag, this check can be bypassed and the changes applied anyway. As the name of the flag suggests, this can result in a longer period of unavailability.

The first commit is from Shengzhe from: https://github.com/youtube/vitess/pull/1241

@alainjobart 