### PR TITLE
example/kubernetes: Enable gRPC in vtgate configuration.

### DIFF
--- a/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
+++ b/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
@@ -40,8 +40,9 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15001
+              -grpc_port 15991
               -tablet_protocol grpc
-              -service_map 'bsonrpc-vt-vtgateservice'
+              -service_map 'bsonrpc-vt-vtgateservice,grpc-vtgateservice'
               -cell test" vitess
           env:
             - name: GOMAXPROCS

--- a/examples/kubernetes/vtgate-controller-template.yaml
+++ b/examples/kubernetes/vtgate-controller-template.yaml
@@ -40,8 +40,9 @@ spec:
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15001
+              -grpc_port 15991
               -tablet_protocol grpc
-              -service_map 'bsonrpc-vt-vtgateservice'
+              -service_map 'bsonrpc-vt-vtgateservice,grpc-vtgateservice'
               -cell test" vitess
       volumes:
         - name: syslog

--- a/examples/kubernetes/vtgate-service.yaml
+++ b/examples/kubernetes/vtgate-service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: vitess
 spec:
   ports:
-    - name: web+bsonrpc
+    - name: web
       port: 15001
     - name: grpc
       port: 15991

--- a/examples/kubernetes/vtgate-service.yaml
+++ b/examples/kubernetes/vtgate-service.yaml
@@ -7,7 +7,10 @@ metadata:
     app: vitess
 spec:
   ports:
-    - port: 15001
+    - name: web+bsonrpc
+      port: 15001
+    - name: grpc
+      port: 15991
   selector:
     component: vtgate
     app: vitess


### PR DESCRIPTION
@enisoc 

(Change isn't tested yet.)