### PR TITLE
Add master_buffering to test/config.json

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -127,6 +127,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"master_buffering": {
+			"File": "master_buffering_test.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 1,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
 			"Args": [],


### PR DESCRIPTION
@enisoc 

I added it in alphabetical order, and checked a few Travis runs to see which shard was the least loaded - they generally seems pretty evenly loaded, so I picked shard 1 based on a couple of skewed runs that I saw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1621)
<!-- Reviewable:end -->
