### PR TITLE
vtworker: Abort when filtered replication is already enabled.

### DIFF
--- a/go/vt/worker/instance.go
+++ b/go/vt/worker/instance.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/tb"
 	"github.com/youtube/vitess/go/vt/logutil"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
@@ -119,7 +120,8 @@ func (wi *Instance) setAndStartWorker(wrk Worker, wr *wrangler.Wrangler) (chan s
 		defer func() {
 			// The recovery code is a copy of servenv.HandlePanic().
 			if x := recover(); x != nil {
-				err = fmt.Errorf("uncaught %v panic: %v", "vtworker", x)
+				log.Errorf("uncaught vtworker panic: %v\n%s", x, tb.Stack(4))
+				err = fmt.Errorf("uncaught vtworker panic: %v", x)
 			}
 
 			wi.currentWorkerMutex.Lock()

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -254,6 +254,15 @@ func (scw *SplitCloneWorker) init(ctx context.Context) error {
 		scw.destinationShards = os.Left
 	}
 
+	// Verify that filtered replication is not already enabled.
+	for _, si := range scw.destinationShards {
+		if len(si.SourceShards) > 0 {
+			return fmt.Errorf("destination shard %v/%v has filtered replication already enabled from a previous resharding (ShardInfo is set)."+
+				" This requires manual intervention e.g. use vtctl SourceShardDelete to remove it",
+				si.Keyspace(), si.ShardName())
+		}
+	}
+
 	// validate all serving types
 	servingTypes := []topodatapb.TabletType{topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY}
 	for _, st := range servingTypes {

--- a/go/vt/worker/vertical_split_clone.go
+++ b/go/vt/worker/vertical_split_clone.go
@@ -243,6 +243,14 @@ func (vscw *VerticalSplitCloneWorker) init(ctx context.Context) error {
 	}
 	vscw.sourceKeyspace = servedFrom
 
+	// Verify that filtered replication is not already enabled.
+	destShardInfo, err := vscw.wr.TopoServer().GetShard(ctx, vscw.destinationKeyspace, vscw.destinationShard)
+	if len(destShardInfo.SourceShards) > 0 {
+		return fmt.Errorf("destination shard %v/%v has filtered replication already enabled from a previous resharding (ShardInfo is set)."+
+			" This requires manual intervention e.g. use vtctl SourceShardDelete to remove it",
+			vscw.destinationKeyspace, vscw.destinationShard)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
@alainjobart 

I ran into this issue during manual testing. Without this check it failed with a duplicate key error when it tried to set the BLP checkpoint entry in the database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1655)
<!-- Reviewable:end -->
