### PR TITLE
tabletmanager: Add integration test for immediate health broadcast after state changes.

### DIFF
--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -243,16 +243,6 @@ func (agent *ActionAgent) runHealthCheck(targetTabletType topodatapb.TabletType)
 		if isServing {
 			// We are not healthy or should not be running the query service.
 			//
-			// We do NOT enter lameduck in this case, because we should only hit this
-			// in the following scenarios:
-			//
-			// * Healthcheck fails: We're probably serving errors anyway, so no point.
-			// * Replication lag exceeds unhealthy threshold: This is very rare, so it
-			//   isn't worth optimizing the potential 1s of errors away. It will also
-			//   go away when vtgate is the only one looking at lag.
-			// * We're in a special state where queryservice should be disabled
-			//   despite being non-SPARE: This is not a live serving instance anyway.
-			//
 			// We don't care if the QueryService state actually changed because we'll
 			// broadcast the latest health status after this immediately anway.
 			_ /* state changed */, err := agent.disallowQueries(tablet.Type,

--- a/go/vt/tabletmanager/state_change.go
+++ b/go/vt/tabletmanager/state_change.go
@@ -247,6 +247,7 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 				log.Errorf("Can't start query service for MASTER+REPLICA mode: %v", err)
 			}
 		}
+
 		if stateChanged, err := agent.allowQueries(newTablet.Type); err == nil {
 			// If the state changed, broadcast to vtgate.
 			// (e.g. this happens when the tablet was already master, but it just
@@ -269,6 +270,7 @@ func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTabl
 			agent.broadcastHealth()
 			time.Sleep(*gracePeriod)
 		}
+
 		if stateChanged, err := agent.disallowQueries(newTablet.Type, disallowQueryReason); err == nil {
 			// If the state changed, broadcast to vtgate.
 			// (e.g. this happens when the tablet was already master, but it just

--- a/go/vt/tabletserver/tabletservermock/controller.go
+++ b/go/vt/tabletserver/tabletservermock/controller.go
@@ -82,9 +82,9 @@ func (tqsc *Controller) InitDBConfig(target querypb.Target, dbConfigs dbconfigs.
 func (tqsc *Controller) SetServingType(tabletType topodatapb.TabletType, serving bool, alsoAllow []topodatapb.TabletType) (bool, error) {
 	stateChanged := false
 	if tqsc.SetServingTypeError == nil {
+		stateChanged = tqsc.QueryServiceEnabled != serving || tqsc.CurrentTarget.TabletType != tabletType
 		tqsc.CurrentTarget.TabletType = tabletType
 		tqsc.QueryServiceEnabled = serving
-		stateChanged = tqsc.QueryServiceEnabled != serving || tqsc.CurrentTarget.TabletType != tabletType
 	}
 	return stateChanged, tqsc.SetServingTypeError
 }


### PR DESCRIPTION
@alainjobart @enisoc 

This adss a test for the change in https://github.com/youtube/vitess/pull/1551.

I've also refactored the test in general and made it more "tight": It has to consume each health broadcast message now and mustn't leave out any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1569)
<!-- Reviewable:end -->
