### PR TITLE
vtgate: Fix wrong call to log.Warning() where log.Warningf() was necessary.

### DIFF
--- a/go/vt/vtgate/planner.go
+++ b/go/vt/vtgate/planner.go
@@ -141,7 +141,7 @@ func (plr *Planner) WatchVSchema(ctx context.Context) {
 		go func(keyspace string, n <-chan string) {
 			for kschema := range n {
 				if err := processKeyspace(keyspace, kschema); err != nil {
-					log.Warning("%v", err)
+					log.Warningf("%v", err)
 				}
 			}
 		}(keyspace, n)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1672)
<!-- Reviewable:end -->
