### PR TITLE
Refactoring shard_conn.multiGo code.

### DIFF
--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -42,7 +42,7 @@ type ScatterConn struct {
 // and return an error if any.
 // multiGo is capable of executing multiple shardActionFunc actions in parallel
 // and consolidating the results and errors for the caller.
-type shardActionFunc func(shard string, transactionID int64, sResults chan<- interface{}) error
+type shardActionFunc func(shard string, transactionID int64) error
 
 // NewScatterConn creates a new ScatterConn. All input parameters are passed through
 // for creating the appropriate connections.
@@ -84,6 +84,44 @@ func (stc *ScatterConn) InitializeConnections(ctx context.Context) error {
 	return stc.gateway.InitializeConnections(ctx)
 }
 
+func (stc *ScatterConn) startAction(ctx context.Context, name, keyspace, shard string, tabletType topodatapb.TabletType, session *SafeSession, notInTransaction bool, allErrors *concurrency.AllErrorRecorder) (time.Time, []string, int64, error) {
+	statsKey := []string{name, keyspace, shard, strings.ToLower(tabletType.String())}
+	startTime := time.Now()
+
+	transactionID, err := stc.updateSession(ctx, keyspace, shard, tabletType, session, notInTransaction)
+	return startTime, statsKey, transactionID, err
+}
+
+func (stc *ScatterConn) endAction(startTime time.Time, allErrors *concurrency.AllErrorRecorder, statsKey []string, err *error) {
+	if *err != nil {
+		allErrors.RecordError(*err)
+
+		// Don't increment the error counter for duplicate
+		// keys, as those errors are caused by client queries
+		// and are not VTGate's fault.
+		// TODO(aaijazi): get rid of this string parsing, and
+		// handle all cases of invalid input
+		strErr := (*err).Error()
+		if !strings.Contains(strErr, errDupKey) && !strings.Contains(strErr, errOutOfRange) {
+			stc.tabletCallErrorCount.Add(statsKey, 1)
+		}
+	}
+	stc.timings.Record(statsKey, startTime)
+}
+
+func (stc *ScatterConn) rollbackIfNeeded(ctx context.Context, allErrors *concurrency.AllErrorRecorder, session *SafeSession) {
+	if session.InTransaction() {
+		errstr := allErrors.Error().Error()
+		// We cannot recover from these errors
+		// TODO(aaijazi): get rid of this string parsing. Might
+		// want a function that searches through a deeply
+		// nested error chain for a particular error.
+		if strings.Contains(errstr, "tx_pool_full") || strings.Contains(errstr, "not_in_tx") {
+			stc.Rollback(ctx, session)
+		}
+	}
+}
+
 // Execute executes a non-streaming query on the specified shards.
 func (stc *ScatterConn) Execute(
 	ctx context.Context,
@@ -95,7 +133,12 @@ func (stc *ScatterConn) Execute(
 	session *SafeSession,
 	notInTransaction bool,
 ) (*sqltypes.Result, error) {
-	results, allErrors := stc.multiGo(
+
+	// mu protects qr
+	var mu sync.Mutex
+	qr := new(sqltypes.Result)
+
+	allErrors := stc.multiGo(
 		ctx,
 		"Execute",
 		keyspace,
@@ -103,21 +146,20 @@ func (stc *ScatterConn) Execute(
 		tabletType,
 		session,
 		notInTransaction,
-		func(shard string, transactionID int64, sResults chan<- interface{}) error {
+		func(shard string, transactionID int64) error {
 			innerqr, err := stc.gateway.Execute(ctx, keyspace, shard, tabletType, query, bindVars, transactionID)
 			if err != nil {
 				return err
 			}
-			sResults <- innerqr
+
+			mu.Lock()
+			defer mu.Unlock()
+			appendResult(qr, innerqr)
 			return nil
 		})
 
-	qr := new(sqltypes.Result)
-	for innerqr := range results {
-		innerqr := innerqr.(*sqltypes.Result)
-		appendResult(qr, innerqr)
-	}
 	if allErrors.HasErrors() {
+		stc.rollbackIfNeeded(ctx, allErrors, session)
 		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	return qr, nil
@@ -135,7 +177,12 @@ func (stc *ScatterConn) ExecuteMulti(
 	session *SafeSession,
 	notInTransaction bool,
 ) (*sqltypes.Result, error) {
-	results, allErrors := stc.multiGo(
+
+	// mu protects qr
+	var mu sync.Mutex
+	qr := new(sqltypes.Result)
+
+	allErrors := stc.multiGo(
 		ctx,
 		"Execute",
 		keyspace,
@@ -143,21 +190,20 @@ func (stc *ScatterConn) ExecuteMulti(
 		tabletType,
 		session,
 		notInTransaction,
-		func(shard string, transactionID int64, sResults chan<- interface{}) error {
+		func(shard string, transactionID int64) error {
 			innerqr, err := stc.gateway.Execute(ctx, keyspace, shard, tabletType, query, shardVars[shard], transactionID)
 			if err != nil {
 				return err
 			}
-			sResults <- innerqr
+
+			mu.Lock()
+			defer mu.Unlock()
+			appendResult(qr, innerqr)
 			return nil
 		})
 
-	qr := new(sqltypes.Result)
-	for innerqr := range results {
-		innerqr := innerqr.(*sqltypes.Result)
-		appendResult(qr, innerqr)
-	}
 	if allErrors.HasErrors() {
+		stc.rollbackIfNeeded(ctx, allErrors, session)
 		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	return qr, nil
@@ -174,7 +220,12 @@ func (stc *ScatterConn) ExecuteEntityIds(
 	session *SafeSession,
 	notInTransaction bool,
 ) (*sqltypes.Result, error) {
-	results, allErrors := stc.multiGo(
+
+	// mu protects qr
+	var mu sync.Mutex
+	qr := new(sqltypes.Result)
+
+	allErrors := stc.multiGo(
 		ctx,
 		"ExecuteEntityIds",
 		keyspace,
@@ -182,23 +233,21 @@ func (stc *ScatterConn) ExecuteEntityIds(
 		tabletType,
 		session,
 		notInTransaction,
-		func(shard string, transactionID int64, sResults chan<- interface{}) error {
+		func(shard string, transactionID int64) error {
 			sql := sqls[shard]
 			bindVar := bindVars[shard]
 			innerqr, err := stc.gateway.Execute(ctx, keyspace, shard, tabletType, sql, bindVar, transactionID)
 			if err != nil {
 				return err
 			}
-			sResults <- innerqr
+
+			mu.Lock()
+			defer mu.Unlock()
+			appendResult(qr, innerqr)
 			return nil
 		})
-
-	qr := new(sqltypes.Result)
-	for innerqr := range results {
-		innerqr := innerqr.(*sqltypes.Result)
-		appendResult(qr, innerqr)
-	}
 	if allErrors.HasErrors() {
+		stc.rollbackIfNeeded(ctx, allErrors, session)
 		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	return qr, nil
@@ -237,59 +286,65 @@ func (stc *ScatterConn) ExecuteBatch(
 	for _, req := range batchRequest.Requests {
 		wg.Add(1)
 		go func(req *shardBatchRequest) {
-			statsKey := []string{"ExecuteBatch", req.Keyspace, req.Shard, strings.ToLower(tabletType.String())}
 			defer wg.Done()
-			startTime := time.Now()
-			defer stc.timings.Record(statsKey, startTime)
 
-			transactionID, err := stc.updateSession(ctx, req.Keyspace, req.Shard, tabletType, session, false)
+			startTime, statsKey, transactionID, err := stc.startAction(ctx, "ExecuteBatch", req.Keyspace, req.Shard, tabletType, session, false, allErrors)
+			defer stc.endAction(startTime, allErrors, statsKey, &err)
 			if err != nil {
-				allErrors.RecordError(err)
-				stc.tabletCallErrorCount.Add(statsKey, 1)
 				return
 			}
 
-			innerqrs, err := stc.gateway.ExecuteBatch(ctx, req.Keyspace, req.Shard, tabletType, req.Queries, asTransaction, transactionID)
+			var innerqrs []sqltypes.Result
+			innerqrs, err = stc.gateway.ExecuteBatch(ctx, req.Keyspace, req.Shard, tabletType, req.Queries, asTransaction, transactionID)
 			if err != nil {
-				allErrors.RecordError(err)
-				// Don't increment the error counter for duplicate keys, as those errors
-				// are caused by client queries and are not VTGate's fault.
-				// TODO(aaijazi): get rid of this string parsing, and handle all cases of invalid input
-				if !strings.Contains(err.Error(), errDupKey) && !strings.Contains(err.Error(), errOutOfRange) {
-					stc.tabletCallErrorCount.Add(statsKey, 1)
-				}
 				return
 			}
-			// Encapsulate in a function for safe mutex operation.
-			func() {
-				resMutex.Lock()
-				defer resMutex.Unlock()
-				for i, result := range innerqrs {
-					appendResult(&results[req.ResultIndexes[i]], &result)
-				}
-			}()
+
+			resMutex.Lock()
+			defer resMutex.Unlock()
+			for i, result := range innerqrs {
+				appendResult(&results[req.ResultIndexes[i]], &result)
+			}
 		}(req)
 	}
 	wg.Wait()
 	// If we want to rollback, we have to do it before closing results
 	// so that the session is updated to be not InTransaction.
 	if allErrors.HasErrors() {
-		if session.InTransaction() {
-			errstr := allErrors.Error().Error()
-			// We cannot recover from these errors
-			// TODO(aaijazi): get rid of this string parsing
-			if strings.Contains(errstr, "tx_pool_full") || strings.Contains(errstr, "not_in_tx") {
-				stc.Rollback(ctx, session)
-			}
-		}
+		stc.rollbackIfNeeded(ctx, allErrors, session)
 		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	return results, nil
 }
 
+func (stc *ScatterConn) processOneStreamingResult(mu *sync.Mutex, sr <-chan *sqltypes.Result, replyErr *error, fieldSent *bool, sendReply func(reply *sqltypes.Result) error) {
+	if sr == nil {
+		return
+	}
+	for qr := range sr {
+		mu.Lock()
+		if *replyErr != nil {
+			mu.Unlock()
+			// we had an error sending results, drain input
+			for range sr {
+			}
+			return
+		}
+
+		// only send field info once for scattered streaming
+		if len(qr.Fields) > 0 && len(qr.Rows) == 0 {
+			if *fieldSent {
+				mu.Unlock()
+				continue
+			}
+			*fieldSent = true
+		}
+		*replyErr = sendReply(qr)
+		mu.Unlock()
+	}
+}
+
 // StreamExecute executes a streaming query on vttablet. The retry rules are the same.
-// The implementation of this function is similar to multiGo. A change there is likely
-// to require a change in this function also.
 func (stc *ScatterConn) StreamExecute(
 	ctx context.Context,
 	query string,
@@ -299,7 +354,13 @@ func (stc *ScatterConn) StreamExecute(
 	tabletType topodatapb.TabletType,
 	sendReply func(reply *sqltypes.Result) error,
 ) error {
-	results, allErrors := stc.multiGo(
+
+	// mu protects fieldSent, replyErr and sendReply
+	var mu sync.Mutex
+	var replyErr error
+	fieldSent := false
+
+	allErrors := stc.multiGo(
 		ctx,
 		"StreamExecute",
 		keyspace,
@@ -307,32 +368,11 @@ func (stc *ScatterConn) StreamExecute(
 		tabletType,
 		NewSafeSession(nil),
 		false,
-		func(shard string, transactionID int64, sResults chan<- interface{}) error {
+		func(shard string, transactionID int64) error {
 			sr, errFunc := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, bindVars, transactionID)
-			if sr != nil {
-				for qr := range sr {
-					sResults <- qr
-				}
-			}
+			stc.processOneStreamingResult(&mu, sr, &replyErr, &fieldSent, sendReply)
 			return errFunc()
 		})
-	var replyErr error
-	fieldSent := false
-	for innerqr := range results {
-		// We still need to finish pumping
-		if replyErr != nil {
-			continue
-		}
-		mqr := innerqr.(*sqltypes.Result)
-		// only send field info once for scattered streaming
-		if len(mqr.Fields) > 0 && len(mqr.Rows) == 0 {
-			if fieldSent {
-				continue
-			}
-			fieldSent = true
-		}
-		replyErr = sendReply(mqr)
-	}
 	if replyErr != nil {
 		allErrors.RecordError(replyErr)
 	}
@@ -350,7 +390,12 @@ func (stc *ScatterConn) StreamExecuteMulti(
 	tabletType topodatapb.TabletType,
 	sendReply func(reply *sqltypes.Result) error,
 ) error {
-	results, allErrors := stc.multiGo(
+	// mu protects fieldSent, sendReply and replyErr
+	var mu sync.Mutex
+	var replyErr error
+	fieldSent := false
+
+	allErrors := stc.multiGo(
 		ctx,
 		"StreamExecute",
 		keyspace,
@@ -358,32 +403,11 @@ func (stc *ScatterConn) StreamExecuteMulti(
 		tabletType,
 		NewSafeSession(nil),
 		false,
-		func(shard string, transactionID int64, sResults chan<- interface{}) error {
+		func(shard string, transactionID int64) error {
 			sr, errFunc := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, shardVars[shard], transactionID)
-			if sr != nil {
-				for qr := range sr {
-					sResults <- qr
-				}
-			}
+			stc.processOneStreamingResult(&mu, sr, &replyErr, &fieldSent, sendReply)
 			return errFunc()
 		})
-	var replyErr error
-	fieldSent := false
-	for innerqr := range results {
-		// We still need to finish pumping
-		if replyErr != nil {
-			continue
-		}
-		mqr := innerqr.(*sqltypes.Result)
-		// only send field info once for scattered streaming
-		if len(mqr.Fields) > 0 && len(mqr.Rows) == 0 {
-			if fieldSent {
-				continue
-			}
-			fieldSent = true
-		}
-		replyErr = sendReply(mqr)
-	}
 	if replyErr != nil {
 		allErrors.RecordError(replyErr)
 	}
@@ -436,7 +460,12 @@ func (stc *ScatterConn) Rollback(ctx context.Context, session *SafeSession) (err
 // all shards in no specific order and returns.
 func (stc *ScatterConn) SplitQueryKeyRange(ctx context.Context, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64, keyRangeByShard map[string]*topodatapb.KeyRange, keyspace string) ([]*vtgatepb.SplitQueryResponse_Part, error) {
 	tabletType := topodatapb.TabletType_RDONLY
-	actionFunc := func(shard string, transactionID int64, results chan<- interface{}) error {
+
+	// mu protects allSplits
+	var mu sync.Mutex
+	var allSplits []*vtgatepb.SplitQueryResponse_Part
+
+	actionFunc := func(shard string, transactionID int64) error {
 		// Get all splits from this shard
 		queries, err := stc.gateway.SplitQuery(ctx, keyspace, shard, tabletType, sql, bindVariables, splitColumn, splitCount)
 		if err != nil {
@@ -467,8 +496,11 @@ func (stc *ScatterConn) SplitQueryKeyRange(ctx context.Context, sql string, bind
 				Size: query.RowCount,
 			}
 		}
-		// Push all the splits from this shard to results channel
-		results <- splits
+
+		// aggregate splits
+		mu.Lock()
+		defer mu.Unlock()
+		allSplits = append(allSplits, splits...)
 		return nil
 	}
 
@@ -476,14 +508,9 @@ func (stc *ScatterConn) SplitQueryKeyRange(ctx context.Context, sql string, bind
 	for shard := range keyRangeByShard {
 		shards = append(shards, shard)
 	}
-	allSplits, allErrors := stc.multiGo(ctx, "SplitQuery", keyspace, shards, tabletType, NewSafeSession(&vtgatepb.Session{}), false, actionFunc)
-	splits := []*vtgatepb.SplitQueryResponse_Part{}
-	for s := range allSplits {
-		splits = append(splits, s.([]*vtgatepb.SplitQueryResponse_Part)...)
-	}
+	allErrors := stc.multiGo(ctx, "SplitQuery", keyspace, shards, tabletType, NewSafeSession(&vtgatepb.Session{}), false, actionFunc)
 	if allErrors.HasErrors() {
-		err := allErrors.AggrError(stc.aggregateErrors)
-		return nil, err
+		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	// We shuffle the query-parts here. External frameworks like MapReduce may
 	// "deal" these jobs to workers in the order they are in the list. Without
@@ -491,8 +518,8 @@ func (stc *ScatterConn) SplitQueryKeyRange(ctx context.Context, sql string, bind
 	// the shards they query. E.g. all workers will first query the first shard,
 	// then most of them to the second shard, etc, which results with uneven
 	// load balancing among shards.
-	shuffleQueryParts(splits)
-	return splits, nil
+	shuffleQueryParts(allSplits)
+	return allSplits, nil
 }
 
 // SplitQueryCustomSharding scatters a SplitQuery request to all
@@ -502,7 +529,12 @@ func (stc *ScatterConn) SplitQueryKeyRange(ctx context.Context, sql string, bind
 // order and returns.
 func (stc *ScatterConn) SplitQueryCustomSharding(ctx context.Context, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64, shards []string, keyspace string) ([]*vtgatepb.SplitQueryResponse_Part, error) {
 	tabletType := topodatapb.TabletType_RDONLY
-	actionFunc := func(shard string, transactionID int64, results chan<- interface{}) error {
+
+	// mu protects allSplits
+	var mu sync.Mutex
+	var allSplits []*vtgatepb.SplitQueryResponse_Part
+
+	actionFunc := func(shard string, transactionID int64) error {
 		// Get all splits from this shard
 		queries, err := stc.gateway.SplitQuery(ctx, keyspace, shard, tabletType, sql, bindVariables, splitColumn, splitCount)
 		if err != nil {
@@ -528,24 +560,21 @@ func (stc *ScatterConn) SplitQueryCustomSharding(ctx context.Context, sql string
 				Size: query.RowCount,
 			}
 		}
-		// Push all the splits from this shard to results channel
-		results <- splits
+
+		// aggregate splits
+		mu.Lock()
+		defer mu.Unlock()
+		allSplits = append(allSplits, splits...)
 		return nil
 	}
-
-	allSplits, allErrors := stc.multiGo(ctx, "SplitQuery", keyspace, shards, tabletType, NewSafeSession(&vtgatepb.Session{}), false, actionFunc)
-	splits := []*vtgatepb.SplitQueryResponse_Part{}
-	for s := range allSplits {
-		splits = append(splits, s.([]*vtgatepb.SplitQueryResponse_Part)...)
-	}
+	allErrors := stc.multiGo(ctx, "SplitQuery", keyspace, shards, tabletType, NewSafeSession(&vtgatepb.Session{}), false, actionFunc)
 	if allErrors.HasErrors() {
-		err := allErrors.AggrError(stc.aggregateErrors)
-		return nil, err
+		return nil, allErrors.AggrError(stc.aggregateErrors)
 	}
 	// See the comment for the analogues line in SplitQueryKeyRange for
 	// the motivation for shuffling.
-	shuffleQueryParts(splits)
-	return splits, nil
+	shuffleQueryParts(allSplits)
+	return allSplits, nil
 }
 
 // randomGenerator is the randomGenerator used for the randomness
@@ -640,11 +669,7 @@ func (stc *ScatterConn) aggregateErrors(errors []error) error {
 // session is in a transaction, it opens a new transactions on the connection,
 // and updates the Session with the transaction id. If the session already
 // contains a transaction id for the shard, it reuses it.
-// If there are any unrecoverable errors during a transaction, multiGo
-// rolls back the transaction for all shards.
 // The action function must match the shardActionFunc signature.
-// This function has similarities with StreamExecute. A change there will likely
-// require a change here also.
 func (stc *ScatterConn) multiGo(
 	ctx context.Context,
 	name string,
@@ -654,55 +679,41 @@ func (stc *ScatterConn) multiGo(
 	session *SafeSession,
 	notInTransaction bool,
 	action shardActionFunc,
-) (rResults <-chan interface{}, allErrors *concurrency.AllErrorRecorder) {
+) (allErrors *concurrency.AllErrorRecorder) {
 	allErrors = new(concurrency.AllErrorRecorder)
-	results := make(chan interface{}, len(shards))
+	shardMap := unique(shards)
+	if len(shardMap) == 0 {
+		return allErrors
+	}
+	if len(shardMap) == 1 {
+		for shard := range shardMap {
+			startTime, statsKey, transactionID, err := stc.startAction(ctx, name, keyspace, shard, tabletType, session, notInTransaction, allErrors)
+			defer stc.endAction(startTime, allErrors, statsKey, &err)
+			if err != nil {
+				return allErrors
+			}
+			err = action(shard, transactionID)
+			return allErrors
+		}
+	}
+
 	var wg sync.WaitGroup
-	for shard := range unique(shards) {
+	for shard := range shardMap {
 		wg.Add(1)
 		go func(shard string) {
-			statsKey := []string{name, keyspace, shard, strings.ToLower(tabletType.String())}
 			defer wg.Done()
-			startTime := time.Now()
-			defer stc.timings.Record(statsKey, startTime)
 
-			transactionID, err := stc.updateSession(ctx, keyspace, shard, tabletType, session, notInTransaction)
+			startTime, statsKey, transactionID, err := stc.startAction(ctx, name, keyspace, shard, tabletType, session, notInTransaction, allErrors)
+			defer stc.endAction(startTime, allErrors, statsKey, &err)
 			if err != nil {
-				allErrors.RecordError(err)
-				stc.tabletCallErrorCount.Add(statsKey, 1)
 				return
 			}
-			err = action(shard, transactionID, results)
-			if err != nil {
-				allErrors.RecordError(err)
-				// Don't increment the error counter for duplicate keys, as those errors
-				// are caused by client queries and are not VTGate's fault.
-				// TODO(aaijazi): get rid of this string parsing, and handle all cases of invalid input
-				if !strings.Contains(err.Error(), errDupKey) && !strings.Contains(err.Error(), errOutOfRange) {
-					stc.tabletCallErrorCount.Add(statsKey, 1)
-				}
-				return
-			}
+
+			err = action(shard, transactionID)
 		}(shard)
 	}
-	go func() {
-		wg.Wait()
-		// If we want to rollback, we have to do it before closing results
-		// so that the session is updated to be not InTransaction.
-		if allErrors.HasErrors() {
-			if session.InTransaction() {
-				errstr := allErrors.Error().Error()
-				// We cannot recover from these errors
-				// TODO(aaijazi): get rid of this string parsing. Might want a function that searches
-				// through a deeply nested error chain a particular error.
-				if strings.Contains(errstr, "tx_pool_full") || strings.Contains(errstr, "not_in_tx") {
-					stc.Rollback(ctx, session)
-				}
-			}
-		}
-		close(results)
-	}()
-	return results, allErrors
+	wg.Wait()
+	return allErrors
 }
 
 func (stc *ScatterConn) updateSession(


### PR DESCRIPTION
To limit code duplication, and add an optimization to not
create go routines for single calls. Not using channels for
results either.

@guoliang100 not sure if the removal of the go channel and the extra 2 go routines in the single case will help tail latency or not. But the code seems better this way?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1593)
<!-- Reviewable:end -->
