### PR TITLE
test/utils: Close grpc connections even with --skip-teardown.

### DIFF
--- a/test/backup.py
+++ b/test/backup.py
@@ -41,6 +41,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/binlog.py
+++ b/test/binlog.py
@@ -115,6 +115,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -42,6 +42,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -69,6 +69,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -69,6 +69,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/mysql_flavor.py
+++ b/test/mysql_flavor.py
@@ -101,7 +101,7 @@ class MariaDB(MysqlFlavor):
       return gtid
 
   def change_master_commands(self, host, port, pos):
-    (_flavor, gtid) = pos.split("/")
+    gtid = pos.split("/")[1]
     return [
         "SET GLOBAL gtid_slave_pos = '%s'" % gtid,
         "CHANGE MASTER TO MASTER_HOST='%s', MASTER_PORT=%d, "
@@ -110,7 +110,7 @@ class MariaDB(MysqlFlavor):
 
 
 class MySQL56(MysqlFlavor):
-  """Overrides specific to MySQL 5.6"""
+  """Overrides specific to MySQL 5.6."""
 
   def master_position(self, tablet):
     gtid = tablet.mquery("", "SELECT @@GLOBAL.gtid_executed")[0][0]
@@ -135,7 +135,7 @@ class MySQL56(MysqlFlavor):
     return environment.vttop + "/config/mycnf/master_mysql56.cnf"
 
   def change_master_commands(self, host, port, pos):
-    (_flavor, gtid) = pos.split("/")
+    gtid = pos.split("/")[1]
     return [
         "RESET MASTER",
         "SET GLOBAL gtid_purged = '%s'" % gtid,
@@ -162,7 +162,7 @@ def set_mysql_flavor(flavor):
   if not flavor:
     flavor = os.environ.get("MYSQL_FLAVOR", "MariaDB")
     # The environment variable might be set, but equal to "".
-    if flavor == "":
+    if not flavor:
       flavor = "MariaDB"
 
   # Set the environment variable explicitly in case we're overriding it via

--- a/test/mysqlctl.py
+++ b/test/mysqlctl.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 
 import warnings
-# Dropping a table inexplicably produces a warning despite
-# the "IF EXISTS" clause. Squelch these warnings.
-warnings.simplefilter('ignore')
-
 import unittest
-
 import environment
 import tablet
 import utils
+
+# Dropping a table inexplicably produces a warning despite
+# the "IF EXISTS" clause. Squelch these warnings.
+warnings.simplefilter('ignore')
 
 master_tablet = tablet.Tablet()
 replica_tablet = tablet.Tablet()

--- a/test/mysqlctl.py
+++ b/test/mysqlctl.py
@@ -39,6 +39,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/reparent.py
+++ b/test/reparent.py
@@ -38,6 +38,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -73,6 +73,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/rowcache_invalidator.py
+++ b/test/rowcache_invalidator.py
@@ -67,6 +67,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
   logging.debug('Tearing down the servers and setup')

--- a/test/schema.py
+++ b/test/schema.py
@@ -122,6 +122,7 @@ def _teardown_shard_2():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/secure.py
+++ b/test/secure.py
@@ -166,6 +166,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/sharded.py
+++ b/test/sharded.py
@@ -33,6 +33,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -41,6 +41,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -116,6 +116,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
   logging.debug('Tearing down the servers and setup')

--- a/test/utils.py
+++ b/test/utils.py
@@ -192,15 +192,17 @@ def _add_proc(proc):
     print >> f, proc.pid, os.path.basename(proc.args[0])
 
 
-def kill_sub_processes():
-  # FIXME(alainjobart): this part is not really related to sub-processes,
-  # but it's a general clean-up. Maybe a utils.clean_up() might be better,
-  # as all integration tests end up running this anyway.
+def required_teardown():
+  """Required cleanup steps that can't be skipped with --skip-teardown."""
+  # We can't skip closing of gRPC connections, because the Python interpreter
+  # won't let us die if any connections are left open.
   global vtctld_connection
   if vtctld_connection:
     vtctld_connection.close()
     vtctld_connection = None
 
+
+def kill_sub_processes():
   for proc in pid_map.values():
     if proc.pid and proc.returncode is None:
       proc.kill()
@@ -1152,6 +1154,7 @@ def uint64_to_hex(integer):
   if integer > (1<<64)-1 or integer < 0:
     raise ValueError('Integer out of range: %d' % integer)
   return '%016X' % integer
+
 
 def get_shard_name(shard, num_shards):
   """Returns an appropriate shard name, as a string.

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -54,6 +54,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -38,6 +38,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -109,6 +109,7 @@ def setUpModule():
 
 def tearDownModule():
   logging.debug('in tearDownModule')
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
   logging.debug('Tearing down the servers and setup')

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -224,6 +224,7 @@ def setUpModule():
 
 def tearDownModule():
   logging.debug('in tearDownModule')
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
   logging.debug('Tearing down the servers and setup')

--- a/test/worker.py
+++ b/test/worker.py
@@ -123,6 +123,7 @@ def setUpModule():
 
 
 def tearDownModule():
+  utils.required_teardown()
   if utils.options.skip_teardown:
     return
 


### PR DESCRIPTION
@alainjobart 

We can't skip closing of grpc connections, or else the Python
interpreter will never exit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1513)
<!-- Reviewable:end -->
