### PR TITLE
Add a reason message when killing queries

### DIFF
--- a/go/vt/tabletserver/dbconn.go
+++ b/go/vt/tabletserver/dbconn.go
@@ -138,9 +138,9 @@ func (dbc *DBConn) Recycle() {
 // Kill kills the currently executing query both on MySQL side
 // and on the connection side. If no query is executing, it's a no-op.
 // Kill will also not kill a query more than once.
-func (dbc *DBConn) Kill() error {
+func (dbc *DBConn) Kill(reason string) error {
 	dbc.queryServiceStats.KillStats.Add("Queries", 1)
-	log.Infof("killing query %s", dbc.Current())
+	log.Infof("Due to %s, killing query %s", reason, dbc.Current())
 	killConn, err := dbc.pool.dbaPool.Get(0)
 	if err != nil {
 		log.Warningf("Failed to get conn from dba pool: %v", err)
@@ -194,7 +194,7 @@ func (dbc *DBConn) setDeadline(ctx context.Context) chan bool {
 				return
 			default:
 			}
-			dbc.Kill()
+			dbc.Kill(ctx.Err().Error())
 		case <-done:
 			return
 		}

--- a/go/vt/tabletserver/dbconn_test.go
+++ b/go/vt/tabletserver/dbconn_test.go
@@ -67,12 +67,12 @@ func TestDBConnKill(t *testing.T) {
 	db.AddQuery(query, &sqltypes.Result{})
 	// Kill failed because we are not able to connect to the database
 	db.EnableConnFail()
-	err = dbConn.Kill()
+	err = dbConn.Kill("test kill")
 	testUtils.checkTabletError(t, err, ErrFail, "Failed to get conn from dba pool")
 	db.DisableConnFail()
 
 	// Kill succeed
-	err = dbConn.Kill()
+	err = dbConn.Kill("test kill")
 	if err != nil {
 		t.Fatalf("kill should succeed, but got error: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestDBConnKill(t *testing.T) {
 	newKillQuery := fmt.Sprintf("kill %d", dbConn.ID())
 	// Kill failed because "kill query_id" failed
 	db.AddRejectedQuery(newKillQuery, errRejected)
-	err = dbConn.Kill()
+	err = dbConn.Kill("test kill")
 	testUtils.checkTabletError(t, err, ErrFail, "Could not kill query")
 
 }

--- a/go/vt/tabletserver/query_list.go
+++ b/go/vt/tabletserver/query_list.go
@@ -22,7 +22,7 @@ type QueryDetail struct {
 type killable interface {
 	Current() string
 	ID() int64
-	Kill() error
+	Kill(string) error
 }
 
 // NewQueryDetail creates a new QueryDetail
@@ -63,7 +63,7 @@ func (ql *QueryList) Terminate(connID int64) error {
 	if qd == nil {
 		return fmt.Errorf("query %v not found", connID)
 	}
-	qd.conn.Kill()
+	qd.conn.Kill("QueryList.Terminate()")
 	return nil
 }
 
@@ -72,7 +72,7 @@ func (ql *QueryList) TerminateAll() {
 	ql.mu.Lock()
 	defer ql.mu.Unlock()
 	for _, qd := range ql.queryDetails {
-		qd.conn.Kill()
+		qd.conn.Kill("QueryList.TerminateAll()")
 	}
 }
 

--- a/go/vt/tabletserver/query_list_test.go
+++ b/go/vt/tabletserver/query_list_test.go
@@ -16,7 +16,7 @@ func (tc *testConn) Current() string { return tc.query }
 
 func (tc *testConn) ID() int64 { return tc.id }
 
-func (tc *testConn) Kill() error {
+func (tc *testConn) Kill(string) error {
 	tc.killed = true
 	return nil
 }


### PR DESCRIPTION
@sougou @erzel 

Couldn't think of a cleaner way to do this.