### PR TITLE
java/example: Exit with non-zero return value in case of an error.

### DIFF
--- a/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
@@ -72,6 +72,7 @@ public class VitessClientExample {
       System.out.println("Vitess Java example failed.");
       System.out.println("Error Details:");
       e.printStackTrace();
+      System.exit(2);
     }
   }
 }


### PR DESCRIPTION
@enisoc Since the example is currently broken, Travis will fail now on this PR :)

I've confirmed locally that adding .checkedGet() to the two transaction calls makes the example pass again. So I'll wait for your commit to be merged before merging this one.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1534)
<!-- Reviewable:end -->
