### PR TITLE
vtworker: Make populating blp_checkpoint table the default.

### DIFF
--- a/doc/HorizontalReshardingGuide.md
+++ b/doc/HorizontalReshardingGuide.md
@@ -207,15 +207,14 @@ The following command starts the `vtworker`:
 
 ```
 vtworker -min_healthy_rdonly_endpoints 1 -cell=<cell name> \
-    SplitClone -strategy=-populate_blp_checkpoint \
-    <keyspace name>/<source shard name>
+    SplitClone <keyspace name>/<source shard name>
 ```
 
 For this example, run this command:
 
 ```
 vtworker -min_healthy_rdonly_endpoints 1 -cell=<cell name> \
-    SplitClone -strategy=-populate_blp_checkpoint user_keyspace/0
+    SplitClone user_keyspace/0
 ```
 
 The amount of time that the worker takes to complete will depend

--- a/doc/ShardingKubernetes.md
+++ b/doc/ShardingKubernetes.md
@@ -110,7 +110,7 @@ single source to multiple destinations, routing each row based on its
 *keyspace_id*:
 
 ``` sh
-vitess/examples/kubernetes$ ./sharded-vtworker.sh SplitClone --strategy=-populate_blp_checkpoint test_keyspace/0
+vitess/examples/kubernetes$ ./sharded-vtworker.sh SplitClone test_keyspace/0
 ### example output:
 # Creating vtworker pod in cell test...
 # pods/vtworker

--- a/go/vt/automation/split_clone_task.go
+++ b/go/vt/automation/split_clone_task.go
@@ -20,8 +20,7 @@ func (t *SplitCloneTask) Run(parameters map[string]string) ([]*automationpb.Task
 	//                        '--source_reader_count', '1',
 	//                        '--destination_pack_count', '1',
 	//                        '--destination_writer_count', '1',
-	//                        '--strategy=-populate_blp_checkpoint',
-	args := []string{"SplitClone", "--strategy=-populate_blp_checkpoint"}
+	args := []string{"SplitClone"}
 	if excludeTables := parameters["exclude_tables"]; excludeTables != "" {
 		args = append(args, "--exclude_tables="+excludeTables)
 	}

--- a/go/vt/automation/split_clone_task_test.go
+++ b/go/vt/automation/split_clone_task_test.go
@@ -17,7 +17,7 @@ func TestSplitCloneTask(t *testing.T) {
 	vtworkerclient.RegisterFactory("fake", fake.FakeVtworkerClientFactory)
 	defer vtworkerclient.UnregisterFactoryForTest("fake")
 	flag.Set("vtworker_client_protocol", "fake")
-	fake.RegisterResult([]string{"SplitClone", "--strategy=-populate_blp_checkpoint", "test_keyspace/0"},
+	fake.RegisterResult([]string{"SplitClone", "test_keyspace/0"},
 		"",  // No output.
 		nil) // No error.
 

--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -21,7 +21,7 @@ func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automatio
 	//                        '--source_reader_count', '1',
 	//                        '--destination_pack_count', '1',
 	//                        '--destination_writer_count', '1',
-	args := []string{"VerticalSplitClone", "--strategy=-populate_blp_checkpoint"}
+	args := []string{"VerticalSplitClone"}
 	if tables := parameters["tables"]; tables != "" {
 		args = append(args, "--tables="+tables)
 	}

--- a/go/vt/automation/vertical_split_task_test.go
+++ b/go/vt/automation/vertical_split_task_test.go
@@ -33,7 +33,7 @@ func TestVerticalSplitTask(t *testing.T) {
 	vtctld.RegisterResult([]string{"CopySchemaShard", "--tables=table1,table2", "source_keyspace/0", "destination_keyspace/0"},
 		"",  // No output.
 		nil) // No error.
-	vtworker.RegisterResult([]string{"VerticalSplitClone", "--strategy=-populate_blp_checkpoint", "--tables=table1,table2", "destination_keyspace/0"}, "", nil)
+	vtworker.RegisterResult([]string{"VerticalSplitClone", "--tables=table1,table2", "destination_keyspace/0"}, "", nil)
 	vtctld.RegisterResult([]string{"WaitForFilteredReplication", "-max_delay", "30s", "destination_keyspace/0"}, "", nil)
 	vtworker.RegisterResult([]string{"VerticalSplitDiff", "destination_keyspace/0"}, "", nil)
 	vtctld.RegisterResult([]string{"MigrateServedFrom", "destination_keyspace/0", "rdonly"}, "", nil)

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -529,7 +529,9 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 	}
 
 	// then create and populate the blp_checkpoint table
-	if scw.strategy.populateBlpCheckpoint {
+	if scw.strategy.skipPopulateBlpCheckpoint {
+		scw.wr.Logger().Infof("Skipping populating the blp_checkpoint table")
+	} else {
 		queries := make([]string, 0, 4)
 		queries = append(queries, binlogplayer.CreateBlpCheckpoint()...)
 		flags := ""

--- a/go/vt/worker/split_clone_cmd.go
+++ b/go/vt/worker/split_clone_cmd.go
@@ -53,7 +53,7 @@ const splitCloneHTML2 = `
       <LABEL for="excludeTables">Exclude Tables: </LABEL>
         <INPUT type="text" id="excludeTables" name="excludeTables" value="moving.*"></BR>
       <LABEL for="strategy">Strategy: </LABEL>
-        <INPUT type="text" id="strategy" name="strategy" value="-populate_blp_checkpoint"></BR>
+        <INPUT type="text" id="strategy" name="strategy" value=""></BR>
       <LABEL for="sourceReaderCount">Source Reader Count: </LABEL>
         <INPUT type="text" id="sourceReaderCount" name="sourceReaderCount" value="{{.DefaultSourceReaderCount}}"></BR>
       <LABEL for="destinationPackCount">Destination Pack Count: </LABEL>
@@ -70,8 +70,8 @@ const splitCloneHTML2 = `
   <h1>Help</h1>
     <p>Strategy can have the following values, comma separated:</p>
     <ul>
-      <li><b>populateBlpCheckpoint</b>: creates (if necessary) and populates the blp_checkpoint table in the destination. Required for filtered replication to start.</li>
-      <li><b>dontStartBinlogPlayer</b>: (requires populateBlpCheckpoint) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
+      <li><b>skipPopulateBlpCheckpoint</b>: skips creating (if necessary) and populating the blp_checkpoint table in the destination. Not skipped by default because it's required for filtered replication to start.</li>
+      <li><b>dontStartBinlogPlayer</b>: (requires skipPopulateBlpCheckpoint to be false) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
       <li><b>skipSetSourceShards</b>: we won't set SourceShards on the destination shards, disabling filtered replication. Useful for worker tests.</li>
     </ul>
   </body>

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -254,11 +254,7 @@ func DestinationsFactory(t *testing.T, insertCount int64) func() (dbconnpool.Poo
 	}
 }
 
-func TestSplitClonePopulateBlpCheckpoint(t *testing.T) {
-	testSplitClone(t, "-populate_blp_checkpoint")
-}
-
-func testSplitClone(t *testing.T, strategy string) {
+func TestSplitClone(t *testing.T) {
 	db := fakesqldb.Register()
 	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
@@ -306,7 +302,6 @@ func testSplitClone(t *testing.T, strategy string) {
 
 	subFlags := flag.NewFlagSet("SplitClone", flag.ContinueOnError)
 	gwrk, err := commandSplitClone(wi, wi.wr, subFlags, []string{
-		"-strategy", strategy,
 		"-source_reader_count", "10",
 		"-destination_pack_count", "4",
 		"-min_table_size_for_split", "1",

--- a/go/vt/worker/split_strategy.go
+++ b/go/vt/worker/split_strategy.go
@@ -14,8 +14,8 @@ import (
 
 // splitStrategy is the configuration for a split clone.
 type splitStrategy struct {
-	// populateBlpCheckpoint will drive the population of the blp_checkpoint table
-	populateBlpCheckpoint bool
+	// skipPopulateBlpCheckpoint will skip the population of the blp_checkpoint table
+	skipPopulateBlpCheckpoint bool
 
 	// dontStartBinlogPlayer will delay starting the binlog replication
 	dontStartBinlogPlayer bool
@@ -35,7 +35,7 @@ func newSplitStrategy(logger logutil.Logger, argsStr string) (*splitStrategy, er
 		logger.Printf("Strategy flag has the following options:\n")
 		flagSet.PrintDefaults()
 	}
-	populateBlpCheckpoint := flagSet.Bool("populate_blp_checkpoint", false, "populates the blp checkpoint table")
+	skipPopulateBlpCheckpoint := flagSet.Bool("skip_populate_blp_checkpoint", false, "do not populate the blp checkpoint table")
 	dontStartBinlogPlayer := flagSet.Bool("dont_start_binlog_player", false, "do not start the binlog player after restore is complete")
 	skipSetSourceShards := flagSet.Bool("skip_set_source_shards", false, "do not set the SourceShar field on destination shards")
 	if err := flagSet.Parse(args); err != nil {
@@ -46,16 +46,16 @@ func newSplitStrategy(logger logutil.Logger, argsStr string) (*splitStrategy, er
 	}
 
 	return &splitStrategy{
-		populateBlpCheckpoint: *populateBlpCheckpoint,
-		dontStartBinlogPlayer: *dontStartBinlogPlayer,
-		skipSetSourceShards:   *skipSetSourceShards,
+		skipPopulateBlpCheckpoint: *skipPopulateBlpCheckpoint,
+		dontStartBinlogPlayer:     *dontStartBinlogPlayer,
+		skipSetSourceShards:       *skipSetSourceShards,
 	}, nil
 }
 
 func (strategy *splitStrategy) String() string {
 	var result []string
-	if strategy.populateBlpCheckpoint {
-		result = append(result, "-populate_blp_checkpoint")
+	if strategy.skipPopulateBlpCheckpoint {
+		result = append(result, "-skip_populate_blp_checkpoint")
 	}
 	if strategy.dontStartBinlogPlayer {
 		result = append(result, "-dont_start_binlog_player")

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -459,7 +459,9 @@ func (vscw *VerticalSplitCloneWorker) copy(ctx context.Context) error {
 	}
 
 	// then create and populate the blp_checkpoint table
-	if vscw.strategy.populateBlpCheckpoint {
+	if vscw.strategy.skipPopulateBlpCheckpoint {
+		vscw.wr.Logger().Infof("Skipping populating the blp_checkpoint table")
+	} else {
 		// get the current position from the source
 		shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 		status, err := vscw.wr.TabletManagerClient().SlaveStatus(shortCtx, vscw.sourceTablet)

--- a/go/vt/worker/vertical_split_clone_cmd.go
+++ b/go/vt/worker/vertical_split_clone_cmd.go
@@ -52,7 +52,7 @@ const verticalSplitCloneHTML2 = `
       <LABEL for="tables">Tables: </LABEL>
         <INPUT type="text" id="tables" name="tables" value="moving.*"></BR>
       <LABEL for="strategy">Strategy: </LABEL>
-        <INPUT type="text" id="strategy" name="strategy" value="-populate_blp_checkpoint"></BR>
+        <INPUT type="text" id="strategy" name="strategy" value=""></BR>
       <LABEL for="sourceReaderCount">Source Reader Count: </LABEL>
         <INPUT type="text" id="sourceReaderCount" name="sourceReaderCount" value="{{.DefaultSourceReaderCount}}"></BR>
       <LABEL for="destinationPackCount">Destination Pack Count: </LABEL>
@@ -68,8 +68,8 @@ const verticalSplitCloneHTML2 = `
   <h1>Help</h1>
     <p>Strategy can have the following values, comma separated:</p>
     <ul>
-      <li><b>populateBlpCheckpoint</b>: creates (if necessary) and populates the blp_checkpoint table in the destination. Required for filtered replication to start.</li>
-      <li><b>dontStartBinlogPlayer</b>: (requires populateBlpCheckpoint) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
+      <li><b>skipPopulateBlpCheckpoint</b>: skips creating (if necessary) and populating the blp_checkpoint table in the destination. Not skipped by default because it's required for filtered replication to start.</li>
+      <li><b>dontStartBinlogPlayer</b>: (requires skipPopulateBlpCheckpoint to be false) will setup, but not start binlog replication on the destination. The flag has to be manually cleared from the _vt.blp_checkpoint table.</li>
       <li><b>skipSetSourceShards</b>: we won't set SourceShards on the destination shards, disabling filtered replication. Useful for worker tests.</li>
     </ul>
   </body>

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -239,11 +239,7 @@ func VerticalDestinationsFactory(t *testing.T, insertCount int64) func() (dbconn
 	}
 }
 
-func TestVerticalSplitClonePopulateBlpCheckpoint(t *testing.T) {
-	testVerticalSplitClone(t, "-populate_blp_checkpoint")
-}
-
-func testVerticalSplitClone(t *testing.T, strategy string) {
+func TestVerticalSplitClone(t *testing.T) {
 	db := fakesqldb.Register()
 	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	ctx := context.Background()
@@ -296,7 +292,6 @@ func testVerticalSplitClone(t *testing.T, strategy string) {
 	subFlags := flag.NewFlagSet("SplitClone", flag.ContinueOnError)
 	gwrk, err := commandVerticalSplitClone(wi, wi.wr, subFlags, []string{
 		"-tables", "moving.*,view1",
-		"-strategy", strategy,
 		"-source_reader_count", "10",
 		"-destination_pack_count", "4",
 		"-min_table_size_for_split", "1",

--- a/test/binlog.py
+++ b/test/binlog.py
@@ -101,7 +101,6 @@ def setUpModule():
     logging.debug('Running the clone worker to start binlog stream...')
     utils.run_vtworker(['--cell', 'test_nj',
                         'SplitClone',
-                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/0'],

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -390,7 +390,6 @@ index by_msg (msg)
                         '--command_display_interval', '10ms',
                         'SplitClone',
                         '--exclude_tables', 'unrelated',
-                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/0'],

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -565,7 +565,6 @@ primary key (name)
                         '--command_display_interval', '10ms',
                         'SplitClone',
                         '--exclude_tables', 'unrelated',
-                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'test_keyspace/80-'],

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -371,7 +371,6 @@ index by_msg (msg)
                         '--command_display_interval', '10ms',
                         'VerticalSplitClone',
                         '--tables', 'moving.*,view1',
-                        '--strategy=-populate_blp_checkpoint',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
                         'destination_keyspace/0'],

--- a/test/worker.py
+++ b/test/worker.py
@@ -430,7 +430,6 @@ class TestBaseSplitCloneResiliency(TestBaseSplitClone):
          '--source_reader_count', '1',
          '--destination_pack_count', '1',
          '--destination_writer_count', '1',
-         '--strategy=-populate_blp_checkpoint',
          'test_keyspace/0'],
         worker_rpc_port)
 


### PR DESCRIPTION
@alainjobart 

Renamed strategy flag from "-populate_blp_checkpoint" to
"-skip_populate_blp_checkpoint".

Since it's on by default now, I've removed all occurrences where the old
flag was set explicitly.