### PR TITLE
sqltypes bug: incorrect vitess type returned

### DIFF
--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -99,14 +99,10 @@ const (
 // bit-shift the mysql flags by two byte so we
 // can merge them with the mysql or vitess types.
 const (
-	originalUnsigned = 32
-	originalBinary   = 128
-	originalEnum     = 256
-	originalSet      = 2048
-	mysqlUnsigned    = originalUnsigned << 16
-	mysqlBinary      = originalBinary << 16
-	mysqlEnum        = originalEnum << 16
-	mysqlSet         = originalSet << 16
+	mysqlUnsigned = 32
+	mysqlBinary   = 128
+	mysqlEnum     = 256
+	mysqlSet      = 2048
 )
 
 // If you add to this map, make sure you add a test case
@@ -140,7 +136,6 @@ var mysqlToType = map[int64]querypb.Type{
 // on the type. This allows us to ignore stray flags
 // that MySQL occasionally sets.
 func modifyType(typ querypb.Type, flags int64) querypb.Type {
-	flags = flags << 16
 	switch typ {
 	case Int8:
 		if flags&mysqlUnsigned != 0 {
@@ -239,5 +234,5 @@ var typeToMySQL = map[querypb.Type]struct {
 // TypeToMySQL returns the equivalent mysql type and flag for a vitess type.
 func TypeToMySQL(typ querypb.Type) (mysqlType, flags int64) {
 	val := typeToMySQL[typ]
-	return val.typ, val.flags >> 16
+	return val.typ, val.flags
 }

--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -99,31 +99,15 @@ const (
 // bit-shift the mysql flags by two byte so we
 // can merge them with the mysql or vitess types.
 const (
-	mysqlUnsigned = 32 << 16
-	mysqlBinary   = 128 << 16
-	mysqlEnum     = 256 << 16
-	mysqlSet      = 2048 << 16
+	originalUnsigned = 32
+	originalBinary   = 128
+	originalEnum     = 256
+	originalSet      = 2048
+	mysqlUnsigned    = originalUnsigned << 16
+	mysqlBinary      = originalBinary << 16
+	mysqlEnum        = originalEnum << 16
+	mysqlSet         = originalSet << 16
 )
-
-// convertFlags converts the mysql flags into the bit-shifted
-// version. It also normalizes it by removing stray bits.
-// This allows us to treat the result as a value.
-func convertFlags(flags int64) int64 {
-	flags = flags << 16
-	if flags&mysqlUnsigned != 0 {
-		return mysqlUnsigned
-	}
-	if flags&mysqlBinary != 0 {
-		return mysqlBinary
-	}
-	if flags&mysqlEnum != 0 {
-		return mysqlEnum
-	}
-	if flags&mysqlSet != 0 {
-		return mysqlSet
-	}
-	return 0
-}
 
 // If you add to this map, make sure you add a test case
 // in tabletserver/endtoend.
@@ -151,17 +135,70 @@ var mysqlToType = map[int64]querypb.Type{
 	254: Char,
 }
 
-var modifier = map[int64]querypb.Type{
-	int64(Int8) | mysqlUnsigned:  Uint8,
-	int64(Int16) | mysqlUnsigned: Uint16,
-	int64(Int32) | mysqlUnsigned: Uint32,
-	int64(Int64) | mysqlUnsigned: Uint64,
-	int64(Int24) | mysqlUnsigned: Uint24,
-	int64(Text) | mysqlBinary:    Blob,
-	int64(VarChar) | mysqlBinary: VarBinary,
-	int64(Char) | mysqlBinary:    Binary,
-	int64(Char) | mysqlEnum:      Enum,
-	int64(Char) | mysqlSet:       Set,
+// modifyType modifies the vitess type based on the
+// mysql flag. The function checks specific flags based
+// on the type. This allows us to ignore stray flags
+// that MySQL occasionally sets.
+func modifyType(typ querypb.Type, flags int64) querypb.Type {
+	flags = flags << 16
+	switch typ {
+	case Int8:
+		if flags&mysqlUnsigned != 0 {
+			return Uint8
+		}
+		return Int8
+	case Int16:
+		if flags&mysqlUnsigned != 0 {
+			return Uint16
+		}
+		return Int16
+	case Int32:
+		if flags&mysqlUnsigned != 0 {
+			return Uint32
+		}
+		return Int32
+	case Int64:
+		if flags&mysqlUnsigned != 0 {
+			return Uint64
+		}
+		return Int64
+	case Int24:
+		if flags&mysqlUnsigned != 0 {
+			return Uint24
+		}
+		return Int24
+	case Text:
+		if flags&mysqlBinary != 0 {
+			return Blob
+		}
+		return Text
+	case VarChar:
+		if flags&mysqlBinary != 0 {
+			return VarBinary
+		}
+		return VarChar
+	case Char:
+		if flags&mysqlBinary != 0 {
+			return Binary
+		}
+		if flags&mysqlEnum != 0 {
+			return Enum
+		}
+		if flags&mysqlSet != 0 {
+			return Set
+		}
+		return Char
+	}
+	return typ
+}
+
+// MySQLToType computes the vitess type from mysql type and flags.
+func MySQLToType(mysqlType, flags int64) (typ querypb.Type, err error) {
+	result, ok := mysqlToType[mysqlType]
+	if !ok {
+		return 0, fmt.Errorf("unsupported type: %d", mysqlType)
+	}
+	return modifyType(result, flags), nil
 }
 
 // typeToMySQL is the reverse of mysqlToType.
@@ -197,21 +234,6 @@ var typeToMySQL = map[querypb.Type]struct {
 	Binary:    {typ: 254, flags: mysqlBinary},
 	Enum:      {typ: 254, flags: mysqlEnum},
 	Set:       {typ: 254, flags: mysqlSet},
-}
-
-// MySQLToType computes the vitess type from mysql type and flags.
-func MySQLToType(mysqlType, flags int64) (typ querypb.Type, err error) {
-	result, ok := mysqlToType[mysqlType]
-	if !ok {
-		return 0, fmt.Errorf("unsupported type: %d", mysqlType)
-	}
-
-	converted := convertFlags(flags)
-	modified, ok := modifier[int64(result)|converted]
-	if ok {
-		return modified, nil
-	}
-	return result, nil
 }
 
 // TypeToMySQL returns the equivalent mysql type and flag for a vitess type.

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -159,15 +159,15 @@ func TestTypeToMySQL(t *testing.T) {
 	if v != 16 {
 		t.Errorf("Bit: %d, want 16", v)
 	}
-	if f != mysqlUnsigned>>16 {
-		t.Errorf("Bit flag: %x, want %x", f, mysqlUnsigned>>16)
+	if f != mysqlUnsigned {
+		t.Errorf("Bit flag: %x, want %x", f, mysqlUnsigned)
 	}
 	v, f = TypeToMySQL(Date)
 	if v != 10 {
 		t.Errorf("Bit: %d, want 10", v)
 	}
-	if f != mysqlBinary>>16 {
-		t.Errorf("Bit flag: %x, want %x", f, mysqlBinary>>16)
+	if f != mysqlBinary {
+		t.Errorf("Bit flag: %x, want %x", f, mysqlBinary)
 	}
 }
 
@@ -181,21 +181,21 @@ func TestMySQLToType(t *testing.T) {
 		outtype: Int8,
 	}, {
 		intype:  1,
-		inflags: originalUnsigned,
+		inflags: mysqlUnsigned,
 		outtype: Uint8,
 	}, {
 		intype:  2,
 		outtype: Int16,
 	}, {
 		intype:  2,
-		inflags: originalUnsigned,
+		inflags: mysqlUnsigned,
 		outtype: Uint16,
 	}, {
 		intype:  3,
 		outtype: Int32,
 	}, {
 		intype:  3,
-		inflags: originalUnsigned,
+		inflags: mysqlUnsigned,
 		outtype: Uint32,
 	}, {
 		intype:  4,
@@ -214,14 +214,14 @@ func TestMySQLToType(t *testing.T) {
 		outtype: Int64,
 	}, {
 		intype:  8,
-		inflags: originalUnsigned,
+		inflags: mysqlUnsigned,
 		outtype: Uint64,
 	}, {
 		intype:  9,
 		outtype: Int24,
 	}, {
 		intype:  9,
-		inflags: originalUnsigned,
+		inflags: mysqlUnsigned,
 		outtype: Uint24,
 	}, {
 		intype:  10,
@@ -255,39 +255,39 @@ func TestMySQLToType(t *testing.T) {
 		outtype: Text,
 	}, {
 		intype:  252,
-		inflags: originalBinary,
+		inflags: mysqlBinary,
 		outtype: Blob,
 	}, {
 		intype:  253,
 		outtype: VarChar,
 	}, {
 		intype:  253,
-		inflags: originalBinary,
+		inflags: mysqlBinary,
 		outtype: VarBinary,
 	}, {
 		intype:  254,
 		outtype: Char,
 	}, {
 		intype:  254,
-		inflags: originalBinary,
+		inflags: mysqlBinary,
 		outtype: Binary,
 	}, {
 		intype:  254,
-		inflags: originalEnum,
+		inflags: mysqlEnum,
 		outtype: Enum,
 	}, {
 		intype:  254,
-		inflags: originalSet,
+		inflags: mysqlSet,
 		outtype: Set,
 	}, {
 		// Binary flag must be ignored.
 		intype:  8,
-		inflags: originalUnsigned | originalBinary,
+		inflags: mysqlUnsigned | mysqlBinary,
 		outtype: Uint64,
 	}, {
 		// Unsigned flag must be ignored
 		intype:  252,
-		inflags: originalUnsigned | originalBinary,
+		inflags: mysqlUnsigned | mysqlBinary,
 		outtype: Blob,
 	}}
 	for _, tcase := range testcases {

--- a/go/vt/tabletserver/endtoend/compatibility_test.go
+++ b/go/vt/tabletserver/endtoend/compatibility_test.go
@@ -138,6 +138,31 @@ func TestInts(t *testing.T) {
 	if !reflect.DeepEqual(*qr, want) {
 		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
 	}
+	// This test was added because the following query causes mysql to
+	// return flags with both binary and unsigned set. The test ensures
+	// that a Uint64 is produced in spite of the stray binary flag.
+	qr, err = client.Execute("select max(bigu) from vitess_ints", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	want = sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "max(bigu)",
+				Type: sqltypes.Uint64,
+			},
+		},
+		RowsAffected: 1,
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(sqltypes.Uint64, []byte("18446744073709551615")),
+			},
+		},
+	}
+	if !reflect.DeepEqual(*qr, want) {
+		t.Errorf("Execute: \n%#v, want \n%#v", *qr, want)
+	}
 }
 
 func TestFractionals(t *testing.T) {


### PR DESCRIPTION
@erzel 
Bug: b/28409793
MySQL sometimes sets stray flags that have to be ignored.
Specifically, for this query:
select max(uint) from t
MySQL sets the binary flag along with the unsigned flag.
The bug fix changes the behavior where vitess only looks at
the relevant flags and ignores all others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1665)
<!-- Reviewable:end -->
