### PR TITLE
automation: Retry vtworker commands when busy until cancelled.

### DIFF
--- a/go/cmd/vtworkerclient/vtworkerclient.go
+++ b/go/cmd/vtworkerclient/vtworkerclient.go
@@ -7,6 +7,8 @@ package main
 import (
 	"flag"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	log "github.com/golang/glog"
@@ -29,6 +31,13 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), *actionTimeout)
 	defer cancel()
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		s := <-sigChan
+		log.Errorf("Trying to cancel current command after receiving signal: %v", s)
+		cancel()
+	}()
 
 	logger := logutil.NewConsoleLogger()
 

--- a/go/vt/automation/scheduler_test.go
+++ b/go/vt/automation/scheduler_test.go
@@ -76,8 +76,8 @@ func waitForClusterOperation(t *testing.T, scheduler *Scheduler, id string, expe
 				}
 			}
 			if expectedOutputLastTask != "" {
-				if got := lastTc.ParallelTasks[len(lastTc.ParallelTasks)-1].Output; got != expectedOutputLastTask {
-					t.Fatalf("ClusterOperation finished but did not return expected output. got: %v want: %v Full ClusterOperation details: %v", got, expectedOutputLastTask, proto.MarshalTextString(getDetailsResponse.ClusterOp))
+				if got := lastTc.ParallelTasks[len(lastTc.ParallelTasks)-1].Output; !strings.Contains(got, expectedOutputLastTask) {
+					t.Fatalf("ClusterOperation finished but did not contain expected output. got: %v want: %v Full ClusterOperation details: %v", got, expectedOutputLastTask, proto.MarshalTextString(getDetailsResponse.ClusterOp))
 				}
 			}
 			if expectedErrorLastTask != "" {

--- a/go/vt/automation/vtworkerclient_wrapper.go
+++ b/go/vt/automation/vtworkerclient_wrapper.go
@@ -7,14 +7,25 @@ package automation
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	log "github.com/golang/glog"
 
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 	"golang.org/x/net/context"
 )
 
-// ExecuteVtworker runs vtworker using vtworkerclient. The stream of LoggerEvent messages is concatenated into one output string.
+const retryInterval time.Duration = 5 * time.Second
+
+// ExecuteVtworker executes the vtworker command in "args" via an RPC to
+// "server".
+// The output of the RPC, a stream of LoggerEvent messages, is concatenated into
+// one output string.
+// If a retryable error is encountered (e.g. the vtworker process is already
+// executing another command), this function will keep retrying infinitely until
+// "ctx" is cancelled.
 func ExecuteVtworker(ctx context.Context, server string, args []string) (string, error) {
 	var output bytes.Buffer
 	loggerToBufferFunc := createLoggerEventToBufferFunction(&output)
@@ -23,13 +34,63 @@ func ExecuteVtworker(ctx context.Context, server string, args []string) (string,
 	startMsg := fmt.Sprintf("Executing remote vtworker command: %v server: %v", args, server)
 	outputLogger.Infof(startMsg)
 	log.Info(startMsg)
-	err := vtworkerclient.RunCommandAndWait(
-		ctx, server, args,
-		CreateLoggerEventToBufferFunction(&output))
+
+	var err error
+	var loggedRetryStart bool
+	var retryStart time.Time
+	for {
+		err = vtworkerclient.RunCommandAndWait(
+			ctx, server, args,
+			loggerToBufferFunc)
+		if err == nil {
+			break
+		}
+
+		if !isRetryable(err) {
+			break
+		}
+
+		if !loggedRetryStart {
+			loggedRetryStart = true
+			retryStart = time.Now()
+			retryStartMsg := fmt.Sprintf("vtworker responded with a retryable error (%v). keeping retrying every %.0f seconds until cancelled.", err, retryInterval.Seconds())
+			outputLogger.Infof(retryStartMsg)
+			log.Info(retryStartMsg)
+		}
+
+		// Sleep until the next retry.
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			// Context is up. The next retry should result in a non-retryable error.
+			timer.Stop()
+		case <-timer.C:
+		}
+	} // retry loop
+
+	if loggedRetryStart {
+		// Log end of retrying explicitly as well.
+		d := time.Now().Sub(retryStart)
+		retryEndMsg := fmt.Sprintf("Stopped retrying after %.1f seconds.", d.Seconds())
+		outputLogger.Infof(retryEndMsg)
+		log.Info(retryEndMsg)
+	}
+
 	endMsg := fmt.Sprintf("Executed remote vtworker command: %v server: %v err: %v", args, server, err)
 	outputLogger.Infof(endMsg)
 	// Log full output to log file (but not to the buffer).
 	log.Infof("%v output (starting on next line):\n%v", endMsg, output.String())
 
 	return output.String(), err
+}
+
+// TODO(mberlin): Discuss with the team if it should go to the vterrors package.
+// TODO(mberlin): Add other error codes here as well?
+func isRetryable(err error) bool {
+	switch vterrors.RecoverVtErrorCode(err) {
+	case vtrpcpb.ErrorCode_TRANSIENT_ERROR:
+		return true
+	default:
+		return false
+	}
 }

--- a/go/vt/proto/vtrpc/vtrpc.pb.go
+++ b/go/vt/proto/vtrpc/vtrpc.pb.go
@@ -33,10 +33,10 @@ const _ = proto.ProtoPackageIsVersion1
 type ErrorCode int32
 
 const (
-	// SUCCESS is returned from a successful call
+	// SUCCESS is returned from a successful call.
 	ErrorCode_SUCCESS ErrorCode = 0
 	// CANCELLED means that the context was cancelled (and noticed in the app layer,
-	// as opposed to the RPC layer)
+	// as opposed to the RPC layer).
 	ErrorCode_CANCELLED ErrorCode = 1
 	// UNKNOWN_ERROR includes:
 	// 1. MySQL error codes that we don't explicitly handle.
@@ -50,7 +50,7 @@ const (
 	// DEADLINE_EXCEEDED is returned when an action is taking longer than a given timeout.
 	ErrorCode_DEADLINE_EXCEEDED ErrorCode = 4
 	// INTEGRITY_ERROR is returned on integrity error from MySQL, usually due to
-	// duplicate primary keys
+	// duplicate primary keys.
 	ErrorCode_INTEGRITY_ERROR ErrorCode = 5
 	// PERMISSION_DENIED errors are returned when a user requests access to something
 	// that they don't have permissions for.
@@ -82,8 +82,8 @@ const (
 	// Examples of scenarios where INTERNAL_ERROR is returned:
 	//  1. Something is not configured correctly internally.
 	//  2. A necessary resource is not available, and we don't expect it to become available by itself.
-	//  3. A sanity check fails
-	//  4. Some other internal error occurs
+	//  3. A sanity check fails.
+	//  4. Some other internal error occurs.
 	// Clients should not retry immediately, as there is little chance of success.
 	// However, it's acceptable for retries to happen internally, for example to
 	// multiple backends, in case only a subset of backend are not functional.

--- a/go/vt/vterrors/grpc.go
+++ b/go/vt/vterrors/grpc.go
@@ -23,7 +23,7 @@ import (
 // See: https://github.com/grpc/grpc-go/issues/319
 const GRPCServerErrPrefix = "gRPCServerError:"
 
-// GRPCCodeToErrorCode maps a gRPC codes.Code to a vtrpcpb.ErrorCode
+// GRPCCodeToErrorCode maps a gRPC codes.Code to a vtrpcpb.ErrorCode.
 func GRPCCodeToErrorCode(code codes.Code) vtrpcpb.ErrorCode {
 	switch code {
 	case codes.OK:
@@ -57,7 +57,7 @@ func GRPCCodeToErrorCode(code codes.Code) vtrpcpb.ErrorCode {
 	}
 }
 
-// ErrorCodeToGRPCCode maps a vtrpcpb.ErrorCode to a gRPC codes.Code
+// ErrorCodeToGRPCCode maps a vtrpcpb.ErrorCode to a gRPC codes.Code.
 func ErrorCodeToGRPCCode(code vtrpcpb.ErrorCode) codes.Code {
 	switch code {
 	case vtrpcpb.ErrorCode_SUCCESS:
@@ -99,7 +99,7 @@ func toGRPCCode(err error) codes.Code {
 	if vtErr, ok := err.(VtError); ok {
 		return ErrorCodeToGRPCCode(vtErr.VtErrorCode())
 	}
-	// Returns the underlying grpc Code, or codes.Unknown if one doesn't exist
+	// Returns the underlying gRPC Code, or codes.Unknown if one doesn't exist.
 	return grpc.Code(err)
 }
 
@@ -118,7 +118,7 @@ func truncateError(err error) error {
 	return fmt.Errorf("%v %v", truncatedErr, truncateInfo)
 }
 
-// ToGRPCError returns an error as a grpc error, with the appropriate error code
+// ToGRPCError returns an error as a gRPC error, with the appropriate error code.
 func ToGRPCError(err error) error {
 	if err == nil {
 		return nil
@@ -126,7 +126,7 @@ func ToGRPCError(err error) error {
 	return grpc.Errorf(toGRPCCode(err), "%v %v", GRPCServerErrPrefix, truncateError(err))
 }
 
-// FromGRPCError return a grpc error as a VitessError, translating between error codes
+// FromGRPCError returns a gRPC error as a VitessError, translating between error codes.
 func FromGRPCError(err error) error {
 	if err == nil {
 		return nil

--- a/go/vt/vterrors/proto3.go
+++ b/go/vt/vterrors/proto3.go
@@ -10,7 +10,7 @@ import (
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
-// This files contains the necessary methods to send and receive errors
+// This file contains the necessary methods to send and receive errors
 // as payloads of proto3 structures. It converts VitessError to and from
 // vtrpcpb.Error. Use these methods when a RPC call can return both
 // data and an error.
@@ -27,7 +27,7 @@ func FromVtRPCError(rpcErr *vtrpcpb.RPCError) error {
 	}
 }
 
-// VtRPCErrorFromVtError convert from a VtError to a vtrpcpb.RPCError
+// VtRPCErrorFromVtError converts from a VtError to a vtrpcpb.RPCError.
 func VtRPCErrorFromVtError(err error) *vtrpcpb.RPCError {
 	if err == nil {
 		return nil

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -75,6 +75,19 @@ func (e *VitessError) AsString() string {
 	return fmt.Sprintf("Code: %v, err: %v", e.Code, e.err)
 }
 
+// FromError returns a VitessError with the supplied error code by wrapping an
+// existing error.
+// Use this method also when you want to create a VitessError without a custom
+// message. For example:
+//	 err := vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR,
+//     errors.New("no valid endpoint"))
+func FromError(code vtrpcpb.ErrorCode, err error) error {
+	return &VitessError{
+		Code: code,
+		err:  err,
+	}
+}
+
 // NewVitessError returns a VitessError backed error with the given arguments.
 // Useful for preserving an underlying error while creating a new error message.
 func NewVitessError(code vtrpcpb.ErrorCode, err error, format string, args ...interface{}) error {
@@ -82,15 +95,6 @@ func NewVitessError(code vtrpcpb.ErrorCode, err error, format string, args ...in
 		Code:    code,
 		Message: fmt.Sprintf(format, args...),
 		err:     err,
-	}
-}
-
-// FromError returns a VitessError with the supplied error code by wrapping an
-// existing error.
-func FromError(code vtrpcpb.ErrorCode, err error) error {
-	return &VitessError{
-		Code: code,
-		err:  err,
 	}
 }
 

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -14,7 +14,7 @@ import (
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
-// ConcatenateErrors aggregates an array of errors into a single error by string concatenation
+// ConcatenateErrors aggregates an array of errors into a single error by string concatenation.
 func ConcatenateErrors(errors []error) error {
 	errStrs := make([]string, 0, len(errors))
 	for _, e := range errors {
@@ -25,12 +25,12 @@ func ConcatenateErrors(errors []error) error {
 	return fmt.Errorf("%v", strings.Join(errStrs, "\n"))
 }
 
-// VtError is implemented by any type that exposes a vtrpcpb.ErrorCode
+// VtError is implemented by any type that exposes a vtrpcpb.ErrorCode.
 type VtError interface {
 	VtErrorCode() vtrpcpb.ErrorCode
 }
 
-// RecoverVtErrorCode attempts to recover a vtrpcpb.ErrorCode from an error
+// RecoverVtErrorCode attempts to recover a vtrpcpb.ErrorCode from an error.
 func RecoverVtErrorCode(err error) vtrpcpb.ErrorCode {
 	if vtErr, ok := err.(VtError); ok {
 		return vtErr.VtErrorCode()
@@ -38,9 +38,9 @@ func RecoverVtErrorCode(err error) vtrpcpb.ErrorCode {
 	return vtrpcpb.ErrorCode_UNKNOWN_ERROR
 }
 
-// VitessError is the error type that we use internally for passing structured errors
+// VitessError is the error type that we use internally for passing structured errors.
 type VitessError struct {
-	// Error code of the Vitess error
+	// Error code of the Vitess error.
 	Code vtrpcpb.ErrorCode
 	// Error message that should be returned. This allows us to change an error message
 	// without losing the underlying error. For example, if you have an error like
@@ -62,7 +62,7 @@ func (e *VitessError) Error() string {
 	return e.Message
 }
 
-// VtErrorCode returns the underlying Vitess error code
+// VtErrorCode returns the underlying Vitess error code.
 func (e *VitessError) VtErrorCode() vtrpcpb.ErrorCode {
 	return e.Code
 }

--- a/go/vt/worker/block.go
+++ b/go/vt/worker/block.go
@@ -1,0 +1,87 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package worker
+
+import (
+	"html/template"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/wrangler"
+)
+
+// BlockWorker will block infinitely until its context is cancelled.
+type BlockWorker struct {
+	StatusWorker
+
+	// We use the Wrangler's logger to print the message.
+	wr *wrangler.Wrangler
+}
+
+// NewBlockWorker returns a new BlockWorker object.
+func NewBlockWorker(wr *wrangler.Wrangler) (Worker, error) {
+	return &BlockWorker{
+		StatusWorker: NewStatusWorker(),
+		wr:           wr,
+	}, nil
+}
+
+// StatusAsHTML implements the Worker interface.
+func (bw *BlockWorker) StatusAsHTML() template.HTML {
+	bw.Mu.Lock()
+	defer bw.Mu.Unlock()
+	result := "<b>Block Command</b> (blocking infinitely until context is cancelled)</br>\n"
+	result += "<b>State:</b> " + bw.State.String() + "</br>\n"
+	switch bw.State {
+	case WorkerStateCopy:
+		result += "<b>Running (blocking)</b></br>\n"
+	case WorkerStateDone:
+		result += "<b>Success (unblocked)</b></br>\n"
+	}
+
+	return template.HTML(result)
+}
+
+// StatusAsText implements the Worker interface.
+func (bw *BlockWorker) StatusAsText() string {
+	bw.Mu.Lock()
+	defer bw.Mu.Unlock()
+	result := "Block Command\n"
+	result += "State: " + bw.State.String() + "\n"
+	switch bw.State {
+	case WorkerStateCopy:
+		result += "Running (blocking)\n"
+	case WorkerStateDone:
+		result += "Success (unblocked)\n"
+	}
+	return result
+}
+
+// Run implements the Worker interface.
+func (bw *BlockWorker) Run(ctx context.Context) error {
+	resetVars()
+	err := bw.run(ctx)
+
+	bw.SetState(WorkerStateCleanUp)
+	if err != nil {
+		bw.SetState(WorkerStateError)
+		return err
+	}
+	bw.SetState(WorkerStateDone)
+	return nil
+}
+
+func (bw *BlockWorker) run(ctx context.Context) error {
+	// We reuse the Copy state to reflect that the blocking is in progress.
+	bw.SetState(WorkerStateCopy)
+	bw.wr.Logger().Printf("Block command was called and will block infinitely until the RPC context is cancelled.\n")
+	select {
+	case <-ctx.Done():
+	}
+	bw.wr.Logger().Printf("Block command finished because the context is done: '%v'.\n", ctx.Err())
+	bw.SetState(WorkerStateDone)
+
+	return nil
+}

--- a/go/vt/worker/block_cmd.go
+++ b/go/vt/worker/block_cmd.go
@@ -1,0 +1,75 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package worker
+
+import (
+	"flag"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/youtube/vitess/go/vt/wrangler"
+	"golang.org/x/net/context"
+)
+
+const blockHTML = `
+<!DOCTYPE html>
+<head>
+  <title>Block Action</title>
+</head>
+<body>
+  <h1>Block Action</h1>
+
+    {{if .Error}}
+      <b>Error:</b> {{.Error}}</br>
+    {{else}}
+	    <form action="/Debugging/Block" method="post">
+	      <INPUT type="submit" name="submit" value="Block (until cancelled)"/>
+    </form>
+    {{end}}
+</body>
+`
+
+var blockTemplate = mustParseTemplate("block", blockHTML)
+
+func commandBlock(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
+	if err := subFlags.Parse(args); err != nil {
+		return nil, err
+	}
+	if subFlags.NArg() != 0 {
+		subFlags.Usage()
+		return nil, fmt.Errorf("command Block does not accept any parameter")
+	}
+
+	worker, err := NewBlockWorker(wr)
+	if err != nil {
+		return nil, fmt.Errorf("Could not create Block worker: %v", err)
+	}
+	return worker, nil
+}
+
+func interactiveBlock(ctx context.Context, wi *Instance, wr *wrangler.Wrangler, w http.ResponseWriter, r *http.Request) (Worker, *template.Template, map[string]interface{}, error) {
+	if err := r.ParseForm(); err != nil {
+		return nil, nil, nil, fmt.Errorf("Cannot parse form: %s", err)
+	}
+
+	if submit := r.FormValue("submit"); submit == "" {
+		result := make(map[string]interface{})
+		return nil, blockTemplate, result, nil
+	}
+
+	wrk, err := NewBlockWorker(wr)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Could not create Block worker: %v", err)
+	}
+	return wrk, nil, nil, nil
+}
+
+func init() {
+	AddCommand("Debugging", Command{"Block",
+		commandBlock, interactiveBlock,
+		"<message>",
+		"For internal tests only. When triggered, the command will block until cancelled."})
+}

--- a/go/vt/worker/command.go
+++ b/go/vt/worker/command.go
@@ -105,9 +105,15 @@ func commandWorker(wi *Instance, wr *wrangler.Wrangler, args []string, cell stri
 // If you pass a wr wrangler, note that a MemoryLogger will be added to its current logger.
 // The returned worker and done channel may be nil if no worker was started e.g. in case of a "Reset".
 func (wi *Instance) RunCommand(args []string, wr *wrangler.Wrangler, runFromCli bool) (Worker, chan struct{}, error) {
-	if len(args) >= 1 && args[0] == "Reset" {
-		err := wi.Reset()
-		return nil, nil, err
+	if len(args) >= 1 {
+		switch args[0] {
+		case "Reset":
+			err := wi.Reset()
+			return nil, nil, err
+		case "Cancel":
+			wi.Cancel()
+			return nil, nil, nil
+		}
 	}
 
 	if wr == nil {

--- a/go/vt/worker/command.go
+++ b/go/vt/worker/command.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/wrangler"
 )
 
@@ -125,7 +126,7 @@ func (wi *Instance) RunCommand(args []string, wr *wrangler.Wrangler, runFromCli 
 	}
 	done, err := wi.setAndStartWorker(wrk, wr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("cannot set worker: %v", err)
+		return nil, nil, vterrors.WithPrefix("cannot set worker: ", err)
 	}
 	return wrk, done, nil
 }

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -57,7 +58,7 @@ type eventStreamAdapter struct {
 func (e *eventStreamAdapter) Recv() (*logutilpb.Event, error) {
 	le, err := e.stream.Recv()
 	if err != nil {
-		return nil, err
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return le.Event, nil
 }
@@ -70,7 +71,7 @@ func (client *gRPCVtworkerClient) ExecuteVtworkerCommand(ctx context.Context, ar
 
 	stream, err := client.c.ExecuteVtworkerCommand(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return &eventStreamAdapter{stream}, nil
 }

--- a/go/vt/worker/grpcvtworkerclient/client_test.go
+++ b/go/vt/worker/grpcvtworkerclient/client_test.go
@@ -40,5 +40,5 @@ func TestVtworkerServer(t *testing.T) {
 	}
 	defer client.Close()
 
-	vtworkerclienttest.TestSuite(t, wi, client)
+	vtworkerclienttest.TestSuite(t, client)
 }

--- a/go/vt/worker/grpcvtworkerserver/server.go
+++ b/go/vt/worker/grpcvtworkerserver/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/worker"
 
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
@@ -60,7 +61,7 @@ func (s *VtworkerServer) ExecuteVtworkerCommand(args *vtworkerdatapb.ExecuteVtwo
 		err = s.wi.WaitForCommand(worker, done)
 	}
 
-	return err
+	return vterrors.ToGRPCError(err)
 }
 
 // StartServer registers the VtworkerServer for RPCs

--- a/go/vt/worker/instance.go
+++ b/go/vt/worker/instance.go
@@ -149,3 +149,22 @@ func (wi *Instance) Reset() error {
 
 	return errors.New("worker still executing")
 }
+
+// Cancel calls the cancel function of the current vtworker job.
+// It returns true, if a job was running. False otherwise.
+// NOTE: Cancel won't reset the state as well. Use Reset() to do so.
+func (wi *Instance) Cancel() bool {
+	wi.currentWorkerMutex.Lock()
+
+	if wi.currentWorker == nil || wi.currentCancelFunc == nil {
+		wi.currentWorkerMutex.Unlock()
+		return false
+	}
+
+	cancel := wi.currentCancelFunc
+	wi.currentWorkerMutex.Unlock()
+
+	cancel()
+
+	return true
+}

--- a/go/vt/worker/instance.go
+++ b/go/vt/worker/instance.go
@@ -15,8 +15,10 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/logutil"
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"golang.org/x/net/context"
 )
@@ -69,8 +71,10 @@ func (wi *Instance) CreateWrangler(logger logutil.Logger) *wrangler.Wrangler {
 func (wi *Instance) setAndStartWorker(wrk Worker, wr *wrangler.Wrangler) (chan struct{}, error) {
 	wi.currentWorkerMutex.Lock()
 	defer wi.currentWorkerMutex.Unlock()
+
 	if wi.currentWorker != nil {
-		return nil, fmt.Errorf("A worker is already in progress: %v", wi.currentWorker)
+		return nil, vterrors.FromError(vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+			fmt.Errorf("A worker job is already in progress: %v", wi.currentWorker))
 	}
 
 	wi.currentWorker = wrk

--- a/go/vt/worker/status.go
+++ b/go/vt/worker/status.go
@@ -121,20 +121,12 @@ func (wi *Instance) InitStatusHandling() {
 			return
 		}
 
-		wi.currentWorkerMutex.Lock()
-
-		// no worker, or not running, we go to the menu
-		if wi.currentWorker == nil || wi.currentCancelFunc == nil {
-			wi.currentWorkerMutex.Unlock()
+		if wi.Cancel() {
+			// We cancelled the running worker. Go back to the status page.
+			http.Redirect(w, r, servenv.StatusURLPath(), http.StatusTemporaryRedirect)
+		} else {
+			// No worker, or not running, we go to the menu.
 			http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
-			return
 		}
-
-		// otherwise, cancel the running worker and go back to the status page
-		cancel := wi.currentCancelFunc
-		wi.currentWorkerMutex.Unlock()
-		cancel()
-		http.Redirect(w, r, servenv.StatusURLPath(), http.StatusTemporaryRedirect)
-
 	})
 }

--- a/go/vt/worker/status.go
+++ b/go/vt/worker/status.go
@@ -73,6 +73,7 @@ func (wi *Instance) InitStatusHandling() {
 		logger := wi.currentMemoryLogger
 		ctx := wi.currentContext
 		err := wi.lastRunError
+		stopTime := wi.lastRunStopTime
 		wi.currentWorkerMutex.Unlock()
 
 		data := make(map[string]interface{})
@@ -83,6 +84,7 @@ func (wi *Instance) InitStatusHandling() {
 				if err != nil {
 					status += template.HTML(fmt.Sprintf("<br>\nEnded with an error: %v<br>\n", err))
 				}
+				status += template.HTML(fmt.Sprintf("<br>\n<b>End Time:</b> %v<br>\n", stopTime))
 			}
 			data["Status"] = status
 			if logger != nil {

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -47,8 +47,8 @@ func CreateWorkerInstance(t *testing.T) *worker.Instance {
 	return worker.NewInstance(context.Background(), ts, "cell1", 1*time.Second)
 }
 
-// TestSuite runs the test suite on the given vtworker and vtworkerclient
-func TestSuite(t *testing.T, wi *worker.Instance, c vtworkerclient.Client) {
+// TestSuite runs the test suite on the given vtworker and vtworkerclient.
+func TestSuite(t *testing.T, c vtworkerclient.Client) {
 	commandSucceeds(t, c)
 
 	commandErrors(t, c)

--- a/proto/vtrpc.proto
+++ b/proto/vtrpc.proto
@@ -37,11 +37,11 @@ message CallerID {
 // be created with one of these codes. These will then be translated over the wire
 // by various RPC frameworks.
 enum ErrorCode {
-  // SUCCESS is returned from a successful call
+  // SUCCESS is returned from a successful call.
   SUCCESS = 0;
 
   // CANCELLED means that the context was cancelled (and noticed in the app layer,
-  // as opposed to the RPC layer)
+  // as opposed to the RPC layer).
   CANCELLED = 1;
 
   // UNKNOWN_ERROR includes:
@@ -59,7 +59,7 @@ enum ErrorCode {
   DEADLINE_EXCEEDED = 4;
 
   // INTEGRITY_ERROR is returned on integrity error from MySQL, usually due to
-  // duplicate primary keys
+  // duplicate primary keys.
   INTEGRITY_ERROR = 5;
 
   // PERMISSION_DENIED errors are returned when a user requests access to something
@@ -96,8 +96,8 @@ enum ErrorCode {
   // Examples of scenarios where INTERNAL_ERROR is returned:
   //  1. Something is not configured correctly internally.
   //  2. A necessary resource is not available, and we don't expect it to become available by itself.
-  //  3. A sanity check fails
-  //  4. Some other internal error occurs
+  //  3. A sanity check fails.
+  //  4. Some other internal error occurs.
   // Clients should not retry immediately, as there is little chance of success.
   // However, it's acceptable for retries to happen internally, for example to
   // multiple backends, in case only a subset of backend are not functional.


### PR DESCRIPTION
@alainjobart 

I recommend to review this change one commit at a time.

This change is required to parallelize vtworker commands in the automation when we have more pending vtworker commands than vtworker processes. Using this simple retry mechanism all commands will be processed eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1607)
<!-- Reviewable:end -->
