### PR TITLE
Refactoring options for vttest local cluster.

### DIFF
--- a/go/vt/tabletserver/endtoend/main_test.go
+++ b/go/vt/tabletserver/endtoend/main_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	tabletserver.Init()
 
 	exitCode := func() int {
-		hdl, err := vttest.LaunchMySQL("vttest", testSchema, testing.Verbose())
+		hdl, err := vttest.LaunchVitess(vttest.MySQLOnly("vttest"), vttest.Schema(testSchema), vttest.Verbose(testing.Verbose()))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "could not launch mysql: %v\n", err)
 			return 1

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -37,8 +37,13 @@ type Handle struct {
 
 // VitessOption is the type for generic options to be passed in to LaunchVitess.
 type VitessOption struct {
+	// beforeRun is executed before we start run_local_database.py.
 	beforeRun func(*Handle) error
-	afterRun  func()
+
+	// afterRun is executed after run_local_database.py has been
+	// started and is running (and is done reading and applying
+	// the schema).
+	afterRun func()
 }
 
 // Verbose makes the underlying local_cluster verbose.
@@ -54,7 +59,7 @@ func Verbose(verbose bool) VitessOption {
 }
 
 // SchemaDirectory is used to specify a directory to read schema from.
-// It conflicts with Schema / MySQLOnly.
+// It cannot be used at the same time as Schema.
 func SchemaDirectory(dir string) VitessOption {
 	return VitessOption{
 		beforeRun: func(hdl *Handle) error {
@@ -67,7 +72,7 @@ func SchemaDirectory(dir string) VitessOption {
 }
 
 // Topology is used to pass in the topology string.
-// It conflicts with MySQLOnly.
+// It cannot be used at the same time as MySQLOnly.
 func Topology(topo string) VitessOption {
 	return VitessOption{
 		beforeRun: func(hdl *Handle) error {
@@ -79,7 +84,7 @@ func Topology(topo string) VitessOption {
 
 // MySQLOnly is used to launch only a mysqld instance, with the specified db name.
 // Use it before Schema option.
-// It is incompativle with the Topology option.
+// It cannot be used at the same as Topology.
 func MySQLOnly(dbName string) VitessOption {
 	return VitessOption{
 		beforeRun: func(hdl *Handle) error {
@@ -198,7 +203,7 @@ func (hdl *Handle) TearDown() error {
 }
 
 // MySQLConnParams builds the MySQL connection params.
-// It's valid only if you used LaunchMySQL.
+// It's valid only if you used MySQLOnly option.
 func (hdl *Handle) MySQLConnParams() (sqldb.ConnParams, error) {
 	params := sqldb.ConnParams{
 		Charset: "utf8",

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestVitess(t *testing.T) {
-	hdl, err := LaunchVitess("test_keyspace/0:test_keyspace", "", false, nil /* initDataOptions */)
+	hdl, err := LaunchVitess(Topology("test_keyspace/0:test_keyspace"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -57,7 +57,7 @@ func TestVitess(t *testing.T) {
 }
 
 func TestMySQL(t *testing.T) {
-	hdl, err := LaunchMySQL("vttest", "create table a(id int, name varchar(128), primary key(id))", false)
+	hdl, err := LaunchVitess(MySQLOnly("vttest"), Schema("create table a(id int, name varchar(128), primary key(id))"))
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Using the same style as gRPC Dial options, for instance.

@erzel I think this works better, more code in the library, but argument passing in the tests is much better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1702)
<!-- Reviewable:end -->
