### PR TITLE
examples/local: Update to VTGateV3 and add resharding walkthrough

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -395,7 +395,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
 
 1.  **Start vtctld**
 
-    The `vtctld` server provides a web interface that
+    The *vtctld* server provides a web interface that
     displays all of the coordination information stored in ZooKeeper.
 
     ``` sh
@@ -406,19 +406,22 @@ lock service. ZooKeeper is included in the Vitess distribution.
     ```
 
     Open `http://localhost:15000` to verify that
-    `vtctld` is running. There won't be any information
+    *vtctld* is running. There won't be any information
     there yet, but the menu should come up, which indicates that
-    `vtctld` is running.
+    *vtctld* is running.
 
-    The `vtctld` server also accepts commands from the `vtctlclient` tool,
+    The *vtctld* server also accepts commands from the `vtctlclient` tool,
     which is used to administer the cluster. Note that the port for RPCs
     (in this case `15999`) is different from the web UI port (`15000`).
     These ports can be configured with command-line flags, as demonstrated
     in `vtctld-up.sh`.
 
+    For convenience, we'll use the `lvtctl.sh` script in example commands,
+    to avoid having to type the *vtctld* address every time.
+
     ``` sh
     # List available commands
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 Help
+    vitess/examples/local$ ./lvtctl.sh help
     ```
 
 1.  **Start vttablets**
@@ -442,7 +445,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     # Access tablet test-0000000102 at http://localhost:15102/debug/status
     ```
 
-    After this command completes, refresh the `vtctld` web UI, and you should
+    After this command completes, refresh the *vtctld* web UI, and you should
     see a keyspace named `test_keyspace` with a single shard named `0`.
     This is what an unsharded keyspace looks like.
 
@@ -464,7 +467,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
     named `test_keyspace`, the MySQL database will be named `vt_test_keyspace`.
 
     ``` sh
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 InitShardMaster -force test_keyspace/0 test-0000000100
+    vitess/examples/local$ ./lvtctl.sh InitShardMaster -force test_keyspace/0 test-100
     ### example output:
     # master-elect tablet test-0000000100 is not the shard master, proceeding anyway as -force was used
     # master-elect tablet test-0000000100 is not a master in the shard, proceeding anyway as -force was used
@@ -477,14 +480,14 @@ lock service. ZooKeeper is included in the Vitess distribution.
     brand new shard.
 
     After running this command, go back to the **Shard Status** page
-    in the `vtctld` web interface. When you refresh the
-    page, you should see that one `vttablet` is the master
+    in the *vtctld* web interface. When you refresh the
+    page, you should see that one *vttablet* is the master
     and the other two are replicas.
 
     You can also see this on the command line:
 
     ``` sh
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 ListAllTablets test
+    vitess/examples/local$ ./lvtctl.sh ListAllTablets test
     ### example output:
     # test-0000000100 test_keyspace 0 master localhost:15100 localhost:33100 []
     # test-0000000101 test_keyspace 0 replica localhost:15101 localhost:33101 []
@@ -499,7 +502,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
 
     ``` sh
     # Make sure to run this from the examples/local dir, so it finds the file.
-    vitess/examples/local$ $VTROOT/bin/vtctlclient -server localhost:15999 ApplySchema -sql "$(cat create_test_table.sql)" test_keyspace
+    vitess/examples/local$ ./lvtctl.sh ApplySchema -sql "$(cat create_test_table.sql)" test_keyspace
     ```
 
     The SQL to create the table is shown below:
@@ -523,29 +526,29 @@ lock service. ZooKeeper is included in the Vitess distribution.
     also automatically restore from the latest backup and then resume replication.
 
     ``` sh
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 Backup test-0000000101
+    vitess/examples/local$ ./lvtctl.sh Backup test-0000000102
     ```
 
     After the backup completes, you can list available backups for the shard:
 
     ``` sh
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 ListBackups test_keyspace/0
+    vitess/examples/local$ ./lvtctl.sh ListBackups test_keyspace/0
     ### example output:
-    # 2015-10-21.042940.test-0000000104
+    # 2016-05-06.072724.test-0000000102
     ```
 
     **Note:** In this single-server example setup, backups are stored at
     `$VTDATAROOT/backups`. In a multi-server deployment, you would usually mount
     an NFS directory there. You can also change the location by setting the
-    `-file_backup_storage_root` flag on `vtctld` and `vttablet`, as demonstrated
+    `-file_backup_storage_root` flag on *vtctld* and *vttablet*, as demonstrated
     in `vtctld-up.sh` and `vttablet-up.sh`.
 
 1.  **Start vtgate**
 
-    Vitess uses `vtgate` to route each client query to
-    the correct `vttablet`. This local example runs a
-    single `vtgate` instance, though a real deployment
-    would likely run multiple `vtgate` instances to share
+    Vitess uses *vtgate* to route each client query to
+    the correct *vttablet*. This local example runs a
+    single *vtgate* instance, though a real deployment
+    would likely run multiple *vtgate* instances to share
     the load.
 
     ``` sh
@@ -555,7 +558,7 @@ lock service. ZooKeeper is included in the Vitess distribution.
 ### Run a Client Application
 
 The `client.py` file is a simple sample application
-that connects to `vtgate` and executes some queries.
+that connects to *vtgate* and executes some queries.
 To run it, you need to either:
 
 *   Add the Vitess Python packages to your `PYTHONPATH`.
@@ -570,13 +573,24 @@ To run it, you need to either:
     ### example output:
     # Inserting into master...
     # Reading from master...
-    # (1L, 'V is for speed')
-    # Reading from replica...
-    # (1L, 'V is for speed')
+    # (5L, 1462510331910124032L, 'V is for speed')
+    # (15L, 1462519383758071808L, 'V is for speed')
+    # (42L, 1462510369213753088L, 'V is for speed')
+    # ...
     ```
 
 There are also sample clients in the same directory for Java, PHP, and Go.
 See the comments at the top of each sample file for usage instructions.
+
+### Try Vitess resharding
+
+Now that you have a full Vitess stack running, you may want to go on to the
+[Horizontal Sharding](http://vitess.io/user-guide/horizontal-sharding.html)
+guide to try out
+[dynamic resharding](http://vitess.io/user-guide/sharding.html#resharding).
+
+If so, you can skip the tear-down since the sharding guide picks up right here.
+If not, continue to the clean-up steps below.
 
 ### Tear down the cluster
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -455,20 +455,6 @@ lock service. ZooKeeper is included in the Vitess distribution.
     status page, showing more details on its operation. Every Vitess server has
     a status page served at `/debug/status` on its web port.
 
-1.  **Initialize the new keyspace**
-
-    By launching tablets assigned to a nonexistent keyspace, we've essentially
-    created a new keyspace. To complete the initialization of the
-    [local topology data](http://vitess.io/doc/TopologyService/#local-data),
-    perform a keyspace rebuild:
-
-    ``` sh
-    $ $VTROOT/bin/vtctlclient -server localhost:15999 RebuildKeyspaceGraph test_keyspace
-    ```
-
-    **Note:** Many `vtctlclient` commands yield no output if
-    they run successfully.
-
 1.  **Initialize MySQL databases**
 
     Next, designate one of the tablets to be the initial master.
@@ -519,11 +505,12 @@ lock service. ZooKeeper is included in the Vitess distribution.
     The SQL to create the table is shown below:
 
     ``` sql
-    CREATE TABLE test_table (
-      id BIGINT AUTO_INCREMENT,
-      msg VARCHAR(250),
-      PRIMARY KEY(id)
-    ) Engine=InnoDB
+    CREATE TABLE messages (
+      page BIGINT(20) UNSIGNED,
+      time_created_ns BIGINT(20) UNSIGNED,
+      message VARCHAR(10000),
+      PRIMARY KEY (page, time_created_ns)
+    ) ENGINE=InnoDB
     ```
 
 1.  **Take a backup**
@@ -587,6 +574,9 @@ To run it, you need to either:
     # Reading from replica...
     # (1L, 'V is for speed')
     ```
+
+There are also sample clients in the same directory for Java, PHP, and Go.
+See the comments at the top of each sample file for usage instructions.
 
 ### Tear down the cluster
 

--- a/doc/ShardingKubernetes.md
+++ b/doc/ShardingKubernetes.md
@@ -12,7 +12,7 @@ have left the cluster running.
 
 We will follow a process similar to the one in the general
 [Horizontal Sharding](http://vitess.io/user-guide/horizontal-sharding.html)
-guide, except that here we'll give the exact commands you'll need to do it for
+guide, except that here we'll give the commands you'll need to do it for
 the example Vitess cluster in Kubernetes.
 
 Since Vitess makes [sharding](http://vitess.io/user-guide/sharding.html)
@@ -119,12 +119,12 @@ vitess/examples/kubernetes$ ./kvtctl.sh CopySchemaShard test_keyspace/0 test_key
 ```
 
 Next we copy the data. Since the amount of data to copy can be very large,
-we use a special batch process called `vtworker` to stream the data from a
+we use a special batch process called *vtworker* to stream the data from a
 single source to multiple destinations, routing each row based on its
 *keyspace_id*:
 
 ``` sh
-vitess/examples/kubernetes$ ./sharded-vtworker.sh -use_v3_resharding_mode SplitClone test_keyspace/0
+vitess/examples/kubernetes$ ./sharded-vtworker.sh SplitClone test_keyspace/0
 ### example output:
 # Creating vtworker pod in cell test...
 # pods/vtworker
@@ -153,7 +153,7 @@ will be served only by the remaining, un-paused *rdonly* tablets.
 
 ## Check filtered replication
 
-Once the copy from the paused snapshot finishes, `vtworker` turns on
+Once the copy from the paused snapshot finishes, *vtworker* turns on
 [filtered replication](http://vitess.io/user-guide/sharding.html#filtered-replication)
 from the source shard to each destination shard. This allows the destination
 shards to catch up on updates that have continued to flow in from the app since
@@ -178,13 +178,13 @@ Add some messages on various pages of the Guestbook to see how they get routed.
 
 ## Check copied data integrity
 
-The `vtworker` batch process has another mode that will compare the source
+The *vtworker* batch process has another mode that will compare the source
 and destination to ensure all the data is present and correct.
 The following commands will run a diff for each destination shard:
 
 ``` sh
-vitess/examples/kubernetes$ ./sharded-vtworker.sh -use_v3_resharding_mode SplitDiff test_keyspace/-80
-vitess/examples/kubernetes$ ./sharded-vtworker.sh -use_v3_resharding_mode SplitDiff test_keyspace/80-
+vitess/examples/kubernetes$ ./sharded-vtworker.sh SplitDiff test_keyspace/-80
+vitess/examples/kubernetes$ ./sharded-vtworker.sh SplitDiff test_keyspace/80-
 ```
 
 If any discrepancies are found, they will be printed.

--- a/examples/kubernetes/vtworker-pod-template.yaml
+++ b/examples/kubernetes/vtworker-pod-template.yaml
@@ -29,6 +29,7 @@ spec:
           -cell {{cell}}
           -tablet_protocol grpc
           -tablet_manager_protocol grpc
+          -use_v3_resharding_mode
           {{vtworker_command}}" vitess
   restartPolicy: Never
   volumes:

--- a/examples/local/client.php
+++ b/examples/local/client.php
@@ -1,10 +1,15 @@
 <?php
 
 /*
- * This is a sample for using the PHP Vitess client with an unsharded keyspace.
+ * This is a sample for using the low-level PHP Vitess client.
+ * For a sample of using the PDO wrapper, see client_pdo.php.
  *
  * Before running this, start up a local example cluster as described in the
  * README.md file.
+ *
+ * You will also need to install the gRPC PHP extension as described in
+ * vitess/php/README.md, and download dependencies with:
+ * vitess$ composer install
  *
  * Then run:
  * vitess/examples/local$ php client.php --server=localhost:15991
@@ -19,41 +24,40 @@ $opts = getopt('', array(
     'server:'
 ));
 
-$keyspace = 'test_keyspace';
-
-// An unsharded keyspace is the same as custom sharding (0, 1, 2, ...),
-// but with only a single shard (0).
-$shards = array(
-    '0'
-);
-
 // Create a connection.
 $ctx = Context::getDefault();
 $conn = new VTGateConn(new \Vitess\Grpc\Client($opts['server'], [
     'credentials' => Grpc\ChannelCredentials::createInsecure()
 ]));
 
-// Insert something.
+// Insert some messages on random pages.
 echo "Inserting into master...\n";
-$tx = $conn->begin($ctx);
-$tx->executeShards($ctx, 'INSERT INTO test_table (msg) VALUES (:msg)', $keyspace, $shards, array(
-    'msg' => 'V is for speed'
-));
-$tx->commit($ctx);
+for ($i = 0; $i < 3; $i ++) {
+    $page = rand(1, 100);
+    $time_created = sprintf('%.0f', microtime(true) * 1000000000);;
+
+    $tx = $conn->begin($ctx);
+    $tx->execute($ctx, 'INSERT INTO messages (page,time_created_ns,message) VALUES (:page,:time_created_ns,:message)', array(
+        'page' => $page,
+        'time_created_ns' => $time_created,
+        'message' => 'V is for speed'
+    ));
+    $tx->commit($ctx);
+}
 
 // Read it back from the master.
 echo "Reading from master...\n";
-$cursor = $conn->executeShards($ctx, 'SELECT * FROM test_table', $keyspace, $shards, array(), TabletType::MASTER);
+$cursor = $conn->execute($ctx, 'SELECT page, time_created_ns, message FROM messages', array(), TabletType::MASTER);
 while (($row = $cursor->next()) !== FALSE) {
-    printf("(%s)\n", implode(', ', $row));
+    printf("(%d, %d, %s)\n", $row[0], $row[1], $row[2]);
 }
 
 // Read from a replica.
 // Note that this may be behind master due to replication lag.
 echo "Reading from replica...\n";
-$cursor = $conn->executeShards($ctx, 'SELECT * FROM test_table', $keyspace, $shards, array(), TabletType::REPLICA);
+$cursor = $conn->execute($ctx, 'SELECT page, time_created_ns, message FROM messages', array(), TabletType::REPLICA);
 while (($row = $cursor->next()) !== FALSE) {
-    printf("(%s)\n", implode(', ', $row));
+    printf("(%d, %d, %s)\n", $row[0], $row[1], $row[2]);
 }
 
 $conn->close();

--- a/examples/local/client_java.sh
+++ b/examples/local/client_java.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is a wrapper script that installs and runs the example
+# client for the low-level Java interface.
+
+set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+
+# We have to install the "example" module first because Maven cannot resolve
+# them when we run "exec:java". See also: http://stackoverflow.com/questions/11091311/maven-execjava-goal-on-a-multi-module-project
+# Install only "example". See also: http://stackoverflow.com/questions/1114026/maven-modules-building-a-single-specific-module
+mvn -f $script_root/../../java/pom.xml -pl example -am install -DskipTests
+mvn -f $script_root/../../java/example/pom.xml exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass="com.youtube.vitess.example.VitessClientExample" -Dexec.args="localhost:15991"

--- a/examples/local/client_jdbc.sh
+++ b/examples/local/client_jdbc.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This is a wrapper script that installs and runs the example
+# client for the JDBC interface.
+
+set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+
+# We have to install the "example" module first because Maven cannot resolve
+# them when we run "exec:java". See also: http://stackoverflow.com/questions/11091311/maven-execjava-goal-on-a-multi-module-project
+# Install only "example". See also: http://stackoverflow.com/questions/1114026/maven-modules-building-a-single-specific-module
+mvn -f $script_root/../../java/pom.xml -pl example -am install -DskipTests
+mvn -f $script_root/../../java/example/pom.xml exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass="com.youtube.vitess.example.VitessJDBCExample" -Dexec.args="localhost:15991"

--- a/examples/local/client_pdo.php
+++ b/examples/local/client_pdo.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This is a sample for using the PDO Vitess client.
+ *
+ * Before running this, start up a local example cluster as described in the
+ * README.md file.
+ *
+ * You'll also need to install the gRPC PHP extension as described in
+ * php/README.md, and then download dependencies for the PDO wrapper:
+ *   vitess/php/pdo$ composer install
+ *
+ * Then run:
+ *   vitess/examples/local$ php client.php --server=localhost:15991
+ */
+require_once __DIR__ . '/../../php/pdo/vendor/autoload.php';
+
+$opts = getopt('', array(
+    'server:'
+));
+list($host, $port) = explode(':', $opts['server']);
+
+$keyspace = 'test_keyspace';
+
+// Create a connection.
+$pdo = new \VitessPdo\PDO("vitess:dbname={$keyspace};host={$host};port={$port}");
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+// Insert some messages on random pages.
+echo "Inserting into master...\n";
+for ($i = 0; $i < 3; $i ++) {
+    $page = rand(1, 100);
+    $time_created = sprintf('%.0f', microtime(true) * 1000000000);;
+
+    $stmt = $pdo->prepare('INSERT INTO messages (page,time_created_ns,message) VALUES (?,?,?)');
+    $stmt->execute([$page, $time_created, 'V is for speed']);
+}
+
+// Read from a replica.
+// Note that this may be behind master due to replication lag.
+echo "Reading from replica...\n";
+$stmt = $pdo->prepare('SELECT page, time_created_ns, message FROM messages');
+$stmt->execute();
+while (($row = $stmt->fetch()) !== FALSE) {
+    printf("(%d, %d, %s)\n", $row[0], $row[1], $row[2]);
+}

--- a/examples/local/create_test_table.sql
+++ b/examples/local/create_test_table.sql
@@ -1,6 +1,7 @@
-CREATE TABLE test_table (
-  id BIGINT AUTO_INCREMENT,
-  msg VARCHAR(250),
-  PRIMARY KEY (id)
+CREATE TABLE messages (
+  page BIGINT(20) UNSIGNED,
+  time_created_ns BIGINT(20) UNSIGNED,
+  message VARCHAR(10000),
+  PRIMARY KEY (page, time_created_ns)
 ) ENGINE=InnoDB
 

--- a/examples/local/lvtctl.sh
+++ b/examples/local/lvtctl.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This is a convenience script to run vtctlclient against the local example.
+
+exec vtctlclient -server localhost:15999 "$@"

--- a/examples/local/sharded-vttablet-down.sh
+++ b/examples/local/sharded-vttablet-down.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This is an example script that stops the mysqld and vttablet instances
+# created by sharded-vttablet-up.sh
+
+script_root=`dirname "${BASH_SOURCE}"`
+
+UID_BASE=200 $script_root/vttablet-down.sh "$@"
+UID_BASE=300 $script_root/vttablet-down.sh "$@"
+

--- a/examples/local/sharded-vttablet-up.sh
+++ b/examples/local/sharded-vttablet-up.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This is an example script that creates a sharded vttablet deployment.
+
+set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+
+# Shard -80 contains all entries whose keyspace ID has a first byte < 0x80.
+# See: http://vitess.io/overview/concepts.html#keyspace-id
+SHARD=-80 UID_BASE=200 $script_root/vttablet-up.sh "$@"
+
+# Shard 80- contains all entries whose keyspace ID has a first byte >= 0x80.
+SHARD=80- UID_BASE=300 $script_root/vttablet-up.sh "$@"
+

--- a/examples/local/sharded-vtworker.sh
+++ b/examples/local/sharded-vtworker.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This is an example script that runs vtworker.
+
+set -e
+
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
+
+echo "Starting vtworker..."
+exec $VTROOT/bin/vtworker \
+  -cell test \
+  -tablet_protocol grpc \
+  -tablet_manager_protocol grpc \
+  -log_dir $VTDATAROOT/tmp \
+  -alsologtostderr \
+  -use_v3_resharding_mode \
+  "$@"
+

--- a/examples/local/vschema.json
+++ b/examples/local/vschema.json
@@ -1,0 +1,18 @@
+{
+  "Sharded": true,
+  "Vindexes": {
+    "hash": {
+      "Type": "hash"
+    }
+  },
+  "Tables": {
+    "messages": {
+      "ColVindexes": [
+        {
+          "Col": "page",
+          "Name": "hash"
+        }
+      ]
+    }
+  }
+}

--- a/examples/local/vttablet-down.sh
+++ b/examples/local/vttablet-down.sh
@@ -11,7 +11,7 @@ source $script_root/env.sh
 
 # Stop 3 vttablets by default.
 # Pass a list of UID indices on the command line to override.
-uids=${@:-'0 1 2'}
+uids=${@:-'0 1 2 3 4'}
 
 wait_pids=''
 

--- a/examples/local/vttablet-down.sh
+++ b/examples/local/vttablet-down.sh
@@ -3,10 +3,8 @@
 # This is an example script that stops the mysqld and vttablet instances
 # created by vttablet-up.sh
 
-set -e
-
 cell='test'
-uid_base=100
+uid_base=${UID_BASE:-'100'}
 
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -6,12 +6,12 @@ set -e
 
 cell='test'
 keyspace='test_keyspace'
-shard=0
-uid_base=100
+shard=${SHARD:-'0'}
+uid_base=${UID_BASE:-'100'}
 tablet_type='replica'
-port_base=15100
-grpc_port_base=16100
-mysql_port_base=33100
+port_base=$[15000 + $uid_base]
+grpc_port_base=$[16000 + $uid_base]
+mysql_port_base=$[33000 + $uid_base]
 tablet_hostname=''
 
 # Travis hostnames are too long for MySQL, so we use IP.

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -8,10 +8,9 @@ cell='test'
 keyspace='test_keyspace'
 shard=${SHARD:-'0'}
 uid_base=${UID_BASE:-'100'}
-tablet_type='replica'
 port_base=$[15000 + $uid_base]
 grpc_port_base=$[16000 + $uid_base]
-mysql_port_base=$[33000 + $uid_base]
+mysql_port_base=$[17000 + $uid_base]
 tablet_hostname=''
 
 # Travis hostnames are too long for MySQL, so we use IP.
@@ -59,9 +58,9 @@ if [ -z "$memcached_path" ]; then
   exit 1
 fi
 
-# Start 3 vttablets by default.
+# Start 5 vttablets by default.
 # Pass a list of UID indices on the command line to override.
-uids=${@:-'0 1 2'}
+uids=${@:-'0 1 2 3 4'}
 
 # Start all mysqlds in background.
 for uid_index in $uids; do
@@ -94,6 +93,10 @@ for uid_index in $uids; do
   grpc_port=$[$grpc_port_base + $uid_index]
   printf -v alias '%s-%010d' $cell $uid
   printf -v tablet_dir 'vt_%010d' $uid
+  tablet_type=replica
+  if [[ $uid_index -gt 2 ]]; then
+    tablet_type=rdonly
+  fi
 
   echo "Starting vttablet for $alias..."
   $VTROOT/bin/vttablet \

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -8,8 +8,30 @@ import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
 import com.youtube.vitess.proto.Topodata;
 
-import java.sql.*;
-import java.util.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.ClientInfoStatus;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 
@@ -602,7 +624,9 @@ public class VitessConnection implements Connection {
     private void closeAllOpenStatements() throws SQLException {
         SQLException postponedException = null;
 
-        for (Statement statement : this.openStatements) {
+        // Copy openStatements, since VitessStatement.close()
+        // deregisters itself, modifying the original set.
+        for (Statement statement : new ArrayList<>(this.openStatements)) {
             try {
                 VitessStatement vitessStatement = (VitessStatement) statement;
                 vitessStatement.close();

--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -82,11 +82,10 @@ echo "Run Go client script..."
 go run client.go -server=localhost:15991 || teardown
 
 echo "Run Java client script..."
-# We have to install the "example" module first because Maven cannot resolve
-# them when we run "exec:java". See also: http://stackoverflow.com/questions/11091311/maven-execjava-goal-on-a-multi-module-project
-# Install only "example". See also: http://stackoverflow.com/questions/1114026/maven-modules-building-a-single-specific-module
-mvn -f ../../java/pom.xml -pl example -am install -DskipTests
-mvn -f ../../java/example/pom.xml exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass="com.youtube.vitess.example.VitessClientExample" -Dexec.args="localhost:15991" || teardown
+./client_java.sh || teardown
+
+echo "Run JDBC client script..."
+./client_jdbc.sh || teardown
 
 exitcode=0
 teardown


### PR DESCRIPTION
@alainjobart 

* Convert all sample clients to VTGateV3 API.
* Add example clients for PDO and JDBC.
* Local example now uses the same schema as the Kubernetes example.
* Port resharding walkthrough from Kubernetes example to local example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1684)
<!-- Reviewable:end -->
