### PR TITLE
Fixing a bug in table blacklisting.

### DIFF
--- a/go/vt/tabletmanager/state_change.go
+++ b/go/vt/tabletmanager/state_change.go
@@ -52,9 +52,8 @@ func (agent *ActionAgent) loadBlacklistRules(tablet *topodatapb.Tablet, blacklis
 			return err
 		}
 
-		// if the wildcards resolve into real tables, blacklist them.
-		// (if there are no tables here, the rule would blacklist
-		// all queries, oops).
+		// Verify that at least one table matches the wildcards, so
+		// that we don't add a rule to blacklist all tables
 		if len(tables) > 0 {
 			log.Infof("Blacklisting tables %v", strings.Join(tables, ", "))
 			qr := tabletserver.NewQueryRule("enforce blacklisted tables", "blacklisted_table", tabletserver.QRFailRetry)


### PR DESCRIPTION
If a tablet has blacklisted table rules that don't match
any existing tables, don't blacklist exverything.
In the process, allowing schema changes on databases with views,
as the integration test needs it, and it's a good fix anyway.

@michael-berlin @aaijazi @enisoc Note the test fails as expected with 'blacklisted table' when the fix is not applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1561)
<!-- Reviewable:end -->
