### PR TITLE
Switching the style of binlog player RPC.

### DIFF
--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -335,19 +334,41 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 		}()
 	}
 
-	var responseChan chan *binlogdatapb.BinlogTransaction
-	var errFunc ErrFunc
+	var stream BinlogTransactionStream
 	if len(blp.tables) > 0 {
-		responseChan, errFunc, err = blplClient.StreamTables(ctx, replication.EncodePosition(blp.position), blp.tables, blp.defaultCharset)
+		stream, err = blplClient.StreamTables(ctx, replication.EncodePosition(blp.position), blp.tables, blp.defaultCharset)
 	} else {
-		responseChan, errFunc, err = blplClient.StreamKeyRange(ctx, replication.EncodePosition(blp.position), blp.keyRange, blp.defaultCharset)
+		stream, err = blplClient.StreamKeyRange(ctx, replication.EncodePosition(blp.position), blp.keyRange, blp.defaultCharset)
 	}
 	if err != nil {
 		log.Errorf("Error sending streaming query to binlog server: %v", err)
 		return fmt.Errorf("error sending streaming query to binlog server: %v", err)
 	}
 
-	for response := range responseChan {
+	for {
+		// get the response
+		response, err := stream.Recv()
+		if err != nil {
+			switch err {
+			case context.Canceled:
+				return nil
+			default:
+				// if the context is canceled, we
+				// return nil (some RPC
+				// implementations will remap the
+				// context error to their own errors)
+				select {
+				case <-ctx.Done():
+					if ctx.Err() == context.Canceled {
+						return nil
+					}
+				default:
+				}
+				return fmt.Errorf("Error received from Stream %v", err)
+			}
+		}
+
+		// process the transaction
 		for {
 			ok, err = blp.processTransaction(response)
 			if err != nil {
@@ -365,24 +386,6 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 			log.Infof("Retrying txn")
 			time.Sleep(1 * time.Second)
 		}
-	}
-	switch err := errFunc(); err {
-	case nil:
-		return io.EOF
-	case context.Canceled:
-		return nil
-	default:
-		// if the context is canceled, we return nil (some RPC
-		// implementations will remap the context error to their own
-		// errors)
-		select {
-		case <-ctx.Done():
-			if ctx.Err() == context.Canceled {
-				return nil
-			}
-		default:
-		}
-		return fmt.Errorf("Error received from ServeBinlog %v", err)
 	}
 }
 

--- a/go/vt/binlog/binlogplayer/client.go
+++ b/go/vt/binlog/binlogplayer/client.go
@@ -22,8 +22,21 @@ This file contains the API and registration mechanism for binlog player client.
 
 var binlogPlayerProtocol = flag.String("binlog_player_protocol", "grpc", "the protocol to download binlogs from a vttablet")
 
-// ErrFunc is a return value for streaming events
-type ErrFunc func() error
+// StreamEventStream is the interface of the object returned by
+// ServeUpdateStream
+type StreamEventStream interface {
+	// Recv returns the next StreamEvent, or an error if the RPC was
+	// interrupted.
+	Recv() (*binlogdatapb.StreamEvent, error)
+}
+
+// BinlogTransactionStream is the interface of the object returned by
+// StreamTables and StreamKeyRange
+type BinlogTransactionStream interface {
+	// Recv returns the next BinlogTransaction, or an error if the RPC was
+	// interrupted.
+	Recv() (*binlogdatapb.BinlogTransaction, error)
+}
 
 // Client is the interface all clients must satisfy
 type Client interface {
@@ -35,15 +48,15 @@ type Client interface {
 
 	// Ask the server to stream binlog updates.
 	// Should return context.Canceled if the context is canceled.
-	ServeUpdateStream(ctx context.Context, position string) (chan *binlogdatapb.StreamEvent, ErrFunc, error)
+	ServeUpdateStream(ctx context.Context, position string) (StreamEventStream, error)
 
 	// Ask the server to stream updates related to the provided tables.
 	// Should return context.Canceled if the context is canceled.
-	StreamTables(ctx context.Context, position string, tables []string, charset *binlogdatapb.Charset) (chan *binlogdatapb.BinlogTransaction, ErrFunc, error)
+	StreamTables(ctx context.Context, position string, tables []string, charset *binlogdatapb.Charset) (BinlogTransactionStream, error)
 
 	// Ask the server to stream updates related to the provided keyrange.
 	// Should return context.Canceled if the context is canceled.
-	StreamKeyRange(ctx context.Context, position string, keyRange *topodatapb.KeyRange, charset *binlogdatapb.Charset) (chan *binlogdatapb.BinlogTransaction, ErrFunc, error)
+	StreamKeyRange(ctx context.Context, position string, keyRange *topodatapb.KeyRange, charset *binlogdatapb.Charset) (BinlogTransactionStream, error)
 }
 
 // ClientFactory is the factory method to create a Client

--- a/go/vt/binlog/binlogplayertest/player.go
+++ b/go/vt/binlog/binlogplayertest/player.go
@@ -90,37 +90,34 @@ func (fake *FakeBinlogStreamer) ServeUpdateStream(position string, sendReply fun
 
 func testServeUpdateStream(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.ServeUpdateStream(ctx, testUpdateStreamRequest)
+	stream, err := bpc.ServeUpdateStream(ctx, testUpdateStreamRequest)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; !ok {
-		t.Fatalf("got no response")
+	if se, err := stream.Recv(); err != nil {
+		t.Fatalf("got error: %v", err)
 	} else {
 		if !reflect.DeepEqual(*se, *testStreamEvent) {
 			t.Errorf("got wrong result, got \n%#v expected \n%#v", *se, *testStreamEvent)
 		}
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	if err := errFunc(); err != nil {
-		t.Errorf("got unexpected error: %v", err)
 	}
 }
 
 func testServeUpdateStreamPanics(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.ServeUpdateStream(ctx, testUpdateStreamRequest)
+	stream, err := bpc.ServeUpdateStream(ctx, testUpdateStreamRequest)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	err = errFunc()
-	if err == nil || !strings.Contains(err.Error(), "test-triggered panic") {
-		t.Errorf("wrong error from panic: %v", err)
+	} else {
+		if !strings.Contains(err.Error(), "test-triggered panic") {
+			t.Errorf("wrong error from panic: %v", err)
+		}
 	}
 }
 
@@ -176,37 +173,34 @@ func (fake *FakeBinlogStreamer) StreamKeyRange(position string, keyRange *topoda
 
 func testStreamKeyRange(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.StreamKeyRange(ctx, testKeyRangeRequest.Position, testKeyRangeRequest.KeyRange, testKeyRangeRequest.Charset)
+	stream, err := bpc.StreamKeyRange(ctx, testKeyRangeRequest.Position, testKeyRangeRequest.KeyRange, testKeyRangeRequest.Charset)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; !ok {
-		t.Fatalf("got no response")
+	if se, err := stream.Recv(); err != nil {
+		t.Fatalf("got error: %v", err)
 	} else {
 		if !reflect.DeepEqual(*se, *testBinlogTransaction) {
 			t.Errorf("got wrong result, got %v expected %v", *se, *testBinlogTransaction)
 		}
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	if err := errFunc(); err != nil {
-		t.Errorf("got unexpected error: %v", err)
 	}
 }
 
 func testStreamKeyRangePanics(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.StreamKeyRange(ctx, testKeyRangeRequest.Position, testKeyRangeRequest.KeyRange, testKeyRangeRequest.Charset)
+	stream, err := bpc.StreamKeyRange(ctx, testKeyRangeRequest.Position, testKeyRangeRequest.KeyRange, testKeyRangeRequest.Charset)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	err = errFunc()
-	if err == nil || !strings.Contains(err.Error(), "test-triggered panic") {
-		t.Errorf("wrong error from panic: %v", err)
+	} else {
+		if !strings.Contains(err.Error(), "test-triggered panic") {
+			t.Errorf("wrong error from panic: %v", err)
+		}
 	}
 }
 
@@ -243,37 +237,34 @@ func (fake *FakeBinlogStreamer) StreamTables(position string, tables []string, c
 
 func testStreamTables(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.StreamTables(ctx, testTablesRequest.Position, testTablesRequest.Tables, testTablesRequest.Charset)
+	stream, err := bpc.StreamTables(ctx, testTablesRequest.Position, testTablesRequest.Tables, testTablesRequest.Charset)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; !ok {
-		t.Fatalf("got no response")
+	if se, err := stream.Recv(); err != nil {
+		t.Fatalf("got error: %v", err)
 	} else {
 		if !reflect.DeepEqual(*se, *testBinlogTransaction) {
 			t.Errorf("got wrong result, got %v expected %v", *se, *testBinlogTransaction)
 		}
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	if err := errFunc(); err != nil {
-		t.Errorf("got unexpected error: %v", err)
 	}
 }
 
 func testStreamTablesPanics(t *testing.T, bpc binlogplayer.Client) {
 	ctx := context.Background()
-	c, errFunc, err := bpc.StreamTables(ctx, testTablesRequest.Position, testTablesRequest.Tables, testTablesRequest.Charset)
+	stream, err := bpc.StreamTables(ctx, testTablesRequest.Position, testTablesRequest.Tables, testTablesRequest.Charset)
 	if err != nil {
 		t.Fatalf("got error: %v", err)
 	}
-	if se, ok := <-c; ok {
+	if se, err := stream.Recv(); err == nil {
 		t.Fatalf("got a response when error expected: %v", se)
-	}
-	err = errFunc()
-	if err == nil || !strings.Contains(err.Error(), "test-triggered panic") {
-		t.Errorf("wrong error from panic: %v", err)
+	} else {
+		if !strings.Contains(err.Error(), "test-triggered panic") {
+			t.Errorf("wrong error from panic: %v", err)
+		}
 	}
 }
 

--- a/go/vt/tabletmanager/binlog_players_test.go
+++ b/go/vt/tabletmanager/binlog_players_test.go
@@ -82,60 +82,40 @@ func (fbc *fakeBinlogClient) Close() {
 }
 
 // ServeUpdateStream is part of the binlogplayer.Client interface
-func (fbc *fakeBinlogClient) ServeUpdateStream(ctx context.Context, position string) (chan *binlogdatapb.StreamEvent, binlogplayer.ErrFunc, error) {
-	return nil, nil, fmt.Errorf("Should never be called")
+func (fbc *fakeBinlogClient) ServeUpdateStream(ctx context.Context, position string) (binlogplayer.StreamEventStream, error) {
+	return nil, fmt.Errorf("Should never be called")
+}
+
+type testStreamEventAdapter struct {
+	c   chan *binlogdatapb.BinlogTransaction
+	ctx context.Context
+}
+
+func (t *testStreamEventAdapter) Recv() (*binlogdatapb.BinlogTransaction, error) {
+	select {
+	case bt := <-t.c:
+		return bt, nil
+	case <-t.ctx.Done():
+		return nil, t.ctx.Err()
+	}
 }
 
 // StreamTables is part of the binlogplayer.Client interface
-func (fbc *fakeBinlogClient) StreamTables(ctx context.Context, position string, tables []string, charset *binlogdatapb.Charset) (chan *binlogdatapb.BinlogTransaction, binlogplayer.ErrFunc, error) {
+func (fbc *fakeBinlogClient) StreamTables(ctx context.Context, position string, tables []string, charset *binlogdatapb.Charset) (binlogplayer.BinlogTransactionStream, error) {
 	actualTables := strings.Join(tables, ",")
 	if actualTables != fbc.expectedTables {
-		return nil, nil, fmt.Errorf("Got wrong tables %v, expected %v", actualTables, fbc.expectedTables)
+		return nil, fmt.Errorf("Got wrong tables %v, expected %v", actualTables, fbc.expectedTables)
 	}
-
-	c := make(chan *binlogdatapb.BinlogTransaction)
-	var finalErr error
-	go func() {
-		for {
-			select {
-			case bt := <-fbc.tablesChannel:
-				c <- bt
-			case <-ctx.Done():
-				finalErr = ctx.Err()
-				close(c)
-				return
-			}
-		}
-	}()
-	return c, func() error {
-		return finalErr
-	}, nil
+	return &testStreamEventAdapter{c: fbc.tablesChannel, ctx: ctx}, nil
 }
 
 // StreamKeyRange is part of the binlogplayer.Client interface
-func (fbc *fakeBinlogClient) StreamKeyRange(ctx context.Context, position string, keyRange *topodatapb.KeyRange, charset *binlogdatapb.Charset) (chan *binlogdatapb.BinlogTransaction, binlogplayer.ErrFunc, error) {
+func (fbc *fakeBinlogClient) StreamKeyRange(ctx context.Context, position string, keyRange *topodatapb.KeyRange, charset *binlogdatapb.Charset) (binlogplayer.BinlogTransactionStream, error) {
 	actualKeyRange := key.KeyRangeString(keyRange)
 	if actualKeyRange != fbc.expectedKeyRange {
-		return nil, nil, fmt.Errorf("Got wrong keyrange %v, expected %v", actualKeyRange, fbc.expectedKeyRange)
+		return nil, fmt.Errorf("Got wrong keyrange %v, expected %v", actualKeyRange, fbc.expectedKeyRange)
 	}
-
-	c := make(chan *binlogdatapb.BinlogTransaction)
-	var finalErr error
-	go func() {
-		for {
-			select {
-			case bt := <-fbc.keyRangeChannel:
-				c <- bt
-			case <-ctx.Done():
-				finalErr = ctx.Err()
-				close(c)
-				return
-			}
-		}
-	}()
-	return c, func() error {
-		return finalErr
-	}, nil
+	return &testStreamEventAdapter{c: fbc.keyRangeChannel, ctx: ctx}, nil
 }
 
 // fakeTabletConn implement TabletConn interface. We only care about the


### PR DESCRIPTION
From channel based to interface/Recv method. This gets rid
of a couple go routines, and of the ErrFunc.

@enisoc @aaijazi @michael-berlin @guoliang100 @sougou 

One question: I went from channel to interface with a single Recv() method. I could also just return the Recv function:

ServeUpdateStream(ctx context.Context, position string) (func recv()(*binlogdatapb.StreamEvent, error), err error)

instead. Then in the implementations, a closure can be used, and we don't define the temporary types. What do you guys think? Would it be better?

(Originally, I thought the interface was better, because I was hoping we could return the gRPC stream object directly. But usually we can't, as the steaming response structure has the object we're interested in as a sub-object, not as the main streamed object. In this case for instance, we stream binlogdata.StreamUpdateResponse, but the client wants binlogdatapb.StreamEvent, which is a sub-object of binlogdata.StreamUpdateResponse. Same when we use proto2.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1570)
<!-- Reviewable:end -->
