### PR TITLE
Py keyspace

### DIFF
--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -19,13 +19,16 @@ from vtdb import vtgate_client
 from vtdb import grpc_vtgate_client  # pylint: disable=unused-import
 
 
-def exec_query(conn, title, query, response, keyspace=None, kr=None):
+def exec_query(conn, title, query, response, keyspace=None, kr=None):  # pylint: disable=missing-docstring
   if kr:
     # v2 cursor to address individual shards directly, for debug display
-    cursor = conn.cursor(keyspace, "master", keyranges=[keyrange.KeyRange(kr)])
+    cursor = conn.cursor(
+        tablet_type="master", keyspace=keyspace,
+        keyranges=[keyrange.KeyRange(kr)])
   else:
     # v3 cursor is automated
-    cursor = conn.cursor(keyspace, "master", writable=True)
+    cursor = conn.cursor(
+        tablet_type="master", keyspace=keyspace, writable=True)
 
   try:
     if not query or query == "undefined":
@@ -44,14 +47,14 @@ def exec_query(conn, title, query, response, keyspace=None, kr=None):
         "results": cursor.results,
         }
     cursor.close()
-  except Exception as e:
+  except Exception as e:  # pylint: disable=broad-except
     response[title] = {
         "title": title,
         "error": str(e),
         }
 
 
-def capture_log(port, queries):
+def capture_log(port, queries):  # pylint: disable=missing-docstring
   p = subprocess.Popen(
       ["curl", "-s", "-N", "http://localhost:%d/debug/querylog" % port],
       stdout=subprocess.PIPE)
@@ -131,7 +134,7 @@ def main():
         keyspace="lookup", kr="-")
 
     print json.dumps(response)
-  except Exception as e:
+  except Exception as e:  # pylint: disable=broad-except
     print json.dumps({"error": str(e)})
 
 

--- a/examples/kubernetes/guestbook/main.py
+++ b/examples/kubernetes/guestbook/main.py
@@ -1,3 +1,5 @@
+"""Main python file."""
+
 import os
 import time
 import json
@@ -10,13 +12,14 @@ app = Flask(__name__)
 from vtdb import vtgate_client
 
 # Register gRPC protocol.
-from vtdb import grpc_vtgate_client # pylint: disable=unused-import
+from vtdb import grpc_vtgate_client  # pylint: disable=unused-import
 
 # conn is the connection to vtgate.
 conn = None
 
 # When using the "uint64" keyspace_id type, Vitess expects big-endian encoding.
 uint64 = struct.Struct('!Q')
+
 
 def get_keyspace_id(page):
   """Compute the keyspace_id for a given page number.
@@ -31,72 +34,91 @@ def get_keyspace_id(page):
   For more about keyspace_id, see these references:
   - http://vitess.io/overview/concepts.html#keyspace-id
   - http://vitess.io/user-guide/sharding.html
+
+  Args:
+    page: Int page number.
+
+  Returns:
+    8-byte md5 of packed page number.
   """
   m = hashlib.md5()
   m.update(uint64.pack(page))
   return m.digest()[:8]
 
+
 def unpack_keyspace_id(keyspace_id):
   """Return the corresponding 64-bit unsigned integer for a keyspace_id."""
   return uint64.unpack(keyspace_id)[0]
 
-@app.route("/")
+
+@app.route('/')
 def index():
   return app.send_static_file('index.html')
 
-@app.route("/page/<int:page>")
+
+@app.route('/page/<int:page>')
 def view(page):
+  _ = page
   return app.send_static_file('index.html')
 
-@app.route("/lrange/guestbook/<int:page>")
+
+@app.route('/lrange/guestbook/<int:page>')
 def list_guestbook(page):
-  # Read the list from a replica.
+  """Read the list from a replica."""
   keyspace_id = get_keyspace_id(page)
-  cursor = conn.cursor('test_keyspace', 'replica', keyspace_ids=[keyspace_id])
+  cursor = conn.cursor(
+      tablet_type='replica', keyspace='test_keyspace',
+      keyspace_ids=[keyspace_id])
 
   cursor.execute(
-      'SELECT message FROM messages WHERE page=%(page)s ORDER BY time_created_ns',
+      'SELECT message FROM messages WHERE page=%(page)s'
+      ' ORDER BY time_created_ns',
       {'page': page})
   entries = [row[0] for row in cursor.fetchall()]
   cursor.close()
 
   return json.dumps(entries)
 
-@app.route("/rpush/guestbook/<int:page>/<value>")
+
+@app.route('/rpush/guestbook/<int:page>/<value>')
 def add_entry(page, value):
-  # Insert a row on the master.
+  """Insert a row on the master."""
   keyspace_id = get_keyspace_id(page)
   keyspace_id_int = unpack_keyspace_id(keyspace_id)
-  cursor = conn.cursor('test_keyspace', 'master', keyspace_ids=[keyspace_id], writable=True)
+  cursor = conn.cursor(
+      tablet_type='master', keyspace='test_keyspace',
+      keyspace_ids=[keyspace_id], writable=True)
 
   cursor.begin()
   cursor.execute(
       'INSERT INTO messages (page, time_created_ns, keyspace_id, message)'
       ' VALUES (%(page)s, %(time_created_ns)s, %(keyspace_id)s, %(message)s)',
       {
-        'page': page,
-        'time_created_ns': int(time.time() * 1e9),
-        'keyspace_id': keyspace_id_int,
-        'message': value,
+          'page': page,
+          'time_created_ns': int(time.time() * 1e9),
+          'keyspace_id': keyspace_id_int,
+          'message': value,
       })
   cursor.commit()
 
   # Read the list back from master (critical read) because it's
   # important that the user sees his own addition immediately.
   cursor.execute(
-      'SELECT message FROM messages WHERE page=%(page)s ORDER BY time_created_ns',
+      'SELECT message FROM messages WHERE page=%(page)s'
+      ' ORDER BY time_created_ns',
       {'page': page})
   entries = [row[0] for row in cursor.fetchall()]
   cursor.close()
 
   return json.dumps(entries)
 
-@app.route("/env")
+
+@app.route('/env')
 def env():
   return json.dumps(dict(os.environ))
 
-if __name__ == "__main__":
-  timeout = 10 # connect timeout in seconds
+if __name__ == '__main__':
+  timeout = 10  # connect timeout in seconds
 
   # Get vtgate service address from Kubernetes DNS.
   addr = 'vtgate-test:15991'

--- a/examples/local/client.py
+++ b/examples/local/client.py
@@ -35,8 +35,9 @@ conn = vtgate_client.connect('grpc', args.server, args.timeout)
 try:
   # Insert something.
   print 'Inserting into master...'
-  cursor = conn.cursor('test_keyspace', 'master',
-                       keyranges=UNSHARDED, writable=True)
+  cursor = conn.cursor(
+      tablet_type='master', keyspace='test_keyspace',
+      keyranges=UNSHARDED, writable=True)
   cursor.begin()
   cursor.execute(
       'INSERT INTO test_table (msg) VALUES (%(msg)s)',
@@ -54,8 +55,8 @@ try:
   # Read from a replica.
   # Note that this may be behind master due to replication lag.
   print 'Reading from replica...'
-  cursor = conn.cursor('test_keyspace', 'replica',
-                       keyranges=UNSHARDED)
+  cursor = conn.cursor(
+      tablet_type='replica', keyspace='test_keyspace', keyranges=UNSHARDED)
   cursor.execute('SELECT * FROM test_table', {})
   for row in cursor.fetchall():
     print row

--- a/py/vtdb/grpc_vtgate_client.py
+++ b/py/vtdb/grpc_vtgate_client.py
@@ -108,12 +108,11 @@ class GRPCVTGateConnection(vtgate_client.VTGateClient):
       self.effective_caller_id = None
 
   @vtgate_utils.exponential_backoff_retry((dbexceptions.TransientError))
-  def _execute(self, sql, bind_variables, keyspace_name, tablet_type,
-               shards=None,
-               keyspace_ids=None,
-               keyranges=None,
-               entity_keyspace_id_map=None, entity_column_name=None,
-               not_in_transaction=False, effective_caller_id=None, **kwargs):
+  def _execute(
+      self, sql, bind_variables, tablet_type, keyspace_name=None,
+      shards=None, keyspace_ids=None, keyranges=None,
+      entity_keyspace_id_map=None, entity_column_name=None,
+      not_in_transaction=False, effective_caller_id=None, **kwargs):
 
     # FIXME(alainjobart): keyspace should be in routing_kwargs,
     # as it's not used for v3.
@@ -289,7 +288,7 @@ class GRPCVTGateConnection(vtgate_client.VTGateClient):
 
   @vtgate_utils.exponential_backoff_retry((dbexceptions.TransientError))
   def _stream_execute(
-      self, sql, bind_variables, keyspace_name, tablet_type,
+      self, sql, bind_variables, tablet_type, keyspace_name=None,
       shards=None, keyspace_ids=None, keyranges=None,
       not_in_transaction=False, effective_caller_id=None,
       **kwargs):

--- a/py/vtdb/vtgate_client.py
+++ b/py/vtdb/vtgate_client.py
@@ -180,7 +180,7 @@ class VTGateClient(object):
     raise NotImplementedError('Child class needs to implement this')
 
   def _execute(self, sql, bind_variables, tablet_type,
-               keyspace=None,
+               keyspace_name=None,
                shards=None,
                keyspace_ids=None,
                keyranges=None,
@@ -195,7 +195,7 @@ class VTGateClient(object):
       sql: query to execute.
       bind_variables: map of bind variables for the query.
       tablet_type: the (string) version of the tablet type.
-      keyspace: if specified, the keyspace to send the query to.
+      keyspace_name: if specified, the keyspace to send the query to.
         Required if any of the routing parameters is used.
         Not required only if using vtgate v3 API.
       shards: if specified, use this list of shards names to route the query.

--- a/py/vtdb/vtgate_cursor.py
+++ b/py/vtdb/vtgate_cursor.py
@@ -35,14 +35,15 @@ class VTGateCursor(base_cursor.BaseListCursor, VTGateCursorMixin):
   """
 
   def __init__(
-      self, connection, keyspace, tablet_type, shards=None, keyspace_ids=None,
-      keyranges=None, writable=False, as_transaction=False):
+      self, connection, tablet_type, keyspace=None,
+      shards=None, keyspace_ids=None, keyranges=None,
+      writable=False, as_transaction=False):
     """Init VTGateCursor.
 
     Args:
       connection: A PEP0249 connection object.
-      keyspace: Str keyspace or None if batch API will be used.
       tablet_type: Str tablet_type.
+      keyspace: Str keyspace or None if batch API will be used.
       shards: List of strings.
       keyspace_ids: Struct('!Q').packed keyspace IDs.
       keyranges: Str keyranges.
@@ -215,7 +216,8 @@ class StreamVTGateCursor(base_cursor.BaseStreamCursor, VTGateCursorMixin):
   """
 
   def __init__(
-      self, connection, keyspace, tablet_type, shards=None, keyspace_ids=None,
+      self, connection, tablet_type, keyspace=None,
+      shards=None, keyspace_ids=None,
       keyranges=None, writable=False):
     super(StreamVTGateCursor, self).__init__()
     self._conn = connection

--- a/py/vtdb/vtgate_cursor.py
+++ b/py/vtdb/vtgate_cursor.py
@@ -89,8 +89,8 @@ class VTGateCursor(base_cursor.BaseListCursor, VTGateCursorMixin):
         self.connection._execute(  # pylint: disable=protected-access
             sql,
             bind_variables,
-            self.keyspace,
-            self.tablet_type,
+            tablet_type=self.tablet_type,
+            keyspace_name=self.keyspace,
             shards=self.shards,
             keyspace_ids=self.keyspace_ids,
             keyranges=self.keyranges,
@@ -240,8 +240,8 @@ class StreamVTGateCursor(base_cursor.BaseStreamCursor, VTGateCursorMixin):
     self.generator, self.description = self.connection._stream_execute(  # pylint: disable=protected-access
         sql,
         bind_variables,
-        self.keyspace,
-        self.tablet_type,
+        tablet_type=self.tablet_type,
+        keyspace_name=self.keyspace,
         shards=self.shards,
         keyspace_ids=self.keyspace_ids,
         keyranges=self.keyranges,

--- a/py/vtdb/vtgatev2.py
+++ b/py/vtdb/vtgatev2.py
@@ -273,7 +273,7 @@ class VTGateConnection(vtgate_client.VTGateClient):
 
   @vtgate_utils.exponential_backoff_retry((dbexceptions.TransientError))
   def _execute(
-      self, sql, bind_variables, keyspace_name, tablet_type,
+      self, sql, bind_variables, tablet_type, keyspace_name=None,
       shards=None, keyspace_ids=None, keyranges=None,
       entity_keyspace_id_map=None, entity_column_name=None,
       not_in_transaction=False, effective_caller_id=None, **kwargs):
@@ -283,8 +283,8 @@ class VTGateConnection(vtgate_client.VTGateClient):
       sql: The sql text, with %(format)s-style tokens.
       bind_variables: (str: value) dict of bind variables corresponding
         to sql %(format)s tokens.
-      keyspace_name: Str name of keyspace.
       tablet_type: Str tablet type (e.g. master, rdonly, replica).
+      keyspace_name: Str name of keyspace.
       shards: list of shard names as strings.
       keyspace_ids: bytes list of keyspace ID lists.
       keyranges: KeyRange objects.
@@ -495,7 +495,7 @@ class VTGateConnection(vtgate_client.VTGateClient):
 
   @vtgate_utils.exponential_backoff_retry((dbexceptions.TransientError))
   def _stream_execute(
-      self, sql, bind_variables, keyspace_name, tablet_type,
+      self, sql, bind_variables, tablet_type, keyspace_name=None,
       shards=None, keyspace_ids=None, keyranges=None,
       not_in_transaction=False, effective_caller_id=None,
       **kwargs):
@@ -507,8 +507,8 @@ class VTGateConnection(vtgate_client.VTGateClient):
     Args:
       sql: Str sql.
       bind_variables: A (str: value) dict.
-      keyspace_name: Str keyspace name.
       tablet_type: Str tablet_type.
+      keyspace_name: Str keyspace name.
       shards: List of strings.
       keyspace_ids: List of uint64 or bytes keyspace_ids.
       keyranges: KeyRange objects.
@@ -734,7 +734,7 @@ def connect(vtgate_addrs, timeout, user=None, password=None):
       conn = VTGateConnection(**db_params)
       conn.dial()
       return conn
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
       db_exception = e
       logging.warning('db connection failed: %s, %s', host_addr, e)
 

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -74,7 +74,7 @@ class TestCustomSharding(unittest.TestCase):
     sql = 'insert into ' + table + '(id, name) values (%(id)s, %(name)s)'
     conn = self._vtdb_conn()
     cursor = conn.cursor(
-        'test_keyspace', 'master',
+        tablet_type='master', keyspace='test_keyspace',
         shards=[shard],
         writable=True)
     for x in xrange(count):
@@ -91,7 +91,7 @@ class TestCustomSharding(unittest.TestCase):
     sql = 'select name from ' + table + ' where id=%(id)s'
     conn = self._vtdb_conn()
     cursor = conn.cursor(
-        'test_keyspace', 'master',
+        tablet_type='master', keyspace='test_keyspace',
         shards=[shard])
     for x in xrange(count):
       bindvars = {

--- a/test/python_client_test.py
+++ b/test/python_client_test.py
@@ -88,38 +88,41 @@ class TestPythonClientBase(unittest.TestCase):
 
   def _open_shards_cursor(self):
     return self.conn.cursor(
-        'keyspace', 'master', shards=['-80'])
+        tablet_type='master', keyspace='keyspace', shards=['-80'])
 
   def _open_keyspace_ids_cursor(self):
     return self.conn.cursor(
-        'keyspace', 'master', keyspace_ids=[self.KEYSPACE_ID_0X80])
+        tablet_type='master', keyspace='keyspace',
+        keyspace_ids=[self.KEYSPACE_ID_0X80])
 
   def _open_keyranges_cursor(self):
     kr = keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)
-    return self.conn.cursor('keyspace', 'master', keyranges=[kr])
+    return self.conn.cursor(
+        tablet_type='master', keyspace='keyspace', keyranges=[kr])
 
   def _open_batch_cursor(self):
-    return self.conn.cursor(keyspace=None, tablet_type='master')
+    return self.conn.cursor(tablet_type='master', keyspace=None)
 
   def _open_stream_v3_cursor(self):
     return self.conn.cursor(
-        keyspace=None, tablet_type='master',
+        tablet_type='master', keyspace=None,
         cursorclass=vtgate_cursor.StreamVTGateCursor)
 
   def _open_stream_shards_cursor(self):
     return self.conn.cursor(
-        'keyspace', 'master', shards=['-80'],
+        tablet_type='master', keyspace='keyspace', shards=['-80'],
         cursorclass=vtgate_cursor.StreamVTGateCursor)
 
   def _open_stream_keyspace_ids_cursor(self):
     return self.conn.cursor(
-        'keyspace', 'master', keyspace_ids=[self.KEYSPACE_ID_0X80],
+        tablet_type='master', keyspace='keyspace',
+        keyspace_ids=[self.KEYSPACE_ID_0X80],
         cursorclass=vtgate_cursor.StreamVTGateCursor)
 
   def _open_stream_keyranges_cursor(self):
     kr = keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)
     return self.conn.cursor(
-        'keyspace', 'master', keyranges=[kr],
+        tablet_type='master', keyspace='keyspace', keyranges=[kr],
         cursorclass=vtgate_cursor.StreamVTGateCursor)
 
 
@@ -173,7 +176,7 @@ class TestErrors(TestPythonClientBase):
     cursor.close()
 
     # ExecuteEntityIds test
-    cursor = self.conn.cursor('keyspace', 'master')
+    cursor = self.conn.cursor(tablet_type='master', keyspace='keyspace')
     with self.assertRaises(exception):
       cursor.execute(
           query, {},
@@ -387,7 +390,7 @@ class TestCallerId(TestPythonClientBase):
           entity_column_name='user_id')
 
     check_good_and_bad_effective_caller_ids(
-        self.conn.cursor('keyspace', 'master'),
+        self.conn.cursor(tablet_type='master', keyspace='keyspace'),
         cursor_execute_entity_ids_method)
 
     # test ExecuteBatchKeyspaceIds
@@ -505,7 +508,7 @@ class TestEcho(TestPythonClientBase):
   def test_echo_execute(self):
 
     # Execute
-    cursor = self.conn.cursor(keyspace=None, tablet_type=self.tablet_type)
+    cursor = self.conn.cursor(tablet_type=self.tablet_type, keyspace=None)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.execute(self.echo_prefix+self.query, self.bind_variables)
     self._check_echo(cursor, {
@@ -518,9 +521,9 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteShards
-    cursor = self.conn.cursor(keyspace=self.keyspace,
-                              tablet_type=self.tablet_type,
-                              shards=self.shards)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=self.keyspace,
+        shards=self.shards)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.execute(self.echo_prefix+self.query, self.bind_variables)
     self._check_echo(cursor, {
@@ -534,9 +537,9 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteKeyspaceIds
-    cursor = self.conn.cursor(keyspace=self.keyspace,
-                              tablet_type=self.tablet_type,
-                              keyspace_ids=self.keyspace_ids)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=self.keyspace,
+        keyspace_ids=self.keyspace_ids)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.execute(self.echo_prefix+self.query, self.bind_variables)
     self._check_echo(cursor, {
@@ -550,9 +553,9 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteKeyRanges
-    cursor = self.conn.cursor(keyspace=self.keyspace,
-                              tablet_type=self.tablet_type,
-                              keyranges=self.key_ranges)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=self.keyspace,
+        keyranges=self.key_ranges)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.execute(self.echo_prefix+self.query, self.bind_variables)
     self._check_echo(cursor, {
@@ -566,8 +569,8 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteEntityIds
-    cursor = self.conn.cursor(keyspace=self.keyspace,
-                              tablet_type=self.tablet_type)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=self.keyspace)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.execute(self.echo_prefix+self.query, self.bind_variables,
                    entity_keyspace_id_map=self.entity_keyspace_ids,
@@ -584,9 +587,9 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteBatchShards
-    cursor = self.conn.cursor(keyspace=None,
-                              tablet_type=self.tablet_type,
-                              as_transaction=True)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=None,
+        as_transaction=True)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.executemany(sql=None,
                        params_list=[
@@ -607,9 +610,9 @@ class TestEcho(TestPythonClientBase):
     cursor.close()
 
     # ExecuteBatchKeyspaceIds
-    cursor = self.conn.cursor(keyspace=None,
-                              tablet_type=self.tablet_type,
-                              as_transaction=True)
+    cursor = self.conn.cursor(
+        tablet_type=self.tablet_type, keyspace=None,
+        as_transaction=True)
     cursor.set_effective_caller_id(self.caller_id)
     cursor.executemany(sql=None,
                        params_list=[

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -318,7 +318,8 @@ index by_msg (msg)
       for tbl in moved_tables:
         try:
           rows = conn._execute(
-              'select * from %s' % tbl, {}, destination_ks, db_type,
+              'select * from %s' % tbl, {}, tablet_type=db_type,
+              keyspace_name=destination_ks,
               keyranges=[keyrange.KeyRange(
                   keyrange_constants.NON_PARTIAL_KEYRANGE)])
           logging.debug(

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -212,7 +212,7 @@ index by_msg (msg)
     result = self.insert_index
     conn = self._vtdb_conn()
     cursor = conn.cursor(
-        'source_keyspace', 'master',
+        tablet_type='master', keyspace='source_keyspace',
         keyranges=[keyrange.KeyRange(keyrange_constants.NON_PARTIAL_KEYRANGE)],
         writable=True)
     for _ in xrange(count):

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -263,7 +263,8 @@ class TestVTGateFunctions(unittest.TestCase):
   def test_user(self):
     count = 4
     vtgate_conn = get_connection()
-    cursor = vtgate_conn.cursor(None, 'master', writable=True)
+    cursor = vtgate_conn.cursor(
+        tablet_type='master', keyspace=None, writable=True)
 
     # Test insert
     for x in xrange(count):
@@ -361,10 +362,12 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test stream over scatter
     stream_cursor_1 = vtgate_conn.cursor(
-        None, 'master', cursorclass=vtgate_cursor.StreamVTGateCursor)
+        tablet_type='master', keyspace=None,
+        cursorclass=vtgate_cursor.StreamVTGateCursor)
     stream_cursor_1.execute('select * from vt_user', {})
     stream_cursor_2 = vtgate_conn.cursor(
-        None, 'master', cursorclass=vtgate_cursor.StreamVTGateCursor)
+        tablet_type='master', keyspace=None,
+        cursorclass=vtgate_cursor.StreamVTGateCursor)
     stream_cursor_2.execute('select * from vt_user', {})
     self.assertEqual(stream_cursor_1.description,
                      [('id', self.int_type), ('name', self.string_type)])

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -256,6 +256,10 @@ class TestVTGateFunctions(unittest.TestCase):
       self.int_type = 8L
       self.string_type = 253L
 
+  def _execute_on_master(self, vtgate_conn, sql, bind_vars):
+    return vtgate_conn._execute(
+        sql, bind_vars, tablet_type='master', keyspace_name=None)
+
   def test_user(self):
     count = 4
     vtgate_conn = get_connection()
@@ -286,15 +290,17 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test insert with no auto-inc, then auto-inc
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_user (id, name) values (:id, :name)',
         {'id': 6, 'name': 'test 6'},
-        keyspace_name=None, tablet_type='master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_user (name) values (:name)',
         {'name': 'test 7'},
-        keyspace_name=None, tablet_type='master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 7L, []))
     vtgate_conn.commit()
 
@@ -307,17 +313,19 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, ((1L,), (2L,), (3L,), (4L,), (6L,), (7L,)))
 
     # Test IN clause
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'select * from vt_user where id in (:a, :b)', {'a': 1, 'b': 4},
-        keyspace_name=None, tablet_type='master')
+        tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
         ([(1L, 'test 1'), (4L, 'test 4')], 2L, 0,
          [('id', self.int_type), ('name', self.string_type)]))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'select * from vt_user where id in (:a, :b)', {'a': 1, 'b': 2},
-        keyspace_name=None, tablet_type='master')
+        tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
@@ -329,9 +337,10 @@ class TestVTGateFunctions(unittest.TestCase):
     # causing the encoding to fail. Check with Sugu on what to do.
     # Maybe the keyrange should be HEX-encoded in the query to avoid the issue.
     if protocols_flavor().vtgate_python_protocol() != 'grpc':
-      result = vtgate_conn._execute(
+      result = self.execute_on_master(
+          vtgate_conn,
           "select * from vt_user where keyrange('', '\x80')", {},
-          keyspace_name=None, tablet_type='master')
+          tablet_type='master', keyspace_name=None)
       self.assertEqual(
           result,
           ([(1L, 'test 1'), (2L, 'test 2'), (3L, 'test 3')], 3L, 0,
@@ -339,7 +348,7 @@ class TestVTGateFunctions(unittest.TestCase):
 
       result = vtgate_conn._execute(
           "select * from vt_user where keyrange('\x80', '')", {},
-          keyspace_name=None, tablet_type='master')
+          tablet_type='master', keyspace_name=None)
       self.assertEqual(
           result,
           ([(4L, 'test 4'), (6L, 'test 6'), (7L, 'test 7')], 3L, 0,
@@ -347,7 +356,7 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test scatter
     result = vtgate_conn._execute(
-        'select * from vt_user', {}, keyspace_name=None, tablet_type='master')
+        'select * from vt_user', {}, tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
@@ -382,15 +391,17 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test updates
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_user set name = :name where id = :id',
         {'id': 1, 'name': 'test one'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_user set name = :name where id = :id',
         {'id': 4, 'name': 'test four'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user')
@@ -402,15 +413,17 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test deletes
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_user where id = :id',
         {'id': 1},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_user where id = :id',
         {'id': 4},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user')
@@ -424,20 +437,23 @@ class TestVTGateFunctions(unittest.TestCase):
     # user2 is for testing non-unique vindexes
     vtgate_conn = get_connection()
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_user2 (id, name) values (:id, :name)',
         {'id': 1, 'name': 'name1'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_user2 (id, name) values (:id, :name)',
         {'id': 7, 'name': 'name1'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_user2 (id, name) values (:id, :name)',
         {'id': 2, 'name': 'name2'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user2')
@@ -448,17 +464,19 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, (('name1', 1L), ('name1', 7L), ('name2', 2L)))
 
     # Test select by id
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'select * from vt_user2 where id = :id', {'id': 1},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(
         result, ([(1, 'name1')], 1L, 0,
                  [('id', self.int_type), ('name', self.string_type)]))
 
     # Test select by lookup
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'select * from vt_user2 where name = :name', {'name': 'name1'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
@@ -466,17 +484,19 @@ class TestVTGateFunctions(unittest.TestCase):
          [('id', self.int_type), ('name', self.string_type)]))
 
     # Test IN clause using non-unique vindex
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         "select * from vt_user2 where name in ('name1', 'name2')", {},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
         ([(1, 'name1'), (2, 'name2'), (7, 'name1')], 3L, 0,
          [('id', self.int_type), ('name', self.string_type)]))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         "select * from vt_user2 where name in ('name1')", {},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     result[0].sort()
     self.assertEqual(
         result,
@@ -485,15 +505,17 @@ class TestVTGateFunctions(unittest.TestCase):
 
     # Test delete
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_user2 where id = :id',
         {'id': 1},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_user2 where id = :id',
         {'id': 2},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user2')
@@ -510,18 +532,20 @@ class TestVTGateFunctions(unittest.TestCase):
     for x in xrange(count):
       i = x+1
       vtgate_conn.begin()
-      result = vtgate_conn._execute(
+      result = self.execute_on_master(
+          vtgate_conn,
           'insert into vt_user_extra (user_id, email) '
           'values (:user_id, :email)',
           {'user_id': i, 'email': 'test %s' % i},
-          None, 'master')
+          tablet_type='master', keyspace_name=None)
       self.assertEqual(result, ([], 1L, 0L, []))
       vtgate_conn.commit()
     for x in xrange(count):
       i = x+1
-      result = vtgate_conn._execute(
+      result = self.execute_on_master(
+          vtgate_conn,
           'select * from vt_user_extra where user_id = :user_id',
-          {'user_id': i}, None, 'master')
+          {'user_id': i}, tablet_type='master', keyspace_name=None)
       self.assertEqual(
           result,
           ([(i, 'test %s' % i)], 1L, 0,
@@ -532,15 +556,17 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, ((4L, 'test 4'),))
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_user_extra set email = :email where user_id = :user_id',
         {'user_id': 1, 'email': 'test one'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_user_extra set email = :email where user_id = :user_id',
         {'user_id': 4, 'email': 'test four'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user_extra')
@@ -549,15 +575,17 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, ((4L, 'test four'),))
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_user_extra where user_id = :user_id',
         {'user_id': 1},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from  vt_user_extra where user_id = :user_id',
         {'user_id': 4},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_user_extra')
@@ -572,17 +600,19 @@ class TestVTGateFunctions(unittest.TestCase):
     for x in xrange(count):
       i = x+1
       vtgate_conn.begin()
-      result = vtgate_conn._execute(
+      result = self.execute_on_master(
+          vtgate_conn,
           'insert into vt_music (user_id, song) values (:user_id, :song)',
           {'user_id': i, 'song': 'test %s' % i},
-          None, 'master')
+          tablet_type='master', keyspace_name=None)
       self.assertEqual(result, ([], 1L, i, []))
       vtgate_conn.commit()
     for x in xrange(count):
       i = x+1
-      result = vtgate_conn._execute(
+      result = self.execute_on_master(
+          vtgate_conn,
           'select * from vt_music where id = :id', {'id': i},
-          None, 'master')
+          tablet_type='master', keyspace_name=None)
       self.assertEqual(
           result,
           ([(i, i, 'test %s' % i)], 1, 0,
@@ -590,21 +620,24 @@ class TestVTGateFunctions(unittest.TestCase):
             ('id', self.int_type),
             ('song', self.string_type)]))
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_music (user_id, id, song) '
         'values (:user_id, :id, :song)',
         {'user_id': 5, 'id': 6, 'song': 'test 6'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_music (user_id, song) values (:user_id, :song)',
         {'user_id': 6, 'song': 'test 7'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 7L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_music (user_id, song) values (:user_id, :song)',
         {'user_id': 6, 'song': 'test 8'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 8L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_music')
@@ -621,15 +654,17 @@ class TestVTGateFunctions(unittest.TestCase):
         ((1L, 1L), (2L, 2L), (3L, 3L), (4L, 4L), (6L, 5L), (7L, 6L), (8L, 6L)))
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_music set song = :song where id = :id',
         {'id': 6, 'song': 'test six'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_music set song = :song where id = :id',
         {'id': 7, 'song': 'test seven'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_music')
@@ -642,15 +677,17 @@ class TestVTGateFunctions(unittest.TestCase):
                  (6L, 8L, 'test 8')))
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_music where id = :id',
         {'id': 3},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_music where user_id = :user_id',
         {'user_id': 6},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 2L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_music')
@@ -665,22 +702,25 @@ class TestVTGateFunctions(unittest.TestCase):
     # music_extra is for testing unonwed lookup index
     vtgate_conn = get_connection()
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_music_extra (music_id, user_id, artist) '
         'values (:music_id, :user_id, :artist)',
         {'music_id': 1, 'user_id': 1, 'artist': 'test 1'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'insert into vt_music_extra (music_id, artist) '
         'values (:music_id, :artist)',
         {'music_id': 6, 'artist': 'test 6'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
     vtgate_conn.commit()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'select * from vt_music_extra where music_id = :music_id',
-        {'music_id': 6}, None, 'master')
+        {'music_id': 6}, tablet_type='master', keyspace_name=None)
     self.assertEqual(
         result, ([(6L, 5L, 'test 6')], 1, 0,
                  [('music_id', self.int_type),
@@ -692,32 +732,36 @@ class TestVTGateFunctions(unittest.TestCase):
     self.assertEqual(result, ())
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_music_extra set artist = :artist '
         'where music_id = :music_id',
         {'music_id': 6, 'artist': 'test six'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'update vt_music_extra set artist = :artist '
         'where music_id = :music_id',
         {'music_id': 7, 'artist': 'test seven'},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 0L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_music_extra')
     self.assertEqual(result, ((1L, 1L, 'test 1'), (6L, 5L, 'test six')))
 
     vtgate_conn.begin()
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_music_extra where music_id = :music_id',
         {'music_id': 6},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 1L, 0L, []))
-    result = vtgate_conn._execute(
+    result = self.execute_on_master(
+        vtgate_conn,
         'delete from vt_music_extra where music_id = :music_id',
         {'music_id': 7},
-        None, 'master')
+        tablet_type='master', keyspace_name=None)
     self.assertEqual(result, ([], 0L, 0L, []))
     vtgate_conn.commit()
     result = shard_0_master.mquery('vt_user', 'select * from vt_music_extra')
@@ -729,10 +773,11 @@ class TestVTGateFunctions(unittest.TestCase):
       vtgate_conn.begin()
       with self.assertRaisesRegexp(
           dbexceptions.DatabaseError, '.*value must be supplied.*'):
-        vtgate_conn._execute(
+        self.execute_on_master(
+            vtgate_conn,
             'insert into vt_user_extra (email) values (:email)',
             {'email': 'test 10'},
-            None, 'master')
+            tablet_type='master', keyspace_name=None)
     finally:
       vtgate_conn.rollback()
 

--- a/test/vttest_sample_test.py
+++ b/test/vttest_sample_test.py
@@ -92,7 +92,8 @@ class TestMysqlctl(unittest.TestCase):
     row_id = 123
     keyspace_id = get_keyspace_id(row_id)
     cursor = conn.cursor(
-        'test_keyspace', 'master', keyspace_ids=[pack_kid(keyspace_id)],
+        tablet_type='master', keyspace='test_keyspace',
+        keyspace_ids=[pack_kid(keyspace_id)],
         writable=True)
     cursor.begin()
     insert = ('insert into test_table (id, msg, keyspace_id) values (%(id)s, '
@@ -132,7 +133,8 @@ class TestMysqlctl(unittest.TestCase):
     # Try to fetch a large number of rows
     # (more than one streaming result packet).
     stream_cursor = conn.cursor(
-        'test_keyspace', 'master', keyspace_ids=[pack_kid(keyspace_id)],
+        tablet_type='master', keyspace='test_keyspace',
+        keyspace_ids=[pack_kid(keyspace_id)],
         cursorclass=vtgate_cursor.StreamVTGateCursor)
     stream_cursor.execute('select * from test_table where id >= %(id_start)s',
                           {'id_start': id_start})


### PR DESCRIPTION
Change derived vtgate_client execute parameter order so that tablet_type precedes keyspace_name.