### PR TITLE
java: Add blocking (synchronous) client wrapper.

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
@@ -1,0 +1,187 @@
+package com.youtube.vitess.client;
+
+import com.youtube.vitess.client.cursor.Cursor;
+import com.youtube.vitess.proto.Topodata.KeyRange;
+import com.youtube.vitess.proto.Topodata.SrvKeyspace;
+import com.youtube.vitess.proto.Topodata.TabletType;
+import com.youtube.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
+import com.youtube.vitess.proto.Vtgate.BoundShardQuery;
+import com.youtube.vitess.proto.Vtgate.SplitQueryResponse;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A synchronous wrapper around a VTGate connection.
+ *
+ * <p>This is a wrapper around the asynchronous {@link VTGateConn} class
+ * that converts all methods to synchronous.
+ */
+public class VTGateBlockingConn implements Closeable {
+  private final VTGateConn conn;
+
+  /**
+   * Creates a new {@link VTGateConn} with the given {@link RpcClient}
+   * and wraps it in a synchronous API.
+   */
+  public VTGateBlockingConn(RpcClient client) {
+    conn = new VTGateConn(client);
+  }
+
+  /**
+   * Wraps an existing {@link VTGateConn} in a synchronous API.
+   */
+  public VTGateBlockingConn(VTGateConn conn) {
+    this.conn = conn;
+  }
+
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
+    return conn.execute(ctx, query, bindVars, tabletType).checkedGet();
+  }
+
+  public Cursor executeShards(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<String> shards,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+  }
+
+  public Cursor executeKeyspaceIds(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<byte[]> keyspaceIds,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+        .checkedGet();
+  }
+
+  public Cursor executeKeyRanges(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<? extends KeyRange> keyRanges,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
+        .checkedGet();
+  }
+
+  public Cursor executeEntityIds(
+      Context ctx,
+      String query,
+      String keyspace,
+      String entityColumnName,
+      Map<byte[], ?> entityKeyspaceIds,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.executeEntityIds(
+            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType)
+        .checkedGet();
+  }
+
+  /**
+   * Execute multiple keyspace ID queries as a batch.
+   *
+   * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
+   * the batch queries.
+   */
+  public List<Cursor> executeBatchShards(
+      Context ctx,
+      Iterable<? extends BoundShardQuery> queries,
+      TabletType tabletType,
+      boolean asTransaction)
+      throws SQLException {
+    return conn.executeBatchShards(ctx, queries, tabletType, asTransaction).checkedGet();
+  }
+
+  /**
+   * Execute multiple keyspace ID queries as a batch.
+   *
+   * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
+   * the batch queries.
+   */
+  public List<Cursor> executeBatchKeyspaceIds(
+      Context ctx,
+      Iterable<? extends BoundKeyspaceIdQuery> queries,
+      TabletType tabletType,
+      boolean asTransaction)
+      throws SQLException {
+    return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction).checkedGet();
+  }
+
+  public Cursor streamExecute(
+      Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
+    return conn.streamExecute(ctx, query, bindVars, tabletType);
+  }
+
+  public Cursor streamExecuteShards(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<String> shards,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType);
+  }
+
+  public Cursor streamExecuteKeyspaceIds(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<byte[]> keyspaceIds,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType);
+  }
+
+  public Cursor streamExecuteKeyRanges(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<? extends KeyRange> keyRanges,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType);
+  }
+
+  public VTGateBlockingTx begin(Context ctx) throws SQLException {
+    return new VTGateBlockingTx(conn.begin(ctx).checkedGet());
+  }
+
+  public List<SplitQueryResponse.Part> splitQuery(
+      Context ctx,
+      String keyspace,
+      String query,
+      Map<String, ?> bindVars,
+      String splitColumn,
+      long splitCount)
+      throws SQLException {
+    return conn.splitQuery(ctx, keyspace, query, bindVars, splitColumn, splitCount).checkedGet();
+  }
+
+  public SrvKeyspace getSrvKeyspace(Context ctx, String keyspace) throws SQLException {
+    return conn.getSrvKeyspace(ctx, keyspace).checkedGet();
+  }
+
+  @Override
+  public void close() throws IOException {
+    conn.close();
+  }
+}

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
@@ -1,0 +1,101 @@
+package com.youtube.vitess.client;
+
+import com.youtube.vitess.client.cursor.Cursor;
+import com.youtube.vitess.proto.Topodata.KeyRange;
+import com.youtube.vitess.proto.Topodata.TabletType;
+import com.youtube.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
+import com.youtube.vitess.proto.Vtgate.BoundShardQuery;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A synchronous wrapper around a VTGate transaction.
+ *
+ * <p>This is a wrapper around the asynchronous {@link VTGateTx} class
+ * that converts all methods to synchronous.
+ */
+public class VTGateBlockingTx {
+  private final VTGateTx tx;
+
+  /**
+   * Wraps an existing {@link VTGateTx} in a synchronous API.
+   */
+  public VTGateBlockingTx(VTGateTx tx) {
+    this.tx = tx;
+  }
+
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+      throws SQLException {
+    return tx.execute(ctx, query, bindVars, tabletType).checkedGet();
+  }
+
+  public Cursor executeShards(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<String> shards,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return tx.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+  }
+
+  public Cursor executeKeyspaceIds(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<byte[]> keyspaceIds,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return tx.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+        .checkedGet();
+  }
+
+  public Cursor executeKeyRanges(
+      Context ctx,
+      String query,
+      String keyspace,
+      Iterable<? extends KeyRange> keyRanges,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return tx.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType).checkedGet();
+  }
+
+  public Cursor executeEntityIds(
+      Context ctx,
+      String query,
+      String keyspace,
+      String entityColumnName,
+      Map<byte[], ?> entityKeyspaceIds,
+      Map<String, ?> bindVars,
+      TabletType tabletType)
+      throws SQLException {
+    return tx.executeEntityIds(
+            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType)
+        .checkedGet();
+  }
+
+  public List<Cursor> executeBatchShards(
+      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType)
+      throws SQLException {
+    return tx.executeBatchShards(ctx, queries, tabletType).checkedGet();
+  }
+
+  public List<Cursor> executeBatchKeyspaceIds(
+      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType)
+      throws SQLException {
+    return tx.executeBatchKeyspaceIds(ctx, queries, tabletType).checkedGet();
+  }
+
+  public void commit(Context ctx) throws SQLException {
+    tx.commit(ctx).checkedGet();
+  }
+
+  public void rollback(Context ctx) throws SQLException {
+    tx.rollback(ctx).checkedGet();
+  }
+}

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -49,19 +49,15 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * VTGateConn manages a VTGate connection.
+ * An asynchronous VTGate connection.
  *
  * <p>See the
  * <a href="https://github.com/youtube/vitess/blob/master/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java">VitessClientExample</a>
  * for a usage example.
  *
- * <p>Non-streaming calls are asynchronous by default. To use these calls synchronously,
- * append {@code .checkedGet()}. For example:
- *
- * <blockquote><pre>
- * Cursor cursor = vtgateConn.execute(...).checkedGet();
- * </pre></blockquote>
- * */
+ * <p>All non-streaming calls on {@code VTGateConn} are asynchronous.
+ * Use {@link VTGateBlockingConn} if you want synchronous calls.
+ */
 public final class VTGateConn implements Closeable {
   private final RpcClient client;
 
@@ -370,7 +366,7 @@ public final class VTGateConn implements Closeable {
               @Override
               public ListenableFuture<VTGateTx> apply(BeginResponse response) throws Exception {
                 return Futures.<VTGateTx>immediateFuture(
-                    VTGateTx.withRpcClientAndSession(client, response.getSession()));
+                    new VTGateTx(client, response.getSession()));
               }
             }));
   }

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -39,7 +39,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Manages a pending transaction.
+ * An asynchronous VTGate transaction session.
  *
  * <p>Because {@code VTGateTx} manages a session cookie, only one operation can be in flight
  * at a time on a given instance. The methods are {@code synchronized} only because the
@@ -49,24 +49,23 @@ import java.util.Map;
  * complete before calling any other methods on that {@code VTGateTx} instance.
  * An {@link IllegalStateException} will be thrown if this constraint is violated.
  *
- * <p>To use these calls synchronously, append {@code .checkedGet()}. For example:
+ * <p>All operations on {@code VTGateTx} are asynchronous, including those whose ultimate
+ * return type is {@link Void}, such as {@link #commit(Context)} and {@link #rollback(Context)}.
+ * You must still wait for the futures returned by these methods to complete and check the
+ * error on them (such as by calling {@code checkedGet()} before you can assume the operation
+ * has finished successfully.
  *
- * <blockquote><pre>
- * Cursor cursor = tx.execute(...).checkedGet();
- * </pre></blockquote>
+ * <p>If you prefer a synchronous API, you can use {@link VTGateBlockingConn#begin(Context)},
+ * which returns a {@link VTGateBlockingTx} instead.
  */
 public class VTGateTx {
   private final RpcClient client;
   private Session session;
   private SQLFuture<?> lastCall;
 
-  private VTGateTx(RpcClient client, Session session) {
+  VTGateTx(RpcClient client, Session session) {
     this.client = checkNotNull(client);
     setSession(checkNotNull(session));
-  }
-
-  public static VTGateTx withRpcClientAndSession(RpcClient client, Session session) {
-    return new VTGateTx(client, session);
   }
 
   public synchronized SQLFuture<Cursor> execute(

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -44,12 +44,13 @@ public abstract class RpcClientTest {
   protected static RpcClient client;
 
   private Context ctx;
-  private VTGateConn conn;
+  private VTGateBlockingConn conn;
 
   @Before
   public void setUp() {
     ctx = Context.getDefault().withDeadlineAfter(Duration.millis(5000)).withCallerId(CALLER_ID);
-    conn = new VTGateConn(client);
+    // Test VTGateConn via the synchronous VTGateBlockingConn wrapper.
+    conn = new VTGateBlockingConn(client);
   }
 
   private static final String ECHO_PREFIX = "echo://";
@@ -117,19 +118,6 @@ public abstract class RpcClientTest {
           .build();
   private static final String CALLER_ID_ECHO =
       "principal:\"test_principal\" component:\"test_component\" subcomponent:\"test_subcomponent\" ";
-
-  private static Map<String, String> getEcho(SQLFuture<?> future) throws Exception {
-    Object obj = future.checkedGet();
-    if (obj instanceof Cursor) {
-      return getEcho((Cursor) obj);
-    }
-    if (obj instanceof List<?>) {
-      @SuppressWarnings("unchecked") // by specification
-      List<Cursor> results = (List<Cursor>) obj;
-      return getEcho(results.get(0));
-    }
-    throw new Exception("unknown type");
-  }
 
   private static Map<String, String> getEcho(Cursor cursor) throws Exception {
     Map<String, String> values = new HashMap<String, String>();
@@ -223,11 +211,12 @@ public abstract class RpcClientTest {
     echo =
         getEcho(
             conn.executeBatchShards(
-                ctx,
-                Arrays.asList(
-                    Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-                TABLET_TYPE,
-                true));
+                    ctx,
+                    Arrays.asList(
+                        Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
+                    TABLET_TYPE,
+                    true)
+                .get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -239,12 +228,13 @@ public abstract class RpcClientTest {
     echo =
         getEcho(
             conn.executeBatchKeyspaceIds(
-                ctx,
-                Arrays.asList(
-                    Proto.bindKeyspaceIdQuery(
-                        KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-                TABLET_TYPE,
-                true));
+                    ctx,
+                    Arrays.asList(
+                        Proto.bindKeyspaceIdQuery(
+                            KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
+                    TABLET_TYPE,
+                    true)
+                .get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -302,9 +292,9 @@ public abstract class RpcClientTest {
   public void testEchoTransactionExecute() throws Exception {
     Map<String, String> echo;
 
-    VTGateTx tx = conn.begin(ctx).checkedGet();
+    VTGateBlockingTx tx = conn.begin(ctx);
 
-    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE).checkedGet());
+    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
@@ -371,15 +361,16 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     tx.rollback(ctx);
-    tx = conn.begin(ctx).checkedGet();
+    tx = conn.begin(ctx);
 
     echo =
         getEcho(
             tx.executeBatchShards(
-                ctx,
-                Arrays.asList(
-                    Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-                TABLET_TYPE));
+                    ctx,
+                    Arrays.asList(
+                        Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
+                    TABLET_TYPE)
+                .get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -392,11 +383,12 @@ public abstract class RpcClientTest {
     echo =
         getEcho(
             tx.executeBatchKeyspaceIds(
-                ctx,
-                Arrays.asList(
-                    Proto.bindKeyspaceIdQuery(
-                        KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-                TABLET_TYPE));
+                    ctx,
+                    Arrays.asList(
+                        Proto.bindKeyspaceIdQuery(
+                            KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
+                    TABLET_TYPE)
+                .get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -418,9 +410,7 @@ public abstract class RpcClientTest {
                 SplitQueryResponse.KeyRangePart.newBuilder().setKeyspace(KEYSPACE).build())
             .build();
     SplitQueryResponse.Part actual =
-        conn.splitQuery(ctx, KEYSPACE, ECHO_PREFIX + QUERY, BIND_VARS, "split_column", 123)
-            .checkedGet()
-            .get(0);
+        conn.splitQuery(ctx, KEYSPACE, ECHO_PREFIX + QUERY, BIND_VARS, "split_column", 123).get(0);
     Assert.assertEquals(expected, actual);
   }
 
@@ -453,7 +443,7 @@ public abstract class RpcClientTest {
                     .build())
             .setSplitShardCount(128)
             .build();
-    SrvKeyspace actual = conn.getSrvKeyspace(ctx, "big").checkedGet();
+    SrvKeyspace actual = conn.getSrvKeyspace(ctx, "big");
     Assert.assertEquals(expected, actual);
   }
 
@@ -495,7 +485,7 @@ public abstract class RpcClientTest {
   }
 
   abstract class TransactionExecutable {
-    abstract void execute(VTGateTx tx, String query) throws Exception;
+    abstract void execute(VTGateBlockingTx tx, String query) throws Exception;
   }
 
   void checkTransactionExecuteErrors(TransactionExecutable exe) throws Exception {
@@ -503,7 +493,7 @@ public abstract class RpcClientTest {
       Class<?> cls = EXECUTE_ERRORS.get(error);
 
       try {
-        VTGateTx tx = conn.begin(ctx).checkedGet();
+        VTGateBlockingTx tx = conn.begin(ctx);
         String query = ERROR_PREFIX + error;
         exe.execute(tx, query);
         Assert.fail("no exception thrown for " + query);
@@ -512,7 +502,7 @@ public abstract class RpcClientTest {
       }
 
       // Don't close the transaction on partial error.
-      VTGateTx tx = conn.begin(ctx).checkedGet();
+      VTGateBlockingTx tx = conn.begin(ctx);
       try {
         String query = PARTIAL_ERROR_PREFIX + error;
         exe.execute(tx, query);
@@ -524,7 +514,7 @@ public abstract class RpcClientTest {
       tx.rollback(ctx);
 
       // Close the transaction on partial error.
-      tx = conn.begin(ctx).checkedGet();
+      tx = conn.begin(ctx);
       try {
         String query = PARTIAL_ERROR_PREFIX + error + "/close transaction";
         exe.execute(tx, query);
@@ -549,30 +539,28 @@ public abstract class RpcClientTest {
         new Executable() {
           @Override
           void execute(String query) throws Exception {
-            conn.execute(ctx, query, BIND_VARS, TABLET_TYPE).checkedGet();
+            conn.execute(ctx, query, BIND_VARS, TABLET_TYPE);
           }
         });
     checkExecuteErrors(
         new Executable() {
           @Override
           void execute(String query) throws Exception {
-            conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE).checkedGet();
+            conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkExecuteErrors(
         new Executable() {
           @Override
           void execute(String query) throws Exception {
-            conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+            conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkExecuteErrors(
         new Executable() {
           @Override
           void execute(String query) throws Exception {
-            conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+            conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
           }
         });
     checkExecuteErrors(
@@ -580,8 +568,7 @@ public abstract class RpcClientTest {
           @Override
           void execute(String query) throws Exception {
             conn.executeEntityIds(
-                    ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+                ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkExecuteErrors(
@@ -589,11 +576,10 @@ public abstract class RpcClientTest {
           @Override
           void execute(String query) throws Exception {
             conn.executeBatchShards(
-                    ctx,
-                    Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)),
-                    TABLET_TYPE,
-                    true)
-                .checkedGet();
+                ctx,
+                Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)),
+                TABLET_TYPE,
+                true);
           }
         });
     checkExecuteErrors(
@@ -601,12 +587,10 @@ public abstract class RpcClientTest {
           @Override
           void execute(String query) throws Exception {
             conn.executeBatchKeyspaceIds(
-                    ctx,
-                    Arrays.asList(
-                        Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-                    TABLET_TYPE,
-                    true)
-                .checkedGet();
+                ctx,
+                Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
+                TABLET_TYPE,
+                true);
           }
         });
   }
@@ -651,63 +635,57 @@ public abstract class RpcClientTest {
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
-            tx.execute(ctx, query, BIND_VARS, TABLET_TYPE).checkedGet();
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
+            tx.execute(ctx, query, BIND_VARS, TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
-            tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE).checkedGet();
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
+            tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
-            tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
+            tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
-            tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
+            tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
             tx.executeEntityIds(
-                    ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
-                .checkedGet();
+                ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
             tx.executeBatchShards(
-                    ctx,
-                    Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)),
-                    TABLET_TYPE)
-                .checkedGet();
+                ctx,
+                Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)),
+                TABLET_TYPE);
           }
         });
     checkTransactionExecuteErrors(
         new TransactionExecutable() {
           @Override
-          void execute(VTGateTx tx, String query) throws Exception {
+          void execute(VTGateBlockingTx tx, String query) throws Exception {
             tx.executeBatchKeyspaceIds(
-                    ctx,
-                    Arrays.asList(
-                        Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-                    TABLET_TYPE)
-                .checkedGet();
+                ctx,
+                Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
+                TABLET_TYPE);
           }
         });
   }

--- a/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessInputFormat.java
+++ b/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessInputFormat.java
@@ -2,12 +2,13 @@ package com.youtube.vitess.hadoop;
 
 import com.google.api.client.util.Lists;
 import com.google.common.net.HostAndPort;
+
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.RpcClient;
 import com.youtube.vitess.client.RpcClientFactory;
-import com.youtube.vitess.client.VTGateConn;
-import com.youtube.vitess.client.cursor.Row;
+import com.youtube.vitess.client.VTGateBlockingConn;
 import com.youtube.vitess.proto.Vtgate.SplitQueryResponse;
+
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -33,52 +34,61 @@ public class VitessInputFormat extends InputFormat<NullWritable, RowWritable> {
 
   @Override
   public List<InputSplit> getSplits(JobContext context) {
-      VitessConf conf = new VitessConf(context.getConfiguration());
-      Class<? extends RpcClientFactory> rpcFactoryClass = null;
-      VTGateConn vtgate;
-      try {
-        rpcFactoryClass =
-                (Class<? extends RpcClientFactory>)Class.forName(conf.getRpcFactoryClass());
-        List<String> addressList = Arrays.asList(conf.getHosts().split(","));
-        int index = new Random().nextInt(addressList.size());
-        HostAndPort hostAndPort = HostAndPort.fromString(addressList.get(index));
-        RpcClient rpcClient = rpcFactoryClass.newInstance().create(
-                Context.getDefault().withDeadlineAfter(Duration.millis(conf.getTimeoutMs())),
-                new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort()));
-        vtgate = new VTGateConn(rpcClient);
-      } catch (ClassNotFoundException|InstantiationException|IllegalAccessException e) {
-        throw new RuntimeException(e);
-      }
+    VitessConf conf = new VitessConf(context.getConfiguration());
+    Class<? extends RpcClientFactory> rpcFactoryClass = null;
+    VTGateBlockingConn vtgate;
+    try {
+      rpcFactoryClass =
+          (Class<? extends RpcClientFactory>) Class.forName(conf.getRpcFactoryClass());
+      List<String> addressList = Arrays.asList(conf.getHosts().split(","));
+      int index = new Random().nextInt(addressList.size());
+      HostAndPort hostAndPort = HostAndPort.fromString(addressList.get(index));
+      RpcClient rpcClient =
+          rpcFactoryClass
+              .newInstance()
+              .create(
+                  Context.getDefault().withDeadlineAfter(Duration.millis(conf.getTimeoutMs())),
+                  new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort()));
+      vtgate = new VTGateBlockingConn(rpcClient);
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
 
-      List<SplitQueryResponse.Part> splitResult;
-      try {
-        splitResult = vtgate.splitQuery(
-                Context.getDefault(), conf.getKeyspace(), conf.getInputQuery(),
-                null, conf.getSplitColumn(), conf.getSplits()).checkedGet();
-      } catch (SQLException e) {
-        throw new RuntimeException(e);
-      }
+    List<SplitQueryResponse.Part> splitResult;
+    try {
+      splitResult =
+          vtgate.splitQuery(
+              Context.getDefault(),
+              conf.getKeyspace(),
+              conf.getInputQuery(),
+              null,
+              conf.getSplitColumn(),
+              conf.getSplits());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
 
-      List<InputSplit> splits = Lists.newArrayList();
-      for (SplitQueryResponse.Part part : splitResult) {
-        splits.add(new VitessInputSplit(part));
-      }
+    List<InputSplit> splits = Lists.newArrayList();
+    for (SplitQueryResponse.Part part : splitResult) {
+      splits.add(new VitessInputSplit(part));
+    }
 
-      for (InputSplit split : splits) {
-        ((VitessInputSplit) split).setLocations(conf.getHosts().split(VitessConf.HOSTS_DELIM));
-      }
-      return splits;
+    for (InputSplit split : splits) {
+      ((VitessInputSplit) split).setLocations(conf.getHosts().split(VitessConf.HOSTS_DELIM));
+    }
+    return splits;
   }
 
-  public RecordReader<NullWritable, RowWritable> createRecordReader(InputSplit split,
-      TaskAttemptContext context) throws IOException, InterruptedException {
+  public RecordReader<NullWritable, RowWritable> createRecordReader(
+      InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
     return new VitessRecordReader();
   }
 
   /**
    * Sets the necessary configurations for Vitess table input source
    */
-  public static void setInput(Job job,
+  public static void setInput(
+      Job job,
       String hosts,
       String keyspace,
       String query,


### PR DESCRIPTION
@erzel 

Using this wrapper when you want a synchronous API ensures that you don't accidentally forget to call `checkedGet()` on asynchronous methods when you don't use the result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1566)
<!-- Reviewable:end -->
