### PR TITLE
test: Introduce new flag --num_insert_rows_long for TestReparentDurin…

### DIFF
--- a/test/worker.py
+++ b/test/worker.py
@@ -157,6 +157,10 @@ def tearDownModule():
 class TestBaseSplitClone(unittest.TestCase):
   """Abstract test base class for testing the SplitClone worker."""
 
+  def __init__(self, *args, **kwargs):
+    super(TestBaseSplitClone, self).__init__(*args, **kwargs)
+    self.num_insert_rows = utils.options.num_insert_rows
+
   def run_shard_tablets(
       self, shard_name, shard_tablets, create_table=True):
     """Handles all the necessary work for initially running a shard's tablets.
@@ -356,8 +360,8 @@ class TestBaseSplitClone(unittest.TestCase):
           '80-', shard_1_tablets, create_table=False)
 
       logging.debug('Start inserting initial data: %s rows',
-                    utils.options.num_insert_rows)
-      self.insert_values(shard_master, utils.options.num_insert_rows, 2)
+                    self.num_insert_rows)
+      self.insert_values(shard_master, self.num_insert_rows, 2)
       logging.debug(
           'Done inserting initial data, waiting for replication to catch up')
       utils.wait_for_replication_pos(shard_master, shard_rdonly1)
@@ -498,6 +502,10 @@ class TestBaseSplitCloneResiliency(TestBaseSplitClone):
 
 class TestReparentDuringWorkerCopy(TestBaseSplitCloneResiliency):
 
+  def __init__(self, *args, **kwargs):
+    super(TestReparentDuringWorkerCopy, self).__init__(*args, **kwargs)
+    self.num_insert_rows = utils.options.num_insert_rows_before_reparent_test
+
   def test_reparent_during_worker_copy(self):
     """Simulates a destination reparent during a worker SplitClone copy.
 
@@ -599,9 +607,15 @@ class TestVtworkerWebinterface(unittest.TestCase):
 
 def add_test_options(parser):
   parser.add_option(
-      '--num_insert_rows', type='int', default=3000,
+      '--num_insert_rows', type='int', default=100,
       help='The number of rows, per shard, that we should insert before '
       'resharding for this test.')
+  parser.add_option(
+      '--num_insert_rows_before_reparent_test', type='int', default=3000,
+      help='The number of rows, per shard, that we should insert before '
+      'running TestReparentDuringWorkerCopy (supersedes --num_insert_rows in '
+      'that test). There must be enough rows such that SplitClone takes '
+      'several seconds to run while we run a planned reparent.')
 
 if __name__ == '__main__':
   utils.main(test_options=add_test_options)


### PR DESCRIPTION
…gWorkerCopy.

Only TestReparentDuringWorkerCopy requires a large amount of rows to keep vtworker SplitClone busy for a long time such that we can time it and run a planned reparent just after it started.

With this change, only TestReparentDuringWorkerCopy will use the new flag which should usually have a high value (default in open-source: 3k).

The existing flag --num_insert_rows covers all test and requires no mimum number of rows. Therefore, I've reduced its value from 3k to 100.

@aaijazi 