### PR TITLE
Adding combo methods Begin+Execute{Batch}

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -345,6 +345,26 @@ func (itc *internalTabletConn) Rollback(ctx context.Context, transactionID int64
 	return tabletconn.TabletErrorFromGRPC(tabletserver.ToGRPCError(err))
 }
 
+// BeginExecute is part of tabletconn.TabletConn
+func (itc *internalTabletConn) BeginExecute(ctx context.Context, query string, bindVars map[string]interface{}) (*sqltypes.Result, int64, error) {
+	transactionID, err := itc.Begin(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	result, err := itc.Execute(ctx, query, bindVars, transactionID)
+	return result, transactionID, err
+}
+
+// BeginExecuteBatch is part of tabletconn.TabletConn
+func (itc *internalTabletConn) BeginExecuteBatch(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	transactionID, err := itc.Begin(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	results, err := itc.ExecuteBatch(ctx, queries, asTransaction, transactionID)
+	return results, transactionID, err
+}
+
 // Close is part of tabletconn.TabletConn
 func (itc *internalTabletConn) Close() {
 }

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -232,7 +232,9 @@ func (hc *HealthCheckImpl) checkConn(hcc *healthCheckConn, cell, name string, en
 
 // connect creates connection to the endpoint and starts streaming.
 func (hcc *healthCheckConn) connect(hc *HealthCheckImpl, endPoint *topodatapb.EndPoint) (tabletconn.StreamHealthReader, error) {
-	conn, err := tabletconn.GetDialer()(hcc.ctx, endPoint, "" /*keyspace*/, "" /*shard*/, topodatapb.TabletType_RDONLY, hc.connTimeout)
+	// Keyspace, shard and tabletType are not known yet, but they're unused
+	// by StreamHealth. We'll use SetTarget later to set them.
+	conn, err := tabletconn.GetDialer()(hcc.ctx, endPoint, "" /*keyspace*/, "" /*shard*/, topodatapb.TabletType_UNKNOWN, hc.connTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -307,19 +307,9 @@ func (fc *fakeConn) Execute(ctx context.Context, query string, bindVars map[stri
 	return nil, fmt.Errorf("not implemented")
 }
 
-// Execute2 implements tabletconn.TabletConn.
-func (fc *fakeConn) Execute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (*sqltypes.Result, error) {
-	return fc.Execute(ctx, query, bindVars, transactionID)
-}
-
 // ExecuteBatch implements tabletconn.TabletConn.
 func (fc *fakeConn) ExecuteBatch(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error) {
 	return nil, fmt.Errorf("not implemented")
-}
-
-// ExecuteBatch2 implements tabletconn.TabletConn.
-func (fc *fakeConn) ExecuteBatch2(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error) {
-	return fc.ExecuteBatch(ctx, queries, asTransaction, transactionID)
 }
 
 // StreamExecute implements tabletconn.TabletConn.
@@ -340,6 +330,16 @@ func (fc *fakeConn) Commit(ctx context.Context, transactionID int64) error {
 // Rollback implements tabletconn.TabletConn.
 func (fc *fakeConn) Rollback(ctx context.Context, transactionID int64) error {
 	return fmt.Errorf("not implemented")
+}
+
+// BeginExecute implements tabletconn.TabletConn.
+func (fc *fakeConn) BeginExecute(ctx context.Context, query string, bindVars map[string]interface{}) (*sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("not implemented")
+}
+
+// BeginExecuteBatch implements tabletconn.TabletConn.
+func (fc *fakeConn) BeginExecuteBatch(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("not implemented")
 }
 
 // SplitQuery implements tabletconn.TabletConn.

--- a/go/vt/tabletmanager/binlog_players_test.go
+++ b/go/vt/tabletmanager/binlog_players_test.go
@@ -158,14 +158,14 @@ func (ftc *fakeTabletConn) Rollback(ctx context.Context, transactionID int64) er
 	return fmt.Errorf("not implemented in this test")
 }
 
-// Execute2 is part of the TabletConn interface
-func (ftc *fakeTabletConn) Execute2(ctx context.Context, query string, bindVars map[string]interface{}, transactionID int64) (*sqltypes.Result, error) {
-	return nil, fmt.Errorf("not implemented in this test")
+// BeginExecute is part of the TabletConn interface
+func (ftc *fakeTabletConn) BeginExecute(ctx context.Context, query string, bindVars map[string]interface{}) (*sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("not implemented in this test")
 }
 
-// ExecuteBatch2 is part of the TabletConn interface
-func (ftc *fakeTabletConn) ExecuteBatch2(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error) {
-	return nil, fmt.Errorf("not implemented in this test")
+// BeginExecuteBatch is part of the TabletConn interface
+func (ftc *fakeTabletConn) BeginExecuteBatch(ctx context.Context, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("not implemented in this test")
 }
 
 // Close is part of the TabletConn interface

--- a/go/vt/tabletserver/tabletconn/tablet_conn.go
+++ b/go/vt/tabletserver/tabletconn/tablet_conn.go
@@ -78,11 +78,10 @@ type StreamHealthReader interface {
 // TabletDialer represents a function that will return a TabletConn
 // object that can communicate with a tablet.
 //
-// We support two modes of operation:
-// 1 - using GetSessionId (right after dialing) to get a sessionId.
-// 2 - using Target with each call (and never calling GetSessionId).
-// If tabletType is set to UNKNOWN, we'll use mode 1.
-// Mode 1 is being deprecated.
+// keyspace, shard and tabletType are remembered and used as Target.
+// Use SetTarget to update them later.
+// If the TabletDialer is used for StreamHealth only, then keyspace, shard
+// and tabletType won't be used.
 type TabletDialer func(ctx context.Context, endPoint *topodatapb.EndPoint, keyspace, shard string, tabletType topodatapb.TabletType, timeout time.Duration) (TabletConn, error)
 
 // TabletConn defines the interface for a vttablet client. It should
@@ -116,8 +115,7 @@ type TabletConn interface {
 	Close()
 
 	// SetTarget can be called to change the target used for
-	// subsequent calls. Can only be called if tabletType was not
-	// set to UNKNOWN in TabletDialer.
+	// subsequent calls.
 	SetTarget(keyspace, shard string, tabletType topodatapb.TabletType) error
 
 	// GetEndPoint returns the end point info.

--- a/go/vt/tabletserver/tabletconntest/tabletconntest.go
+++ b/go/vt/tabletserver/tabletconntest/tabletconntest.go
@@ -139,7 +139,7 @@ var testVTGateCallerID = &querypb.VTGateCallerID{
 
 const testAsTransaction bool = true
 
-func (f *FakeQueryService) checkTargetCallerID(ctx context.Context, name string, target *querypb.Target, sessionID int64) {
+func (f *FakeQueryService) checkTargetCallerID(ctx context.Context, name string, target *querypb.Target) {
 	if !reflect.DeepEqual(target, testTarget) {
 		f.t.Errorf("invalid Target for %v: got %#v expected %#v", name, target, testTarget)
 	}
@@ -177,7 +177,7 @@ func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, se
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	f.checkTargetCallerID(ctx, "Begin", target, sessionID)
+	f.checkTargetCallerID(ctx, "Begin", target)
 	return beginTransactionID, nil
 }
 
@@ -219,7 +219,7 @@ func (f *FakeQueryService) Commit(ctx context.Context, target *querypb.Target, s
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	f.checkTargetCallerID(ctx, "Commit", target, sessionID)
+	f.checkTargetCallerID(ctx, "Commit", target)
 	if transactionID != commitTransactionID {
 		f.t.Errorf("Commit: invalid TransactionId: got %v expected %v", transactionID, commitTransactionID)
 	}
@@ -259,7 +259,7 @@ func (f *FakeQueryService) Rollback(ctx context.Context, target *querypb.Target,
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	f.checkTargetCallerID(ctx, "Rollback", target, sessionID)
+	f.checkTargetCallerID(ctx, "Rollback", target)
 	if transactionID != rollbackTransactionID {
 		f.t.Errorf("Rollback: invalid TransactionId: got %v expected %v", transactionID, rollbackTransactionID)
 	}
@@ -304,7 +304,7 @@ func (f *FakeQueryService) Execute(ctx context.Context, target *querypb.Target, 
 	if !reflect.DeepEqual(bindVariables, executeBindVars) {
 		f.t.Errorf("invalid Execute.BindVariables: got %v expected %v", bindVariables, executeBindVars)
 	}
-	f.checkTargetCallerID(ctx, "Execute", target, sessionID)
+	f.checkTargetCallerID(ctx, "Execute", target)
 	if transactionID != f.expectedTransactionID {
 		f.t.Errorf("invalid Execute.TransactionId: got %v expected %v", transactionID, f.expectedTransactionID)
 	}
@@ -432,7 +432,7 @@ func (f *FakeQueryService) StreamExecute(ctx context.Context, target *querypb.Ta
 	if !reflect.DeepEqual(bindVariables, streamExecuteBindVars) {
 		f.t.Errorf("invalid StreamExecute.BindVariables: got %v expected %v", bindVariables, streamExecuteBindVars)
 	}
-	f.checkTargetCallerID(ctx, "StreamExecute", target, sessionID)
+	f.checkTargetCallerID(ctx, "StreamExecute", target)
 	if err := sendReply(&streamExecuteQueryResult1); err != nil {
 		f.t.Errorf("sendReply1 failed: %v", err)
 	}
@@ -601,7 +601,7 @@ func (f *FakeQueryService) ExecuteBatch(ctx context.Context, target *querypb.Tar
 	if !reflect.DeepEqual(queries, executeBatchQueries) {
 		f.t.Errorf("invalid ExecuteBatch.Queries: got %v expected %v", queries, executeBatchQueries)
 	}
-	f.checkTargetCallerID(ctx, "ExecuteBatch", target, sessionID)
+	f.checkTargetCallerID(ctx, "ExecuteBatch", target)
 	if asTransaction != testAsTransaction {
 		f.t.Errorf("invalid ExecuteBatch.AsTransaction: got %v expected %v", asTransaction, testAsTransaction)
 	}
@@ -752,7 +752,7 @@ func (f *FakeQueryService) SplitQuery(ctx context.Context, target *querypb.Targe
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	f.checkTargetCallerID(ctx, "SplitQuery", target, sessionID)
+	f.checkTargetCallerID(ctx, "SplitQuery", target)
 	if !reflect.DeepEqual(querytypes.BoundQuery{
 		Sql:           sql,
 		BindVariables: bindVariables,
@@ -787,7 +787,7 @@ func (f *FakeQueryService) SplitQueryV2(
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
 	}
-	f.checkTargetCallerID(ctx, "SplitQueryV2", target, sessionID)
+	f.checkTargetCallerID(ctx, "SplitQueryV2", target)
 	if !reflect.DeepEqual(querytypes.BoundQuery{
 		Sql:           sql,
 		BindVariables: bindVariables,

--- a/go/vt/tabletserver/tabletconntest/tabletconntest.go
+++ b/go/vt/tabletserver/tabletconntest/tabletconntest.go
@@ -30,17 +30,24 @@ import (
 
 // FakeQueryService has the server side of this fake
 type FakeQueryService struct {
-	t                        *testing.T
-	hasError                 bool
-	hasBeginError            bool
-	panics                   bool
-	streamExecutePanicsEarly bool
-	panicWait                chan struct{}
-	errorWait                chan struct{}
-	expectedTransactionID    int64
+	t *testing.T
 
 	// if set, we check target, if not set we check sessionId
 	checkTarget bool
+
+	// these fields are used to simulate and synchronize on errors
+	hasError      bool
+	hasBeginError bool
+	tabletError   *tabletserver.TabletError
+	errorWait     chan struct{}
+
+	// these fields are used to simulate and synchronize on panics
+	panics                   bool
+	streamExecutePanicsEarly bool
+	panicWait                chan struct{}
+
+	// expectedTransactionID is what transactionID to expect for Execute
+	expectedTransactionID int64
 }
 
 // HandlePanic is part of the queryservice.QueryService interface
@@ -50,40 +57,70 @@ func (f *FakeQueryService) HandlePanic(err *error) {
 	}
 }
 
-const expectedErrMatch string = "error: generic error"
-const expectedCode vtrpcpb.ErrorCode = vtrpcpb.ErrorCode_BAD_INPUT
+// testErrorHelper will check one instance of each error type,
+// to make sure we propagate the errors properly.
+func testErrorHelper(t *testing.T, f *FakeQueryService, name string, ef func(context.Context) error) {
+	errors := []*tabletserver.TabletError{
+		// ErrFail is associated with a number of errors
+		tabletserver.NewTabletError(tabletserver.ErrFail, vtrpcpb.ErrorCode_BAD_INPUT, "generic error"),
+		tabletserver.NewTabletError(tabletserver.ErrFail, vtrpcpb.ErrorCode_UNKNOWN_ERROR, "uncaught panic"),
+		tabletserver.NewTabletError(tabletserver.ErrFail, vtrpcpb.ErrorCode_UNAUTHENTICATED, "missing caller id"),
+		tabletserver.NewTabletError(tabletserver.ErrFail, vtrpcpb.ErrorCode_PERMISSION_DENIED, "table acl error: nil acl"),
 
-var testTabletError = tabletserver.NewTabletError(tabletserver.ErrFail, expectedCode, "generic error")
+		// ErrRetry is always associated with QUERY_NOT_SERVED
+		tabletserver.NewTabletError(tabletserver.ErrRetry, vtrpcpb.ErrorCode_QUERY_NOT_SERVED, "Query disallowed due to rule: %v", "cool rule"),
 
-// Verifies the returned error has the properties that we expect.
-func verifyError(t *testing.T, err error, method string) {
-	if err == nil {
-		t.Errorf("%s was expecting an error, didn't get one", method)
-		return
+		// ErrFatal is always associated with INTERNAL_ERROR
+		tabletserver.NewTabletError(tabletserver.ErrFatal, vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not verify strict mode"),
+
+		// ErrTxPoolFull is always associated with RESOURCE_EXHAUSTED
+		tabletserver.NewTabletError(tabletserver.ErrTxPoolFull, vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, "Transaction pool connection limit exceeded"),
+
+		// ErrNotInTx is always associated with NOT_IN_TX
+		tabletserver.NewTabletError(tabletserver.ErrNotInTx, vtrpcpb.ErrorCode_NOT_IN_TX, "Transaction 12"),
 	}
-	code := vterrors.RecoverVtErrorCode(err)
-	if code != expectedCode {
-		t.Errorf("Unexpected server code from %s: got %v, wanted %v", method, code, expectedCode)
+	for _, e := range errors {
+		f.tabletError = e
+		ctx := context.Background()
+		err := ef(ctx)
+		if err == nil {
+			t.Errorf("error wasn't returned for %v?", name)
+			continue
+		}
+
+		// First we check the vtrpc code is right.
+		code := vterrors.RecoverVtErrorCode(err)
+		if code != e.ErrorCode {
+			t.Errorf("unexpected server code from %v: got %v, wanted %v", name, code, e.ErrorCode)
+		}
+		sError, ok := err.(*tabletconn.ServerError)
+		if !ok {
+			t.Errorf("error wasn't a tabletconn.ServerError for %v?", name)
+			continue
+		}
+
+		// Then we check the code is right. This depends on
+		// the values for tabletserver.TabletError.ErrorType
+		// and tabletconn.ServerError.Code using the same values.
+		if sError.Code != e.ErrorType {
+			t.Errorf("unexpected ServerError code from %v: got %v, wanted %v", name, sError.Code, e.ErrorType)
+		}
+
+		// and last we check we preserve the text, with the right prefix
+		if !strings.Contains(err.Error(), e.Prefix()+e.Message) {
+			t.Errorf("client error message '%v' for %v doesn't contain expected server text message '%v'", err.Error(), name, e.Prefix()+e.Message)
+		}
 	}
-	verifyErrorExceptServerCode(t, err, method)
+	f.tabletError = nil
 }
 
-func verifyErrorExceptServerCode(t *testing.T, err error, method string) {
-	if err == nil {
-		t.Errorf("%s was expecting an error, didn't get one", method)
-		return
+func testPanicHelper(t *testing.T, f *FakeQueryService, name string, pf func(context.Context) error) {
+	f.panics = true
+	ctx := context.Background()
+	if err := pf(ctx); err == nil || !strings.Contains(err.Error(), "caught test panic") {
+		t.Fatalf("unexpected panic error for %v: %v", name, err)
 	}
-
-	if se, ok := err.(*tabletconn.ServerError); ok {
-		if se.Code != tabletconn.ERR_NORMAL {
-			t.Errorf("Unexpected error code from %s: got %v, wanted %v", method, se.Code, tabletconn.ERR_NORMAL)
-		}
-	} else {
-		t.Errorf("Unexpected error type from %s: got %v, wanted *tabletconn.ServerError", method, reflect.TypeOf(err))
-	}
-	if !strings.Contains(err.Error(), expectedErrMatch) {
-		t.Errorf("Unexpected error from %s: got %v, wanted err containing %v", method, err, expectedErrMatch)
-	}
+	f.panics = false
 }
 
 // testTarget is the target we use for this test
@@ -151,7 +188,7 @@ func (f *FakeQueryService) GetSessionId(keyspace, shard string) (int64, error) {
 // Begin is part of the queryservice.QueryService interface
 func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, sessionID int64) (int64, error) {
 	if f.hasBeginError {
-		return 0, testTabletError
+		return 0, f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -162,7 +199,7 @@ func (f *FakeQueryService) Begin(ctx context.Context, target *querypb.Target, se
 
 const beginTransactionID int64 = 9990
 
-func testBegin(t *testing.T, conn tabletconn.TabletConn) {
+func testBegin(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	transactionID, err := conn.Begin(ctx)
@@ -174,23 +211,26 @@ func testBegin(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testBeginError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, err := conn.Begin(ctx)
-	verifyError(t, err, "Begin")
+func testBeginError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasBeginError = true
+	testErrorHelper(t, f, "Begin", func(ctx context.Context) error {
+		_, err := conn.Begin(ctx)
+		return err
+	})
+	f.hasBeginError = false
 }
 
-func testBeginPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, err := conn.Begin(ctx); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testBeginPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Begin", func(ctx context.Context) error {
+		_, err := conn.Begin(ctx)
+		return err
+	})
 }
 
 // Commit is part of the queryservice.QueryService interface
 func (f *FakeQueryService) Commit(ctx context.Context, target *querypb.Target, sessionID, transactionID int64) error {
 	if f.hasError {
-		return testTabletError
+		return f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -204,7 +244,7 @@ func (f *FakeQueryService) Commit(ctx context.Context, target *querypb.Target, s
 
 const commitTransactionID int64 = 999044
 
-func testCommit(t *testing.T, conn tabletconn.TabletConn) {
+func testCommit(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	err := conn.Commit(ctx, commitTransactionID)
@@ -213,23 +253,24 @@ func testCommit(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testCommitError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	err := conn.Commit(ctx, commitTransactionID)
-	verifyError(t, err, "Commit")
+func testCommitError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "Commit", func(ctx context.Context) error {
+		return conn.Commit(ctx, commitTransactionID)
+	})
+	f.hasError = false
 }
 
-func testCommitPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if err := conn.Commit(ctx, commitTransactionID); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testCommitPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Commit", func(ctx context.Context) error {
+		return conn.Commit(ctx, commitTransactionID)
+	})
 }
 
 // Rollback is part of the queryservice.QueryService interface
 func (f *FakeQueryService) Rollback(ctx context.Context, target *querypb.Target, sessionID, transactionID int64) error {
 	if f.hasError {
-		return testTabletError
+		return f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -243,7 +284,7 @@ func (f *FakeQueryService) Rollback(ctx context.Context, target *querypb.Target,
 
 const rollbackTransactionID int64 = 999044
 
-func testRollback(t *testing.T, conn tabletconn.TabletConn) {
+func testRollback(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	err := conn.Rollback(ctx, rollbackTransactionID)
@@ -252,23 +293,23 @@ func testRollback(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testRollbackError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	err := conn.Rollback(ctx, commitTransactionID)
-	verifyError(t, err, "Rollback")
+func testRollbackError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "Rollback", func(ctx context.Context) error {
+		return conn.Rollback(ctx, commitTransactionID)
+	})
 }
 
-func testRollbackPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if err := conn.Rollback(ctx, rollbackTransactionID); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testRollbackPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Commit", func(ctx context.Context) error {
+		return conn.Rollback(ctx, rollbackTransactionID)
+	})
 }
 
 // Execute is part of the queryservice.QueryService interface
 func (f *FakeQueryService) Execute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, sessionID, transactionID int64) (*sqltypes.Result, error) {
 	if f.hasError {
-		return nil, testTabletError
+		return nil, f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -332,17 +373,20 @@ func testExecute(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) 
 	}
 }
 
-func testExecuteError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, err := conn.Execute(ctx, executeQuery, executeBindVars, executeTransactionID)
-	verifyError(t, err, "Execute")
+func testExecuteError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "Execute", func(ctx context.Context) error {
+		_, err := conn.Execute(ctx, executeQuery, executeBindVars, executeTransactionID)
+		return err
+	})
+	f.hasError = false
 }
 
-func testExecutePanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, err := conn.Execute(ctx, executeQuery, executeBindVars, executeTransactionID); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testExecutePanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Commit", func(ctx context.Context) error {
+		_, err := conn.Execute(ctx, executeQuery, executeBindVars, executeTransactionID)
+		return err
+	})
 }
 
 func testBeginExecute(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
@@ -361,30 +405,36 @@ func testBeginExecute(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryServ
 	}
 }
 
-func testBeginExecuteErrorInBegin(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, transactionID, err := conn.BeginExecute(ctx, executeQuery, executeBindVars)
-	verifyError(t, err, "Execute")
-	if transactionID != 0 {
-		t.Errorf("Unexpected transactionID from BeginExecute: got %v wanted 0", transactionID)
-	}
+func testBeginExecuteErrorInBegin(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasBeginError = true
+	testErrorHelper(t, f, "BeginExecute.Begin", func(ctx context.Context) error {
+		_, transactionID, err := conn.BeginExecute(ctx, executeQuery, executeBindVars)
+		if transactionID != 0 {
+			t.Errorf("Unexpected transactionID from BeginExecute: got %v wanted 0", transactionID)
+		}
+		return err
+	})
+	f.hasBeginError = false
 }
 
-func testBeginExecuteErrorInExecute(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	_, transactionID, err := conn.BeginExecute(ctx, executeQuery, executeBindVars)
-	verifyError(t, err, "Execute")
-	if transactionID != beginTransactionID {
-		t.Errorf("Unexpected transactionID from BeginExecute: got %v wanted %v", transactionID, beginTransactionID)
-	}
+func testBeginExecuteErrorInExecute(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "BeginExecute.Execute", func(ctx context.Context) error {
+		ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
+		_, transactionID, err := conn.BeginExecute(ctx, executeQuery, executeBindVars)
+		if transactionID != beginTransactionID {
+			t.Errorf("Unexpected transactionID from BeginExecute: got %v wanted %v", transactionID, beginTransactionID)
+		}
+		return err
+	})
+	f.hasError = false
 }
 
-func testBeginExecutePanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, _, err := conn.BeginExecute(ctx, executeQuery, executeBindVars); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testBeginExecutePanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Commit", func(ctx context.Context) error {
+		_, _, err := conn.BeginExecute(ctx, executeQuery, executeBindVars)
+		return err
+	})
 }
 
 // StreamExecute is part of the queryservice.QueryService interface
@@ -405,15 +455,14 @@ func (f *FakeQueryService) StreamExecute(ctx context.Context, target *querypb.Ta
 	if f.panics && !f.streamExecutePanicsEarly {
 		// wait until the client gets the response, then panics
 		<-f.panicWait
-		f.panicWait = make(chan struct{}) // for next test
 		panic(fmt.Errorf("test-triggered panic late"))
 	}
 	if f.hasError {
-		// wait until the client has the response, since all streaming implementation may not
-		// send previous messages if an error has been triggered.
+		// wait until the client has the response, since all
+		// streaming implementation may not send previous
+		// messages if an error has been triggered.
 		<-f.errorWait
-		f.errorWait = make(chan struct{}) // for next test
-		return testTabletError
+		return f.tabletError
 	}
 	if err := sendReply(&streamExecuteQueryResult2); err != nil {
 		f.t.Errorf("sendReply2 failed: %v", err)
@@ -453,7 +502,7 @@ var streamExecuteQueryResult2 = sqltypes.Result{
 	},
 }
 
-func testStreamExecute(t *testing.T, conn tabletconn.TabletConn) {
+func testStreamExecute(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
@@ -486,78 +535,81 @@ func testStreamExecute(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testStreamExecuteError(t *testing.T, conn tabletconn.TabletConn, fake *FakeQueryService) {
-	ctx := context.Background()
-	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
-	if err != nil {
-		t.Fatalf("StreamExecute failed: %v", err)
-	}
-	qr, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("StreamExecute failed: cannot read result1: %v", err)
-	}
-	if len(qr.Rows) == 0 {
-		qr.Rows = nil
-	}
-	if !reflect.DeepEqual(*qr, streamExecuteQueryResult1) {
-		t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, streamExecuteQueryResult1)
-	}
-	// signal to the server that the first result has been received
-	close(fake.errorWait)
-	// After 1 result, we expect to get an error (no more results).
-	qr, err = stream.Recv()
-	if err == nil {
-		t.Fatalf("StreamExecute channel wasn't closed")
-	}
-	verifyError(t, err, "StreamExecute")
+func testStreamExecuteError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "StreamExecute", func(ctx context.Context) error {
+		f.errorWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
+		stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
+		if err != nil {
+			t.Fatalf("StreamExecute failed: %v", err)
+		}
+		qr, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("StreamExecute failed: cannot read result1: %v", err)
+		}
+		if len(qr.Rows) == 0 {
+			qr.Rows = nil
+		}
+		if !reflect.DeepEqual(*qr, streamExecuteQueryResult1) {
+			t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, streamExecuteQueryResult1)
+		}
+		// signal to the server that the first result has been received
+		close(f.errorWait)
+		// After 1 result, we expect to get an error (no more results).
+		qr, err = stream.Recv()
+		if err == nil {
+			t.Fatalf("StreamExecute channel wasn't closed")
+		}
+		return err
+	})
+	f.hasError = false
 }
 
-func testStreamExecutePanics(t *testing.T, conn tabletconn.TabletConn, fake *FakeQueryService) {
+func testStreamExecutePanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	// early panic is before sending the Fields, that is returned
 	// by the StreamExecute call itself, or as the first error
 	// by ErrFunc
-	ctx := context.Background()
-	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	fake.streamExecutePanicsEarly = true
-	stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
-	if err != nil {
-		if !strings.Contains(err.Error(), "caught test panic") {
-			t.Fatalf("unexpected panic error: %v", err)
+	f.streamExecutePanicsEarly = true
+	testPanicHelper(t, f, "StreamExecute.Early", func(ctx context.Context) error {
+		ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
+		stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
+		if err != nil {
+			return err
 		}
-	} else {
-		_, err := stream.Recv()
-		if err == nil || !strings.Contains(err.Error(), "caught test panic") {
-			t.Fatalf("unexpected panic error: %v", err)
-		}
-	}
+		_, err = stream.Recv()
+		return err
+	})
 
 	// late panic is after sending Fields
-	fake.streamExecutePanicsEarly = false
-	stream, err = conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
-	if err != nil {
-		t.Fatalf("StreamExecute failed: %v", err)
-	}
-	qr, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("StreamExecute failed: cannot read result1: %v", err)
-	}
-	if len(qr.Rows) == 0 {
-		qr.Rows = nil
-	}
-	if !reflect.DeepEqual(*qr, streamExecuteQueryResult1) {
-		t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, streamExecuteQueryResult1)
-	}
-	close(fake.panicWait)
-	if _, err := stream.Recv(); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+	f.streamExecutePanicsEarly = false
+	testPanicHelper(t, f, "StreamExecute.Late", func(ctx context.Context) error {
+		f.panicWait = make(chan struct{})
+		ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
+		stream, err := conn.StreamExecute(ctx, streamExecuteQuery, streamExecuteBindVars)
+		if err != nil {
+			t.Fatalf("StreamExecute failed: %v", err)
+		}
+		qr, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("StreamExecute failed: cannot read result1: %v", err)
+		}
+		if len(qr.Rows) == 0 {
+			qr.Rows = nil
+		}
+		if !reflect.DeepEqual(*qr, streamExecuteQueryResult1) {
+			t.Errorf("Unexpected result1 from StreamExecute: got %v wanted %v", qr, streamExecuteQueryResult1)
+		}
+		close(f.panicWait)
+		_, err = stream.Recv()
+		return err
+	})
 }
 
 // ExecuteBatch is part of the queryservice.QueryService interface
 func (f *FakeQueryService) ExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, sessionID int64, asTransaction bool, transactionID int64) ([]sqltypes.Result, error) {
 	if f.hasError {
-		return nil, testTabletError
+		return nil, f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -644,17 +696,20 @@ func testExecuteBatch(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryServ
 	}
 }
 
-func testExecuteBatchError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, err := conn.ExecuteBatch(ctx, executeBatchQueries, true, executeBatchTransactionID)
-	verifyError(t, err, "ExecuteBatch")
+func testExecuteBatchError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "ExecuteBatch", func(ctx context.Context) error {
+		_, err := conn.ExecuteBatch(ctx, executeBatchQueries, true, executeBatchTransactionID)
+		return err
+	})
+	f.hasError = true
 }
 
-func testExecuteBatchPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, err := conn.ExecuteBatch(ctx, executeBatchQueries, true, executeBatchTransactionID); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testExecuteBatchPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "ExecuteBatch", func(ctx context.Context) error {
+		_, err := conn.ExecuteBatch(ctx, executeBatchQueries, true, executeBatchTransactionID)
+		return err
+	})
 }
 
 func testBeginExecuteBatch(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
@@ -673,36 +728,42 @@ func testBeginExecuteBatch(t *testing.T, conn tabletconn.TabletConn, f *FakeQuer
 	}
 }
 
-func testBeginExecuteBatchErrorInBegin(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, transactionID, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true)
-	verifyError(t, err, "ExecuteBatch")
-	if transactionID != 0 {
-		t.Errorf("Unexpected transactionID from BeginExecuteBatch: got %v wanted 0", transactionID)
-	}
+func testBeginExecuteBatchErrorInBegin(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasBeginError = true
+	testErrorHelper(t, f, "BeginExecuteBatch.Begin", func(ctx context.Context) error {
+		_, transactionID, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true)
+		if transactionID != 0 {
+			t.Errorf("Unexpected transactionID from BeginExecuteBatch: got %v wanted 0", transactionID)
+		}
+		return err
+	})
+	f.hasBeginError = false
 }
 
-func testBeginExecuteBatchErrorInExecuteBatch(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
-	_, transactionID, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true)
-	verifyError(t, err, "ExecuteBatch")
-	if transactionID != beginTransactionID {
-		t.Errorf("Unexpected transactionID from BeginExecuteBatch: got %v wanted %v", transactionID, beginTransactionID)
-	}
+func testBeginExecuteBatchErrorInExecuteBatch(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "BeginExecute.ExecuteBatch", func(ctx context.Context) error {
+		ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
+		_, transactionID, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true)
+		if transactionID != beginTransactionID {
+			t.Errorf("Unexpected transactionID from BeginExecuteBatch: got %v wanted %v", transactionID, beginTransactionID)
+		}
+		return err
+	})
+	f.hasError = false
 }
 
-func testBeginExecuteBatchPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, _, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testBeginExecuteBatchPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "Begin", func(ctx context.Context) error {
+		_, _, err := conn.BeginExecuteBatch(ctx, executeBatchQueries, true)
+		return err
+	})
 }
 
 // SplitQuery is part of the queryservice.QueryService interface
 func (f *FakeQueryService) SplitQuery(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64, sessionID int64) ([]querytypes.QuerySplit, error) {
 	if f.hasError {
-		return nil, testTabletError
+		return nil, f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -737,7 +798,7 @@ func (f *FakeQueryService) SplitQueryV2(
 	sessionID int64) ([]querytypes.QuerySplit, error) {
 
 	if f.hasError {
-		return nil, testTabletError
+		return nil, f.tabletError
 	}
 	if f.panics {
 		panic(fmt.Errorf("test-triggered panic"))
@@ -816,7 +877,7 @@ var splitQueryQueryV2SplitList = []querytypes.QuerySplit{
 	},
 }
 
-func testSplitQuery(t *testing.T, conn tabletconn.TabletConn) {
+func testSplitQuery(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	qsl, err := conn.SplitQuery(ctx, splitQueryBoundQuery, splitQuerySplitColumn, splitQuerySplitCount)
@@ -829,7 +890,7 @@ func testSplitQuery(t *testing.T, conn tabletconn.TabletConn) {
 }
 
 // TODO(erez): Rename to SplitQuery after migration to SplitQuery V2 is done.
-func testSplitQueryV2(t *testing.T, conn tabletconn.TabletConn) {
+func testSplitQueryV2(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 	ctx = callerid.NewContext(ctx, testCallerID, testVTGateCallerID)
 	qsl, err := conn.SplitQueryV2(
@@ -848,17 +909,20 @@ func testSplitQueryV2(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testSplitQueryError(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	_, err := conn.SplitQuery(ctx, splitQueryBoundQuery, splitQuerySplitColumn, splitQuerySplitCount)
-	verifyError(t, err, "SplitQuery")
+func testSplitQueryError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
+	testErrorHelper(t, f, "SplitQuery", func(ctx context.Context) error {
+		_, err := conn.SplitQuery(ctx, splitQueryBoundQuery, splitQuerySplitColumn, splitQuerySplitCount)
+		return err
+	})
+	f.hasError = false
 }
 
-func testSplitQueryPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	if _, err := conn.SplitQuery(ctx, splitQueryBoundQuery, splitQuerySplitColumn, splitQuerySplitCount); err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testSplitQueryPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "SplitQuery", func(ctx context.Context) error {
+		_, err := conn.SplitQuery(ctx, splitQueryBoundQuery, splitQuerySplitColumn, splitQuerySplitCount)
+		return err
+	})
 }
 
 // this test is a bit of a hack: we write something on the channel
@@ -900,7 +964,7 @@ func (f *FakeQueryService) StreamHealthUnregister(int) error {
 	return nil
 }
 
-func testStreamHealth(t *testing.T, conn tabletconn.TabletConn) {
+func testStreamHealth(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
 	ctx := context.Background()
 
 	stream, err := conn.StreamHealth(ctx)
@@ -918,7 +982,8 @@ func testStreamHealth(t *testing.T, conn tabletconn.TabletConn) {
 	}
 }
 
-func testStreamHealthError(t *testing.T, conn tabletconn.TabletConn) {
+func testStreamHealthError(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	f.hasError = true
 	ctx := context.Background()
 	stream, err := conn.StreamHealth(ctx)
 	if err != nil {
@@ -928,33 +993,69 @@ func testStreamHealthError(t *testing.T, conn tabletconn.TabletConn) {
 	if err == nil || !strings.Contains(err.Error(), testStreamHealthErrorMsg) {
 		t.Fatalf("StreamHealth failed with the wrong error: %v", err)
 	}
+	f.hasError = false
 }
 
-func testStreamHealthPanics(t *testing.T, conn tabletconn.TabletConn) {
-	ctx := context.Background()
-	stream, err := conn.StreamHealth(ctx)
-	if err != nil {
-		t.Fatalf("StreamHealth failed: %v", err)
-	}
-	_, err = stream.Recv()
-	if err == nil || !strings.Contains(err.Error(), "caught test panic") {
-		t.Fatalf("unexpected panic error: %v", err)
-	}
+func testStreamHealthPanics(t *testing.T, conn tabletconn.TabletConn, f *FakeQueryService) {
+	testPanicHelper(t, f, "StreamHealth", func(ctx context.Context) error {
+		stream, err := conn.StreamHealth(ctx)
+		if err != nil {
+			t.Fatalf("StreamHealth failed: %v", err)
+		}
+		_, err = stream.Recv()
+		return err
+	})
 }
 
 // CreateFakeServer returns the fake server for the tests
 func CreateFakeServer(t *testing.T) *FakeQueryService {
 	return &FakeQueryService{
-		t:      t,
-		panics: false,
-		streamExecutePanicsEarly: false,
-		panicWait:                make(chan struct{}),
-		errorWait:                make(chan struct{}),
+		t: t,
 	}
 }
 
 // TestSuite runs all the tests
 func TestSuite(t *testing.T, protocol string, endPoint *topodatapb.EndPoint, fake *FakeQueryService) {
+	tests := []func(*testing.T, tabletconn.TabletConn, *FakeQueryService){
+		// positive test cases
+		testBegin,
+		testCommit,
+		testRollback,
+		testExecute,
+		testBeginExecute,
+		testStreamExecute,
+		testExecuteBatch,
+		testBeginExecuteBatch,
+		testSplitQuery,
+		testStreamHealth,
+
+		// error test cases
+		testBeginError,
+		testCommitError,
+		testRollbackError,
+		testExecuteError,
+		testBeginExecuteErrorInBegin,
+		testBeginExecuteErrorInExecute,
+		testStreamExecuteError,
+		testExecuteBatchError,
+		testBeginExecuteBatchErrorInBegin,
+		testBeginExecuteBatchErrorInExecuteBatch,
+		testSplitQueryError,
+		testStreamHealthError,
+
+		// panic test cases
+		testBeginPanics,
+		testCommitPanics,
+		testRollbackPanics,
+		testExecutePanics,
+		testBeginExecutePanics,
+		testStreamExecutePanics,
+		testExecuteBatchPanics,
+		testBeginExecuteBatchPanics,
+		testSplitQueryPanics,
+		testStreamHealthPanics,
+	}
+
 	// make sure we use the right client
 	*tabletconn.TabletProtocol = protocol
 
@@ -967,49 +1068,9 @@ func TestSuite(t *testing.T, protocol string, endPoint *topodatapb.EndPoint, fak
 	fake.checkTarget = false
 
 	// run the tests
-	testBegin(t, conn)
-	testCommit(t, conn)
-	testRollback(t, conn)
-	testExecute(t, conn, fake)
-	testBeginExecute(t, conn, fake)
-	testStreamExecute(t, conn)
-	testExecuteBatch(t, conn, fake)
-	testBeginExecuteBatch(t, conn, fake)
-	testSplitQuery(t, conn)
-	testStreamHealth(t, conn)
-
-	// fake should return an error, make sure errors are handled properly
-	fake.hasError = true
-	fake.hasBeginError = true
-	testBeginError(t, conn)
-	testCommitError(t, conn)
-	testRollbackError(t, conn)
-	testExecuteError(t, conn)
-	testBeginExecuteErrorInBegin(t, conn)
-	testStreamExecuteError(t, conn, fake)
-	testExecuteBatchError(t, conn)
-	testBeginExecuteBatchErrorInBegin(t, conn)
-	fake.hasBeginError = false
-	testBeginExecuteErrorInExecute(t, conn)
-	testBeginExecuteBatchErrorInExecuteBatch(t, conn)
-	testSplitQueryError(t, conn)
-	testStreamHealthError(t, conn)
-	fake.hasError = false
-	fake.hasBeginError = false
-
-	// force panics, make sure they're caught
-	fake.panics = true
-	testBeginPanics(t, conn)
-	testCommitPanics(t, conn)
-	testRollbackPanics(t, conn)
-	testExecutePanics(t, conn)
-	testBeginExecutePanics(t, conn)
-	testStreamExecutePanics(t, conn, fake)
-	testExecuteBatchPanics(t, conn)
-	testBeginExecuteBatchPanics(t, conn)
-	testSplitQueryPanics(t, conn)
-	testStreamHealthPanics(t, conn)
-	fake.panics = false
+	for _, c := range tests {
+		c(t, conn, fake)
+	}
 
 	// create a new connection that expects the target
 	conn.Close()
@@ -1020,47 +1081,9 @@ func TestSuite(t *testing.T, protocol string, endPoint *topodatapb.EndPoint, fak
 	fake.checkTarget = true
 
 	// run the tests
-	testBegin(t, conn)
-	testCommit(t, conn)
-	testRollback(t, conn)
-	testExecute(t, conn, fake)
-	testBeginExecute(t, conn, fake)
-	testStreamExecute(t, conn)
-	testExecuteBatch(t, conn, fake)
-	testBeginExecuteBatch(t, conn, fake)
-	testSplitQuery(t, conn)
-	testStreamHealth(t, conn)
-
-	// fake should return an error, make sure errors are handled properly
-	fake.hasError = true
-	fake.hasBeginError = true
-	testBeginError(t, conn)
-	testCommitError(t, conn)
-	testRollbackError(t, conn)
-	testExecuteError(t, conn)
-	testStreamExecuteError(t, conn, fake)
-	testExecuteBatchError(t, conn)
-	testSplitQueryError(t, conn)
-	testStreamHealthError(t, conn)
-	fake.hasBeginError = false
-	testBeginExecuteErrorInExecute(t, conn)
-	testBeginExecuteBatchErrorInExecuteBatch(t, conn)
-	fake.hasError = false
-	fake.hasBeginError = false
-
-	// force panics, make sure they're caught
-	fake.panics = true
-	testBeginPanics(t, conn)
-	testCommitPanics(t, conn)
-	testRollbackPanics(t, conn)
-	testExecutePanics(t, conn)
-	testBeginExecutePanics(t, conn)
-	testStreamExecutePanics(t, conn, fake)
-	testExecuteBatchPanics(t, conn)
-	testBeginExecuteBatchPanics(t, conn)
-	testSplitQueryPanics(t, conn)
-	testStreamHealthPanics(t, conn)
-	fake.panics = false
+	for _, c := range tests {
+		c(t, conn, fake)
+	}
 
 	// and we're done
 	conn.Close()

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -469,8 +469,8 @@ func commandVtTabletStreamHealth(ctx context.Context, wr *wrangler.Wrangler, sub
 		return fmt.Errorf("cannot get EndPoint from tablet record: %v", err)
 	}
 
-	// pass in a non-UNKNOWN tablet type to not use sessionId
-	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_MASTER, *connectTimeout)
+	// tablet type is unused for StreamHealth, use UNKNOWN
+	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_UNKNOWN, *connectTimeout)
 	if err != nil {
 		return fmt.Errorf("cannot connect to tablet %v: %v", tabletAlias, err)
 	}

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -276,7 +276,7 @@ func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags
 	bindVariables := newBindvars(subFlags)
 	keyspace := subFlags.String("keyspace", "", "keyspace the tablet belongs to")
 	shard := subFlags.String("shard", "", "shard the tablet belongs to")
-	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet (use unknown to use sessionId)")
+	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet")
 	connectTimeout := subFlags.Duration("connect_timeout", 30*time.Second, "Connection timeout for vttablet client")
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
 
@@ -323,7 +323,7 @@ func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags
 func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	keyspace := subFlags.String("keyspace", "", "keyspace the tablet belongs to")
 	shard := subFlags.String("shard", "", "shard the tablet belongs to")
-	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet (use unknown to use sessionId)")
+	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet")
 	connectTimeout := subFlags.Duration("connect_timeout", 30*time.Second, "Connection timeout for vttablet client")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -367,7 +367,7 @@ func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	keyspace := subFlags.String("keyspace", "", "keyspace the tablet belongs to")
 	shard := subFlags.String("shard", "", "shard the tablet belongs to")
-	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet (use unknown to use sessionId)")
+	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet")
 	connectTimeout := subFlags.Duration("connect_timeout", 30*time.Second, "Connection timeout for vttablet client")
 	if err := subFlags.Parse(args); err != nil {
 		return err
@@ -408,7 +408,7 @@ func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 func commandVtTabletRollback(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	keyspace := subFlags.String("keyspace", "", "keyspace the tablet belongs to")
 	shard := subFlags.String("shard", "", "shard the tablet belongs to")
-	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet (use unknown to use sessionId)")
+	tabletType := subFlags.String("tablet_type", "unknown", "tablet type we expect from the tablet")
 	connectTimeout := subFlags.Duration("connect_timeout", 30*time.Second, "Connection timeout for vttablet client")
 	if err := subFlags.Parse(args); err != nil {
 		return err

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -1416,8 +1416,8 @@ func commandWaitForFilteredReplication(ctx context.Context, wr *wrangler.Wrangle
 		return fmt.Errorf("failed to run explicit healthcheck on tablet: %v err: %v", tabletInfo, err)
 	}
 
-	// pass in a non-UNKNOWN tablet type to not use sessionId
-	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_MASTER, 30*time.Second)
+	// TabletType is unused for StreamHealth, use UNKNOWN
+	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_UNKNOWN, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("cannot connect to tablet %v: %v", alias, err)
 	}

--- a/go/vt/vtctld/tablet_data.go
+++ b/go/vt/vtctld/tablet_data.go
@@ -87,9 +87,8 @@ func (th *tabletHealth) stream(ctx context.Context, ts topo.Server, tabletAlias 
 		return err
 	}
 
-	// Pass in a tablet type that is not UNKNOWN, so we don't ask
-	// for sessionId.
-	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_MASTER, 30*time.Second)
+	// TabletType is unused for StreamHealth, use UNKNOWN
+	conn, err := tabletconn.GetDialer()(ctx, ep, "", "", topodatapb.TabletType_UNKNOWN, 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/gateway.go
+++ b/go/vt/vtgate/gateway.go
@@ -53,6 +53,14 @@ type Gateway interface {
 	// Rollback rolls back the current transaction for the specified keyspace, shard, and tablet type.
 	Rollback(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, transactionID int64) error
 
+	// BeginExecute executes a begin and the non-streaming query
+	// for the specified keyspace, shard, and tablet type.
+	BeginExecute(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}) (*sqltypes.Result, int64, error)
+
+	// BeginExecuteBatch executes a begin and a group of queries
+	// for the specified keyspace, shard, and tablet type.
+	BeginExecuteBatch(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error)
+
 	// SplitQuery splits a query into sub-queries for the specified keyspace, shard, and tablet type.
 	SplitQuery(ctx context.Context, keyspace, shard string, tabletType topodatapb.TabletType, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error)
 

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -345,7 +345,6 @@ type sandboxConn struct {
 	mustFailConn   int
 	mustFailTxPool int
 	mustFailNotTx  int
-	mustDelay      time.Duration
 
 	// A callback to tweak the behavior on each conn call
 	onConnUse func(*sandboxConn)
@@ -440,9 +439,6 @@ func (sbc *sandboxConn) Execute(ctx context.Context, query string, bindVars map[
 		Sql:           query,
 		BindVariables: bv,
 	})
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
-	}
 	if err := sbc.getError(); err != nil {
 		return nil, err
 	}
@@ -457,9 +453,6 @@ func (sbc *sandboxConn) ExecuteBatch(ctx context.Context, queries []querytypes.B
 	sbc.ExecCount.Add(1)
 	if asTransaction {
 		sbc.AsTransactionCount.Add(1)
-	}
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
 	}
 	if err := sbc.getError(); err != nil {
 		return nil, err
@@ -499,9 +492,6 @@ func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVar
 		Sql:           query,
 		BindVariables: bv,
 	})
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
-	}
 	err := sbc.getError()
 	if err != nil {
 		return nil, err
@@ -512,9 +502,6 @@ func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVar
 
 func (sbc *sandboxConn) Begin(ctx context.Context) (int64, error) {
 	sbc.BeginCount.Add(1)
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
-	}
 	err := sbc.getError()
 	if err != nil {
 		return 0, err
@@ -524,17 +511,11 @@ func (sbc *sandboxConn) Begin(ctx context.Context) (int64, error) {
 
 func (sbc *sandboxConn) Commit(ctx context.Context, transactionID int64) error {
 	sbc.CommitCount.Add(1)
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
-	}
 	return sbc.getError()
 }
 
 func (sbc *sandboxConn) Rollback(ctx context.Context, transactionID int64) error {
 	sbc.RollbackCount.Add(1)
-	if sbc.mustDelay != 0 {
-		time.Sleep(sbc.mustDelay)
-	}
 	return sbc.getError()
 }
 

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -511,7 +511,6 @@ func (sbc *sandboxConn) StreamExecute(ctx context.Context, query string, bindVar
 }
 
 func (sbc *sandboxConn) Begin(ctx context.Context) (int64, error) {
-	sbc.ExecCount.Add(1)
 	sbc.BeginCount.Add(1)
 	if sbc.mustDelay != 0 {
 		time.Sleep(sbc.mustDelay)
@@ -524,7 +523,6 @@ func (sbc *sandboxConn) Begin(ctx context.Context) (int64, error) {
 }
 
 func (sbc *sandboxConn) Commit(ctx context.Context, transactionID int64) error {
-	sbc.ExecCount.Add(1)
 	sbc.CommitCount.Add(1)
 	if sbc.mustDelay != 0 {
 		time.Sleep(sbc.mustDelay)
@@ -533,7 +531,6 @@ func (sbc *sandboxConn) Commit(ctx context.Context, transactionID int64) error {
 }
 
 func (sbc *sandboxConn) Rollback(ctx context.Context, transactionID int64) error {
-	sbc.ExecCount.Add(1)
 	sbc.RollbackCount.Add(1)
 	if sbc.mustDelay != 0 {
 		time.Sleep(sbc.mustDelay)

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -444,8 +444,8 @@ func TestScatterConnQueryNotInTransaction(t *testing.T) {
 	{
 		execCount0 := sbc0.ExecCount.Get()
 		execCount1 := sbc1.ExecCount.Get()
-		if execCount0 != 1 || execCount1 != 3 {
-			t.Errorf("want 1/3, got %d/%d", execCount0, execCount1)
+		if execCount0 != 1 || execCount1 != 1 {
+			t.Errorf("want 1/1, got %d/%d", execCount0, execCount1)
 		}
 	}
 	if commitCount := sbc0.CommitCount.Get(); commitCount != 0 {
@@ -484,8 +484,8 @@ func TestScatterConnQueryNotInTransaction(t *testing.T) {
 	{
 		execCount0 := sbc0.ExecCount.Get()
 		execCount1 := sbc1.ExecCount.Get()
-		if execCount0 != 3 || execCount1 != 1 {
-			t.Errorf("want 3/1, got %d/%d", execCount0, execCount1)
+		if execCount0 != 1 || execCount1 != 1 {
+			t.Errorf("want 1/1, got %d/%d", execCount0, execCount1)
 		}
 	}
 	if commitCount := sbc0.CommitCount.Get(); commitCount != 1 {
@@ -524,8 +524,8 @@ func TestScatterConnQueryNotInTransaction(t *testing.T) {
 	{
 		execCount0 := sbc0.ExecCount.Get()
 		execCount1 := sbc1.ExecCount.Get()
-		if execCount0 != 4 || execCount1 != 1 {
-			t.Errorf("want 4/1, got %d/%d", execCount0, execCount1)
+		if execCount0 != 2 || execCount1 != 1 {
+			t.Errorf("want 2/1, got %d/%d", execCount0, execCount1)
 		}
 	}
 	if commitCount := sbc0.CommitCount.Get(); commitCount != 1 {

--- a/go/vt/vtgate/shard_conn.go
+++ b/go/vt/vtgate/shard_conn.go
@@ -369,7 +369,7 @@ func (sdc *ShardConn) getNewConn(ctx context.Context) (conn tabletconn.TabletCon
 	allErrors := new(concurrency.AllErrorRecorder)
 	for _, endPoint := range endPoints {
 		perConnStartTime := time.Now()
-		conn, err = tabletconn.GetDialer()(ctx, endPoint, sdc.keyspace, sdc.shard, topodatapb.TabletType_UNKNOWN, perConnTimeout)
+		conn, err = tabletconn.GetDialer()(ctx, endPoint, sdc.keyspace, sdc.shard, sdc.tabletType, perConnTimeout)
 		if err == nil {
 			sdc.connectTimings.Record([]string{sdc.keyspace, sdc.shard, strings.ToLower(sdc.tabletType.String())}, perConnStartTime)
 			sdc.mu.Lock()

--- a/go/vt/vtgate/shard_conn_flaky_test.go
+++ b/go/vt/vtgate/shard_conn_flaky_test.go
@@ -143,8 +143,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 		t.Errorf("want 2, got %v", s.DialCounter)
 	}
 	// Ensure we executed 2 times before failing.
-	if execCount := sbc.ExecCount.Get(); execCount != 2 {
-		t.Errorf("want 2, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != 2 {
+		t.Errorf("want 2, got %v", count)
 	}
 
 	// retry error (one failure)
@@ -160,8 +160,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 		t.Errorf("want 2, got %v", s.DialCounter)
 	}
 	// Ensure we executed twice (second one succeeded)
-	if execCount := sbc.ExecCount.Get(); execCount != 2 {
-		t.Errorf("want 2, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != 2 {
+		t.Errorf("want 2, got %v", count)
 	}
 
 	// fatal error (one failure)
@@ -187,8 +187,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 		t.Errorf("want %v, got %v", wantCounter, s.DialCounter)
 	}
 	// Ensure we executed twice (second one succeeded)
-	if execCount := sbc.ExecCount.Get(); execCount != int64(wantCounter) {
-		t.Errorf("want %v, got %v", wantCounter, execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != int64(wantCounter) {
+		t.Errorf("want %v, got %v", wantCounter, count)
 	}
 
 	// server error
@@ -203,8 +203,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 		t.Errorf("want 1, got %v", s.DialCounter)
 	}
 	// Ensure we did not re-execute.
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 
 	// conn error (one failure)
@@ -223,8 +223,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 		t.Errorf("want 1, got %v", s.DialCounter)
 	}
 	// Ensure we did not re-execute.
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 
 	// no failures
@@ -238,8 +238,8 @@ func testShardConnGeneric(t *testing.T, name string, streaming bool, f func() er
 	if s.DialCounter != 1 {
 		t.Errorf("want 1, got %v", s.DialCounter)
 	}
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.BeginCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 }
 
@@ -254,8 +254,8 @@ func testShardConnTransact(t *testing.T, name string, f func() error) {
 		t.Errorf("want %s, got %v", want, err)
 	}
 	// Should not retry if we're in transaction
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.BeginCount.Get() + sbc.ExecCount.Get() + sbc.CommitCount.Get() + sbc.RollbackCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 
 	// conn error
@@ -268,8 +268,8 @@ func testShardConnTransact(t *testing.T, name string, f func() error) {
 		t.Errorf("want %s, got %v", want, err)
 	}
 	// Should not retry if we're in transaction
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.ExecCount.Get() + sbc.CommitCount.Get() + sbc.RollbackCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 }
 
@@ -289,8 +289,8 @@ func TestShardConnBeginOther(t *testing.T) {
 		t.Errorf("want 1, got %v", s.DialCounter)
 	}
 	// Account for 1 call to Begin.
-	if execCount := sbc.ExecCount.Get(); execCount != 1 {
-		t.Errorf("want 1, got %v", execCount)
+	if count := sbc.BeginCount.Get(); count != 1 {
+		t.Errorf("want 1, got %v", count)
 	}
 }
 

--- a/go/vt/vtgate/shardgateway.go
+++ b/go/vt/vtgate/shardgateway.go
@@ -136,6 +136,18 @@ func (sg *shardGateway) Rollback(ctx context.Context, keyspace string, shard str
 	return sg.getConnection(ctx, keyspace, shard, tabletType).Rollback(ctx, transactionID)
 }
 
+// BeginExecute executes a begin and the non-streaming query for the
+// specified keyspace, shard, and tablet type.
+func (sg *shardGateway) BeginExecute(ctx context.Context, keyspace string, shard string, tabletType topodatapb.TabletType, query string, bindVars map[string]interface{}) (*sqltypes.Result, int64, error) {
+	return sg.getConnection(ctx, keyspace, shard, tabletType).BeginExecute(ctx, query, bindVars)
+}
+
+// BeginExecuteBatch executes a begin and a group of queries for the
+// specified keyspace, shard, and tablet type.
+func (sg *shardGateway) BeginExecuteBatch(ctx context.Context, keyspace string, shard string, tabletType topodatapb.TabletType, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	return sg.getConnection(ctx, keyspace, shard, tabletType).BeginExecuteBatch(ctx, queries, asTransaction)
+}
+
 // SplitQuery splits a query into sub-queries for the specified keyspace, shard, and tablet type.
 func (sg *shardGateway) SplitQuery(ctx context.Context, keyspace string, shard string, tabletType topodatapb.TabletType, sql string, bindVars map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error) {
 	return sg.getConnection(ctx, keyspace, shard, tabletType).SplitQuery(ctx, sql, bindVars, splitColumn, splitCount)

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -49,8 +49,7 @@ func NewQueryResultReaderForTablet(ctx context.Context, ts topo.Server, tabletAl
 		return nil, err
 	}
 
-	// use sessionId for now
-	conn, err := tabletconn.GetDialer()(ctx, endPoint, tablet.Keyspace, tablet.Shard, topodatapb.TabletType_UNKNOWN, *remoteActionsTimeout)
+	conn, err := tabletconn.GetDialer()(ctx, endPoint, tablet.Keyspace, tablet.Shard, tablet.Type, *remoteActionsTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/test/sharded.py
+++ b/test/sharded.py
@@ -178,12 +178,15 @@ class TestSharded(unittest.TestCase):
     qr = shard_1_master.execute(sql)
     self.assertEqual(qr['rows'], [[10, 'test 10'],])
 
+    # make sure that if we use a wrong target, the destination rejects
+    # the query.
     _, stderr = utils.run_vtctl(['VtTabletExecute', '-json',
                                  '-keyspace', 'test_keyspace',
                                  '-shard', '-90',
+                                 '-tablet_type', 'master',
                                  shard_0_master.tablet_alias, sql],
                                 expect_fail=True)
-    self.assertIn('fatal: Shard mismatch, expecting -80, received -90', stderr)
+    self.assertIn('retry: Invalid shard -90', stderr)
 
     tablet.kill_tablets([shard_0_master, shard_0_replica, shard_1_master,
                          shard_1_replica])

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -739,6 +739,7 @@ class Tablet(object):
         'VtTabletExecute', '-json',
         '-keyspace', self.keyspace,
         '-shard', self.shard,
+        '-tablet_type', self.tablet_type,
     ]
     if bindvars:
       args.extend(['-bind_variables', json.dumps(bindvars)])
@@ -760,6 +761,7 @@ class Tablet(object):
         'VtTabletBegin',
         '-keyspace', self.keyspace,
         '-shard', self.shard,
+        '-tablet_type', self.tablet_type,
         self.tablet_alias,
     ]
     result = utils.run_vtctl_json(args, auto_log=auto_log)
@@ -779,6 +781,7 @@ class Tablet(object):
         'VtTabletCommit',
         '-keyspace', self.keyspace,
         '-shard', self.shard,
+        '-tablet_type', self.tablet_type,
         self.tablet_alias,
         str(transaction_id),
     ]
@@ -798,6 +801,7 @@ class Tablet(object):
         'VtTabletRollback',
         '-keyspace', self.keyspace,
         '-shard', self.shard,
+        '-tablet_type', self.tablet_type,
         self.tablet_alias,
         str(transaction_id),
     ]

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -129,11 +129,13 @@ class TestVerticalSplit(unittest.TestCase, base_sharding.BaseShardingTest):
                              'ServedFrom(rdonly): source_keyspace\n'
                              'ServedFrom(replica): source_keyspace\n')
 
-    # reparent to make the tablets work
+    # reparent to make the tablets work (we use health check, fix their types)
     utils.run_vtctl(['InitShardMaster', '-force', 'source_keyspace/0',
                      source_master.tablet_alias], auto_log=True)
+    source_master.tablet_type = 'master'
     utils.run_vtctl(['InitShardMaster', '-force', 'destination_keyspace/0',
                      destination_master.tablet_alias], auto_log=True)
+    destination_master.tablet_type = 'master'
 
     for t in all_setup_tablets:
       t.wait_for_vttablet_state('SERVING')
@@ -284,6 +286,7 @@ index by_msg (msg)
         _, stderr = utils.run_vtctl(['VtTabletExecute', '-json',
                                      '-keyspace', t.keyspace,
                                      '-shard', t.shard,
+                                     '-tablet_type', t.tablet_type,
                                      t.tablet_alias,
                                      'select count(1) from %s' % table],
                                     expect_fail=True)


### PR DESCRIPTION
vtgate always does a Begin followed by an Execute (or ExecuteBatch) to vttablet. This change creates a client-side BeginExecute (and beginExecuteBatch) method on tabletconn. The idea is to merge both RPCs into one.

The gRPC implementation still does both calls for now, to prove this is exactly the same. Will implement the combo RPC in a separate change.

Note I also refactored the tabletconn test quite a lot, to test all error cases, and be more readable in general.

@guoliang100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1650)
<!-- Reviewable:end -->
