### PR TITLE
Makefile: Remove optimization that we skip installing the gRPC Go pro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,9 +89,7 @@ php_test:
 
 # TODO(mberlin): Remove the manual copy once govendor supports a way to
 # install vendor'd programs: https://github.com/kardianos/govendor/issues/117
-install_protoc-gen-go: $(GOPATH)/bin/protoc-gen-go
-
-$(GOPATH)/bin/protoc-gen-go:
+install_protoc-gen-go:
 	mkdir -p $${GOPATH}/src/github.com/golang/
 	cp -au vendor/github.com/golang/protobuf $${GOPATH}/src/github.com/golang/
 	go install github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
…tobuf plugin if it already exists in $GOROOT/bin.

This optimization would not pick up version changes (e.g. when we
upgrade the vendor'd "github.com/golang/protobuf/protoc-gen-go" repo
copy by running bootstrap.sh) and unnecessarily introduce confusion.

Without the optimization, "make proto" won't be slowed down noticeable
when the plugin was already installed.

@enisoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1648)
<!-- Reviewable:end -->
