### PR TITLE
tabletmanager: Broadcast the health immediately after the QueryService state has changed.

### DIFF
--- a/go/vt/tabletmanager/rpc_replication.go
+++ b/go/vt/tabletmanager/rpc_replication.go
@@ -208,7 +208,9 @@ func (agent *ActionAgent) DemoteMaster(ctx context.Context) (string, error) {
 	// Now disallow queries, to make sure nobody is writing to the
 	// database.
 	tablet := agent.Tablet()
-	if err := agent.disallowQueries(tablet.Type, "DemoteMaster marks server rdonly"); err != nil {
+	// We don't care if the QueryService state actually changed because we'll
+	// let vtgate keep serving read traffic from this master (see comment below).
+	if _ /* state changed */, err := agent.disallowQueries(tablet.Type, "DemoteMaster marks server rdonly"); err != nil {
 		return "", fmt.Errorf("disallowQueries failed: %v", err)
 	}
 
@@ -227,7 +229,7 @@ func (agent *ActionAgent) DemoteMaster(ctx context.Context) (string, error) {
 	// There is no serving graph update - the master tablet will
 	// be replaced. Even though writes may fail, reads will
 	// succeed. It will be less noisy to simply leave the entry
-	// until well promote the master.
+	// until we'll promote the master.
 }
 
 // PromoteSlaveWhenCaughtUp waits for this slave to be caught up on

--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -196,7 +196,8 @@ type Controller interface {
 	InitDBConfig(querypb.Target, dbconfigs.DBConfigs, []SchemaOverride, mysqlctl.MysqlDaemon) error
 
 	// SetServingType transitions the query service to the required serving type.
-	SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) error
+	// Returns true if the state of QueryService or the tablet type changed.
+	SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (bool, error)
 
 	// EnterLameduck causes tabletserver to enter the lameduck state.
 	EnterLameduck()

--- a/go/vt/tabletserver/tabletserver_test.go
+++ b/go/vt/tabletserver/tabletserver_test.go
@@ -249,25 +249,37 @@ func TestSetServingType(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = tsv.SetServingType(topodatapb.TabletType_REPLICA, false, nil)
+	stateChanged, err := tsv.SetServingType(topodatapb.TabletType_REPLICA, false, nil)
+	if stateChanged != false {
+		t.Errorf("SetServingType() should NOT have changed the QueryService state, but did")
+	}
 	if err != nil {
 		t.Error(err)
 	}
 	checkTabletServerState(t, tsv, StateNotConnected)
 
-	err = tsv.SetServingType(topodatapb.TabletType_REPLICA, true, nil)
+	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_REPLICA, true, nil)
+	if stateChanged != true {
+		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
+	}
 	if err != nil {
 		t.Error(err)
 	}
 	checkTabletServerState(t, tsv, StateServing)
 
-	err = tsv.SetServingType(topodatapb.TabletType_RDONLY, true, nil)
+	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_RDONLY, true, nil)
+	if stateChanged != true {
+		t.Errorf("SetServingType() should have changed the tablet type, but did not")
+	}
 	if err != nil {
 		t.Error(err)
 	}
 	checkTabletServerState(t, tsv, StateServing)
 
-	err = tsv.SetServingType(topodatapb.TabletType_SPARE, false, nil)
+	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_SPARE, false, nil)
+	if stateChanged != true {
+		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
+	}
 	if err != nil {
 		t.Error(err)
 	}
@@ -278,7 +290,10 @@ func TestSetServingType(t *testing.T) {
 	if stateName := tsv.GetState(); stateName != "NOT_SERVING" {
 		t.Errorf("GetState: %s, want NOT_SERVING", stateName)
 	}
-	err = tsv.SetServingType(topodatapb.TabletType_REPLICA, true, nil)
+	stateChanged, err = tsv.SetServingType(topodatapb.TabletType_REPLICA, true, nil)
+	if stateChanged != true {
+		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
+	}
 	if err != nil {
 		t.Error(err)
 	}
@@ -396,9 +411,12 @@ func TestTabletServerCheckMysql(t *testing.T) {
 	if !tsv.isMySQLReachable() {
 		t.Error("isMySQLReachable should return true")
 	}
-	err = tsv.SetServingType(topodatapb.TabletType_SPARE, false, nil)
+	stateChanged, err := tsv.SetServingType(topodatapb.TabletType_SPARE, false, nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if stateChanged != true {
+		t.Errorf("SetServingType() should have changed the QueryService state, but did not")
 	}
 	if !tsv.isMySQLReachable() {
 		t.Error("isMySQLReachable should return true")

--- a/go/vt/tabletserver/tabletservermock/controller.go
+++ b/go/vt/tabletserver/tabletservermock/controller.go
@@ -79,12 +79,14 @@ func (tqsc *Controller) InitDBConfig(target querypb.Target, dbConfigs dbconfigs.
 }
 
 // SetServingType is part of the tabletserver.Controller interface
-func (tqsc *Controller) SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) error {
+func (tqsc *Controller) SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (bool, error) {
+	stateChanged := false
 	if tqsc.SetServingTypeError == nil {
 		tqsc.CurrentTarget.TabletType = tabletType
 		tqsc.QueryServiceEnabled = serving
+		stateChanged = tqsc.QueryServiceEnabled != serving || tqsc.CurrentTarget.TabletType != tabletType
 	}
-	return tqsc.SetServingTypeError
+	return stateChanged, tqsc.SetServingTypeError
 }
 
 // IsServing is part of the tabletserver.Controller interface


### PR DESCRIPTION
@enisoc 

@guoliang100 for FYI

This reduces the downtime a master will be unavailable during a traffic migration (MigrateServed(From|Types)) during resharding. Before this change, vtgate will not use the master in the destination keyspace until the next healthcheck does run (default interval = 20s).

During resharding, vtgate will see the following healthcheck messages for the destination master:
(This is with health_check_interval=15s. See the timestamps for periodic vs. immediate updates.)

```
# serving=True before filtered replication is enabled (periodic update):
I0304 17:34:15.304606    2570 query.go:491] {"target":{"keyspace":"destination_keyspace","shard":"0","tablet_type":1},"serving":true,"realtime_stats":{}}
```

```
# serving=False because filtered replication is enabled now (NEW immediate update)
I0304 17:34:23.601918    2570 query.go:491] {"target":{"keyspace":"destination_keyspace","shard":"0","tablet_type":1},"realtime_stats":{"binlog_players_count":1}}
```

```
# serving=True because traffic was migrated to destination master (NEW immediate update)
I0304 17:36:02.331239    2570 query.go:491] {"target":{"keyspace":"destination_keyspace","shard":"0","tablet_type":1},"serving":true,"realtime_stats":{}}
```

```
# serving=True by next periodic update
I0304 17:36:15.306677    2570 query.go:491] {"target":{"keyspace":"destination_keyspace","shard":"0","tablet_type":1},"serving":true,"realtime_stats":{}}
```

Other changes:
- Always use the return values of allowQueries() and disallowQueries().

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1551)
<!-- Reviewable:end -->
