### PR TITLE
Fix from bloating the byte[] values in GetByte()/GetBytes()

### DIFF
--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -218,13 +218,18 @@ public class VitessResultSet implements ResultSet {
         byte value;
 
         preAccessor(columnIndex);
-
         if (isNull(columnIndex)) {
             return 0;
         }
 
-        byteString = this.getString(columnIndex);
+        //If the return column type is of byte,
+        // return byte otherwise typecast
+        Object object = this.row.getObject(columnIndex);
+        if(object instanceof Byte) {
+            return (byte) object;
+        }
 
+        byteString = this.getString(columnIndex);
         try {
             value = Byte.parseByte(byteString);
         } catch (NumberFormatException nfe) {
@@ -366,13 +371,17 @@ public class VitessResultSet implements ResultSet {
         byte[] value;
 
         preAccessor(columnIndex);
-
         if (isNull(columnIndex)) {
             return null;
         }
+        //If the return column type is of byte[],
+        // return byte[] otherwise typecast
+        Object object = this.row.getObject(columnIndex);
+        if(object instanceof byte[]) {
+            return (byte[]) object;
+        }
 
         bytesString = this.getString(columnIndex);
-
         try {
             value = bytesString.getBytes();
         } catch (Exception ex) {

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessResultSetTest.java
@@ -263,6 +263,7 @@ public class VitessResultSetTest {
         VitessResultSet vitessResultSet = new VitessResultSet(cursor);
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte(1));
+        Assert.assertEquals(1, vitessResultSet.getByte(25));
     }
 
     @Test
@@ -396,6 +397,7 @@ public class VitessResultSetTest {
         VitessResultSet vitessResultSet = new VitessResultSet(cursor);
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte("col1"));
+        Assert.assertEquals(1, vitessResultSet.getByte("col25"));
     }
 
     @Test


### PR DESCRIPTION
This Pull request contains the following change:

- Changes to avoid bloating Byte Array in GetBytes()/GetByte() function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1664)
<!-- Reviewable:end -->
