### PR TITLE
discovery: Provide filter helper functions to reduce code duplication.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -1,3 +1,30 @@
+// Package discovery provides a way to discover all tablets e.g. within a
+// specific shard and monitor their current health.
+//
+// Use the HealthCheck object to query for tablets (in this package also
+// referred to as endpoints) and their health.
+//
+// For an example how to use the HealthCheck object, see worker/topo_utils.go.
+//
+// Tablets have to be manually added to the HealthCheck using AddEndPoint().
+// Alternatively, use a Watcher implementation which will constantly watch
+// a source (e.g. the topology) and add and remove tablets as they are
+// added or removed from the source.
+// For a Watcher example have a look at NewShardReplicationWatcher().
+//
+// Note that the getter functions GetEndPointStatsFrom* will always return
+// an unfiltered list of all known tablets.
+// Use the helper functions in utils.go to filter them e.g.
+// RemoveUnhealthyEndpoints() or GetCurrentMaster().
+// replicationlag.go contains a more advanced health filter which is used by
+// vtgate.
+//
+// Internally, the HealthCheck module is connected to each tablet and has a
+// streaming RPC (StreamHealth) open to receive periodic health infos.
+//
+// NOTE: This requires that the health check is enabled on the tablet.
+// As of 04/2016 you enable the health check by setting the vttablet flag
+// --target_tablet_type to the tablet's type i.e. REPLICA or RDONLY.
 package discovery
 
 import (

--- a/go/vt/discovery/utils.go
+++ b/go/vt/discovery/utils.go
@@ -1,0 +1,49 @@
+package discovery
+
+import (
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// This file contains helper filter methods to process the unfiltered list of
+// tablets returned by HealthCheck.GetEndPointStatsFrom*.
+// See also replicationlag.go for a more sophisicated filter used by vtgate.
+
+// RemoveUnhealthyEndpoints filters all unhealthy tablets out.
+// NOTE: Non-serving tablets are considered healthy.
+func RemoveUnhealthyEndpoints(epsList []*EndPointStats) []*EndPointStats {
+	result := make([]*EndPointStats, 0, len(epsList))
+	for _, eps := range epsList {
+		// Note we do not check the 'Serving' flag here.
+		// This is mainly to avoid the case where we run a vtworker Diff between a
+		// source and destination, and the source is not serving (disabled by
+		// TabletControl). When we switch the tablet to 'worker', it will
+		// go back to serving state.
+		if eps.Stats == nil || eps.Stats.HealthError != "" || float64(eps.Stats.SecondsBehindMaster) > LowReplicationLag.Seconds() {
+			continue
+		}
+		result = append(result, eps)
+	}
+	return result
+}
+
+// GetCurrentMaster returns the MASTER tablet with the highest
+// TabletExternallyReparentedTimestamp value.
+func GetCurrentMaster(epsList []*EndPointStats) []*EndPointStats {
+	var master *EndPointStats
+	// If there are multiple masters (e.g. during a reparent), pick the most
+	// recent one (i.e. with the highest TabletExternallyReparentedTimestamp value).
+	for _, eps := range epsList {
+		if eps.Target.TabletType != topodatapb.TabletType_MASTER {
+			continue
+		}
+
+		if master == nil || master.TabletExternallyReparentedTimestamp < eps.TabletExternallyReparentedTimestamp {
+			master = eps
+		}
+	}
+	if master == nil {
+		return []*EndPointStats{}
+	}
+
+	return []*EndPointStats{master}
+}

--- a/go/vt/discovery/utils.go
+++ b/go/vt/discovery/utils.go
@@ -42,7 +42,7 @@ func GetCurrentMaster(epsList []*EndPointStats) []*EndPointStats {
 		}
 	}
 	if master == nil {
-		return []*EndPointStats{}
+		return nil
 	}
 
 	return []*EndPointStats{master}

--- a/go/vt/discovery/utils_test.go
+++ b/go/vt/discovery/utils_test.go
@@ -1,0 +1,139 @@
+package discovery
+
+import (
+	"reflect"
+	"testing"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+func TestRemoveUnhealthyEndpoints(t *testing.T) {
+	var testcases = []struct {
+		desc  string
+		input []*EndPointStats
+		want  []*EndPointStats
+	}{
+		{
+			desc:  "tablets missing Stats",
+			input: []*EndPointStats{replica(1), replica(2)},
+			want:  []*EndPointStats{},
+		},
+		{
+			desc:  "all tablets healthy",
+			input: []*EndPointStats{healthy(replica(1)), healthy(replica(2))},
+			want:  []*EndPointStats{healthy(replica(1)), healthy(replica(2))},
+		},
+		{
+			desc:  "one unhealthy tablet (error)",
+			input: []*EndPointStats{healthy(replica(1)), unhealthyError(replica(2))},
+			want:  []*EndPointStats{healthy(replica(1))},
+		},
+		{
+			desc:  "one unhealthy tablet (lag)",
+			input: []*EndPointStats{healthy(replica(1)), unhealthyLag(replica(2))},
+			want:  []*EndPointStats{healthy(replica(1))},
+		},
+		{
+			desc:  "no filtering by tablet type",
+			input: []*EndPointStats{healthy(master(1)), healthy(replica(2)), healthy(rdonly(3))},
+			want:  []*EndPointStats{healthy(master(1)), healthy(replica(2)), healthy(rdonly(3))},
+		},
+		{
+			desc:  "non-serving tablets won't be removed",
+			input: []*EndPointStats{notServing(healthy(replica(1)))},
+			want:  []*EndPointStats{notServing(healthy(replica(1)))},
+		},
+	}
+
+	for _, tc := range testcases {
+		if got := RemoveUnhealthyEndpoints(tc.input); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("test case '%v' failed: RemoveUnhealthyEndpoints(%v) = %#v, want: %#v", tc.desc, tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestGetCurrentMaster(t *testing.T) {
+	var testcases = []struct {
+		desc  string
+		input []*EndPointStats
+		want  []*EndPointStats
+	}{
+		{
+			desc:  "zero masters remains zero",
+			input: []*EndPointStats{replica(1), rdonly(2)},
+			want:  []*EndPointStats{},
+		},
+		{
+			desc:  "single master",
+			input: []*EndPointStats{master(1)},
+			want:  []*EndPointStats{master(1)},
+		},
+		{
+			desc:  "multiple masters with different reparent times",
+			input: []*EndPointStats{reparentAt(10, master(1)), reparentAt(11, master(2))},
+			want:  []*EndPointStats{reparentAt(11, master(2))},
+		},
+	}
+
+	for _, tc := range testcases {
+		if got := GetCurrentMaster(tc.input); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("test case '%v' failed: GetCurrentMaster(%v) = %v, want: %v", tc.desc, tc.input, got, tc.want)
+		}
+	}
+}
+
+func master(uid uint32) *EndPointStats {
+	return minimalEndPointStats(uid, topodatapb.TabletType_MASTER)
+}
+
+func replica(uid uint32) *EndPointStats {
+	return minimalEndPointStats(uid, topodatapb.TabletType_REPLICA)
+}
+
+func rdonly(uid uint32) *EndPointStats {
+	return minimalEndPointStats(uid, topodatapb.TabletType_RDONLY)
+}
+
+func minimalEndPointStats(uid uint32, tabletType topodatapb.TabletType) *EndPointStats {
+	return &EndPointStats{
+		EndPoint: &topodatapb.EndPoint{Uid: uid},
+		Target: &querypb.Target{
+			Keyspace:   "test_keyspace",
+			Shard:      "-80",
+			TabletType: tabletType,
+		},
+		Serving: true,
+	}
+}
+
+func reparentAt(timestamp int64, eps *EndPointStats) *EndPointStats {
+	eps.TabletExternallyReparentedTimestamp = timestamp
+	return eps
+}
+
+func healthy(eps *EndPointStats) *EndPointStats {
+	eps.Stats = &querypb.RealtimeStats{
+		SecondsBehindMaster: uint32(1),
+	}
+	return eps
+}
+
+func unhealthyLag(eps *EndPointStats) *EndPointStats {
+	eps.Stats = &querypb.RealtimeStats{
+		SecondsBehindMaster: uint32(3600),
+	}
+	return eps
+}
+
+func unhealthyError(eps *EndPointStats) *EndPointStats {
+	eps.Stats = &querypb.RealtimeStats{
+		HealthError: "unhealthy",
+	}
+	return eps
+}
+
+func notServing(eps *EndPointStats) *EndPointStats {
+	eps.Serving = false
+	return eps
+}

--- a/go/vt/discovery/utils_test.go
+++ b/go/vt/discovery/utils_test.go
@@ -62,7 +62,7 @@ func TestGetCurrentMaster(t *testing.T) {
 		{
 			desc:  "zero masters remains zero",
 			input: []*EndPointStats{replica(1), rdonly(2)},
-			want:  []*EndPointStats{},
+			want:  nil,
 		},
 		{
 			desc:  "single master",

--- a/go/vt/tabletmanager/binlog_players.go
+++ b/go/vt/tabletmanager/binlog_players.go
@@ -276,9 +276,10 @@ func (bpc *BinlogPlayerController) Iteration() (err error) {
 	}
 
 	// Find the server list from the health check
-	addrs := bpc.healthCheck.GetEndPointStatsFromTarget(bpc.sourceShard.Keyspace, bpc.sourceShard.Shard, topodatapb.TabletType_REPLICA)
+	addrs := discovery.RemoveUnhealthyEndpoints(
+		bpc.healthCheck.GetEndPointStatsFromTarget(bpc.sourceShard.Keyspace, bpc.sourceShard.Shard, topodatapb.TabletType_REPLICA))
 	if len(addrs) == 0 {
-		return fmt.Errorf("can't find any source tablet for %v %v %v", bpc.cell, bpc.sourceShard.String(), topodatapb.TabletType_REPLICA)
+		return fmt.Errorf("can't find any healthy source tablet for %v %v %v", bpc.cell, bpc.sourceShard.String(), topodatapb.TabletType_REPLICA)
 	}
 	newServerIndex := rand.Intn(len(addrs))
 	endPoint := addrs[newServerIndex].EndPoint

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -503,32 +503,23 @@ func (wr *Wrangler) waitForDrainInCell(ctx context.Context, cell, keyspace, shar
 	// Now check the QPS rate of all tablets until the timeout expires.
 	startTime := time.Now()
 	for {
-		healthyTabletsCount := 0
 		// map key: tablet uid
 		drainedHealthyTablets := make(map[uint32]*discovery.EndPointStats)
 		notDrainedHealtyTablets := make(map[uint32]*discovery.EndPointStats)
 
-		addrs := hc.GetEndPointStatsFromTarget(keyspace, shard, servedType)
-		healthyTabletsCount = 0
-		for _, addr := range addrs {
-			// TODO(mberlin): Move this health check logic into a common function
-			// because other code uses it as well e.g. go/vt/worker/topo_utils.go.
-			if addr.Stats == nil || addr.Stats.HealthError != "" || addr.Stats.SecondsBehindMaster > 30 {
-				// not healthy
-				continue
-			}
-
-			healthyTabletsCount++
-			if addr.Stats.Qps == 0.0 {
-				drainedHealthyTablets[addr.EndPoint.Uid] = addr
+		healthyTablets := discovery.RemoveUnhealthyEndpoints(
+			hc.GetEndPointStatsFromTarget(keyspace, shard, servedType))
+		for _, eps := range healthyTablets {
+			if eps.Stats.Qps == 0.0 {
+				drainedHealthyTablets[eps.EndPoint.Uid] = eps
 			} else {
-				notDrainedHealtyTablets[addr.EndPoint.Uid] = addr
+				notDrainedHealtyTablets[eps.EndPoint.Uid] = eps
 			}
 		}
 
-		if len(drainedHealthyTablets) == healthyTabletsCount {
+		if len(drainedHealthyTablets) == len(healthyTablets) {
 			wr.Logger().Infof("%v: All %d healthy tablets were drained after %.1f seconds (not counting %.1f seconds for the initial wait).",
-				cell, healthyTabletsCount, time.Now().Sub(startTime).Seconds(), healthCheckTimeout.Seconds())
+				cell, len(healthyTablets), time.Now().Sub(startTime).Seconds(), healthCheckTimeout.Seconds())
 			break
 		}
 
@@ -538,7 +529,7 @@ func (wr *Wrangler) waitForDrainInCell(ctx context.Context, cell, keyspace, shar
 			deadlineString = fmt.Sprintf(" up to %.1f more seconds", d.Sub(time.Now()).Seconds())
 		}
 		wr.Logger().Infof("%v: Waiting%v for all healthy tablets to be drained (%d/%d done).",
-			cell, deadlineString, len(drainedHealthyTablets), healthyTabletsCount)
+			cell, deadlineString, len(drainedHealthyTablets), len(healthyTablets))
 
 		timer := time.NewTimer(retryDelay)
 		select {
@@ -550,7 +541,7 @@ func (wr *Wrangler) waitForDrainInCell(ctx context.Context, cell, keyspace, shar
 				l = append(l, formatEndpointStats(eps))
 			}
 			return fmt.Errorf("%v: WaitForDrain failed for %v tablets in %v/%v. Only %d/%d tablets were drained. err: %v List of tablets which were not drained: %v",
-				cell, servedType, keyspace, shard, len(drainedHealthyTablets), healthyTabletsCount, ctx.Err(), strings.Join(l, ";"))
+				cell, servedType, keyspace, shard, len(drainedHealthyTablets), len(healthyTablets), ctx.Err(), strings.Join(l, ";"))
 		case <-timer.C:
 		}
 	}


### PR DESCRIPTION
@guoliang100 
@alainjobart 

discovery: Provide filter helper functions to reduce code duplication.

Note: The GetCurrentMaster() function which will be used by vtworker when we switch to the discovery package.

BinlogPlayer: Do not use unhealthy REPLICA tablets as source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1661)
<!-- Reviewable:end -->
