### PR TITLE
Update sql_builder.AfterPrevValues.

### DIFF
--- a/test/sql_builder_test.py
+++ b/test/sql_builder_test.py
@@ -559,23 +559,27 @@ class TestSqlWhereExprs(BaseTestCase):
   def test_tuple_compare(self):
     self._check_build_where_sql(
         sql_builder.TupleGreater([('x', 3), ('y', 5), ('z', 7)]),
-        '(x, y, z) > (%(x_3)s, %(y_4)s, %(z_5)s)',
-        dict(x_3=3, y_4=5, z_5=7),
+        'x = %(x_5)s AND '
+        '(y = %(y_4)s AND z > %(z_3)s OR y > %(y_4)s) OR x > %(x_5)s',
+        dict(x_5=3, y_4=5, z_3=7),
         column_name=None)
     self._check_build_where_sql(
         sql_builder.TupleGreaterEqual([('x', 3), ('y', 5), ('z', 7)]),
-        '(x, y, z) >= (%(x_3)s, %(y_4)s, %(z_5)s)',
-        dict(x_3=3, y_4=5, z_5=7),
+        'x = %(x_5)s AND '
+        '(y = %(y_4)s AND z >= %(z_3)s OR y > %(y_4)s) OR x > %(x_5)s',
+        dict(x_5=3, y_4=5, z_3=7),
         column_name=None)
     self._check_build_where_sql(
         sql_builder.TupleLess([('x', 3), ('y', 5), ('z', 7)]),
-        '(x, y, z) < (%(x_3)s, %(y_4)s, %(z_5)s)',
-        dict(x_3=3, y_4=5, z_5=7),
+        'x = %(x_5)s AND '
+        '(y = %(y_4)s AND z < %(z_3)s OR y < %(y_4)s) OR x < %(x_5)s',
+        dict(x_5=3, y_4=5, z_3=7),
         column_name=None)
     self._check_build_where_sql(
         sql_builder.TupleLessEqual([('x', 3), ('y', 5), ('z', 7)]),
-        '(x, y, z) <= (%(x_3)s, %(y_4)s, %(z_5)s)',
-        dict(x_3=3, y_4=5, z_5=7),
+        'x = %(x_5)s AND '
+        '(y = %(y_4)s AND z <= %(z_3)s OR y < %(y_4)s) OR x < %(x_5)s',
+        dict(x_5=3, y_4=5, z_3=7),
         column_name=None)
 
   def test_greater_than(self):

--- a/test/sql_builder_test.py
+++ b/test/sql_builder_test.py
@@ -556,25 +556,26 @@ class TestSqlWhereExprs(BaseTestCase):
         '(col_a = %(col_a_5)s))',
         dict(col_a_3=11, col_a_4=20, col_a_5=30))
 
-  def test_after_prev__values(self):
+  def test_tuple_compare(self):
     self._check_build_where_sql(
-        sql_builder.AfterPrevValues([('x', 3), ('y', 5), ('z', 7)]),
-        'x = %(x_5)s AND (y = %(y_4)s AND z > %(z_3)s OR y > %(y_4)s) '
-        'OR x > %(x_5)s',
-        dict(x_5=3, y_4=5, z_3=7),
+        sql_builder.TupleGreater([('x', 3), ('y', 5), ('z', 7)]),
+        '(x, y, z) > (%(x_3)s, %(y_4)s, %(z_5)s)',
+        dict(x_3=3, y_4=5, z_5=7),
         column_name=None)
     self._check_build_where_sql(
-        sql_builder.AfterPrevValues(
-            [('x', 3), ('y', 5), ('z', 7)], inclusive=True),
-        'x = %(x_5)s AND (y = %(y_4)s AND z >= %(z_3)s OR y > %(y_4)s) '
-        'OR x > %(x_5)s',
-        dict(x_5=3, y_4=5, z_3=7),
+        sql_builder.TupleGreaterEqual([('x', 3), ('y', 5), ('z', 7)]),
+        '(x, y, z) >= (%(x_3)s, %(y_4)s, %(z_5)s)',
+        dict(x_3=3, y_4=5, z_5=7),
         column_name=None)
     self._check_build_where_sql(
-        sql_builder.AfterPrevValues([('x', 3), ('y', 5), ('z', 7)], asc=False),
-        'x = %(x_5)s AND (y = %(y_4)s AND z < %(z_3)s OR y < %(y_4)s) '
-        'OR x < %(x_5)s',
-        dict(x_5=3, y_4=5, z_3=7),
+        sql_builder.TupleLess([('x', 3), ('y', 5), ('z', 7)]),
+        '(x, y, z) < (%(x_3)s, %(y_4)s, %(z_5)s)',
+        dict(x_3=3, y_4=5, z_5=7),
+        column_name=None)
+    self._check_build_where_sql(
+        sql_builder.TupleLessEqual([('x', 3), ('y', 5), ('z', 7)]),
+        '(x, y, z) <= (%(x_3)s, %(y_4)s, %(z_5)s)',
+        dict(x_3=3, y_4=5, z_5=7),
         column_name=None)
 
   def test_greater_than(self):


### PR DESCRIPTION
Use tuple-comparison instead of complex boolean expression. Add
helper classes TupleGreater, TupleGreaterEqual, TupleLess, TupleLessEqual.

Note: AfterPrevValues is not used by clients yet.