### PR TITLE
tabletserver: allow strings for ints in SQL

### DIFF
--- a/go/vt/tabletserver/codex_test.go
+++ b/go/vt/tabletserver/codex_test.go
@@ -223,7 +223,7 @@ func TestCodexResolvePKValues(t *testing.T) {
 	pkValues = make([]interface{}, 0, 10)
 	pkValues = append(pkValues, sqltypes.MakeString([]byte("type_mismatch")))
 	_, _, err = resolvePKValues(&tableInfo, pkValues, nil)
-	testUtils.checkTabletError(t, err, ErrFail, "type mismatch")
+	testUtils.checkTabletError(t, err, ErrFail, "strconv.ParseInt")
 	// pkValues with different length
 	bindVariables = make(map[string]interface{})
 	bindVariables[key] = 1
@@ -324,16 +324,6 @@ func TestCodexBuildStreamComment(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("case 1 failed, got %v, want %v", got, want)
 	}
-}
-
-func TestCodexResolveValueWithIncompatibleValueType(t *testing.T) {
-	testUtils := newTestUtils()
-	tableInfo := createTableInfo("Table",
-		[]string{"pk1", "pk2", "col1"},
-		[]querypb.Type{sqltypes.Int64, sqltypes.VarBinary, sqltypes.Int32},
-		[]string{"pk1", "pk2"})
-	_, err := resolveValue(tableInfo.GetPKColumn(0), 0, nil)
-	testUtils.checkTabletError(t, err, ErrFail, "incompatible value type ")
 }
 
 func TestCodexValidateRow(t *testing.T) {

--- a/go/vt/tabletserver/endtoend/cache_test.go
+++ b/go/vt/tabletserver/endtoend/cache_test.go
@@ -283,7 +283,7 @@ func TestCacheTypes(t *testing.T) {
 		out   string
 	}{{
 		query: "select * from vitess_cached2 where eid = 'str' and bid = 'str'",
-		out:   "error: type mismatch",
+		out:   "error: strconv.ParseInt",
 	}, {
 		query: "select * from vitess_cached2 where eid = :str and bid = :str",
 		bv:    map[string]interface{}{"str": "str"},

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -400,7 +400,7 @@ func TestTypeLimits(t *testing.T) {
 	}{{
 		query: "insert into vitess_ints(tiny) values('str')",
 		bv:    nil,
-		out:   "error: type mismatch",
+		out:   "error: strconv.ParseInt",
 	}, {
 		query: "insert into vitess_ints(tiny) values(:str)",
 		bv:    map[string]interface{}{"str": "str"},


### PR DESCRIPTION
This change is more flexible than the previous one.
It implicitly converts strings to ints for bind vars
as well as hard-coded values in SQL.