### PR TITLE
Fix zero length field to be zero length again.

### DIFF
--- a/go/vt/mysqlctl/replication/replication.go
+++ b/go/vt/mysqlctl/replication/replication.go
@@ -23,12 +23,16 @@ import (
 // underlying GTIDSet might use slices, which are not comparable. Using == in
 // those cases will result in a run-time panic.
 type Position struct {
-	GTIDSet GTIDSet
-
 	// This is a zero byte compile-time check that no one is trying to
 	// use == or != with Position. Without this, we won't know there's
-	// a problem until the runtime panic.
+	// a problem until the runtime panic. Note that this must not be
+	// the last field of the struct, or else the Go compiler will add
+	// padding to prevent pointers to this field from becoming invalid.
 	_ [0]struct{ notComparable []byte }
+
+	// GTIDSet is the underlying GTID set. It must not be anonymous,
+	// or else Position would itself also implement the GTIDSet interface.
+	GTIDSet GTIDSet
 }
 
 // Equal returns true if this position is equal to another.


### PR DESCRIPTION
@sougou 

As of Go 1.5, it's only zero length if it's NOT the last field in the struct:

https://github.com/golang/go/commit/6f07ac2f280847ee0346b871b23cab90869f84a4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1689)
<!-- Reviewable:end -->
