### PR TITLE
v3: analyze FROM clause

### DIFF
--- a/data/test/vtgate/select2_cases.txt
+++ b/data/test/vtgate/select2_cases.txt
@@ -1,0 +1,220 @@
+# Single table sharded scatter
+"select * from user"
+{
+  "From": "user",
+  "Route": {
+    "PlanID": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    }
+  }
+}
+
+# Single table unsharded
+"select * from main1"
+{
+  "From": "main1",
+  "Route": {
+    "PlanID": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    }
+  }
+}
+
+# Multi-table unsharded
+"select * from main1 as m1 join main1 as m2"
+{
+  "From": "main1 as m1 join main1 as m2",
+  "Route": {
+    "PlanID": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    }
+  }
+}
+
+# Multi-table, multi-chunk
+"select * from user join music"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "music",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# Sharded & Unsharded join
+"select * from user join main1"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "main1",
+    "Route": {
+      "PlanID": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      }
+    }
+  }
+}
+
+# Left join, single chunk
+"select * from main1 as m1 left join main1 as m2 on a=b"
+{
+  "From": "main1 as m1 left join main1 as m2 on a = b",
+  "Route": {
+    "PlanID": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    }
+  }
+}
+
+# Left join , multi-chunk
+"select * from user left join main1 on a = b"
+{
+  "IsLeft": true,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "main1",
+    "Route": {
+      "PlanID": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      }
+    }
+  }
+}
+
+# Straight-join
+"select * from main1 as m1 straight_join main1 as m2"
+{
+  "From": "main1 as m1 straight_join main1 as m2",
+  "Route": {
+    "PlanID": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    }
+  }
+}
+
+# Parenthesized, single chunk
+"select * from user join (main1 as m1 join main1 as m2)"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "(main1 as m1 join main1 as m2)",
+    "Route": {
+      "PlanID": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      }
+    }
+  }
+}
+
+# Parenthesized, multi-chunk
+"select * from user join (user as u1 join main1)"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "IsLeft": false,
+    "Left": {
+      "From": "user as u1",
+      "Route": {
+        "PlanID": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        }
+      }
+    },
+    "Right": {
+      "From": "main1",
+      "Route": {
+        "PlanID": "SelectUnsharded",
+        "Keyspace": {
+          "Name": "main",
+          "Sharded": false
+        }
+      }
+    }
+  }
+}
+
+# ondex hints, make sure they're not stripped.
+"select * from user use index(a)"
+{
+  "From": "user use index (a)",
+  "Route": {
+    "PlanID": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    }
+  }
+}

--- a/data/test/vtgate/select2_cases.txt
+++ b/data/test/vtgate/select2_cases.txt
@@ -206,7 +206,7 @@
   }
 }
 
-# ondex hints, make sure they're not stripped.
+# index hints, make sure they're not stripped.
 "select * from user use index(a)"
 {
   "From": "user use index (a)",
@@ -215,6 +215,201 @@
     "Keyspace": {
       "Name": "user",
       "Sharded": true
+    }
+  }
+}
+
+# mergeable sharded join on unique vindex
+"select * from user join user_extra on user.id = user_extra.user_id"
+{
+  "From": "user join user_extra on user.id = user_extra.user_id",
+  "Route": {
+    "PlanID": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    }
+  }
+}
+
+# mergeable sharded join on unique vindex, swapped operands
+"select * from user join user_extra on user_extra.user_id = user.id"
+{
+  "From": "user join user_extra on user_extra.user_id = user.id",
+  "Route": {
+    "PlanID": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    }
+  }
+}
+
+# mergeable sharded join on unique vindex, and condition
+"select * from user join user_extra on user.id = 5 and user.id = user_extra.user_id"
+{
+  "From": "user join user_extra on user.id = 5 and user.id = user_extra.user_id",
+  "Route": {
+    "PlanID": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    }
+  }
+}
+
+# sharded join on unique vindex, inequality
+"select * from user join user_extra on user.id < user_extra.user_id"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# sharded join, non-col reference RHS
+"select * from user join user_extra on user.id = 5"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# sharded join, non-col reference LHS
+"select * from user join user_extra on 5 = user.id"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# sharded join, invalid table reference
+"select * from user join user_extra on notable.id = user_extra.user_id"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# sharded join, non-vindex col
+"select * from user join user_extra on user.id = user_extra.col"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  }
+}
+
+# sharded join, non-unique vindex
+"select * from user_extra join user on user_extra.user_id = user.name"
+{
+  "IsLeft": false,
+  "Left": {
+    "From": "user_extra",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
+    }
+  },
+  "Right": {
+    "From": "user",
+    "Route": {
+      "PlanID": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      }
     }
   }
 }

--- a/data/test/vtgate/select2_cases.txt
+++ b/data/test/vtgate/select2_cases.txt
@@ -2,6 +2,7 @@
 "select * from user"
 {
   "From": "user",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectScatter",
     "Keyspace": {
@@ -15,6 +16,7 @@
 "select * from main1"
 {
   "From": "main1",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectUnsharded",
     "Keyspace": {
@@ -28,6 +30,7 @@
 "select * from main1 as m1 join main1 as m2"
 {
   "From": "main1 as m1 join main1 as m2",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectUnsharded",
     "Keyspace": {
@@ -41,8 +44,10 @@
 "select * from user join music"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -53,6 +58,7 @@
   },
   "Right": {
     "From": "music",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -67,8 +73,10 @@
 "select * from user join main1"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -79,6 +87,7 @@
   },
   "Right": {
     "From": "main1",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectUnsharded",
       "Keyspace": {
@@ -93,6 +102,7 @@
 "select * from main1 as m1 left join main1 as m2 on a=b"
 {
   "From": "main1 as m1 left join main1 as m2 on a = b",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectUnsharded",
     "Keyspace": {
@@ -106,8 +116,10 @@
 "select * from user left join main1 on a = b"
 {
   "IsLeft": true,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -118,6 +130,7 @@
   },
   "Right": {
     "From": "main1",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectUnsharded",
       "Keyspace": {
@@ -132,6 +145,7 @@
 "select * from main1 as m1 straight_join main1 as m2"
 {
   "From": "main1 as m1 straight_join main1 as m2",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectUnsharded",
     "Keyspace": {
@@ -145,8 +159,10 @@
 "select * from user join (main1 as m1 join main1 as m2)"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -157,6 +173,7 @@
   },
   "Right": {
     "From": "(main1 as m1 join main1 as m2)",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectUnsharded",
       "Keyspace": {
@@ -171,8 +188,10 @@
 "select * from user join (user as u1 join main1)"
 {
   "IsLeft": false,
+  "Order": 3,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -183,8 +202,10 @@
   },
   "Right": {
     "IsLeft": false,
+    "Order": 3,
     "Left": {
       "From": "user as u1",
+      "Order": 2,
       "Route": {
         "PlanID": "SelectScatter",
         "Keyspace": {
@@ -195,6 +216,7 @@
     },
     "Right": {
       "From": "main1",
+      "Order": 3,
       "Route": {
         "PlanID": "SelectUnsharded",
         "Keyspace": {
@@ -210,6 +232,7 @@
 "select * from user use index(a)"
 {
   "From": "user use index (a)",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectScatter",
     "Keyspace": {
@@ -223,6 +246,7 @@
 "select * from user join user_extra on user.id = user_extra.user_id"
 {
   "From": "user join user_extra on user.id = user_extra.user_id",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectScatter",
     "Keyspace": {
@@ -236,6 +260,7 @@
 "select * from user join user_extra on user_extra.user_id = user.id"
 {
   "From": "user join user_extra on user_extra.user_id = user.id",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectScatter",
     "Keyspace": {
@@ -249,6 +274,7 @@
 "select * from user join user_extra on user.id = 5 and user.id = user_extra.user_id"
 {
   "From": "user join user_extra on user.id = 5 and user.id = user_extra.user_id",
+  "Order": 1,
   "Route": {
     "PlanID": "SelectScatter",
     "Keyspace": {
@@ -262,8 +288,10 @@
 "select * from user join user_extra on user.id < user_extra.user_id"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -274,6 +302,7 @@
   },
   "Right": {
     "From": "user_extra",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -288,8 +317,10 @@
 "select * from user join user_extra on user.id = 5"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -300,6 +331,7 @@
   },
   "Right": {
     "From": "user_extra",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -314,8 +346,10 @@
 "select * from user join user_extra on 5 = user.id"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -326,6 +360,7 @@
   },
   "Right": {
     "From": "user_extra",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -340,8 +375,10 @@
 "select * from user join user_extra on notable.id = user_extra.user_id"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -352,6 +389,7 @@
   },
   "Right": {
     "From": "user_extra",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -366,8 +404,10 @@
 "select * from user join user_extra on user.id = user_extra.col"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -378,6 +418,7 @@
   },
   "Right": {
     "From": "user_extra",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -392,8 +433,10 @@
 "select * from user_extra join user on user_extra.user_id = user.name"
 {
   "IsLeft": false,
+  "Order": 2,
   "Left": {
     "From": "user_extra",
+    "Order": 1,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {
@@ -404,6 +447,7 @@
   },
   "Right": {
     "From": "user",
+    "Order": 2,
     "Route": {
       "PlanID": "SelectScatter",
       "Keyspace": {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -341,6 +341,7 @@ func (*JoinTableExpr) iTableExpr()    {}
 
 // AliasedTableExpr represents a table expression
 // coupled with an optional alias or index hint.
+// If As is empty, no alias was used.
 type AliasedTableExpr struct {
 	Expr  SimpleTableExpr
 	As    SQLName
@@ -369,6 +370,9 @@ func (*TableName) iSimpleTableExpr() {}
 func (*Subquery) iSimpleTableExpr()  {}
 
 // TableName represents a table  name.
+// Qualifier, if specified, represents a database.
+// It's generally not supported because vitess has its own
+// rules about which database to send a query to.
 type TableName struct {
 	Name, Qualifier SQLName
 }

--- a/go/vt/vtgate/planbuilder/filter.go
+++ b/go/vt/vtgate/planbuilder/filter.go
@@ -1,0 +1,18 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package planbuilder
+
+import "github.com/youtube/vitess/go/vt/sqlparser"
+
+// appendFilters breaks up the BoolExpr into AND-separated conditions
+// and appends them to filters, which can be shuffled and recombined
+// as needed.
+func appendFilters(filters []sqlparser.BoolExpr, node sqlparser.BoolExpr) []sqlparser.BoolExpr {
+	if node, ok := node.(*sqlparser.AndExpr); ok {
+		filters = appendFilters(filters, node.Left)
+		return appendFilters(filters, node.Right)
+	}
+	return append(filters, node)
+}

--- a/go/vt/vtgate/planbuilder/filter.go
+++ b/go/vt/vtgate/planbuilder/filter.go
@@ -6,13 +6,13 @@ package planbuilder
 
 import "github.com/youtube/vitess/go/vt/sqlparser"
 
-// appendFilters breaks up the BoolExpr into AND-separated conditions
+// splitAndExpression breaks up the BoolExpr into AND-separated conditions
 // and appends them to filters, which can be shuffled and recombined
 // as needed.
-func appendFilters(filters []sqlparser.BoolExpr, node sqlparser.BoolExpr) []sqlparser.BoolExpr {
+func splitAndExpression(filters []sqlparser.BoolExpr, node sqlparser.BoolExpr) []sqlparser.BoolExpr {
 	if node, ok := node.(*sqlparser.AndExpr); ok {
-		filters = appendFilters(filters, node.Left)
-		return appendFilters(filters, node.Right)
+		filters = splitAndExpression(filters, node.Left)
+		return splitAndExpression(filters, node.Right)
 	}
 	return append(filters, node)
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -110,19 +109,6 @@ func testFile(t *testing.T, filename string, schema *Schema) {
 			t.Errorf("File: %s, Line:%v\n%s\n%s", filename, tcase.lineno, tcase.output, out)
 		}
 	}
-}
-
-func loadSchema(name string) *Schema {
-	b, err := ioutil.ReadFile(locateFile(name))
-	if err != nil {
-		panic(err)
-	}
-	var schema Schema
-	err = json.Unmarshal(b, &schema)
-	if err != nil {
-		panic(err)
-	}
-	return &schema
 }
 
 type testCase struct {

--- a/go/vt/vtgate/planbuilder/select2.go
+++ b/go/vt/vtgate/planbuilder/select2.go
@@ -1,0 +1,200 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package planbuilder
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+)
+
+// PlanBuilder represents any object that's used to
+// build a plan.
+type PlanBuilder interface{}
+
+// JoinBuilder is used to build a Join primitive.
+type JoinBuilder struct {
+	IsLeft      bool
+	Left, Right PlanBuilder
+}
+
+// RouteBuilder is used to build a Route primitive.
+type RouteBuilder struct {
+	From     sqlparser.TableExpr
+	ChunkNum int
+	Route    *Route
+}
+
+// Route represents a Route primitive.
+type Route struct {
+	PlanID   PlanID
+	Keyspace *Keyspace
+	Vindex   Vindex      `json:",omitempty"`
+	Values   interface{} `json:",omitempty"`
+}
+
+// MarshalJSON marshals RouteBuilder into a readable form.
+func (rtb *RouteBuilder) MarshalJSON() ([]byte, error) {
+	marshalRoute := struct {
+		From     string `json:",omitempty"`
+		ChunkNum int    `json:",omitempty"`
+		Route    *Route
+	}{
+		From:     sqlparser.String(rtb.From),
+		ChunkNum: rtb.ChunkNum,
+		Route:    rtb.Route,
+	}
+	return json.Marshal(marshalRoute)
+}
+
+// buildSelectPlan2 is the new function to build a Select plan. It will be renamed
+// after the old one is removed.
+func buildSelectPlan2(sel *sqlparser.Select, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	return processTableExprs(sel.From, schema)
+}
+
+// processTableExprs is the root function to process the FROM clause. It produces a PlanBuilder
+// and the associated SymbolTable. The PlanBuilder is a tree of JoinBuilder and RouteBuilder
+// objects, where all the chunks are identified, and each chunk is grouped under one RouteBuilder.
+func processTableExprs(tableExprs sqlparser.TableExprs, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	if len(tableExprs) != 1 {
+		return nil, nil, errors.New("no list")
+	}
+	return processTableExpr(tableExprs[0], schema)
+}
+
+// processTableExpr produces a PlanBuilder subtree and SymbolTable for the given TableExpr.
+func processTableExpr(tableExpr sqlparser.TableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	switch tableExpr := tableExpr.(type) {
+	case *sqlparser.AliasedTableExpr:
+		return processAliasedTable(tableExpr, schema)
+	case *sqlparser.ParenTableExpr:
+		planBuilder, symbols, err := processTableExprs(tableExpr.Exprs, schema)
+		if route, ok := planBuilder.(*RouteBuilder); ok {
+			route.From = tableExpr
+		}
+		return planBuilder, symbols, err
+	case *sqlparser.JoinTableExpr:
+		return processJoin(tableExpr, schema)
+	}
+	panic("unreachable")
+}
+
+// processAliasedTable produces a PlanBuilder subtree and SymbolTable for the given AliasedTableExpr.
+func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	switch expr := tableExpr.Expr.(type) {
+	case *sqlparser.TableName:
+		route, table, err := getTablePlan(expr, schema)
+		if err != nil {
+			return nil, nil, err
+		}
+		planBuilder := &RouteBuilder{
+			From:  tableExpr,
+			Route: route,
+		}
+		alias := expr.Name
+		if tableExpr.As != "" {
+			alias = tableExpr.As
+		}
+		symbols := NewSymbolTable(alias, table, planBuilder)
+		return planBuilder, symbols, nil
+	case *sqlparser.Subquery:
+		return nil, nil, errors.New("no subqueries")
+	}
+	panic("unreachable")
+}
+
+// getTablePlan produces the initial Route for the specified TableName. It also returns
+// the associated vschema info (*Table) so that it can be used to create the symbol table
+// entry.
+func getTablePlan(tableName *sqlparser.TableName, schema *Schema) (*Route, *Table, error) {
+	if tableName.Qualifier != "" {
+		return nil, nil, errors.New("tablename qualifier not allowed")
+	}
+	table, reason := schema.FindTable(string(tableName.Name))
+	if reason != "" {
+		return nil, nil, errors.New(reason)
+	}
+	if table.Keyspace.Sharded {
+		return &Route{
+			PlanID:   SelectScatter,
+			Keyspace: table.Keyspace,
+		}, table, nil
+	}
+	return &Route{
+		PlanID:   SelectUnsharded,
+		Keyspace: table.Keyspace,
+	}, table, nil
+}
+
+// processJoin produces a PlanBuilder subtree and SymbolTable for the given Join. If the left and
+// right node can be merged into one chunk, then it's a RouteBuilder. Otherwise, it's a JoinBuilder.
+func processJoin(join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	switch join.Join {
+	case sqlparser.JoinStr, sqlparser.StraightJoinStr, sqlparser.LeftJoinStr:
+	default:
+		return nil, nil, errors.New("unsupported join")
+	}
+	lplanBuilder, lsymbols, err := processTableExpr(join.LeftExpr, schema)
+	if err != nil {
+		return nil, nil, err
+	}
+	rplanBuilder, rsymbols, err := processTableExpr(join.RightExpr, schema)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch lplanBuilder := lplanBuilder.(type) {
+	case *JoinBuilder:
+		return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+	case *RouteBuilder:
+		switch rplanBuilder := rplanBuilder.(type) {
+		case *JoinBuilder:
+			return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+		case *RouteBuilder:
+			return joinRoutes(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+		}
+	}
+	panic("unreachable")
+}
+
+// makeChink creates a new chunk for the join operation. This function is called when
+// two chunks cannot be merged into one.
+func makeChunk(lplanBuilder PlanBuilder, lsymbols *SymbolTable, rplanBuilder PlanBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	err := lsymbols.AddChunk(rsymbols)
+	if err != nil {
+		return nil, nil, err
+	}
+	isLeft := false
+	if join.Join == sqlparser.LeftJoinStr {
+		isLeft = true
+	}
+	return &JoinBuilder{
+		IsLeft: isLeft,
+		Left:   lplanBuilder,
+		Right:  rplanBuilder,
+	}, lsymbols, nil
+}
+
+// joinRoutes attempts to join to RouteBuilder objects into one. If it's not possible,
+// it produces a joined RouteBuilder. Otherwise, it's a JoinBuilder.
+func joinRoutes(lplanBuilder *RouteBuilder, lsymbols *SymbolTable, rplanBuilder *RouteBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
+	switch lplanBuilder.Route.PlanID {
+	case SelectUnsharded:
+		switch rplanBuilder.Route.PlanID {
+		case SelectUnsharded:
+			// Two Routes from the same unsharded keyspace can be merged.
+			if lplanBuilder.Route.Keyspace.Name == rplanBuilder.Route.Keyspace.Name {
+				lplanBuilder.From = join
+				err := lsymbols.Merge(rsymbols, lplanBuilder)
+				if err != nil {
+					return nil, nil, err
+				}
+				return lplanBuilder, lsymbols, nil
+			}
+		}
+	}
+	return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+}

--- a/go/vt/vtgate/planbuilder/select2.go
+++ b/go/vt/vtgate/planbuilder/select2.go
@@ -324,7 +324,7 @@ func mergeRoutes(lRouteBuilder *RouteBuilder, lsymbols *SymbolTable, rRouteBuild
 // If a merge is possible, it builds one using lRouteBuilder as the base route.
 // If not, it builds a JoinBuilder instead.
 func joinShardedRoutes(lRouteBuilder *RouteBuilder, lsymbols *SymbolTable, rRouteBuilder *RouteBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr) (PlanBuilder, *SymbolTable, error) {
-	onFilters := appendFilters(nil, join.On)
+	onFilters := splitAndExpression(nil, join.On)
 	for _, filter := range onFilters {
 		if isSameRoute(filter, lsymbols, rsymbols) {
 			return mergeRoutes(lRouteBuilder, lsymbols, rRouteBuilder, rsymbols, join)

--- a/go/vt/vtgate/planbuilder/select2.go
+++ b/go/vt/vtgate/planbuilder/select2.go
@@ -12,61 +12,99 @@ import (
 )
 
 // PlanBuilder represents any object that's used to
-// build a plan.
+// build a plan. The top-level PlanBuilder will be a
+// tree that points to other PlanBuilder objects.
+// Currently, JoinBuilder and RouteBuilder are the
+// only two supported PlanBuilder objects. More will be
+// added as we extend the functionality.
+// Each Builder object builds a Plan object, and they
+// will mirror the same tree. Once all the plans are built,
+// the builder objects will be discarded, and only
+// the Plan objects will remain.
 type PlanBuilder interface{}
 
 // JoinBuilder is used to build a Join primitive.
+// It's used to buid a normal join or a left join
+// operation.
+// TODO(sougou): struct is incomplete.
 type JoinBuilder struct {
+	// IsLeft is true if the operation is a left join.
 	IsLeft      bool
 	Left, Right PlanBuilder
 }
 
 // RouteBuilder is used to build a Route primitive.
+// It's used to build one of the Select routes like
+// SelectScatter, etc. Portions of the original Select AST
+// are moved into this node, which will be used to build
+// the final SQL for this route.
+// TODO(sougou): struct is incomplete.
 type RouteBuilder struct {
-	From     sqlparser.TableExpr
-	ChunkNum int
-	Route    *Route
+	// From points to the portion of the AST this route represents.
+	From sqlparser.TableExpr
+	// Route is the plan object being built. It will contain all the
+	// information necessary to execute the route operation.
+	Route *Route
 }
 
-// Route represents a Route primitive.
+// Route is a Plan object that represents a route.
+// It can be any one of the Select primitives from PlanID.
+// Some plan ids correspond to a multi-shard query,
+// and some are for a single-shard query. The rules
+// of what can be merged, or what can be pushed down
+// depend on the PlanID. They're explained in code
+// where such decisions are made.
+// TODO(sougou): struct is incomplete.
+// TODO(sougou): integrate with the older v3 Plan.
 type Route struct {
-	PlanID   PlanID
+	// PlanID will be one of the Select IDs from PlanID.
+	PlanID PlanID
+	// Keypsace represents the keyspace to which
+	// the query will be sent.
 	Keyspace *Keyspace
-	Vindex   Vindex      `json:",omitempty"`
-	Values   interface{} `json:",omitempty"`
+	// Vindex represents the vindex that will be used
+	// to resolve the route.
+	Vindex Vindex `json:",omitempty"`
+	// Values represents a single value or a list of
+	// values that will be used as input to the Vindex
+	// to compute the target shard(s) where the query must
+	// be sent.
+	// TODO(sougou): explain contents of Values.
+	Values interface{} `json:",omitempty"`
 }
 
 // MarshalJSON marshals RouteBuilder into a readable form.
+// It's used for testing and diagnostics. The representation
+// is lossy and cannot be used to reconstruct a RouteBuilder.
 func (rtb *RouteBuilder) MarshalJSON() ([]byte, error) {
 	marshalRoute := struct {
-		From     string `json:",omitempty"`
-		ChunkNum int    `json:",omitempty"`
-		Route    *Route
+		From  string `json:",omitempty"`
+		Route *Route
 	}{
-		From:     sqlparser.String(rtb.From),
-		ChunkNum: rtb.ChunkNum,
-		Route:    rtb.Route,
+		From:  sqlparser.String(rtb.From),
+		Route: rtb.Route,
 	}
 	return json.Marshal(marshalRoute)
 }
 
-// buildSelectPlan2 is the new function to build a Select plan. It will be renamed
-// after the old one is removed.
+// buildSelectPlan2 is the new function to build a Select plan.
+// TODO(sougou): rename after deprecating old one.
 func buildSelectPlan2(sel *sqlparser.Select, schema *Schema) (PlanBuilder, *SymbolTable, error) {
 	return processTableExprs(sel.From, schema)
 }
 
-// processTableExprs is the root function to process the FROM clause. It produces a PlanBuilder
-// and the associated SymbolTable. The PlanBuilder is a tree of JoinBuilder and RouteBuilder
-// objects, where all the chunks are identified, and each chunk is grouped under one RouteBuilder.
+// processTableExprs analyzes the FROM clause. It produces a PlanBuilder
+// and the associated SymbolTable with all the routes identified.
 func processTableExprs(tableExprs sqlparser.TableExprs, schema *Schema) (PlanBuilder, *SymbolTable, error) {
 	if len(tableExprs) != 1 {
+		// TODO(sougou): better error message.
 		return nil, nil, errors.New("no list")
 	}
 	return processTableExpr(tableExprs[0], schema)
 }
 
-// processTableExpr produces a PlanBuilder subtree and SymbolTable for the given TableExpr.
+// processTableExpr produces a PlanBuilder subtree and SymbolTable
+// for the given TableExpr.
 func processTableExpr(tableExpr sqlparser.TableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
 	switch tableExpr := tableExpr.(type) {
 	case *sqlparser.AliasedTableExpr:
@@ -83,7 +121,8 @@ func processTableExpr(tableExpr sqlparser.TableExpr, schema *Schema) (PlanBuilde
 	panic("unreachable")
 }
 
-// processAliasedTable produces a PlanBuilder subtree and SymbolTable for the given AliasedTableExpr.
+// processAliasedTable produces a PlanBuilder subtree and SymbolTable
+// for the given AliasedTableExpr.
 func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
 	switch expr := tableExpr.Expr.(type) {
 	case *sqlparser.TableName:
@@ -102,16 +141,18 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, schema *Schema) 
 		symbols := NewSymbolTable(alias, table, planBuilder)
 		return planBuilder, symbols, nil
 	case *sqlparser.Subquery:
+		// TODO(sougou): implement.
 		return nil, nil, errors.New("no subqueries")
 	}
 	panic("unreachable")
 }
 
-// getTablePlan produces the initial Route for the specified TableName. It also returns
-// the associated vschema info (*Table) so that it can be used to create the symbol table
-// entry.
+// getTablePlan produces the initial Route for the specified TableName.
+// It also returns the associated vschema info (*Table) so that
+// it can be used to create the symbol table entry.
 func getTablePlan(tableName *sqlparser.TableName, schema *Schema) (*Route, *Table, error) {
 	if tableName.Qualifier != "" {
+		// TODO(sougou): better error message.
 		return nil, nil, errors.New("tablename qualifier not allowed")
 	}
 	table, reason := schema.FindTable(string(tableName.Name))
@@ -130,12 +171,15 @@ func getTablePlan(tableName *sqlparser.TableName, schema *Schema) (*Route, *Tabl
 	}, table, nil
 }
 
-// processJoin produces a PlanBuilder subtree and SymbolTable for the given Join. If the left and
-// right node can be merged into one chunk, then it's a RouteBuilder. Otherwise, it's a JoinBuilder.
+// processJoin produces a PlanBuilder subtree and SymbolTable
+// for the given Join. If the left and right nodes can be part
+// of the same route, then it's a RouteBuilder. Otherwise,
+// it's a JoinBuilder.
 func processJoin(join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
 	switch join.Join {
 	case sqlparser.JoinStr, sqlparser.StraightJoinStr, sqlparser.LeftJoinStr:
 	default:
+		// TODO(sougou): better error message.
 		return nil, nil, errors.New("unsupported join")
 	}
 	lplanBuilder, lsymbols, err := processTableExpr(join.LeftExpr, schema)
@@ -148,22 +192,23 @@ func processJoin(join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *S
 	}
 	switch lplanBuilder := lplanBuilder.(type) {
 	case *JoinBuilder:
-		return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+		return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
 	case *RouteBuilder:
 		switch rplanBuilder := rplanBuilder.(type) {
 		case *JoinBuilder:
-			return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+			return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
 		case *RouteBuilder:
-			return joinRoutes(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+			return joinRoutes(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
 		}
 	}
 	panic("unreachable")
 }
 
-// makeChink creates a new chunk for the join operation. This function is called when
-// two chunks cannot be merged into one.
-func makeChunk(lplanBuilder PlanBuilder, lsymbols *SymbolTable, rplanBuilder PlanBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
-	err := lsymbols.AddChunk(rsymbols)
+// makeJoinBuilder creates a new JoinBuilder node out of the two builders.
+// This function is called when the two builders cannot be part of
+// the same route.
+func makeJoinBuilder(lplanBuilder PlanBuilder, lsymbols *SymbolTable, rplanBuilder PlanBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr) (PlanBuilder, *SymbolTable, error) {
+	err := lsymbols.Add(rsymbols)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -178,23 +223,90 @@ func makeChunk(lplanBuilder PlanBuilder, lsymbols *SymbolTable, rplanBuilder Pla
 	}, lsymbols, nil
 }
 
-// joinRoutes attempts to join to RouteBuilder objects into one. If it's not possible,
-// it produces a joined RouteBuilder. Otherwise, it's a JoinBuilder.
-func joinRoutes(lplanBuilder *RouteBuilder, lsymbols *SymbolTable, rplanBuilder *RouteBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr, schema *Schema) (PlanBuilder, *SymbolTable, error) {
-	switch lplanBuilder.Route.PlanID {
-	case SelectUnsharded:
-		switch rplanBuilder.Route.PlanID {
-		case SelectUnsharded:
-			// Two Routes from the same unsharded keyspace can be merged.
-			if lplanBuilder.Route.Keyspace.Name == rplanBuilder.Route.Keyspace.Name {
-				lplanBuilder.From = join
-				err := lsymbols.Merge(rsymbols, lplanBuilder)
-				if err != nil {
-					return nil, nil, err
-				}
-				return lplanBuilder, lsymbols, nil
-			}
-		}
+// joinRoutes attempts to join two RouteBuilder objects into one.
+// If it's possible, it produces a joined RouteBuilder.
+// Otherwise, it's a JoinBuilder.
+func joinRoutes(lplanBuilder *RouteBuilder, lsymbols *SymbolTable, rplanBuilder *RouteBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr) (PlanBuilder, *SymbolTable, error) {
+	if lplanBuilder.Route.Keyspace.Name != rplanBuilder.Route.Keyspace.Name {
+		return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
 	}
-	return makeChunk(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join, schema)
+	if lplanBuilder.Route.PlanID == SelectUnsharded {
+		if rplanBuilder.Route.PlanID == SelectUnsharded {
+			// Two Routes from the same unsharded keyspace can be merged.
+			return mergeRoutes(lplanBuilder, lsymbols, rsymbols, join)
+		}
+		return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
+	}
+	// lplanBuilder is a sharded route. It can't merge with an unsharded route.
+	if rplanBuilder.Route.PlanID == SelectUnsharded {
+		return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
+	}
+	// TODO(sougou): Handle special case for SelectEqual and SelectKeyrange.
+	// Both planBuilders are sharded routes. Analyze join condition for merging.
+	return joinShardedRoutes(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
+}
+
+// mergeRoutes makes a new RouteBuilder by joining the left and right
+// nodes of a join. This is called if two routes can be merged.
+func mergeRoutes(lplanBuilder *RouteBuilder, lsymbols, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr) (PlanBuilder, *SymbolTable, error) {
+	lplanBuilder.From = join
+	err := lsymbols.Merge(rsymbols, lplanBuilder)
+	if err != nil {
+		return nil, nil, err
+	}
+	return lplanBuilder, lsymbols, nil
+}
+
+// joinShardedRoutes tries to join two sharded routes into a RouteBuilder.
+// If a merge is possible, it builds one using lplanBuilder as the base route.
+// If not, it builds a JoinBuilder instead.
+func joinShardedRoutes(lplanBuilder *RouteBuilder, lsymbols *SymbolTable, rplanBuilder *RouteBuilder, rsymbols *SymbolTable, join *sqlparser.JoinTableExpr) (PlanBuilder, *SymbolTable, error) {
+	onFilters := appendFilters(nil, join.On)
+	for _, filter := range onFilters {
+		if !isSameRoute(filter, lsymbols, rsymbols) {
+			continue
+		}
+		return mergeRoutes(lplanBuilder, lsymbols, rsymbols, join)
+	}
+	return makeJoinBuilder(lplanBuilder, lsymbols, rplanBuilder, rsymbols, join)
+}
+
+// isSameRoute returns true if the filter constraint causes the
+// left and right routes to be part of the same route. For this
+// to happen, the constraint has to be an equality like a.id = b.id,
+// one should address a table from the left side, the other from the
+// right, the referenced columns have to be the same Vindex, and the
+// Vindex must be unique.
+func isSameRoute(filter sqlparser.BoolExpr, lsymbols, rsymbols *SymbolTable) bool {
+	comparison, ok := filter.(*sqlparser.ComparisonExpr)
+	if !ok {
+		return false
+	}
+	if comparison.Operator != sqlparser.EqualStr {
+		return false
+	}
+	lcol, ok := comparison.Left.(*sqlparser.ColName)
+	if !ok {
+		return false
+	}
+	rcol, ok := comparison.Right.(*sqlparser.ColName)
+	if !ok {
+		return false
+	}
+	_, lColVindex := lsymbols.FindColumn(lcol, false)
+	if lColVindex == nil {
+		lcol, rcol = rcol, lcol
+		_, lColVindex = lsymbols.FindColumn(lcol, false)
+	}
+	if lColVindex == nil || !IsUnique(lColVindex.Vindex) {
+		return false
+	}
+	_, rColVindex := rsymbols.FindColumn(rcol, false)
+	if rColVindex == nil {
+		return false
+	}
+	if rColVindex.Vindex != lColVindex.Vindex {
+		return false
+	}
+	return true
 }

--- a/go/vt/vtgate/planbuilder/select2_test.go
+++ b/go/vt/vtgate/planbuilder/select2_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package planbuilder
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+)
+
+func TestSelect2(t *testing.T) {
+	schema, err := LoadFile(locateFile("schema_test.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tcase := range iterateExecFile("select2_cases.txt") {
+		statement, err := sqlparser.Parse(tcase.input)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		sel, ok := statement.(*sqlparser.Select)
+		if !ok {
+			t.Errorf("unexpected type: %T", statement)
+			continue
+		}
+		plan, _, err := buildSelectPlan2(sel, schema)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		bout, err := json.Marshal(plan)
+		if err != nil {
+			panic(fmt.Sprintf("Error marshalling %v: %v", plan, err))
+		}
+		out := string(bout)
+		if out != tcase.output {
+			t.Errorf("Line:%v\n%s\n%s", tcase.lineno, tcase.output, out)
+		}
+	}
+}

--- a/go/vt/vtgate/planbuilder/select2_test.go
+++ b/go/vt/vtgate/planbuilder/select2_test.go
@@ -41,5 +41,8 @@ func TestSelect2(t *testing.T) {
 		if out != tcase.output {
 			t.Errorf("Line:%v\n%s\n%s", tcase.lineno, tcase.output, out)
 		}
+		// Comment these line out to see the expected outputs
+		// bout, err = json.MarshalIndent(plan, "", "  ")
+		// fmt.Printf("%s\n", bout)
 	}
 }

--- a/go/vt/vtgate/planbuilder/symboltable.go
+++ b/go/vt/vtgate/planbuilder/symboltable.go
@@ -1,0 +1,79 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package planbuilder
+
+import (
+	"errors"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+)
+
+// SymbolTable contains the symbols for a SELECT
+// statement. If it's for a subquery, it points to
+// an outer scope.
+type SymbolTable struct {
+	tables map[sqlparser.SQLName]*TableAlias
+	outer  *SymbolTable
+}
+
+// TableAlias is part of SymbolTable.
+// It represnts a table alias in a FROM clause.
+type TableAlias struct {
+	// Name represents the name of the alias.
+	Name sqlparser.SQLName
+	// Keyspace points to the keyspace to which this
+	// alias belongs.
+	Keyspace *Keyspace
+	// CoVindexes is the list of column Vindexes for this alisas.
+	ColVindexes []*ColVindex
+	// Route points to the RouteBuilder object under which this alias
+	// was created.
+	Route *RouteBuilder
+}
+
+// NewSymbolTable creates a new SymbolTable initialized
+// to contain the provided table alias.
+func NewSymbolTable(alias sqlparser.SQLName, table *Table, route *RouteBuilder) *SymbolTable {
+	return &SymbolTable{
+		tables: map[sqlparser.SQLName]*TableAlias{
+			alias: {
+				Name:        alias,
+				Keyspace:    table.Keyspace,
+				ColVindexes: table.ColVindexes,
+				Route:       route,
+			},
+		},
+	}
+}
+
+// AddChunk merges the new symbol table into the current one
+// without mergine their routes. This means that the new symbols
+// will belong to a different chunk (or route).
+func (smt *SymbolTable) AddChunk(symbols *SymbolTable) error {
+	for k, v := range symbols.tables {
+		if _, found := smt.tables[k]; found {
+			return errors.New("duplicate symbols")
+		}
+		smt.tables[k] = v
+	}
+	return nil
+}
+
+// Merge merges the new symbol table into the current as part of
+// the same chunk. So, all symbols will be changed to point to the new
+// RouteBuilder.
+func (smt *SymbolTable) Merge(symbols *SymbolTable, route *RouteBuilder) error {
+	for _, v := range smt.tables {
+		v.Route = route
+	}
+	for k, v := range symbols.tables {
+		if _, found := smt.tables[k]; found {
+			return errors.New("duplicate symbols")
+		}
+		smt.tables[k] = v
+		v.Route = route
+	}
+	return nil
+}

--- a/go/vt/vtgate/planbuilder/symboltable.go
+++ b/go/vt/vtgate/planbuilder/symboltable.go
@@ -12,7 +12,7 @@ import (
 
 // SymbolTable contains the symbols for a SELECT
 // statement. If it's for a subquery, it points to
-// an outer scope.
+// an outer scope. For now, it only contains tables.
 type SymbolTable struct {
 	tables map[sqlparser.SQLName]*TableAlias
 	outer  *SymbolTable
@@ -20,13 +20,14 @@ type SymbolTable struct {
 
 // TableAlias is part of SymbolTable.
 // It represnts a table alias in a FROM clause.
+// TODO(sougou): Update comments after the struct is finalized.
 type TableAlias struct {
 	// Name represents the name of the alias.
 	Name sqlparser.SQLName
 	// Keyspace points to the keyspace to which this
 	// alias belongs.
 	Keyspace *Keyspace
-	// CoVindexes is the list of column Vindexes for this alisas.
+	// CoVindexes is the list of column Vindexes for this alias.
 	ColVindexes []*ColVindex
 	// Route points to the RouteBuilder object under which this alias
 	// was created.
@@ -49,7 +50,7 @@ func NewSymbolTable(alias sqlparser.SQLName, table *Table, route *RouteBuilder) 
 }
 
 // Add merges the new symbol table into the current one
-// without mergine their routes. This means that the new symbols
+// without merging their routes. This means that the new symbols
 // will belong to different routes
 func (smt *SymbolTable) Add(symbols *SymbolTable) error {
 	for k, v := range symbols.tables {
@@ -61,9 +62,8 @@ func (smt *SymbolTable) Add(symbols *SymbolTable) error {
 	return nil
 }
 
-// Merge merges the new symbol table into the current as part of
-// the same route. So, all symbols will be changed to point to the new
-// RouteBuilder.
+// Merge merges the new symbol table into the current one and makes
+// all the tables part of the specified RouteBuilder.
 func (smt *SymbolTable) Merge(symbols *SymbolTable, route *RouteBuilder) error {
 	for _, v := range smt.tables {
 		v.Route = route


### PR DESCRIPTION
@erzel 
This is the first installment for the new v3 analysis. This change
analyzes just the FROM clause, without the ON clauses, and identifies
possible chunks. For now, chunks are possible only for unsharded
keyspaces. Once we add ON clause analysis, we'll be able to find
chunks for sharded keyspaces also.
The new functions are currently not called from anywhere. There
are some basic unit tests for now, which will also be evolved as
functionality grows.