### PR TITLE
Removing all the StreamExecute...2 methods.

### DIFF
--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -329,11 +329,6 @@ func (fc *fakeConn) StreamExecute(ctx context.Context, query string, bindVars ma
 	return nil, nil, fmt.Errorf("not implemented")
 }
 
-// StreamExecute2 implements tabletconn.TabletConn.
-func (fc *fakeConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (<-chan *sqltypes.Result, tabletconn.ErrFunc, error) {
-	return fc.StreamExecute(ctx, query, bindVars, transactionID)
-}
-
 // Begin implements tabletconn.TabletConn.
 func (fc *fakeConn) Begin(ctx context.Context) (int64, error) {
 	return 0, fmt.Errorf("not implemented")

--- a/go/vt/tabletmanager/binlog_players_test.go
+++ b/go/vt/tabletmanager/binlog_players_test.go
@@ -182,11 +182,6 @@ func (ftc *fakeTabletConn) Rollback2(ctx context.Context, transactionID int64) e
 	return fmt.Errorf("not implemented in this test")
 }
 
-// StreamExecute2 is part of the TabletConn interface
-func (ftc *fakeTabletConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (<-chan *sqltypes.Result, tabletconn.ErrFunc, error) {
-	return nil, nil, fmt.Errorf("not implemented in this test")
-}
-
 // Close is part of the TabletConn interface
 func (ftc *fakeTabletConn) Close() {
 }

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -276,18 +276,8 @@ func (conn *FakeVTGateConn) StreamExecute(ctx context.Context, sql string, bindV
 	return resultChan, func() error { return nil }, nil
 }
 
-// StreamExecute2 please see vtgateconn.Impl.StreamExecute2
-func (conn *FakeVTGateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	panic("not implemented")
-}
-
 // StreamExecuteShards please see vtgateconn.Impl.StreamExecuteShards
 func (conn *FakeVTGateConn) StreamExecuteShards(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	panic("not implemented")
-}
-
-// StreamExecuteShards2 please see vtgateconn.Impl.StreamExecuteShards2
-func (conn *FakeVTGateConn) StreamExecuteShards2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
 	panic("not implemented")
 }
 
@@ -296,18 +286,8 @@ func (conn *FakeVTGateConn) StreamExecuteKeyRanges(ctx context.Context, query st
 	panic("not implemented")
 }
 
-// StreamExecuteKeyRanges2 please see vtgateconn.Impl.StreamExecuteKeyRanges2
-func (conn *FakeVTGateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	panic("not implemented")
-}
-
 // StreamExecuteKeyspaceIds please see vtgateconn.Impl.StreamExecuteKeyspaceIds
 func (conn *FakeVTGateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	panic("not implemented")
-}
-
-// StreamExecuteKeyspaceIds2 please see vtgateconn.Impl.StreamExecuteKeyspaceIds2
-func (conn *FakeVTGateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
 	panic("not implemented")
 }
 

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -261,10 +261,6 @@ func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVar
 	}, nil
 }
 
-func (conn *vtgateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	return conn.StreamExecute(ctx, query, bindVars, tabletType)
-}
-
 func (conn *vtgateConn) StreamExecuteShards(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
 	q, err := querytypes.BoundQueryToProto3(query, bindVars)
 	if err != nil {
@@ -303,10 +299,6 @@ func (conn *vtgateConn) StreamExecuteShards(ctx context.Context, query string, k
 	return sr, func() error {
 		return finalError
 	}, nil
-}
-
-func (conn *vtgateConn) StreamExecuteShards2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	return conn.StreamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType)
 }
 
 func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
@@ -349,10 +341,6 @@ func (conn *vtgateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	}, nil
 }
 
-func (conn *vtgateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	return conn.StreamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
-}
-
 func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
 	q, err := querytypes.BoundQueryToProto3(query, bindVars)
 	if err != nil {
@@ -391,10 +379,6 @@ func (conn *vtgateConn) StreamExecuteKeyspaceIds(ctx context.Context, query stri
 	return sr, func() error {
 		return finalError
 	}, nil
-}
-
-func (conn *vtgateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, vtgateconn.ErrFunc, error) {
-	return conn.StreamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
 }
 
 func (conn *vtgateConn) Begin(ctx context.Context) (interface{}, error) {

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -487,10 +487,6 @@ func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVar
 	return ch, func() error { return err }, err
 }
 
-func (sbc *sandboxConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (<-chan *sqltypes.Result, tabletconn.ErrFunc, error) {
-	return sbc.StreamExecute(ctx, query, bindVars, transactionID)
-}
-
 func (sbc *sandboxConn) Begin(ctx context.Context) (int64, error) {
 	sbc.ExecCount.Add(1)
 	sbc.BeginCount.Add(1)

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -90,15 +90,6 @@ func (conn *VTGateConn) StreamExecute(ctx context.Context, query string, bindVar
 	return conn.impl.StreamExecute(ctx, query, bindVars, tabletType)
 }
 
-// StreamExecute2 executes a streaming query on vtgate. It returns a
-// channel, an ErrFunc, and error. First check the error. Then you can
-// pull values from the channel till it's closed. Following this, you
-// can call ErrFunc to see if the stream ended normally or due to a
-// failure.
-func (conn *VTGateConn) StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
-	return conn.impl.StreamExecute2(ctx, query, bindVars, tabletType)
-}
-
 // StreamExecuteShards executes a streaming query on vtgate, on a set
 // of shards.  It returns a channel, an ErrFunc, and error. First
 // check the error. Then you can pull values from the channel till
@@ -106,15 +97,6 @@ func (conn *VTGateConn) StreamExecute2(ctx context.Context, query string, bindVa
 // stream ended normally or due to a failure.
 func (conn *VTGateConn) StreamExecuteShards(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
 	return conn.impl.StreamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType)
-}
-
-// StreamExecuteShards2 executes a streaming query on vtgate, on a set
-// of shards.  It returns a channel, an ErrFunc, and error. First
-// check the error. Then you can pull values from the channel till
-// it's closed. Following this, you can call ErrFunc to see if the
-// stream ended normally or due to a failure.
-func (conn *VTGateConn) StreamExecuteShards2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
-	return conn.impl.StreamExecuteShards2(ctx, query, keyspace, shards, bindVars, tabletType)
 }
 
 // StreamExecuteKeyRanges executes a streaming query on vtgate, on a
@@ -126,15 +108,6 @@ func (conn *VTGateConn) StreamExecuteKeyRanges(ctx context.Context, query string
 	return conn.impl.StreamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
 }
 
-// StreamExecuteKeyRanges2 executes a streaming query on vtgate, on a
-// set of keyranges.  It returns a channel, an ErrFunc, and
-// error. First check the error. Then you can pull values from the
-// channel till it's closed. Following this, you can call ErrFunc to
-// see if the stream ended normally or due to a failure.
-func (conn *VTGateConn) StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
-	return conn.impl.StreamExecuteKeyRanges2(ctx, query, keyspace, keyRanges, bindVars, tabletType)
-}
-
 // StreamExecuteKeyspaceIds executes a streaming query on vtgate, for
 // the given keyspaceIds.  It returns a channel, an ErrFunc, and
 // error. First check the error. Then you can pull values from the
@@ -142,15 +115,6 @@ func (conn *VTGateConn) StreamExecuteKeyRanges2(ctx context.Context, query strin
 // see if the stream ended normally or due to a failure.
 func (conn *VTGateConn) StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
 	return conn.impl.StreamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
-}
-
-// StreamExecuteKeyspaceIds2 executes a streaming query on vtgate, for
-// the given keyspaceIds.  It returns a channel, an ErrFunc, and
-// error. First check the error. Then you can pull values from the
-// channel till it's closed. Following this, you can call ErrFunc to
-// see if the stream ended normally or due to a failure.
-func (conn *VTGateConn) StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error) {
-	return conn.impl.StreamExecuteKeyspaceIds2(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
 }
 
 // Begin starts a transaction and returns a VTGateTX.
@@ -347,26 +311,14 @@ type Impl interface {
 	// StreamExecute executes a streaming query on vtgate.
 	StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
 
-	// StreamExecute2 executes a streaming query on vtgate.
-	StreamExecute2(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
-
 	// StreamExecuteShards executes a streaming query on vtgate, on a set of shards.
 	StreamExecuteShards(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
-
-	// StreamExecuteShards2 executes a streaming query on vtgate, on a set of shards.
-	StreamExecuteShards2(ctx context.Context, query string, keyspace string, shards []string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
 
 	// StreamExecuteKeyRanges executes a streaming query on vtgate, on a set of keyranges.
 	StreamExecuteKeyRanges(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
 
-	// StreamExecuteKeyRanges2 executes a streaming query on vtgate, on a set of keyranges.
-	StreamExecuteKeyRanges2(ctx context.Context, query string, keyspace string, keyRanges []*topodatapb.KeyRange, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
-
 	// StreamExecuteKeyspaceIds executes a streaming query on vtgate, for the given keyspaceIds.
 	StreamExecuteKeyspaceIds(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
-
-	// StreamExecuteKeyspaceIds2 executes a streaming query on vtgate, for the given keyspaceIds.
-	StreamExecuteKeyspaceIds2(ctx context.Context, query string, keyspace string, keyspaceIds [][]byte, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (<-chan *sqltypes.Result, ErrFunc, error)
 
 	// Begin starts a transaction and returns a VTGateTX.
 	Begin(ctx context.Context) (interface{}, error)

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -765,13 +765,9 @@ func TestErrorSuite(t *testing.T, fakeServer vtgateservice.VTGateService) {
 	testExecuteBatchShardsError(t, conn, fs)
 	testExecuteBatchKeyspaceIdsError(t, conn, fs)
 	testStreamExecuteError(t, conn, fs)
-	testStreamExecute2Error(t, conn, fs)
 	testStreamExecuteShardsError(t, conn, fs)
-	testStreamExecuteShards2Error(t, conn, fs)
 	testStreamExecuteKeyRangesError(t, conn, fs)
-	testStreamExecuteKeyRanges2Error(t, conn, fs)
 	testStreamExecuteKeyspaceIdsError(t, conn, fs)
-	testStreamExecuteKeyspaceIds2Error(t, conn, fs)
 	testSplitQueryError(t, conn)
 	testGetSrvKeyspaceError(t, conn)
 	fs.hasError = false
@@ -1115,32 +1111,6 @@ func testStreamExecuteError(t *testing.T, conn *vtgateconn.VTGateConn, fake *fak
 	verifyErrorString(t, err, "StreamExecute")
 }
 
-func testStreamExecute2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
-	ctx := newContext()
-	execCase := execMap["request1"]
-	stream, errFunc, err := conn.StreamExecute2(ctx, execCase.execQuery.SQL, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
-	if err != nil {
-		t.Fatalf("StreamExecute2 failed: %v", err)
-	}
-	qr, ok := <-stream
-	if !ok {
-		t.Fatalf("StreamExecute2 failed: cannot read result1")
-	}
-
-	if !reflect.DeepEqual(qr, &streamResultFields) {
-		t.Errorf("Unexpected result from StreamExecute2: got %#v want %#v", qr, &streamResultFields)
-	}
-	// signal to the server that the first result has been received
-	close(fake.errorWait)
-	// After 1 result, we expect to get an error (no more results).
-	qr, ok = <-stream
-	if ok {
-		t.Fatalf("StreamExecute2 channel wasn't closed")
-	}
-	err = errFunc()
-	verifyError(t, err, "StreamExecute2")
-}
-
 func testStreamExecutePanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -1219,32 +1189,6 @@ func testStreamExecuteShardsError(t *testing.T, conn *vtgateconn.VTGateConn, fak
 	}
 	err = errFunc()
 	verifyErrorString(t, err, "StreamExecuteShards")
-}
-
-func testStreamExecuteShards2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
-	ctx := newContext()
-	execCase := execMap["request1"]
-	stream, errFunc, err := conn.StreamExecuteShards2(ctx, execCase.shardQuery.SQL, execCase.shardQuery.Keyspace, execCase.shardQuery.Shards, execCase.execQuery.BindVariables, execCase.execQuery.TabletType)
-	if err != nil {
-		t.Fatalf("StreamExecuteShards2 failed: %v", err)
-	}
-	qr, ok := <-stream
-	if !ok {
-		t.Fatalf("StreamExecuteShards2 failed: cannot read result1")
-	}
-
-	if !reflect.DeepEqual(qr, &streamResultFields) {
-		t.Errorf("Unexpected result from StreamExecuteShards2: got %#v want %#v", qr, &streamResultFields)
-	}
-	// signal to the server that the first result has been received
-	close(fake.errorWait)
-	// After 1 result, we expect to get an error (no more results).
-	qr, ok = <-stream
-	if ok {
-		t.Fatalf("StreamExecuteShards2 channel wasn't closed")
-	}
-	err = errFunc()
-	verifyError(t, err, "StreamExecuteShards2")
 }
 
 func testStreamExecuteShardsPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
@@ -1327,32 +1271,6 @@ func testStreamExecuteKeyRangesError(t *testing.T, conn *vtgateconn.VTGateConn, 
 	verifyErrorString(t, err, "StreamExecuteKeyRanges")
 }
 
-func testStreamExecuteKeyRanges2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
-	ctx := newContext()
-	execCase := execMap["request1"]
-	stream, errFunc, err := conn.StreamExecuteKeyRanges2(ctx, execCase.keyRangeQuery.SQL, execCase.keyRangeQuery.Keyspace, execCase.keyRangeQuery.KeyRanges, execCase.keyRangeQuery.BindVariables, execCase.keyRangeQuery.TabletType)
-	if err != nil {
-		t.Fatalf("StreamExecuteKeyRanges2 failed: %v", err)
-	}
-	qr, ok := <-stream
-	if !ok {
-		t.Fatalf("StreamExecuteKeyRanges2 failed: cannot read result1")
-	}
-
-	if !reflect.DeepEqual(qr, &streamResultFields) {
-		t.Errorf("Unexpected result from StreamExecuteKeyRanges2: got %#v want %#v", qr, &streamResultFields)
-	}
-	// signal to the server that the first result has been received
-	close(fake.errorWait)
-	// After 1 result, we expect to get an error (no more results).
-	qr, ok = <-stream
-	if ok {
-		t.Fatalf("StreamExecuteKeyRanges2 channel wasn't closed")
-	}
-	err = errFunc()
-	verifyError(t, err, "StreamExecuteKeyRanges2")
-}
-
 func testStreamExecuteKeyRangesPanic(t *testing.T, conn *vtgateconn.VTGateConn) {
 	ctx := newContext()
 	execCase := execMap["request1"]
@@ -1431,32 +1349,6 @@ func testStreamExecuteKeyspaceIdsError(t *testing.T, conn *vtgateconn.VTGateConn
 	}
 	err = errFunc()
 	verifyErrorString(t, err, "StreamExecuteKeyspaceIds")
-}
-
-func testStreamExecuteKeyspaceIds2Error(t *testing.T, conn *vtgateconn.VTGateConn, fake *fakeVTGateService) {
-	ctx := newContext()
-	execCase := execMap["request1"]
-	stream, errFunc, err := conn.StreamExecuteKeyspaceIds2(ctx, execCase.keyspaceIDQuery.SQL, execCase.keyspaceIDQuery.Keyspace, execCase.keyspaceIDQuery.KeyspaceIds, execCase.keyspaceIDQuery.BindVariables, execCase.keyspaceIDQuery.TabletType)
-	if err != nil {
-		t.Fatalf("StreamExecuteKeyspaceIds2 failed: %v", err)
-	}
-	qr, ok := <-stream
-	if !ok {
-		t.Fatalf("StreamExecuteKeyspaceIds2 failed: cannot read result1")
-	}
-
-	if !reflect.DeepEqual(qr, &streamResultFields) {
-		t.Errorf("Unexpected result from StreamExecuteKeyspaceIds2: got %#v want %#v", qr, &streamResultFields)
-	}
-	// signal to the server that the first result has been received
-	close(fake.errorWait)
-	// After 1 result, we expect to get an error (no more results).
-	qr, ok = <-stream
-	if ok {
-		t.Fatalf("StreamExecuteKeyspaceIds2 channel wasn't closed")
-	}
-	err = errFunc()
-	verifyError(t, err, "StreamExecuteKeyspaceIds2")
 }
 
 func testStreamExecuteKeyspaceIdsPanic(t *testing.T, conn *vtgateconn.VTGateConn) {


### PR DESCRIPTION
Both in vtgate and vttablet services. They are unused,
and don't map to any real RPC difference.

@aaijazi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1594)
<!-- Reviewable:end -->
