### PR TITLE
Removing an extra channel in server RPC logs.

### DIFF
--- a/go/vt/logutil/logger_test.go
+++ b/go/vt/logutil/logger_test.go
@@ -60,7 +60,7 @@ func TestLogEvent(t *testing.T) {
 			t.Errorf("ml.Events[%v].Value = %q, want %q", i, got, want)
 		}
 		if got, want := ml.Events[i].File, "logger_test.go"; got != want && ml.Events[i].Level != logutilpb.Level_CONSOLE {
-			t.Errorf("ml.Events[%v].File = %q, want %q", i, got, want)
+			t.Errorf("ml.Events[%v].File = %q (line = %v), want %q", i, got, ml.Events[i].Line, want)
 		}
 	}
 }
@@ -96,10 +96,10 @@ func TestChannelLogger(t *testing.T) {
 	cl.Warningf("test %v", 123)
 	cl.Errorf("test %v", 123)
 	cl.Printf("test %v", 123)
-	close(cl)
+	close(cl.C)
 
 	count := 0
-	for e := range cl {
+	for e := range cl.C {
 		if got, want := e.Value, "test 123"; got != want {
 			t.Errorf("e.Value = %q, want %q", got, want)
 		}
@@ -122,10 +122,10 @@ func TestTeeLogger(t *testing.T) {
 	tl.Warningf("test warningf %v %v", 2, 3)
 	tl.Errorf("test errorf %v %v", 3, 4)
 	tl.Printf("test printf %v %v", 4, 5)
-	close(cl)
+	close(cl.C)
 
 	clEvents := []*logutilpb.Event{}
-	for e := range cl {
+	for e := range cl.C {
 		clEvents = append(clEvents, e)
 	}
 

--- a/go/vt/tabletmanager/grpctmserver/server.go
+++ b/go/vt/tabletmanager/grpctmserver/server.go
@@ -5,7 +5,6 @@
 package grpctmserver
 
 import (
-	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -21,6 +20,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/actionnode"
 	"github.com/youtube/vitess/go/vt/vterrors"
 
+	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
 	tabletmanagerservicepb "github.com/youtube/vitess/go/vt/proto/tabletmanagerservice"
 )
@@ -448,28 +448,18 @@ func (s *server) Backup(request *tabletmanagerdatapb.BackupRequest, stream table
 	ctx := callinfo.GRPCCallInfo(stream.Context())
 	return s.agent.RPCWrapLockAction(ctx, actionnode.TabletActionBackup, request, nil, true, func() error {
 		// create a logger, send the result back to the caller
-		logger := logutil.NewChannelLogger(10)
-		wg := sync.WaitGroup{}
-		wg.Add(1)
-		go func() {
-			for e := range logger {
-				// Note we don't interrupt the loop here, as
-				// we still need to flush and finish the
-				// command, even if the channel to the client
-				// has been broken. We'll just keep trying
-				// to send.
-				stream.Send(&tabletmanagerdatapb.BackupResponse{
-					Event: e,
-				})
+		logger := logutil.NewCallbackLogger(func(e *logutilpb.Event) {
+			// Note we don't interrupt the loop here, as
+			// we still need to flush and finish the
+			// command, even if the channel to the client
+			// has been broken. We'll just keep trying
+			// to send.
+			stream.Send(&tabletmanagerdatapb.BackupResponse{
+				Event: e,
+			})
+		})
 
-			}
-			wg.Done()
-		}()
-
-		err := s.agent.Backup(ctx, int(request.Concurrency), logger)
-		close(logger)
-		wg.Wait()
-		return err
+		return s.agent.Backup(ctx, int(request.Concurrency), logger)
 	})
 }
 

--- a/go/vt/tabletmanager/grpctmserver/server.go
+++ b/go/vt/tabletmanager/grpctmserver/server.go
@@ -449,11 +449,9 @@ func (s *server) Backup(request *tabletmanagerdatapb.BackupRequest, stream table
 	return s.agent.RPCWrapLockAction(ctx, actionnode.TabletActionBackup, request, nil, true, func() error {
 		// create a logger, send the result back to the caller
 		logger := logutil.NewCallbackLogger(func(e *logutilpb.Event) {
-			// Note we don't interrupt the loop here, as
-			// we still need to flush and finish the
-			// command, even if the channel to the client
-			// has been broken. We'll just keep trying
-			// to send.
+			// If the client disconnects, we will just fail
+			// to send the log events, but won't interrupt
+			// the backup.
 			stream.Send(&tabletmanagerdatapb.BackupResponse{
 				Event: e,
 			})

--- a/go/vt/vtctl/grpcvtctlserver/server.go
+++ b/go/vt/vtctl/grpcvtctlserver/server.go
@@ -39,10 +39,9 @@ func (s *VtctlServer) ExecuteVtctlCommand(args *vtctldatapb.ExecuteVtctlCommandR
 
 	// create a logger, send the result back to the caller
 	logstream := logutil.NewCallbackLogger(func(e *logutilpb.Event) {
-		// Note we don't interrupt the loop here, as
-		// we still need to flush and finish the
-		// command, even if the channel to the client
-		// has been broken. We'll just keep trying.
+		// If the client disconnects, we will just fail
+		// to send the log events, but won't interrupt
+		// the command.
 		stream.Send(&vtctldatapb.ExecuteVtctlCommandResponse{
 			Event: e,
 		})

--- a/go/vt/worker/grpcvtworkerserver/server.go
+++ b/go/vt/worker/grpcvtworkerserver/server.go
@@ -39,10 +39,9 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *vtworkerdatapb.ExecuteVtwo
 
 	// Stream everything back what the Wrangler is logging.
 	logstream := logutil.NewCallbackLogger(func(e *logutilpb.Event) {
-		// Note we don't interrupt the loop here, as
-		// we still need to flush and finish the
-		// command, even if the channel to the client
-		// has been broken. We'll just keep trying.
+		// If the client disconnects, we will just fail
+		// to send the log events, but won't interrupt
+		// the command.
 		stream.Send(&vtworkerdatapb.ExecuteVtworkerCommandResponse{
 			Event: e,
 		})

--- a/go/vt/worker/grpcvtworkerserver/server.go
+++ b/go/vt/worker/grpcvtworkerserver/server.go
@@ -9,14 +9,13 @@ of the remote execution of vtworker commands.
 package grpcvtworkerserver
 
 import (
-	"sync"
-
 	"google.golang.org/grpc"
 
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/worker"
 
+	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 	vtworkerdatapb "github.com/youtube/vitess/go/vt/proto/vtworkerdata"
 	vtworkerservicepb "github.com/youtube/vitess/go/vt/proto/vtworkerservice"
 )
@@ -39,27 +38,19 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *vtworkerdatapb.ExecuteVtwo
 	defer servenv.HandlePanic("vtworker", &err)
 
 	// Stream everything back what the Wrangler is logging.
-	logstream := logutil.NewChannelLogger(10)
+	logstream := logutil.NewCallbackLogger(func(e *logutilpb.Event) {
+		// Note we don't interrupt the loop here, as
+		// we still need to flush and finish the
+		// command, even if the channel to the client
+		// has been broken. We'll just keep trying.
+		stream.Send(&vtworkerdatapb.ExecuteVtworkerCommandResponse{
+			Event: e,
+		})
+	})
 	// Let the Wrangler also log everything to the console (and thereby
 	// effectively to a logfile) to make sure that any information or errors
 	// is preserved in the logs in case the RPC or vtworker crashes.
 	logger := logutil.NewTeeLogger(logstream, logutil.NewConsoleLogger())
-
-	// send logs to the caller
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		for e := range logstream {
-			// Note we don't interrupt the loop here, as
-			// we still need to flush and finish the
-			// command, even if the channel to the client
-			// has been broken. We'll just keep trying.
-			stream.Send(&vtworkerdatapb.ExecuteVtworkerCommandResponse{
-				Event: e,
-			})
-		}
-		wg.Done()
-	}()
 
 	// create the wrangler
 	wr := s.wi.CreateWrangler(logger)
@@ -69,10 +60,6 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *vtworkerdatapb.ExecuteVtwo
 	if err == nil && worker != nil && done != nil {
 		err = s.wi.WaitForCommand(worker, done)
 	}
-
-	// close the log channel, and wait for them all to be sent
-	close(logstream)
-	wg.Wait()
 
 	return err
 }


### PR DESCRIPTION
Instead of using a channel logger plus a go routine to
get the data out, use a callback logger, and write data
to the stream directly. Simpler all around.

@enisoc @michael-berlin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1586)
<!-- Reviewable:end -->
