### PR TITLE
Couple fixes / clean-up related to SrvKeyspace watches:

### DIFF
--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -680,7 +680,7 @@ func (tee *Tee) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]string,
 
 // WatchSrvKeyspace is part of the topo.Server interface.
 // We only watch for changes on the primary.
-func (tee *Tee) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, chan<- struct{}, error) {
+func (tee *Tee) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, error) {
 	return tee.primary.WatchSrvKeyspace(ctx, cell, keyspace)
 }
 

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -242,15 +242,15 @@ type Impl interface {
 	// It should receive a notification with the initial value fairly
 	// quickly after this is set. A value of nil means the SrvKeyspace
 	// object doesn't exist or is empty. To stop watching this
-	// SrvKeyspace object, close the stopWatching channel.
+	// SrvKeyspace object, cancel the context.
 	// If the underlying topo.Server encounters an error watching the node,
 	// it should retry on a regular basis until it can succeed.
 	// The initial error returned by this method is meant to catch
 	// the obvious bad cases (invalid cell, invalid tabletType, ...)
 	// that are never going to work. Mutiple notifications with the
 	// same contents may be sent (for instance when the serving graph
-	// is rebuilt, but the content hasn't changed).
-	WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (notifications <-chan *topodatapb.SrvKeyspace, stopWatching chan<- struct{}, err error)
+	// is rebuilt, the version changes, but the content hasn't changed).
+	WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (notifications <-chan *topodatapb.SrvKeyspace, err error)
 
 	// UpdateSrvShard updates the serving records for a cell,
 	// keyspace, shard.

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -248,8 +248,10 @@ type Impl interface {
 	// The initial error returned by this method is meant to catch
 	// the obvious bad cases (invalid cell, invalid tabletType, ...)
 	// that are never going to work. Mutiple notifications with the
-	// same contents may be sent (for instance when the serving graph
-	// is rebuilt, the version changes, but the content hasn't changed).
+	// same contents may be sent (for instance, when the serving graph
+	// is rebuilt, but the content of SrvKeyspace is the same,
+	// the object version will change, most likely triggering the
+	// notification, but the content hasn't changed).
 	WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (notifications <-chan *topodatapb.SrvKeyspace, err error)
 
 	// UpdateSrvShard updates the serving records for a cell,

--- a/go/vt/topo/test/faketopo/faketopo.go
+++ b/go/vt/topo/test/faketopo/faketopo.go
@@ -175,8 +175,8 @@ func (ft FakeTopo) DeleteEndPoints(ctx context.Context, cell, keyspace, shard st
 }
 
 // WatchSrvKeyspace implements topo.Server.WatchSrvKeyspace
-func (ft FakeTopo) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, chan<- struct{}, error) {
-	return nil, nil, errNotImplemented
+func (ft FakeTopo) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, error) {
+	return nil, errNotImplemented
 }
 
 // UpdateSrvShard implements topo.Server.

--- a/go/vt/topo/test/serving.go
+++ b/go/vt/topo/test/serving.go
@@ -230,7 +230,8 @@ func CheckWatchSrvKeyspace(ctx context.Context, t *testing.T, ts topo.Impl) {
 	keyspace := "test_keyspace"
 
 	// start watching, should get nil first
-	notifications, stopWatching, err := ts.WatchSrvKeyspace(ctx, cell, keyspace)
+	ctx, cancel := context.WithCancel(ctx)
+	notifications, err := ts.WatchSrvKeyspace(ctx, cell, keyspace)
 	if err != nil {
 		t.Fatalf("WatchSrvKeyspace failed: %v", err)
 	}
@@ -319,9 +320,9 @@ func CheckWatchSrvKeyspace(ctx context.Context, t *testing.T, ts topo.Impl) {
 		break
 	}
 
-	// close the stopWatching channel, should eventually get a closed
+	// close the context, should eventually get a closed
 	// notifications channel too
-	close(stopWatching)
+	cancel()
 	for {
 		sk, ok := <-notifications
 		if !ok {

--- a/go/vt/vtgate/resilient_srv_topo_server.go
+++ b/go/vt/vtgate/resilient_srv_topo_server.go
@@ -110,9 +110,38 @@ type srvKeyspaceEntry struct {
 	// the mutex protects any access to this structure (read or write)
 	mutex sync.RWMutex
 
+	// watchRunning describes if the watch go routine is running.
+	// It is easier to have an explicit field instead of guessing
+	// based on value and lastError.
+	//
+	// if watchrunning is not set, the next time we try to access the
+	// keyspace, we will start a watch.
+	// if watchrunning is set, we are guaranteed to have exactly one of
+	// value or lastError be nil, and the other non-nil.
+	watchRunning bool
 	value        *topodatapb.SrvKeyspace
 	lastError    error
+
+	// lastErrorCtx tries to remember the context of the query
+	// that failed to get the SrvKeyspace, so we can display it in
+	// the status UI. The background routine that refreshes the
+	// keyspace will not populate this field.
+	// The intent is to have the source of a query that for instance
+	// has a bad keyspace or cell name.
 	lastErrorCtx context.Context
+}
+
+// setValue remembers the current value (or nil if the node doesn't exist)
+// and sets lastError / lastErrorCtx if necessary.
+func (ske *srvKeyspaceEntry) setValue(ctx context.Context, value *topodatapb.SrvKeyspace) {
+	ske.value = value
+	if value == nil {
+		ske.lastError = fmt.Errorf("no SrvKeyspace %v in cell %v", ske.keyspace, ske.cell)
+		ske.lastErrorCtx = ctx
+	} else {
+		ske.lastError = nil
+		ske.lastErrorCtx = nil
+	}
 }
 
 type srvShardEntry struct {
@@ -284,12 +313,12 @@ func (server *ResilientSrvTopoServer) getSrvKeyspaceEntry(cell, keyspace string)
 func (server *ResilientSrvTopoServer) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*topodatapb.SrvKeyspace, error) {
 	entry := server.getSrvKeyspaceEntry(cell, keyspace)
 
-	// If the entry exists, return it
+	// If the watch is already running, return the value
 	entry.mutex.RLock()
-	if entry.value != nil {
-		v := entry.value
+	if entry.watchRunning {
+		v, e := entry.value, entry.lastError
 		entry.mutex.RUnlock()
-		return v, nil
+		return v, e
 	}
 	entry.mutex.RUnlock()
 
@@ -299,47 +328,54 @@ func (server *ResilientSrvTopoServer) GetSrvKeyspace(ctx context.Context, cell, 
 	entry.mutex.Lock()
 	defer entry.mutex.Unlock()
 
-	// If the entry exists, return it
-	if entry.value != nil {
-		return entry.value, nil
+	// If the watch is already running, return the value
+	if entry.watchRunning {
+		return entry.value, entry.lastError
 	}
 
-	// not in cache, get the real value
+	// watch is not running, let's try to start it
 	newCtx := context.Background()
-
-	// start watching
-	notifications, stopWatching, err := server.topoServer.WatchSrvKeyspace(newCtx, cell, keyspace)
+	notifications, err := server.topoServer.WatchSrvKeyspace(newCtx, cell, keyspace)
 	if err != nil {
+		// lastError and lastErrorCtx will be visible from the UI
+		// until the next try
+		entry.value = nil
 		entry.lastError = err
 		entry.lastErrorCtx = ctx
 		log.Errorf("WatchSrvKeyspace failed for %v/%v: %v", cell, keyspace, err)
-		return nil, entry.lastError
+		return nil, err
 	}
 	sk, ok := <-notifications
 	if !ok {
-		entry.lastError = fmt.Errorf("failed to receive from channel")
+		// lastError and lastErrorCtx will be visible from the UI
+		// until the next try
+		entry.value = nil
+		entry.lastError = fmt.Errorf("failed to receive initial value from topology watcher")
 		entry.lastErrorCtx = ctx
 		log.Errorf("WatchSrvKeyspace first result failed for %v/%v", cell, keyspace)
-		close(stopWatching)
 		return nil, entry.lastError
 	}
 
-	// cache the first notification
-	entry.value = sk
-	entry.lastError = nil
-	entry.lastErrorCtx = nil
+	// we are now watching, cache the first notification
+	entry.watchRunning = true
+	entry.setValue(ctx, sk)
 
 	go func() {
 		for sk := range notifications {
 			entry.mutex.Lock()
-			entry.value = sk
+			entry.setValue(nil, sk)
 			entry.mutex.Unlock()
 		}
 		log.Errorf("failed to receive from channel")
-		close(stopWatching)
+		entry.mutex.Lock()
+		entry.watchRunning = false
+		entry.value = nil
+		entry.lastError = fmt.Errorf("watch for SrvKeyspace %v in cell %v ended", keyspace, cell)
+		entry.lastErrorCtx = nil
+		entry.mutex.Unlock()
 	}()
 
-	return entry.value, nil
+	return entry.value, entry.lastError
 }
 
 // GetSrvShard returns SrvShard object for the given cell, keyspace, and shard.

--- a/go/vt/vtgate/resilient_srv_topo_server_test.go
+++ b/go/vt/vtgate/resilient_srv_topo_server_test.go
@@ -198,7 +198,6 @@ type fakeTopo struct {
 	keyspace      string
 	callCount     int
 	notifications chan *topodatapb.SrvKeyspace
-	stopWatching  chan struct{}
 }
 
 func (ft *fakeTopo) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]string, error) {
@@ -213,15 +212,14 @@ func (ft *fakeTopo) UpdateSrvKeyspace(ctx context.Context, cell, keyspace string
 	return nil
 }
 
-func (ft *fakeTopo) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, chan<- struct{}, error) {
+func (ft *fakeTopo) WatchSrvKeyspace(ctx context.Context, cell, keyspace string) (<-chan *topodatapb.SrvKeyspace, error) {
 	ft.callCount++
 	if keyspace == ft.keyspace {
 		ft.notifications = make(chan *topodatapb.SrvKeyspace, 10)
-		ft.stopWatching = make(chan struct{})
 		ft.notifications <- &topodatapb.SrvKeyspace{}
-		return ft.notifications, ft.stopWatching, nil
+		return ft.notifications, nil
 	}
-	return nil, nil, fmt.Errorf("Unknown keyspace")
+	return nil, fmt.Errorf("Unknown keyspace")
 }
 
 func (ft *fakeTopo) GetSrvShard(ctx context.Context, cell, keyspace, shard string) (*topodatapb.SrvShard, error) {

--- a/go/vt/vtgate/resilient_srv_topo_server_test.go
+++ b/go/vt/vtgate/resilient_srv_topo_server_test.go
@@ -366,13 +366,15 @@ func TestGetSrvKeyspace(t *testing.T) {
 	}
 
 	// now send an updated real value, see it come through
-	ft.notifications <- &topodatapb.SrvKeyspace{
-		ShardingColumnName: "test_matching",
+	want = &topodatapb.SrvKeyspace{
+		ShardingColumnName: "id2",
+		ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
 	}
+	ft.notifications <- want
 	expiry = time.Now().Add(5 * time.Second)
 	for {
 		got, err = rsts.GetSrvKeyspace(context.Background(), "", "test_ks")
-		if err == nil && got.ShardingColumnName == "test_matching" {
+		if err == nil && proto.Equal(want, got) {
 			break
 		}
 		if time.Now().After(expiry) {


### PR DESCRIPTION
- simplify the topo server API to cancel the watch on
context cancellation. No need to create an extra channel.
- fix vtgate's side to handle the nil SrvKeyspace case properly.

@guoliang100 @michael-berlin 