### PR TITLE
vtworker: Do not reuse the mutex from StatusWorker in implementations.

### DIFF
--- a/go/vt/worker/block.go
+++ b/go/vt/worker/block.go
@@ -30,11 +30,11 @@ func NewBlockWorker(wr *wrangler.Wrangler) (Worker, error) {
 
 // StatusAsHTML implements the Worker interface.
 func (bw *BlockWorker) StatusAsHTML() template.HTML {
-	bw.Mu.Lock()
-	defer bw.Mu.Unlock()
+	state := bw.State()
+
 	result := "<b>Block Command</b> (blocking infinitely until context is cancelled)</br>\n"
-	result += "<b>State:</b> " + bw.State.String() + "</br>\n"
-	switch bw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "<b>Running (blocking)</b></br>\n"
 	case WorkerStateDone:
@@ -46,11 +46,11 @@ func (bw *BlockWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText implements the Worker interface.
 func (bw *BlockWorker) StatusAsText() string {
-	bw.Mu.Lock()
-	defer bw.Mu.Unlock()
+	state := bw.State()
+
 	result := "Block Command\n"
-	result += "State: " + bw.State.String() + "\n"
-	switch bw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "Running (blocking)\n"
 	case WorkerStateDone:

--- a/go/vt/worker/panic.go
+++ b/go/vt/worker/panic.go
@@ -30,11 +30,11 @@ func NewPanicWorker(wr *wrangler.Wrangler) (Worker, error) {
 
 // StatusAsHTML implements the Worker interface
 func (pw *PanicWorker) StatusAsHTML() template.HTML {
-	pw.Mu.Lock()
-	defer pw.Mu.Unlock()
+	state := pw.State()
+
 	result := "<b>Panic Command</br>\n"
-	result += "<b>State:</b> " + pw.State.String() + "</br>\n"
-	switch pw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateDone:
 		result += "<b>Success</b>:</br>\n"
 		result += "panic() should have been executed and logged by the vtworker framework.</br>\n"
@@ -45,11 +45,11 @@ func (pw *PanicWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText implements the Worker interface.
 func (pw *PanicWorker) StatusAsText() string {
-	pw.Mu.Lock()
-	defer pw.Mu.Unlock()
+	state := pw.State()
+
 	result := "Panic Command\n"
-	result += "State: " + pw.State.String() + "\n"
-	switch pw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateDone:
 		result += "panic() should have been executed and logged by the vtworker framework.\n"
 	}

--- a/go/vt/worker/ping.go
+++ b/go/vt/worker/ping.go
@@ -32,11 +32,11 @@ func NewPingWorker(wr *wrangler.Wrangler, message string) (Worker, error) {
 
 // StatusAsHTML implements the Worker interface
 func (pw *PingWorker) StatusAsHTML() template.HTML {
-	pw.Mu.Lock()
-	defer pw.Mu.Unlock()
+	state := pw.State()
+
 	result := "<b>Ping Command with message:</b> '" + pw.message + "'</br>\n"
-	result += "<b>State:</b> " + pw.State.String() + "</br>\n"
-	switch pw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "<b>Running</b>:</br>\n"
 		result += "Logging message: '" + pw.message + "'</br>\n"
@@ -50,11 +50,11 @@ func (pw *PingWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText implements the Worker interface.
 func (pw *PingWorker) StatusAsText() string {
-	pw.Mu.Lock()
-	defer pw.Mu.Unlock()
+	state := pw.State()
+
 	result := "Ping Command with message: '" + pw.message + "'\n"
-	result += "State: " + pw.State.String() + "\n"
-	switch pw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "Logging message: '" + pw.message + "'\n"
 	case WorkerStateDone:

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -47,8 +47,6 @@ type SplitCloneWorker struct {
 	minHealthyRdonlyEndPoints int
 	cleaner                   *wrangler.Cleaner
 
-	// all subsequent fields are protected by the mutex
-
 	// populated during WorkerStateInit, read-only after that
 	keyspaceInfo      *topo.KeyspaceInfo
 	sourceShards      []*topo.ShardInfo
@@ -59,8 +57,8 @@ type SplitCloneWorker struct {
 	sourceTablets []*topo.TabletInfo
 
 	// populated during WorkerStateCopy
-	tableStatus []*tableStatus
-	startTime   time.Time
+	// tableStatusList holds the status for each table.
+	tableStatusList tableStatusList
 	// aliases of tablets that need to have their schema reloaded.
 	// Only populated once, read-only after that.
 	reloadAliases [][]*topodatapb.TabletAlias
@@ -127,20 +125,20 @@ func (scw *SplitCloneWorker) formatSources() string {
 
 // StatusAsHTML implements the Worker interface
 func (scw *SplitCloneWorker) StatusAsHTML() template.HTML {
-	scw.Mu.Lock()
-	defer scw.Mu.Unlock()
+	state := scw.State()
+
 	result := "<b>Working on:</b> " + scw.keyspace + "/" + scw.shard + "</br>\n"
-	result += "<b>State:</b> " + scw.State.String() + "</br>\n"
-	switch scw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "<b>Running</b>:</br>\n"
 		result += "<b>Copying from</b>: " + scw.formatSources() + "</br>\n"
-		statuses, eta := formatTableStatuses(scw.tableStatus, scw.startTime)
+		statuses, eta := scw.tableStatusList.format()
 		result += "<b>ETA</b>: " + eta.String() + "</br>\n"
 		result += strings.Join(statuses, "</br>\n")
 	case WorkerStateDone:
 		result += "<b>Success</b>:</br>\n"
-		statuses, _ := formatTableStatuses(scw.tableStatus, scw.startTime)
+		statuses, _ := scw.tableStatusList.format()
 		result += strings.Join(statuses, "</br>\n")
 	}
 
@@ -149,20 +147,20 @@ func (scw *SplitCloneWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText implements the Worker interface
 func (scw *SplitCloneWorker) StatusAsText() string {
-	scw.Mu.Lock()
-	defer scw.Mu.Unlock()
+	state := scw.State()
+
 	result := "Working on: " + scw.keyspace + "/" + scw.shard + "\n"
-	result += "State: " + scw.State.String() + "\n"
-	switch scw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateCopy:
 		result += "Running:\n"
 		result += "Copying from: " + scw.formatSources() + "\n"
-		statuses, eta := formatTableStatuses(scw.tableStatus, scw.startTime)
+		statuses, eta := scw.tableStatusList.format()
 		result += "ETA: " + eta.String() + "\n"
 		result += strings.Join(statuses, "\n")
 	case WorkerStateDone:
 		result += "Success:\n"
-		statuses, _ := formatTableStatuses(scw.tableStatus, scw.startTime)
+		statuses, _ := scw.tableStatusList.format()
 		result += strings.Join(statuses, "\n")
 	}
 	return result
@@ -399,30 +397,7 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 		return fmt.Errorf("no tables matching the table filter in tablet %v", topoproto.TabletAliasString(scw.sourceAliases[0]))
 	}
 	scw.wr.Logger().Infof("Source tablet 0 has %v tables to copy", len(sourceSchemaDefinition.TableDefinitions))
-
-	scw.Mu.Lock()
-	scw.tableStatus = make([]*tableStatus, len(sourceSchemaDefinition.TableDefinitions))
-	for i, td := range sourceSchemaDefinition.TableDefinitions {
-		scw.tableStatus[i] = &tableStatus{
-			name:     td.Name,
-			rowCount: td.RowCount * uint64(len(scw.sourceAliases)),
-		}
-	}
-	scw.startTime = time.Now()
-	scw.Mu.Unlock()
-
-	// Count rows for source tables
-	for tableIndex, td := range sourceSchemaDefinition.TableDefinitions {
-		if td.Type == tmutils.TableBaseTable {
-			scw.tableStatus[tableIndex].mu.Lock()
-			scw.tableStatus[tableIndex].rowCount = td.RowCount
-			scw.tableStatus[tableIndex].mu.Unlock()
-		} else {
-			scw.tableStatus[tableIndex].mu.Lock()
-			scw.tableStatus[tableIndex].isView = true
-			scw.tableStatus[tableIndex].mu.Unlock()
-		}
-	}
+	scw.tableStatusList.initialize(sourceSchemaDefinition)
 
 	// In parallel, setup the channels to send SQL data chunks to for each destination tablet:
 	//
@@ -515,7 +490,7 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			scw.tableStatus[tableIndex].setThreadCount(len(chunks) - 1)
+			scw.tableStatusList.setThreadCount(tableIndex, len(chunks)-1)
 
 			for chunkIndex := 0; chunkIndex < len(chunks)-1; chunkIndex++ {
 				sourceWaitGroup.Add(1)
@@ -525,7 +500,7 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 					sema.Acquire()
 					defer sema.Release()
 
-					scw.tableStatus[tableIndex].threadStarted()
+					scw.tableStatusList.threadStarted(tableIndex)
 
 					// build the query, and start the streaming
 					selectSQL := buildSQLFromChunks(scw.wr, td, chunks, chunkIndex, scw.sourceAliases[shardIndex].String())
@@ -540,7 +515,7 @@ func (scw *SplitCloneWorker) copy(ctx context.Context) error {
 					if err := scw.processData(ctx, td, tableIndex, qrr, rowSplitter, insertChannels, scw.destinationPackCount); err != nil {
 						processError("processData failed: %v", err)
 					}
-					scw.tableStatus[tableIndex].threadDone()
+					scw.tableStatusList.threadDone(tableIndex)
 				}(td, tableIndex, chunkIndex)
 			}
 		}
@@ -666,7 +641,7 @@ func (scw *SplitCloneWorker) processData(ctx context.Context, td *tabletmanagerd
 		if err := rowSplitter.Split(sr, r.Rows); err != nil {
 			return fmt.Errorf("RowSplitter failed for table %v: %v", td.Name, err)
 		}
-		scw.tableStatus[tableIndex].addCopiedRows(len(r.Rows))
+		scw.tableStatusList.addCopiedRows(tableIndex, len(r.Rows))
 
 		// see if we reach the destination pack count
 		packCount++

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -386,17 +386,8 @@ func testSplitClone(t *testing.T, v3 bool) {
 		"-min_table_size_for_split", "1",
 		"-destination_writer_count", "10",
 		"ks/-80"}
-	worker, done, err := wi.RunCommand(args, wi.wr, false /* runFromCli */)
-	if err != nil {
-		t.Fatalf("Worker creation failed: %v", err)
-	}
-	if err := wi.WaitForCommand(worker, done); err != nil {
-		t.Fatalf("Worker failed: %v", err)
-	}
-
-	t.Logf("Got status: %v", worker.StatusAsText())
-	if worker.(*SplitCloneWorker).State != WorkerStateDone {
-		t.Fatalf("Worker run failed: %v", err)
+	if err := runCommand(t, wi, wi.wr, args); err != nil {
+		t.Fatal(err)
 	}
 
 	if statsDestinationAttemptedResolves.String() != "3" {

--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -38,8 +38,6 @@ type SplitDiffWorker struct {
 	minHealthyRdonlyEndPoints int
 	cleaner                   *wrangler.Cleaner
 
-	// all subsequent fields are protected by the mutex
-
 	// populated during WorkerStateInit, read-only after that
 	keyspaceInfo *topo.KeyspaceInfo
 	shardInfo    *topo.ShardInfo
@@ -70,11 +68,11 @@ func NewSplitDiffWorker(wr *wrangler.Wrangler, cell, keyspace, shard string, sou
 
 // StatusAsHTML is part of the Worker interface
 func (sdw *SplitDiffWorker) StatusAsHTML() template.HTML {
-	sdw.Mu.Lock()
-	defer sdw.Mu.Unlock()
+	state := sdw.State()
+
 	result := "<b>Working on:</b> " + sdw.keyspace + "/" + sdw.shard + "</br>\n"
-	result += "<b>State:</b> " + sdw.State.String() + "</br>\n"
-	switch sdw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateDiff:
 		result += "<b>Running...</b></br>\n"
 	case WorkerStateDone:
@@ -86,11 +84,11 @@ func (sdw *SplitDiffWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText is part of the Worker interface
 func (sdw *SplitDiffWorker) StatusAsText() string {
-	sdw.Mu.Lock()
-	defer sdw.Mu.Unlock()
+	state := sdw.State()
+
 	result := "Working on: " + sdw.keyspace + "/" + sdw.shard + "\n"
-	result += "State: " + sdw.State.String() + "\n"
-	switch sdw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateDiff:
 		result += "Running...\n"
 	case WorkerStateDone:

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -330,17 +330,8 @@ func testSplitDiff(t *testing.T, v3 bool) {
 	// have a good way to fake the binlog player yet, which is
 	// necessary for synchronizing replication.
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, faketmclient.NewFakeTabletManagerClient())
-	worker, done, err := wi.RunCommand(args, wr, false /* runFromCli */)
-	if err != nil {
-		t.Fatalf("Worker creation failed: %v", err)
-	}
-	if err := wi.WaitForCommand(worker, done); err != nil {
-		t.Fatalf("Worker failed: %v", err)
-	}
-
-	t.Logf("Got status: %v", worker.StatusAsText())
-	if worker.(*SplitDiffWorker).State != WorkerStateDone {
-		t.Fatalf("Worker run failed: %v", err)
+	if err := runCommand(t, wi, wr, args); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/go/vt/worker/status_worker.go
+++ b/go/vt/worker/status_worker.go
@@ -13,18 +13,29 @@ import (
 type StatusWorkerState string
 
 // All possible status strings (if your implementation needs more,
-// just add them)
+// just add them).
 
 const (
-	WorkerStateNotSarted       StatusWorkerState = "not started"
-	WorkerStateDone            StatusWorkerState = "done"
-	WorkerStateError           StatusWorkerState = "error"
-	WorkerStateInit            StatusWorkerState = "initializing"
-	WorkerStateFindTargets     StatusWorkerState = "finding target instances"
+	// WorkerStateNotStarted is the initial state.
+	WorkerStateNotStarted StatusWorkerState = "not started"
+	// WorkerStateDone is set when the worker successfully finished.
+	WorkerStateDone StatusWorkerState = "done"
+	// WorkerStateError is set when the worker failed.
+	WorkerStateError StatusWorkerState = "error"
+	// WorkerStateInit is set when the worker does initialize its state.
+	WorkerStateInit StatusWorkerState = "initializing"
+	// WorkerStateFindTargets is set when the worker searches healthy RDONLY tablets.
+	WorkerStateFindTargets StatusWorkerState = "finding target instances"
+	// WorkerStateSyncReplication is set when the worker ensures that source and
+	// destination tablets are at the same GTID during the diff.
 	WorkerStateSyncReplication StatusWorkerState = "synchronizing replication"
-	WorkerStateCopy            StatusWorkerState = "copying the data"
-	WorkerStateDiff            StatusWorkerState = "running the diff"
-	WorkerStateCleanUp         StatusWorkerState = "cleaning up"
+	// WorkerStateCopy is set when the worker copies the data.
+	WorkerStateCopy StatusWorkerState = "copying the data"
+	// WorkerStateDiff is set when the worker compares the data.
+	WorkerStateDiff StatusWorkerState = "running the diff"
+	// WorkerStateCleanUp is set when the worker reverses the initialization e.g.
+	// the type of a taken out RDONLY tablet is changed back from "worker" to "spare".
+	WorkerStateCleanUp StatusWorkerState = "cleaning up"
 )
 
 func (state StatusWorkerState) String() string {
@@ -32,47 +43,53 @@ func (state StatusWorkerState) String() string {
 }
 
 // StatusWorker is the base type for a worker which keeps a status.
-// The status is protected by a mutex. Any other internal variable
-// can also be protected by that mutex.
+// The status is protected by a mutex.
 // StatusWorker also provides default implementations for StatusAsHTML
 // and StatusAsText to make it easier on workers if they don't need to
 // export more.
 type StatusWorker struct {
-	// Mu is protecting the state variable, and can also be used
-	// by implementations to protect their own variables.
-	Mu *sync.Mutex
-
-	// State contains the worker's current state, and should only
-	// be accessed under Mu.
-	State StatusWorkerState
+	mu *sync.Mutex
+	// state contains the worker's current state. Guarded by mu.
+	state StatusWorkerState
 }
 
-// NewStatusWorker returns a StatusWorker in state WorkerStateNotSarted
+// NewStatusWorker returns a StatusWorker in state WorkerStateNotStarted.
 func NewStatusWorker() StatusWorker {
 	return StatusWorker{
-		Mu:    &sync.Mutex{},
-		State: WorkerStateNotSarted,
+		mu:    &sync.Mutex{},
+		state: WorkerStateNotStarted,
 	}
 }
 
-// SetState is a convenience function for workers
-func (worker *StatusWorker) SetState(state StatusWorkerState) {
-	worker.Mu.Lock()
-	worker.State = state
+// SetState is a convenience function for workers.
+func (w *StatusWorker) SetState(state StatusWorkerState) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.state = state
 	statsState.Set(string(state))
-	worker.Mu.Unlock()
 }
 
-// StatusAsHTML is part of the Worker interface
-func (worker *StatusWorker) StatusAsHTML() template.HTML {
-	worker.Mu.Lock()
-	defer worker.Mu.Unlock()
-	return template.HTML("<b>State:</b> " + worker.State.String() + "</br>\n")
+// State is part of the Worker interface.
+func (w *StatusWorker) State() StatusWorkerState {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.state
 }
 
-// StatusAsText is part of the Worker interface
-func (worker *StatusWorker) StatusAsText() string {
-	worker.Mu.Lock()
-	defer worker.Mu.Unlock()
-	return "State: " + worker.State.String() + "\n"
+// StatusAsHTML is part of the Worker interface.
+func (w *StatusWorker) StatusAsHTML() template.HTML {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return template.HTML("<b>State:</b> " + w.state.String() + "</br>\n")
+}
+
+// StatusAsText is part of the Worker interface.
+func (w *StatusWorker) StatusAsText() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return "State: " + w.state.String() + "\n"
 }

--- a/go/vt/worker/table_status.go
+++ b/go/vt/worker/table_status.go
@@ -1,0 +1,173 @@
+// Copyright 2014, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package worker
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
+
+	tabletmanagerdatapb "github.com/youtube/vitess/go/vt/proto/tabletmanagerdata"
+)
+
+// tableStatusList contains the status for each table of a schema.
+// Functions which modify the status of a table must use the same index for
+// the table which the table had in schema passed in to initialize().
+type tableStatusList struct {
+	// mu guards all fields in the group below.
+	mu sync.Mutex
+	// initialized is true when initialize() was called.
+	initialized bool
+	// tableStatuses is written once by initialize().
+	tableStatuses []*tableStatus
+	// startTime records the time initialize() was called.
+	// Same as tableStatuses it's a write-once field.
+	startTime time.Time
+}
+
+func (t *tableStatusList) initialize(schema *tabletmanagerdatapb.SchemaDefinition) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.initialized {
+		panic(fmt.Errorf("tableStatusList is already initialized: %v", t.tableStatuses))
+	}
+
+	t.tableStatuses = make([]*tableStatus, len(schema.TableDefinitions))
+	for i, td := range schema.TableDefinitions {
+		t.tableStatuses[i] = newTableStatus(td.Name, td.Type != tmutils.TableBaseTable /* isView */, td.RowCount)
+	}
+
+	t.startTime = time.Now()
+
+	t.initialized = true
+}
+
+// isInitialized returns true when initialize() was called.
+func (t *tableStatusList) isInitialized() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.initialized
+}
+
+func (t *tableStatusList) setThreadCount(tableIndex, threadCount int) {
+	if !t.isInitialized() {
+		panic("setThreadCount() requires an initialized tableStatusList")
+	}
+
+	t.tableStatuses[tableIndex].setThreadCount(threadCount)
+}
+
+func (t *tableStatusList) threadStarted(tableIndex int) {
+	if !t.isInitialized() {
+		panic("threadStarted() requires an initialized tableStatusList")
+	}
+
+	t.tableStatuses[tableIndex].threadStarted()
+}
+
+func (t *tableStatusList) threadDone(tableIndex int) {
+	if !t.isInitialized() {
+		panic("threadDone() requires an initialized tableStatusList")
+	}
+
+	t.tableStatuses[tableIndex].threadDone()
+}
+
+func (t *tableStatusList) addCopiedRows(tableIndex, copiedRows int) {
+	if !t.isInitialized() {
+		panic("addCopiedRows() requires an initialized tableStatusList")
+	}
+
+	t.tableStatuses[tableIndex].addCopiedRows(copiedRows)
+}
+
+// format returns a status for each table and the overall ETA.
+func (t *tableStatusList) format() ([]string, time.Time) {
+	if !t.isInitialized() {
+		return nil, time.Now()
+	}
+
+	copiedRows := uint64(0)
+	rowCount := uint64(0)
+	result := make([]string, len(t.tableStatuses))
+	for i, ts := range t.tableStatuses {
+		ts.mu.Lock()
+		if ts.isView {
+			// views are not copied
+			result[i] = fmt.Sprintf("%v is a view", ts.name)
+		} else if ts.threadsStarted == 0 {
+			// we haven't started yet
+			result[i] = fmt.Sprintf("%v: copy not started (estimating %v rows)", ts.name, ts.rowCount)
+		} else if ts.threadsDone == ts.threadCount {
+			// we are done with the copy
+			result[i] = fmt.Sprintf("%v: copy done, copied %v rows", ts.name, ts.rowCount)
+		} else {
+			// copy is running
+			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount)
+		}
+		copiedRows += ts.copiedRows
+		rowCount += ts.rowCount
+		ts.mu.Unlock()
+	}
+	now := time.Now()
+	if rowCount == 0 || copiedRows == 0 {
+		return result, now
+	}
+	eta := now.Add(time.Duration(float64(now.Sub(t.startTime)) * float64(rowCount) / float64(copiedRows)))
+	return result, eta
+}
+
+// tableStatus keeps track of the status for a given table.
+type tableStatus struct {
+	name   string
+	isView bool
+
+	// mu guards all fields in the group below.
+	mu             sync.Mutex
+	rowCount       uint64 // set to approximate value, until copy ends
+	copiedRows     uint64 // actual count of copied rows
+	threadCount    int    // how many concurrent threads will copy the data
+	threadsStarted int    // how many threads have started
+	threadsDone    int    // how many threads are done
+}
+
+func newTableStatus(name string, isView bool, rowCount uint64) *tableStatus {
+	return &tableStatus{
+		name:     name,
+		isView:   isView,
+		rowCount: rowCount,
+	}
+}
+
+func (ts *tableStatus) setThreadCount(threadCount int) {
+	ts.mu.Lock()
+	ts.threadCount = threadCount
+	ts.mu.Unlock()
+}
+
+func (ts *tableStatus) threadStarted() {
+	ts.mu.Lock()
+	ts.threadsStarted++
+	ts.mu.Unlock()
+}
+
+func (ts *tableStatus) threadDone() {
+	ts.mu.Lock()
+	ts.threadsDone++
+	ts.mu.Unlock()
+}
+
+func (ts *tableStatus) addCopiedRows(copiedRows int) {
+	ts.mu.Lock()
+	ts.copiedRows += uint64(copiedRows)
+	if ts.copiedRows > ts.rowCount {
+		// since rowCount is not accurate, update it if we go past it.
+		ts.rowCount = ts.copiedRows
+	}
+	ts.mu.Unlock()
+}

--- a/go/vt/worker/utils_test.go
+++ b/go/vt/worker/utils_test.go
@@ -1,0 +1,26 @@
+package worker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/wrangler"
+)
+
+// This file contains common test helper.
+
+func runCommand(t *testing.T, wi *Instance, wr *wrangler.Wrangler, args []string) error {
+	worker, done, err := wi.RunCommand(args, wr, false /* runFromCli */)
+	if err != nil {
+		return fmt.Errorf("Worker creation failed: %v", err)
+	}
+	if err := wi.WaitForCommand(worker, done); err != nil {
+		return fmt.Errorf("Worker failed: %v", err)
+	}
+
+	t.Logf("Got status: %v", worker.StatusAsText())
+	if worker.State() != WorkerStateDone {
+		return fmt.Errorf("Worker finished but not successfully: %v", err)
+	}
+	return nil
+}

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -343,17 +343,8 @@ func TestVerticalSplitClone(t *testing.T) {
 		"-destination_writer_count", "10",
 		"destination_ks/0",
 	}
-	worker, done, err := wi.RunCommand(args, wi.wr, false /* runFromCli */)
-	if err != nil {
-		t.Fatalf("Worker creation failed: %v", err)
-	}
-	if err := wi.WaitForCommand(worker, done); err != nil {
-		t.Fatalf("Worker failed: %v", err)
-	}
-
-	t.Logf("Got status: %v", worker.StatusAsText())
-	if worker.(*VerticalSplitCloneWorker).State != WorkerStateDone {
-		t.Fatalf("Worker run failed")
+	if err := runCommand(t, wi, wi.wr, args); err != nil {
+		t.Fatal(err)
 	}
 
 	if statsDestinationAttemptedResolves.String() != "2" {

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -5,7 +5,6 @@
 package worker
 
 import (
-	"flag"
 	"fmt"
 	"strconv"
 	"strings"
@@ -289,20 +288,6 @@ func TestVerticalSplitClone(t *testing.T) {
 		t.Fatalf("RebuildKeyspaceGraph failed: %v", err)
 	}
 
-	subFlags := flag.NewFlagSet("SplitClone", flag.ContinueOnError)
-	gwrk, err := commandVerticalSplitClone(wi, wi.wr, subFlags, []string{
-		"-tables", "moving.*,view1",
-		"-source_reader_count", "10",
-		"-destination_pack_count", "4",
-		"-min_table_size_for_split", "1",
-		"-destination_writer_count", "10",
-		"destination_ks/0",
-	})
-	if err != nil {
-		t.Errorf("Worker creation failed: %v", err)
-	}
-	wrk := gwrk.(*VerticalSplitCloneWorker)
-
 	for _, sourceRdonly := range []*testlib.FakeTablet{sourceRdonly1, sourceRdonly2} {
 		sourceRdonly.FakeMysqlDaemon.Schema = &tabletmanagerdatapb.SchemaDefinition{
 			DatabaseSchema: "",
@@ -348,11 +333,27 @@ func TestVerticalSplitClone(t *testing.T) {
 	// Only wait 1 ms between retries, so that the test passes faster
 	*executeFetchRetryTime = (1 * time.Millisecond)
 
-	err = wrk.Run(ctx)
-	status := wrk.StatusAsText()
-	t.Logf("Got status: %v", status)
-	if err != nil || wrk.State != WorkerStateDone {
-		t.Errorf("Worker run failed")
+	// Run the vtworker command.
+	args := []string{
+		"VerticalSplitClone",
+		"-tables", "moving.*,view1",
+		"-source_reader_count", "10",
+		"-destination_pack_count", "4",
+		"-min_table_size_for_split", "1",
+		"-destination_writer_count", "10",
+		"destination_ks/0",
+	}
+	worker, done, err := wi.RunCommand(args, wi.wr, false /* runFromCli */)
+	if err != nil {
+		t.Fatalf("Worker creation failed: %v", err)
+	}
+	if err := wi.WaitForCommand(worker, done); err != nil {
+		t.Fatalf("Worker failed: %v", err)
+	}
+
+	t.Logf("Got status: %v", worker.StatusAsText())
+	if worker.(*VerticalSplitCloneWorker).State != WorkerStateDone {
+		t.Fatalf("Worker run failed")
 	}
 
 	if statsDestinationAttemptedResolves.String() != "2" {

--- a/go/vt/worker/vertical_split_diff.go
+++ b/go/vt/worker/vertical_split_diff.go
@@ -34,8 +34,6 @@ type VerticalSplitDiffWorker struct {
 	minHealthyRdonlyEndPoints int
 	cleaner                   *wrangler.Cleaner
 
-	// all subsequent fields are protected by the mutex
-
 	// populated during WorkerStateInit, read-only after that
 	keyspaceInfo *topo.KeyspaceInfo
 	shardInfo    *topo.ShardInfo
@@ -64,11 +62,11 @@ func NewVerticalSplitDiffWorker(wr *wrangler.Wrangler, cell, keyspace, shard str
 
 // StatusAsHTML is part of the Worker interface.
 func (vsdw *VerticalSplitDiffWorker) StatusAsHTML() template.HTML {
-	vsdw.Mu.Lock()
-	defer vsdw.Mu.Unlock()
+	state := vsdw.State()
+
 	result := "<b>Working on:</b> " + vsdw.keyspace + "/" + vsdw.shard + "</br>\n"
-	result += "<b>State:</b> " + vsdw.State.String() + "</br>\n"
-	switch vsdw.State {
+	result += "<b>State:</b> " + state.String() + "</br>\n"
+	switch state {
 	case WorkerStateDiff:
 		result += "<b>Running</b>:</br>\n"
 	case WorkerStateDone:
@@ -80,11 +78,11 @@ func (vsdw *VerticalSplitDiffWorker) StatusAsHTML() template.HTML {
 
 // StatusAsText is part of the Worker interface.
 func (vsdw *VerticalSplitDiffWorker) StatusAsText() string {
-	vsdw.Mu.Lock()
-	defer vsdw.Mu.Unlock()
+	state := vsdw.State()
+
 	result := "Working on: " + vsdw.keyspace + "/" + vsdw.shard + "\n"
-	result += "State: " + vsdw.State.String() + "\n"
-	switch vsdw.State {
+	result += "State: " + state.String() + "\n"
+	switch state {
 	case WorkerStateDiff:
 		result += "Running...\n"
 	case WorkerStateDone:

--- a/go/vt/worker/vertical_split_diff_test.go
+++ b/go/vt/worker/vertical_split_diff_test.go
@@ -192,16 +192,7 @@ func TestVerticalSplitDiff(t *testing.T) {
 	// have a good way to fake the binlog player yet, which is
 	// necessary for synchronizing replication.
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, faketmclient.NewFakeTabletManagerClient())
-	worker, done, err := wi.RunCommand(args, wr, false /* runFromCli */)
-	if err != nil {
-		t.Fatalf("Worker creation failed: %v", err)
-	}
-	if err := wi.WaitForCommand(worker, done); err != nil {
-		t.Fatalf("Worker failed: %v", err)
-	}
-
-	t.Logf("Got status: %v", worker.StatusAsText())
-	if worker.(*VerticalSplitDiffWorker).State != WorkerStateDone {
-		t.Fatalf("Worker run failed")
+	if err := runCommand(t, wi, wr, args); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -21,10 +21,13 @@ import (
 
 // Worker is the base interface for all long running workers.
 type Worker interface {
-	// StatusAsHTML returns the current worker status in HTML
+	// State returns the current state using the internal representation.
+	State() StatusWorkerState
+
+	// StatusAsHTML returns the current worker status in HTML.
 	StatusAsHTML() template.HTML
 
-	// StatusAsText returns the current worker status in plain text
+	// StatusAsText returns the current worker status in plain text.
 	StatusAsText() string
 
 	// Run is the main entry point for the worker. It will be


### PR DESCRIPTION
@alainjobart 

Removing this dependency makes it easier to reason about which components need synchronization and use the lock.

StatusWorker is now fully isolated and can be accessed only through its exported methods.

Other changes:
- Unexported remaining fields in StatusWorker 
- Added State() to worker interface to deduplicate code in unit tests.
- created TabletStatusList which aggregates TableStatus objects and has its own lock now. By resing it, we reduce code duplication in SplitClone and VerticalSplitClone.
- Status* functions in worker implementations do not use the previous global mutex. Instead, StatusWorker and TabletStatusList are called independently now.

- Simplified running vtworker commands in unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1659)
<!-- Reviewable:end -->
