### PR TITLE
vtworker: Increase the default for how many rows the *Clone commands aggregate in one transaction.

### DIFF
--- a/go/vt/automation/split_clone_task.go
+++ b/go/vt/automation/split_clone_task.go
@@ -18,7 +18,6 @@ type SplitCloneTask struct {
 func (t *SplitCloneTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
 	// TODO(mberlin): Add parameters for the following options?
 	//                        '--source_reader_count', '1',
-	//                        '--destination_pack_count', '1',
 	//                        '--destination_writer_count', '1',
 	args := []string{"SplitClone"}
 	if excludeTables := parameters["exclude_tables"]; excludeTables != "" {

--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -19,7 +19,6 @@ type VerticalSplitCloneTask struct {
 func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
 	// TODO(mberlin): Add parameters for the following options?
 	//                        '--source_reader_count', '1',
-	//                        '--destination_pack_count', '1',
 	//                        '--destination_writer_count', '1',
 	args := []string{"VerticalSplitClone"}
 	args = append(args, "--tables="+parameters["tables"])

--- a/go/vt/worker/defaults.go
+++ b/go/vt/worker/defaults.go
@@ -5,8 +5,11 @@
 package worker
 
 const (
-	defaultSourceReaderCount      = 10
-	defaultDestinationPackCount   = 10
+	defaultSourceReaderCount = 10
+	// defaultDestinationPackCount is the number of rows which will be aggreated
+	// into one transaction. Note that higher values will increase memory
+	// consumption in vtworker, vttablet and mysql.
+	defaultDestinationPackCount   = 1000
 	defaultMinTableSizeForSplit   = 1024 * 1024
 	defaultDestinationWriterCount = 20
 )


### PR DESCRIPTION
@alainjobart 

The previous default of 10 was too low because it did not utilize mysql
enough/the overhead for transactions was too high.