### PR TITLE
throttler: First version which supports throttling by a fixed rate across multiple threads.

### DIFF
--- a/go/vt/throttler/max_rate_module.go
+++ b/go/vt/throttler/max_rate_module.go
@@ -1,0 +1,26 @@
+package throttler
+
+import "github.com/youtube/vitess/go/sync2"
+
+// MaxRateModule allows to set and retrieve a maximum rate limit.
+// It implements the Module interface.
+type MaxRateModule struct {
+	maxRate sync2.AtomicInt64
+}
+
+// NewMaxRateModule will create a new module instance and set the initial
+// rate limit to maxRate.
+func NewMaxRateModule(maxRate int64) Module {
+	return &MaxRateModule{sync2.NewAtomicInt64(maxRate)}
+}
+
+// Start currently does nothing. It implements the Module interface.
+func (m *MaxRateModule) Start(rateUpdateChan chan<- struct{}) {}
+
+// Stop currently does nothing. It implements the Module interface.
+func (m *MaxRateModule) Stop() {}
+
+// MaxRate returns the current maximum allowed rate.
+func (m *MaxRateModule) MaxRate() int64 {
+	return m.maxRate.Get()
+}

--- a/go/vt/throttler/module.go
+++ b/go/vt/throttler/module.go
@@ -1,0 +1,17 @@
+package throttler
+
+// Module specifies the API for a Decision Module which can tell the throttler
+// to dynamically increase or decrease the current rate limit.
+type Module interface {
+	// Start can be implemented to e.g. start own Go routines and initialize the
+	// module.
+	// rateUpdateChan must be used to notify the Throttler when the module's
+	// maximum rate limit has changed and a subsequent MaxRate() call would return
+	// a different value.
+	Start(rateUpdateChan chan<- struct{})
+	// Stop will free all resources and be called by Throttler.Close().
+	Stop()
+
+	// MaxRate returns the maximum allowed rate determined by the module.
+	MaxRate() int64
+}

--- a/go/vt/throttler/thread_throttler_test.go
+++ b/go/vt/throttler/thread_throttler_test.go
@@ -1,0 +1,40 @@
+package throttler
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThrottle_RateIncreaseDoesNotBurst(t *testing.T) {
+	// If we're within a second, a rate increase won't apply retroactively.
+	// This way we prevent a burst of requests at the end of the second.
+	tt := newThreadThrottler(0)
+	tt.setMaxRate(2)
+	// 1st request.
+	if gotBackoff := tt.throttle(sinceZero(0 * time.Millisecond)); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+
+	// 2nd request after rate increase (allowed based on old rate limit).
+	tt.setMaxRate(1000)
+	if gotBackoff := tt.throttle(sinceZero(500 * time.Millisecond)); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+
+	// 3rd request not allowed since the old limit still applies.
+	wantBackoff := 499 * time.Millisecond
+	if gotBackoff := tt.throttle(sinceZero(501 * time.Millisecond)); gotBackoff != wantBackoff {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
+	}
+
+	// More than two requests succeed starting with the next limit.
+	if gotBackoff := tt.throttle(sinceZero(1000 * time.Millisecond)); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+	if gotBackoff := tt.throttle(sinceZero(1001 * time.Millisecond)); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+	if gotBackoff := tt.throttle(sinceZero(1002 * time.Millisecond)); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+}

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -1,0 +1,222 @@
+// Package throttler provides a client-side, local throttler which is used to
+// throttle (and actively pace) writes during the resharding process.
+//
+// The throttler has two main goals:
+// a) allow resharding data into an existing keyspace by throttling at a fixed
+//    rate
+// b) ensure that the MySQL replicas do not become overloaded
+//
+// To support b), the throttler constantly monitors the health of all replicas
+// and reduces the allowed rate if the replication lag is above a certain
+// threshold.
+// TODO(mberlin): Implement b).
+package throttler
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+// NotThrottled will be returned by Throttle() if the application is currently
+// not throttled.
+const NotThrottled time.Duration = 0
+
+// MaxRateModuleDisabled can be set in NewThrottler() to disable throttling
+// by a fixed rate.
+const MaxRateModuleDisabled = -1
+
+// ReplicationLagModuleDisabled can be set in NewThrottler() to disable
+// throttling based on the MySQL replication lag.
+const ReplicationLagModuleDisabled = -1
+
+// Throttler provides a client-side, thread-aware throttler.
+// See the package doc for more information.
+//
+// Calls of Throttle() and ThreadFinished() take threadID as parameter which is
+// in the range [0, threadCount). (threadCount is set in NewThrottler().)
+// NOTE: Trottle() and ThreadFinished() assume that *per thread* calls to them
+//       are serialized and must not happen concurrently.
+type Throttler struct {
+	// name describes the Throttler instance and is used e.g. in the webinterface.
+	name string
+	// unit describes the entity the throttler is limiting e.g. "queries" or
+	// "transactions". It is used for example in the webinterface.
+	unit string
+
+	closed bool
+	// modules is the list of modules which can limit the current rate. The order
+	// of the list defines the priority of the module. (Lower rates trump.)
+	modules []Module
+	// rateUpdateChan is used to notify the throttler that the current max rate
+	// must be recalculated and updated.
+	rateUpdateChan chan struct{}
+
+	// The group below is unguarded because the fields are immutable and each
+	// thread accesses an element at a different index.
+	threadThrottlers []*threadThrottler
+	threadFinished   []bool
+
+	nowFunc func() time.Time
+
+	// The group below is unguarded because it's only accessed by the update Go
+	// routine which reads the rateUpdateChan channel.
+	maxRate          int64
+	maxRatePerThread int64
+
+	mu sync.Mutex
+	// runningThreads tracks which threads have not finished yet.
+	runningThreads map[int]bool
+	// threadRunningsLastUpdate caches for updateMaxRate() how many threads were
+	// running at the previous run.
+	threadRunningsLastUpdate int
+}
+
+// NewThrottler creates a new Throttler instance.
+// Use the constants MaxRateModuleDisabled or ReplicationLagModuleDisabled
+// if you want to disable parts of its functionality.
+// maxRate will be distributed across all threadCount threads.
+// unit refers to the type of entity you want to throttle e.g. "queries" or
+// "transactions".
+// name describes the Throttler instance and will be used by the webinterface.
+func NewThrottler(name, unit string, threadCount int, maxRate int64, maxReplicationLag int) *Throttler {
+	return newThrottler(name, unit, threadCount, maxRate, maxReplicationLag, time.Now)
+}
+
+// newThrottlerWithClock should only be used for testing.
+func newThrottlerWithClock(name, unit string, threadCount int, maxRate int64, maxReplicationLag int, nowFunc func() time.Time) *Throttler {
+	return newThrottler(name, unit, threadCount, maxRate, maxReplicationLag, nowFunc)
+}
+
+func newThrottler(name, unit string, threadCount int, maxRate int64, maxReplicationLag int, nowFunc func() time.Time) *Throttler {
+	// Enable the configured modules.
+	var modules []Module
+	if maxRate == MaxRateModuleDisabled {
+		// We never disable this module. Assume an infinite rate.
+		maxRate = int64(math.MaxInt64)
+	}
+	modules = append(modules, NewMaxRateModule(maxRate))
+	// TODO(mberlin): Append ReplicationLagModule once it's implemented.
+
+	// Start each module (which might start own Go routines).
+	rateUpdateChan := make(chan struct{}, 10)
+	for _, m := range modules {
+		m.Start(rateUpdateChan)
+	}
+
+	runningThreads := make(map[int]bool, threadCount)
+	threadThrottlers := make([]*threadThrottler, threadCount, threadCount)
+	for i := 0; i < threadCount; i++ {
+		threadThrottlers[i] = newThreadThrottler(i)
+		runningThreads[i] = true
+	}
+	t := &Throttler{
+		name:             name,
+		unit:             unit,
+		modules:          modules,
+		rateUpdateChan:   rateUpdateChan,
+		threadThrottlers: threadThrottlers,
+		threadFinished:   make([]bool, threadCount, threadCount),
+		runningThreads:   runningThreads,
+		nowFunc:          nowFunc,
+	}
+
+	// Initialize maxRate.
+	t.updateMaxRate()
+
+	// Watch for rate updates from the modules and update the internal maxRate.
+	go func() {
+		for range rateUpdateChan {
+			t.updateMaxRate()
+		}
+	}()
+
+	return t
+}
+
+// Throttle returns a backoff duration which specifies for how long "threadId"
+// should wait before it issues the next request.
+// If the duration is zero, the thread is not throttled.
+// If the duration is not zero, the thread must call Throttle() again after
+// the backoff duration elapsed.
+func (t *Throttler) Throttle(threadID int) time.Duration {
+	if t.closed {
+		panic(fmt.Sprintf("BUG: thread with ID: %v must not access closed Throttler", threadID))
+	}
+	if t.threadFinished[threadID] {
+		panic(fmt.Sprintf("BUG: thread with ID: %v already finished", threadID))
+	}
+	return t.threadThrottlers[threadID].throttle(t.nowFunc())
+}
+
+// ThreadFinished marks threadID as finished and redistributes the thread's
+// rate allotment across the other threads.
+// After ThreadFinished() is called, Throttle() must not be called anymore.
+func (t *Throttler) ThreadFinished(threadID int) {
+	if t.threadFinished[threadID] {
+		return
+	}
+
+	t.mu.Lock()
+	delete(t.runningThreads, threadID)
+	t.mu.Unlock()
+
+	t.threadFinished[threadID] = true
+	t.rateUpdateChan <- struct{}{}
+}
+
+// Close stops all modules and frees all resources.
+// When Close() returned, the Throttler object must not be used anymore.
+func (t *Throttler) Close() {
+	for _, m := range t.modules {
+		m.Stop()
+	}
+	close(t.rateUpdateChan)
+	t.closed = true
+}
+
+// updateMaxRate recalculates the current max rate and updates all
+// threadThrottlers accordingly.
+// The rate changes when the number of thread changes or a module updated its
+// max rate.
+func (t *Throttler) updateMaxRate() {
+	// Set it to infinite initially.
+	maxRate := int64(math.MaxInt64)
+
+	// Find out the new max rate.
+	for _, m := range t.modules {
+		if moduleMaxRate := m.MaxRate(); moduleMaxRate < maxRate {
+			maxRate = moduleMaxRate
+		}
+	}
+
+	// Set the new max rate on each thread.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	threadsRunning := len(t.runningThreads)
+	if threadsRunning == 0 {
+		// Throttler is done. Set rates don't matter anymore.
+		return
+	}
+	if maxRate == t.maxRate && threadsRunning == t.threadRunningsLastUpdate {
+		// Rate for each thread is unchanged.
+		return
+	}
+
+	maxRatePerThread := maxRate / int64(threadsRunning)
+	// Distribute the remainder of the division across all threads.
+	remainder := maxRate % int64(threadsRunning)
+	remainderPerThread := make(map[int]int64, threadsRunning)
+	for id := 0; remainder > 0; {
+		remainderPerThread[id]++
+		remainder--
+		id++
+	}
+
+	for threadID := range t.runningThreads {
+		t.threadThrottlers[threadID].setMaxRate(
+			maxRatePerThread + remainderPerThread[threadID])
+	}
+	t.threadRunningsLastUpdate = threadsRunning
+}

--- a/go/vt/throttler/throttler_test.go
+++ b/go/vt/throttler/throttler_test.go
@@ -1,0 +1,334 @@
+package throttler
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Example for benchmark results on Lenovo Thinkpad X250, i7-5600U, Quadcore:
+//
+// $ go test -run=XXX -bench=. -cpu=4
+// PASS
+// BenchmarkThrottler-4        	 1000000	      9255 ns/op
+// BenchmarkThrottlerParallel-4	  200000	      9498 ns/op
+// BenchmarkThrottlerDisabled-4	20000000	        84.2 ns/op
+// ok  	github.com/youtube/vitess/go/vt/throttler	13.067s
+
+// BenchmarkThrottler is not a benchmark, but a real-world demonstration of the
+// Throttler and verifies that it actually throttles requests.
+// This benchmark should show ~10000 ns (10 us) per op.
+func BenchmarkThrottler(b *testing.B) {
+	// 1 Thread, 100,000 QPS (10 us request interval).
+	throttler := NewThrottler("test", "queries", 1, 100*1000, ReplicationLagModuleDisabled)
+	defer throttler.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		backedOff := 0
+		for {
+			backoff := throttler.Throttle(0)
+			if backoff == NotThrottled {
+				break
+			}
+			backedOff++
+			if backedOff > 1 {
+				b.Logf("did not wait long have after backoff. n = %v, last backoff = %v", i, backoff)
+			}
+			time.Sleep(backoff)
+		}
+	}
+}
+
+// BenchmarkThrottlerParallel is the parallel version of BenchmarkThrottler.
+// Set -cpu to change the number of threads. The QPS should be distributed
+// across all threads and the reported benchmark value should be similar
+// to the value of BenchmarkThrottler.
+func BenchmarkThrottlerParallel(b *testing.B) {
+	// 1 Thread, 100,000 QPS (10 us request interval).
+	threadCount := runtime.GOMAXPROCS(0)
+	throttler := NewThrottler("test", "queries", threadCount, 100*1000, ReplicationLagModuleDisabled)
+	defer throttler.Close()
+	threadIDs := make(chan int, threadCount)
+	for id := 0; id < threadCount; id++ {
+		threadIDs <- id
+	}
+	close(threadIDs)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		threadID := <-threadIDs
+
+		for pb.Next() {
+			backedOff := 0
+			for {
+				backoff := throttler.Throttle(threadID)
+				if backoff == NotThrottled {
+					break
+				}
+				backedOff++
+				if backedOff > 1 {
+					b.Logf("did not wait long have after backoff. threadID = %v, last backoff = %v", threadID, backoff)
+				}
+				time.Sleep(backoff)
+			}
+		}
+		throttler.ThreadFinished(threadID)
+	})
+}
+
+// BenchmarkThrottlerDisabled is the unthrottled version of
+// BenchmarkThrottler. It should report a much lower ns/op value.
+func BenchmarkThrottlerDisabled(b *testing.B) {
+	throttler := NewThrottler("test", "queries", 1, MaxRateModuleDisabled, ReplicationLagModuleDisabled)
+	defer throttler.Close()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for {
+			backoff := throttler.Throttle(0)
+			if backoff != NotThrottled {
+				b.Fatalf("unthrottled throttler should never have throttled us: %v", backoff)
+			}
+			break
+		}
+	}
+}
+
+type fakeClock struct {
+	nowValue time.Time
+}
+
+func (f *fakeClock) now() time.Time {
+	return f.nowValue
+}
+
+func (f *fakeClock) setNow(timeOffset time.Duration) {
+	f.nowValue = sinceZero(timeOffset)
+}
+
+func sinceZero(sinceZero time.Duration) time.Time {
+	return time.Time{}.Add(sinceZero)
+}
+
+func TestThrottle(t *testing.T) {
+	fc := &fakeClock{}
+	// 1 Thread, 2 QPS.
+	throttler := newThrottlerWithClock("test", "queries", 1, 2, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	// 2 QPS should divide the current second into two chunks of 500 ms:
+	// a) [0s, 500ms), b) [500ms, 1s)
+	// First call goes through since the chunk is not "used" yet.
+	fc.setNow(0 * time.Millisecond)
+	if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+
+	// Next call should tell us to backoff until we reach the second chunk.
+	fc.setNow(0 * time.Millisecond)
+	wantBackoff := 500 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
+	}
+
+	// Some time elpased, but we are still in the first chunk and must backoff.
+	fc.setNow(111 * time.Millisecond)
+	wantBackoff2 := 389 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff2 {
+		t.Fatalf("throttler should have still throttled us. got = %v, want = %v", gotBackoff, wantBackoff2)
+	}
+
+	// Enough time elapsed that we are in the second chunk now.
+	fc.setNow(500 * time.Millisecond)
+	if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+
+	// We're in the third chunk and are allowed to issue the third request.
+	fc.setNow(1500 * time.Millisecond)
+	if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+}
+
+func TestThrottle_RateRemainderIsDistributedAcrossThreads(t *testing.T) {
+	fc := &fakeClock{}
+	// 3 Threads, 5 QPS.
+	throttler := newThrottlerWithClock("test", "queries", 3, 5, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	// Out of 5 QPS, each thread gets 1 and two threads get 1 query extra.
+	fc.setNow(0 * time.Millisecond)
+	for threadID := 0; threadID < 2; threadID++ {
+		if gotBackoff := throttler.Throttle(threadID); gotBackoff != NotThrottled {
+			t.Fatalf("throttler should not have throttled thread %d: backoff = %v", threadID, gotBackoff)
+		}
+	}
+
+	fc.setNow(500 * time.Millisecond)
+	// Find the thread which got one extra query.
+	threadsWithMoreThanOneQPS := 0
+	for threadID := 0; threadID < 2; threadID++ {
+		if gotBackoff := throttler.Throttle(threadID); gotBackoff == NotThrottled {
+			threadsWithMoreThanOneQPS++
+		} else {
+			wantBackoff := 500 * time.Millisecond
+			if gotBackoff != wantBackoff {
+				t.Fatalf("throttler did throttle us with the wrong backoff time. got = %v, want = %v", gotBackoff, wantBackoff)
+			}
+		}
+	}
+	if want := 2; threadsWithMoreThanOneQPS != want {
+		t.Fatalf("wrong number of threads were throttled: %v != %v", threadsWithMoreThanOneQPS, want)
+	}
+
+	// Now, all threads are throttled.
+	for threadID := 0; threadID < 2; threadID++ {
+		wantBackoff := 500 * time.Millisecond
+		if gotBackoff := throttler.Throttle(threadID); gotBackoff != wantBackoff {
+			t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
+		}
+	}
+}
+
+func TestThreadFinished(t *testing.T) {
+	fc := &fakeClock{}
+	// 2 Threads, 2 QPS.
+	throttler := newThrottlerWithClock("test", "queries", 2, 2, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	// First second: Each thread consumes their 1 QPS.
+	fc.setNow(0 * time.Millisecond)
+	for threadID := 0; threadID < 2; threadID++ {
+		if gotBackoff := throttler.Throttle(threadID); gotBackoff != NotThrottled {
+			t.Fatalf("throttler should not have throttled thread %d: backoff = %v", threadID, gotBackoff)
+		}
+	}
+	// Now they would be throttled.
+	wantBackoff := 1000 * time.Millisecond
+	for threadID := 0; threadID < 2; threadID++ {
+		if gotBackoff := throttler.Throttle(threadID); gotBackoff != wantBackoff {
+			t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
+		}
+	}
+
+	// Second second: One thread finishes, other one gets remaining 1 QPS extra.
+	fc.setNow(1000 * time.Millisecond)
+	throttler.ThreadFinished(1)
+	// ThreadFinished() is idempotent.
+	throttler.ThreadFinished(1)
+
+	// Max rate update to threadThrottlers happens asynchronously. Wait for it.
+	timer := time.NewTimer(2 * time.Second)
+	for {
+		if throttler.threadThrottlers[0].maxRate.Get() == 2 {
+			timer.Stop()
+			break
+		}
+		select {
+		case <-timer.C:
+			t.Fatalf("max rate was not propapgated to threadThrottler[0] in time: %v", throttler.threadThrottlers[0].maxRate.Get())
+		default:
+			// Timer not up yet. Try again.
+		}
+	}
+
+	// Consume 2 QPS.
+	if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+	fc.setNow(1500 * time.Millisecond)
+	if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+		t.Fatalf("throttler should not have throttled us: backoff = %v", gotBackoff)
+	}
+
+	// 2 QPS are consumed. Thread 0 should be throttled now.
+	wantBackoff2 := 500 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff2 {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff2)
+	}
+
+	// Throttle() from a finished thread will panic.
+	defer func() {
+		msg := recover()
+		if msg == nil {
+			t.Fatal("Throttle() from a thread which called ThreadFinished() should panic")
+		}
+		if !strings.Contains(msg.(string), "already finished") {
+			t.Fatalf("Throttle() after ThreadFinished() panic'd for wrong reason: %v", msg)
+		}
+	}()
+	throttler.Throttle(1)
+}
+
+// TestThrottle_MaxRateIsZero tests the behavior if max rate is set to zero.
+// In this case, the throttler won't let any requests through until the rate
+// changes.
+func TestThrottle_MaxRateIsZero(t *testing.T) {
+	fc := &fakeClock{}
+	// 1 Thread, 0 QPS.
+	throttler := newThrottlerWithClock("test", "queries", 1, 0, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	fc.setNow(0 * time.Millisecond)
+	wantBackoff := 1000 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff)
+	}
+	fc.setNow(111 * time.Millisecond)
+	wantBackoff2 := 889 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff2 {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff2)
+	}
+	fc.setNow(1000 * time.Millisecond)
+	wantBackoff3 := 1000 * time.Millisecond
+	if gotBackoff := throttler.Throttle(0); gotBackoff != wantBackoff3 {
+		t.Fatalf("throttler should have throttled us. got = %v, want = %v", gotBackoff, wantBackoff3)
+	}
+}
+
+func TestThrottle_MaxRateDisabled(t *testing.T) {
+	fc := &fakeClock{}
+	throttler := newThrottlerWithClock("test", "queries", 1, MaxRateModuleDisabled, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	fc.setNow(0 * time.Millisecond)
+	// No QPS set. 10 requests in a row are fine.
+	for i := 0; i < 10; i++ {
+		if gotBackoff := throttler.Throttle(0); gotBackoff != NotThrottled {
+			t.Fatalf("throttler should not have throttled us: request = %v, backoff = %v", i, gotBackoff)
+		}
+	}
+}
+
+func TestUpdateMaxRate_AllThreadsFinished(t *testing.T) {
+	fc := &fakeClock{}
+	throttler := newThrottlerWithClock("test", "queries", 2, 1e9, ReplicationLagModuleDisabled, fc.now)
+	defer throttler.Close()
+
+	throttler.ThreadFinished(0)
+	throttler.ThreadFinished(1)
+
+	// Make sure that there's no division by zero error (threadsRunning == 0).
+	throttler.updateMaxRate()
+	// We don't care about the Throttler state at this point.
+}
+
+func TestClose(t *testing.T) {
+	fc := &fakeClock{}
+	throttler := newThrottlerWithClock("test", "queries", 1, 1, ReplicationLagModuleDisabled, fc.now)
+	throttler.Close()
+
+	defer func() {
+		msg := recover()
+		if msg == nil {
+			t.Fatal("Throttle() after Close() should panic")
+		}
+		if !strings.Contains(msg.(string), "must not access closed Throttler") {
+			t.Fatalf("Throttle() after ThreadFinished() panic'd for wrong reason: %v", msg)
+		}
+	}()
+	throttler.Throttle(0)
+}


### PR DESCRIPTION
@alainjobart 

Next steps (outside of this PR) will be:
- use Throttler in vtworker and filtered replication
- implement MaxReplicationLag module
- implement a read-only webinterface which displays the actual and throttled rate
- make the webinterface read-write e.g. to override the fixed rate limit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1674)
<!-- Reviewable:end -->
