### PR TITLE
Making keyspace_id check optional in vttablet.

### DIFF
--- a/go/vt/tabletmanager/action_agent.go
+++ b/go/vt/tabletmanager/action_agent.go
@@ -653,7 +653,8 @@ func (agent *ActionAgent) initializeKeyRangeRule(ctx context.Context, keyspace s
 		return fmt.Errorf("cannot read keyspace %v to get sharding key: %v", keyspace, err)
 	}
 	if keyspaceInfo.ShardingColumnName == "" {
-		return fmt.Errorf("keyspace %v has an empty ShardingColumnName, cannot setup KeyRange rule", keyspace)
+		log.Infof("Keyspace %v has an empty ShardingColumnName, not adding KeyRange query rule", keyspace)
+		return nil
 	}
 
 	// create the rules

--- a/go/vt/vtgate/router.go
+++ b/go/vt/vtgate/router.go
@@ -19,10 +19,6 @@ import (
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 )
 
-const (
-	ksidName = "keyspace_id"
-)
-
 // Router is the layer to route queries to the correct shards
 // based on the values in the query.
 type Router struct {
@@ -260,7 +256,6 @@ func (rtr *Router) execUpdateEqual(vcursor *requestContext, route *engine.Route)
 	if len(ksid) == 0 {
 		return &sqltypes.Result{}, nil
 	}
-	vcursor.bindVars[ksidName] = string(ksid)
 	rewritten := sqlannotation.AddKeyspaceID(route.Query, ksid, vcursor.comments)
 	return rtr.scatterConn.Execute(
 		vcursor.ctx,
@@ -291,7 +286,6 @@ func (rtr *Router) execDeleteEqual(vcursor *requestContext, route *engine.Route)
 			return nil, fmt.Errorf("execDeleteEqual: %v", err)
 		}
 	}
-	vcursor.bindVars[ksidName] = string(ksid)
 	rewritten := sqlannotation.AddKeyspaceID(route.Query, ksid, vcursor.comments)
 	return rtr.scatterConn.Execute(
 		vcursor.ctx,
@@ -328,7 +322,6 @@ func (rtr *Router) execInsertSharded(vcursor *requestContext, route *engine.Rout
 			return nil, err
 		}
 	}
-	vcursor.bindVars[ksidName] = string(ksid)
 	rewritten := sqlannotation.AddKeyspaceID(route.Query, ksid, vcursor.comments)
 	result, err := rtr.scatterConn.Execute(
 		vcursor.ctx,

--- a/go/vt/vtgate/router_dml_test.go
+++ b/go/vt/vtgate/router_dml_test.go
@@ -24,10 +24,8 @@ func TestUpdateEqual(t *testing.T) {
 		t.Error(err)
 	}
 	wantQueries := []querytypes.BoundQuery{{
-		Sql: "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-		},
+		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
 		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
@@ -42,10 +40,8 @@ func TestUpdateEqual(t *testing.T) {
 		t.Error(err)
 	}
 	wantQueries = []querytypes.BoundQuery{{
-		Sql: "update user set a = 2 where id = 3 /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "N\xb1\x90ɢ\xfa\x16\x9c",
-		},
+		Sql:           "update user set a = 2 where id = 3 /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
 		t.Errorf("sbc2.Queries: %+v, want %+v\n", sbc2.Queries, wantQueries)
@@ -86,10 +82,8 @@ func TestUpdateComments(t *testing.T) {
 		t.Error(err)
 	}
 	wantQueries := []querytypes.BoundQuery{{
-		Sql: "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-		},
+		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
 		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
@@ -158,10 +152,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "select name from user where id = 1 for update",
 		BindVariables: map[string]interface{}{},
 	}, {
-		Sql: "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-		},
+		Sql:           "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
@@ -189,10 +181,8 @@ func TestDeleteEqual(t *testing.T) {
 		Sql:           "select name from user where id = 1 for update",
 		BindVariables: map[string]interface{}{},
 	}, {
-		Sql: "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-		},
+		Sql:           "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
@@ -243,10 +233,8 @@ func TestDeleteComments(t *testing.T) {
 		Sql:           "select name from user where id = 1 for update",
 		BindVariables: map[string]interface{}{},
 	}, {
-		Sql: "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
-		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-		},
+		Sql:           "delete from user where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
+		BindVariables: map[string]interface{}{},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
 		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
@@ -312,10 +300,9 @@ func TestInsertSharded(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id, 2, :_name) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-			"_Id":         int64(1),
-			"_name":       []byte("myname"),
-			"__seq":       int64(1),
+			"_Id":   int64(1),
+			"_name": []byte("myname"),
+			"__seq": int64(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
@@ -344,10 +331,9 @@ func TestInsertSharded(t *testing.T) {
 	wantQueries = []querytypes.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id, 2, :_name) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "N\xb1\x90ɢ\xfa\x16\x9c",
-			"_Id":         int64(3),
-			"__seq":       int64(3),
-			"_name":       []byte("myname2"),
+			"_Id":   int64(3),
+			"__seq": int64(3),
+			"_name": []byte("myname2"),
 		},
 	}}
 	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
@@ -378,10 +364,9 @@ func TestInsertComments(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into user(id, v, name) values (:_Id, 2, :_name) /* vtgate:: keyspace_id:166b40b44aba4bd6 */ /* trailing */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-			"_Id":         int64(1),
-			"_name":       []byte("myname"),
-			"__seq":       int64(1),
+			"_Id":   int64(1),
+			"_name": []byte("myname"),
+			"__seq": int64(1),
 		},
 	}}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
@@ -419,10 +404,9 @@ func TestInsertGenerator(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into user(v, name, Id) values (2, :_name, :_Id) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-			"_Id":         int64(1),
-			"__seq":       int64(1),
-			"_name":       []byte("myname"),
+			"_Id":   int64(1),
+			"__seq": int64(1),
+			"_name": []byte("myname"),
 		},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
@@ -458,10 +442,9 @@ func TestInsertLookupOwned(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into music(user_id, id) values (:_user_id, :_id) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x06\xe7\xea\"Βp\x8f",
-			"_user_id":    int64(2),
-			"_id":         int64(3),
-			"__seq":       int64(3),
+			"_user_id": int64(2),
+			"_id":      int64(3),
+			"__seq":    int64(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
@@ -496,10 +479,9 @@ func TestInsertLookupOwnedGenerator(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into music(user_id, id) values (:_user_id, :_id) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x06\xe7\xea\"Βp\x8f",
-			"_user_id":    int64(2),
-			"_id":         int64(4),
-			"__seq":       int64(4),
+			"_user_id": int64(2),
+			"_id":      int64(4),
+			"__seq":    int64(4),
 		},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
@@ -535,9 +517,8 @@ func TestInsertLookupUnowned(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into music_extra(user_id, music_id) values (:_user_id, :_music_id) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x06\xe7\xea\"Βp\x8f",
-			"_user_id":    int64(2),
-			"_music_id":   int64(3),
+			"_user_id":  int64(2),
+			"_music_id": int64(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
@@ -565,9 +546,8 @@ func TestInsertLookupUnownedUnsupplied(t *testing.T) {
 	wantQueries := []querytypes.BoundQuery{{
 		Sql: "insert into music_extra_reversed(music_id, user_id) values (:_music_id, :_user_id) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]interface{}{
-			"keyspace_id": "\x16k@\xb4J\xbaK\xd6",
-			"_user_id":    int64(1),
-			"_music_id":   int64(3),
+			"_user_id":  int64(1),
+			"_music_id": int64(3),
 		},
 	}}
 	if !reflect.DeepEqual(sbc.Queries, wantQueries) {

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -69,14 +69,7 @@ func (tc *splitCloneTestCase) setUp(v3 bool) {
 	tc.wi = NewInstance(ctx, tc.ts, "cell1", time.Second)
 
 	if v3 {
-		// FIXME(alainjobart): ShardingColumnName and ShardingColumnType
-		// are not used by v3 split_clone, but they are required
-		// by tabletmanager to setup the rules. We have b/27901260
-		// open internally to fix this.
-		if err := tc.ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
-			ShardingColumnName: "keyspace_id",
-			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
-		}); err != nil {
+		if err := tc.ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{}); err != nil {
 			tc.t.Fatalf("CreateKeyspace v3 failed: %v", err)
 		}
 

--- a/go/vt/worker/split_diff_test.go
+++ b/go/vt/worker/split_diff_test.go
@@ -164,14 +164,7 @@ func testSplitDiff(t *testing.T, v3 bool) {
 	wi := NewInstance(ctx, ts, "cell1", time.Second)
 
 	if v3 {
-		// FIXME(alainjobart): ShardingColumnName and ShardingColumnType
-		// are not used by v3 split_clone, but they are required
-		// by tabletmanager to setup the rules. We have b/27901260
-		// open internally to fix this.
-		if err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{
-			ShardingColumnName: "keyspace_id",
-			ShardingColumnType: topodatapb.KeyspaceIdType_UINT64,
-		}); err != nil {
+		if err := ts.CreateKeyspace(ctx, "ks", &topodatapb.Keyspace{}); err != nil {
 			t.Fatalf("CreateKeyspace v3 failed: %v", err)
 		}
 

--- a/test/keyspace_util.py
+++ b/test/keyspace_util.py
@@ -32,10 +32,6 @@ class TestEnv(object):
     utils.run_vtctl(['CreateKeyspace', keyspace])
     if not shards or shards[0] == '0':
       shards = ['0']
-    else:
-      utils.run_vtctl(
-          ['SetKeyspaceShardingInfo', '-force', keyspace, 'keyspace_id',
-           'uint64'])
 
     # Create tablets and start mysqld.
     procs = []


### PR DESCRIPTION
It's only enabled now if the Keyspace object has a ShardingColumnName
set. We do not require the ShardingColumnName field any more.

For v3, do not send a hardcoded keyspace_id any more. That was just a
hack.

The worker tests do not need to set ShardingColumnName any more.
v3 test doesn't need to anymore either.

@sougou this is what we talked about
@enisoc this is different from the design we agreed upon, but still doing the check for v3 was just a nightmare in the code. Also, now the examples probably don't need to set ShardingColumnName, as they use v3, let's get rid of that next.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1694)
<!-- Reviewable:end -->
