### PR TITLE
java: Remove "notInTransaction" parameter from transaction Execute* methods.

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -165,6 +165,12 @@ public class VTGateConn implements Closeable {
     return new SimpleCursor(response.getResult());
   }
 
+  /**
+   * Execute multiple keyspace ID queries as a batch.
+   *
+   * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
+   * the batch queries.
+   */
   public List<Cursor> executeBatchShards(Context ctx, Iterable<? extends BoundShardQuery> queries,
       TabletType tabletType, boolean asTransaction) throws SQLException {
     ExecuteBatchShardsRequest.Builder requestBuilder =
@@ -180,6 +186,12 @@ public class VTGateConn implements Closeable {
     return Proto.toCursorList(response.getResultsList());
   }
 
+  /**
+   * Execute multiple keyspace ID queries as a batch.
+   *
+   * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
+   * the batch queries.
+   */
   public List<Cursor> executeBatchKeyspaceIds(Context ctx,
       Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
       boolean asTransaction) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -47,8 +47,8 @@ public class VTGateTx {
     return new VTGateTx(client, session);
   }
 
-  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType,
-      boolean notInTransaction) throws SQLException {
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("execute: not in transaction");
     }
@@ -56,7 +56,6 @@ public class VTGateTx {
         ExecuteRequest.newBuilder()
             .setQuery(Proto.bindQuery(query, bindVars))
             .setTabletType(tabletType)
-            .setNotInTransaction(notInTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -68,7 +67,7 @@ public class VTGateTx {
   }
 
   public Cursor executeShards(Context ctx, String query, String keyspace, Iterable<String> shards,
-      Map<String, ?> bindVars, TabletType tabletType, boolean notInTransaction)
+      Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeShards: not in transaction");
@@ -79,7 +78,6 @@ public class VTGateTx {
             .setKeyspace(keyspace)
             .addAllShards(shards)
             .setTabletType(tabletType)
-            .setNotInTransaction(notInTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -91,8 +89,8 @@ public class VTGateTx {
   }
 
   public Cursor executeKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
-      boolean notInTransaction) throws SQLException {
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeKeyspaceIds: not in transaction");
     }
@@ -102,7 +100,6 @@ public class VTGateTx {
             .setKeyspace(keyspace)
             .addAllKeyspaceIds(Iterables.transform(keyspaceIds, Proto.BYTE_ARRAY_TO_BYTE_STRING))
             .setTabletType(tabletType)
-            .setNotInTransaction(notInTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -114,8 +111,8 @@ public class VTGateTx {
   }
 
   public Cursor executeKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
-      boolean notInTransaction) throws SQLException {
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeKeyRanges: not in transaction");
     }
@@ -125,7 +122,6 @@ public class VTGateTx {
             .setKeyspace(keyspace)
             .addAllKeyRanges(keyRanges)
             .setTabletType(tabletType)
-            .setNotInTransaction(notInTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -138,7 +134,7 @@ public class VTGateTx {
 
   public Cursor executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
-      TabletType tabletType, boolean notInTransaction) throws SQLException {
+      TabletType tabletType) throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeEntityIds: not in transaction");
     }
@@ -150,7 +146,6 @@ public class VTGateTx {
             .addAllEntityKeyspaceIds(Iterables.transform(
                 entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
             .setTabletType(tabletType)
-            .setNotInTransaction(notInTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -162,7 +157,7 @@ public class VTGateTx {
   }
 
   public List<Cursor> executeBatchShards(Context ctx, Iterable<? extends BoundShardQuery> queries,
-      TabletType tabletType, boolean asTransaction) throws SQLException {
+      TabletType tabletType) throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeBatchShards: not in transaction");
     }
@@ -170,7 +165,6 @@ public class VTGateTx {
         ExecuteBatchShardsRequest.newBuilder()
             .addAllQueries(queries)
             .setTabletType(tabletType)
-            .setAsTransaction(asTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
@@ -182,8 +176,7 @@ public class VTGateTx {
   }
 
   public List<Cursor> executeBatchKeyspaceIds(Context ctx,
-      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType) throws SQLException {
     if (!inTransaction()) {
       throw new SQLDataException("executeBatchKeyspaceIds: not in transaction");
     }
@@ -191,7 +184,6 @@ public class VTGateTx {
         ExecuteBatchKeyspaceIdsRequest.newBuilder()
             .addAllQueries(queries)
             .setTabletType(tabletType)
-            .setAsTransaction(asTransaction)
             .setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -258,16 +258,16 @@ public abstract class RpcClientTest {
 
     VTGateTx tx = conn.begin(ctx);
 
-    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, true));
+    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("notInTransaction"));
+    Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(
-        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, true));
+        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -275,10 +275,10 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("notInTransaction"));
+    Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyspaceIds(
-        ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, true));
+        ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -286,10 +286,10 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("notInTransaction"));
+    Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyRanges(
-        ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, true));
+        ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -297,10 +297,10 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("notInTransaction"));
+    Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
-        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, true));
+        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -309,14 +309,14 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("notInTransaction"));
+    Assert.assertEquals("false", echo.get("notInTransaction"));
 
     tx.rollback(ctx);
     tx = conn.begin(ctx);
 
     echo = getEcho(tx.executeBatchShards(ctx, Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS,
                                                   ECHO_PREFIX + QUERY, BIND_VARS)),
-                         TABLET_TYPE, true).get(0));
+                         TABLET_TYPE).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -324,12 +324,12 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("asTransaction"));
+    Assert.assertEquals("false", echo.get("asTransaction"));
 
     echo =
         getEcho(tx.executeBatchKeyspaceIds(ctx, Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE,
                                                     KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-                      TABLET_TYPE, true).get(0));
+                      TABLET_TYPE).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -337,7 +337,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
-    Assert.assertEquals("true", echo.get("asTransaction"));
+    Assert.assertEquals("false", echo.get("asTransaction"));
 
     tx.commit(ctx);
   }
@@ -559,40 +559,39 @@ public abstract class RpcClientTest {
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
-        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE, true);
+        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
-        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, true);
+        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
-        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, true);
+        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
-        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, true);
+        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
         tx.executeEntityIds(
-            ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, true);
+            ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateTx tx, String query) throws Exception {
         tx.executeBatchShards(ctx,
-            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE,
-            true);
+            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
@@ -600,7 +599,7 @@ public abstract class RpcClientTest {
       void execute(VTGateTx tx, String query) throws Exception {
         tx.executeBatchKeyspaceIds(ctx,
             Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-            TABLET_TYPE, true);
+            TABLET_TYPE);
       }
     });
   }

--- a/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
@@ -53,7 +53,7 @@ public class VitessClientExample {
       System.out.println("Inserting into master...");
       VTGateTx tx = conn.begin(ctx);
       tx.executeShards(ctx, "INSERT INTO test_table (msg) VALUES (:msg)", keyspace, shards,
-          bindVars, TabletType.MASTER, false /* notInTransaction (ignore this because we will soon remove it) */);
+          bindVars, TabletType.MASTER);
       tx.commit(ctx);
 
       // Read it back from the master.


### PR DESCRIPTION
@enisoc 

The underlying protobuf field is not used in open-source and therefore we don't want to expose it in our API.

Since the protobuf field will no longer be set, proto3 should always return "false" as zero value for it.