### PR TITLE
bootstrap: Fix pkg-config work-around for MariaDB 10.1.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -160,7 +160,7 @@ echo "Cflags:" "$($VT_MYSQL_ROOT/bin/mysql_config --cflags) -ggdb -fPIC" >> $VTR
 if [ "$MYSQL_FLAVOR" == "MariaDB" ]; then
   # Use static linking because the shared library doesn't export
   # some internal functions we use, like cli_safe_read.
-  echo "Libs:" "$($VT_MYSQL_ROOT/bin/mysql_config --libs_r | sed 's,-lmysqlclient_r,-l:libmysqlclient.a -lstdc++,')" >> $VTROOT/lib/gomysql.pc
+  echo "Libs:" "$($VT_MYSQL_ROOT/bin/mysql_config --libs_r | sed -r 's,-lmysqlclient(_r)?,-l:libmysqlclient.a -lstdc++,')" >> $VTROOT/lib/gomysql.pc
 else
   echo "Libs:" "$($VT_MYSQL_ROOT/bin/mysql_config --libs_r)" >> $VTROOT/lib/gomysql.pc
 fi


### PR DESCRIPTION
It looks like with 10.1 MariaDB libmysqlclient is reentrant by default and they got rid of the special library "libmysqlclient_r". Therefore, mysql_config --libs_r now returns "libmysqlclient" instead of "libmysqlclient_r". Replace any of these two values with the static library.

Fixes issue https://github.com/youtube/vitess/issues/1437

@enisoc 