### PR TITLE
vtcombo now doesn't check mysql port.

### DIFF
--- a/go/vt/tabletmanager/action_agent.go
+++ b/go/vt/tabletmanager/action_agent.go
@@ -84,6 +84,12 @@ type ActionAgent struct {
 	// only used if exportStats is true.
 	statsTabletType *stats.String
 
+	// skipMysqlPortCheck is set when we don't want healthcheck to
+	// alter the mysql port of the Tablet record. This is used by
+	// vtcombo, because we dont configure the 'dba' pool, used to
+	// get the mysql port.
+	skipMysqlPortCheck bool
+
 	// batchCtx is given to the agent by its creator, and should be used for
 	// any background tasks spawned by the agent.
 	batchCtx context.Context
@@ -106,8 +112,8 @@ type ActionAgent struct {
 	initReplication bool
 
 	// initialTablet remembers the state of the tablet record at startup.
-	// It can be used to notice, for example, if another tablet has taken over
-	// the record.
+	// It can be used to notice, for example, if another tablet has taken
+	// over the record.
 	initialTablet *topodatapb.Tablet
 
 	// mutex protects all the following fields (that start with '_'),
@@ -311,6 +317,7 @@ func NewComboActionAgent(batchCtx context.Context, ts topo.Server, tabletAlias *
 		DBConfigs:           dbcfgs,
 		SchemaOverrides:     nil,
 		BinlogPlayerMap:     nil,
+		skipMysqlPortCheck:  true,
 		History:             history.New(historyLength),
 		_healthy:            fmt.Errorf("healthcheck not run yet"),
 	}

--- a/go/vt/tabletmanager/healthcheck.go
+++ b/go/vt/tabletmanager/healthcheck.go
@@ -271,7 +271,7 @@ func (agent *ActionAgent) runHealthCheckProtected() {
 	agent.History.Add(record)
 
 	// try to figure out the mysql port if we don't have it yet
-	if _, ok := tablet.PortMap["mysql"]; !ok {
+	if _, ok := tablet.PortMap["mysql"]; !ok && !agent.skipMysqlPortCheck {
 		// we don't know the port, try to get it from mysqld
 		mysqlPort, err := agent.MysqlDaemon.GetMysqlPort()
 		if err != nil {


### PR DESCRIPTION
It's a useless check for vtcombo, and uses the dba connection pool,
which is not configured.

@guoliang100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1693)
<!-- Reviewable:end -->
