### PR TITLE
php: Remove not_in_transaction parameter.

### DIFF
--- a/php/src/Vitess/VTGateConn.php
+++ b/php/src/Vitess/VTGateConn.php
@@ -5,6 +5,7 @@ class VTGateConn
 {
 
     /**
+     *
      * @var RpcClient
      */
     protected $client;
@@ -88,6 +89,13 @@ class VTGateConn
         return new Cursor($response->getResult());
     }
 
+    /**
+     * Execute multiple shard queries as a batch.
+     *
+     * @param boolean $as_transaction
+     *            If true, automatically create a transaction (per shard) that
+     *            encloses all the batch queries.
+     */
     public function executeBatchShards(Context $ctx, array $bound_shard_queries, $tablet_type, $as_transaction)
     {
         $request = new Proto\Vtgate\ExecuteBatchShardsRequest();
@@ -106,6 +114,13 @@ class VTGateConn
         return $results;
     }
 
+    /**
+     * Execute multiple keyspace ID queries as a batch.
+     *
+     * @param boolean $as_transaction
+     *            If true, automatically create a transaction (per shard) that
+     *            encloses all the batch queries.
+     */
     public function executeBatchKeyspaceIds(Context $ctx, array $bound_keyspace_id_queries, $tablet_type, $as_transaction)
     {
         $request = new Proto\Vtgate\ExecuteBatchKeyspaceIdsRequest();

--- a/php/src/Vitess/VTGateTx.php
+++ b/php/src/Vitess/VTGateTx.php
@@ -19,7 +19,7 @@ class VTGateTx
         return ! is_null($this->session) && $this->session->getInTransaction();
     }
 
-    public function execute(Context $ctx, $query, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER, $not_in_transaction = FALSE)
+    public function execute(Context $ctx, $query, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -29,7 +29,6 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
-        $request->setNotInTransaction($not_in_transaction);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }
@@ -39,7 +38,7 @@ class VTGateTx
         return new Cursor($response->getResult());
     }
 
-    public function executeShards(Context $ctx, $query, $keyspace, array $shards, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER, $not_in_transaction = FALSE)
+    public function executeShards(Context $ctx, $query, $keyspace, array $shards, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -49,7 +48,6 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
-        $request->setNotInTransaction($not_in_transaction);
         $request->setKeyspace($keyspace);
         $request->setShards($shards);
         if ($ctx->getCallerId()) {
@@ -61,7 +59,7 @@ class VTGateTx
         return new Cursor($response->getResult());
     }
 
-    public function executeKeyspaceIds(Context $ctx, $query, $keyspace, array $keyspace_ids, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER, $not_in_transaction = FALSE)
+    public function executeKeyspaceIds(Context $ctx, $query, $keyspace, array $keyspace_ids, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -71,7 +69,6 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
-        $request->setNotInTransaction($not_in_transaction);
         $request->setKeyspace($keyspace);
         $request->setKeyspaceIds($keyspace_ids);
         if ($ctx->getCallerId()) {
@@ -83,7 +80,7 @@ class VTGateTx
         return new Cursor($response->getResult());
     }
 
-    public function executeKeyRanges(Context $ctx, $query, $keyspace, array $key_ranges, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER, $not_in_transaction = FALSE)
+    public function executeKeyRanges(Context $ctx, $query, $keyspace, array $key_ranges, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -93,7 +90,6 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
-        $request->setNotInTransaction($not_in_transaction);
         $request->setKeyspace($keyspace);
         ProtoUtils::addKeyRanges($request, $key_ranges);
         if ($ctx->getCallerId()) {
@@ -105,7 +101,7 @@ class VTGateTx
         return new Cursor($response->getResult());
     }
 
-    public function executeEntityIds(Context $ctx, $query, $keyspace, $entity_column_name, array $entity_keyspace_ids, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER, $not_in_transaction = FALSE)
+    public function executeEntityIds(Context $ctx, $query, $keyspace, $entity_column_name, array $entity_keyspace_ids, array $bind_vars, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -115,7 +111,6 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
-        $request->setNotInTransaction($not_in_transaction);
         $request->setKeyspace($keyspace);
         $request->setEntityColumnName($entity_column_name);
         ProtoUtils::addEntityKeyspaceIds($request, $entity_keyspace_ids);
@@ -128,7 +123,7 @@ class VTGateTx
         return new Cursor($response->getResult());
     }
 
-    public function executeBatchShards(Context $ctx, array $bound_shard_queries, $tablet_type = Proto\Topodata\TabletType::MASTER, $as_transaction = TRUE)
+    public function executeBatchShards(Context $ctx, array $bound_shard_queries, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -138,7 +133,6 @@ class VTGateTx
         $request->setSession($this->session);
         ProtoUtils::addQueries($request, $bound_shard_queries);
         $request->setTabletType($tablet_type);
-        $request->setAsTransaction($as_transaction);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }
@@ -152,7 +146,7 @@ class VTGateTx
         return $results;
     }
 
-    public function executeBatchKeyspaceIds(Context $ctx, array $bound_keyspace_id_queries, $tablet_type = Proto\Topodata\TabletType::MASTER, $as_transaction = TRUE)
+    public function executeBatchKeyspaceIds(Context $ctx, array $bound_keyspace_id_queries, $tablet_type = Proto\Topodata\TabletType::MASTER)
     {
         if (! $this->inTransaction()) {
             throw new \Vitess\Exception('execute called while not in transaction.');
@@ -162,7 +156,6 @@ class VTGateTx
         $request->setSession($this->session);
         ProtoUtils::addQueries($request, $bound_keyspace_id_queries);
         $request->setTabletType($tablet_type);
-        $request->setAsTransaction($as_transaction);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -285,15 +285,15 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
 
         $tx = $conn->begin($ctx);
 
-        $echo = $this->getEcho($tx->execute($ctx, self::$ECHO_QUERY, self::$BIND_VARS, self::$TABLET_TYPE, TRUE));
+        $echo = $this->getEcho($tx->execute($ctx, self::$ECHO_QUERY, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['notInTransaction']);
+        $this->assertEquals('false', $echo['notInTransaction']);
 
-        $echo = $this->getEcho($tx->executeShards($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$SHARDS, self::$BIND_VARS, self::$TABLET_TYPE, TRUE));
+        $echo = $this->getEcho($tx->executeShards($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$SHARDS, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
@@ -301,9 +301,9 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['notInTransaction']);
+        $this->assertEquals('false', $echo['notInTransaction']);
 
-        $echo = $this->getEcho($tx->executeKeyspaceIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE, TRUE));
+        $echo = $this->getEcho($tx->executeKeyspaceIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
@@ -311,9 +311,9 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['notInTransaction']);
+        $this->assertEquals('false', $echo['notInTransaction']);
 
-        $echo = $this->getEcho($tx->executeKeyRanges($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEY_RANGES, self::$BIND_VARS, self::$TABLET_TYPE, TRUE));
+        $echo = $this->getEcho($tx->executeKeyRanges($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEY_RANGES, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
@@ -321,9 +321,9 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['notInTransaction']);
+        $this->assertEquals('false', $echo['notInTransaction']);
 
-        $echo = $this->getEcho($tx->executeEntityIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$ENTITY_COLUMN_NAME, self::$ENTITY_KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE, TRUE));
+        $echo = $this->getEcho($tx->executeEntityIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$ENTITY_COLUMN_NAME, self::$ENTITY_KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
@@ -332,14 +332,14 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['notInTransaction']);
+        $this->assertEquals('false', $echo['notInTransaction']);
 
         $tx->rollback($ctx);
         $tx = $conn->begin($ctx);
 
         $results = $tx->executeBatchShards($ctx, array(
             ProtoUtils::BoundShardQuery(self::$ECHO_QUERY, self::$BIND_VARS, self::$KEYSPACE, self::$SHARDS)
-        ), self::$TABLET_TYPE, TRUE);
+        ), self::$TABLET_TYPE);
         $echo = $this->getEcho($results[0]);
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
@@ -348,11 +348,11 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['asTransaction']);
+        $this->assertEquals('false', $echo['asTransaction']);
 
         $results = $tx->executeBatchKeyspaceIds($ctx, array(
             ProtoUtils::BoundKeyspaceIdQuery(self::$ECHO_QUERY, self::$BIND_VARS, self::$KEYSPACE, self::$KEYSPACE_IDS)
-        ), self::$TABLET_TYPE, TRUE);
+        ), self::$TABLET_TYPE);
         $echo = $this->getEcho($results[0]);
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
@@ -361,7 +361,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
-        $this->assertEquals('true', $echo['asTransaction']);
+        $this->assertEquals('false', $echo['asTransaction']);
 
         $tx->commit($ctx);
     }


### PR DESCRIPTION
@michael-berlin 

This parameter is deprecated, so we should not expose it in the new
clients.

Also removing as_transaction from `executeBatch*()` methods in VTGateTx
since that parameter doesn't make sense when you're calling
`executeBatch*()` on a VTGateTx object. If you want as_transaction, you
should call `executeBatch*()` directly on VTGateConn.