### PR TITLE
Allow equal splits algorithm to work without specifying split columns.

### DIFF
--- a/go/vt/tabletserver/splitquery/equal_splits_algorithm_test.go
+++ b/go/vt/tabletserver/splitquery/equal_splits_algorithm_test.go
@@ -14,7 +14,7 @@ import (
 
 // Table-driven test for equal-splits algorithm.
 // Fields are exported so that "%v" would print them using their String() method.
-type testCaseType struct {
+type equalSplitsAlgorithmTestCaseType struct {
 	SplitColumn        string
 	SplitCount         int64
 	MinValue           sqltypes.Value
@@ -22,99 +22,99 @@ type testCaseType struct {
 	ExpectedBoundaries []tuple
 }
 
-var testCases = []testCaseType{
+var equalSplitsAlgorithmTestCases = []equalSplitsAlgorithmTestCaseType{
 	{ // Split the interval [10, 60] into 5 parts.
 		SplitColumn: "int64_col",
 		SplitCount:  5,
-		MinValue:    Int64Value(10),
-		MaxValue:    Int64Value(60),
+		MinValue:    int64Value(10),
+		MaxValue:    int64Value(60),
 		ExpectedBoundaries: []tuple{
-			{Int64Value(20)},
-			{Int64Value(30)},
-			{Int64Value(40)},
-			{Int64Value(50)},
+			{int64Value(20)},
+			{int64Value(30)},
+			{int64Value(40)},
+			{int64Value(50)},
 		},
 	},
 	{ // Split the interval [10, 60] into 4 parts.
 		SplitColumn: "int64_col",
 		SplitCount:  4,
-		MinValue:    Int64Value(10),
-		MaxValue:    Int64Value(60),
+		MinValue:    int64Value(10),
+		MaxValue:    int64Value(60),
 		ExpectedBoundaries: []tuple{
-			{Int64Value(22)},
-			{Int64Value(35)},
-			{Int64Value(47)},
+			{int64Value(22)},
+			{int64Value(35)},
+			{int64Value(47)},
 		},
 	},
 	{ // Split the interval [-30, 60] into 4 parts.
 		SplitColumn: "int64_col",
 		SplitCount:  4,
-		MinValue:    Int64Value(-30),
-		MaxValue:    Int64Value(60),
+		MinValue:    int64Value(-30),
+		MaxValue:    int64Value(60),
 		ExpectedBoundaries: []tuple{
-			{Int64Value(-7)},
-			{Int64Value(15)},
-			{Int64Value(37)},
+			{int64Value(-7)},
+			{int64Value(15)},
+			{int64Value(37)},
 		},
 	},
 	{ // Split the interval [18446744073709551610,18446744073709551615] into 4 parts.
 		SplitColumn: "uint64_col",
 		SplitCount:  4,
-		MinValue:    Uint64Value(18446744073709551610),
-		MaxValue:    Uint64Value(18446744073709551615),
+		MinValue:    uint64Value(18446744073709551610),
+		MaxValue:    uint64Value(18446744073709551615),
 		ExpectedBoundaries: []tuple{
-			{Uint64Value(18446744073709551611)},
-			{Uint64Value(18446744073709551612)},
-			{Uint64Value(18446744073709551613)},
+			{uint64Value(18446744073709551611)},
+			{uint64Value(18446744073709551612)},
+			{uint64Value(18446744073709551613)},
 		},
 	},
 	{ // Split the interval [0,95] into 10 parts.
 		SplitColumn: "uint64_col",
 		SplitCount:  10,
-		MinValue:    Uint64Value(0),
-		MaxValue:    Uint64Value(95),
+		MinValue:    uint64Value(0),
+		MaxValue:    uint64Value(95),
 		ExpectedBoundaries: []tuple{
-			{Uint64Value(9)},
-			{Uint64Value(19)},
-			{Uint64Value(28)},
-			{Uint64Value(38)},
-			{Uint64Value(47)},
-			{Uint64Value(57)},
-			{Uint64Value(66)},
-			{Uint64Value(76)},
-			{Uint64Value(85)},
+			{uint64Value(9)},
+			{uint64Value(19)},
+			{uint64Value(28)},
+			{uint64Value(38)},
+			{uint64Value(47)},
+			{uint64Value(57)},
+			{uint64Value(66)},
+			{uint64Value(76)},
+			{uint64Value(85)},
 		},
 	},
 	{ // Split the interval [-30.25, 60.25] into 4 parts.
 		SplitColumn: "float64_col",
 		SplitCount:  4,
-		MinValue:    Float64Value(-30.25),
-		MaxValue:    Float64Value(60.25),
+		MinValue:    float64Value(-30.25),
+		MaxValue:    float64Value(60.25),
 		ExpectedBoundaries: []tuple{
-			{Float64Value(-7.625)},
-			{Float64Value(15)},
-			{Float64Value(37.625)},
+			{float64Value(-7.625)},
+			{float64Value(15)},
+			{float64Value(37.625)},
 		},
 	},
 	{ // Split the interval [-30, -30] into 4 parts.
 		// (should return an empty boundary list).
 		SplitColumn:        "int64_col",
 		SplitCount:         4,
-		MinValue:           Int64Value(-30),
-		MaxValue:           Int64Value(-30),
+		MinValue:           int64Value(-30),
+		MaxValue:           int64Value(-30),
 		ExpectedBoundaries: []tuple{},
 	},
 }
 
 func TestEqualSplitsAlgorithm(t *testing.T) {
 	// singleTest is a function that executes a single-test.
-	singleTest := func(testCase *testCaseType) {
+	singleTest := func(testCase *equalSplitsAlgorithmTestCaseType) {
 		splitParams, err := NewSplitParamsGivenSplitCount(
 			"select * from test_table where int_col > 5",
 			/* bindVariables */ nil,
 			[]sqlparser.ColIdent{sqlparser.NewColIdent(testCase.SplitColumn)},
 			testCase.SplitCount,
-			GetSchema(),
+			getTestSchema(),
 		)
 		if err != nil {
 			t.Errorf("NewSplitParamsWithNumRowsPerQueryPart failed with: %v", err)
@@ -150,7 +150,7 @@ func TestEqualSplitsAlgorithm(t *testing.T) {
 				boundaries, testCase.ExpectedBoundaries, testCase)
 		}
 	} // singleTest()
-	for _, testCase := range testCases {
+	for _, testCase := range equalSplitsAlgorithmTestCases {
 		singleTest(&testCase)
 	}
 }

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
@@ -22,7 +22,7 @@ func TestMultipleBoundaries(t *testing.T) {
 			sqlparser.NewColIdent("user_id"),
 		}, /* splitColumns */
 		1000,
-		GetSchema(),
+		getTestSchema(),
 	)
 	if err != nil {
 		t.Fatalf("NewSplitParamsGivenNumRowsPerQueryPart failed with: %v", err)
@@ -37,7 +37,7 @@ func TestMultipleBoundaries(t *testing.T) {
 	expectedCall1.Return(
 		&sqltypes.Result{
 			Rows: [][]sqltypes.Value{
-				{Int64Value(1), Int64Value(1)}},
+				{int64Value(1), int64Value(1)}},
 		},
 		nil)
 	expectedCall2 := mockSQLExecuter.EXPECT().SQLExecute(
@@ -54,7 +54,7 @@ func TestMultipleBoundaries(t *testing.T) {
 	expectedCall2.Return(
 		&sqltypes.Result{
 			Rows: [][]sqltypes.Value{
-				{Int64Value(2), Int64Value(10)}},
+				{int64Value(2), int64Value(10)}},
 		},
 		nil)
 	expectedCall2.After(expectedCall1)
@@ -82,8 +82,8 @@ func TestMultipleBoundaries(t *testing.T) {
 		t.Fatalf("FullScanAlgorithm.generateBoundaries() failed with: %v", err)
 	}
 	expectedBoundaries := []tuple{
-		{Int64Value(1), Int64Value(1)},
-		{Int64Value(2), Int64Value(10)},
+		{int64Value(1), int64Value(1)},
+		{int64Value(2), int64Value(10)},
 	}
 	if !reflect.DeepEqual(expectedBoundaries, boundaries) {
 		t.Fatalf("expected: %v, got: %v", expectedBoundaries, boundaries)
@@ -101,7 +101,7 @@ func TestSmallNumberOfRows(t *testing.T) {
 			sqlparser.NewColIdent("user_id"),
 		}, /* splitColumns */
 		1000,
-		GetSchema(),
+		getTestSchema(),
 	)
 	if err != nil {
 		t.Fatalf("NewSplitParamsGivenNumRowsPerQueryPart failed with: %v", err)
@@ -141,7 +141,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 			sqlparser.NewColIdent("user_id"),
 		}, /* splitColumns */
 		1000,
-		GetSchema(),
+		getTestSchema(),
 	)
 	if err != nil {
 		t.Fatalf("NewSplitParamsGivenNumRowsPerQueryPart failed with: %v", err)
@@ -156,7 +156,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 	expectedCall1.Return(
 		&sqltypes.Result{
 			Rows: [][]sqltypes.Value{
-				{Int64Value(1), Int64Value(1)}},
+				{int64Value(1), int64Value(1)}},
 		},
 		nil)
 	expectedCall2 := mockSQLExecuter.EXPECT().SQLExecute(

--- a/go/vt/tabletserver/splitquery/split_algorithm_interface.go
+++ b/go/vt/tabletserver/splitquery/split_algorithm_interface.go
@@ -1,19 +1,25 @@
 package splitquery
 
-import "github.com/youtube/vitess/go/sqltypes"
+import (
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/schema"
+)
 
 type tuple []sqltypes.Value
 
-// SplitAlgorithmInterface defines the interface for a splitting algorithm. A splitting algorithm
-// implements the generateBoundaries() method that returns a list of "boundary tuples".
-// Each tuple is expected to contain values of the split columns, in the order these are defined
-// in SplitParams.splitColumns, at a specific "boundary point". The returned list should be
-// ordered using ascending lexicographical order.
-// If the resulting list of boundary tuples is: {t1, t2, ..., t_k}, the splitquery.Splitter.Split()
-// method would generate k+1 query parts. For i=0,1,...,k, the ith query-part contains the rows
-// whose tuple of split-column values 't' satisfies t_i < t <= t+1, where the comparison
-// is performed lexicographically, and t_0 and t_k+1 are taken to be a "-infinity" tuple and a
-// "+infinity" tuple, respectively.
+// SplitAlgorithmInterface defines the interface for a splitting algorithm.
 type SplitAlgorithmInterface interface {
+	// generateBoundaries() method should return a list of "boundary tuples".
+	// Each tuple is expected to contain values of the split columns, in the order these are returned
+	// in getSplitColumns(), at a specific "boundary point". The returned list should be
+	// ordered using ascending lexicographical order.
+	// If the resulting list of boundary tuples is: {t1, t2, ..., t_k}, the
+	// splitquery.Splitter.Split() method would generate k+1 query parts.
+	// For i=0,1,...,k, the ith query-part contains the rows whose tuple of split-column values 't'
+	// satisfies t_i < t <= t+1, where the comparison is performed lexicographically, and t_0 and
+	// t_k+1 are taken to be a "-infinity" tuple and a "+infinity" tuple, respectively.
 	generateBoundaries() ([]tuple, error)
+
+	// getSplitColumns() should return the list of split-columns used by the algorithm.
+	getSplitColumns() []*schema.TableColumn
 }

--- a/go/vt/tabletserver/splitquery/split_params_test.go
+++ b/go/vt/tabletserver/splitquery/split_params_test.go
@@ -1,0 +1,206 @@
+package splitquery
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/schema"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+)
+
+var splitParamsTestCases = []struct {
+	SQL                 string
+	BindVariables       map[string]interface{}
+	SplitColumnNames    []sqlparser.ColIdent
+	NumRowsPerQueryPart int64
+	SplitCount          int64
+
+	ExpectedErrorRegex  *regexp.Regexp
+	ExpectedSplitParams SplitParams
+}{
+	{ // Test NewSplitParamsGivenSplitCount; correct input.
+		SQL:              "select id from test_table",
+		BindVariables:    map[string]interface{}{"foo": "123"},
+		SplitColumnNames: []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		SplitCount:       100,
+
+		ExpectedSplitParams: SplitParams{
+			splitCount:          100,
+			numRowsPerQueryPart: 10, // TableRows of 'test_table' should be 1000
+			splitColumns:        []*schema.TableColumn{getTestSchemaColumn("test_table", "id")},
+			splitTableSchema:    testSchema["test_table"],
+		},
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; correct input.
+		SQL:                 "select user_id from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedSplitParams: SplitParams{
+			splitCount:          10,
+			numRowsPerQueryPart: 100, // TableRows of 'test_table' should be 1000
+			splitColumns:        []*schema.TableColumn{getTestSchemaColumn("test_table", "id")},
+			splitTableSchema:    testSchema["test_table"],
+		},
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; correct input; default split columns
+		SQL:                 "select user_id from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedSplitParams: SplitParams{
+			splitCount:          10,
+			numRowsPerQueryPart: 100, // TableRows of 'test_table' should be 1000
+			splitColumns: []*schema.TableColumn{
+				getTestSchemaColumn("test_table", "id"),
+				getTestSchemaColumn("test_table", "user_id"),
+			},
+			splitTableSchema: testSchema["test_table"],
+		},
+	},
+
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; invalid query.
+		SQL:                 "not a valid query",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("failed parsing query: 'not a valid query'"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; not a select statement.
+		SQL:                 "delete from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("not a select statement"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select t1.user_id from test_table as t1 join test_table as t2",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported FROM clause"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select distinct user_id from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported query"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select user_id from test_table group by id",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported query"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select user_id from test_table having user_id > 5",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported query"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select user_id from test_table order by id asc",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported query"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select user_id from test_table lock in share mode",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported query"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unsupported select statement.
+		SQL:                 "select user_id from (select * from test_table) as t1",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("unsupported FROM clause"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unknown table.
+		SQL:                 "select user_id from missing_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("id")},
+		NumRowsPerQueryPart: 100,
+
+		ExpectedErrorRegex: regexp.MustCompile("can't find table in schema"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; unknown split column.
+		SQL:                 "select * from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("missing_column")},
+		NumRowsPerQueryPart: 100,
+		ExpectedErrorRegex:  regexp.MustCompile("can't find split column"),
+	},
+	{ // Test NewSplitParamsGivenNumRowsPerQueryPart; split columns not a prefix of an index.
+		SQL:                 "select * from test_table",
+		BindVariables:       map[string]interface{}{"foo": "123"},
+		SplitColumnNames:    []sqlparser.ColIdent{sqlparser.NewColIdent("float32_col")},
+		NumRowsPerQueryPart: 100,
+		ExpectedErrorRegex: regexp.MustCompile(
+			"split-columns must be a prefix of the columns composing an index"),
+	},
+}
+
+func TestSplitParams(t *testing.T) {
+	for _, testCase := range splitParamsTestCases {
+		var splitParams *SplitParams
+		var err error
+		if testCase.NumRowsPerQueryPart != 0 {
+			splitParams, err = NewSplitParamsGivenNumRowsPerQueryPart(
+				testCase.SQL,
+				testCase.BindVariables,
+				testCase.SplitColumnNames,
+				testCase.NumRowsPerQueryPart,
+				testSchema)
+		} else {
+			splitParams, err = NewSplitParamsGivenSplitCount(
+				testCase.SQL,
+				testCase.BindVariables,
+				testCase.SplitColumnNames,
+				testCase.SplitCount,
+				testSchema)
+		}
+		if testCase.ExpectedErrorRegex != nil {
+			if !testCase.ExpectedErrorRegex.MatchString(err.Error()) {
+				t.Errorf("Testcase: %+v, want: %+v, got: %+v", testCase, testCase.ExpectedErrorRegex, err)
+			}
+			continue
+		}
+		// Here, we don't expect an error.
+		if err != nil {
+			t.Errorf("TestCase: %+v, want: %+v, got: %+v", testCase, nil, err)
+			continue
+		}
+		if splitParams == nil {
+			t.Errorf("TestCase: %+v, got nil splitParams", testCase)
+			continue
+		}
+		expectedSplitParams := testCase.ExpectedSplitParams
+		// We don't require testCaset.ExpectedSplitParams to specify common expected fields like 'sql',
+		// so we compute them here and store them in 'expectedSplitParams'.
+		expectedSplitParams.sql = testCase.SQL
+		expectedSplitParams.bindVariables = testCase.BindVariables
+		statement, _ := sqlparser.Parse(testCase.SQL)
+		expectedSplitParams.selectAST = statement.(*sqlparser.Select)
+		if !reflect.DeepEqual(&expectedSplitParams, splitParams) {
+			t.Errorf("TestCase: %+v, want: %+v, got: %+v", testCase, expectedSplitParams, *splitParams)
+		}
+	}
+}


### PR DESCRIPTION
1. Made each split algorithm return the split columns that it uses. This fixes b/28559068
2. Made the max-iterations limit in the full scan algorithm be 10*split_count rather than
a fixed constant.
3. Added tests for SplitParams and and integration test for splitter.
@dumbunny @michael-berlin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1690)
<!-- Reviewable:end -->
