### PR TITLE
worker: Refactored FakePoolConnection.

### DIFF
--- a/go/vt/worker/fake_pool_connection_test.go
+++ b/go/vt/worker/fake_pool_connection_test.go
@@ -1,0 +1,166 @@
+package worker
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/dbconnpool"
+)
+
+const appendEntry = -1
+
+// FakePoolConnection fakes out a MySQL database and implements
+// dbconnpool.PoolConnection.
+// The fake will error the test if an unexpected query was received.
+type FakePoolConnection struct {
+	t *testing.T
+	// name is used in log output to reference this specific instance.
+	name   string
+	closed bool
+
+	// mu guards all fields in the group below.
+	// (vtworker writes multi-threaded. Therefore, synchronization is required.)
+	// This mutex effectively serializes the parallel writes and makes the test
+	// more deterministic. For example, you can set a callback on the last write
+	// and have the guarantee that no other writes occur during the callback.
+	mu                        sync.Mutex
+	expectedExecuteFetch      []ExpectedExecuteFetch
+	expectedExecuteFetchIndex int
+}
+
+// ExpectedExecuteFetch defines for an expected query the to be faked output.
+type ExpectedExecuteFetch struct {
+	Query       string
+	MaxRows     int
+	WantFields  bool
+	QueryResult *sqltypes.Result
+	Error       error
+}
+
+// NewFakePoolConnectionQuery creates a new fake database.
+// Set "name" to distinguish between the different instances in your tests.
+func NewFakePoolConnectionQuery(t *testing.T, name string) *FakePoolConnection {
+	return &FakePoolConnection{t: t, name: name}
+}
+
+func (f *FakePoolConnection) addExpectedExecuteFetch(entry ExpectedExecuteFetch) {
+	f.addExpectedExecuteFetchAtIndex(appendEntry, entry)
+}
+
+// addExpectedExecuteFetchAtIndex inserts a new entry at index.
+// index values start at 0.
+func (f *FakePoolConnection) addExpectedExecuteFetchAtIndex(index int, entry ExpectedExecuteFetch) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.expectedExecuteFetch == nil || index < 0 || index >= len(f.expectedExecuteFetch) {
+		index = appendEntry
+	}
+	if index == appendEntry {
+		f.expectedExecuteFetch = append(f.expectedExecuteFetch, entry)
+	} else {
+		// Grow the slice by one element.
+		f.expectedExecuteFetch = f.expectedExecuteFetch[0 : len(f.expectedExecuteFetch)+1]
+		// Use copy to move the upper part of the slice out of the way and open a hole.
+		copy(f.expectedExecuteFetch[index+1:], f.expectedExecuteFetch[index:])
+		// Store the new value.
+		f.expectedExecuteFetch[index] = entry
+	}
+}
+
+func (f *FakePoolConnection) addExpectedQuery(query string, err error) {
+	f.addExpectedExecuteFetch(ExpectedExecuteFetch{
+		Query:       query,
+		QueryResult: &sqltypes.Result{},
+		Error:       err,
+	})
+}
+
+func (f *FakePoolConnection) addExpectedQueryAtIndex(index int, query string, err error) {
+	f.addExpectedExecuteFetchAtIndex(index, ExpectedExecuteFetch{
+		Query:       query,
+		QueryResult: &sqltypes.Result{},
+		Error:       err,
+	})
+}
+
+// verifyAllExecutedOrFail checks that all expected queries where actually
+// received and executed. If not, it will let the test fail.
+func (f *FakePoolConnection) verifyAllExecutedOrFail() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.expectedExecuteFetchIndex != len(f.expectedExecuteFetch) {
+		f.t.Errorf("%v: not all expected queries were executed. leftovers: %v", f.name, f.expectedExecuteFetch[f.expectedExecuteFetchIndex:])
+	}
+}
+
+func (f *FakePoolConnection) getFactory() func() (dbconnpool.PoolConnection, error) {
+	return func() (dbconnpool.PoolConnection, error) {
+		return f, nil
+	}
+}
+
+// ExecuteFetch implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	index := f.expectedExecuteFetchIndex
+	if index >= len(f.expectedExecuteFetch) {
+		f.t.Errorf("%v: got unexpected out of bound fetch: %v >= %v", f.name, index, len(f.expectedExecuteFetch))
+		return nil, errors.New("unexpected out of bound fetch")
+	}
+	entry := f.expectedExecuteFetch[index]
+
+	f.expectedExecuteFetchIndex++
+
+	expected := entry.Query
+	if strings.HasSuffix(expected, "*") {
+		if !strings.HasPrefix(query, expected[0:len(expected)-1]) {
+			f.t.Errorf("%v: got unexpected query start (index=%v): %v != %v", f.name, index, query, expected)
+		}
+	} else {
+		if query != expected {
+			f.t.Errorf("%v: got unexpected query (index=%v): %v != %v", f.name, index, query, expected)
+			return nil, errors.New("unexpected query")
+		}
+	}
+	f.t.Logf("ExecuteFetch: %v: %v", f.name, query)
+	if entry.Error != nil {
+		return nil, entry.Error
+	}
+	return entry.QueryResult, nil
+}
+
+// ExecuteStreamFetch implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) ExecuteStreamFetch(query string, callback func(*sqltypes.Result) error, streamBufferSize int) error {
+	return nil
+}
+
+// ID implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) ID() int64 {
+	return 1
+}
+
+// Close implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) Close() {
+	f.closed = true
+}
+
+// IsClosed implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) IsClosed() bool {
+	return f.closed
+}
+
+// Recycle implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) Recycle() {
+}
+
+// Reconnect implements dbconnpool.PoolConnection.
+func (f *FakePoolConnection) Reconnect() error {
+	return nil
+}

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -5,19 +5,19 @@
 package worker
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/mysqlctl/replication"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
 	"github.com/youtube/vitess/go/vt/tabletserver/grpcqueryservice"
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice/fakes"
+	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
 	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
@@ -28,6 +28,184 @@ import (
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
+const (
+	// splitCloneTestMin is the minimum value of the primary key.
+	splitCloneTestMin int = 100
+	// splitCloneTestMax is the maximum value of the primary key.
+	splitCloneTestMax int = 200
+)
+
+var (
+	errReadOnly = errors.New("The MariaDB server is running with the --read-only option so it cannot execute this statement (errno 1290) during query:")
+)
+
+type splitCloneTestCase struct {
+	t *testing.T
+
+	ts      topo.Server
+	wi      *Instance
+	tablets []*testlib.FakeTablet
+
+	leftMasterFakeDb  *FakePoolConnection
+	leftMasterQs      *fakes.StreamHealthQueryService
+	rightMasterFakeDb *FakePoolConnection
+	rightMasterQs     *fakes.StreamHealthQueryService
+
+	// defaultWorkerArgs are the full default arguments to run SplitClone.
+	defaultWorkerArgs []string
+}
+
+func (tc *splitCloneTestCase) setUp(v3 bool) {
+	*useV3ReshardingMode = v3
+	db := fakesqldb.Register()
+	tc.ts = zktestserver.New(tc.t, []string{"cell1", "cell2"})
+	ctx := context.Background()
+	tc.wi = NewInstance(ctx, tc.ts, "cell1", time.Second)
+
+	if v3 {
+		// FIXME(alainjobart): ShardingColumnName and ShardingColumnType
+		// are not used by v3 split_clone, but they are required
+		// by tabletmanager to setup the rules. We have b/27901260
+		// open internally to fix this.
+		if err := tc.ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
+			ShardingColumnName: "keyspace_id",
+			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
+		}); err != nil {
+			tc.t.Fatalf("CreateKeyspace v3 failed: %v", err)
+		}
+
+		if err := tc.ts.SaveVSchema(ctx, "ks", `{
+  "Sharded": true,
+  "Vindexes": {
+    "table1_index": {
+      "Type": "numeric"
+    }
+  },
+  "Tables": {
+    "table1": {
+      "ColVindexes": [
+        {
+          "Col": "keyspace_id",
+          "Name": "table1_index"
+        }
+      ]
+    }
+  }
+}`); err != nil {
+			tc.t.Fatalf("SaveVSchema v3 failed: %v", err)
+		}
+	} else {
+		if err := tc.ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
+			ShardingColumnName: "keyspace_id",
+			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
+		}); err != nil {
+			tc.t.Fatalf("CreateKeyspace v2 failed: %v", err)
+		}
+	}
+
+	sourceMaster := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 0,
+		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(tc.t, "ks", "-80"))
+	sourceRdonly1 := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 1,
+		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(tc.t, "ks", "-80"))
+	sourceRdonly2 := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 2,
+		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(tc.t, "ks", "-80"))
+
+	leftMaster := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 10,
+		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(tc.t, "ks", "-40"))
+	leftRdonly := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 11,
+		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(tc.t, "ks", "-40"))
+
+	rightMaster := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 20,
+		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(tc.t, "ks", "40-80"))
+	rightRdonly := testlib.NewFakeTablet(tc.t, tc.wi.wr, "cell1", 21,
+		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(tc.t, "ks", "40-80"))
+
+	tc.tablets = []*testlib.FakeTablet{sourceMaster, sourceRdonly1, sourceRdonly2, leftMaster, leftRdonly, rightMaster, rightRdonly}
+
+	for _, ft := range tc.tablets {
+		ft.StartActionLoop(tc.t, tc.wi.wr)
+	}
+
+	// add the topo and schema data we'll need
+	if err := tc.ts.CreateShard(ctx, "ks", "80-"); err != nil {
+		tc.t.Fatalf("CreateShard(\"-80\") failed: %v", err)
+	}
+	if err := tc.wi.wr.SetKeyspaceShardingInfo(ctx, "ks", "keyspace_id", topodatapb.KeyspaceIdType_UINT64, 4, false); err != nil {
+		tc.t.Fatalf("SetKeyspaceShardingInfo failed: %v", err)
+	}
+	if err := tc.wi.wr.RebuildKeyspaceGraph(ctx, "ks", nil, true); err != nil {
+		tc.t.Fatalf("RebuildKeyspaceGraph failed: %v", err)
+	}
+
+	for _, sourceRdonly := range []*testlib.FakeTablet{sourceRdonly1, sourceRdonly2} {
+		sourceRdonly.FakeMysqlDaemon.Schema = &tabletmanagerdatapb.SchemaDefinition{
+			DatabaseSchema: "",
+			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+				{
+					Name:              "table1",
+					Columns:           []string{"id", "msg", "keyspace_id"},
+					PrimaryKeyColumns: []string{"id"},
+					Type:              tmutils.TableBaseTable,
+					// This informs how many rows we can pack into a single insert
+					DataLength: 2048,
+				},
+			},
+		}
+		sourceRdonly.FakeMysqlDaemon.DbAppConnectionFactory = sourceRdonlyFactory(
+			tc.t, "vt_ks.table1", splitCloneTestMin, splitCloneTestMax)
+		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = replication.Position{
+			GTIDSet: replication.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
+		}
+		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
+			"STOP SLAVE",
+			"START SLAVE",
+		}
+		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
+		qs.AddDefaultHealthResponse()
+		grpcqueryservice.RegisterForTest(sourceRdonly.RPCServer, &testQueryService{
+			t: tc.t,
+			StreamHealthQueryService: qs,
+		})
+	}
+
+	// We read 100 source rows. sourceReaderCount is set to 10, so
+	// we'll have 100/10=10 rows per table chunk.
+	// destinationPackCount is set to 4, so we take 4 source rows
+	// at once. So we'll process 4 + 4 + 2 rows to get to 10.
+	// That means 3 insert statements on each target (each
+	// containing half of the rows, i.e. 2 + 2 + 1 rows). So 3 * 10
+	// = 30 insert statements on each destination.
+	tc.leftMasterFakeDb = NewFakePoolConnectionQuery(tc.t, "leftMaster")
+	tc.rightMasterFakeDb = NewFakePoolConnectionQuery(tc.t, "rightMaster")
+
+	for i := 1; i <= 30; i++ {
+		tc.leftMasterFakeDb.addExpectedQuery("INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*", nil)
+		// leftReplica is unused by default.
+		tc.rightMasterFakeDb.addExpectedQuery("INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*", nil)
+	}
+	expectBlpCheckpointCreationQueries(tc.leftMasterFakeDb)
+	expectBlpCheckpointCreationQueries(tc.rightMasterFakeDb)
+
+	leftMaster.FakeMysqlDaemon.DbAppConnectionFactory = tc.leftMasterFakeDb.getFactory()
+	rightMaster.FakeMysqlDaemon.DbAppConnectionFactory = tc.rightMasterFakeDb.getFactory()
+
+	tc.defaultWorkerArgs = []string{
+		"SplitClone",
+		"-source_reader_count", "10",
+		"-destination_pack_count", "4",
+		"-min_table_size_for_split", "1",
+		"-destination_writer_count", "10",
+		"ks/-80"}
+}
+
+func (tc *splitCloneTestCase) tearDown() {
+	for _, ft := range tc.tablets {
+		ft.StopActionLoop(tc.t)
+	}
+	tc.leftMasterFakeDb.verifyAllExecutedOrFail()
+	tc.rightMasterFakeDb.verifyAllExecutedOrFail()
+}
+
 // testQueryService is a local QueryService implementation to support the tests.
 type testQueryService struct {
 	t *testing.T
@@ -36,9 +214,9 @@ type testQueryService struct {
 }
 
 func (sq *testQueryService) StreamExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, sessionID int64, sendReply func(reply *sqltypes.Result) error) error {
-	// Custom parsing of the query we expect
-	min := 100
-	max := 200
+	// Custom parsing of the query we expect.
+	min := splitCloneTestMin
+	max := splitCloneTestMax
 	var err error
 	parts := strings.Split(sql, " ")
 	for _, part := range parts {
@@ -92,304 +270,55 @@ func (sq *testQueryService) StreamExecute(ctx context.Context, target *querypb.T
 	return nil
 }
 
-type ExpectedExecuteFetch struct {
-	Query       string
-	MaxRows     int
-	WantFields  bool
-	QueryResult *sqltypes.Result
-	Error       error
-}
-
-// FakePoolConnection implements dbconnpool.PoolConnection
-type FakePoolConnection struct {
-	t      *testing.T
-	Closed bool
-
-	ExpectedExecuteFetch      []ExpectedExecuteFetch
-	ExpectedExecuteFetchIndex int
-}
-
-func NewFakePoolConnectionQuery(t *testing.T, query string, err error) *FakePoolConnection {
-	return &FakePoolConnection{
-		t: t,
-		ExpectedExecuteFetch: []ExpectedExecuteFetch{
-			{
-				Query:       query,
-				QueryResult: &sqltypes.Result{},
-				Error:       err,
-			},
-		},
-	}
-}
-
-func (fpc *FakePoolConnection) ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
-	if fpc.ExpectedExecuteFetchIndex >= len(fpc.ExpectedExecuteFetch) {
-		fpc.t.Errorf("got unexpected out of bound fetch: %v >= %v", fpc.ExpectedExecuteFetchIndex, len(fpc.ExpectedExecuteFetch))
-		return nil, fmt.Errorf("unexpected out of bound fetch")
-	}
-	expected := fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Query
-	if strings.HasSuffix(expected, "*") {
-		if !strings.HasPrefix(query, expected[0:len(expected)-1]) {
-			fpc.t.Errorf("got unexpected query start: %v != %v", query, expected)
-			return nil, fmt.Errorf("unexpected query")
-		}
-	} else {
-		if query != expected {
-			fpc.t.Errorf("got unexpected query: %v != %v", query, expected)
-			return nil, fmt.Errorf("unexpected query")
-		}
-	}
-	fpc.t.Logf("ExecuteFetch: %v", query)
-	defer func() {
-		fpc.ExpectedExecuteFetchIndex++
-	}()
-	if fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Error != nil {
-		return nil, fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Error
-	}
-	return fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].QueryResult, nil
-}
-
-func (fpc *FakePoolConnection) ExecuteStreamFetch(query string, callback func(*sqltypes.Result) error, streamBufferSize int) error {
-	return nil
-}
-
-func (fpc *FakePoolConnection) ID() int64 {
-	return 1
-}
-
-func (fpc *FakePoolConnection) Close() {
-	fpc.Closed = true
-}
-
-func (fpc *FakePoolConnection) IsClosed() bool {
-	return fpc.Closed
-}
-
-func (fpc *FakePoolConnection) Recycle() {
-}
-
-func (fpc *FakePoolConnection) Reconnect() error {
-	return nil
-}
-
-// on the source rdonly guy, should only have one query to find min & max
-func SourceRdonlyFactory(t *testing.T) func() (dbconnpool.PoolConnection, error) {
-	return func() (dbconnpool.PoolConnection, error) {
-		return &FakePoolConnection{
-			t: t,
-			ExpectedExecuteFetch: []ExpectedExecuteFetch{
-				{
-					Query: "SELECT MIN(id), MAX(id) FROM vt_ks.table1",
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name: "min",
-								Type: sqltypes.Int64,
-							},
-							{
-								Name: "max",
-								Type: sqltypes.Int64,
-							},
-						},
-						Rows: [][]sqltypes.Value{
-							{
-								sqltypes.MakeString([]byte("100")),
-								sqltypes.MakeString([]byte("200")),
-							},
-						},
-					},
-				},
-			},
-		}, nil
-	}
-}
-
-// on the destinations
-func DestinationsFactory(t *testing.T, insertCount int64) func() (dbconnpool.PoolConnection, error) {
-	var queryIndex int64 = -1
-
-	return func() (dbconnpool.PoolConnection, error) {
-		qi := atomic.AddInt64(&queryIndex, 1)
-		switch {
-		// Return an error on the first query, to make sure that it's retried successfully
-		case qi == 0:
-			return NewFakePoolConnectionQuery(t,
-				"INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*",
-				fmt.Errorf("The MariaDB server is running with the --read-only option so it cannot execute this statement (errno 1290) during query:"),
-			), nil
-		case qi <= insertCount:
-			return NewFakePoolConnectionQuery(t, "INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*", nil), nil
-		case qi == insertCount+1:
-			return NewFakePoolConnectionQuery(t, "CREATE DATABASE IF NOT EXISTS _vt", nil), nil
-		case qi == insertCount+2:
-			return NewFakePoolConnectionQuery(t, "CREATE TABLE IF NOT EXISTS _vt.blp_checkpoint (\n"+
-				"  source_shard_uid INT(10) UNSIGNED NOT NULL,\n"+
-				"  pos VARCHAR(250) DEFAULT NULL,\n"+
-				"  time_updated BIGINT UNSIGNED NOT NULL,\n"+
-				"  transaction_timestamp BIGINT UNSIGNED NOT NULL,\n"+
-				"  flags VARCHAR(250) DEFAULT NULL,\n"+
-				"  PRIMARY KEY (source_shard_uid)) ENGINE=InnoDB", nil), nil
-		case qi == insertCount+3:
-			return NewFakePoolConnectionQuery(t, "INSERT INTO _vt.blp_checkpoint (source_shard_uid, pos, time_updated, transaction_timestamp, flags) VALUES (0, 'MariaDB/12-34-5678', *", nil), nil
-		}
-
-		return nil, fmt.Errorf("Unexpected connection")
-	}
-}
-
-func testSplitClone(t *testing.T, v3 bool) {
-	*useV3ReshardingMode = v3
-	db := fakesqldb.Register()
-	ts := zktestserver.New(t, []string{"cell1", "cell2"})
-	ctx := context.Background()
-	wi := NewInstance(ctx, ts, "cell1", time.Second)
-
-	if v3 {
-		// FIXME(alainjobart): ShardingColumnName and ShardingColumnType
-		// are not used by v3 split_clone, but they are required
-		// by tabletmanager to setup the rules. We have b/27901260
-		// open internally to fix this.
-		if err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
-			ShardingColumnName: "keyspace_id",
-			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
-		}); err != nil {
-			t.Fatalf("CreateKeyspace v3 failed: %v", err)
-		}
-
-		if err := ts.SaveVSchema(ctx, "ks", `{
-  "Sharded": true,
-  "Vindexes": {
-    "table1_index": {
-      "Type": "numeric"
-    }
-  },
-  "Tables": {
-    "table1": {
-      "ColVindexes": [
-        {
-          "Col": "keyspace_id",
-          "Name": "table1_index"
-        }
-      ]
-    }
-  }
-}`); err != nil {
-			t.Fatalf("SaveVSchema v3 failed: %v", err)
-		}
-	} else {
-		if err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
-			ShardingColumnName: "keyspace_id",
-			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
-		}); err != nil {
-			t.Fatalf("CreateKeyspace v2 failed: %v", err)
-		}
-	}
-
-	sourceMaster := testlib.NewFakeTablet(t, wi.wr, "cell1", 0,
-		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(t, "ks", "-80"))
-	sourceRdonly1 := testlib.NewFakeTablet(t, wi.wr, "cell1", 1,
-		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(t, "ks", "-80"))
-	sourceRdonly2 := testlib.NewFakeTablet(t, wi.wr, "cell1", 2,
-		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(t, "ks", "-80"))
-
-	leftMaster := testlib.NewFakeTablet(t, wi.wr, "cell1", 10,
-		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(t, "ks", "-40"))
-	leftRdonly := testlib.NewFakeTablet(t, wi.wr, "cell1", 11,
-		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(t, "ks", "-40"))
-
-	rightMaster := testlib.NewFakeTablet(t, wi.wr, "cell1", 20,
-		topodatapb.TabletType_MASTER, db, testlib.TabletKeyspaceShard(t, "ks", "40-80"))
-	rightRdonly := testlib.NewFakeTablet(t, wi.wr, "cell1", 21,
-		topodatapb.TabletType_RDONLY, db, testlib.TabletKeyspaceShard(t, "ks", "40-80"))
-
-	for _, ft := range []*testlib.FakeTablet{sourceMaster, sourceRdonly1, sourceRdonly2, leftMaster, leftRdonly, rightMaster, rightRdonly} {
-		ft.StartActionLoop(t, wi.wr)
-		defer ft.StopActionLoop(t)
-	}
-
-	// add the topo and schema data we'll need
-	if err := ts.CreateShard(ctx, "ks", "80-"); err != nil {
-		t.Fatalf("CreateShard(\"-80\") failed: %v", err)
-	}
-	if err := wi.wr.SetKeyspaceShardingInfo(ctx, "ks", "keyspace_id", topodatapb.KeyspaceIdType_UINT64, 4, false); err != nil {
-		t.Fatalf("SetKeyspaceShardingInfo failed: %v", err)
-	}
-	if err := wi.wr.RebuildKeyspaceGraph(ctx, "ks", nil, true); err != nil {
-		t.Fatalf("RebuildKeyspaceGraph failed: %v", err)
-	}
-
-	for _, sourceRdonly := range []*testlib.FakeTablet{sourceRdonly1, sourceRdonly2} {
-		sourceRdonly.FakeMysqlDaemon.Schema = &tabletmanagerdatapb.SchemaDefinition{
-			DatabaseSchema: "",
-			TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
-				{
-					Name:              "table1",
-					Columns:           []string{"id", "msg", "keyspace_id"},
-					PrimaryKeyColumns: []string{"id"},
-					Type:              tmutils.TableBaseTable,
-					// This informs how many rows we can pack into a single insert
-					DataLength: 2048,
-				},
-			},
-		}
-		sourceRdonly.FakeMysqlDaemon.DbAppConnectionFactory = SourceRdonlyFactory(t)
-		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = replication.Position{
-			GTIDSet: replication.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
-		}
-		sourceRdonly.FakeMysqlDaemon.ExpectedExecuteSuperQueryList = []string{
-			"STOP SLAVE",
-			"START SLAVE",
-		}
-		qs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
-		qs.AddDefaultHealthResponse()
-		grpcqueryservice.RegisterForTest(sourceRdonly.RPCServer, &testQueryService{
-			t: t,
-			StreamHealthQueryService: qs,
-		})
-	}
-
-	// We read 100 source rows. sourceReaderCount is set to 10, so
-	// we'll have 100/10=10 rows per table chunk.
-	// destinationPackCount is set to 4, so we take 4 source rows
-	// at once. So we'll process 4 + 4 + 2 rows to get to 10.
-	// That means 3 insert statements on each target (each
-	// containing half of the rows, i.e. 2 + 2 + 1 rows). So 3 * 10
-	// = 30 insert statements on each destination.
-	leftMaster.FakeMysqlDaemon.DbAppConnectionFactory = DestinationsFactory(t, 30)
-	leftRdonly.FakeMysqlDaemon.DbAppConnectionFactory = DestinationsFactory(t, 30)
-	rightMaster.FakeMysqlDaemon.DbAppConnectionFactory = DestinationsFactory(t, 30)
-	rightRdonly.FakeMysqlDaemon.DbAppConnectionFactory = DestinationsFactory(t, 30)
-
-	// Only wait 1 ms between retries, so that the test passes faster
-	*executeFetchRetryTime = (1 * time.Millisecond)
+func TestSplitCloneV2(t *testing.T) {
+	tc := &splitCloneTestCase{t: t}
+	tc.setUp(false /* v3 */)
+	defer tc.tearDown()
 
 	// Run the vtworker command.
-	args := []string{
-		"SplitClone",
-		"-source_reader_count", "10",
-		"-destination_pack_count", "4",
-		"-min_table_size_for_split", "1",
-		"-destination_writer_count", "10",
-		"ks/-80"}
-	if err := runCommand(t, wi, wi.wr, args); err != nil {
+	if err := runCommand(t, tc.wi, tc.wi.wr, tc.defaultWorkerArgs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestSplitCloneV2_RetryDueToReadonly is identical to the regular test
+// TestSplitCloneV2 with the additional twist that the destination masters
+// fail the first write because they are read-only and succeed after that.
+func TestSplitCloneV2_RetryDueToReadonly(t *testing.T) {
+	tc := &splitCloneTestCase{t: t}
+	tc.setUp(false /* v3 */)
+	defer tc.tearDown()
+
+	// Provoke a retry to test the error handling.
+	tc.leftMasterFakeDb.addExpectedQueryAtIndex(0, "INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*", errReadOnly)
+	tc.rightMasterFakeDb.addExpectedQueryAtIndex(0, "INSERT INTO `vt_ks`.table1(id, msg, keyspace_id) VALUES (*", errReadOnly)
+	// Only wait 1 ms between retries, so that the test passes faster.
+	*executeFetchRetryTime = 1 * time.Millisecond
+
+	// Run the vtworker command.
+	if err := runCommand(t, tc.wi, tc.wi.wr, tc.defaultWorkerArgs); err != nil {
 		t.Fatal(err)
 	}
 
-	if statsDestinationAttemptedResolves.String() != "3" {
-		t.Errorf("Wrong statsDestinationAttemptedResolves: wanted %v, got %v", "3", statsDestinationAttemptedResolves.String())
-	}
-	if statsDestinationActualResolves.String() != "1" {
-		t.Errorf("Wrong statsDestinationActualResolves: wanted %v, got %v", "1", statsDestinationActualResolves.String())
-	}
-	if statsRetryCounters.String() != "{\"ReadOnly\": 2}" {
-		t.Errorf("Wrong statsRetryCounters: wanted %v, got %v", "{\"ReadOnly\": 2}", statsRetryCounters.String())
-	}
+  if statsDestinationAttemptedResolves.String() != "3" {
+    t.Errorf("Wrong statsDestinationAttemptedResolves: wanted %v, got %v", "3", statsDestinationAttemptedResolves.String())
+  }
+  if statsDestinationActualResolves.String() != "1" {
+    t.Errorf("Wrong statsDestinationActualResolves: wanted %v, got %v", "1", statsDestinationActualResolves.String())
+  }
+  if statsRetryCounters.String() != "{\"ReadOnly\": 2}" {
+    t.Errorf("Wrong statsRetryCounters: wanted %v, got %v", "{\"ReadOnly\": 2}", statsRetryCounters.String())
+  }
 }
 
-func TestSplitCloneV2(t *testing.T) {
-	testSplitClone(t, false)
-}
 
 func TestSplitCloneV3(t *testing.T) {
-	testSplitClone(t, true)
+	tc := &splitCloneTestCase{t: t}
+	tc.setUp(true /* v3 */)
+	defer tc.tearDown()
+
+	// Run the vtworker command.
+	if err := runCommand(t, tc.wi, tc.wi.wr, tc.defaultWorkerArgs); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/go/vt/worker/utils_test.go
+++ b/go/vt/worker/utils_test.go
@@ -2,9 +2,14 @@ package worker
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/wrangler"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // This file contains common test helper.
@@ -23,4 +28,47 @@ func runCommand(t *testing.T, wi *Instance, wr *wrangler.Wrangler, args []string
 		return fmt.Errorf("Worker finished but not successfully: %v", err)
 	}
 	return nil
+}
+
+// expectBlpCheckpointCreationQueries fakes out the queries which vtworker
+// sends out to create the Binlog Player (BLP) checkpoint.
+func expectBlpCheckpointCreationQueries(f *FakePoolConnection) {
+	f.addExpectedQuery("CREATE DATABASE IF NOT EXISTS _vt", nil)
+	f.addExpectedQuery("CREATE TABLE IF NOT EXISTS _vt.blp_checkpoint (\n"+
+		"  source_shard_uid INT(10) UNSIGNED NOT NULL,\n"+
+		"  pos VARCHAR(250) DEFAULT NULL,\n"+
+		"  time_updated BIGINT UNSIGNED NOT NULL,\n"+
+		"  transaction_timestamp BIGINT UNSIGNED NOT NULL,\n"+
+		"  flags VARCHAR(250) DEFAULT NULL,\n"+
+		"  PRIMARY KEY (source_shard_uid)) ENGINE=InnoDB", nil)
+	f.addExpectedQuery("INSERT INTO _vt.blp_checkpoint (source_shard_uid, pos, time_updated, transaction_timestamp, flags) VALUES (0, 'MariaDB/12-34-5678', *", nil)
+}
+
+// sourceRdonlyFactory fakes out the MIN, MAX query on the primary key.
+// (This query is used to calculate the split points for reading a table
+// using multiple threads.)
+func sourceRdonlyFactory(t *testing.T, dbAndTableName string, min, max int) func() (dbconnpool.PoolConnection, error) {
+	f := NewFakePoolConnectionQuery(t, "sourceRdonly")
+	f.addExpectedExecuteFetch(ExpectedExecuteFetch{
+		Query: fmt.Sprintf("SELECT MIN(id), MAX(id) FROM %s", dbAndTableName),
+		QueryResult: &sqltypes.Result{
+			Fields: []*querypb.Field{
+				{
+					Name: "min",
+					Type: sqltypes.Int64,
+				},
+				{
+					Name: "max",
+					Type: sqltypes.Int64,
+				},
+			},
+			Rows: [][]sqltypes.Value{
+				{
+					sqltypes.MakeString([]byte(strconv.Itoa(min))),
+					sqltypes.MakeString([]byte(strconv.Itoa(max))),
+				},
+			},
+		},
+	})
+	return f.getFactory()
 }

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/mysqlctl/replication"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
 	"github.com/youtube/vitess/go/vt/tabletserver/grpcqueryservice"
@@ -28,6 +26,13 @@ import (
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
+const (
+	// verticalSplitCloneTestMin is the minimum value of the primary key.
+	verticalSplitCloneTestMin int = 100
+	// verticalSplitCloneTestMax is the maximum value of the primary key.
+	verticalSplitCloneTestMax int = 200
+)
+
 // verticalTabletServer is a local QueryService implementation to support the tests.
 type verticalTabletServer struct {
 	t *testing.T
@@ -37,8 +42,8 @@ type verticalTabletServer struct {
 
 func (sq *verticalTabletServer) StreamExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, sessionID int64, sendReply func(reply *sqltypes.Result) error) error {
 	// Custom parsing of the query we expect
-	min := 100
-	max := 200
+	min := verticalSplitCloneTestMin
+	max := verticalSplitCloneTestMax
 	var err error
 	parts := strings.Split(sql, " ")
 	for _, part := range parts {
@@ -85,141 +90,19 @@ func (sq *verticalTabletServer) StreamExecute(ctx context.Context, target *query
 	return nil
 }
 
-// VerticalFakePoolConnection implements dbconnpool.PoolConnection
-type VerticalFakePoolConnection struct {
-	t      *testing.T
-	Closed bool
+func createVerticalSplitCloneDestinationFakeDb(t *testing.T, name string, insertCount int) *FakePoolConnection {
+	f := NewFakePoolConnectionQuery(t, name)
 
-	ExpectedExecuteFetch      []ExpectedExecuteFetch
-	ExpectedExecuteFetchIndex int
-}
+	// Provoke a retry to test the error handling. (Let the first write fail.)
+	f.addExpectedQuery("INSERT INTO `vt_destination_ks`.moving1(id, msg) VALUES (*", errReadOnly)
 
-func NewVerticalFakePoolConnectionQuery(t *testing.T, query string, err error) *VerticalFakePoolConnection {
-	return &VerticalFakePoolConnection{
-		t: t,
-		ExpectedExecuteFetch: []ExpectedExecuteFetch{
-			{
-				Query:       query,
-				QueryResult: &sqltypes.Result{},
-				Error:       err,
-			},
-		},
+	for i := 1; i <= insertCount; i++ {
+		f.addExpectedQuery("INSERT INTO `vt_destination_ks`.moving1(id, msg) VALUES (*", nil)
 	}
-}
 
-func (fpc *VerticalFakePoolConnection) ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
-	if fpc.ExpectedExecuteFetchIndex >= len(fpc.ExpectedExecuteFetch) {
-		fpc.t.Errorf("got unexpected out of bound fetch: %v >= %v", fpc.ExpectedExecuteFetchIndex, len(fpc.ExpectedExecuteFetch))
-		return nil, fmt.Errorf("unexpected out of bound fetch")
-	}
-	expected := fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Query
-	if strings.HasSuffix(expected, "*") {
-		if !strings.HasPrefix(query, expected[0:len(expected)-1]) {
-			fpc.t.Errorf("got unexpected query start: %v != %v", query, expected)
-			return nil, fmt.Errorf("unexpected query")
-		}
-	} else {
-		if query != expected {
-			fpc.t.Errorf("got unexpected query: %v != %v", query, expected)
-			return nil, fmt.Errorf("unexpected query")
-		}
-	}
-	fpc.t.Logf("ExecuteFetch: %v", query)
-	defer func() {
-		fpc.ExpectedExecuteFetchIndex++
-	}()
-	if fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Error != nil {
-		return nil, fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].Error
-	}
-	return fpc.ExpectedExecuteFetch[fpc.ExpectedExecuteFetchIndex].QueryResult, nil
-}
+	expectBlpCheckpointCreationQueries(f)
 
-func (fpc *VerticalFakePoolConnection) ExecuteStreamFetch(query string, callback func(*sqltypes.Result) error, streamBufferSize int) error {
-	return nil
-}
-
-func (fpc *VerticalFakePoolConnection) ID() int64 {
-	return 1
-}
-
-func (fpc *VerticalFakePoolConnection) Close() {
-	fpc.Closed = true
-}
-
-func (fpc *VerticalFakePoolConnection) IsClosed() bool {
-	return fpc.Closed
-}
-
-func (fpc *VerticalFakePoolConnection) Recycle() {
-}
-
-func (fpc *VerticalFakePoolConnection) Reconnect() error {
-	return nil
-}
-
-// on the source rdonly guy, should only have one query to find min & max
-func VerticalSourceRdonlyFactory(t *testing.T) func() (dbconnpool.PoolConnection, error) {
-	return func() (dbconnpool.PoolConnection, error) {
-		return &VerticalFakePoolConnection{
-			t: t,
-			ExpectedExecuteFetch: []ExpectedExecuteFetch{
-				{
-					Query: "SELECT MIN(id), MAX(id) FROM vt_source_ks.moving1",
-					QueryResult: &sqltypes.Result{
-						Fields: []*querypb.Field{
-							{
-								Name: "min",
-								Type: sqltypes.Int64,
-							},
-							{
-								Name: "max",
-								Type: sqltypes.Int64,
-							},
-						},
-						Rows: [][]sqltypes.Value{
-							{
-								sqltypes.MakeString([]byte("100")),
-								sqltypes.MakeString([]byte("200")),
-							},
-						},
-					},
-				},
-			},
-		}, nil
-	}
-}
-
-// on the destinations
-func VerticalDestinationsFactory(t *testing.T, insertCount int64) func() (dbconnpool.PoolConnection, error) {
-	var queryIndex int64 = -1
-
-	return func() (dbconnpool.PoolConnection, error) {
-		qi := atomic.AddInt64(&queryIndex, 1)
-		switch {
-		// Return an error on the first query, to make sure that it's retried successfully
-		case qi == 0:
-			return NewFakePoolConnectionQuery(t,
-				"INSERT INTO `vt_destination_ks`.moving1(id, msg) VALUES (*",
-				fmt.Errorf("The MariaDB server is running with the --read-only option so it cannot execute this statement (errno 1290) during query:"),
-			), nil
-		case qi <= insertCount:
-			return NewVerticalFakePoolConnectionQuery(t, "INSERT INTO `vt_destination_ks`.moving1(id, msg) VALUES (*", nil), nil
-		case qi == insertCount+1:
-			return NewVerticalFakePoolConnectionQuery(t, "CREATE DATABASE IF NOT EXISTS _vt", nil), nil
-		case qi == insertCount+2:
-			return NewVerticalFakePoolConnectionQuery(t, "CREATE TABLE IF NOT EXISTS _vt.blp_checkpoint (\n"+
-				"  source_shard_uid INT(10) UNSIGNED NOT NULL,\n"+
-				"  pos VARCHAR(250) DEFAULT NULL,\n"+
-				"  time_updated BIGINT UNSIGNED NOT NULL,\n"+
-				"  transaction_timestamp BIGINT UNSIGNED NOT NULL,\n"+
-				"  flags VARCHAR(250) DEFAULT NULL,\n"+
-				"  PRIMARY KEY (source_shard_uid)) ENGINE=InnoDB", nil), nil
-		case qi == insertCount+3:
-			return NewVerticalFakePoolConnectionQuery(t, "INSERT INTO _vt.blp_checkpoint (source_shard_uid, pos, time_updated, transaction_timestamp, flags) VALUES (0, 'MariaDB/12-34-5678', *", nil), nil
-		}
-
-		return nil, fmt.Errorf("Unexpected connection")
-	}
+	return f
 }
 
 func TestVerticalSplitClone(t *testing.T) {
@@ -290,7 +173,8 @@ func TestVerticalSplitClone(t *testing.T) {
 				},
 			},
 		}
-		sourceRdonly.FakeMysqlDaemon.DbAppConnectionFactory = VerticalSourceRdonlyFactory(t)
+		sourceRdonly.FakeMysqlDaemon.DbAppConnectionFactory = sourceRdonlyFactory(
+			t, "vt_source_ks.moving1", verticalSplitCloneTestMin, verticalSplitCloneTestMax)
 		sourceRdonly.FakeMysqlDaemon.CurrentMasterPosition = replication.Position{
 			GTIDSet: replication.MariadbGTID{Domain: 12, Server: 34, Sequence: 5678},
 		}
@@ -312,8 +196,9 @@ func TestVerticalSplitClone(t *testing.T) {
 	// at once. So we'll process 4 + 4 + 2 rows to get to 10.
 	// That means 3 insert statements on the target. So 3 * 10
 	// = 30 insert statements on the destination.
-	destMaster.FakeMysqlDaemon.DbAppConnectionFactory = VerticalDestinationsFactory(t, 30)
-	destRdonly.FakeMysqlDaemon.DbAppConnectionFactory = VerticalDestinationsFactory(t, 30)
+	destMasterFakeDb := createVerticalSplitCloneDestinationFakeDb(t, "destMaster", 30)
+	defer destMasterFakeDb.verifyAllExecutedOrFail()
+	destMaster.FakeMysqlDaemon.DbAppConnectionFactory = destMasterFakeDb.getFactory()
 
 	// Only wait 1 ms between retries, so that the test passes faster
 	*executeFetchRetryTime = (1 * time.Millisecond)


### PR DESCRIPTION
- Moved out into own file.
- Easier to manipulate the fake.
- More code reuse between tests.
- Split split_clone_test.go into multiple tests to better sepearate between a test which tests the normal case and tests which test specific error situations.

@alainjobart 

PR 2/3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1667)
<!-- Reviewable:end -->
