### PR TITLE
worker: Remove global flag --min_healthy_rdonly_endpoints and make it a flag in each vtworker command.

### DIFF
--- a/doc/HorizontalReshardingGuide.md
+++ b/doc/HorizontalReshardingGuide.md
@@ -206,15 +206,15 @@ to the destination shards. The `vtworker` performs the following tasks:
 The following command starts the `vtworker`:
 
 ```
-vtworker -min_healthy_rdonly_endpoints 1 -cell=<cell name> \
-    SplitClone <keyspace name>/<source shard name>
+vtworker -cell=<cell name> \
+    SplitClone -min_healthy_rdonly_endpoints=1 <keyspace name>/<source shard name>
 ```
 
 For this example, run this command:
 
 ```
-vtworker -min_healthy_rdonly_endpoints 1 -cell=<cell name> \
-    SplitClone user_keyspace/0
+vtworker -cell=<cell name> \
+    SplitClone -min_healthy_rdonly_endpoints=1 user_keyspace/0
 ```
 
 The amount of time that the worker takes to complete will depend
@@ -256,8 +256,8 @@ might not be equal.
 To start the `vtworker`, run the following `SplitDiff` command:
 
 ``` sh
-vtworker -min_healthy_rdonly_endpoints=1 -cell=<cell name> \
-    SplitDiff <keyspace name>/<shard name>
+vtworker -cell=<cell name> \
+    SplitDiff -min_healthy_rdonly_endpoints=1 <keyspace name>/<shard name>
 ```
 
 The commands for the two new destination shards in this example are shown
@@ -268,10 +268,10 @@ sequentially rather than in parallel.
 
 
 ``` sh
-vtworker -min_healthy_rdonly_endpoints=1 -cell=<cell name> \
-    SplitDiff user_keyspace/-80
-vtworker -min_healthy_rdonly_endpoints=1 -cell=<cell name> \
-    SplitDiff user_keyspace/80-
+vtworker -cell=<cell name> \
+    SplitDiff -min_healthy_rdonly_endpoints=1 user_keyspace/-80
+vtworker -cell=<cell name> \
+    SplitDiff -min_healthy_rdonly_endpoints=1 user_keyspace/80-
 ```
 
 The vtworker performs the following tasks:

--- a/examples/kubernetes/vtworker-pod-template.yaml
+++ b/examples/kubernetes/vtworker-pod-template.yaml
@@ -26,7 +26,6 @@ spec:
           -port {{port}}
           -topo_implementation etcd
           -etcd_global_addrs http://etcd-global:4001
-          -min_healthy_rdonly_endpoints 1
           -cell {{cell}}
           -tablet_protocol grpc
           -tablet_manager_protocol grpc

--- a/go/vt/automation/horizontal_resharding_task.go
+++ b/go/vt/automation/horizontal_resharding_task.go
@@ -17,6 +17,7 @@ type HorizontalReshardingTask struct {
 
 // Run is part of the Task interface.
 func (t *HorizontalReshardingTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
+	// Required parameters.
 	// Example: test_keyspace
 	keyspace := parameters["keyspace"]
 	// Example: 10-20
@@ -28,13 +29,19 @@ func (t *HorizontalReshardingTask) Run(parameters map[string]string) ([]*automat
 	// Example: localhost:15001
 	vtworkerEndpoint := parameters["vtworker_endpoint"]
 
+	// Optional parameters.
+	// Example: unrelated1,unrelated2
+	excludeTables := parameters["exclude_tables"]
+	// Example: 1
+	minHealthyRdonlyEndPoints := parameters["min_healthy_rdonly_endpoints"]
+
 	var newTasks []*automationpb.TaskContainer
 	copySchemaTasks := NewTaskContainer()
 	for _, destShard := range destShards {
 		AddTask(copySchemaTasks, "CopySchemaShardTask", map[string]string{
 			"source_keyspace_and_shard": topoproto.KeyspaceShardString(keyspace, sourceShards[0]),
 			"dest_keyspace_and_shard":   topoproto.KeyspaceShardString(keyspace, destShard),
-			"exclude_tables":            parameters["exclude_tables"],
+			"exclude_tables":            excludeTables,
 			"vtctld_endpoint":           vtctldEndpoint,
 		})
 	}
@@ -44,9 +51,11 @@ func (t *HorizontalReshardingTask) Run(parameters map[string]string) ([]*automat
 	for _, sourceShard := range sourceShards {
 		// TODO(mberlin): Add a semaphore as argument to limit the parallism.
 		AddTask(splitCloneTasks, "SplitCloneTask", map[string]string{
-			"keyspace":          keyspace,
-			"source_shard":      sourceShard,
-			"vtworker_endpoint": vtworkerEndpoint,
+			"keyspace":                     keyspace,
+			"source_shard":                 sourceShard,
+			"vtworker_endpoint":            vtworkerEndpoint,
+			"exclude_tables":               excludeTables,
+			"min_healthy_rdonly_endpoints": minHealthyRdonlyEndPoints,
 		})
 	}
 	newTasks = append(newTasks, splitCloneTasks)
@@ -67,9 +76,11 @@ func (t *HorizontalReshardingTask) Run(parameters map[string]string) ([]*automat
 	for _, destShard := range destShards {
 		splitDiffTask := NewTaskContainer()
 		AddTask(splitDiffTask, "SplitDiffTask", map[string]string{
-			"keyspace":          keyspace,
-			"dest_shard":        destShard,
-			"vtworker_endpoint": vtworkerEndpoint,
+			"keyspace":                     keyspace,
+			"dest_shard":                   destShard,
+			"vtworker_endpoint":            vtworkerEndpoint,
+			"exclude_tables":               excludeTables,
+			"min_healthy_rdonly_endpoints": minHealthyRdonlyEndPoints,
 		})
 		newTasks = append(newTasks, splitDiffTask)
 	}
@@ -98,5 +109,5 @@ func (t *HorizontalReshardingTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *HorizontalReshardingTask) OptionalParameters() []string {
-	return []string{"exclude_tables"}
+	return []string{"exclude_tables", "min_healthy_rdonly_endpoints"}
 }

--- a/go/vt/automation/horizontal_resharding_task_test.go
+++ b/go/vt/automation/horizontal_resharding_task_test.go
@@ -14,11 +14,15 @@ func TestHorizontalReshardingTaskEmittedTasks(t *testing.T) {
 	reshardingTask := &HorizontalReshardingTask{}
 
 	parameters := map[string]string{
+		// Required parameters.
 		"keyspace":          "test_keyspace",
 		"source_shard_list": "10-20",
 		"dest_shard_list":   "10-18,18-20",
 		"vtctld_endpoint":   "localhost:15000",
 		"vtworker_endpoint": "localhost:15001",
+		// Optional parameters.
+		"exclude_tables":               "unrelated1,unrelated2",
+		"min_healthy_rdonly_endpoints": "1",
 	}
 
 	err := validateParameters(reshardingTask, parameters)

--- a/go/vt/automation/split_clone_task.go
+++ b/go/vt/automation/split_clone_task.go
@@ -26,6 +26,9 @@ func (t *SplitCloneTask) Run(parameters map[string]string) ([]*automationpb.Task
 	if destinationPackCount := parameters["destination_pack_count"]; destinationPackCount != "" {
 		args = append(args, "--destination_pack_count="+destinationPackCount)
 	}
+	if minHealthyRdonlyEndPoints := parameters["min_healthy_rdonly_endpoints"]; minHealthyRdonlyEndPoints != "" {
+		args = append(args, "--min_healthy_rdonly_endpoints="+minHealthyRdonlyEndPoints)
+	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["keyspace"], parameters["source_shard"]))
 	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
@@ -44,5 +47,5 @@ func (t *SplitCloneTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *SplitCloneTask) OptionalParameters() []string {
-	return []string{"exclude_tables", "destination_pack_count"}
+	return []string{"exclude_tables", "destination_pack_count", "min_healthy_rdonly_endpoints"}
 }

--- a/go/vt/automation/split_clone_task_test.go
+++ b/go/vt/automation/split_clone_task_test.go
@@ -17,15 +17,17 @@ func TestSplitCloneTask(t *testing.T) {
 	vtworkerclient.RegisterFactory("fake", fake.FakeVtworkerClientFactory)
 	defer vtworkerclient.UnregisterFactoryForTest("fake")
 	flag.Set("vtworker_client_protocol", "fake")
-	fake.RegisterResult([]string{"SplitClone", "test_keyspace/0"},
+	fake.RegisterResult([]string{"SplitClone", "--exclude_tables=unrelated1", "--min_healthy_rdonly_endpoints=1", "test_keyspace/0"},
 		"",  // No output.
 		nil) // No error.
 
 	task := &SplitCloneTask{}
 	parameters := map[string]string{
-		"keyspace":          "test_keyspace",
-		"source_shard":      "0",
-		"vtworker_endpoint": "localhost:15001",
+		"keyspace":                     "test_keyspace",
+		"source_shard":                 "0",
+		"vtworker_endpoint":            "localhost:15001",
+		"exclude_tables":               "unrelated1",
+		"min_healthy_rdonly_endpoints": "1",
 	}
 
 	err := validateParameters(task, parameters)

--- a/go/vt/automation/split_diff_task.go
+++ b/go/vt/automation/split_diff_task.go
@@ -20,6 +20,9 @@ func (t *SplitDiffTask) Run(parameters map[string]string) ([]*automationpb.TaskC
 	if excludeTables := parameters["exclude_tables"]; excludeTables != "" {
 		args = append(args, "--exclude_tables="+excludeTables)
 	}
+	if minHealthyRdonlyEndPoints := parameters["min_healthy_rdonly_endpoints"]; minHealthyRdonlyEndPoints != "" {
+		args = append(args, "--min_healthy_rdonly_endpoints="+minHealthyRdonlyEndPoints)
+	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["keyspace"], parameters["dest_shard"]))
 	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
@@ -38,5 +41,5 @@ func (t *SplitDiffTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *SplitDiffTask) OptionalParameters() []string {
-	return []string{"exclude_tables"}
+	return []string{"exclude_tables", "min_healthy_rdonly_endpoints"}
 }

--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -25,6 +25,9 @@ func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automatio
 	if destinationPackCount := parameters["destination_pack_count"]; destinationPackCount != "" {
 		args = append(args, "--destination_pack_count="+destinationPackCount)
 	}
+	if minHealthyRdonlyEndPoints := parameters["min_healthy_rdonly_endpoints"]; minHealthyRdonlyEndPoints != "" {
+		args = append(args, "--min_healthy_rdonly_endpoints="+minHealthyRdonlyEndPoints)
+	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["dest_keyspace"], parameters["shard"]))
 	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
@@ -43,5 +46,5 @@ func (t *VerticalSplitCloneTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *VerticalSplitCloneTask) OptionalParameters() []string {
-	return []string{"destination_pack_count"}
+	return []string{"destination_pack_count", "min_healthy_rdonly_endpoints"}
 }

--- a/go/vt/automation/vertical_split_diff_task.go
+++ b/go/vt/automation/vertical_split_diff_task.go
@@ -18,6 +18,9 @@ type VerticalSplitDiffTask struct {
 // Run is part of the Task interface.
 func (t *VerticalSplitDiffTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
 	args := []string{"VerticalSplitDiff"}
+	if minHealthyRdonlyEndPoints := parameters["min_healthy_rdonly_endpoints"]; minHealthyRdonlyEndPoints != "" {
+		args = append(args, "--min_healthy_rdonly_endpoints="+minHealthyRdonlyEndPoints)
+	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["dest_keyspace"], parameters["shard"]))
 	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
@@ -36,5 +39,5 @@ func (t *VerticalSplitDiffTask) RequiredParameters() []string {
 
 // OptionalParameters is part of the Task interface.
 func (t *VerticalSplitDiffTask) OptionalParameters() []string {
-	return []string{""}
+	return []string{"min_healthy_rdonly_endpoints"}
 }

--- a/go/vt/automation/vertical_split_task_test.go
+++ b/go/vt/automation/vertical_split_task_test.go
@@ -33,9 +33,9 @@ func TestVerticalSplitTask(t *testing.T) {
 	vtctld.RegisterResult([]string{"CopySchemaShard", "--tables=table1,table2", "source_keyspace/0", "destination_keyspace/0"},
 		"",  // No output.
 		nil) // No error.
-	vtworker.RegisterResult([]string{"VerticalSplitClone", "--tables=table1,table2", "destination_keyspace/0"}, "", nil)
+	vtworker.RegisterResult([]string{"VerticalSplitClone", "--tables=table1,table2", "--min_healthy_rdonly_endpoints=1", "destination_keyspace/0"}, "", nil)
 	vtctld.RegisterResult([]string{"WaitForFilteredReplication", "-max_delay", "30s", "destination_keyspace/0"}, "", nil)
-	vtworker.RegisterResult([]string{"VerticalSplitDiff", "destination_keyspace/0"}, "", nil)
+	vtworker.RegisterResult([]string{"VerticalSplitDiff", "--min_healthy_rdonly_endpoints=1", "destination_keyspace/0"}, "", nil)
 	vtctld.RegisterResult([]string{"MigrateServedFrom", "destination_keyspace/0", "rdonly"}, "", nil)
 	vtctld.RegisterResult([]string{"MigrateServedFrom", "destination_keyspace/0", "replica"}, "", nil)
 	vtctld.RegisterResult([]string{"MigrateServedFrom", "destination_keyspace/0", "master"},
@@ -53,12 +53,13 @@ func TestVerticalSplitTask(t *testing.T) {
 	enqueueRequest := &automationpb.EnqueueClusterOperationRequest{
 		Name: "VerticalSplitTask",
 		Parameters: map[string]string{
-			"source_keyspace":   "source_keyspace",
-			"dest_keyspace":     "destination_keyspace",
-			"shard_list":        "0",
-			"tables":            "table1,table2",
-			"vtctld_endpoint":   "localhost:15000",
-			"vtworker_endpoint": "localhost:15001",
+			"source_keyspace":              "source_keyspace",
+			"dest_keyspace":                "destination_keyspace",
+			"shard_list":                   "0",
+			"tables":                       "table1,table2",
+			"vtctld_endpoint":              "localhost:15000",
+			"vtworker_endpoint":            "localhost:15001",
+			"min_healthy_rdonly_endpoints": "1",
 		},
 	}
 	enqueueResponse, err := scheduler.EnqueueClusterOperation(context.Background(), enqueueRequest)

--- a/go/vt/worker/defaults.go
+++ b/go/vt/worker/defaults.go
@@ -9,7 +9,8 @@ const (
 	// defaultDestinationPackCount is the number of rows which will be aggreated
 	// into one transaction. Note that higher values will increase memory
 	// consumption in vtworker, vttablet and mysql.
-	defaultDestinationPackCount   = 1000
-	defaultMinTableSizeForSplit   = 1024 * 1024
-	defaultDestinationWriterCount = 20
+	defaultDestinationPackCount      = 1000
+	defaultMinTableSizeForSplit      = 1024 * 1024
+	defaultDestinationWriterCount    = 20
+	defaultMinHealthyRdonlyEndPoints = 2
 )

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -59,7 +59,7 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 	for {
 		select {
 		case <-busywaitCtx.Done():
-			return nil, fmt.Errorf("Not enough healthy rdonly endpoints to choose from in (%v,%v/%v), have %v healthy ones, need at least %v Context Error: %v",
+			return nil, fmt.Errorf("not enough healthy rdonly endpoints to choose from in (%v,%v/%v), have %v healthy ones, need at least %v Context error: %v",
 				cell, keyspace, shard, len(healthyEndpoints), minHealthyRdonlyEndPoints, busywaitCtx.Err())
 		default:
 		}

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -20,8 +20,6 @@ import (
 )
 
 var (
-	minHealthyEndPoints = flag.Int("min_healthy_rdonly_endpoints", 2, "minimum number of healthy rdonly endpoints before taking out one")
-
 	// WaitForHealthyEndPointsTimeout intent is to wait for the
 	// healthcheck to automatically return rdonly instances which
 	// have been taken out by previous *Clone or *Diff runs.
@@ -52,7 +50,7 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 
 	deadlineForLog, _ := busywaitCtx.Deadline()
 	wr.Logger().Infof("Waiting for enough healthy rdonly endpoints to become available. required: %v Waiting up to %.1f seconds.",
-		*minHealthyEndPoints, deadlineForLog.Sub(time.Now()).Seconds())
+		minHealthyRdonlyEndPoints, deadlineForLog.Sub(time.Now()).Seconds())
 	if err := discovery.WaitForEndPoints(busywaitCtx, healthCheck, cell, keyspace, shard, []topodatapb.TabletType{topodatapb.TabletType_RDONLY}); err != nil {
 		return nil, fmt.Errorf("error waiting for rdonly endpoints for (%v,%v/%v): %v", cell, keyspace, shard, err)
 	}
@@ -62,7 +60,7 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 		select {
 		case <-busywaitCtx.Done():
 			return nil, fmt.Errorf("Not enough healthy rdonly endpoints to choose from in (%v,%v/%v), have %v healthy ones, need at least %v Context Error: %v",
-				cell, keyspace, shard, len(healthyEndpoints), *minHealthyEndPoints, busywaitCtx.Err())
+				cell, keyspace, shard, len(healthyEndpoints), minHealthyRdonlyEndPoints, busywaitCtx.Err())
 		default:
 		}
 
@@ -81,13 +79,13 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 			healthyEndpoints = append(healthyEndpoints, addr.EndPoint)
 		}
 
-		if len(healthyEndpoints) >= *minHealthyEndPoints {
+		if len(healthyEndpoints) >= minHealthyRdonlyEndPoints {
 			break
 		}
 
 		deadlineForLog, _ := busywaitCtx.Deadline()
 		wr.Logger().Infof("Waiting for enough healthy rdonly endpoints to become available. available: %v required: %v Waiting up to %.1f more seconds.",
-			len(healthyEndpoints), *minHealthyEndPoints, deadlineForLog.Sub(time.Now()).Seconds())
+			len(healthyEndpoints), minHealthyRdonlyEndPoints, deadlineForLog.Sub(time.Now()).Seconds())
 		// Block for 1 second because 2 seconds is the -health_check_interval flag value in integration tests.
 		timer := time.NewTimer(1 * time.Second)
 		select {
@@ -109,8 +107,8 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 // - find a rdonly instance in the keyspace / shard
 // - mark it as worker
 // - tag it with our worker process
-func FindWorkerTablet(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrangler.Cleaner, cell, keyspace, shard string) (*topodatapb.TabletAlias, error) {
-	tabletAlias, err := FindHealthyRdonlyEndPoint(ctx, wr, cell, keyspace, shard)
+func FindWorkerTablet(ctx context.Context, wr *wrangler.Wrangler, cleaner *wrangler.Cleaner, cell, keyspace, shard string, minHealthyRdonlyEndPoints int) (*topodatapb.TabletAlias, error) {
+	tabletAlias, err := FindHealthyRdonlyEndPoint(ctx, wr, cell, keyspace, shard, minHealthyRdonlyEndPoints)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -20,13 +20,12 @@ import (
 )
 
 var (
-	// WaitForHealthyEndPointsTimeout intent is to wait for the
+	// waitForHealthyEndPointsTimeout intends to wait for the
 	// healthcheck to automatically return rdonly instances which
 	// have been taken out by previous *Clone or *Diff runs.
 	// Therefore, the default for this variable must be higher
-	// than -health_check_interval.
-	// (it is public for tests to override it)
-	WaitForHealthyEndPointsTimeout = flag.Duration("wait_for_healthy_rdonly_endpoints_timeout", 60*time.Second, "maximum time to wait if less than --min_healthy_rdonly_endpoints are available")
+	// than vttablet's -health_check_interval.
+	waitForHealthyEndPointsTimeout = flag.Duration("wait_for_healthy_rdonly_endpoints_timeout", 60*time.Second, "maximum time to wait if less than --min_healthy_rdonly_endpoints are available")
 
 	healthCheckTopologyRefresh = flag.Duration("worker_healthcheck_topology_refresh", 30*time.Second, "refresh interval for re-reading the topology")
 	healthcheckRetryDelay      = flag.Duration("worker_healthcheck_retry_delay", 5*time.Second, "delay before retrying a failed healthcheck")
@@ -37,8 +36,8 @@ var (
 // Since we don't want to use them all, we require at least
 // minHealthyEndPoints servers to be healthy.
 // May block up to -wait_for_healthy_rdonly_endpoints_timeout.
-func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell, keyspace, shard string) (*topodatapb.TabletAlias, error) {
-	busywaitCtx, busywaitCancel := context.WithTimeout(ctx, *WaitForHealthyEndPointsTimeout)
+func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell, keyspace, shard string, minHealthyRdonlyEndPoints int) (*topodatapb.TabletAlias, error) {
+	busywaitCtx, busywaitCancel := context.WithTimeout(ctx, *waitForHealthyEndPointsTimeout)
 	defer busywaitCancel()
 
 	// create a discovery healthcheck, wait for it to have one rdonly

--- a/go/vt/worker/vertical_split_diff_cmd.go
+++ b/go/vt/worker/vertical_split_diff_cmd.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"net/http"
+	"strconv"
 	"sync"
 
 	"github.com/youtube/vitess/go/vt/concurrency"
@@ -43,7 +44,8 @@ const verticalSplitDiffHTML2 = `
   <p>Shard involved: {{.Keyspace}}/{{.Shard}}</p>
   <h1>Vertical Split Diff Action</h1>
     <form action="/Diffs/VerticalSplitDiff" method="post">
-      <INPUT type="hidden" name="keyspace" value="{{.Keyspace}}"/>
+      <LABEL for="minHealthyRdonlyEndPoints">Minimum Number of required healthy RDONLY tablets: </LABEL>
+        <INPUT type="text" id="minHealthyRdonlyEndPoints" name="minHealthyRdonlyEndPoints" value="{{.DefaultMinHealthyRdonlyEndPoints}}"></BR>      <INPUT type="hidden" name="keyspace" value="{{.Keyspace}}"/>
       <INPUT type="hidden" name="shard" value="{{.Shard}}"/>
       <INPUT type="submit" name="submit" value="Vertical Split Diff"/>
     </form>
@@ -54,6 +56,7 @@ var verticalSplitDiffTemplate = mustParseTemplate("verticalSplitDiff", verticalS
 var verticalSplitDiffTemplate2 = mustParseTemplate("verticalSplitDiff2", verticalSplitDiffHTML2)
 
 func commandVerticalSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
+	minHealthyRdonlyEndPoints := subFlags.Int("min_healthy_rdonly_endpoints", defaultMinHealthyRdonlyEndPoints, "minimum number of healthy rdonly endpoints before taking out one")
 	if err := subFlags.Parse(args); err != nil {
 		return nil, err
 	}
@@ -65,7 +68,7 @@ func commandVerticalSplitDiff(wi *Instance, wr *wrangler.Wrangler, subFlags *fla
 	if err != nil {
 		return nil, err
 	}
-	return NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard), nil
+	return NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard, *minHealthyRdonlyEndPoints), nil
 }
 
 // shardsWithTablesSources returns all the shards that have SourceShards set
@@ -153,11 +156,19 @@ func interactiveVerticalSplitDiff(ctx context.Context, wi *Instance, wr *wrangle
 		result := make(map[string]interface{})
 		result["Keyspace"] = keyspace
 		result["Shard"] = shard
+		result["DefaultMinHealthyRdonlyEndPoints"] = fmt.Sprintf("%v", defaultMinHealthyRdonlyEndPoints)
 		return nil, verticalSplitDiffTemplate2, result, nil
 	}
 
+	// get other parameters
+	minHealthyRdonlyEndPointsStr := r.FormValue("minHealthyRdonlyEndPoints")
+	minHealthyRdonlyEndPoints, err := strconv.ParseInt(minHealthyRdonlyEndPointsStr, 0, 64)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("cannot parse minHealthyRdonlyEndPoints: %s", err)
+	}
+
 	// start the diff job
-	wrk := NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard)
+	wrk := NewVerticalSplitDiffWorker(wr, wi.cell, keyspace, shard, int(minHealthyRdonlyEndPoints))
 	return wrk, nil, nil, nil
 }
 

--- a/test/automation_horizontal_resharding.py
+++ b/test/automation_horizontal_resharding.py
@@ -51,7 +51,8 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
         ' --param source_shard_list=' + source_shard_list +
         ' --param dest_shard_list=' + dest_shard_list +
         ' --param vtctld_endpoint=' + vtctld_endpoint +
-        ' --param vtworker_endpoint=' + vtworker_endpoint)
+        ' --param vtworker_endpoint=' + vtworker_endpoint +
+        ' --param min_healthy_rdonly_endpoints=1')
 
     self.verify()
 

--- a/test/automation_horizontal_resharding.py
+++ b/test/automation_horizontal_resharding.py
@@ -5,6 +5,12 @@
 # be found in the LICENSE file.
 """End-to-end test for horizontal resharding automation."""
 
+# "unittest" is used indirectly by importing "worker", but pylint does
+# not grasp this.
+# Import it explicitly to make pylint happy and stop it complaining about
+# setUpModule, tearDownModule and the missing module docstring.
+import unittest  # pylint: disable=unused-import
+
 import environment
 import utils
 import worker

--- a/test/binlog.py
+++ b/test/binlog.py
@@ -103,6 +103,7 @@ def setUpModule():
                         'SplitClone',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
+                        '--min_healthy_rdonly_endpoints', '1',
                         'test_keyspace/0'],
                        auto_log=True)
     dst_master.wait_for_binlog_player_count(1)

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -409,6 +409,7 @@ index by_msg (msg)
                         '--exclude_tables', 'unrelated',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
+                        '--min_healthy_rdonly_endpoints', '1',
                         'test_keyspace/0'],
                        auto_log=True)
 
@@ -440,11 +441,15 @@ index by_msg (msg)
     logging.debug('Running vtworker SplitDiff for -80')
     for t in [shard_0_rdonly1, shard_1_rdonly1]:
       utils.run_vtctl(['RunHealthCheck', t.tablet_alias, 'rdonly'])
-    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff', 'test_keyspace/-80'],
+    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff',
+                        '--min_healthy_rdonly_endpoints', '1',
+                        'test_keyspace/-80'],
                        auto_log=True)
 
     logging.debug('Running vtworker SplitDiff for 80-')
-    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff', 'test_keyspace/80-'],
+    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff',
+                        '--min_healthy_rdonly_endpoints', '1',
+                        'test_keyspace/80-'],
                        auto_log=True)
 
     utils.pause('Good time to test vtworker for diffs')

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -572,6 +572,7 @@ primary key (name)
                         '--exclude_tables', 'unrelated',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
+                        '--min_healthy_rdonly_endpoints', '1',
                         'test_keyspace/80-'],
                        auto_log=True)
     utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly1.tablet_alias,
@@ -619,8 +620,10 @@ primary key (name)
     # rdonly tablets so discovery works)
     utils.run_vtctl(['RunHealthCheck', shard_3_rdonly1.tablet_alias, 'rdonly'])
     logging.debug('Running vtworker SplitDiff')
-    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff', '--exclude_tables',
-                        'unrelated', 'test_keyspace/c0-'],
+    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff',
+                        '--exclude_tables', 'unrelated',
+                        '--min_healthy_rdonly_endpoints', '1',
+                        'test_keyspace/c0-'],
                        auto_log=True)
     utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly1.tablet_alias, 'rdonly'],
                     auto_log=True)
@@ -783,8 +786,10 @@ primary key (name)
 
     # use vtworker to compare the data again
     logging.debug('Running vtworker SplitDiff')
-    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff', '--exclude_tables',
-                        'unrelated', 'test_keyspace/c0-'],
+    utils.run_vtworker(['-cell', 'test_nj', 'SplitDiff',
+                        '--exclude_tables', 'unrelated',
+                        '--min_healthy_rdonly_endpoints', '1',
+                        'test_keyspace/c0-'],
                        auto_log=True)
     utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly1.tablet_alias, 'rdonly'],
                     auto_log=True)

--- a/test/utils.py
+++ b/test/utils.py
@@ -763,7 +763,6 @@ def _get_vtworker_cmd(clargs, auto_log=False):
   rpc_port = port
   args = environment.binary_args('vtworker') + [
       '-log_dir', environment.vtlogroot,
-      '-min_healthy_rdonly_endpoints', '1',
       '-port', str(port),
       # use a long resolve TTL because of potential race conditions with doing
       # an EmergencyReparent and resolving the master (as EmergencyReparent

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -372,6 +372,7 @@ index by_msg (msg)
                         '--tables', 'moving.*,view1',
                         '--source_reader_count', '10',
                         '--min_table_size_for_split', '1',
+                        '--min_healthy_rdonly_endpoints', '1',
                         'destination_keyspace/0'],
                        auto_log=True)
     # One of the two source rdonly tablets went spare after the clone.
@@ -404,6 +405,7 @@ index by_msg (msg)
       utils.run_vtctl(['RunHealthCheck', t.tablet_alias, 'rdonly'])
     logging.debug('Running vtworker VerticalSplitDiff')
     utils.run_vtworker(['-cell', 'test_nj', 'VerticalSplitDiff',
+                        '--min_healthy_rdonly_endpoints', '1',
                         'destination_keyspace/0'], auto_log=True)
     # One of each source and dest rdonly tablet went spare after the diff.
     # Force a healthcheck on all four to get them back to "rdonly".


### PR DESCRIPTION
Added end-to-end test in worker.py which verifies that --min_healthy_rdonly_endpoints works correctly when there are not enough RDONLY tablets.

Updated tests and documentation.

@alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1595)
<!-- Reviewable:end -->
