### PR TITLE
Enable replication lag check in examples.

### DIFF
--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -77,6 +77,7 @@ spec:
           -db-config-filtered-charset utf8
           -enable-rowcache
           -enable_semi_sync
+          -enable_replication_lag_check
           -rowcache-bin /usr/bin/memcached
           -rowcache-socket $VTDATAROOT/{{tablet_subdir}}/memcache.sock
           -restore_from_backup {{backup_flags}}" vitess

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -109,6 +109,7 @@ for uid_index in $uids; do
     -health_check_interval 5s \
     -enable-rowcache \
     -enable_semi_sync \
+    -enable_replication_lag_check \
     -rowcache-bin $memcached_path \
     -rowcache-socket $VTDATAROOT/$tablet_dir/memcache.sock \
     -backup_storage_implementation file \

--- a/go/vt/mysqlctl/health.go
+++ b/go/vt/mysqlctl/health.go
@@ -1,7 +1,6 @@
 package mysqlctl
 
 import (
-	"fmt"
 	"html/template"
 	"time"
 
@@ -23,9 +22,9 @@ func (mrl *mysqlReplicationLag) Report(isSlaveType, shouldQueryServiceBeRunning 
 	if err != nil {
 		return 0, err
 	}
-	if !slaveStatus.SlaveRunning() {
-		return 0, fmt.Errorf("Replication is not running")
-	}
+	// If the slave is not running, mysqld.SlaveStatus() will set
+	// SecondsBehindMaster to 0. We allow this because we don't want
+	// a stopped slave to be forced unhealthy.
 	return time.Duration(slaveStatus.SecondsBehindMaster) * time.Second, nil
 }
 


### PR DESCRIPTION
@alainjobart 

Previously, I disabled this check because it was too aggressive.
Any time replication was stopped, it would take the tablet unhealthy.
That meant any problem with the master would take out all tablets
in the whole shard.

In order to get back the replication lag reporting in realtime stats,
I've removed the check that replication is running and re-enabled the
replication lack health reporter.

The replication lag is returned as 0 when not replicating, but this
should be a better compromise than having no lag info at all,
in the absence of a more resilient heartbeat-based measurement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1686)
<!-- Reviewable:end -->
