### PR TITLE
java/client: Return JDBC-compatible types for BIT and DATE/TIME

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
@@ -364,9 +364,9 @@ public class Row {
       case YEAR:
         return Short.valueOf(value.toStringUtf8());
       case ENUM: // fall through
-      case SET: // fall through
-      case BIT:
+      case SET:
         return value.toStringUtf8();
+      case BIT: // fall through
       case TEXT: // fall through
       case BLOB: // fall through
       case VARCHAR: // fall through

--- a/java/client/src/main/java/com/youtube/vitess/mysql/DateTime.java
+++ b/java/client/src/main/java/com/youtube/vitess/mysql/DateTime.java
@@ -1,0 +1,278 @@
+package com.youtube.vitess.mysql;
+
+import com.google.common.math.IntMath;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+/**
+ * Utility methods for processing MySQL TIME, DATE, DATETIME, and TIMESTAMP.
+ *
+ * <p>These provide functionality similar to {@code valueOf()} and {@code toString()}
+ * in {@link java.sql.Date} et al. The difference is that these support MySQL-specific
+ * syntax like fractional seconds, negative times, and hours > 24 for elapsed time.
+ */
+public class DateTime {
+  private static final String DATE_FORMAT = "yyyy-MM-dd";
+  private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+  private static final long SECONDS_TO_MILLIS = 1000L;
+  private static final long MINUTES_TO_MILLIS = 60L * SECONDS_TO_MILLIS;
+  private static final long HOURS_TO_MILLIS = 60L * MINUTES_TO_MILLIS;
+
+  /**
+   * Parse a MySQL DATE format into a {@link Date} with the default time zone.
+   *
+   * <p>This should match {@link Date#valueOf(String)}.
+   */
+  public static Date parseDate(String value) throws ParseException {
+    return parseDate(value, Calendar.getInstance());
+  }
+
+  /**
+   * Parse a MySQL DATE format into a {@link Date} with the given {@link Calendar}.
+   */
+  public static Date parseDate(String value, Calendar cal) throws ParseException {
+    DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+    dateFormat.setCalendar(cal);
+    return new Date(dateFormat.parse(value).getTime());
+  }
+
+  /**
+   * Format a {@link Date} as a MySQL DATE with the default time zone.
+   *
+   * <p>This should match {@link Date#toString()}.
+   */
+  public static String formatDate(Date value) {
+    return formatDate(value, Calendar.getInstance());
+  }
+
+  /**
+   * Format a {@link Date} as a MySQL DATE with the given {@link Calendar}.
+   */
+  public static String formatDate(Date value, Calendar cal) {
+    DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+    dateFormat.setCalendar(cal);
+    return dateFormat.format(value);
+  }
+
+  /**
+   * Parse a MySQL TIME format into a {@link Time} with the default time zone.
+   *
+   * <p>This should match {@link Time#valueOf(String)} for the format it supports.
+   * For MySQL-specific syntax, this will succeed where {@code valueOf()} fails.
+   */
+  public static Time parseTime(String value) throws ParseException {
+    return parseTime(value, Calendar.getInstance());
+  }
+
+  /**
+   * Parse a MySQL TIME format into a {@link Time} with the given {@link Calendar}.
+   *
+   * <p>The range for TIME values is '-838:59:59.000000' to '838:59:59.000000'
+   * <a href="http://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
+   *
+   * <p>Note that this is meant to parse only valid values, assumed to be
+   * returned by MySQL. Results are undefined for invalid input.
+   */
+  public static Time parseTime(String value, Calendar cal) throws ParseException {
+    // MySQL TIME can be negative and have hours > 24,
+    // because it can also represent elapsed time.
+    // So we just parse the integers rather than using DateFormat.
+    long hours = 0, minutes = 0, seconds = 0, millis = 0;
+
+    try {
+      // Hours
+      int sepIndex1 = value.indexOf(':');
+      if (sepIndex1 == -1) {
+        throw new ParseException("Invalid MySQL TIME format: " + value, value.length());
+      }
+      hours = Long.parseLong(value.substring(0, sepIndex1));
+
+      // Minutes and seconds
+      int sepIndex2 = value.indexOf(':', sepIndex1 + 1);
+      if (sepIndex2 == -1) {
+        // There's no seconds.
+        minutes = Long.parseLong(value.substring(sepIndex1 + 1));
+      } else {
+        minutes = Long.parseLong(value.substring(sepIndex1 + 1, sepIndex2));
+
+        // Fractional seconds
+        int dotIndex = value.lastIndexOf('.');
+        if (dotIndex == -1) {
+          // There's no fraction.
+          seconds = Long.parseLong(value.substring(sepIndex2 + 1));
+        } else {
+          seconds = Long.parseLong(value.substring(sepIndex2 + 1, dotIndex));
+
+          String fraction = value.substring(dotIndex + 1, value.length());
+
+          if (fraction.length() > 0) {
+            // Convert the fraction to millis.
+            if (fraction.length() > 3) {
+              fraction = fraction.substring(0, 3);
+            }
+            millis = Long.parseLong(fraction) * IntMath.pow(10, 3 - fraction.length());
+          }
+        }
+      }
+    } catch (NumberFormatException e) {
+      throw new ParseException("Invalid MYSQL TIME format: " + value, 0);
+    }
+
+    if (hours < 0) {
+      // If hours are negative, make the whole thing negative.
+      minutes = -minutes;
+      seconds = -seconds;
+      millis = -millis;
+    }
+
+    // Convert to millis since epoch (UTC).
+    long time =
+        hours * HOURS_TO_MILLIS
+            + minutes * MINUTES_TO_MILLIS
+            + seconds * SECONDS_TO_MILLIS
+            + millis;
+    // Adjust time zone.
+    time -= cal.get(Calendar.ZONE_OFFSET);
+    return new Time(time);
+  }
+
+  /**
+   * Format a {@link Time} as a MySQL TIME with the default time zone.
+   *
+   * <p>This should match {@link Time#toString()} for the values it supports.
+   * For MySQL-specific syntax (like fractional seconds, negative times,
+   * and hours > 24) the results will differ.
+   */
+  public static String formatTime(Time value) {
+    return formatTime(value, Calendar.getInstance());
+  }
+
+  /**
+   * Format a {@link Time} as a MySQL TIME with the given {@link Calendar}.
+   *
+   * <p>The range for TIME values is '-838:59:59.000000' to '838:59:59.000000'
+   * <a href="http://dev.mysql.com/doc/refman/5.6/en/time.html">[1]</a>.
+   * We don't enforce that range, but we do print >24 hours rather than
+   * wrapping around to the next day.
+   */
+  public static String formatTime(Time value, Calendar cal) {
+    long millis = value.getTime();
+
+    String sign = "";
+    if (millis < 0) {
+      sign = "-";
+      millis = -millis;
+    }
+
+    // Adjust for time zone.
+    millis += cal.get(Calendar.ZONE_OFFSET);
+
+    long hours = millis / HOURS_TO_MILLIS;
+    millis -= hours * HOURS_TO_MILLIS;
+    long minutes = millis / MINUTES_TO_MILLIS;
+    millis -= minutes * MINUTES_TO_MILLIS;
+    long seconds = millis / SECONDS_TO_MILLIS;
+    millis -= seconds * SECONDS_TO_MILLIS;
+
+    if (millis == 0) {
+      return String.format("%s%02d:%02d:%02d", sign, hours, minutes, seconds);
+    } else {
+      return String.format("%s%02d:%02d:%02d.%03d", sign, hours, minutes, seconds, millis);
+    }
+  }
+
+  /**
+   * Parse a MySQL TIMESTAMP format into a {@link Timestamp} with the default time zone.
+   *
+   * <p>This should match {@link Timestamp#valueOf(String)} for the format it supports.
+   * For MySQL-specific syntax, this will succeed where {@code valueOf()} fails.
+   */
+  public static Timestamp parseTimestamp(String value) throws ParseException {
+    return parseTimestamp(value, Calendar.getInstance());
+  }
+
+  /**
+   * Parse a MySQL TIMESTAMP format into a {@link Timestamp} with the given {@link Calendar}.
+   *
+   * <p>The format is 'YYYY-MM-DD HH:MM:SS[.fraction]' where the fraction
+   * can be up to 6 digits.
+   * <a href="http://dev.mysql.com/doc/refman/5.6/en/datetime.html">[1]</a>.
+   *
+   * <p>Note that this is meant to parse only valid values, assumed to be
+   * returned by MySQL. Results are undefined for invalid input.
+   */
+  public static Timestamp parseTimestamp(String value, Calendar cal) throws ParseException {
+    // Value to pass to Timestamp.setNanos().
+    int nanos = 0;
+
+    // Strip the fraction (if any) before using DateFormat.
+    // Timestamp stores second-level precision separate from the fraction.
+    int dotIndex = value.lastIndexOf('.');
+    if (dotIndex != -1) {
+      String fraction = value.substring(dotIndex + 1, value.length());
+
+      if (fraction.length() > 0) {
+        // Convert the fraction to nanoseconds.
+        if (fraction.length() > 9) {
+          fraction = fraction.substring(0, 9);
+        }
+        try {
+          nanos = Integer.parseInt(fraction) * IntMath.pow(10, 9 - fraction.length());
+        } catch (NumberFormatException e) {
+          throw new ParseException("Invalid MySQL TIMESTAMP format: " + value, dotIndex + 1);
+        }
+      }
+
+      value = value.substring(0, dotIndex);
+    }
+
+    // Parse with second precision, then add nanos.
+    DateFormat dateFormat = new SimpleDateFormat(DATETIME_FORMAT);
+    dateFormat.setCalendar(cal);
+    Timestamp result = new Timestamp(dateFormat.parse(value).getTime());
+    result.setNanos(nanos);
+    return result;
+  }
+
+  /**
+   * Format a {@link Timestamp} as a MySQL TIMESTAMP with the default time zone.
+   *
+   * <p>This should match {@link Timestamp#toString()} for the values it supports.
+   * For MySQL-specific syntax, the results will differ.
+   */
+  public static String formatTimestamp(Timestamp value) {
+    return formatTimestamp(value, Calendar.getInstance());
+  }
+
+  /**
+   * Format a {@link Timestamp} as a MySQL TIMESTAMP with the given {@link Calendar}.
+   */
+  public static String formatTimestamp(Timestamp value, Calendar cal) {
+    // The java.util.Date portion of a Timestamp only contains second-level precision.
+    // When printing the nanos, limit to microseconds since that's all MySQL allows.
+    long millis = value.getNanos() / 1000;
+    DateFormat dateFormat = new SimpleDateFormat(DATETIME_FORMAT);
+    dateFormat.setCalendar(cal);
+    String dateString = dateFormat.format(value);
+    if (millis == 0) {
+      // For whole numbered seconds, we add ".0" to match Timestamp.toString().
+      return dateString + ".0";
+    } else {
+      // Otherwise, we print the full fraction, then trim off trailing zeros.
+      // This is also done to match Timestamp.toString().
+      String result = String.format("%s.%06d", dateString, millis);
+      int end = result.length();
+      while (end > 0 && result.charAt(end - 1) == '0') {
+        --end;
+      }
+      return result.substring(0, end);
+    }
+  }
+}

--- a/java/client/src/test/java/com/youtube/vitess/client/cursor/CursorTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/cursor/CursorTest.java
@@ -22,13 +22,13 @@ import java.util.List;
 public class CursorTest {
   @Test
   public void testFindColumn() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").build())
-                .addFields(Field.newBuilder().setName("col1").build())
-                .addFields(Field.newBuilder().setName("col2").build())
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(Field.newBuilder().setName("col0").build())
+                    .addFields(Field.newBuilder().setName("col1").build())
+                    .addFields(Field.newBuilder().setName("col2").build())
+                    .build())) {
       Assert.assertEquals(0, cursor.findColumn("col0"));
       Assert.assertEquals(1, cursor.findColumn("col1"));
       Assert.assertEquals(2, cursor.findColumn("col2"));
@@ -37,20 +37,27 @@ public class CursorTest {
 
   @Test
   public void testGetInt() throws Exception {
-    List<Query.Type> types = Arrays.asList(Query.Type.INT8, Query.Type.UINT8, Query.Type.INT16,
-        Query.Type.UINT16, Query.Type.INT24, Query.Type.UINT24, Query.Type.INT32);
+    List<Query.Type> types =
+        Arrays.asList(
+            Query.Type.INT8,
+            Query.Type.UINT8,
+            Query.Type.INT16,
+            Query.Type.UINT16,
+            Query.Type.INT24,
+            Query.Type.UINT24,
+            Query.Type.INT32);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("12345".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("12345")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("12345".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("12345")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(12345, row.getInt("col0"));
@@ -65,17 +72,19 @@ public class CursorTest {
 
   @Test
   public void testGetULong() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.UINT64).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.UINT64).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("18446744073709551615".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("18446744073709551615")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(
+                        Field.newBuilder().setName("col0").setType(Query.Type.UINT64).build())
+                    .addFields(
+                        Field.newBuilder().setName("null").setType(Query.Type.UINT64).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("18446744073709551615".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("18446744073709551615")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(UnsignedLong.fromLongBits(-1), row.getULong("col0"));
@@ -87,19 +96,19 @@ public class CursorTest {
 
   @Test
   public void testGetString() throws Exception {
-    List<Query.Type> types = Arrays.asList(Query.Type.ENUM, Query.Type.SET, Query.Type.BIT);
+    List<Query.Type> types = Arrays.asList(Query.Type.ENUM, Query.Type.SET);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("val123".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("val123")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("val123".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("val123")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals("val123", row.getString("col0"));
@@ -114,17 +123,17 @@ public class CursorTest {
   public void testGetLong() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.UINT32, Query.Type.INT64);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("12345".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("12345")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("12345".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("12345")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(12345L, row.getLong("col0"));
@@ -139,17 +148,19 @@ public class CursorTest {
 
   @Test
   public void testGetDouble() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.FLOAT64).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.FLOAT64).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("2.5".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("2.5")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(
+                        Field.newBuilder().setName("col0").setType(Query.Type.FLOAT64).build())
+                    .addFields(
+                        Field.newBuilder().setName("null").setType(Query.Type.FLOAT64).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("2.5".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("2.5")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(2.5, row.getDouble("col0"), 0.01);
@@ -163,17 +174,19 @@ public class CursorTest {
 
   @Test
   public void testGetFloat() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.FLOAT32).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.FLOAT32).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("2.5".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("2.5")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(
+                        Field.newBuilder().setName("col0").setType(Query.Type.FLOAT32).build())
+                    .addFields(
+                        Field.newBuilder().setName("null").setType(Query.Type.FLOAT32).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("2.5".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("2.5")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(2.5f, row.getFloat("col0"), 0.01f);
@@ -189,17 +202,17 @@ public class CursorTest {
   public void testGetDateTime() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.DATETIME, Query.Type.TIMESTAMP);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("2008-01-02 14:15:16".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("2008-01-02 14:15:16")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("2008-01-02 14:15:16".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("2008-01-02 14:15:16")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(new DateTime(2008, 1, 2, 14, 15, 16), row.getDateTime("col0"));
@@ -211,17 +224,17 @@ public class CursorTest {
 
     types = Arrays.asList(Query.Type.DATE);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("2008-01-02".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("2008-01-02")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("2008-01-02".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("2008-01-02")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(new DateTime(2008, 1, 2, 0, 0, 0), row.getDateTime("col0"));
@@ -231,17 +244,17 @@ public class CursorTest {
       }
     }
 
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.TIME).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.TIME).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("12:34:56".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("12:34:56")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(Field.newBuilder().setName("col0").setType(Query.Type.TIME).build())
+                    .addFields(Field.newBuilder().setName("null").setType(Query.Type.TIME).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("12:34:56".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("12:34:56")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(new DateTime(1970, 1, 1, 12, 34, 56), row.getDateTime("col0"));
@@ -253,20 +266,27 @@ public class CursorTest {
 
   @Test
   public void testGetBytes() throws Exception {
-    List<Query.Type> types = Arrays.asList(Query.Type.TEXT, Query.Type.BLOB, Query.Type.VARCHAR,
-        Query.Type.VARBINARY, Query.Type.CHAR, Query.Type.BINARY);
+    List<Query.Type> types =
+        Arrays.asList(
+            Query.Type.TEXT,
+            Query.Type.BLOB,
+            Query.Type.VARCHAR,
+            Query.Type.VARBINARY,
+            Query.Type.CHAR,
+            Query.Type.BINARY,
+            Query.Type.BIT);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("hello world".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("hello world")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("hello world".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("hello world")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertArrayEquals("hello world".getBytes("UTF-8"), row.getBytes("col0"));
@@ -281,17 +301,17 @@ public class CursorTest {
   public void testGetBigDecimal() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.DECIMAL);
     for (Query.Type type : types) {
-      try (
-          Cursor cursor = new SimpleCursor(
-              QueryResult.newBuilder()
-                  .addFields(Field.newBuilder().setName("col0").setType(type).build())
-                  .addFields(Field.newBuilder().setName("null").setType(type).build())
-                  .addRows(
-                      Query.Row.newBuilder()
-                          .addLengths("1234.56789".length())
-                          .addLengths(-1) // SQL NULL
-                          .setValues(ByteString.copyFromUtf8("1234.56789")))
-                  .build())) {
+      try (Cursor cursor =
+              new SimpleCursor(
+                  QueryResult.newBuilder()
+                      .addFields(Field.newBuilder().setName("col0").setType(type).build())
+                      .addFields(Field.newBuilder().setName("null").setType(type).build())
+                      .addRows(
+                          Query.Row.newBuilder()
+                              .addLengths("1234.56789".length())
+                              .addLengths(-1) // SQL NULL
+                              .setValues(ByteString.copyFromUtf8("1234.56789")))
+                      .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(
@@ -305,17 +325,17 @@ public class CursorTest {
 
   @Test
   public void testGetShort() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.YEAR).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.YEAR).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("1234".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("1234")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(Field.newBuilder().setName("col0").setType(Query.Type.YEAR).build())
+                    .addFields(Field.newBuilder().setName("null").setType(Query.Type.YEAR).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("1234".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("1234")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(1234, row.getShort("col0"));
@@ -329,17 +349,19 @@ public class CursorTest {
 
   @Test
   public void testNull() throws Exception {
-    try (
-        Cursor cursor = new SimpleCursor(
-            QueryResult.newBuilder()
-                .addFields(Field.newBuilder().setName("col0").setType(Query.Type.NULL_TYPE).build())
-                .addFields(Field.newBuilder().setName("null").setType(Query.Type.NULL_TYPE).build())
-                .addRows(
-                    Query.Row.newBuilder()
-                        .addLengths("1234".length())
-                        .addLengths(-1) // SQL NULL
-                        .setValues(ByteString.copyFromUtf8("1234")))
-                .build())) {
+    try (Cursor cursor =
+            new SimpleCursor(
+                QueryResult.newBuilder()
+                    .addFields(
+                        Field.newBuilder().setName("col0").setType(Query.Type.NULL_TYPE).build())
+                    .addFields(
+                        Field.newBuilder().setName("null").setType(Query.Type.NULL_TYPE).build())
+                    .addRows(
+                        Query.Row.newBuilder()
+                            .addLengths("1234".length())
+                            .addLengths(-1) // SQL NULL
+                            .setValues(ByteString.copyFromUtf8("1234")))
+                    .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(null, row.getObject("col0"));

--- a/java/client/src/test/java/com/youtube/vitess/mysql/DateTimeTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/mysql/DateTimeTest.java
@@ -1,0 +1,218 @@
+package com.youtube.vitess.mysql;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+@RunWith(JUnit4.class)
+public class DateTimeTest {
+  private static final Calendar GMT = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+
+  private static final Map<String, Date> TEST_DATES =
+      new ImmutableMap.Builder<String, Date>()
+          .put("1970-01-01", new Date(0L))
+          .put("2008-01-02", new Date(1199232000000L))
+          .build();
+
+  private static Timestamp makeTimestamp(long millis, int nanos) {
+    Timestamp ts = new Timestamp(millis);
+    ts.setNanos(nanos);
+    return ts;
+  }
+
+  @Test
+  public void testParseDate() throws Exception {
+    // Check that our default time zone matches valueOf().
+    for (String dateString : TEST_DATES.keySet()) {
+      assertEquals(dateString, Date.valueOf(dateString), DateTime.parseDate(dateString));
+    }
+  }
+
+  @Test
+  public void testFormatDate() throws Exception {
+    // Check that our default time zone matches toString().
+    for (Date date : TEST_DATES.values()) {
+      assertEquals(date.toString(), DateTime.formatDate(date));
+    }
+  }
+
+  @Test
+  public void testParseDateGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT.
+    for (Map.Entry<String, Date> entry : TEST_DATES.entrySet()) {
+      String dateString = entry.getKey();
+      Date date = entry.getValue();
+      assertEquals(dateString, date, DateTime.parseDate(dateString, GMT));
+    }
+  }
+
+  @Test
+  public void testFormatDateGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT.
+    for (Map.Entry<String, Date> entry : TEST_DATES.entrySet()) {
+      String dateString = entry.getKey();
+      Date date = entry.getValue();
+      assertEquals(dateString, DateTime.formatDate(date, GMT));
+    }
+  }
+
+  @Test
+  public void testParseTime() throws Exception {
+    // Check that our default time zone matches valueOf().
+    // We can only check syntax that Time.valueOf() supports.
+    final List<String> TEST_TIMES =
+        new ImmutableList.Builder<String>().add("00:00:00").add("01:23:45").add("12:34:56").build();
+
+    for (String timeString : TEST_TIMES) {
+      assertEquals(timeString, Time.valueOf(timeString), DateTime.parseTime(timeString));
+    }
+  }
+
+  @Test
+  public void testFormatTime() throws Exception {
+    // Check that our default time zone matches toString().
+    // We can only check syntax that Time.toString() supports.
+    final List<String> TEST_TIMES =
+        new ImmutableList.Builder<String>().add("00:00:00").add("01:23:45").add("12:34:56").build();
+
+    for (String timeString : TEST_TIMES) {
+      Time time = Time.valueOf(timeString);
+      assertEquals(timeString, time.toString(), DateTime.formatTime(time));
+    }
+  }
+
+  @Test
+  public void testParseTimeGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT,
+    // including MySQL-specific syntax that Time.valueOf() doesn't support.
+    final Map<String, Time> TEST_TIMES =
+        new ImmutableMap.Builder<String, Time>()
+            .put("00:00:00", new Time(0))
+            .put("12:34", new Time(45240000L))
+            .put("01:23", new Time(4980000L))
+            .put("1:23", new Time(4980000L))
+            .put("12:34:56", new Time(45296000L))
+            .put("-12:34:56", new Time(-45296000L))
+            .put("812:34:56.", new Time(2925296000L))
+            .put("812:34:56.123", new Time(2925296123L))
+            .put("-812:34:56.123", new Time(-2925296123L))
+            .put("812:34:56.123456", new Time(2925296123L))
+            .build();
+
+    for (Map.Entry<String, Time> entry : TEST_TIMES.entrySet()) {
+      String timeString = entry.getKey();
+      Time time = entry.getValue();
+      assertEquals(time, DateTime.parseTime(timeString, GMT));
+    }
+  }
+
+  @Test
+  public void testFormatTimeGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT,
+    // including MySQL-specific syntax that Time.toString() doesn't support.
+    final Map<String, Time> TEST_TIMES =
+        new ImmutableMap.Builder<String, Time>()
+            .put("00:00:00", new Time(0))
+            .put("12:34:00", new Time(45240000L))
+            .put("01:23:00", new Time(4980000L))
+            .put("12:34:56", new Time(45296000L))
+            .put("-12:34:56", new Time(-45296000L))
+            .put("812:34:56", new Time(2925296000L))
+            .put("-812:34:56", new Time(-2925296000L))
+            .put("812:34:56.010", new Time(2925296010L))
+            .build();
+
+    for (Map.Entry<String, Time> entry : TEST_TIMES.entrySet()) {
+      String timeString = entry.getKey();
+      Time time = entry.getValue();
+      assertEquals(timeString, DateTime.formatTime(time, GMT));
+    }
+  }
+
+  @Test
+  public void testParseTimestamp() throws Exception {
+    // Check that our default time zone matches valueOf().
+    final List<String> TEST_TIMESTAMPS =
+        new ImmutableList.Builder<String>()
+            .add("1970-01-01 00:00:00")
+            .add("2008-01-02 14:15:16")
+            .add("2008-01-02 14:15:16.123456")
+            .build();
+
+    for (String tsString : TEST_TIMESTAMPS) {
+      assertEquals(tsString, Timestamp.valueOf(tsString), DateTime.parseTimestamp(tsString));
+    }
+  }
+
+  @Test
+  public void testFormatTimestamp() throws Exception {
+    // Check that our default time zone matches toString().
+    final List<String> TEST_TIMESTAMPS =
+        new ImmutableList.Builder<String>()
+            .add("1970-01-01 00:00:00")
+            .add("2008-01-02 14:15:16")
+            .add("2008-01-02 14:15:16.001")
+            .add("2008-01-02 14:15:16.123456")
+            .build();
+
+    for (String tsString : TEST_TIMESTAMPS) {
+      Timestamp ts = Timestamp.valueOf(tsString);
+      assertEquals(tsString, ts.toString(), DateTime.formatTimestamp(ts));
+    }
+  }
+
+  @Test
+  public void testParseTimestampGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT.
+    final Map<String, Timestamp> TEST_TIMESTAMPS =
+        new ImmutableMap.Builder<String, Timestamp>()
+            .put("1970-01-01 00:00:00", makeTimestamp(0, 0))
+            .put("2008-01-02 14:15:16", makeTimestamp(1199283316000L, 0))
+            .put("2008-01-02 14:15:16.0", makeTimestamp(1199283316000L, 0))
+            .put("2008-01-02 14:15:16.123", makeTimestamp(1199283316000L, 123000000))
+            .put("2008-01-02 14:15:16.123456", makeTimestamp(1199283316000L, 123456000))
+            .put("2008-01-02 14:15:16.123456789", makeTimestamp(1199283316000L, 123456789))
+            .put("2008-01-02 14:15:16.1234567890123", makeTimestamp(1199283316000L, 123456789))
+            .build();
+
+    for (Map.Entry<String, Timestamp> entry : TEST_TIMESTAMPS.entrySet()) {
+      String tsString = entry.getKey();
+      Timestamp ts = entry.getValue();
+      assertEquals(ts, DateTime.parseTimestamp(tsString, GMT));
+    }
+  }
+
+  @Test
+  public void testFormatTimestampGMT() throws Exception {
+    // Test absolute UNIX epoch values in GMT.
+    // This also tests MySQL-specific features, like truncating to microseconds.
+    final Map<String, Timestamp> TEST_TIMESTAMPS =
+        new ImmutableMap.Builder<String, Timestamp>()
+            .put("1970-01-01 00:00:00.0", makeTimestamp(0, 0))
+            .put("2008-01-02 14:15:16.0", makeTimestamp(1199283316000L, 0))
+            .put("2008-01-02 14:15:16.001", makeTimestamp(1199283316000L, 1000000))
+            .put("2008-01-02 14:15:16.123", makeTimestamp(1199283316000L, 123000000))
+            .put("2008-01-02 14:15:16.123456", makeTimestamp(1199283316000L, 123456000))
+            .put("2008-01-02 14:15:16.234567", makeTimestamp(1199283316000L, 234567891))
+            .build();
+
+    for (Map.Entry<String, Timestamp> entry : TEST_TIMESTAMPS.entrySet()) {
+      String tsString = entry.getKey();
+      Timestamp ts = entry.getValue();
+      assertEquals(tsString, DateTime.formatTimestamp(ts, GMT));
+    }
+  }
+}


### PR DESCRIPTION
@sougou 

These match the [types used by Connector/J](http://dev.mysql.com/doc/connector-j/en/connector-j-reference-type-conversions.html), with one exception: we don't support the special case that BIT(1) is returned as Boolean instead of byte[], because that would require sending field size info along with every query result. If that turns out to be an important use case for users, we can consider workarounds like adding getBoolean() as a convenience to check the first byte.

I haven't found any internal users of the old Joda-based getDateTime(), so it should be safe to break it.