### PR TITLE
Move the test code from zktopo to zktopo/zktestserver.

### DIFF
--- a/go/vt/discovery/healthcheck_wait_test.go
+++ b/go/vt/discovery/healthcheck_wait_test.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -16,7 +16,7 @@ import (
 
 func TestFindAllKeyspaceShards(t *testing.T) {
 	ctx := context.Background()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 
 	// no keyspace / shards
 	ks, err := findAllKeyspaceShards(ctx, ts, "cell1")

--- a/go/vt/tabletmanager/binlog_test.go
+++ b/go/vt/tabletmanager/binlog_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topotools"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -321,7 +321,7 @@ func checkBlpPositionList(t *testing.T, bpm *BinlogPlayerMap, vtClientSyncChanne
 }
 
 func TestBinlogPlayerMapHorizontalSplit(t *testing.T) {
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	ctx := context.Background()
 
 	// create the keyspace, a full set of covering shards,
@@ -497,7 +497,7 @@ func TestBinlogPlayerMapHorizontalSplit(t *testing.T) {
 }
 
 func TestBinlogPlayerMapHorizontalSplitStopStartUntil(t *testing.T) {
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	ctx := context.Background()
 
 	// create the keyspace, a full set of covering shards,
@@ -678,7 +678,7 @@ func TestBinlogPlayerMapHorizontalSplitStopStartUntil(t *testing.T) {
 }
 
 func TestBinlogPlayerMapVerticalSplit(t *testing.T) {
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	ctx := context.Background()
 
 	// create the keyspaces, with one shard each

--- a/go/vt/tabletmanager/healthcheck_test.go
+++ b/go/vt/tabletmanager/healthcheck_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletservermock"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -106,7 +106,7 @@ func (fhc *fakeHealthCheck) HTMLName() template.HTML {
 }
 
 func createTestAgent(ctx context.Context, t *testing.T) *ActionAgent {
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 
 	if err := ts.CreateKeyspace(ctx, "test_keyspace", &topodatapb.Keyspace{}); err != nil {
 		t.Fatalf("CreateKeyspace failed: %v", err)

--- a/go/vt/tabletmanager/init_tablet_test.go
+++ b/go/vt/tabletmanager/init_tablet_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -25,7 +25,7 @@ import (
 func TestInitTablet(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	tabletAlias := &topodatapb.TabletAlias{
 		Cell: "cell1",
 		Uid:  1,

--- a/go/vt/topotools/rebuild_shard_test.go
+++ b/go/vt/topotools/rebuild_shard_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	. "github.com/youtube/vitess/go/vt/topotools"
 
@@ -55,7 +55,7 @@ func TestRebuildShard(t *testing.T) {
 	logger := logutil.NewMemoryLogger()
 
 	// Set up topology.
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 	si, err := GetOrCreateShard(ctx, ts, testKeyspace, testShard)
 	if err != nil {
 		t.Fatalf("GetOrCreateShard: %v", err)
@@ -121,7 +121,7 @@ func TestUpdateTabletEndpoints(t *testing.T) {
 	cell := "test_cell"
 
 	// Set up topology.
-	ts := zktopo.NewTestServer(t, []string{cell})
+	ts := zktestserver.New(t, []string{cell})
 	si, err := GetOrCreateShard(ctx, ts, testKeyspace, testShard)
 	if err != nil {
 		t.Fatalf("GetOrCreateShard: %v", err)

--- a/go/vt/topotools/shard_test.go
+++ b/go/vt/topotools/shard_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/vt/zktopo"
 	"golang.org/x/net/context"
 
 	. "github.com/youtube/vitess/go/vt/topotools"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -25,7 +25,7 @@ func TestCreateShard(t *testing.T) {
 	cells := []string{"test_cell"}
 
 	// Set up topology.
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 
 	keyspace := "test_keyspace"
 	shard := "0"
@@ -53,7 +53,7 @@ func TestCreateShardCustomSharding(t *testing.T) {
 	cells := []string{"test_cell"}
 
 	// Set up topology.
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 
 	// create keyspace
 	keyspace := "test_keyspace"
@@ -96,7 +96,7 @@ func TestGetOrCreateShard(t *testing.T) {
 	cells := []string{"test_cell"}
 
 	// Set up topology.
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 
 	// and do massive parallel GetOrCreateShard
 	keyspace := "test_keyspace"

--- a/go/vt/vtctl/vtctlclienttest/client.go
+++ b/go/vt/vtctl/vtctlclienttest/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctl/vtctlclient"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -38,7 +38,7 @@ func init() {
 
 // CreateTopoServer returns the test topo server properly configured
 func CreateTopoServer(t *testing.T) topo.Server {
-	return zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	return zktestserver.New(t, []string{"cell1", "cell2"})
 }
 
 // TestSuite runs the test suite on the given topo server and client

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/topotools"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -27,7 +27,7 @@ func compactJSON(in []byte) string {
 func TestAPI(t *testing.T) {
 	ctx := context.Background()
 	cells := []string{"cell1", "cell2"}
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 	actionRepo := NewActionRepository(ts)
 	initAPI(ctx, ts, actionRepo)
 

--- a/go/vt/vtctld/explorer_test.go
+++ b/go/vt/vtctld/explorer_test.go
@@ -5,14 +5,14 @@ import (
 	"testing"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 )
 
 func TestHandleExplorerRedirect(t *testing.T) {
 	ctx := context.Background()
 
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	if err := ts.CreateTablet(ctx, &topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
 			Cell: "cell1",

--- a/go/vt/vtctld/tablet_data_test.go
+++ b/go/vt/vtctld/tablet_data_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -79,7 +79,7 @@ func (s *streamHealthTabletServer) BroadcastHealth(terTimestamp int64, stats *qu
 
 func TestTabletData(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	if err := ts.CreateKeyspace(context.Background(), "ks", &topodatapb.Keyspace{

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -260,7 +260,7 @@ func TestSplitClonePopulateBlpCheckpoint(t *testing.T) {
 
 func testSplitClone(t *testing.T, strategy string) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
 	wi := NewInstance(ctx, ts, "cell1", time.Second)
 

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -182,7 +182,7 @@ func (sq *sourceTabletServer) StreamHealthRegister(c chan<- *querypb.StreamHealt
 
 func TestSplitDiff(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
 	wi := NewInstance(ctx, ts, "cell1", time.Second)
 

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -245,7 +245,7 @@ func TestVerticalSplitClonePopulateBlpCheckpoint(t *testing.T) {
 
 func testVerticalSplitClone(t *testing.T, strategy string) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
 	wi := NewInstance(ctx, ts, "cell1", time.Second)
 

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -100,7 +100,7 @@ func (sq *verticalDiffTabletServer) StreamHealthRegister(c chan<- *querypb.Strea
 
 func TestVerticalSplitDiff(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
 	wi := NewInstance(ctx, ts, "cell1", time.Second)
 

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -21,8 +21,8 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/worker"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
-	"github.com/youtube/vitess/go/vt/zktopo"
 	"golang.org/x/net/context"
 
 	// import the gRPC client implementation for tablet manager
@@ -37,7 +37,7 @@ func init() {
 
 // CreateWorkerInstance returns a properly configured vtworker instance.
 func CreateWorkerInstance(t *testing.T) *worker.Instance {
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	return worker.NewInstance(context.Background(), ts, "cell1", 1*time.Second)
 }
 

--- a/go/vt/wrangler/testlib/apply_schema_test.go
+++ b/go/vt/wrangler/testlib/apply_schema_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -29,7 +29,7 @@ import (
 func TestApplySchema_AllowLongUnavailability(t *testing.T) {
 	cells := []string{"cell1"}
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, cells)
+	ts := zktestserver.New(t, cells)
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -31,7 +31,7 @@ func TestBackupRestore(t *testing.T) {
 	// Initialize our environment
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/copy_schema_shard_test.go
+++ b/go/vt/wrangler/testlib/copy_schema_shard_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -32,7 +32,7 @@ func TestCopySchemaShard_UseShardAsSource(t *testing.T) {
 
 func copySchema(t *testing.T, useShardAsSource bool) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/emergency_reparent_shard_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -24,7 +24,7 @@ import (
 
 func TestEmergencyReparentShard(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
@@ -145,7 +145,7 @@ func TestEmergencyReparentShard(t *testing.T) {
 func TestEmergencyReparentShardMasterElectNotBest(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// Create a master, a couple good slaves

--- a/go/vt/wrangler/testlib/init_shard_master_test.go
+++ b/go/vt/wrangler/testlib/init_shard_master_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -28,7 +28,7 @@ import (
 func TestInitMasterShard(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
@@ -128,7 +128,7 @@ func TestInitMasterShard(t *testing.T) {
 func TestInitMasterShardChecks(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
@@ -166,7 +166,7 @@ func TestInitMasterShardChecks(t *testing.T) {
 func TestInitMasterShardOneSlaveFails(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// Create a master, a couple slaves

--- a/go/vt/wrangler/testlib/migrate_served_from_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_from_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -23,7 +23,7 @@ import (
 func TestMigrateServedFrom(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -33,7 +33,7 @@ func checkShardServedTypes(t *testing.T, ts topo.Server, shard string, expected 
 
 func TestMigrateServedTypes(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/permissions_test.go
+++ b/go/vt/wrangler/testlib/permissions_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -24,7 +24,7 @@ func TestPermissions(t *testing.T) {
 	// Initialize our environment
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -15,14 +15,14 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 func TestPlannedReparentShard(t *testing.T) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/reparent_external_test.go
+++ b/go/vt/wrangler/testlib/reparent_external_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topotools/events"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -32,7 +32,7 @@ func TestTabletExternallyReparented(t *testing.T) {
 
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()
@@ -170,7 +170,7 @@ func TestTabletExternallyReparentedWithDifferentMysqlPort(t *testing.T) {
 
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// Create an old master, a new master, two good slaves, one bad slave
@@ -219,7 +219,7 @@ func TestTabletExternallyReparentedContinueOnUnexpectedMaster(t *testing.T) {
 
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1"})
+	ts := zktestserver.New(t, []string{"cell1"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// Create an old master, a new master, two good slaves, one bad slave
@@ -262,7 +262,7 @@ func TestTabletExternallyReparentedFailedOldMaster(t *testing.T) {
 
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// Create an old master, a new master, and a good slave.

--- a/go/vt/wrangler/testlib/reparent_utils_test.go
+++ b/go/vt/wrangler/testlib/reparent_utils_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -23,7 +23,7 @@ import (
 func TestShardReplicationStatuses(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// create shard and tablets
@@ -92,7 +92,7 @@ func TestShardReplicationStatuses(t *testing.T) {
 func TestReparentTablet(t *testing.T) {
 	ctx := context.Background()
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 
 	// create shard and tablets

--- a/go/vt/wrangler/testlib/version_test.go
+++ b/go/vt/wrangler/testlib/version_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -50,7 +50,7 @@ func TestVersion(t *testing.T) {
 
 	// Initialize our environment
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/wrangler/testlib/wait_for_filtered_replication_test.go
+++ b/go/vt/wrangler/testlib/wait_for_filtered_replication_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/grpcqueryservice"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"github.com/youtube/vitess/go/vt/zktopo"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -79,7 +79,7 @@ func TestWaitForFilteredReplication_unhealthy(t *testing.T) {
 
 func waitForFilteredReplication(t *testing.T, expectedErr string, initialStats *querypb.RealtimeStats, broadcastStatsFunc func() *querypb.RealtimeStats) {
 	db := fakesqldb.Register()
-	ts := zktopo.NewTestServer(t, []string{"cell1", "cell2"})
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
 	vp := NewVtctlPipe(t, ts)
 	defer vp.Close()

--- a/go/vt/zktopo/keyspace.go
+++ b/go/vt/zktopo/keyspace.go
@@ -23,12 +23,14 @@ This file contains the Keyspace management code for zktopo.Server
 */
 
 const (
-	globalKeyspacesPath = "/zk/global/vt/keyspaces"
+	// GlobalKeyspacesPath is the path used to store global
+	// information in ZK. Exported for tests.
+	GlobalKeyspacesPath = "/zk/global/vt/keyspaces"
 )
 
 // CreateKeyspace is part of the topo.Server interface
 func (zkts *Server) CreateKeyspace(ctx context.Context, keyspace string, value *topodatapb.Keyspace) error {
-	keyspacePath := path.Join(globalKeyspacesPath, keyspace)
+	keyspacePath := path.Join(GlobalKeyspacesPath, keyspace)
 	pathList := []string{
 		keyspacePath,
 		path.Join(keyspacePath, "action"),
@@ -64,7 +66,7 @@ func (zkts *Server) CreateKeyspace(ctx context.Context, keyspace string, value *
 
 // UpdateKeyspace is part of the topo.Server interface
 func (zkts *Server) UpdateKeyspace(ctx context.Context, keyspace string, value *topodatapb.Keyspace, existingVersion int64) (int64, error) {
-	keyspacePath := path.Join(globalKeyspacesPath, keyspace)
+	keyspacePath := path.Join(GlobalKeyspacesPath, keyspace)
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return -1, err
@@ -82,7 +84,7 @@ func (zkts *Server) UpdateKeyspace(ctx context.Context, keyspace string, value *
 
 // DeleteKeyspace is part of the topo.Server interface.
 func (zkts *Server) DeleteKeyspace(ctx context.Context, keyspace string) error {
-	keyspacePath := path.Join(globalKeyspacesPath, keyspace)
+	keyspacePath := path.Join(GlobalKeyspacesPath, keyspace)
 	err := zk.DeleteRecursive(zkts.zconn, keyspacePath, -1)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
@@ -95,7 +97,7 @@ func (zkts *Server) DeleteKeyspace(ctx context.Context, keyspace string) error {
 
 // GetKeyspace is part of the topo.Server interface
 func (zkts *Server) GetKeyspace(ctx context.Context, keyspace string) (*topodatapb.Keyspace, int64, error) {
-	keyspacePath := path.Join(globalKeyspacesPath, keyspace)
+	keyspacePath := path.Join(GlobalKeyspacesPath, keyspace)
 	data, stat, err := zkts.zconn.Get(keyspacePath)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
@@ -114,7 +116,7 @@ func (zkts *Server) GetKeyspace(ctx context.Context, keyspace string) (*topodata
 
 // GetKeyspaces is part of the topo.Server interface
 func (zkts *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
-	children, _, err := zkts.zconn.Children(globalKeyspacesPath)
+	children, _, err := zkts.zconn.Children(GlobalKeyspacesPath)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
 			return nil, nil
@@ -128,7 +130,7 @@ func (zkts *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
 
 // DeleteKeyspaceShards is part of the topo.Server interface
 func (zkts *Server) DeleteKeyspaceShards(ctx context.Context, keyspace string) error {
-	shardsPath := path.Join(globalKeyspacesPath, keyspace, "shards")
+	shardsPath := path.Join(GlobalKeyspacesPath, keyspace, "shards")
 	if err := zk.DeleteRecursive(zkts.zconn, shardsPath, -1); err != nil && !zookeeper.IsError(err, zookeeper.ZNONODE) {
 		return err
 	}

--- a/go/vt/zktopo/lock.go
+++ b/go/vt/zktopo/lock.go
@@ -110,7 +110,7 @@ func (zkts *Server) unlockForAction(lockPath, results string) error {
 func (zkts *Server) LockKeyspaceForAction(ctx context.Context, keyspace, contents string) (string, error) {
 	// Action paths end in a trailing slash to that when we create
 	// sequential nodes, they are created as children, not siblings.
-	actionDir := path.Join(globalKeyspacesPath, keyspace, "action") + "/"
+	actionDir := path.Join(GlobalKeyspacesPath, keyspace, "action") + "/"
 	return zkts.lockForAction(ctx, actionDir, contents)
 }
 
@@ -123,7 +123,7 @@ func (zkts *Server) UnlockKeyspaceForAction(ctx context.Context, keyspace, lockP
 func (zkts *Server) LockShardForAction(ctx context.Context, keyspace, shard, contents string) (string, error) {
 	// Action paths end in a trailing slash to that when we create
 	// sequential nodes, they are created as children, not siblings.
-	actionDir := path.Join(globalKeyspacesPath, keyspace, "shards", shard, "action") + "/"
+	actionDir := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard, "action") + "/"
 	return zkts.lockForAction(ctx, actionDir, contents)
 }
 

--- a/go/vt/zktopo/shard.go
+++ b/go/vt/zktopo/shard.go
@@ -24,7 +24,7 @@ This file contains the shard management code for zktopo.Server
 
 // CreateShard is part of the topo.Server interface
 func (zkts *Server) CreateShard(ctx context.Context, keyspace, shard string, value *topodatapb.Shard) error {
-	shardPath := path.Join(globalKeyspacesPath, keyspace, "shards", shard)
+	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
 	pathList := []string{
 		shardPath,
 		path.Join(shardPath, "action"),
@@ -59,7 +59,7 @@ func (zkts *Server) CreateShard(ctx context.Context, keyspace, shard string, val
 
 // UpdateShard is part of the topo.Server interface
 func (zkts *Server) UpdateShard(ctx context.Context, keyspace, shard string, value *topodatapb.Shard, existingVersion int64) (int64, error) {
-	shardPath := path.Join(globalKeyspacesPath, keyspace, "shards", shard)
+	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
 		return -1, err
@@ -76,7 +76,7 @@ func (zkts *Server) UpdateShard(ctx context.Context, keyspace, shard string, val
 
 // ValidateShard is part of the topo.Server interface
 func (zkts *Server) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	shardPath := path.Join(globalKeyspacesPath, keyspace, "shards", shard)
+	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
 	zkPaths := []string{
 		path.Join(shardPath, "action"),
 		path.Join(shardPath, "actionlog"),
@@ -92,7 +92,7 @@ func (zkts *Server) ValidateShard(ctx context.Context, keyspace, shard string) e
 
 // GetShard is part of the topo.Server interface
 func (zkts *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
-	shardPath := path.Join(globalKeyspacesPath, keyspace, "shards", shard)
+	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
 	data, stat, err := zkts.zconn.Get(shardPath)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
@@ -111,7 +111,7 @@ func (zkts *Server) GetShard(ctx context.Context, keyspace, shard string) (*topo
 
 // GetShardNames is part of the topo.Server interface
 func (zkts *Server) GetShardNames(ctx context.Context, keyspace string) ([]string, error) {
-	shardsPath := path.Join(globalKeyspacesPath, keyspace, "shards")
+	shardsPath := path.Join(GlobalKeyspacesPath, keyspace, "shards")
 	children, _, err := zkts.zconn.Children(shardsPath)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {
@@ -126,7 +126,7 @@ func (zkts *Server) GetShardNames(ctx context.Context, keyspace string) ([]strin
 
 // DeleteShard is part of the topo.Server interface
 func (zkts *Server) DeleteShard(ctx context.Context, keyspace, shard string) error {
-	shardPath := path.Join(globalKeyspacesPath, keyspace, "shards", shard)
+	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
 	err := zk.DeleteRecursive(zkts.zconn, shardPath, -1)
 	if err != nil {
 		if zookeeper.IsError(err, zookeeper.ZNONODE) {

--- a/go/vt/zktopo/zktestserver/testserver.go
+++ b/go/vt/zktopo/zktestserver/testserver.go
@@ -1,10 +1,11 @@
-package zktopo
+package zktestserver
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/zktopo"
 	"github.com/youtube/vitess/go/zk"
 	"github.com/youtube/vitess/go/zk/fakezk"
 	"golang.org/x/net/context"
@@ -33,11 +34,11 @@ func newTestServer(t *testing.T, cells []string) topo.Impl {
 			t.Fatalf("cannot init ZooKeeper: %v", err)
 		}
 	}
-	return &TestServer{Impl: &Server{zconn}, localCells: cells}
+	return &TestServer{Impl: zktopo.NewServer(zconn), localCells: cells}
 }
 
-// NewTestServer returns a new TestServer (with the required paths created)
-func NewTestServer(t *testing.T, cells []string) topo.Server {
+// New returns a new TestServer (with the required paths created)
+func New(t *testing.T, cells []string) topo.Server {
 	return topo.Server{Impl: newTestServer(t, cells)}
 }
 

--- a/go/vt/zktopo/zktestserver/testserver_test.go
+++ b/go/vt/zktopo/zktestserver/testserver_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package zktopo
+package zktestserver
 
 import (
 	"testing"
@@ -17,7 +17,7 @@ import (
 // the name of our override to match.
 func TestHookLockSrvShardForAction(t *testing.T) {
 	cells := []string{"test_cell"}
-	ts := NewTestServer(t, cells)
+	ts := New(t, cells)
 
 	triggered := false
 	ts.Impl.(*TestServer).HookLockSrvShardForAction = func() {


### PR DESCRIPTION
That way the real binaries don't depend on 'testing'.
Side effect is the zk topo test suite is also moved to
zktopo/zktestserver.

@michael-berlin now vtgate doesn't have the test command line options any more.