### PR TITLE
worker: Resolve destination master using the discovery module.

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -187,7 +187,7 @@ func (mc *MultiCounters) Set(names []string, value int64) {
 // MultiCountersFunc is a multidimensional CountersFunc implementation
 // where names of categories are compound names made with joining
 // multiple strings with '.'.  Since the map is returned by the
-// function, we assume it's in the rigth format (meaning each key is
+// function, we assume it's in the right format (meaning each key is
 // of the form 'aaa.bbb.ccc' with as many elements as there are in
 // Labels).
 type MultiCountersFunc struct {

--- a/go/vt/worker/clone_utils.go
+++ b/go/vt/worker/clone_utils.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/discovery"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/wrangler"
@@ -28,32 +29,6 @@ import (
 //
 // This file contains utility functions for clone workers.
 //
-
-// Does a topo lookup for a single shard, and returns the tablet record of the master tablet.
-func resolveDestinationShardMaster(ctx context.Context, keyspace, shard string, wr *wrangler.Wrangler) (*topo.TabletInfo, error) {
-	var ti *topo.TabletInfo
-	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
-	si, err := wr.TopoServer().GetShard(shortCtx, keyspace, shard)
-	cancel()
-	if err != nil {
-		return ti, fmt.Errorf("unable to resolve destination shard %v/%v", keyspace, shard)
-	}
-
-	if !si.HasMaster() {
-		return ti, fmt.Errorf("no master in destination shard %v/%v", keyspace, shard)
-	}
-
-	wr.Logger().Infof("Found target master alias %v in shard %v/%v", topoproto.TabletAliasString(si.MasterAlias), keyspace, shard)
-
-	shortCtx, cancel = context.WithTimeout(ctx, *remoteActionsTimeout)
-	ti, err = wr.TopoServer().GetTablet(shortCtx, si.MasterAlias)
-	cancel()
-	if err != nil {
-		return ti, fmt.Errorf("unable to get master tablet from alias %v in shard %v/%v: %v",
-			topoproto.TabletAliasString(si.MasterAlias), keyspace, shard, err)
-	}
-	return ti, nil
-}
 
 // Does a topo lookup for a single shard, and returns:
 //	1. Slice of all tablet aliases for the shard.
@@ -84,75 +59,108 @@ var errExtract = regexp.MustCompile(`\(errno (\d+)\)`)
 // If will keep retrying the ExecuteFetch (for a finite but longer duration) if it fails due to a timeout or a
 // retriable application error.
 //
-// executeFetchWithRetries will also re-resolve the topology after errors, to be resistant to a reparent.
-// It takes in a tablet record that it will initially attempt to write to, and will return the final tablet
-// record that it used.
-func executeFetchWithRetries(ctx context.Context, wr *wrangler.Wrangler, ti *topo.TabletInfo, r Resolver, shard string, command string) (*topo.TabletInfo, error) {
+// executeFetchWithRetries will always get the current MASTER tablet from the
+// healthcheck instance. If no MASTER is available, it will keep retrying.
+func executeFetchWithRetries(ctx context.Context, wr *wrangler.Wrangler, healthCheck discovery.HealthCheck, keyspace, shard, command string) error {
 	retryDuration := 2 * time.Hour
-	// We should keep retrying up until the retryCtx runs out
+	// We should keep retrying up until the retryCtx runs out.
 	retryCtx, retryCancel := context.WithTimeout(ctx, retryDuration)
 	defer retryCancel()
 	// Is this current attempt a retry of a previous attempt?
 	isRetry := false
 	for {
-		tryCtx, cancel := context.WithTimeout(retryCtx, 2*time.Minute)
-		_, err := wr.TabletManagerClient().ExecuteFetchAsApp(tryCtx, ti, command, 0)
-		cancel()
-		if err == nil {
-			// success!
-			return ti, nil
+		var master *discovery.EndPointStats
+		var err error
+
+		// Get the current master from the HealthCheck.
+		masters := discovery.GetCurrentMaster(
+			healthCheck.GetEndPointStatsFromTarget(keyspace, shard, topodatapb.TabletType_MASTER))
+		if len(masters) == 0 {
+			wr.Logger().Warningf("ExecuteFetch failed for keyspace/shard %v/%v because no MASTER is available; will retry until there is MASTER again", keyspace, shard)
+			statsRetryCount.Add(1)
+			statsRetryCounters.Add(retryCategoryNoMasterAvailable, 1)
+			goto retry
 		}
-		// If the ExecuteFetch call failed because of an application error, we will try to figure out why.
-		// We need to extract the MySQL error number, and will attempt to retry if we think the error is recoverable.
-		match := errExtract.FindStringSubmatch(err.Error())
-		var errNo string
-		if len(match) == 2 {
-			errNo = match[1]
-		}
-		switch {
-		case wr.TabletManagerClient().IsTimeoutError(err):
-			wr.Logger().Warningf("ExecuteFetch failed on %v; will retry because it was a timeout error: %v", ti, err)
-			statsRetryCounters.Add("TimeoutError", 1)
-		case errNo == "1290":
-			wr.Logger().Warningf("ExecuteFetch failed on %v; will reresolve and retry because it's due to a MySQL read-only error: %v", ti, err)
-			statsRetryCounters.Add("ReadOnly", 1)
-		case errNo == "2002" || errNo == "2006":
-			wr.Logger().Warningf("ExecuteFetch failed on %v; will reresolve and retry because it's due to a MySQL connection error: %v", ti, err)
-			statsRetryCounters.Add("ConnectionError", 1)
-		case errNo == "1062":
-			if !isRetry {
-				return ti, fmt.Errorf("ExecuteFetch failed on %v on the first attempt; not retrying as this is not a recoverable error: %v", ti, err)
+		master = masters[0]
+
+		// Run the command.
+		{
+			tryCtx, cancel := context.WithTimeout(retryCtx, 2*time.Minute)
+			_, err = wr.TabletManagerClient().ExecuteFetchAsApp(tryCtx, endPointToTabletInfo(master), command, 0)
+			cancel()
+
+			if err == nil {
+				// success!
+				return nil
 			}
-			wr.Logger().Infof("ExecuteFetch failed on %v with a duplicate entry error; marking this as a success, because of the likelihood that this query has already succeeded before being retried: %v", ti, err)
-			return ti, nil
-		default:
-			// Unknown error
-			return ti, err
+
+			succeeded, finalErr := checkError(wr, err, isRetry, master, keyspace, shard)
+			if succeeded {
+				// We can ignore the error and don't have to retry.
+				return nil
+			}
+			if finalErr != nil {
+				// Non-retryable error.
+				return finalErr
+			}
 		}
-		t := time.NewTimer(*executeFetchRetryTime)
-		// don't leak memory if the timer isn't triggered
-		defer t.Stop()
+
+	retry:
+		masterAlias := "no-master-was-available"
+		if master != nil {
+			masterAlias = topoproto.TabletAliasString(master.Alias())
+		}
+		tabletString := fmt.Sprintf("%v (%v/%v)", masterAlias, keyspace, shard)
 
 		select {
 		case <-retryCtx.Done():
 			if retryCtx.Err() == context.DeadlineExceeded {
-				return ti, fmt.Errorf("failed to connect to destination tablet %v after retrying for %v", ti, retryDuration)
+				return fmt.Errorf("failed to connect to destination tablet %v after retrying for %v", tabletString, retryDuration)
 			}
-			return ti, fmt.Errorf("interrupted while trying to run %v on tablet %v", command, ti)
-		case <-t.C:
-			// Re-resolve and retry 30s after the failure
-			err = r.ResolveDestinationMasters(ctx)
-			if err != nil {
-				return ti, fmt.Errorf("unable to re-resolve masters for ExecuteFetch, due to: %v", err)
-			}
-			ti, err = r.GetDestinationMaster(shard)
-			if err != nil {
-				// At this point, we probably don't have a valid tablet record to return
-				return nil, fmt.Errorf("unable to run ExecuteFetch due to: %v", err)
-			}
+			return fmt.Errorf("interrupted while trying to run %v on tablet %v", command, tabletString)
+		case <-time.After(*executeFetchRetryTime):
+			// Retry 30s after the failure using the current master seen by the HealthCheck.
 		}
 		isRetry = true
 	}
+}
+
+// checkError returns true if the error can be ignored and the command
+// succeeded, false if the error is retryable and a non-nil error if the
+// command must not be retried.
+func checkError(wr *wrangler.Wrangler, err error, isRetry bool, master *discovery.EndPointStats, keyspace, shard string) (bool, error) {
+	tabletString := fmt.Sprintf("%v (%v/%v)", topoproto.TabletAliasString(master.Alias()), keyspace, shard)
+	// If the ExecuteFetch call failed because of an application error, we will try to figure out why.
+	// We need to extract the MySQL error number, and will attempt to retry if we think the error is recoverable.
+	match := errExtract.FindStringSubmatch(err.Error())
+	var errNo string
+	if len(match) == 2 {
+		errNo = match[1]
+	}
+	switch {
+	case wr.TabletManagerClient().IsTimeoutError(err):
+		wr.Logger().Warningf("ExecuteFetch failed on %v; will retry because it was a timeout error: %v", tabletString, err)
+		statsRetryCount.Add(1)
+		statsRetryCounters.Add(retryCategoryTimeoutError, 1)
+	case errNo == "1290":
+		wr.Logger().Warningf("ExecuteFetch failed on %v; will reresolve and retry because it's due to a MySQL read-only error: %v", tabletString, err)
+		statsRetryCount.Add(1)
+		statsRetryCounters.Add(retryCategoryReadOnly, 1)
+	case errNo == "2002" || errNo == "2006":
+		wr.Logger().Warningf("ExecuteFetch failed on %v; will reresolve and retry because it's due to a MySQL connection error: %v", tabletString, err)
+		statsRetryCount.Add(1)
+		statsRetryCounters.Add(retryCategoryConnectionError, 1)
+	case errNo == "1062":
+		if !isRetry {
+			return false, fmt.Errorf("ExecuteFetch failed on %v on the first attempt; not retrying as this is not a recoverable error: %v", tabletString, err)
+		}
+		wr.Logger().Infof("ExecuteFetch failed on %v with a duplicate entry error; marking this as a success, because of the likelihood that this query has already succeeded before being retried: %v", tabletString, err)
+		return true, nil
+	default:
+		// Unknown error.
+		return false, err
+	}
+	return false, nil
 }
 
 // fillStringTemplate returns the string template filled
@@ -166,20 +174,14 @@ func fillStringTemplate(tmpl string, vars interface{}) (string, error) {
 }
 
 // runSQLCommands will send the sql commands to the remote tablet.
-func runSQLCommands(ctx context.Context, wr *wrangler.Wrangler, r Resolver, shard string, commands []string) error {
-	ti, err := r.GetDestinationMaster(shard)
-	if err != nil {
-		return fmt.Errorf("runSQLCommands failed: %v", err)
-	}
-
+func runSQLCommands(ctx context.Context, wr *wrangler.Wrangler, healthCheck discovery.HealthCheck, keyspace, shard, dbName string, commands []string) error {
 	for _, command := range commands {
-		command, err := fillStringTemplate(command, map[string]string{"DatabaseName": ti.DbName()})
+		command, err := fillStringTemplate(command, map[string]string{"DatabaseName": dbName})
 		if err != nil {
 			return fmt.Errorf("fillStringTemplate failed: %v", err)
 		}
 
-		ti, err = executeFetchWithRetries(ctx, wr, ti, r, shard, command)
-		if err != nil {
+		if err := executeFetchWithRetries(ctx, wr, healthCheck, keyspace, shard, command); err != nil {
 			return err
 		}
 	}
@@ -359,11 +361,7 @@ func makeValueString(fields []*querypb.Field, rows [][]sqltypes.Value) string {
 
 // executeFetchLoop loops over the provided insertChannel
 // and sends the commands to the provided tablet.
-func executeFetchLoop(ctx context.Context, wr *wrangler.Wrangler, r Resolver, shard string, insertChannel chan string) error {
-	ti, err := r.GetDestinationMaster(shard)
-	if err != nil {
-		return fmt.Errorf("executeFetchLoop failed: %v", err)
-	}
+func executeFetchLoop(ctx context.Context, wr *wrangler.Wrangler, healthCheck discovery.HealthCheck, keyspace, shard, dbName string, insertChannel chan string) error {
 	for {
 		select {
 		case cmd, ok := <-insertChannel:
@@ -371,9 +369,8 @@ func executeFetchLoop(ctx context.Context, wr *wrangler.Wrangler, r Resolver, sh
 				// no more to read, we're done
 				return nil
 			}
-			cmd = "INSERT INTO `" + ti.DbName() + "`." + cmd
-			ti, err = executeFetchWithRetries(ctx, wr, ti, r, shard, cmd)
-			if err != nil {
+			cmd = "INSERT INTO `" + dbName + "`." + cmd
+			if err := executeFetchWithRetries(ctx, wr, healthCheck, keyspace, shard, cmd); err != nil {
 				return fmt.Errorf("ExecuteFetch failed: %v", err)
 			}
 		case <-ctx.Done():
@@ -383,4 +380,22 @@ func executeFetchLoop(ctx context.Context, wr *wrangler.Wrangler, r Resolver, sh
 			return nil
 		}
 	}
+}
+
+// endPointToTabletInfo converts an EndPointStats object from the discovery
+// package into a TabletInfo object. The latter one is required by several
+// TabletManagerClient API calls.
+// Note that this is a best-effort conversion and won't result into the same
+// result as a call to topo.GetTablet().
+// Note: We assume that "eps" is immutable and we can reference its data.
+func endPointToTabletInfo(eps *discovery.EndPointStats) *topo.TabletInfo {
+	return topo.NewTabletInfo(&topodatapb.Tablet{
+		Alias:     eps.Alias(),
+		Hostname:  eps.EndPoint.Host,
+		PortMap:   eps.EndPoint.PortMap,
+		HealthMap: eps.EndPoint.HealthMap,
+		Keyspace:  eps.Target.Keyspace,
+		Shard:     eps.Target.Shard,
+		Type:      eps.Target.TabletType,
+	}, -1 /* version */)
 }

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -26,10 +26,6 @@ var (
 	// Therefore, the default for this variable must be higher
 	// than vttablet's -health_check_interval.
 	waitForHealthyEndPointsTimeout = flag.Duration("wait_for_healthy_rdonly_endpoints_timeout", 60*time.Second, "maximum time to wait if less than --min_healthy_rdonly_endpoints are available")
-
-	healthCheckTopologyRefresh = flag.Duration("worker_healthcheck_topology_refresh", 30*time.Second, "refresh interval for re-reading the topology")
-	healthcheckRetryDelay      = flag.Duration("worker_healthcheck_retry_delay", 5*time.Second, "delay before retrying a failed healthcheck")
-	healthCheckTimeout         = flag.Duration("worker_healthcheck_timeout", time.Minute, "the health check timeout period")
 )
 
 // FindHealthyRdonlyEndPoint returns a random healthy endpoint.
@@ -43,7 +39,7 @@ func FindHealthyRdonlyEndPoint(ctx context.Context, wr *wrangler.Wrangler, cell,
 	// create a discovery healthcheck, wait for it to have one rdonly
 	// endpoints at this point
 	healthCheck := discovery.NewHealthCheck(*remoteActionsTimeout, *healthcheckRetryDelay, *healthCheckTimeout, "" /* statsSuffix */)
-	watcher := discovery.NewShardReplicationWatcher(wr.TopoServer(), healthCheck, cell, keyspace, shard, *healthCheckTopologyRefresh, 5 /*topoReadConcurrency*/)
+	watcher := discovery.NewShardReplicationWatcher(wr.TopoServer(), healthCheck, cell, keyspace, shard, *healthCheckTopologyRefresh, discovery.DefaultTopoReadConcurrency)
 	defer watcher.Stop()
 	defer healthCheck.Close()
 

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -485,7 +485,7 @@ func (wr *Wrangler) waitForDrainInCell(ctx context.Context, cell, keyspace, shar
 	retryDelay, healthCheckTopologyRefresh, healthcheckRetryDelay, healthCheckTimeout time.Duration) error {
 	hc := discovery.NewHealthCheck(healthCheckTimeout /* connectTimeout */, healthcheckRetryDelay, healthCheckTimeout, cell)
 	defer hc.Close()
-	watcher := discovery.NewShardReplicationWatcher(wr.TopoServer(), hc, cell, keyspace, shard, healthCheckTopologyRefresh, 5 /* topoReadConcurrency */)
+	watcher := discovery.NewShardReplicationWatcher(wr.TopoServer(), hc, cell, keyspace, shard, healthCheckTopologyRefresh, discovery.DefaultTopoReadConcurrency)
 	defer watcher.Stop()
 
 	if err := discovery.WaitForEndPoints(ctx, hc, cell, keyspace, shard, []topodatapb.TabletType{servedType}); err != nil {
@@ -554,11 +554,7 @@ func formatEndpointStats(eps *discovery.EndPointStats) string {
 	if webPort, ok := eps.EndPoint.PortMap["vt"]; ok {
 		webURL = fmt.Sprintf("http://%v:%d/", eps.EndPoint.Host, webPort)
 	}
-	alias := &topodatapb.TabletAlias{
-		Cell: eps.Cell,
-		Uid:  eps.EndPoint.Uid,
-	}
-	return fmt.Sprintf("%v: %v stats: %v", topoproto.TabletAliasString(alias), webURL, eps.Stats)
+	return fmt.Sprintf("%v: %v stats: %v", topoproto.TabletAliasString(eps.Alias()), webURL, eps.Stats)
 }
 
 // MigrateServedFrom is used during vertical splits to migrate a

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -459,9 +459,13 @@ primary key (name)
 
     # start vttablet on the split shards (no db created,
     # so they're all not serving)
+    # Start masters with enabled healthcheck (necessary for resolving the
+    # destination master).
+    shard_2_master.start_vttablet(wait_for_state=None,
+                                  target_tablet_type='replica')
     shard_3_master.start_vttablet(wait_for_state=None,
                                   target_tablet_type='replica')
-    for t in [shard_2_master, shard_2_replica1, shard_2_replica2,
+    for t in [shard_2_replica1, shard_2_replica2,
               shard_3_replica, shard_3_rdonly1]:
       t.start_vttablet(wait_for_state=None)
     for t in [shard_2_master, shard_2_replica1, shard_2_replica2,
@@ -483,6 +487,11 @@ primary key (name)
         keyspace_id_type=keyspace_id_type,
         sharding_column_name='custom_sharding_key')
 
+    # TODO(mberlin): Use a different approach for the same effect because this
+    #                one doesn't work when the healthcheck is enabled on the
+    #                tablet. In that case the healthcheck will race with the
+    #                test and convert the SPARE tablet back to REPLICA the next
+    #                time it runs.
     # disable shard_1_slave2, so we're sure filtered replication will go
     # from shard_1_slave1
     utils.run_vtctl(['ChangeSlaveType', shard_1_slave2.tablet_alias, 'spare'])

--- a/test/utils.py
+++ b/test/utils.py
@@ -798,11 +798,6 @@ def _get_vtworker_cmd(clargs, auto_log=False):
   args = environment.binary_args('vtworker') + [
       '-log_dir', environment.vtlogroot,
       '-port', str(port),
-      # use a long resolve TTL because of potential race conditions with doing
-      # an EmergencyReparent and resolving the master (as EmergencyReparent
-      # will delete the old master before updating the shard record with the
-      # new master)
-      '-resolve_ttl', '10s',
       '-executefetch_retry_time', '1s',
       '-tablet_manager_protocol',
       protocols_flavor().tablet_manager_protocol(),


### PR DESCRIPTION
@alainjobart 

PR 3/3

- Removed previous Resolver interface and respective implementations.
- Removed respective stat vars and flags (--resolve_ttl).

- Added unit test for case where vtworker fails over to a different replica.
- Added unit test for case when healthcheck retries because currently no master is available.
- Extended FakePoolConnection to support these tests:
  - can define callback (AfterFunc) when expected query was received
  - infinite mode where the last request may be received over and over again

- discovery: Introduce DefaultTopoReadConcurrency to avoid duplication.
- discovery: Added EndPointStats.Alias() to avoid duplication.
- discovery: Added EndPointStats.String() to have pretty printed arrays.

Adapted end-to-end tests:
- resharding.py: Enabled healthcheck for master tablets.
- worker.py: Updated stat vars check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1668)
<!-- Reviewable:end -->
