### PR TITLE
java: Update dependencies.

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -16,17 +16,9 @@
       <version>2.5</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>2.5.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-      <version>2.5.1</version>
-      <!-- Include the test jar to reuse Hadoop testing utils -->
-      <type>test-jar</type>
-      <scope>test</scope>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.0</version>
     </dependency>
   </dependencies>
 

--- a/java/hadoop/pom.xml
+++ b/java/hadoop/pom.xml
@@ -24,8 +24,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-client</artifactId>
+        <version>2.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-        <version>2.5.1</version>
+        <version>2.7.2</version>
         <!-- Include the test jar to reuse Hadoop testing utils -->
         <type>test-jar</type>
         <scope>test</scope>


### PR DESCRIPTION
@alainjobart 

* Get rid of transitive dependency on commons-collections 3.2.1 by
  updating hadoop version.
* Move hadoop dependency from `client` project to `hadoop` project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1567)
<!-- Reviewable:end -->
