### PR TITLE
vtworker: VerticalSplitDiff: Fix problem that not-to-be-migrated tables on the destination were considered an error.

### DIFF
--- a/go/vt/worker/vertical_split_diff_cmd.go
+++ b/go/vt/worker/vertical_split_diff_cmd.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/youtube/vitess/go/vt/concurrency"
@@ -44,8 +43,6 @@ const verticalSplitDiffHTML2 = `
   <p>Shard involved: {{.Keyspace}}/{{.Shard}}</p>
   <h1>Vertical Split Diff Action</h1>
     <form action="/Diffs/VerticalSplitDiff" method="post">
-      <LABEL for="excludeTables">Exclude Tables: </LABEL>
-        <INPUT type="text" id="excludeTables" name="excludeTables" value=""></BR>
       <INPUT type="hidden" name="keyspace" value="{{.Keyspace}}"/>
       <INPUT type="hidden" name="shard" value="{{.Shard}}"/>
       <INPUT type="submit" name="submit" value="Vertical Split Diff"/>
@@ -57,7 +54,6 @@ var verticalSplitDiffTemplate = mustParseTemplate("verticalSplitDiff", verticalS
 var verticalSplitDiffTemplate2 = mustParseTemplate("verticalSplitDiff2", verticalSplitDiffHTML2)
 
 func commandVerticalSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
-	excludeTables := subFlags.String("exclude_tables", "", "comma separated list of tables to exclude")
 	if err := subFlags.Parse(args); err != nil {
 		return nil, err
 	}
@@ -69,11 +65,7 @@ func commandVerticalSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *fla
 	if err != nil {
 		return nil, err
 	}
-	var excludeTableArray []string
-	if *excludeTables != "" {
-		excludeTableArray = strings.Split(*excludeTables, ",")
-	}
-	return NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard, excludeTableArray), nil
+	return NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard), nil
 }
 
 // shardsWithTablesSources returns all the shards that have SourceShards set
@@ -164,21 +156,15 @@ func interactiveVerticalSplitDiff(ctx context.Context, wi *Instance, wr *wrangle
 		return nil, verticalSplitDiffTemplate2, result, nil
 	}
 
-	// Process input form.
-	excludeTables := r.FormValue("excludeTables")
-	var excludeTableArray []string
-	if excludeTables != "" {
-		excludeTableArray = strings.Split(excludeTables, ",")
-	}
-
 	// start the diff job
-	wrk := NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard, excludeTableArray)
+	wrk := NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard)
 	return wrk, nil, nil, nil
 }
 
 func init() {
 	AddCommand("Diffs", Command{"VerticalSplitDiff",
 		commandVerticalSplitDiff, interactiveVerticalSplitDiff,
-		"[--exclude_tables=''] <keyspace/shard>",
-		"Diffs a rdonly destination keyspace against its SourceShard for a vertical split"})
+		"<keyspace/shard>",
+		"Diffs an rdonly tablet from the (destination) keyspace/shard against an rdonly tablet from the respective source keyspace/shard." +
+			" Only compares the tables which were set by a previous VerticalSplitClone command."})
 }


### PR DESCRIPTION
@alainjobart 

Originally, the -exclude_tables flag was supposed to cover this. But this flag does not make sense for a vertical split: At the time of a VerticalSplitClone, the whitelist of tables to be migrated is also specified. With this change, the diff uses this list of tables and ignores any other table, both on the source and the destination.

- Pass tables list directly to GetSchema().
- Extended e2e test to cover this case.
- Removed -exclude_tables flag.
- Updated unit test.