### PR TITLE
vtctl CopySchemaShard: Compare source and destination schemas after the schema was successfully copied.

### DIFF
--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -156,6 +156,10 @@ type FakeMysqlDaemon struct {
 	// PromoteSlaveResult is returned by PromoteSlave
 	PromoteSlaveResult replication.Position
 
+	// SchemaFunc provides the return value for GetSchema.
+	// If not defined, the "Schema" field will be used instead, see below.
+	SchemaFunc func() (*tabletmanagerdatapb.SchemaDefinition, error)
+
 	// Schema will be returned by GetSchema. If nil we'll
 	// return an error.
 	Schema *tabletmanagerdatapb.SchemaDefinition
@@ -397,6 +401,9 @@ func (fmd *FakeMysqlDaemon) CheckSuperQueryList() error {
 
 // GetSchema is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) GetSchema(dbName string, tables, excludeTables []string, includeViews bool) (*tabletmanagerdatapb.SchemaDefinition, error) {
+	if fmd.SchemaFunc != nil {
+		return fmd.SchemaFunc()
+	}
 	if fmd.Schema == nil {
 		return nil, fmt.Errorf("no schema defined")
 	}

--- a/go/vt/proto/automation/automation.pb.go
+++ b/go/vt/proto/automation/automation.pb.go
@@ -30,6 +30,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 type ClusterOperationState int32
 
 const (

--- a/go/vt/proto/automationservice/automationservice.pb.go
+++ b/go/vt/proto/automationservice/automationservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -32,6 +32,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 type BinlogTransaction_Statement_Category int32
 
 const (

--- a/go/vt/proto/binlogservice/binlogservice.pb.go
+++ b/go/vt/proto/binlogservice/binlogservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/logutil/logutil.pb.go
+++ b/go/vt/proto/logutil/logutil.pb.go
@@ -23,6 +23,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Level is the level of the log messages.
 type Level int32
 

--- a/go/vt/proto/mysqlctl/mysqlctl.pb.go
+++ b/go/vt/proto/mysqlctl/mysqlctl.pb.go
@@ -32,6 +32,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 type StartRequest struct {
 }
 

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -51,6 +51,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Flag allows us to qualify types by their common properties.
 type Flag int32
 

--- a/go/vt/proto/queryservice/queryservice.pb.go
+++ b/go/vt/proto/queryservice/queryservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/replicationdata/replicationdata.pb.go
+++ b/go/vt/proto/replicationdata/replicationdata.pb.go
@@ -22,6 +22,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Status is the replication status for MySQL (returned by 'show slave status'
 // and parsed into a Position and fields).
 type Status struct {

--- a/go/vt/proto/tableacl/tableacl.pb.go
+++ b/go/vt/proto/tableacl/tableacl.pb.go
@@ -23,6 +23,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // TableGroupSpec defines ACLs for a group of tables.
 type TableGroupSpec struct {
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -109,6 +109,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 type TableDefinition struct {
 	// the table name
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`

--- a/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
+++ b/go/vt/proto/tabletmanagerservice/tabletmanagerservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/topodata/topodata.pb.go
+++ b/go/vt/proto/topodata/topodata.pb.go
@@ -32,6 +32,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // KeyspaceIdType describes the type of the sharding key for a
 // range-based sharded keyspace.
 type KeyspaceIdType int32

--- a/go/vt/proto/vtctldata/vtctldata.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata.pb.go
@@ -24,6 +24,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // ExecuteVtctlCommandRequest is the payload for ExecuteVtctlCommand.
 // timeouts are in nanoseconds.
 type ExecuteVtctlCommandRequest struct {

--- a/go/vt/proto/vtctlservice/vtctlservice.pb.go
+++ b/go/vt/proto/vtctlservice/vtctlservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/vtgate/vtgate.pb.go
+++ b/go/vt/proto/vtgate/vtgate.pb.go
@@ -59,6 +59,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Session objects are session cookies and are invalidated on
 // use. Query results will contain updated session values.
 // Their content should be opaque to the user.

--- a/go/vt/proto/vtgateservice/vtgateservice.pb.go
+++ b/go/vt/proto/vtgateservice/vtgateservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/proto/vtrpc/vtrpc.pb.go
+++ b/go/vt/proto/vtrpc/vtrpc.pb.go
@@ -23,6 +23,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // ErrorCode is the enum values for Errors. Internally, errors should
 // be created with one of these codes. These will then be translated over the wire
 // by various RPC frameworks.

--- a/go/vt/proto/vtworkerdata/vtworkerdata.pb.go
+++ b/go/vt/proto/vtworkerdata/vtworkerdata.pb.go
@@ -24,6 +24,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // ExecuteVtworkerCommandRequest is the payload for ExecuteVtworkerCommand.
 type ExecuteVtworkerCommandRequest struct {
 	Args []string `protobuf:"bytes,1,rep,name=args" json:"args,omitempty"`

--- a/go/vt/proto/vtworkerservice/vtworkerservice.pb.go
+++ b/go/vt/proto/vtworkerservice/vtworkerservice.pb.go
@@ -27,6 +27,10 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the proto package it is being compiled against.
+const _ = proto.ProtoPackageIsVersion1
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
 var _ grpc.ClientConn

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -363,14 +363,12 @@ func (wr *Wrangler) CopySchemaShard(ctx context.Context, sourceTabletAlias *topo
 	}
 	destSd, err := wr.GetSchema(ctx, destShardInfo.MasterAlias, tables, excludeTables, includeViews)
 	if err != nil {
-		destSd = nil
+		err
 	}
-	if destSd != nil {
-		diffs := tmutils.DiffSchemaToArray("source", sourceSd, "dest", destSd)
-		if diffs == nil {
-			// Return early because dest has already the same schema as source.
-			return nil
-		}
+	diffs := tmutils.DiffSchemaToArray("source", sourceSd, "dest", destSd)
+	if diffs == nil {
+		// Return early because dest has already the same schema as source.
+		return nil
 	}
 
 	createSQL := tmutils.SchemaDefinitionToSQLStrings(sourceSd)

--- a/test/schema.py
+++ b/test/schema.py
@@ -78,10 +78,10 @@ def setUpModule():
 
     # check after all tablets are here and replication is fixed
     utils.validate_topology(ping_tablets=True)
-  except Exception as setup_exception:
+  except Exception as setup_exception:  # pylint: disable=broad-except
     try:
       tearDownModule()
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
       logging.exception('Tearing down a failed setUpModule() failed: %s', e)
     raise setup_exception
 


### PR DESCRIPTION
Although the copy was successful, we have to verify it to catch the case where the database already existed on the destination, but with different options e.g. a different character set.

In that case, MySQL would have skipped our CREATE DATABASE IF NOT EXISTS statement. We want to fail early in this case because vtworker SplitDiff fails in case of such an inconsistency as well.

@alainjobart @aaijazi 