### PR TITLE
composer.json fix - google/auth package set to the same version as defined in grpc/grpc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=5.5.0",
     "datto/protobuf-php": "dev-master",
-    "google/auth": "dev-master",
+    "google/auth": "v0.7",
     "grpc/grpc": "dev-release-0_13"
   },
   "autoload": {


### PR DESCRIPTION
In the current state it is impossible to run composer update. Another fix would be maybe get rid of the google/auth package in composer.json, since it is required by grpc/grpc. I would leave it like this for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1701)
<!-- Reviewable:end -->
