### PR TITLE
Removing transactionID from client side interface.

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -280,7 +280,7 @@ func (a *streamExecuteAdapter) Recv() (*sqltypes.Result, error) {
 
 // StreamExecute is part of tabletconn.TabletConn
 // We need to copy the bind variables as tablet server will change them.
-func (itc *internalTabletConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (itc *internalTabletConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	bv, err := querytypes.BindVariablesToProto3(bindVars)
 	if err != nil {
 		return nil, err

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -323,7 +323,7 @@ func (fc *fakeConn) ExecuteBatch2(ctx context.Context, queries []querytypes.Boun
 }
 
 // StreamExecute implements tabletconn.TabletConn.
-func (fc *fakeConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (fc *fakeConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/go/vt/tabletmanager/binlog_players_test.go
+++ b/go/vt/tabletmanager/binlog_players_test.go
@@ -139,7 +139,7 @@ func (ftc *fakeTabletConn) ExecuteBatch(ctx context.Context, queries []querytype
 }
 
 // StreamExecute is part of the TabletConn interface
-func (ftc *fakeTabletConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (ftc *fakeTabletConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	return nil, fmt.Errorf("not implemented in this test")
 }
 

--- a/go/vt/tabletserver/grpctabletconn/conn.go
+++ b/go/vt/tabletserver/grpctabletconn/conn.go
@@ -173,7 +173,7 @@ func (a *streamExecuteAdapter) Recv() (*sqltypes.Result, error) {
 }
 
 // StreamExecute starts a streaming query to VTTablet.
-func (conn *gRPCQueryClient) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (conn *gRPCQueryClient) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	conn.mu.RLock()
 	defer conn.mu.RUnlock()
 	if conn.cc == nil {

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -94,7 +94,7 @@ type TabletConn interface {
 	// error is non-nil, it means that the StreamExecute failed to
 	// send the request. Otherwise, you can pull values from the
 	// ResultStream until io.EOF, or any other error.
-	StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionId int64) (sqltypes.ResultStream, error)
+	StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error)
 
 	// Transaction support
 	Begin(ctx context.Context) (transactionId int64, err error)

--- a/go/vt/tabletserver/tabletconntest/tabletconntest.go
+++ b/go/vt/tabletserver/tabletconntest/tabletconntest.go
@@ -382,8 +382,6 @@ var streamExecuteBindVars = map[string]interface{}{
 	"bind1": int64(93848000),
 }
 
-const streamExecuteTransactionID int64 = 6789992
-
 var streamExecuteQueryResult1 = sqltypes.Result{
 	Fields: []*querypb.Field{
 		{
@@ -413,7 +411,7 @@ var streamExecuteQueryResult2 = sqltypes.Result{
 func testStreamExecute(t *testing.T, conn tabletconn.TabletConn) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars, streamExecuteTransactionID)
+	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
 	if err != nil {
 		t.Fatalf("StreamExecute failed: %v", err)
 	}
@@ -446,7 +444,7 @@ func testStreamExecute(t *testing.T, conn tabletconn.TabletConn) {
 func testStreamExecuteError(t *testing.T, conn tabletconn.TabletConn, fake *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars, streamExecuteTransactionID)
+	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
 	if err != nil {
 		t.Fatalf("StreamExecute failed: %v", err)
 	}
@@ -477,7 +475,7 @@ func testStreamExecutePanics(t *testing.T, conn tabletconn.TabletConn, fake *Fak
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	fake.streamExecutePanicsEarly = true
-	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars, streamExecuteTransactionID)
+	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
 	if err != nil {
 		if !strings.Contains(err.Error(), "caught test panic") {
 			t.Fatalf("unexpected panic error: %v", err)
@@ -491,7 +489,7 @@ func testStreamExecutePanics(t *testing.T, conn tabletconn.TabletConn, fake *Fak
 
 	// late panic is after sending Fields
 	fake.streamExecutePanicsEarly = false
-	stream, err = conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars, streamExecuteTransactionID)
+	stream, err = conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
 	if err != nil {
 		t.Fatalf("StreamExecute failed: %v", err)
 	}

--- a/go/vt/vtgate/discoverygateway.go
+++ b/go/vt/vtgate/discoverygateway.go
@@ -121,15 +121,15 @@ func (dg *discoveryGateway) ExecuteBatch(ctx context.Context, keyspace, shard st
 }
 
 // StreamExecute executes a streaming query for the specified keyspace, shard, and tablet type.
-func (dg *discoveryGateway) StreamExecute(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (dg *discoveryGateway) StreamExecute(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	var usedConn tabletconn.TabletConn
 	var stream sqltypes.ResultStream
 	err := dg.withRetry(ctx, keyspace, shard, tabletType, func(conn tabletconn.TabletConn) error {
 		var err error
-		stream, err = conn.StreamExecute(ctx, query, bindVars, transactionID)
+		stream, err = conn.StreamExecute(ctx, query, bindVars)
 		usedConn = conn
 		return err
-	}, transactionID, true)
+	}, 0, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/discoverygateway_test.go
+++ b/go/vt/vtgate/discoverygateway_test.go
@@ -43,11 +43,7 @@ func TestDiscoveryGatewayExecuteBatch(t *testing.T) {
 
 func TestDiscoveryGatewayExecuteStream(t *testing.T) {
 	testDiscoveryGatewayGeneric(t, true, func(dg Gateway, keyspace, shard string, tabletType topodatapb.TabletType) error {
-		_, err := dg.StreamExecute(context.Background(), keyspace, shard, tabletType, "query", nil, 0)
-		return err
-	})
-	testDiscoveryGatewayTransact(t, true, func(dg Gateway, keyspace, shard string, tabletType topodatapb.TabletType) error {
-		_, err := dg.StreamExecute(context.Background(), keyspace, shard, tabletType, "query", nil, 1)
+		_, err := dg.StreamExecute(context.Background(), keyspace, shard, tabletType, "query", nil)
 		return err
 	})
 }

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -41,7 +41,7 @@ type Gateway interface {
 	ExecuteBatch(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error)
 
 	// StreamExecute executes a streaming query for the specified keyspace, shard, and tablet type.
-	StreamExecute(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error)
+	StreamExecute(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error)
 
 	// Begin starts a transaction for the specified keyspace, shard, and tablet type.
 	// It returns the transaction ID.

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -489,7 +489,7 @@ func (a *streamExecuteAdapter) Recv() (*sqltypes.Result, error) {
 	return a.result, nil
 }
 
-func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	sbc.ExecCount.Add(1)
 	bv := make(map[string]interface{})
 	for k, v := range bindVars {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -381,7 +381,7 @@ func (stc *ScatterConn) StreamExecute(
 		NewSafeSession(nil),
 		false,
 		func(shard string, transactionID int64) error {
-			stream, err := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, bindVars, transactionID)
+			stream, err := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, bindVars)
 			return stc.processOneStreamingResult(&mu, stream, err, &replyErr, &fieldSent, sendReply)
 		})
 	if replyErr != nil {
@@ -415,7 +415,7 @@ func (stc *ScatterConn) StreamExecuteMulti(
 		NewSafeSession(nil),
 		false,
 		func(shard string, transactionID int64) error {
-			stream, err := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, shardVars[shard], transactionID)
+			stream, err := stc.gateway.StreamExecute(ctx, keyspace, shard, tabletType, query, shardVars[shard])
 			return stc.processOneStreamingResult(&mu, stream, err, &replyErr, &fieldSent, sendReply)
 		})
 	if replyErr != nil {

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -149,15 +149,15 @@ func (sdc *ShardConn) ExecuteBatch(ctx context.Context, queries []querytypes.Bou
 }
 
 // StreamExecute executes a streaming query on vttablet. The retry rules are the same as Execute.
-func (sdc *ShardConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
+func (sdc *ShardConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
 	var usedConn tabletconn.TabletConn
 	var stream sqltypes.ResultStream
 	err := sdc.withRetry(ctx, func(conn tabletconn.TabletConn) error {
 		var err error
-		stream, err = conn.StreamExecute(ctx, query, bindVars, transactionID)
+		stream, err = conn.StreamExecute(ctx, query, bindVars)
 		usedConn = conn
 		return err
-	}, transactionID, true)
+	}, 0, true)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/shard_conn_flaky_test.go
+++ b/go/vt/vtgate/shard_conn_flaky_test.go
@@ -63,12 +63,7 @@ func TestShardConnExecuteBatch(t *testing.T) {
 func TestShardConnExecuteStream(t *testing.T) {
 	testShardConnGeneric(t, "TestShardConnExecuteStream", true, func() error {
 		sdc := NewShardConn(context.Background(), new(sandboxTopo), "aa", "TestShardConnExecuteStream", "0", topodatapb.TabletType_REPLICA, 1*time.Millisecond, 3, connTimeoutTotal, connTimeoutPerConn, connLife, connectTimings)
-		_, err := sdc.StreamExecute(context.Background(), "query", nil, 0)
-		return err
-	})
-	testShardConnTransact(t, "TestShardConnExecuteStream", func() error {
-		sdc := NewShardConn(context.Background(), new(sandboxTopo), "aa", "TestShardConnExecuteStream", "0", topodatapb.TabletType_REPLICA, 1*time.Millisecond, 3, connTimeoutTotal, connTimeoutPerConn, connLife, connectTimings)
-		_, err := sdc.StreamExecute(context.Background(), "query", nil, 1)
+		_, err := sdc.StreamExecute(context.Background(), "query", nil)
 		return err
 	})
 }
@@ -305,7 +300,7 @@ func TestShardConnStreamingRetry(t *testing.T) {
 	sbc := &sandboxConn{mustFailRetry: 1}
 	s.MapTestConn("0", sbc)
 	sdc := NewShardConn(context.Background(), new(sandboxTopo), "aa", "TestShardConnStreamingRetry", "0", topodatapb.TabletType_REPLICA, 10*time.Millisecond, 3, connTimeoutTotal, connTimeoutPerConn, connLife, connectTimings)
-	_, err := sdc.StreamExecute(context.Background(), "query", nil, 0)
+	_, err := sdc.StreamExecute(context.Background(), "query", nil)
 	if err != nil {
 		t.Errorf("want nil, got %v", err)
 	}
@@ -321,7 +316,7 @@ func TestShardConnStreamingRetry(t *testing.T) {
 	sbc = &sandboxConn{mustFailFatal: 1}
 	s.MapTestConn("0", sbc)
 	sdc = NewShardConn(context.Background(), new(sandboxTopo), "aa", "TestShardConnStreamingRetry", "0", topodatapb.TabletType_REPLICA, 10*time.Millisecond, 3, connTimeoutTotal, connTimeoutPerConn, connLife, connectTimings)
-	_, err = sdc.StreamExecute(context.Background(), "query", nil, 0)
+	_, err = sdc.StreamExecute(context.Background(), "query", nil)
 	want := "shard, host: TestShardConnStreamingRetry.0.replica, host:\"0\" port_map:<key:\"vt\" value:1 > , fatal: err"
 	if err == nil || err.Error() != want {
 		t.Errorf("want %v, got %v", want, err)

--- a/go/vt/vtgate/shardgateway.go
+++ b/go/vt/vtgate/shardgateway.go
@@ -116,8 +116,8 @@ func (sg *shardGateway) ExecuteBatch(ctx context.Context, keyspace string, shard
 }
 
 // StreamExecute executes a streaming query for the specified keyspace, shard, and tablet type.
-func (sg *shardGateway) StreamExecute(ctx context.Context, keyspace string, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}, transactionID int64) (sqltypes.ResultStream, error) {
-	return sg.getConnection(ctx, keyspace, shard, tabletType).StreamExecute(ctx, query, bindVars, transactionID)
+func (sg *shardGateway) StreamExecute(ctx context.Context, keyspace string, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}) (sqltypes.ResultStream, error) {
+	return sg.getConnection(ctx, keyspace, shard, tabletType).StreamExecute(ctx, query, bindVars)
 }
 
 // Begin starts a transaction for the specified keyspace, shard, and tablet type.

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -55,7 +55,7 @@ func NewQueryResultReaderForTablet(ctx context.Context, ts topo.Server, tabletAl
 		return nil, err
 	}
 
-	stream, err := conn.StreamExecute(ctx, sql, make(map[string]interface{}), 0)
+	stream, err := conn.StreamExecute(ctx, sql, make(map[string]interface{}))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
transaction_id is not present on the server side for streaming queries
(and won't be in the foreseeable future). So removing it from the
client side interfaces as well. gRPC protos don't even have it.

@guoliang100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1647)
<!-- Reviewable:end -->
