### PR TITLE
vtworker: VerticalSplitClone: Error when --tables is not set.

### DIFF
--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -22,9 +22,7 @@ func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automatio
 	//                        '--destination_pack_count', '1',
 	//                        '--destination_writer_count', '1',
 	args := []string{"VerticalSplitClone"}
-	if tables := parameters["tables"]; tables != "" {
-		args = append(args, "--tables="+tables)
-	}
+	args = append(args, "--tables="+parameters["tables"])
 	args = append(args, topoproto.KeyspaceShardString(parameters["dest_keyspace"], parameters["shard"]))
 	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -5,6 +5,7 @@
 package worker
 
 import (
+	"errors"
 	"fmt"
 	"html/template"
 	"strings"
@@ -71,6 +72,9 @@ type VerticalSplitCloneWorker struct {
 
 // NewVerticalSplitCloneWorker returns a new VerticalSplitCloneWorker object.
 func NewVerticalSplitCloneWorker(wr *wrangler.Wrangler, cell, destinationKeyspace, destinationShard string, tables []string, strategyStr string, sourceReaderCount, destinationPackCount int, minTableSizeForSplit uint64, destinationWriterCount int) (Worker, error) {
+	if len(tables) == 0 {
+		return nil, errors.New("list of tablets to be split out must not be empty")
+	}
 	strategy, err := newSplitStrategy(wr.Logger(), strategyStr)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@alainjobart 

And here I was, wondering why the diff fails complaining that no tables are set in the SourceShard record :)