### PR TITLE
V3: engine work

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -236,6 +236,7 @@
 {
   "Original": "select user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -273,6 +274,7 @@
 {
   "Original": "select user_extra.id from user join user_extra on user.col = user_extra.col where user.id = 5 and user_extra.user_id = 5",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -312,6 +314,7 @@
 {
   "Original": "select user_extra.id from user join user_extra on user.col = user_extra.col where user_extra.user_id = user.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -349,6 +352,7 @@
 {
   "Original": "select user_extra.id from user join user_extra on user.col = user_extra.col where 1 = 1",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -470,6 +474,7 @@
 {
   "Original": "select main1.id from user join main1 where main1.id = user.id",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -505,6 +510,7 @@
 {
   "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col) and u.id in (user_extra.col, 1)",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -545,6 +551,7 @@
 {
   "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = 5) and u.id = 5",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -576,6 +583,7 @@
 {
   "Original": "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col and user.id in (select m3 from user_extra where user_extra.user_id = user.id)) and u.id in (user_extra.col, 1)",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -48,6 +48,7 @@
 {
   "Original": "select music.col from user join music",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -92,7 +93,7 @@
 {
   "Original": "select u.col from user u left join main1 m on u.a = m.b",
   "Instructions": {
-    "IsLeft": true,
+    "Opcode": "LeftJoin",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -128,9 +129,9 @@
 {
   "Original": "select user.col from user left join main1 as m1 on user.col = m1.co left join main1 as m2 on m1.col = m2.col",
   "Instructions": {
-    "IsLeft": true,
+    "Opcode": "LeftJoin",
     "Left": {
-      "IsLeft": true,
+      "Opcode": "LeftJoin",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -186,7 +187,7 @@
 {
   "Original": "select user.col from user left join user_extra as e left join main1 as m1 on m1.col = e.col on user.col = e.col",
   "Instructions": {
-    "IsLeft": true,
+    "Opcode": "LeftJoin",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -197,7 +198,7 @@
       "FieldQuery": "select user.col from user where 1 != 1"
     },
     "Right": {
-      "IsLeft": true,
+      "Opcode": "LeftJoin",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -285,7 +286,9 @@
 {
   "Original": "select user.col from user join main1 as m1 join main1 as m2",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -328,6 +331,7 @@
 {
   "Original": "select user.col from user join (main1 as m1 join main1 as m2)",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -357,6 +361,7 @@
 {
   "Original": "select user.col from user join (user as u1 join main1)",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -367,6 +372,7 @@
       "FieldQuery": "select user.col from user where 1 != 1"
     },
     "Right": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -474,6 +480,7 @@
 {
   "Original": "select user.col from user join user_extra on user.id \u003c user_extra.user_id",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -509,6 +516,7 @@
 {
   "Original": "select user.col from user join user_extra on user.id = 5",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -540,6 +548,7 @@
 {
   "Original": "select user.col from user join user_extra on 5 = user.id",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -571,6 +580,7 @@
 {
   "Original": "select user.col from user join user_extra on user.id = user_extra.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -606,6 +616,7 @@
 {
   "Original": "select user.col from user_extra join user on user_extra.user_id = user.name",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -692,6 +703,7 @@
 {
   "Original": "select t.id from (select id from user where id = 5) as t join user_extra on t.id = user_extra.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {

--- a/data/test/vtgate/onecase.txt
+++ b/data/test/vtgate/onecase.txt
@@ -3,7 +3,9 @@
 {
   "Original": "select u1.id from user u1 join user u2 on u2.col = u1.col join user u3 where u3.col = u1.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -54,6 +54,7 @@
 {
   "Original": "select user.col1 as a, user.col2, user_extra.col3 from user join user_extra having 1 = 1 and a = 1 and a = user.col2 and user_extra.col3 = 1",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -141,6 +142,7 @@
 {
   "Original": "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by a asc, user.col2 desc, music.col3 asc",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -182,6 +184,7 @@
 {
   "Original": "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by 1 asc, 2 desc, 3 asc",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectEqualUnique",
       "Keyspace": {
@@ -274,6 +277,7 @@
 {
   "Original": "select u.id, e.id from user u join user_extra e where u.col = e.col and u.col in (select * from user where user.id = u.id order by col)",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {

--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -4,11 +4,11 @@
       "Sharded": true,
       "Vindexes": {
         "user_index": {
-          "Type": "hash",
+          "Type": "hash_test",
           "Owner": "user"
         },
         "music_user_map": {
-          "Type": "lookup",
+          "Type": "lookup_test",
           "Owner": "music"
         },
         "name_user_map": {

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -33,6 +33,7 @@
 {
   "Original": "select user_extra.id from user join user_extra",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -62,6 +63,7 @@
 {
   "Original": "select user.col, user_extra.id from user join user_extra",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -92,6 +94,7 @@
 {
   "Original": "select user.col, user_extra.id + user_extra.col from user join user_extra",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -122,6 +125,7 @@
 {
   "Original": "select user.col, user_extra.id, user.col2 from user join user_extra",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -230,6 +234,7 @@
 {
   "Original": "select /* comment */ user.col from user join user_extra",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -259,6 +264,7 @@
 {
   "Original": "select user.col from user join user_extra for update",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -288,6 +294,7 @@
 {
   "Original": "select user.id, (select user.id+outm.m+main1.m from main1) from user join main1 outm",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -7,6 +7,7 @@
 {
   "Original": "select e.col, u.id uid, e.id eid from user u join user_extra e having uid = eid",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -44,6 +45,7 @@
 {
   "Original": "select e.col, u.id uid, e.id eid from user u join user_extra e having uid = eid and e.col = :uid",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -81,7 +83,9 @@
 {
   "Original": "select u1.id from user u1 join user u2 join user u3 where u3.col = u1.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -131,7 +135,9 @@
 {
   "Original": "select u1.id from user u1 join user u2 join user u3 where u3.col = u2.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -181,7 +187,9 @@
 {
   "Original": "select u1.id from user u1 join user u2 on u2.col = u1.col join user u3 where u3.col = u1.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectScatter",
         "Keyspace": {
@@ -240,8 +248,11 @@
 {
   "Original": "select u1.id from user u1 join user u2 join user u3 on u3.id = u1.col join user u4 where u4.col = u1.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
+      "Opcode": "Join",
       "Left": {
+        "Opcode": "Join",
         "Left": {
           "Opcode": "SelectScatter",
           "Keyspace": {
@@ -313,6 +324,7 @@
 {
   "Original": "select u1.id from user u1 join (user u2 join user u3) where u2.id = u1.col and u3.id = u1.col",
   "Instructions": {
+    "Opcode": "Join",
     "Left": {
       "Opcode": "SelectScatter",
       "Keyspace": {
@@ -323,6 +335,7 @@
       "FieldQuery": "select u1.id, u1.col from user as u1 where 1 != 1"
     },
     "Right": {
+      "Opcode": "Join",
       "Left": {
         "Opcode": "SelectEqualUnique",
         "Keyspace": {

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -23,7 +23,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctld"
 	"github.com/youtube/vitess/go/vt/vtgate"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/vt/zktopo"
 	"github.com/youtube/vitess/go/zk/fakezk"
 
@@ -88,9 +88,9 @@ func main() {
 	initTabletMap(ts, *topology, mysqld, dbcfgs, mycnf)
 
 	// vschema
-	var vschema *planbuilder.VSchema
+	var vschema *vindexes.VSchema
 	if *vschemaFile != "" {
-		vschema, err = planbuilder.LoadFile(*vschemaFile)
+		vschema, err = vindexes.LoadFile(*vschemaFile)
 		if err != nil {
 			log.Error(err)
 			exit.Return(1)

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -19,7 +19,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vtgate"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -61,10 +61,10 @@ func main() {
 	ts := topo.GetServer()
 	defer topo.CloseServers()
 
-	var vschema *planbuilder.VSchema
+	var vschema *vindexes.VSchema
 	if *vschemaFile != "" {
 		var err error
-		if vschema, err = planbuilder.LoadFile(*vschemaFile); err != nil {
+		if vschema, err = vindexes.LoadFile(*vschemaFile); err != nil {
 			log.Error(err)
 			exit.Return(1)
 		}
@@ -76,7 +76,7 @@ func main() {
 			log.Warningf("Skipping v3 initialization: GetVSchema failed: %v", err)
 			goto startServer
 		}
-		vschema, err = planbuilder.NewVSchema([]byte(schemaJSON))
+		vschema, err = vindexes.NewVSchema([]byte(schemaJSON))
 		if err != nil {
 			log.Warningf("Skipping v3 initialization: GetVSchema failed: %v", err)
 			goto startServer

--- a/go/vt/etcdtopo/vschema.go
+++ b/go/vt/etcdtopo/vschema.go
@@ -2,12 +2,8 @@ package etcdtopo
 
 import (
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"golang.org/x/net/context"
-	// vindexes needs to be imported so that they register
-	// themselves against vtgate/planbuilder. This will allow
-	// us to sanity check the schema being uploaded.
-	_ "github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 /*
@@ -16,7 +12,7 @@ This file contains the vschema management code for etcdtopo.Server
 
 // SaveVSchema saves the JSON vschema into the topo.
 func (s *Server) SaveVSchema(ctx context.Context, vschema string) error {
-	_, err := planbuilder.NewVSchema([]byte(vschema))
+	_, err := vindexes.NewVSchema([]byte(vschema))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -32,9 +32,9 @@ type Join struct {
 	Vars map[string]int `json:",omitempty"`
 }
 
-// Exec performs a non-streaming exec.
-func (jn *Join) Exec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
-	lresult, err := jn.Left.Exec(vcursor, joinvars, wantfields)
+// Execute performs a non-streaming exec.
+func (jn *Join) Execute(vcursor VCursor, joinvars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	lresult, err := jn.Left.Execute(vcursor, joinvars, wantfields)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (jn *Join) Exec(vcursor VCursor, joinvars map[string]interface{}, wantfield
 		for k, col := range jn.Vars {
 			joinvars[k] = lrow[col]
 		}
-		rresult, err := jn.Right.Exec(vcursor, joinvars, wantfields)
+		rresult, err := jn.Right.Execute(vcursor, joinvars, wantfields)
 		if err != nil {
 			return nil, err
 		}
@@ -75,15 +75,15 @@ func (jn *Join) Exec(vcursor VCursor, joinvars map[string]interface{}, wantfield
 	return result, nil
 }
 
-// StreamExec performs a streaming exec.
-func (jn *Join) StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
-	err := jn.Left.StreamExec(vcursor, joinvars, wantfields, func(lresult *sqltypes.Result) error {
+// StreamExecute performs a streaming exec.
+func (jn *Join) StreamExecute(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
+	err := jn.Left.StreamExecute(vcursor, joinvars, wantfields, func(lresult *sqltypes.Result) error {
 		for _, lrow := range lresult.Rows {
 			for k, col := range jn.Vars {
 				joinvars[k] = lrow[col]
 			}
 			rowSent := false
-			err := jn.Right.StreamExec(vcursor, joinvars, wantfields, func(rresult *sqltypes.Result) error {
+			err := jn.Right.StreamExecute(vcursor, joinvars, wantfields, func(rresult *sqltypes.Result) error {
 				result := &sqltypes.Result{}
 				if wantfields {
 					wantfields = false

--- a/go/vt/vtgate/engine/join.go
+++ b/go/vt/vtgate/engine/join.go
@@ -1,0 +1,177 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package engine
+
+import (
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// Join specifies the parameters for a join primitive.
+type Join struct {
+	// IsLeft is true if it's a LEFT JOIN.
+	IsLeft bool `json:",omitempty"`
+	// Left and Right are the LHS and RHS primitives
+	// of the Join. They can be any primitive.
+	Left, Right Primitive `json:",omitempty"`
+	// Cols defines which columns from the left
+	// or right results should be used to build the
+	// return result. For results coming from the
+	// left query, the index values go as -1, -2, etc.
+	// For the right query, they're 1, 2, etc.
+	// If Cols is {-1, -2, 1, 2}, it means that
+	// the returned result will be {Left0, Left1, Right0, Right1}.
+	Cols []int `json:",omitempty"`
+	// Vars defines the list of JoinVars that need to
+	// be built from the LHS result before invoking
+	// the RHS subqquery.
+	Vars map[string]int `json:",omitempty"`
+}
+
+// Exec performs a non-streaming exec.
+func (jn *Join) Exec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	lresult, err := jn.Left.Exec(vcursor, joinvars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+	result := &sqltypes.Result{}
+	if len(lresult.Rows) == 0 && wantfields {
+		for k := range jn.Vars {
+			joinvars[k] = nil
+		}
+		rresult, err := jn.Right.GetFields(vcursor, joinvars)
+		if err != nil {
+			return nil, err
+		}
+		result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
+		return result, nil
+	}
+	for _, lrow := range lresult.Rows {
+		for k, col := range jn.Vars {
+			joinvars[k] = lrow[col]
+		}
+		rresult, err := jn.Right.Exec(vcursor, joinvars, wantfields)
+		if err != nil {
+			return nil, err
+		}
+		if wantfields {
+			wantfields = false
+			result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
+		}
+		for _, rrow := range rresult.Rows {
+			result.Rows = append(result.Rows, joinRows(lrow, rrow, jn.Cols))
+		}
+		if jn.IsLeft && len(rresult.Rows) == 0 {
+			result.Rows = append(result.Rows, joinRows(lrow, nil, jn.Cols))
+			result.RowsAffected++
+		} else {
+			result.RowsAffected += uint64(len(rresult.Rows))
+		}
+	}
+	return result, nil
+}
+
+// StreamExec performs a streaming exec.
+func (jn *Join) StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
+	err := jn.Left.StreamExec(vcursor, joinvars, wantfields, func(lresult *sqltypes.Result) error {
+		for _, lrow := range lresult.Rows {
+			for k, col := range jn.Vars {
+				joinvars[k] = lrow[col]
+			}
+			rowSent := false
+			err := jn.Right.StreamExec(vcursor, joinvars, wantfields, func(rresult *sqltypes.Result) error {
+				result := &sqltypes.Result{}
+				if wantfields {
+					wantfields = false
+					result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
+				}
+				for _, rrow := range rresult.Rows {
+					result.Rows = append(result.Rows, joinRows(lrow, rrow, jn.Cols))
+				}
+				if len(rresult.Rows) != 0 {
+					rowSent = true
+				}
+				return sendReply(result)
+			})
+			if err != nil {
+				return err
+			}
+			if wantfields {
+				// TODO(sougou): remove after testing
+				panic("unexptected")
+			}
+			if jn.IsLeft && !rowSent {
+				result := &sqltypes.Result{}
+				result.Rows = [][]sqltypes.Value{joinRows(
+					lrow,
+					nil,
+					jn.Cols,
+				)}
+				return sendReply(result)
+			}
+		}
+		if wantfields {
+			wantfields = false
+			for k := range jn.Vars {
+				joinvars[k] = nil
+			}
+			result := &sqltypes.Result{}
+			rresult, err := jn.Right.GetFields(vcursor, joinvars)
+			if err != nil {
+				return err
+			}
+			result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
+			return sendReply(result)
+		}
+		return nil
+	})
+	return err
+}
+
+// GetFields fetches the field info.
+func (jn *Join) GetFields(vcursor VCursor, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+	lresult, err := jn.Left.GetFields(vcursor, joinvars)
+	if err != nil {
+		return nil, err
+	}
+	result := &sqltypes.Result{}
+	for k := range jn.Vars {
+		joinvars[k] = nil
+	}
+	rresult, err := jn.Right.GetFields(vcursor, joinvars)
+	if err != nil {
+		return nil, err
+	}
+	result.Fields = joinFields(lresult.Fields, rresult.Fields, jn.Cols)
+	return result, nil
+}
+
+func joinFields(lfields, rfields []*querypb.Field, cols []int) []*querypb.Field {
+	fields := make([]*querypb.Field, len(cols))
+	for i, index := range cols {
+		if index < 0 {
+			fields[i] = lfields[-index-1]
+			continue
+		}
+		fields[i] = rfields[index-1]
+	}
+	return fields
+}
+
+func joinRows(lrow, rrow []sqltypes.Value, cols []int) []sqltypes.Value {
+	row := make([]sqltypes.Value, len(cols))
+	for i, index := range cols {
+		if index < 0 {
+			row[i] = lrow[-index-1]
+			continue
+		}
+		// rrow can be nil on left joins
+		if rrow != nil {
+			row[i] = rrow[index-1]
+		}
+	}
+	return row
+}

--- a/go/vt/vtgate/engine/no_test.go
+++ b/go/vt/vtgate/engine/no_test.go
@@ -1,0 +1,16 @@
+package engine
+
+import (
+	"testing"
+)
+
+// This package is mostly tested from VTGate. This place-holder test
+// is to document this fact. In order to make sure all code paths are
+// covered, you need to run the coverage tool from the vtgate directory
+// using the following command:
+//	go test -coverprofile=c.out -coverpkg ./engine,.
+// You can then follow it with:
+//	go tool cover -html=c.out -o=c.html
+// to see the html output.
+func TestNothing(t *testing.T) {
+}

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -1,0 +1,48 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package engine
+
+import "github.com/youtube/vitess/go/sqltypes"
+
+// SeqVarName is a reserved bind var name for sequence values.
+const SeqVarName = "__seq"
+
+// VCursor defines the interface the engine will use
+// to execute routes.
+type VCursor interface {
+	ExecRoute(route *Route, joinvars map[string]interface{}) (*sqltypes.Result, error)
+	StreamExecRoute(route *Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error
+	GetRouteFields(route *Route, joinvars map[string]interface{}) (*sqltypes.Result, error)
+}
+
+// Plan represents the execution strategy for a given query.
+// For now it's a simple wrapper around the real instructions.
+// An instruction (aka primitive), tells VTGate how to execute
+// a single command. Primitives can be cascaded as long as
+// their inputs and outpus can be combined meaningfully.
+// For example, a Join can depend on another Join or a Route.
+// However, a Route cannot depend on another primitive.
+type Plan struct {
+	// Original is the original query.
+	Original string `json:",omitempty"`
+	// Instructions contains the instructions needed to
+	// fulfil the query. It's a tree of primitives.
+	Instructions Primitive `json:",omitempty"`
+}
+
+// Size is defined so that Plan can be given to a cache.LRUCache.
+// VTGate needs to maintain a cache of plans. It uses LRUCache, which
+// in turn requires its objects to define a Size function.
+func (pln *Plan) Size() int {
+	return 1
+}
+
+// Primitive is the interface that needs to be satisfied by
+// all primitives of a plan.
+type Primitive interface {
+	Exec(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error)
+	StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantields bool, sendReply func(*sqltypes.Result) error) error
+	GetFields(vcursor VCursor, joinvars map[string]interface{}) (*sqltypes.Result, error)
+}

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -17,8 +17,8 @@ const ListVarName = "__vals"
 // VCursor defines the interface the engine will use
 // to execute routes.
 type VCursor interface {
-	ExecRoute(route *Route, joinvars map[string]interface{}) (*sqltypes.Result, error)
-	StreamExecRoute(route *Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error
+	ExecuteRoute(route *Route, joinvars map[string]interface{}) (*sqltypes.Result, error)
+	StreamExecuteRoute(route *Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error
 	GetRouteFields(route *Route, joinvars map[string]interface{}) (*sqltypes.Result, error)
 }
 
@@ -45,7 +45,7 @@ func (pln *Plan) Size() int {
 // Primitive is the interface that needs to be satisfied by
 // all primitives of a plan.
 type Primitive interface {
-	Exec(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error)
-	StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantields bool, sendReply func(*sqltypes.Result) error) error
+	Execute(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error)
+	StreamExecute(vcursor VCursor, joinvars map[string]interface{}, wantields bool, sendReply func(*sqltypes.Result) error) error
 	GetFields(vcursor VCursor, joinvars map[string]interface{}) (*sqltypes.Result, error)
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -9,6 +9,11 @@ import "github.com/youtube/vitess/go/sqltypes"
 // SeqVarName is a reserved bind var name for sequence values.
 const SeqVarName = "__seq"
 
+// ListVarName is the bind var name used for plans
+// that require VTGate to compute custom list values,
+// like for IN clauses.
+const ListVarName = "__vals"
+
 // VCursor defines the interface the engine will use
 // to execute routes.
 type VCursor interface {

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -9,9 +9,9 @@ import "github.com/youtube/vitess/go/sqltypes"
 // SeqVarName is a reserved bind var name for sequence values.
 const SeqVarName = "__seq"
 
-// ListVarName is the bind var name used for plans
-// that require VTGate to compute custom list values,
-// like for IN clauses.
+// ListVarName is a reserved bind var name for list vars.
+// This is used for sending different IN clause values
+// to different shards.
 const ListVarName = "__vals"
 
 // VCursor defines the interface the engine will use
@@ -24,16 +24,14 @@ type VCursor interface {
 
 // Plan represents the execution strategy for a given query.
 // For now it's a simple wrapper around the real instructions.
-// An instruction (aka primitive), tells VTGate how to execute
-// a single command. Primitives can be cascaded as long as
-// their inputs and outpus can be combined meaningfully.
-// For example, a Join can depend on another Join or a Route.
-// However, a Route cannot depend on another primitive.
+// An instruction (aka Primitive) is typically a tree where
+// each node does its part by combining the results of the
+// sub-nodes.
 type Plan struct {
 	// Original is the original query.
 	Original string `json:",omitempty"`
 	// Instructions contains the instructions needed to
-	// fulfil the query. It's a tree of primitives.
+	// fulfil the query.
 	Instructions Primitive `json:",omitempty"`
 }
 

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -28,14 +28,14 @@ type Route struct {
 	Generate   *Generate
 }
 
-// Exec performs a non-streaming exec.
-func (rt *Route) Exec(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error) {
-	return vcursor.ExecRoute(rt, joinvars)
+// Execute performs a non-streaming exec.
+func (rt *Route) Execute(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error) {
+	return vcursor.ExecuteRoute(rt, joinvars)
 }
 
-// StreamExec performs a streaming exec.
-func (rt *Route) StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
-	return vcursor.StreamExecRoute(rt, joinvars, sendReply)
+// StreamExecute performs a streaming exec.
+func (rt *Route) StreamExecute(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
+	return vcursor.StreamExecuteRoute(rt, joinvars, sendReply)
 }
 
 // GetFields fetches the field info.

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -194,9 +194,9 @@ const (
 	NumCodes
 )
 
-// opcodeName must exactly match order of opcode constants.
-var opcodeName = [NumCodes]string{
-	"NoCode",
+// routeName must exactly match order of opcode constants.
+var routeName = [NumCodes]string{
+	"Error",
 	"SelectUnsharded",
 	"SelectEqualUnique",
 	"SelectEqual",
@@ -214,7 +214,7 @@ func (code RouteOpcode) String() string {
 	if code < 0 || code >= NumCodes {
 		return ""
 	}
-	return opcodeName[code]
+	return routeName[code]
 }
 
 // MarshalJSON serializes the RouteOpcode as a JSON string.

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -1,63 +1,47 @@
-// Copyright 2014, Google Inc. All rights reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package planbuilder
+package engine
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
-	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
-
-// Plan represents the execution strategy for a given query.
-// For now it's a simple wrapper around the real instructions.
-// An instruction (aka primitive), tells VTGate how to execute
-// a single command. Primitives can be cascaded as long as
-// their inputs and outpus can be combined meaningfully.
-// For example, a Join can depend on another Join or a Route.
-// However, a Route cannot depend on another primitive.
-type Plan struct {
-	// Original is the original query.
-	Original string `json:",omitempty"`
-	// Instructions contains the instructions needed to
-	// fulfil the query. It's a tree of primitives.
-	Instructions Primitive `json:",omitempty"`
-}
-
-// Size is defined so that Plan can be given to a cache.LRUCache.
-// VTGate needs to maintain a cache of plans. It uses LRUCache, which
-// in turn requires its objects to define a Size function.
-func (pln *Plan) Size() int {
-	return 1
-}
-
-// Primitive is the interface that needs to be satisfied by
-// all primitives of a plan. For now, the primitives just
-// have to define an isPrimitive function that does nothing.
-type Primitive interface {
-	isPrimitive()
-}
 
 // Route represents the instructions to route a query to
 // one or many vttablets. The meaning and values for the
 // the fields are described in the RouteOpcode values comments.
 type Route struct {
 	Opcode     RouteOpcode
-	Keyspace   *Keyspace
+	Keyspace   *vindexes.Keyspace
 	Query      string
 	FieldQuery string
-	Vindex     Vindex
+	Vindex     vindexes.Vindex
 	Values     interface{}
 	JoinVars   map[string]struct{}
-	Table      *Table
+	Table      *vindexes.Table
 	Subquery   string
 	Generate   *Generate
 }
 
-func (rt *Route) isPrimitive() {}
+// Exec performs a non-streaming exec.
+func (rt *Route) Exec(vcursor VCursor, joinvars map[string]interface{}, wantields bool) (*sqltypes.Result, error) {
+	return vcursor.ExecRoute(rt, joinvars)
+}
+
+// StreamExec performs a streaming exec.
+func (rt *Route) StreamExec(vcursor VCursor, joinvars map[string]interface{}, wantfields bool, sendReply func(*sqltypes.Result) error) error {
+	return vcursor.StreamExecRoute(rt, joinvars, sendReply)
+}
+
+// GetFields fetches the field info.
+func (rt *Route) GetFields(vcursor VCursor, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+	return vcursor.GetRouteFields(rt, joinvars)
+}
 
 // MarshalJSON serializes the Route into a JSON representation.
 // It's used for testing and diagnostics.
@@ -71,7 +55,7 @@ func (rt *Route) MarshalJSON() ([]byte, error) {
 	}
 	marshalRoute := struct {
 		Opcode     RouteOpcode         `json:",omitempty"`
-		Keyspace   *Keyspace           `json:",omitempty"`
+		Keyspace   *vindexes.Keyspace  `json:",omitempty"`
 		Query      string              `json:",omitempty"`
 		FieldQuery string              `json:",omitempty"`
 		Vindex     string              `json:",omitempty"`
@@ -102,7 +86,7 @@ func (rt *Route) MarshalJSON() ([]byte, error) {
 type Generate struct {
 	// Opcode can only be SelectUnsharded for now.
 	Opcode   RouteOpcode
-	Keyspace *Keyspace
+	Keyspace *vindexes.Keyspace
 	Query    string
 	// Value is the supplied value. A new value will be generated
 	// only if Value was NULL. Otherwise, the supplied value will
@@ -114,10 +98,10 @@ type Generate struct {
 // It's used for testing and diagnostics.
 func (gen *Generate) MarshalJSON() ([]byte, error) {
 	jsongen := struct {
-		Opcode   RouteOpcode `json:",omitempty"`
-		Keyspace *Keyspace   `json:",omitempty"`
-		Query    string      `json:",omitempty"`
-		Value    interface{} `json:",omitempty"`
+		Opcode   RouteOpcode        `json:",omitempty"`
+		Keyspace *vindexes.Keyspace `json:",omitempty"`
+		Query    string             `json:",omitempty"`
+		Value    interface{}        `json:",omitempty"`
 	}{
 		Opcode:   gen.Opcode,
 		Keyspace: gen.Keyspace,
@@ -237,57 +221,4 @@ func (code RouteOpcode) String() string {
 // It's used for testing and diagnostics.
 func (code RouteOpcode) MarshalJSON() ([]byte, error) {
 	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
-}
-
-// Join specifies the parameters for a join primitive.
-type Join struct {
-	// IsLeft is true if it's a LEFT JOIN.
-	IsLeft bool `json:",omitempty"`
-	// Left and Right are the LHS and RHS primitives
-	// of the Join. They can be any primitive.
-	Left, Right Primitive `json:",omitempty"`
-	// Cols defines which columns from the left
-	// or right results should be used to build the
-	// return result. For results coming from the
-	// left query, the index values go as -1, -2, etc.
-	// For the right query, they're 1, 2, etc.
-	// If Cols is {-1, -2, 1, 2}, it means that
-	// the returned result will be {Left0, Left1, Right0, Right1}.
-	Cols []int `json:",omitempty"`
-	// Vars defines the list of JoinVars that need to
-	// be built from the LHS result before invoking
-	// the RHS subqquery.
-	Vars map[string]int `json:",omitempty"`
-}
-
-func (jn *Join) isPrimitive() {}
-
-// BuildPlan builds a plan for a query based on the specified vschema.
-// It's the main entry point for this package.
-func BuildPlan(query string, vschema *VSchema) (*Plan, error) {
-	statement, err := sqlparser.Parse(query)
-	if err != nil {
-		return nil, err
-	}
-	plan := &Plan{
-		Original: query,
-	}
-	switch statement := statement.(type) {
-	case *sqlparser.Select:
-		plan.Instructions, err = buildSelectPlan(statement, vschema)
-	case *sqlparser.Insert:
-		plan.Instructions, err = buildInsertPlan(statement, vschema)
-	case *sqlparser.Update:
-		plan.Instructions, err = buildUpdatePlan(statement, vschema)
-	case *sqlparser.Delete:
-		plan.Instructions, err = buildDeletePlan(statement, vschema)
-	case *sqlparser.Union, *sqlparser.Set, *sqlparser.DDL, *sqlparser.Other:
-		return nil, errors.New("unsupported construct")
-	default:
-		panic("unexpected statement type")
-	}
-	if err != nil {
-		return nil, err
-	}
-	return plan, nil
 }

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -1,0 +1,107 @@
+// Copyright 2014, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package planbuilder
+
+import (
+	"errors"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+)
+
+// planBuilder represents any object that's used to
+// build a plan. The top-level planBuilder will be a
+// tree that points to other planBuilder objects.
+// Each Builder object builds a Plan object, and they
+// will mirror the same tree. Once all the plans are built,
+// the builder objects will be discarded, and only
+// the Plan objects will remain. Because of the near-equivalent
+// meaning of a planBuilder object and its plan, the variable
+// names are overloaded. The separation exists only because the
+// information in the planBuilder objects are not ultimately
+// required externally.
+// For example, a route variable usually refers to a
+// routeBuilder object, which in turn, has a Route field.
+// This should not cause confusion because we almost never
+// reference the inner Route directly.
+type planBuilder interface {
+	// Symtab returns the associated symtab.
+	Symtab() *symtab
+	// SetSymtab sets the symtab for the current node and
+	// its non-subquery children.
+	SetSymtab(*symtab)
+	// Order is a number that signifies execution order.
+	// A lower Order number Route is executed before a
+	// higher one. For a node that contains other nodes,
+	// the Order represents the highest order of the leaf
+	// nodes. This function is used to travel from a root
+	// node to a target node.
+	Order() int
+	// SetOrder sets the order for the underlying routes.
+	SetOrder(int)
+	// Primitve returns the primitive built by the builder.
+	Primitive() engine.Primitive
+	// Leftmost returns the leftmost route.
+	Leftmost() *routeBuilder
+	// Join joins the two planBuilder objects. The outcome
+	// can be a new planBuilder or a modified one.
+	Join(rhs planBuilder, Join *sqlparser.JoinTableExpr) (planBuilder, error)
+	// SetRHS marks all routes under this node as RHS.
+	SetRHS()
+	// PushSelect pushes the select expression through the tree
+	// all the way to the route that colsym points to.
+	// PushSelect is similar to SupplyCol except that it always
+	// adds a new column, whereas SupplyCol can reuse an existing
+	// column. This is required because the ORDER BY clause
+	// may refer to columns by number. The function must return
+	// a colsym for the expression and the column number of the result.
+	PushSelect(expr *sqlparser.NonStarExpr, route *routeBuilder) (colsym *colsym, colnum int, err error)
+	// PushMisc pushes miscelleaneous constructs to all the routes.
+	PushMisc(sel *sqlparser.Select)
+	// Wireup performs the wire-up work. Nodes should be traversed
+	// from right to left because the rhs nodes can request vars from
+	// the lhs nodes.
+	Wireup(plan planBuilder, jt *jointab) error
+	// SupplyVar finds the common root between from and to. If it's
+	// the common root, it supplies the requested var to the rhs tree.
+	SupplyVar(from, to int, col *sqlparser.ColName, varname string)
+	// SupplyCol will be used for the wire-up process. This function
+	// takes a column reference as input, changes the plan
+	// to supply the requested column and returns the column number of
+	// the result for it. The request is passed down recursively
+	// as needed.
+	SupplyCol(col *sqlparser.ColName) int
+}
+
+// BuildPlan builds a plan for a query based on the specified vschema.
+// It's the main entry point for this package.
+func BuildPlan(query string, vschema *vindexes.VSchema) (*engine.Plan, error) {
+	statement, err := sqlparser.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	plan := &engine.Plan{
+		Original: query,
+	}
+	switch statement := statement.(type) {
+	case *sqlparser.Select:
+		plan.Instructions, err = buildSelectPlan(statement, vschema)
+	case *sqlparser.Insert:
+		plan.Instructions, err = buildInsertPlan(statement, vschema)
+	case *sqlparser.Update:
+		plan.Instructions, err = buildUpdatePlan(statement, vschema)
+	case *sqlparser.Delete:
+		plan.Instructions, err = buildDeletePlan(statement, vschema)
+	case *sqlparser.Union, *sqlparser.Set, *sqlparser.DDL, *sqlparser.Other:
+		return nil, errors.New("unsupported construct")
+	default:
+		panic("unexpected statement type")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return plan, nil
+}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -65,7 +65,7 @@ type builder interface {
 	// to supply the requested column and returns the column number of
 	// the result for it. The request is passed down recursively
 	// as needed.
-	SupplyCol(col *sqlparser.ColName) int
+	SupplyCol(ref colref) int
 }
 
 // Build builds a plan for a query based on the specified vschema.

--- a/go/vt/vtgate/planbuilder/doc.go
+++ b/go/vt/vtgate/planbuilder/doc.go
@@ -8,23 +8,13 @@ plans that describe how to fulfill a query that may
 span multiple keyspaces or shards.
 
 The main entry point for the planbuilder is the
-BuildPlan function that accepts a query and vschema
+Build function that accepts a query and vschema
 and returns the plan.
-
-This package also provides various convenience functions
-to build the VSchema object, which it can later utilize
-to build query plans.
-
-Additionally, this package defines the various Vindex
-related interfaces. These interfaces need to be satisfied
-by plugin code that wants to define a Vindex type.
 */
 package planbuilder
 
 /*
-The planbuilder for the SELECT statement has the highest
-complexity. Currently, VTGate can only perform the following
-two primitives: Route and Join.
+The two core primitives built by this package are Route and Join.
 
 The Route primitive executes a query and returns the result.
 This can be either to a single keyspace or shard, or it can
@@ -45,31 +35,21 @@ will be executed as:
 	select ..., a.col from a (produce "a_col" from a.col)
 	select ... from b where b.col = :a_col
 
-The act of breaking up a join into two such statements
-like the above example is called a vertical break.
-As opposed to this, a horizontal break is one
-that breaks the individual clauses of a statement.
-For example, separating out a where clause from
-the select expressions would be a horizontal break.
-Breaking out a subquery would also be considered
-a horizontal break. The current set of primitives
-only allow for vertical breaks.
-
 The planbuilder tries to push all the constructs of
-the original request into these two primitives. If
-successful, we return the built plan. Otherwise, it's
-an error.
+the original request into a Route. If it's not possible,
+we see if we can build a primitive for it. If none exist,
+we return an error.
 
 The central design element for analyzing queries and
 building plans is the symbol table (symtab). This data
 structure contains tableAlias and colsym elements.
 A tableAlias element represents a table alias defined
 in the FROM clause. A tableAlias must always point
-to a routeBuilder, which is responsible for building
+to a route, which is responsible for building
 the SELECT statement for that alias.
 A colsym represents a result column. It can optionally
 point to a tableAlias if it's a plain column reference
-of that alias. A colsym must always point to a routeBuilder.
+of that alias. A colsym must always point to a route.
 One symtab is created per SELECT statement. tableAlias
 names must be unique within each symtab. Currently,
 duplicates are allowed among colsyms, just like MySQL
@@ -87,52 +67,32 @@ produces the colsyms, which are added to the
 symtab after the analysis is done. Consequently,
 the GROUP BY, HAVING and ORDER BY clauses can only
 see the colsyms. They're not allowed to reference
-the table aliases.
+the table aliases. These access rules transitively
+apply to subqueries in those clauses, which is the
+intended behavior.
 
-The planbuilder supports subqueries. This gives rise
-to multiple symbol tables. As per SQL rules, symbols
-in the inner query can hide those in the outer query.
-However, the life-cycle of the symbol table also needs to
-be taken into account. For example, a subquery that's
-in a WHERE clause cannot see the SELECT symbols (colsyms)
-of the outer query, because those have not been created
-yet. But a subquery in the HAVING clause will be able
-to see them.
-
-The plan builder builds the plan in two phases. In the
+The plan is built in two phases. In the
 first phase (break-up and push-down), the query is
 broken into smaller parts and pushed down into
-Join or Route primitives. In the second phase (generator),
+Join or Route primitives. In the second phase (wire-up),
 external references are wired up using bind vars, and
 the individual ASTs are converted into actual queries.
 
-In the case of joins, the plan builder effectively
-performs a vertical break of the query. This gives rise
-to a possible conflict in the symbol tables. Specifically,
-a WHERE clause was only able to see tableAlias symbols
-during analysis. However, once the query is partitioned
-vertically, the query actually becomes a SELECT statement feeding
-into another. This means that symbols that were previously
-not visible during analysis are now visible. It's very important
-to remember the original resolution. Otherwise, there is
-risk that incorrent values are used when the RHS of a join
-requests values from the LHS. In order to achieve this,
-the sqlparser.ColName type has been ammended with a Metadata
-field that is populated as soon as a symbol is resolved.
-During the generator phase, we do not perform any more symtab
-lookups, but rely on the previously stored Metadata instead.
+Since the symbol table evolved during the first phase,
+the wire-up phase cannot reuse it. In order to address
+this, we save a pointer to the resolved symbol inside
+every column reference, which we can reuse during
+the wire-up. The Route for each symbol is used to
+determine if a reference is local or not. Anything
+external is converted to a bind var.
 
-In the case of a vertical break, we split a select into
-two select statements. If this happens, the symbol table
-is not split, because we still need the ability to find
-all symbols being referenced. Instead, each tableAlias
-points to the Route where the split queries are being
-built. When we need to know if a symbol is local or
-not, we compare the route of the table alias against
-the current route. In the case of a subquery, it initially
-starts off with its own route. After the analysis is done,
-if we decide to merge it with an outer route, we repoint
-all the symbols of the subquery to the outer route.
+A route can be merged with another one. If this happens,
+we should ideally repoint all symbols of that route to the
+new one. This gets complicated because each route would
+need to know the symbols that point to it.
+Instead, we mark the current route as defunct
+by redirecting to point to the new one. During symbol resolution
+we chase this pointer until we reach a non-defunct route.
 
 The VSchema currently doesn't contain the full list of columns
 in the tables. For the sake of convenience, if a query
@@ -159,4 +119,17 @@ column reference is a pointer to a table alias and a
 column name. This is the basis for the definition of the
 colref type. If the colref points to a colsym, then
 the column name is irrelevant.
+
+Variable naming: The AST, planbuilder and engine
+are three different worlds that use overloaded
+names that are contextually similar, but different.
+For example a join is:
+	Join is the AST node that represents the SQL construct
+	join is a builder in the current package
+	Join is a primitive in the engine package
+In order to disambiguate, we'll use the 'a' prefix
+for AST vars, and the 'e' prefix for engine vars.
+So, 'ajoin' would be of type *sqlparser.Join, and
+'ejoin' would be of type *engine.Join. For the planbuilder
+join we'll use 'jb'.
 */

--- a/go/vt/vtgate/planbuilder/doc.go
+++ b/go/vt/vtgate/planbuilder/doc.go
@@ -42,22 +42,22 @@ we return an error.
 
 The central design element for analyzing queries and
 building plans is the symbol table (symtab). This data
-structure contains tableAlias and colsym elements.
-A tableAlias element represents a table alias defined
-in the FROM clause. A tableAlias must always point
+structure contains tabsym and colsym elements.
+A tabsym element represents a table alias defined
+in the FROM clause. A tabsym must always point
 to a route, which is responsible for building
 the SELECT statement for that alias.
 A colsym represents a result column. It can optionally
-point to a tableAlias if it's a plain column reference
+point to a tabsym if it's a plain column reference
 of that alias. A colsym must always point to a route.
-One symtab is created per SELECT statement. tableAlias
+One symtab is created per SELECT statement. tabsym
 names must be unique within each symtab. Currently,
 duplicates are allowed among colsyms, just like MySQL
 does. Different databases implement different rules
-about whether colsym symbols can hide the tableAlias
+about whether colsym symbols can hide the tabsym
 symbols. The rules used by MySQL are not well documented.
 Therefore, we use the conservative rule that no
-tableAlias can be seen if colsyms are present.
+tabsym can be seen if colsyms are present.
 
 The symbol table is modified as various sections of the
 query are parsed. The parsing of the FROM clause

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
 )
 
 // splitAndExpression breaks up the BoolExpr into AND-separated conditions
@@ -109,7 +110,7 @@ func subqueryCanMerge(outer, inner *routeBuilder) error {
 	if !inner.IsSingle() {
 		return errors.New("unsupported: scatter subquery")
 	}
-	if inner.Route.Opcode == SelectUnsharded {
+	if inner.Route.Opcode == engine.SelectUnsharded {
 		return nil
 	}
 	// SelectEqualUnique
@@ -120,7 +121,7 @@ func subqueryCanMerge(outer, inner *routeBuilder) error {
 			return nil
 		}
 	}
-	if outer.Route.Opcode != SelectEqualUnique {
+	if outer.Route.Opcode != engine.SelectEqualUnique {
 		return errors.New("unsupported: subquery does not depend on scatter outer query")
 	}
 	if !valEqual(outer.Route.Values, inner.Route.Values) {

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -147,13 +147,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 func exprIsValue(expr sqlparser.ValExpr, rb *route) bool {
 	switch node := expr.(type) {
 	case *sqlparser.ColName:
-		switch meta := node.Metadata.(type) {
-		case *colsym:
-			return meta.Route() != rb
-		case *tableAlias:
-			return meta.Route() != rb
-		}
-		panic("unreachable")
+		return node.Metadata.(sym).Route() != rb
 	case sqlparser.ValArg, sqlparser.StrVal, sqlparser.NumVal:
 		return true
 	}

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -48,11 +48,11 @@ func processTableExpr(tableExpr sqlparser.TableExpr, vschema *vindexes.VSchema) 
 // processAliasedTable produces a builder subtree for the given AliasedTableExpr.
 // If the expression is a subquery, then the the route built for it will contain
 // the entire subquery tree in the from clause, as if it was a table.
-// The symtab entry for the query will be a tableAlias where the columns
+// The symtab entry for the query will be a tabsym where the columns
 // will be built from the select expressions of the subquery.
 // Since the table aliases only contain vindex columns, we'll follow
 // the same rule: only columns from the subquery that are identified as
-// vindex columns will be added to the tableAlias.
+// vindex columns will be added to the tabsym.
 // A symtab symbol can only point to a route. This means that we canoot
 // support complex joins in subqueries yet.
 func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema *vindexes.VSchema) (builder, error) {

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -41,9 +41,9 @@ func newJoin(lhs, rhs builder, ajoin *sqlparser.JoinTableExpr) (*join, error) {
 	}
 	rhs.SetSymtab(lhs.Symtab())
 	rhs.SetOrder(lhs.Order())
-	isLeft := false
+	opcode := engine.NormalJoin
 	if ajoin.Join == sqlparser.LeftJoinStr {
-		isLeft = true
+		opcode = engine.LeftJoin
 	}
 	jb := &join{
 		LeftOrder:  lhs.Order(),
@@ -52,13 +52,13 @@ func newJoin(lhs, rhs builder, ajoin *sqlparser.JoinTableExpr) (*join, error) {
 		Right:      rhs,
 		symtab:     lhs.Symtab(),
 		ejoin: &engine.Join{
-			IsLeft: isLeft,
+			Opcode: opcode,
 			Left:   lhs.Primitive(),
 			Right:  rhs.Primitive(),
 			Vars:   make(map[string]int),
 		},
 	}
-	if isLeft {
+	if opcode == engine.LeftJoin {
 		err := pushFilter(ajoin.On, rhs, sqlparser.WhereStr)
 		if err != nil {
 			return nil, err

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -4,7 +4,10 @@
 
 package planbuilder
 
-import "github.com/youtube/vitess/go/vt/sqlparser"
+import (
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+)
 
 // joinBuilder is used to build a Join primitive.
 // It's used to buid a normal join or a left join
@@ -22,7 +25,7 @@ type joinBuilder struct {
 	// join.
 	Colsyms []*colsym
 	// Join is the join plan.
-	join *Join
+	join *engine.Join
 }
 
 // newJoinBuilder makes a new joinBuilder using the two nodes.
@@ -49,7 +52,7 @@ func newJoinBuilder(lhs, rhs planBuilder, join *sqlparser.JoinTableExpr) (*joinB
 		Left:       lhs,
 		Right:      rhs,
 		symtab:     lhs.Symtab(),
-		join: &Join{
+		join: &engine.Join{
 			IsLeft: isLeft,
 			Left:   lhs.Primitive(),
 			Right:  rhs.Primitive(),
@@ -98,7 +101,7 @@ func (jb *joinBuilder) SetOrder(order int) {
 }
 
 // Primitve returns the built primitive.
-func (jb *joinBuilder) Primitive() Primitive {
+func (jb *joinBuilder) Primitive() engine.Primitive {
 	return jb.join
 }
 

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -10,11 +10,6 @@ import (
 	"github.com/youtube/vitess/go/vt/sqlparser"
 )
 
-// ListVarName is the bind var name used for plans
-// that require VTGate to compute custom list values,
-// like for IN clauses.
-const ListVarName = "__vals"
-
 // jointab manages procurement and naming of join
 // variables across primitives.
 type jointab struct {
@@ -35,7 +30,7 @@ func newJointab(bindvars map[string]struct{}) *jointab {
 
 // Procure requests for the specified column from the plan
 // and returns the join var name for it.
-func (jt *jointab) Procure(plan planBuilder, col *sqlparser.ColName, to int) string {
+func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string {
 	from, joinVar := jt.Lookup(col)
 	// If joinVar is empty, jterate a unique name.
 	if joinVar == "" {
@@ -56,7 +51,7 @@ func (jt *jointab) Procure(plan planBuilder, col *sqlparser.ColName, to int) str
 		jt.vars[joinVar] = struct{}{}
 		jt.refs[newColref(col)] = joinVar
 	}
-	plan.SupplyVar(from, to, col, joinVar)
+	bldr.SupplyVar(from, to, col, joinVar)
 	return joinVar
 }
 

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -59,11 +59,5 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 // the join var name if one has already been assigned for it.
 func (jt *jointab) Lookup(col *sqlparser.ColName) (order int, joinVar string) {
 	ref := newColref(col)
-	switch meta := col.Metadata.(type) {
-	case *colsym:
-		return meta.Route().Order(), jt.refs[ref]
-	case *tableAlias:
-		return meta.Route().Order(), jt.refs[ref]
-	}
-	panic("unreachable")
+	return ref.Route().Order(), jt.refs[ref]
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/testfiles"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 // hashIndex satisfies Functional, Unique.
@@ -23,14 +24,14 @@ type hashIndex struct{ name string }
 
 func (v *hashIndex) String() string { return v.name }
 func (*hashIndex) Cost() int        { return 1 }
-func (*hashIndex) Verify(VCursor, interface{}, []byte) (bool, error) {
+func (*hashIndex) Verify(vindexes.VCursor, interface{}, []byte) (bool, error) {
 	return false, nil
 }
-func (*hashIndex) Map(VCursor, []interface{}) ([][]byte, error) { return nil, nil }
-func (*hashIndex) Create(VCursor, interface{}) error            { return nil }
-func (*hashIndex) Delete(VCursor, []interface{}, []byte) error  { return nil }
+func (*hashIndex) Map(vindexes.VCursor, []interface{}) ([][]byte, error) { return nil, nil }
+func (*hashIndex) Create(vindexes.VCursor, interface{}) error            { return nil }
+func (*hashIndex) Delete(vindexes.VCursor, []interface{}, []byte) error  { return nil }
 
-func newHashIndex(name string, _ map[string]interface{}) (Vindex, error) {
+func newHashIndex(name string, _ map[string]interface{}) (vindexes.Vindex, error) {
 	return &hashIndex{name: name}, nil
 }
 
@@ -39,14 +40,14 @@ type lookupIndex struct{ name string }
 
 func (v *lookupIndex) String() string { return v.name }
 func (*lookupIndex) Cost() int        { return 2 }
-func (*lookupIndex) Verify(VCursor, interface{}, []byte) (bool, error) {
+func (*lookupIndex) Verify(vindexes.VCursor, interface{}, []byte) (bool, error) {
 	return false, nil
 }
-func (*lookupIndex) Map(VCursor, []interface{}) ([][]byte, error) { return nil, nil }
-func (*lookupIndex) Create(VCursor, interface{}, []byte) error    { return nil }
-func (*lookupIndex) Delete(VCursor, []interface{}, []byte) error  { return nil }
+func (*lookupIndex) Map(vindexes.VCursor, []interface{}) ([][]byte, error) { return nil, nil }
+func (*lookupIndex) Create(vindexes.VCursor, interface{}, []byte) error    { return nil }
+func (*lookupIndex) Delete(vindexes.VCursor, []interface{}, []byte) error  { return nil }
 
-func newLookupIndex(name string, _ map[string]interface{}) (Vindex, error) {
+func newLookupIndex(name string, _ map[string]interface{}) (vindexes.Vindex, error) {
 	return &lookupIndex{name: name}, nil
 }
 
@@ -55,14 +56,14 @@ type multiIndex struct{ name string }
 
 func (v *multiIndex) String() string { return v.name }
 func (*multiIndex) Cost() int        { return 3 }
-func (*multiIndex) Verify(VCursor, interface{}, []byte) (bool, error) {
+func (*multiIndex) Verify(vindexes.VCursor, interface{}, []byte) (bool, error) {
 	return false, nil
 }
-func (*multiIndex) Map(VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
-func (*multiIndex) Create(VCursor, interface{}, []byte) error      { return nil }
-func (*multiIndex) Delete(VCursor, []interface{}, []byte) error    { return nil }
+func (*multiIndex) Map(vindexes.VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
+func (*multiIndex) Create(vindexes.VCursor, interface{}, []byte) error      { return nil }
+func (*multiIndex) Delete(vindexes.VCursor, []interface{}, []byte) error    { return nil }
 
-func newMultiIndex(name string, _ map[string]interface{}) (Vindex, error) {
+func newMultiIndex(name string, _ map[string]interface{}) (vindexes.Vindex, error) {
 	return &multiIndex{name: name}, nil
 }
 
@@ -71,26 +72,26 @@ type costlyIndex struct{ name string }
 
 func (v *costlyIndex) String() string { return v.name }
 func (*costlyIndex) Cost() int        { return 10 }
-func (*costlyIndex) Verify(VCursor, interface{}, []byte) (bool, error) {
+func (*costlyIndex) Verify(vindexes.VCursor, interface{}, []byte) (bool, error) {
 	return false, nil
 }
-func (*costlyIndex) Map(VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
-func (*costlyIndex) Create(VCursor, interface{}, []byte) error      { return nil }
-func (*costlyIndex) Delete(VCursor, []interface{}, []byte) error    { return nil }
+func (*costlyIndex) Map(vindexes.VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
+func (*costlyIndex) Create(vindexes.VCursor, interface{}, []byte) error      { return nil }
+func (*costlyIndex) Delete(vindexes.VCursor, []interface{}, []byte) error    { return nil }
 
-func newCostlyIndex(name string, _ map[string]interface{}) (Vindex, error) {
+func newCostlyIndex(name string, _ map[string]interface{}) (vindexes.Vindex, error) {
 	return &costlyIndex{name: name}, nil
 }
 
 func init() {
-	Register("hash", newHashIndex)
-	Register("lookup", newLookupIndex)
-	Register("multi", newMultiIndex)
-	Register("costly", newCostlyIndex)
+	vindexes.Register("hash_test", newHashIndex)
+	vindexes.Register("lookup_test", newLookupIndex)
+	vindexes.Register("multi", newMultiIndex)
+	vindexes.Register("costly", newCostlyIndex)
 }
 
 func TestPlan(t *testing.T) {
-	vschema, err := LoadFile(locateFile("schema_test.json"))
+	vschema, err := vindexes.LoadFile(locateFile("schema_test.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,14 +105,14 @@ func TestPlan(t *testing.T) {
 }
 
 func TestOne(t *testing.T) {
-	vschema, err := LoadFile(locateFile("schema_test.json"))
+	vschema, err := vindexes.LoadFile(locateFile("schema_test.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	testFile(t, "onecase.txt", vschema)
 }
 
-func testFile(t *testing.T, filename string, vschema *VSchema) {
+func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {
 	for tcase := range iterateExecFile(filename) {
 		plan, err := BuildPlan(tcase.input, vschema)
 		var out string

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -99,7 +99,7 @@ func TestPlan(t *testing.T) {
 	testFile(t, "filter_cases.txt", vschema)
 	testFile(t, "select_cases.txt", vschema)
 	testFile(t, "postprocess_cases.txt", vschema)
-	testFile(t, "generator_cases.txt", vschema)
+	testFile(t, "wireup_cases.txt", vschema)
 	testFile(t, "dml_cases.txt", vschema)
 	testFile(t, "unsupported_cases.txt", vschema)
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -114,7 +114,7 @@ func TestOne(t *testing.T) {
 
 func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {
 	for tcase := range iterateExecFile(filename) {
-		plan, err := BuildPlan(tcase.input, vschema)
+		plan, err := Build(tcase.input, vschema)
 		var out string
 		if err != nil {
 			out = err.Error()

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -20,18 +20,18 @@ import (
 // and ensures that there are no subqueries. It also verifies that the
 // references don't addres an outer query. We only support group by
 // for unsharded or single shard routes.
-func pushGroupBy(groupBy sqlparser.GroupBy, plan planBuilder) error {
+func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 	if groupBy == nil {
 		return nil
 	}
-	route, ok := plan.(*routeBuilder)
+	rb, ok := bldr.(*route)
 	if !ok {
 		return errors.New("unsupported: complex join and group by")
 	}
 	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
-			_, isLocal, err := plan.Symtab().Find(node, true)
+			_, isLocal, err := bldr.Symtab().Find(node, true)
 			if err != nil {
 				return false, err
 			}
@@ -47,16 +47,16 @@ func pushGroupBy(groupBy sqlparser.GroupBy, plan planBuilder) error {
 	if err != nil {
 		return err
 	}
-	if route.IsSingle() {
-		route.SetGroupBy(groupBy)
+	if rb.IsSingle() {
+		rb.SetGroupBy(groupBy)
 		return nil
 	}
 	// It's a scatter route. We can allow group by if it references a
 	// column with a unique vindex.
 	for _, expr := range groupBy {
-		vindex := plan.Symtab().Vindex(expr, route, true)
+		vindex := bldr.Symtab().Vindex(expr, rb, true)
 		if vindex != nil && vindexes.IsUnique(vindex) {
-			route.SetGroupBy(groupBy)
+			rb.SetGroupBy(groupBy)
 			return nil
 		}
 	}
@@ -69,7 +69,7 @@ func pushGroupBy(groupBy sqlparser.GroupBy, plan planBuilder) error {
 // If column numbers were used to reference the columns, those numbers
 // are readjusted on push-down to match the numbers of the individual
 // queries.
-func pushOrderBy(orderBy sqlparser.OrderBy, plan planBuilder) error {
+func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 	if orderBy == nil {
 		return nil
 	}
@@ -79,12 +79,12 @@ func pushOrderBy(orderBy sqlparser.OrderBy, plan planBuilder) error {
 		// If we have to change the order by expression,
 		// we have to build a new node.
 		pushOrder := order
-		var route *routeBuilder
+		var rb *route
 		switch node := order.Expr.(type) {
 		case *sqlparser.ColName:
 			var isLocal bool
 			var err error
-			route, isLocal, err = plan.Symtab().Find(node, true)
+			rb, isLocal, err = bldr.Symtab().Find(node, true)
 			if err != nil {
 				return err
 			}
@@ -96,13 +96,13 @@ func pushOrderBy(orderBy sqlparser.OrderBy, plan planBuilder) error {
 			if err != nil {
 				return fmt.Errorf("error parsing order by clause: %s", string(node))
 			}
-			if num < 1 || num > int64(len(plan.Symtab().Colsyms)) {
+			if num < 1 || num > int64(len(bldr.Symtab().Colsyms)) {
 				return errors.New("order by column number out of range")
 			}
-			colsym := plan.Symtab().Colsyms[num-1]
-			route = colsym.Route()
+			colsym := bldr.Symtab().Colsyms[num-1]
+			rb = colsym.Route()
 			// We have to recompute the column number.
-			for num, s := range route.Colsyms {
+			for num, s := range rb.Colsyms {
 				if s == colsym {
 					pushOrder = &sqlparser.Order{
 						Expr:      sqlparser.NumVal(strconv.AppendInt(nil, int64(num+1), 10)),
@@ -116,31 +116,31 @@ func pushOrderBy(orderBy sqlparser.OrderBy, plan planBuilder) error {
 		default:
 			return errors.New("unsupported: complex expression in order by")
 		}
-		if route.Order() < routeNumber {
+		if rb.Order() < routeNumber {
 			return errors.New("unsupported: complex join and out of sequence order by")
 		}
-		if !route.IsSingle() {
+		if !rb.IsSingle() {
 			return errors.New("unsupported: scatter and order by")
 		}
-		routeNumber = route.Order()
-		if err := route.AddOrder(pushOrder); err != nil {
+		routeNumber = rb.Order()
+		if err := rb.AddOrder(pushOrder); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func pushLimit(limit *sqlparser.Limit, plan planBuilder) error {
+func pushLimit(limit *sqlparser.Limit, bldr builder) error {
 	if limit == nil {
 		return nil
 	}
-	route, ok := plan.(*routeBuilder)
+	rb, ok := bldr.(*route)
 	if !ok {
 		return errors.New("unsupported: limits with complex joins")
 	}
-	if !route.IsSingle() {
+	if !rb.IsSingle() {
 		return errors.New("unsupported: limits with scatter")
 	}
-	route.SetLimit(limit)
+	rb.SetLimit(limit)
 	return nil
 }

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 // This file has functions to analyze postprocessing
@@ -54,7 +55,7 @@ func pushGroupBy(groupBy sqlparser.GroupBy, plan planBuilder) error {
 	// column with a unique vindex.
 	for _, expr := range groupBy {
 		vindex := plan.Symtab().Vindex(expr, route, true)
-		if vindex != nil && IsUnique(vindex) {
+		if vindex != nil && vindexes.IsUnique(vindex) {
 			route.SetGroupBy(groupBy)
 			return nil
 		}

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -8,10 +8,12 @@ import (
 	"errors"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 // buildSelectPlan is the new function to build a Select plan.
-func buildSelectPlan(sel *sqlparser.Select, vschema *VSchema) (primitive Primitive, err error) {
+func buildSelectPlan(sel *sqlparser.Select, vschema *vindexes.VSchema) (primitive engine.Primitive, err error) {
 	bindvars := getBindvars(sel)
 	builder, err := processSelect(sel, vschema, nil)
 	if err != nil {
@@ -41,7 +43,7 @@ func getBindvars(node sqlparser.SQLNode) map[string]struct{} {
 }
 
 // processSelect builds a plan for the given query or subquery.
-func processSelect(sel *sqlparser.Select, vschema *VSchema, outer planBuilder) (planBuilder, error) {
+func processSelect(sel *sqlparser.Select, vschema *vindexes.VSchema, outer planBuilder) (planBuilder, error) {
 	plan, err := processTableExprs(sel.From, vschema)
 	if err != nil {
 		return nil, err
@@ -177,7 +179,7 @@ func checkAggregates(sel *sqlparser.Select, plan planBuilder) error {
 		switch selectExpr := selectExpr.(type) {
 		case *sqlparser.NonStarExpr:
 			vindex := plan.Symtab().Vindex(selectExpr.Expr, route, true)
-			if vindex != nil && IsUnique(vindex) {
+			if vindex != nil && vindexes.IsUnique(vindex) {
 				return nil
 			}
 		}

--- a/go/vt/vtgate/planbuilder/vindex.go
+++ b/go/vt/vtgate/planbuilder/vindex.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/tabletserver/querytypes"
 )
 
 // This file defines interfaces and registration for vindexes.
@@ -17,7 +16,7 @@ import (
 // in the current context and session of a VTGate request. Vindexes
 // can use this interface to execute lookup queries.
 type VCursor interface {
-	Execute(query *querytypes.BoundQuery) (*sqltypes.Result, error)
+	Execute(query string, bindvars map[string]interface{}) (*sqltypes.Result, error)
 }
 
 // Vindex defines the interface required to register a vindex.

--- a/go/vt/vtgate/planner.go
+++ b/go/vt/vtgate/planner.go
@@ -52,7 +52,7 @@ func (plr *Planner) GetPlan(sql string) (*engine.Plan, error) {
 	if result, ok := plr.plans.Get(sql); ok {
 		return result.(*engine.Plan), nil
 	}
-	plan, err := planbuilder.BuildPlan(sql, plr.vschema)
+	plan, err := planbuilder.Build(sql, plr.vschema)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planner.go
+++ b/go/vt/vtgate/planner.go
@@ -16,20 +16,22 @@ import (
 
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/cache"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
 	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 // Planner is used to compute the plan. It contains
 // the vschema, and has a cache of previous computed plans.
 type Planner struct {
-	vschema *planbuilder.VSchema
+	vschema *vindexes.VSchema
 	plans   *cache.LRUCache
 }
 
 var once sync.Once
 
 // NewPlanner creates a new planner for VTGate.
-func NewPlanner(vschema *planbuilder.VSchema, cacheSize int) *Planner {
+func NewPlanner(vschema *vindexes.VSchema, cacheSize int) *Planner {
 	plr := &Planner{
 		vschema: vschema,
 		plans:   cache.NewLRUCache(int64(cacheSize)),
@@ -43,12 +45,12 @@ func NewPlanner(vschema *planbuilder.VSchema, cacheSize int) *Planner {
 
 // GetPlan computes the plan for the given query. If one is in
 // the cache, it reuses it.
-func (plr *Planner) GetPlan(sql string) (*planbuilder.Plan, error) {
+func (plr *Planner) GetPlan(sql string) (*engine.Plan, error) {
 	if plr.vschema == nil {
 		return nil, errors.New("vschema not initialized")
 	}
 	if result, ok := plr.plans.Get(sql); ok {
-		return result.(*planbuilder.Plan), nil
+		return result.(*engine.Plan), nil
 	}
 	plan, err := planbuilder.BuildPlan(sql, plr.vschema)
 	if err != nil {

--- a/go/vt/vtgate/request_context.go
+++ b/go/vt/vtgate/request_context.go
@@ -10,7 +10,6 @@ import (
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	"github.com/youtube/vitess/go/vt/tabletserver/querytypes"
 )
 
 type requestContext struct {
@@ -38,6 +37,6 @@ func newRequestContext(ctx context.Context, sql string, bindVars map[string]inte
 	}
 }
 
-func (vc *requestContext) Execute(boundQuery *querytypes.BoundQuery) (*sqltypes.Result, error) {
-	return vc.router.Execute(vc.ctx, boundQuery.Sql, boundQuery.BindVariables, vc.tabletType, vc.session, false)
+func (vc *requestContext) Execute(query string, bindvars map[string]interface{}) (*sqltypes.Result, error) {
+	return vc.router.Execute(vc.ctx, query, bindvars, vc.tabletType, vc.session, false)
 }

--- a/go/vt/vtgate/request_context.go
+++ b/go/vt/vtgate/request_context.go
@@ -10,6 +10,7 @@ import (
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
 )
 
 type requestContext struct {
@@ -20,8 +21,6 @@ type requestContext struct {
 	session          *vtgatepb.Session
 	notInTransaction bool
 	router           *Router
-	// JoinVars is set by Join and used by Route.
-	JoinVars map[string]interface{}
 }
 
 func newRequestContext(ctx context.Context, sql string, bindVars map[string]interface{}, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool, router *Router) *requestContext {
@@ -33,10 +32,21 @@ func newRequestContext(ctx context.Context, sql string, bindVars map[string]inte
 		session:          session,
 		notInTransaction: notInTransaction,
 		router:           router,
-		JoinVars:         make(map[string]interface{}),
 	}
 }
 
 func (vc *requestContext) Execute(query string, bindvars map[string]interface{}) (*sqltypes.Result, error) {
 	return vc.router.Execute(vc.ctx, query, bindvars, vc.tabletType, vc.session, false)
+}
+
+func (vc *requestContext) ExecRoute(route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+	return vc.router.ExecRoute(vc, route, joinvars)
+}
+
+func (vc *requestContext) StreamExecRoute(route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
+	return vc.router.StreamExecRoute(vc, route, joinvars, sendReply)
+}
+
+func (vc *requestContext) GetRouteFields(route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+	return vc.router.GetRouteFields(vc, route, joinvars)
 }

--- a/go/vt/vtgate/request_context.go
+++ b/go/vt/vtgate/request_context.go
@@ -39,12 +39,12 @@ func (vc *requestContext) Execute(query string, bindvars map[string]interface{})
 	return vc.router.Execute(vc.ctx, query, bindvars, vc.tabletType, vc.session, false)
 }
 
-func (vc *requestContext) ExecRoute(route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
-	return vc.router.ExecRoute(vc, route, joinvars)
+func (vc *requestContext) ExecuteRoute(route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+	return vc.router.ExecuteRoute(vc, route, joinvars)
 }
 
-func (vc *requestContext) StreamExecRoute(route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
-	return vc.router.StreamExecRoute(vc, route, joinvars, sendReply)
+func (vc *requestContext) StreamExecuteRoute(route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
+	return vc.router.StreamExecuteRoute(vc, route, joinvars, sendReply)
 }
 
 func (vc *requestContext) GetRouteFields(route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/router.go
+++ b/go/vt/vtgate/router.go
@@ -11,10 +11,10 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/sqlannotation"
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"golang.org/x/net/context"
 
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 )
@@ -49,7 +49,7 @@ func newScatterParams(ks string, bv map[string]interface{}, shards []string) *sc
 }
 
 // NewRouter creates a new Router.
-func NewRouter(serv topo.SrvTopoServer, cell string, vschema *planbuilder.VSchema, statsName string, scatterConn *ScatterConn) *Router {
+func NewRouter(serv topo.SrvTopoServer, cell string, vschema *vindexes.VSchema, statsName string, scatterConn *ScatterConn) *Router {
 	return &Router{
 		serv:        serv,
 		cell:        cell,
@@ -68,135 +68,50 @@ func (rtr *Router) Execute(ctx context.Context, sql string, bindVars map[string]
 	if err != nil {
 		return nil, err
 	}
-	return rtr.execInstruction(vcursor, plan.Instructions, true)
+	return plan.Instructions.Exec(vcursor, make(map[string]interface{}), true)
 }
 
-// execInstruction performs a non-streaming execution of the specified primitve.
-// If wantFields is true, it makes sure to fetch the field info even if there are
-// no results.
-func (rtr *Router) execInstruction(vcursor *requestContext, instruction planbuilder.Primitive, wantFields bool) (*sqltypes.Result, error) {
-	switch instruction := instruction.(type) {
-	case *planbuilder.Join:
-		res, err := rtr.execJoin(vcursor, instruction, wantFields)
-		return res, err
-	case *planbuilder.Route:
-		return rtr.execRoute(vcursor, instruction)
+// StreamExecute executes a streaming query.
+func (rtr *Router) StreamExecute(ctx context.Context, sql string, bindVars map[string]interface{}, tabletType topodatapb.TabletType, sendReply func(*sqltypes.Result) error) error {
+	if bindVars == nil {
+		bindVars = make(map[string]interface{})
 	}
-	panic("unreachable")
-}
-
-// execJoin performs a non-streaming join operation. It fetches rows from the LHS,
-// builds the necessary join variables for each fetched row, and invokes the RHS.
-// It then joins the left and right results based on the requested columns.
-// If the LHS returned no rows and wantFields is set, it performs a field
-// query to fetch the field info.
-func (rtr *Router) execJoin(vcursor *requestContext, join *planbuilder.Join, wantFields bool) (*sqltypes.Result, error) {
-	lresult, err := rtr.execInstruction(vcursor, join.Left, wantFields)
+	vcursor := newRequestContext(ctx, sql, bindVars, tabletType, nil, false, rtr)
+	plan, err := rtr.planner.GetPlan(sql)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	saved := copyBindVars(vcursor.JoinVars)
-	defer func() { vcursor.JoinVars = saved }()
-	result := &sqltypes.Result{}
-	if len(lresult.Rows) == 0 && wantFields {
-		for k := range join.Vars {
-			vcursor.JoinVars[k] = nil
-		}
-		rresult, err := rtr.getFields(vcursor, join.Right)
-		if err != nil {
-			return nil, err
-		}
-		result.Fields = joinFields(lresult.Fields, rresult.Fields, join.Cols)
-		return result, nil
-	}
-	for _, lrow := range lresult.Rows {
-		for k, col := range join.Vars {
-			vcursor.JoinVars[k] = lrow[col]
-		}
-		rresult, err := rtr.execInstruction(vcursor, join.Right, wantFields)
-		if err != nil {
-			return nil, err
-		}
-		if wantFields {
-			wantFields = false
-			result.Fields = joinFields(lresult.Fields, rresult.Fields, join.Cols)
-		}
-		for _, rrow := range rresult.Rows {
-			result.Rows = append(result.Rows, joinRows(lrow, rrow, join.Cols))
-		}
-		if join.IsLeft && len(rresult.Rows) == 0 {
-			result.Rows = append(result.Rows, joinRows(lrow, nil, join.Cols))
-			result.RowsAffected++
-		} else {
-			result.RowsAffected += uint64(len(rresult.Rows))
-		}
-	}
-	return result, nil
+	return plan.Instructions.StreamExec(vcursor, make(map[string]interface{}), true, sendReply)
 }
 
-func copyBindVars(bindVars map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{})
-	for k, v := range bindVars {
-		out[k] = v
-	}
-	return out
-}
-
-func joinFields(lfields, rfields []*querypb.Field, cols []int) []*querypb.Field {
-	fields := make([]*querypb.Field, len(cols))
-	for i, index := range cols {
-		if index < 0 {
-			fields[i] = lfields[-index-1]
-			continue
-		}
-		fields[i] = rfields[index-1]
-	}
-	return fields
-}
-
-func joinRows(lrow, rrow []sqltypes.Value, cols []int) []sqltypes.Value {
-	row := make([]sqltypes.Value, len(cols))
-	for i, index := range cols {
-		if index < 0 {
-			row[i] = lrow[-index-1]
-			continue
-		}
-		// rrow can be nil on left joins
-		if rrow != nil {
-			row[i] = rrow[index-1]
-		}
-	}
-	return row
-}
-
-// execRoute executes the route query for all route opcodes.
-func (rtr *Router) execRoute(vcursor *requestContext, route *planbuilder.Route) (*sqltypes.Result, error) {
+// ExecRoute executes the route query for all route opcodes.
+func (rtr *Router) ExecRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
 	saved := copyBindVars(vcursor.bindVars)
 	defer func() { vcursor.bindVars = saved }()
-	for k := range route.JoinVars {
-		vcursor.bindVars[k] = vcursor.JoinVars[k]
+	for k := range joinvars {
+		vcursor.bindVars[k] = joinvars[k]
 	}
 
 	switch route.Opcode {
-	case planbuilder.UpdateEqual:
+	case engine.UpdateEqual:
 		return rtr.execUpdateEqual(vcursor, route)
-	case planbuilder.DeleteEqual:
+	case engine.DeleteEqual:
 		return rtr.execDeleteEqual(vcursor, route)
-	case planbuilder.InsertSharded:
+	case engine.InsertSharded:
 		return rtr.execInsertSharded(vcursor, route)
 	}
 
 	var err error
 	var params *scatterParams
 	switch route.Opcode {
-	case planbuilder.SelectUnsharded, planbuilder.UpdateUnsharded,
-		planbuilder.DeleteUnsharded, planbuilder.InsertUnsharded:
+	case engine.SelectUnsharded, engine.UpdateUnsharded,
+		engine.DeleteUnsharded, engine.InsertUnsharded:
 		params, err = rtr.paramsUnsharded(vcursor, route)
-	case planbuilder.SelectEqual, planbuilder.SelectEqualUnique:
+	case engine.SelectEqual, engine.SelectEqualUnique:
 		params, err = rtr.paramsSelectEqual(vcursor, route)
-	case planbuilder.SelectIN:
+	case engine.SelectIN:
 		params, err = rtr.paramsSelectIN(vcursor, route)
-	case planbuilder.SelectScatter:
+	case engine.SelectScatter:
 		params, err = rtr.paramsSelectScatter(vcursor, route)
 	default:
 		// TODO(sougou): improve error.
@@ -216,42 +131,19 @@ func (rtr *Router) execRoute(vcursor *requestContext, route *planbuilder.Route) 
 	)
 }
 
-// getFields fetches the field info for the given primitive.
-func (rtr *Router) getFields(vcursor *requestContext, instruction planbuilder.Primitive) (*sqltypes.Result, error) {
-	switch instruction := instruction.(type) {
-	case *planbuilder.Join:
-		return rtr.getJoinFields(vcursor, instruction)
-	case *planbuilder.Route:
-		return rtr.getRouteFields(vcursor, instruction)
+func copyBindVars(bindVars map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{})
+	for k, v := range bindVars {
+		out[k] = v
 	}
-	panic("unreachable")
+	return out
 }
 
-// getJoinFields fetches the field info for the join.
-func (rtr *Router) getJoinFields(vcursor *requestContext, join *planbuilder.Join) (*sqltypes.Result, error) {
-	lresult, err := rtr.getFields(vcursor, join.Left)
-	if err != nil {
-		return nil, err
-	}
-	saved := copyBindVars(vcursor.JoinVars)
-	defer func() { vcursor.JoinVars = saved }()
-	result := &sqltypes.Result{}
-	for k := range join.Vars {
-		vcursor.JoinVars[k] = nil
-	}
-	rresult, err := rtr.getFields(vcursor, join.Right)
-	if err != nil {
-		return nil, err
-	}
-	result.Fields = joinFields(lresult.Fields, rresult.Fields, join.Cols)
-	return result, nil
-}
-
-// getRouteFields fetches the field info for the route.
-func (rtr *Router) getRouteFields(vcursor *requestContext, route *planbuilder.Route) (*sqltypes.Result, error) {
+// GetRouteFields fetches the field info for the route.
+func (rtr *Router) GetRouteFields(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
 	saved := copyBindVars(vcursor.bindVars)
 	defer func() { vcursor.bindVars = saved }()
-	for k := range route.JoinVars {
+	for k := range joinvars {
 		vcursor.bindVars[k] = nil
 	}
 	ks, shard, err := getAnyShard(vcursor.ctx, rtr.serv, rtr.cell, route.Keyspace.Name, vcursor.tabletType)
@@ -271,105 +163,24 @@ func (rtr *Router) getRouteFields(vcursor *requestContext, route *planbuilder.Ro
 	)
 }
 
-// StreamExecute executes a streaming query.
-func (rtr *Router) StreamExecute(ctx context.Context, sql string, bindVars map[string]interface{}, tabletType topodatapb.TabletType, sendReply func(*sqltypes.Result) error) error {
-	if bindVars == nil {
-		bindVars = make(map[string]interface{})
-	}
-	vcursor := newRequestContext(ctx, sql, bindVars, tabletType, nil, false, rtr)
-	plan, err := rtr.planner.GetPlan(sql)
-	if err != nil {
-		return err
-	}
-	return rtr.streamExecInstruction(vcursor, plan.Instructions, true, sendReply)
-}
-
-// streamExecInstruction performs a streaming execution of the specified instruction.
-func (rtr *Router) streamExecInstruction(vcursor *requestContext, instruction planbuilder.Primitive, wantFields bool, sendReply func(*sqltypes.Result) error) error {
-	switch instruction := instruction.(type) {
-	case *planbuilder.Join:
-		return rtr.streamExecJoin(vcursor, instruction, wantFields, sendReply)
-	case *planbuilder.Route:
-		return rtr.streamExecRoute(vcursor, instruction, sendReply)
-	}
-	panic("unreachable")
-}
-
-// StreamExecJoin performs a streaming join.
-func (rtr *Router) streamExecJoin(vcursor *requestContext, join *planbuilder.Join, wantFields bool, sendReply func(*sqltypes.Result) error) error {
-	err := rtr.streamExecInstruction(vcursor, join.Left, wantFields, func(lresult *sqltypes.Result) error {
-		for _, lrow := range lresult.Rows {
-			for k, col := range join.Vars {
-				vcursor.JoinVars[k] = lrow[col]
-			}
-			rowSent := false
-			err := rtr.streamExecInstruction(vcursor, join.Right, wantFields, func(rresult *sqltypes.Result) error {
-				result := &sqltypes.Result{}
-				if wantFields {
-					wantFields = false
-					result.Fields = joinFields(lresult.Fields, rresult.Fields, join.Cols)
-				}
-				for _, rrow := range rresult.Rows {
-					result.Rows = append(result.Rows, joinRows(lrow, rrow, join.Cols))
-				}
-				if len(rresult.Rows) != 0 {
-					rowSent = true
-				}
-				return sendReply(result)
-			})
-			if err != nil {
-				return err
-			}
-			if wantFields {
-				// TODO(sougou): remove after testing
-				panic("unexptected")
-			}
-			if join.IsLeft && !rowSent {
-				result := &sqltypes.Result{}
-				result.Rows = [][]sqltypes.Value{joinRows(
-					lrow,
-					nil,
-					join.Cols,
-				)}
-				return sendReply(result)
-			}
-		}
-		if wantFields {
-			wantFields = false
-			for k := range join.Vars {
-				vcursor.JoinVars[k] = nil
-			}
-			result := &sqltypes.Result{}
-			rresult, err := rtr.getFields(vcursor, join.Right)
-			if err != nil {
-				return err
-			}
-			result.Fields = joinFields(lresult.Fields, rresult.Fields, join.Cols)
-			return sendReply(result)
-		}
-		return nil
-	})
-	return err
-}
-
-// streamExecRoute performs a streaming route. Only selects are allowed.
-func (rtr *Router) streamExecRoute(vcursor *requestContext, route *planbuilder.Route, sendReply func(*sqltypes.Result) error) error {
+// StreamExecRoute performs a streaming route. Only selects are allowed.
+func (rtr *Router) StreamExecRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
 	saved := copyBindVars(vcursor.bindVars)
 	defer func() { vcursor.bindVars = saved }()
-	for k := range route.JoinVars {
-		vcursor.bindVars[k] = vcursor.JoinVars[k]
+	for k := range joinvars {
+		vcursor.bindVars[k] = joinvars[k]
 	}
 
 	var err error
 	var params *scatterParams
 	switch route.Opcode {
-	case planbuilder.SelectUnsharded:
+	case engine.SelectUnsharded:
 		params, err = rtr.paramsUnsharded(vcursor, route)
-	case planbuilder.SelectEqual, planbuilder.SelectEqualUnique:
+	case engine.SelectEqual, engine.SelectEqualUnique:
 		params, err = rtr.paramsSelectEqual(vcursor, route)
-	case planbuilder.SelectIN:
+	case engine.SelectIN:
 		params, err = rtr.paramsSelectIN(vcursor, route)
-	case planbuilder.SelectScatter:
+	case engine.SelectScatter:
 		params, err = rtr.paramsSelectScatter(vcursor, route)
 	default:
 		return fmt.Errorf("query %q cannot be used for streaming", route.Query)
@@ -387,7 +198,7 @@ func (rtr *Router) streamExecRoute(vcursor *requestContext, route *planbuilder.R
 	)
 }
 
-func (rtr *Router) paramsUnsharded(vcursor *requestContext, route *planbuilder.Route) (*scatterParams, error) {
+func (rtr *Router) paramsUnsharded(vcursor *requestContext, route *engine.Route) (*scatterParams, error) {
 	ks, _, allShards, err := getKeyspaceShards(vcursor.ctx, rtr.serv, rtr.cell, route.Keyspace.Name, vcursor.tabletType)
 	if err != nil {
 		return nil, fmt.Errorf("paramsUnsharded: %v", err)
@@ -398,7 +209,7 @@ func (rtr *Router) paramsUnsharded(vcursor *requestContext, route *planbuilder.R
 	return newScatterParams(ks, vcursor.bindVars, []string{allShards[0].Name}), nil
 }
 
-func (rtr *Router) paramsSelectEqual(vcursor *requestContext, route *planbuilder.Route) (*scatterParams, error) {
+func (rtr *Router) paramsSelectEqual(vcursor *requestContext, route *engine.Route) (*scatterParams, error) {
 	keys, err := rtr.resolveKeys([]interface{}{route.Values}, vcursor.bindVars)
 	if err != nil {
 		return nil, fmt.Errorf("paramsSelectEqual: %v", err)
@@ -410,7 +221,7 @@ func (rtr *Router) paramsSelectEqual(vcursor *requestContext, route *planbuilder
 	return newScatterParams(ks, vcursor.bindVars, routing.Shards()), nil
 }
 
-func (rtr *Router) paramsSelectIN(vcursor *requestContext, route *planbuilder.Route) (*scatterParams, error) {
+func (rtr *Router) paramsSelectIN(vcursor *requestContext, route *engine.Route) (*scatterParams, error) {
 	keys, err := rtr.resolveKeys(route.Values.([]interface{}), vcursor.bindVars)
 	if err != nil {
 		return nil, fmt.Errorf("paramsSelectIN: %v", err)
@@ -425,7 +236,7 @@ func (rtr *Router) paramsSelectIN(vcursor *requestContext, route *planbuilder.Ro
 	}, nil
 }
 
-func (rtr *Router) paramsSelectScatter(vcursor *requestContext, route *planbuilder.Route) (*scatterParams, error) {
+func (rtr *Router) paramsSelectScatter(vcursor *requestContext, route *engine.Route) (*scatterParams, error) {
 	ks, _, allShards, err := getKeyspaceShards(vcursor.ctx, rtr.serv, rtr.cell, route.Keyspace.Name, vcursor.tabletType)
 	if err != nil {
 		return nil, fmt.Errorf("paramsSelectScatter: %v", err)
@@ -437,7 +248,7 @@ func (rtr *Router) paramsSelectScatter(vcursor *requestContext, route *planbuild
 	return newScatterParams(ks, vcursor.bindVars, shards), nil
 }
 
-func (rtr *Router) execUpdateEqual(vcursor *requestContext, route *planbuilder.Route) (*sqltypes.Result, error) {
+func (rtr *Router) execUpdateEqual(vcursor *requestContext, route *engine.Route) (*sqltypes.Result, error) {
 	keys, err := rtr.resolveKeys([]interface{}{route.Values}, vcursor.bindVars)
 	if err != nil {
 		return nil, fmt.Errorf("execUpdateEqual: %v", err)
@@ -462,7 +273,7 @@ func (rtr *Router) execUpdateEqual(vcursor *requestContext, route *planbuilder.R
 		vcursor.notInTransaction)
 }
 
-func (rtr *Router) execDeleteEqual(vcursor *requestContext, route *planbuilder.Route) (*sqltypes.Result, error) {
+func (rtr *Router) execDeleteEqual(vcursor *requestContext, route *engine.Route) (*sqltypes.Result, error) {
 	keys, err := rtr.resolveKeys([]interface{}{route.Values}, vcursor.bindVars)
 	if err != nil {
 		return nil, fmt.Errorf("execDeleteEqual: %v", err)
@@ -493,7 +304,7 @@ func (rtr *Router) execDeleteEqual(vcursor *requestContext, route *planbuilder.R
 		vcursor.notInTransaction)
 }
 
-func (rtr *Router) execInsertSharded(vcursor *requestContext, route *planbuilder.Route) (*sqltypes.Result, error) {
+func (rtr *Router) execInsertSharded(vcursor *requestContext, route *engine.Route) (*sqltypes.Result, error) {
 	insertid, err := rtr.handleGenerate(vcursor, route.Generate)
 	if err != nil {
 		return nil, fmt.Errorf("execInsertSharded: %v", err)
@@ -557,14 +368,14 @@ func (rtr *Router) resolveKeys(vals []interface{}, bindVars map[string]interface
 	return keys, nil
 }
 
-func (rtr *Router) resolveShards(vcursor *requestContext, vindexKeys []interface{}, route *planbuilder.Route) (newKeyspace string, routing routingMap, err error) {
+func (rtr *Router) resolveShards(vcursor *requestContext, vindexKeys []interface{}, route *engine.Route) (newKeyspace string, routing routingMap, err error) {
 	newKeyspace, _, allShards, err := getKeyspaceShards(vcursor.ctx, rtr.serv, rtr.cell, route.Keyspace.Name, vcursor.tabletType)
 	if err != nil {
 		return "", nil, err
 	}
 	routing = make(routingMap)
 	switch mapper := route.Vindex.(type) {
-	case planbuilder.Unique:
+	case vindexes.Unique:
 		ksids, err := mapper.Map(vcursor, vindexKeys)
 		if err != nil {
 			return "", nil, err
@@ -579,7 +390,7 @@ func (rtr *Router) resolveShards(vcursor *requestContext, vindexKeys []interface
 			}
 			routing.Add(shard, vindexKeys[i])
 		}
-	case planbuilder.NonUnique:
+	case vindexes.NonUnique:
 		ksidss, err := mapper.Map(vcursor, vindexKeys)
 		if err != nil {
 			return "", nil, err
@@ -599,12 +410,12 @@ func (rtr *Router) resolveShards(vcursor *requestContext, vindexKeys []interface
 	return newKeyspace, routing, nil
 }
 
-func (rtr *Router) resolveSingleShard(vcursor *requestContext, vindexKey interface{}, route *planbuilder.Route) (newKeyspace, shard string, ksid []byte, err error) {
+func (rtr *Router) resolveSingleShard(vcursor *requestContext, vindexKey interface{}, route *engine.Route) (newKeyspace, shard string, ksid []byte, err error) {
 	newKeyspace, _, allShards, err := getKeyspaceShards(vcursor.ctx, rtr.serv, rtr.cell, route.Keyspace.Name, vcursor.tabletType)
 	if err != nil {
 		return "", "", nil, err
 	}
-	mapper := route.Vindex.(planbuilder.Unique)
+	mapper := route.Vindex.(vindexes.Unique)
 	ksids, err := mapper.Map(vcursor, []interface{}{vindexKey})
 	if err != nil {
 		return "", "", nil, err
@@ -620,7 +431,7 @@ func (rtr *Router) resolveSingleShard(vcursor *requestContext, vindexKey interfa
 	return newKeyspace, shard, ksid, nil
 }
 
-func (rtr *Router) deleteVindexEntries(vcursor *requestContext, route *planbuilder.Route, ks, shard string, ksid []byte) error {
+func (rtr *Router) deleteVindexEntries(vcursor *requestContext, route *engine.Route, ks, shard string, ksid []byte) error {
 	result, err := rtr.scatterConn.Execute(
 		vcursor.ctx,
 		route.Subquery,
@@ -651,7 +462,7 @@ func (rtr *Router) deleteVindexEntries(vcursor *requestContext, route *planbuild
 			ids = append(ids, k)
 		}
 		switch vindex := colVindex.Vindex.(type) {
-		case planbuilder.Lookup:
+		case vindexes.Lookup:
 			if err = vindex.Delete(vcursor, ids, ksid); err != nil {
 				return err
 			}
@@ -662,7 +473,7 @@ func (rtr *Router) deleteVindexEntries(vcursor *requestContext, route *planbuild
 	return nil
 }
 
-func (rtr *Router) handleGenerate(vcursor *requestContext, gen *planbuilder.Generate) (insertid int64, err error) {
+func (rtr *Router) handleGenerate(vcursor *requestContext, gen *engine.Generate) (insertid int64, err error) {
 	if gen == nil {
 		return 0, nil
 	}
@@ -674,7 +485,7 @@ func (rtr *Router) handleGenerate(vcursor *requestContext, gen *planbuilder.Gene
 		}
 	}
 	if val != nil {
-		vcursor.bindVars[planbuilder.SeqVarName] = val
+		vcursor.bindVars[engine.SeqVarName] = val
 		return 0, nil
 	}
 	// TODO(sougou): This is similar to paramsUnsharded.
@@ -706,15 +517,15 @@ func (rtr *Router) handleGenerate(vcursor *requestContext, gen *planbuilder.Gene
 	if err != nil {
 		return 0, err
 	}
-	vcursor.bindVars[planbuilder.SeqVarName] = num
+	vcursor.bindVars[engine.SeqVarName] = num
 	return num, nil
 }
 
-func (rtr *Router) handlePrimary(vcursor *requestContext, vindexKey interface{}, colVindex *planbuilder.ColVindex, bv map[string]interface{}) (ksid []byte, err error) {
+func (rtr *Router) handlePrimary(vcursor *requestContext, vindexKey interface{}, colVindex *vindexes.ColVindex, bv map[string]interface{}) (ksid []byte, err error) {
 	if vindexKey == nil {
 		return nil, fmt.Errorf("value must be supplied for column %s", colVindex.Col)
 	}
-	mapper := colVindex.Vindex.(planbuilder.Unique)
+	mapper := colVindex.Vindex.(vindexes.Unique)
 	ksids, err := mapper.Map(vcursor, []interface{}{vindexKey})
 	if err != nil {
 		return nil, err
@@ -727,18 +538,18 @@ func (rtr *Router) handlePrimary(vcursor *requestContext, vindexKey interface{},
 	return ksid, nil
 }
 
-func (rtr *Router) handleNonPrimary(vcursor *requestContext, vindexKey interface{}, colVindex *planbuilder.ColVindex, bv map[string]interface{}, ksid []byte) error {
+func (rtr *Router) handleNonPrimary(vcursor *requestContext, vindexKey interface{}, colVindex *vindexes.ColVindex, bv map[string]interface{}, ksid []byte) error {
 	if colVindex.Owned {
 		if vindexKey == nil {
 			return fmt.Errorf("value must be supplied for column %s", colVindex.Col)
 		}
-		err := colVindex.Vindex.(planbuilder.Lookup).Create(vcursor, vindexKey, ksid)
+		err := colVindex.Vindex.(vindexes.Lookup).Create(vcursor, vindexKey, ksid)
 		if err != nil {
 			return err
 		}
 	} else {
 		if vindexKey == nil {
-			reversible, ok := colVindex.Vindex.(planbuilder.Reversible)
+			reversible, ok := colVindex.Vindex.(vindexes.Reversible)
 			if !ok {
 				return fmt.Errorf("value must be supplied for column %s", colVindex.Col)
 			}

--- a/go/vt/vtgate/router.go
+++ b/go/vt/vtgate/router.go
@@ -68,7 +68,7 @@ func (rtr *Router) Execute(ctx context.Context, sql string, bindVars map[string]
 	if err != nil {
 		return nil, err
 	}
-	return plan.Instructions.Exec(vcursor, make(map[string]interface{}), true)
+	return plan.Instructions.Execute(vcursor, make(map[string]interface{}), true)
 }
 
 // StreamExecute executes a streaming query.
@@ -81,15 +81,15 @@ func (rtr *Router) StreamExecute(ctx context.Context, sql string, bindVars map[s
 	if err != nil {
 		return err
 	}
-	return plan.Instructions.StreamExec(vcursor, make(map[string]interface{}), true, sendReply)
+	return plan.Instructions.StreamExecute(vcursor, make(map[string]interface{}), true, sendReply)
 }
 
-// ExecRoute executes the route query for all route opcodes.
-func (rtr *Router) ExecRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
+// ExecuteRoute executes the route query for all route opcodes.
+func (rtr *Router) ExecuteRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}) (*sqltypes.Result, error) {
 	saved := copyBindVars(vcursor.bindVars)
 	defer func() { vcursor.bindVars = saved }()
-	for k := range joinvars {
-		vcursor.bindVars[k] = joinvars[k]
+	for k, v := range joinvars {
+		vcursor.bindVars[k] = v
 	}
 
 	switch route.Opcode {
@@ -163,12 +163,12 @@ func (rtr *Router) GetRouteFields(vcursor *requestContext, route *engine.Route, 
 	)
 }
 
-// StreamExecRoute performs a streaming route. Only selects are allowed.
-func (rtr *Router) StreamExecRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
+// StreamExecuteRoute performs a streaming route. Only selects are allowed.
+func (rtr *Router) StreamExecuteRoute(vcursor *requestContext, route *engine.Route, joinvars map[string]interface{}, sendReply func(*sqltypes.Result) error) error {
 	saved := copyBindVars(vcursor.bindVars)
 	defer func() { vcursor.bindVars = saved }()
-	for k := range joinvars {
-		vcursor.bindVars[k] = joinvars[k]
+	for k, v := range joinvars {
+		vcursor.bindVars[k] = v
 	}
 
 	var err error

--- a/go/vt/vtgate/router_framework_test.go
+++ b/go/vt/vtgate/router_framework_test.go
@@ -11,8 +11,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
-	_ "github.com/youtube/vitess/go/vt/vtgate/vindexes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -173,7 +172,7 @@ var routerVSchema = createTestVSchema(`
 
 // createTestVSchema creates a vschema based on the JSON specs.
 // It panics on failure.
-func createTestVSchema(vschemaJSON string) *planbuilder.VSchema {
+func createTestVSchema(vschemaJSON string) *vindexes.VSchema {
 	f, err := ioutil.TempFile("", "vtgate_schema")
 	if err != nil {
 		panic(err)
@@ -186,7 +185,7 @@ func createTestVSchema(vschemaJSON string) *planbuilder.VSchema {
 	if err != nil {
 		panic(err)
 	}
-	vschema, err := planbuilder.LoadFile(fname)
+	vschema, err := vindexes.LoadFile(fname)
 	if err != nil {
 		panic(err)
 	}

--- a/go/vt/vtgate/router_select_test.go
+++ b/go/vt/vtgate/router_select_test.go
@@ -936,7 +936,7 @@ func TestEmptyJoinRecursive(t *testing.T) {
 		},
 	}}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
-		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
+		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
 	}
 	wantResult := &sqltypes.Result{
 		Fields: []*querypb.Field{

--- a/go/vt/vtgate/routing_map.go
+++ b/go/vt/vtgate/routing_map.go
@@ -4,7 +4,7 @@
 
 package vtgate
 
-import "github.com/youtube/vitess/go/vt/vtgate/planbuilder"
+import "github.com/youtube/vitess/go/vt/vtgate/engine"
 
 type routingMap map[string][]interface{}
 
@@ -27,7 +27,7 @@ func (rtm routingMap) ShardVars(bv map[string]interface{}) map[string]map[string
 		for k, v := range bv {
 			newbv[k] = v
 		}
-		newbv[planbuilder.ListVarName] = vals
+		newbv[engine.ListVarName] = vals
 		shardVars[shard] = newbv
 	}
 	return shardVars

--- a/go/vt/vtgate/routing_map.go
+++ b/go/vt/vtgate/routing_map.go
@@ -4,25 +4,12 @@
 
 package vtgate
 
-import (
-	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
-)
+import "github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 
 type routingMap map[string][]interface{}
 
 func (rtm routingMap) Add(shard string, id interface{}) {
-	ids := rtm[shard]
-	// Check for duplicates
-	for _, current := range ids {
-		if c, ok := current.(sqltypes.Value); ok {
-			current = c.String()
-		}
-		if id == current {
-			return
-		}
-	}
-	rtm[shard] = append(ids, id)
+	rtm[shard] = append(rtm[shard], id)
 }
 
 func (rtm routingMap) Shards() []string {

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
 // Hash defines vindex that hashes an int64 to a KeyspaceId
@@ -25,7 +24,7 @@ type Hash struct {
 }
 
 // NewHash creates a new Hash.
-func NewHash(name string, m map[string]interface{}) (planbuilder.Vindex, error) {
+func NewHash(name string, m map[string]interface{}) (Vindex, error) {
 	return &Hash{name: name}, nil
 }
 
@@ -40,7 +39,7 @@ func (vind *Hash) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vind *Hash) Map(_ planbuilder.VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *Hash) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
 		num, err := getNumber(id)
@@ -53,7 +52,7 @@ func (vind *Hash) Map(_ planbuilder.VCursor, ids []interface{}) ([][]byte, error
 }
 
 // Verify returns true if id maps to ksid.
-func (vind *Hash) Verify(_ planbuilder.VCursor, id interface{}, ksid []byte) (bool, error) {
+func (vind *Hash) Verify(_ VCursor, id interface{}, ksid []byte) (bool, error) {
 	num, err := getNumber(id)
 	if err != nil {
 		return false, fmt.Errorf("hash.Verify: %v", err)
@@ -62,7 +61,7 @@ func (vind *Hash) Verify(_ planbuilder.VCursor, id interface{}, ksid []byte) (bo
 }
 
 // ReverseMap returns the id from ksid.
-func (vind *Hash) ReverseMap(_ planbuilder.VCursor, ksid []byte) (interface{}, error) {
+func (vind *Hash) ReverseMap(_ VCursor, ksid []byte) (interface{}, error) {
 	return vunhash(ksid)
 }
 
@@ -110,7 +109,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	planbuilder.Register("hash", NewHash)
+	Register("hash", NewHash)
 }
 
 func vhash(shardKey int64) []byte {

--- a/go/vt/vtgate/vindexes/hash_test.go
+++ b/go/vt/vtgate/vindexes/hash_test.go
@@ -7,14 +7,12 @@ package vindexes
 import (
 	"reflect"
 	"testing"
-
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
-var hash planbuilder.Vindex
+var hash Vindex
 
 func init() {
-	hv, err := planbuilder.CreateVindex("hash", "nn", map[string]interface{}{"Table": "t", "Column": "c"})
+	hv, err := CreateVindex("hash", "nn", map[string]interface{}{"Table": "t", "Column": "c"})
 	if err != nil {
 		panic(err)
 	}
@@ -28,7 +26,7 @@ func TestHashCost(t *testing.T) {
 }
 
 func TestHashMap(t *testing.T) {
-	got, err := hash.(planbuilder.Unique).Map(nil, []interface{}{1, int32(2), int64(3), uint(4), uint32(5), uint64(6)})
+	got, err := hash.(Unique).Map(nil, []interface{}{1, int32(2), int64(3), uint(4), uint32(5), uint64(6)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -56,7 +54,7 @@ func TestHashVerify(t *testing.T) {
 }
 
 func TestHashReverseMap(t *testing.T) {
-	got, err := hash.(planbuilder.Reversible).ReverseMap(nil, []byte("\x16k@\xb4J\xbaK\xd6"))
+	got, err := hash.(Reversible).ReverseMap(nil, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -4,15 +4,11 @@
 
 package vindexes
 
-import (
-	"fmt"
-
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
-)
+import "fmt"
 
 func init() {
-	planbuilder.Register("lookup_hash", NewLookupHash)
-	planbuilder.Register("lookup_hash_unique", NewLookupHashUnique)
+	Register("lookup_hash", NewLookupHash)
+	Register("lookup_hash_unique", NewLookupHashUnique)
 }
 
 //====================================================================
@@ -26,7 +22,7 @@ type LookupHash struct {
 }
 
 // NewLookupHash creates a LookupHash vindex.
-func NewLookupHash(name string, m map[string]interface{}) (planbuilder.Vindex, error) {
+func NewLookupHash(name string, m map[string]interface{}) (Vindex, error) {
 	lhu := &LookupHash{name: name}
 	lhu.lkp.Init(m)
 	return lhu, nil
@@ -43,22 +39,22 @@ func (vind *LookupHash) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vind *LookupHash) Map(vcursor planbuilder.VCursor, ids []interface{}) ([][][]byte, error) {
+func (vind *LookupHash) Map(vcursor VCursor, ids []interface{}) ([][][]byte, error) {
 	return vind.lkp.Map2(vcursor, ids)
 }
 
 // Verify returns true if id maps to ksid.
-func (vind *LookupHash) Verify(vcursor planbuilder.VCursor, id interface{}, ksid []byte) (bool, error) {
+func (vind *LookupHash) Verify(vcursor VCursor, id interface{}, ksid []byte) (bool, error) {
 	return vind.lkp.Verify(vcursor, id, ksid)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vind *LookupHash) Create(vcursor planbuilder.VCursor, id interface{}, ksid []byte) error {
+func (vind *LookupHash) Create(vcursor VCursor, id interface{}, ksid []byte) error {
 	return vind.lkp.Create(vcursor, id, ksid)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vind *LookupHash) Delete(vcursor planbuilder.VCursor, ids []interface{}, ksid []byte) error {
+func (vind *LookupHash) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
 	return vind.lkp.Delete(vcursor, ids, ksid)
 }
 
@@ -73,7 +69,7 @@ type LookupHashUnique struct {
 }
 
 // NewLookupHashUnique creates a LookupHashUnique vindex.
-func NewLookupHashUnique(name string, m map[string]interface{}) (planbuilder.Vindex, error) {
+func NewLookupHashUnique(name string, m map[string]interface{}) (Vindex, error) {
 	lhu := &LookupHashUnique{name: name}
 	lhu.lkp.Init(m)
 	return lhu, nil
@@ -90,22 +86,22 @@ func (vind *LookupHashUnique) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vind *LookupHashUnique) Map(vcursor planbuilder.VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *LookupHashUnique) Map(vcursor VCursor, ids []interface{}) ([][]byte, error) {
 	return vind.lkp.Map1(vcursor, ids)
 }
 
 // Verify returns true if id maps to ksid.
-func (vind *LookupHashUnique) Verify(vcursor planbuilder.VCursor, id interface{}, ksid []byte) (bool, error) {
+func (vind *LookupHashUnique) Verify(vcursor VCursor, id interface{}, ksid []byte) (bool, error) {
 	return vind.lkp.Verify(vcursor, id, ksid)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vind *LookupHashUnique) Create(vcursor planbuilder.VCursor, id interface{}, ksid []byte) error {
+func (vind *LookupHashUnique) Create(vcursor VCursor, id interface{}, ksid []byte) error {
 	return vind.lkp.Create(vcursor, id, ksid)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vind *LookupHashUnique) Delete(vcursor planbuilder.VCursor, ids []interface{}, ksid []byte) error {
+func (vind *LookupHashUnique) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
 	return vind.lkp.Delete(vcursor, ids, ksid)
 }
 
@@ -136,7 +132,7 @@ func (lkp *lookup) Init(m map[string]interface{}) {
 }
 
 // Map1 is for a unique vindex.
-func (lkp *lookup) Map1(vcursor planbuilder.VCursor, ids []interface{}) ([][]byte, error) {
+func (lkp *lookup) Map1(vcursor VCursor, ids []interface{}) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
 		result, err := vcursor.Execute(lkp.sel, map[string]interface{}{
@@ -162,7 +158,7 @@ func (lkp *lookup) Map1(vcursor planbuilder.VCursor, ids []interface{}) ([][]byt
 }
 
 // Map2 is for a non-unique vindex.
-func (lkp *lookup) Map2(vcursor planbuilder.VCursor, ids []interface{}) ([][][]byte, error) {
+func (lkp *lookup) Map2(vcursor VCursor, ids []interface{}) ([][][]byte, error) {
 	out := make([][][]byte, 0, len(ids))
 	for _, id := range ids {
 		result, err := vcursor.Execute(lkp.sel, map[string]interface{}{
@@ -185,7 +181,7 @@ func (lkp *lookup) Map2(vcursor planbuilder.VCursor, ids []interface{}) ([][][]b
 }
 
 // Verify returns true if id maps to ksid.
-func (lkp *lookup) Verify(vcursor planbuilder.VCursor, id interface{}, ksid []byte) (bool, error) {
+func (lkp *lookup) Verify(vcursor VCursor, id interface{}, ksid []byte) (bool, error) {
 	val, err := vunhash(ksid)
 	if err != nil {
 		return false, fmt.Errorf("lookup.Verify: %v", err)
@@ -204,7 +200,7 @@ func (lkp *lookup) Verify(vcursor planbuilder.VCursor, id interface{}, ksid []by
 }
 
 // Create creates an association between id and ksid by inserting a row in the vindex table.
-func (lkp *lookup) Create(vcursor planbuilder.VCursor, id interface{}, ksid []byte) error {
+func (lkp *lookup) Create(vcursor VCursor, id interface{}, ksid []byte) error {
 	val, err := vunhash(ksid)
 	if err != nil {
 		return fmt.Errorf("lookup.Create: %v", err)
@@ -219,7 +215,7 @@ func (lkp *lookup) Create(vcursor planbuilder.VCursor, id interface{}, ksid []by
 }
 
 // Delete deletes the association between ids and ksid.
-func (lkp *lookup) Delete(vcursor planbuilder.VCursor, ids []interface{}, ksid []byte) error {
+func (lkp *lookup) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
 	val, err := vunhash(ksid)
 	if err != nil {
 		return fmt.Errorf("lookup.Delete: %v", err)

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/tabletserver/querytypes"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
 type vcursor struct {
@@ -57,10 +56,10 @@ func (vc *vcursor) Execute(query string, bindvars map[string]interface{}) (*sqlt
 	panic("unexpected")
 }
 
-var lhm planbuilder.Vindex
+var lhm Vindex
 
 func init() {
-	h, err := planbuilder.CreateVindex("lookup_hash", "nn", map[string]interface{}{"Table": "t", "From": "fromc", "To": "toc"})
+	h, err := CreateVindex("lookup_hash", "nn", map[string]interface{}{"Table": "t", "From": "fromc", "To": "toc"})
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +74,7 @@ func TestLookupHashCost(t *testing.T) {
 
 func TestLookupHashMap(t *testing.T) {
 	vc := &vcursor{numRows: 2}
-	got, err := lhm.(planbuilder.NonUnique).Map(vc, []interface{}{1, int32(2)})
+	got, err := lhm.(NonUnique).Map(vc, []interface{}{1, int32(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -104,7 +103,7 @@ func TestLookupHashVerify(t *testing.T) {
 
 func TestLookupHashCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lhm.(planbuilder.Lookup).Create(vc, 1, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lhm.(Lookup).Create(vc, 1, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -121,15 +120,15 @@ func TestLookupHashCreate(t *testing.T) {
 }
 
 func TestLookupHashReverse(t *testing.T) {
-	_, ok := lhm.(planbuilder.Reversible)
+	_, ok := lhm.(Reversible)
 	if ok {
-		t.Errorf("lhm.(planbuilder.Reversible): true, want false")
+		t.Errorf("lhm.(Reversible): true, want false")
 	}
 }
 
 func TestLookupHashDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lhm.(planbuilder.Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lhm.(Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -9,13 +9,12 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/tabletserver/querytypes"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
-var lhu planbuilder.Vindex
+var lhu Vindex
 
 func init() {
-	h, err := planbuilder.CreateVindex("lookup_hash_unique", "nn", map[string]interface{}{"Table": "t", "From": "fromc", "To": "toc"})
+	h, err := CreateVindex("lookup_hash_unique", "nn", map[string]interface{}{"Table": "t", "From": "fromc", "To": "toc"})
 	if err != nil {
 		panic(err)
 	}
@@ -30,7 +29,7 @@ func TestLookupHashUniqueCost(t *testing.T) {
 
 func TestLookupHashUniqueMap(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	got, err := lhu.(planbuilder.Unique).Map(vc, []interface{}{1, int32(2)})
+	got, err := lhu.(Unique).Map(vc, []interface{}{1, int32(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -56,7 +55,7 @@ func TestLookupHashUniqueVerify(t *testing.T) {
 
 func TestLookupHashUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lhu.(planbuilder.Lookup).Create(vc, 1, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lhu.(Lookup).Create(vc, 1, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -73,15 +72,15 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 }
 
 func TestLookupHashUniqueReverse(t *testing.T) {
-	_, ok := lhu.(planbuilder.Reversible)
+	_, ok := lhu.(Reversible)
 	if ok {
-		t.Errorf("lhu.(planbuilder.Reversible): true, want false")
+		t.Errorf("lhu.(Reversible): true, want false")
 	}
 }
 
 func TestLookupHashUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lhu.(planbuilder.Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lhu.(Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -67,8 +67,8 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 			"toc":   int64(1),
 		},
 	}
-	if !reflect.DeepEqual(vc.query, wantQuery) {
-		t.Errorf("vc.query = %#v, want %#v", vc.query, wantQuery)
+	if !reflect.DeepEqual(vc.bq, wantQuery) {
+		t.Errorf("vc.query = %#v, want %#v", vc.bq, wantQuery)
 	}
 }
 
@@ -92,7 +92,7 @@ func TestLookupHashUniqueDelete(t *testing.T) {
 			"toc":   int64(1),
 		},
 	}
-	if !reflect.DeepEqual(vc.query, wantQuery) {
-		t.Errorf("vc.query = %#v, want %#v", vc.query, wantQuery)
+	if !reflect.DeepEqual(vc.bq, wantQuery) {
+		t.Errorf("vc.query = %#v, want %#v", vc.bq, wantQuery)
 	}
 }

--- a/go/vt/vtgate/vindexes/numeric.go
+++ b/go/vt/vtgate/vindexes/numeric.go
@@ -8,8 +8,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
 // Numeric defines a bit-pattern mapping of a uint64 to the KeyspaceId.
@@ -19,7 +17,7 @@ type Numeric struct {
 }
 
 // NewNumeric creates a Numeric vindex.
-func NewNumeric(name string, _ map[string]interface{}) (planbuilder.Vindex, error) {
+func NewNumeric(name string, _ map[string]interface{}) (Vindex, error) {
 	return &Numeric{name: name}, nil
 }
 
@@ -34,7 +32,7 @@ func (*Numeric) Cost() int {
 }
 
 // Verify returns true if id and ksid match.
-func (*Numeric) Verify(_ planbuilder.VCursor, id interface{}, ksid []byte) (bool, error) {
+func (*Numeric) Verify(_ VCursor, id interface{}, ksid []byte) (bool, error) {
 	var keybytes [8]byte
 	num, err := getNumber(id)
 	if err != nil {
@@ -45,7 +43,7 @@ func (*Numeric) Verify(_ planbuilder.VCursor, id interface{}, ksid []byte) (bool
 }
 
 // Map returns the associated keyspae ids for the given ids.
-func (*Numeric) Map(_ planbuilder.VCursor, ids []interface{}) ([][]byte, error) {
+func (*Numeric) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
 		num, err := getNumber(id)
@@ -60,7 +58,7 @@ func (*Numeric) Map(_ planbuilder.VCursor, ids []interface{}) ([][]byte, error) 
 }
 
 // ReverseMap returns the associated id for the ksid.
-func (*Numeric) ReverseMap(_ planbuilder.VCursor, ksid []byte) (interface{}, error) {
+func (*Numeric) ReverseMap(_ VCursor, ksid []byte) (interface{}, error) {
 	if len(ksid) != 8 {
 		return nil, fmt.Errorf("Numeric.ReverseMap: length of keyspace is not 8: %d", len(ksid))
 	}
@@ -68,5 +66,5 @@ func (*Numeric) ReverseMap(_ planbuilder.VCursor, ksid []byte) (interface{}, err
 }
 
 func init() {
-	planbuilder.Register("numeric", NewNumeric)
+	Register("numeric", NewNumeric)
 }

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -9,13 +9,12 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 )
 
-var numeric planbuilder.Vindex
+var numeric Vindex
 
 func init() {
-	numeric, _ = planbuilder.CreateVindex("numeric", "nn", nil)
+	numeric, _ = CreateVindex("numeric", "nn", nil)
 }
 
 func TestNumericCost(t *testing.T) {
@@ -26,7 +25,7 @@ func TestNumericCost(t *testing.T) {
 
 func TestNumericMap(t *testing.T) {
 	sqlVal, _ := sqltypes.BuildIntegral("8")
-	got, err := numeric.(planbuilder.Unique).Map(nil, []interface{}{
+	got, err := numeric.(Unique).Map(nil, []interface{}{
 		1,
 		int32(2),
 		int64(3),
@@ -55,7 +54,7 @@ func TestNumericMap(t *testing.T) {
 }
 
 func TestNumericMapBadData(t *testing.T) {
-	_, err := numeric.(planbuilder.Unique).Map(nil, []interface{}{1.1})
+	_, err := numeric.(Unique).Map(nil, []interface{}{1.1})
 	want := `Numeric.Map: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)
@@ -81,7 +80,7 @@ func TestNumericVerifyBadData(t *testing.T) {
 }
 
 func TestNumericReverseMap(t *testing.T) {
-	got, err := numeric.(planbuilder.Reversible).ReverseMap(nil, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
+	got, err := numeric.(Reversible).ReverseMap(nil, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -91,7 +90,7 @@ func TestNumericReverseMap(t *testing.T) {
 }
 
 func TestNumericReverseMapBadData(t *testing.T) {
-	_, err := numeric.(planbuilder.Reversible).ReverseMap(nil, []byte("aa"))
+	_, err := numeric.(Reversible).ReverseMap(nil, []byte("aa"))
 	want := `Numeric.ReverseMap: length of keyspace is not 8: 2`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package planbuilder
+package vindexes
 
 import (
 	"fmt"

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package planbuilder
+package vindexes
 
 import (
 	"encoding/json"

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package planbuilder
+package vindexes
 
 import (
 	"encoding/json"

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -27,10 +27,8 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vterrors"
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
 
-	// import vindexes implementations
-	_ "github.com/youtube/vitess/go/vt/vtgate/vindexes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateservice"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -96,7 +94,7 @@ type RegisterVTGate func(vtgateservice.VTGateService)
 var RegisterVTGates []RegisterVTGate
 
 // Init initializes VTGate server.
-func Init(hc discovery.HealthCheck, topoServer topo.Server, serv topo.SrvTopoServer, vschema *planbuilder.VSchema, cell string, retryDelay time.Duration, retryCount int, connTimeoutTotal, connTimeoutPerConn, connLife time.Duration, tabletTypesToWait []topodatapb.TabletType, maxInFlight int, testGateway string) *VTGate {
+func Init(hc discovery.HealthCheck, topoServer topo.Server, serv topo.SrvTopoServer, vschema *vindexes.VSchema, cell string, retryDelay time.Duration, retryCount int, connTimeoutTotal, connTimeoutPerConn, connLife time.Duration, tabletTypesToWait []topodatapb.TabletType, maxInFlight int, testGateway string) *VTGate {
 	if rpcVTGate != nil {
 		log.Fatalf("VTGate already initialized")
 	}

--- a/go/vt/zktopo/vschema.go
+++ b/go/vt/zktopo/vschema.go
@@ -5,13 +5,9 @@
 package zktopo
 
 import (
-	"github.com/youtube/vitess/go/vt/vtgate/planbuilder"
-	"golang.org/x/net/context"
-	// vindexes needs to be imported so that they register
-	// themselves against vtgate/planbuilder. This will allow
-	// us to sanity check the schema being uploaded.
-	_ "github.com/youtube/vitess/go/vt/vtgate/vindexes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/zk"
+	"golang.org/x/net/context"
 	"launchpad.net/gozk/zookeeper"
 )
 
@@ -25,7 +21,7 @@ const (
 
 // SaveVSchema saves the JSON vschema into the topo.
 func (zkts *Server) SaveVSchema(ctx context.Context, vschema string) error {
-	_, err := planbuilder.NewVSchema([]byte(vschema))
+	_, err := vindexes.NewVSchema([]byte(vschema))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
@alainjobart 
This is the migration of the primitives into their own package.

* Pulling out the routing operations from the router was too tricky. So, I've left that part alone for now. I'm even wondering if it may be unnatural to pull that out. The IN clause function that converts input column values to per-shard maps is particularly hairy.
* Gateway didn't have the right level of abstraction. It was too low level, underneath ScatterConn.
* Looks like Router is actually using V1 (ScatterConn), not V2 (Resolver). But Resolver doesn't have the equivalent of ExecuteMulti. It has ExecuteEntityId, which is inconvenient for V3. 
* I considered going partial V1/V2, but I think that will cause more confusion. Eventually, I think we should look at extending Resolver to support everything that V3 needs.
* I ran into circular dependencies that got resolved by moving VSchema and Vindex into vindexes.
* Renamed a bunch of things and updated comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1601)
<!-- Reviewable:end -->
