### PR TITLE
vterrors: New call IsEOF() to support wrapped io.EOF errors.

### DIFF
--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -79,7 +79,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"sort"
@@ -101,6 +100,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/topotools"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/wrangler"
 
 	replicationdatapb "github.com/youtube/vitess/go/vt/proto/replicationdata"
@@ -993,14 +993,13 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 	}
 	for {
 		e, err := stream.Recv()
-		switch err {
-		case nil:
-			logutil.LogEvent(wr.Logger(), e)
-		case io.EOF:
-			return nil
-		default:
+		if err != nil {
+			if vterrors.IsEOF(err) {
+				return nil
+			}
 			return err
 		}
+		logutil.LogEvent(wr.Logger(), e)
 	}
 }
 

--- a/go/vt/vtctl/vtctlclient/wrapper.go
+++ b/go/vt/vtctl/vtctlclient/wrapper.go
@@ -7,12 +7,12 @@ package vtctlclient
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"golang.org/x/net/context"
 
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 // RunCommandAndWait executes a single command on a given vtctld and blocks until the command did return or timed out.
@@ -40,13 +40,12 @@ func RunCommandAndWait(ctx context.Context, server string, args []string, dialTi
 	// stream the result
 	for {
 		e, err := stream.Recv()
-		switch err {
-		case nil:
-			recv(e)
-		case io.EOF:
-			return nil
-		default:
+		if err != nil {
+			if vterrors.IsEOF(err) {
+				return nil
+			}
 			return fmt.Errorf("Remote error: %v", err)
 		}
+		recv(e)
 	}
 }

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -8,6 +8,7 @@ package vterrors
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -36,6 +37,18 @@ func RecoverVtErrorCode(err error) vtrpcpb.ErrorCode {
 		return vtErr.VtErrorCode()
 	}
 	return vtrpcpb.ErrorCode_UNKNOWN_ERROR
+}
+
+// IsEOF returns true if "err" equals io.EOF.
+// In case of a VitessError, the wrapped err is checked instead.
+func IsEOF(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+	if vtErr, ok := err.(*VitessError); ok {
+		return vtErr.err == io.EOF
+	}
+	return false
 }
 
 // VitessError is the error type that we use internally for passing structured errors

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -44,6 +45,7 @@ type eventStreamAdapter struct {
 func (e *eventStreamAdapter) Recv() (*logutilpb.Event, error) {
 	le, err := e.stream.Recv()
 	if err != nil {
+		err := vterrors.FromGRPCError(err)
 		return nil, err
 	}
 	return le.Event, nil
@@ -57,7 +59,7 @@ func (client *gRPCVtworkerClient) ExecuteVtworkerCommand(ctx context.Context, ar
 
 	stream, err := client.c.ExecuteVtworkerCommand(ctx, query)
 	if err != nil {
-		return nil, err
+		return nil, vterrors.FromGRPCError(err)
 	}
 	return &eventStreamAdapter{stream}, nil
 }

--- a/go/vt/worker/vtworkerclient/wrapper.go
+++ b/go/vt/worker/vtworkerclient/wrapper.go
@@ -7,12 +7,12 @@ package vtworkerclient
 import (
 	"errors"
 	"fmt"
-	"io"
 	"time"
 
 	"golang.org/x/net/context"
 
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 // RunCommandAndWait executes a single command on a given vtworker and blocks until the command did return or timed out.
@@ -38,13 +38,12 @@ func RunCommandAndWait(ctx context.Context, server string, args []string, recv f
 
 	for {
 		e, err := stream.Recv()
-		switch err {
-		case nil:
-			recv(e)
-		case io.EOF:
-			return nil
-		default:
+		if err != nil {
+			if vterrors.IsEOF(err) {
+				return nil
+			}
 			return fmt.Errorf("Remote error: %v", err)
 		}
+		recv(e)
 	}
 }

--- a/go/vt/worker/vtworkerclienttest/client_testsuite.go
+++ b/go/vt/worker/vtworkerclienttest/client_testsuite.go
@@ -75,15 +75,10 @@ func commandSucceeds(t *testing.T, client vtworkerclient.Client) {
 		t.Fatalf("Cannot execute remote command: %v", err)
 	}
 	for {
-		_, err := stream.Recv()
-		switch err {
-		case nil:
-			// next please!
-		case io.EOF:
-			// done with test
-			return
-		default:
-			// unexpected error
+		if _, err := stream.Recv(); err != nil {
+			if vterrors.IsEOF(err) {
+				return
+			}
 			t.Fatalf("Cannot execute remote command: %v", err)
 		}
 	}

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -7,7 +7,6 @@ package testlib
 import (
 	"flag"
 	"fmt"
-	"io"
 	"net"
 	"testing"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctl/grpcvtctlserver"
 	"github.com/youtube/vitess/go/vt/vtctl/vtctlclient"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"golang.org/x/net/context"
 
 	// we need to import the grpcvtctlclient library so the gRPC
@@ -85,9 +85,10 @@ func (vp *VtctlPipe) Run(args []string) error {
 		switch err {
 		case nil:
 			vp.t.Logf(logutil.EventString(le))
-		case io.EOF:
-			return nil
 		default:
+			if vterrors.IsEOF(err) {
+				return nil
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
@aaijazi @alainjobart 

This is an alternative proposal to the commit: https://github.com/youtube/vitess/pull/1607/commits/18ca616ca34f91ce588ff750b6458b0f406d0342

Please comment which approach you prefer.

The general problem is that our streaming RPC client implementations wrap all RPC errors to VitessError except io.EOF because we check against it to find out if a stream has finished.

Unfortunately, this special case is currently spread out in each client implementation and it looks like this ( e.g. grpcvtgateconn/conn.go):
```
		if err != io.EOF {
			err = vterrors.FromGRPCError(err)
		}
```

This is error prone when we write code for new streaming RPCs or convert existing code to vterrors.FromGRPCError(). I actually ran into this problem.

I see three solutions:
1. keep things as they are
2. move the special handling into vterrors.FromGRPCError() (see the referenced commit above)
3. provide a special function "IsEOF" and always use that instead of "err == io.EOF". (this pull request)

Please comment which solution you prefer. I'm currently tending to 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1608)
<!-- Reviewable:end -->
