### PR TITLE
logutil: Add helper for logging Event protos.

### DIFF
--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -32,20 +31,13 @@ func main() {
 
 	flag.Parse()
 
+	logger := logutil.NewConsoleLogger()
+
 	err := vtctlclient.RunCommandAndWait(
 		context.Background(), *server, flag.Args(),
 		*dialTimeout, *actionTimeout,
 		func(e *logutilpb.Event) {
-			switch e.Level {
-			case logutilpb.Level_INFO:
-				log.Info(logutil.EventString(e))
-			case logutilpb.Level_WARNING:
-				log.Warning(logutil.EventString(e))
-			case logutilpb.Level_ERROR:
-				log.Error(logutil.EventString(e))
-			case logutilpb.Level_CONSOLE:
-				fmt.Print(logutil.EventString(e))
-			}
+			logutil.LogEvent(logger, e)
 		})
 	if err != nil {
 		log.Error(err)

--- a/go/cmd/vtworkerclient/vtworkerclient.go
+++ b/go/cmd/vtworkerclient/vtworkerclient.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -31,19 +30,12 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *actionTimeout)
 	defer cancel()
 
+	logger := logutil.NewConsoleLogger()
+
 	err := vtworkerclient.RunCommandAndWait(
 		ctx, *server, flag.Args(),
 		func(e *logutilpb.Event) {
-			switch e.Level {
-			case logutilpb.Level_INFO:
-				log.Info(logutil.EventString(e))
-			case logutilpb.Level_WARNING:
-				log.Warning(logutil.EventString(e))
-			case logutilpb.Level_ERROR:
-				log.Error(logutil.EventString(e))
-			case logutilpb.Level_CONSOLE:
-				fmt.Print(logutil.EventString(e))
-			}
+			logutil.LogEvent(logger, e)
 		})
 	if err != nil {
 		log.Error(err)

--- a/go/vt/logutil/console_logger.go
+++ b/go/vt/logutil/console_logger.go
@@ -33,3 +33,18 @@ func (cl ConsoleLogger) Errorf(format string, v ...interface{}) {
 func (cl ConsoleLogger) Printf(format string, v ...interface{}) {
 	fmt.Printf(format, v...)
 }
+
+// InfoDepth is part of the Logger interface.
+func (cl ConsoleLogger) InfoDepth(depth int, s string) {
+	log.InfoDepth(1+depth, s)
+}
+
+// WarningDepth is part of the Logger interface.
+func (cl ConsoleLogger) WarningDepth(depth int, s string) {
+	log.WarningDepth(1+depth, s)
+}
+
+// ErrorDepth is part of the Logger interface.
+func (cl ConsoleLogger) ErrorDepth(depth int, s string) {
+	log.ErrorDepth(1+depth, s)
+}

--- a/go/vt/logutil/logger_test.go
+++ b/go/vt/logutil/logger_test.go
@@ -7,7 +7,7 @@ import (
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 )
 
-func TestLoggerEventFormat(t *testing.T) {
+func TestLogEvent(t *testing.T) {
 	testValues := []struct {
 		event    *logutilpb.Event
 		expected string
@@ -35,6 +35,16 @@ func TestLoggerEventFormat(t *testing.T) {
 		{
 			event: &logutilpb.Event{
 				Time:  TimeToProto(time.Date(2014, time.January, 20, 23, 30, 12, 0, time.UTC)),
+				Level: logutilpb.Level_ERROR,
+				File:  "file2.go",
+				Line:  567,
+				Value: "message %v %v",
+			},
+			expected: "E0120 23:30:12.000000 file2.go:567] message %v %v",
+		},
+		{
+			event: &logutilpb.Event{
+				Time:  TimeToProto(time.Date(2014, time.January, 20, 23, 30, 12, 0, time.UTC)),
 				Level: logutilpb.Level_CONSOLE,
 				File:  "file2.go",
 				Line:  567,
@@ -43,10 +53,14 @@ func TestLoggerEventFormat(t *testing.T) {
 			expected: "message %v %v",
 		},
 	}
-	for _, testValue := range testValues {
-		got := EventString(testValue.event)
-		if testValue.expected != got {
-			t.Errorf("invalid printing of %v: expected '%v' got '%v'", testValue.event, testValue.expected, got)
+	ml := NewMemoryLogger()
+	for i, testValue := range testValues {
+		LogEvent(ml, testValue.event)
+		if got, want := ml.Events[i].Value, testValue.expected; got != want {
+			t.Errorf("ml.Events[%v].Value = %q, want %q", i, got, want)
+		}
+		if got, want := ml.Events[i].File, "logger_test.go"; got != want && ml.Events[i].Level != logutilpb.Level_CONSOLE {
+			t.Errorf("ml.Events[%v].File = %q, want %q", i, got, want)
 		}
 	}
 }
@@ -54,28 +68,48 @@ func TestLoggerEventFormat(t *testing.T) {
 func TestMemoryLogger(t *testing.T) {
 	ml := NewMemoryLogger()
 	ml.Infof("test %v", 123)
-	if len(ml.Events) != 1 {
-		t.Fatalf("Invalid MemoryLogger size: %v", ml)
+	if got, want := len(ml.Events), 1; got != want {
+		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
 	}
-	if ml.Events[0].File != "logger_test.go" {
-		t.Errorf("Invalid file name: %v", ml.Events[0].File)
+	if got, want := ml.Events[0].File, "logger_test.go"; got != want {
+		t.Errorf("ml.Events[0].File = %q, want %q", got, want)
 	}
-	ml.Errorf("test %v", 456)
-	if len(ml.Events) != 2 {
-		t.Fatalf("Invalid MemoryLogger size: %v", ml)
+	ml.Warningf("test %v", 456)
+	if got, want := len(ml.Events), 2; got != want {
+		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
 	}
-	if ml.Events[1].File != "logger_test.go" {
-		t.Errorf("Invalid file name: %v", ml.Events[1].File)
+	if got, want := ml.Events[1].File, "logger_test.go"; got != want {
+		t.Errorf("ml.Events[1].File = %q, want %q", got, want)
+	}
+	ml.Errorf("test %v", 789)
+	if got, want := len(ml.Events), 3; got != want {
+		t.Fatalf("len(ml.Events) = %v, want %v", got, want)
+	}
+	if got, want := ml.Events[2].File, "logger_test.go"; got != want {
+		t.Errorf("ml.Events[2].File = %q, want %q", got, want)
 	}
 }
 
 func TestChannelLogger(t *testing.T) {
 	cl := NewChannelLogger(10)
+	cl.Infof("test %v", 123)
 	cl.Warningf("test %v", 123)
+	cl.Errorf("test %v", 123)
+	cl.Printf("test %v", 123)
+	close(cl)
 
-	e := <-cl
-	if e.File != "logger_test.go" {
-		t.Errorf("Invalid file name: %v", e.File)
+	count := 0
+	for e := range cl {
+		if got, want := e.Value, "test 123"; got != want {
+			t.Errorf("e.Value = %q, want %q", got, want)
+		}
+		if e.File != "logger_test.go" {
+			t.Errorf("Invalid file name: %v", e.File)
+		}
+		count++
+	}
+	if got, want := count, 4; got != want {
+		t.Errorf("count = %v, want %v", got, want)
 	}
 }
 
@@ -87,8 +121,11 @@ func TestTeeLogger(t *testing.T) {
 	tl.Warningf("test warningf %v %v", 2, 3)
 	tl.Errorf("test errorf %v %v", 3, 4)
 	tl.Printf("test printf %v %v", 4, 5)
+	tl.InfoDepth(0, "test infoDepth")
+	tl.WarningDepth(0, "test warningDepth")
+	tl.ErrorDepth(0, "test errorDepth")
 	for i, ml := range []*MemoryLogger{ml1, ml2} {
-		if len(ml.Events) != 4 {
+		if len(ml.Events) != 7 {
 			t.Fatalf("Invalid ml%v size: %v", i+1, ml)
 		}
 		if ml.Events[0].Value != "test infof 1 2" {
@@ -114,6 +151,30 @@ func TestTeeLogger(t *testing.T) {
 		}
 		if ml.Events[3].Level != logutilpb.Level_CONSOLE {
 			t.Errorf("Invalid ml%v[0].level: %v", i+1, ml.Events[3].Level)
+		}
+		if ml.Events[4].Value != "test infoDepth" {
+			t.Errorf("Invalid ml%v[0]: %v", i+1, ml.Events[4].Value)
+		}
+		if ml.Events[4].Level != logutilpb.Level_INFO {
+			t.Errorf("Invalid ml%v[0].level: %v", i+1, ml.Events[4].Level)
+		}
+		if ml.Events[5].Value != "test warningDepth" {
+			t.Errorf("Invalid ml%v[0]: %v", i+1, ml.Events[5].Value)
+		}
+		if ml.Events[5].Level != logutilpb.Level_WARNING {
+			t.Errorf("Invalid ml%v[0].level: %v", i+1, ml.Events[5].Level)
+		}
+		if ml.Events[6].Value != "test errorDepth" {
+			t.Errorf("Invalid ml%v[0]: %v", i+1, ml.Events[6].Value)
+		}
+		if ml.Events[6].Level != logutilpb.Level_ERROR {
+			t.Errorf("Invalid ml%v[0].level: %v", i+1, ml.Events[6].Level)
+		}
+
+		for j := range ml.Events {
+			if got, want := ml.Events[j].File, "logger_test.go"; got != want && ml.Events[j].Level != logutilpb.Level_CONSOLE {
+				t.Errorf("ml%v[%v].File = %q, want %q", i+1, j, got, want)
+			}
 		}
 	}
 }

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -972,7 +972,7 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		return err
 	}
 	for e := range logStream {
-		wr.Logger().Infof("%v", e)
+		logutil.LogEvent(wr.Logger(), e)
 	}
 	return errFunc()
 }


### PR DESCRIPTION
@alainjobart 

In "vtctl Backup", we were using the default protobuf string conversion,
which looked like this:

time:<seconds:1455660279 nanoseconds:648616540 > file:"logger.go"
line:251 value:"resetting mysqld read-only to true"

This fixes the Backup command to use logutil.EventString() and
consolidates other similar uses into a common function.