### PR TITLE
SplitQuery will now not split a varchar column.

### DIFF
--- a/go/vt/tabletserver/query_splitter.go
+++ b/go/vt/tabletserver/query_splitter.go
@@ -203,7 +203,7 @@ func (qs *QuerySplitter) splitBoundaries(columnType querypb.Type, pkMinMax *sqlt
 		return qs.splitBoundariesUintColumn(pkMinMax)
 	case sqltypes.IsFloat(columnType):
 		return qs.splitBoundariesFloatColumn(pkMinMax)
-	case sqltypes.IsBinary(columnType) || sqltypes.IsText(columnType):
+	case sqltypes.IsBinary(columnType):
 		return qs.splitBoundariesStringColumn()
 	}
 	return []sqltypes.Value{}, nil


### PR DESCRIPTION
SplitQuery worked incorrectly for VARCHAR columns (it didn't take collation into account which can result with a row being mapped over more than once). This temporarily fixes the issue by not splitting the original query if the split_column has VARCHAR type. After the re-design we will reject such split-queries with an error (I'd rather not do that now since I don't know how many users actually rely on this behavior).