### PR TITLE
Increase default mysqlctl wait_time to 5min.

### DIFF
--- a/go/cmd/mysqlctl/mysqlctl.go
+++ b/go/cmd/mysqlctl/mysqlctl.go
@@ -34,7 +34,7 @@ var (
 )
 
 func initCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 2*time.Minute, "how long to wait for startup")
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
 	initDBSQLFile := subFlags.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
 	subFlags.Parse(args)
 
@@ -47,7 +47,7 @@ func initCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) err
 }
 
 func shutdownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 2*time.Minute, "how long to wait for shutdown")
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
 	subFlags.Parse(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
@@ -59,7 +59,7 @@ func shutdownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string)
 }
 
 func startCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 2*time.Minute, "how long to wait for startup")
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for startup")
 	subFlags.Parse(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
@@ -71,7 +71,7 @@ func startCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) er
 }
 
 func teardownCmd(mysqld *mysqlctl.Mysqld, subFlags *flag.FlagSet, args []string) error {
-	waitTime := subFlags.Duration("wait_time", 2*time.Minute, "how long to wait for shutdown")
+	waitTime := subFlags.Duration("wait_time", 5*time.Minute, "how long to wait for shutdown")
 	force := subFlags.Bool("force", false, "will remove the root directory even if mysqld shutdown fails")
 	subFlags.Parse(args)
 
@@ -126,13 +126,13 @@ type command struct {
 }
 
 var commands = []command{
-	{"init", initCmd, "[-wait_time=20s] [-init_db_sql_file=]",
+	{"init", initCmd, "[-wait_time=5m] [-init_db_sql_file=]",
 		"Initalizes the directory structure and starts mysqld"},
-	{"teardown", teardownCmd, "[-force]",
+	{"teardown", teardownCmd, "[-wait_time=5m] [-force]",
 		"Shuts mysqld down, and removes the directory"},
-	{"start", startCmd, "[-wait_time=20s]",
+	{"start", startCmd, "[-wait_time=5m]",
 		"Starts mysqld on an already 'init'-ed directory"},
-	{"shutdown", shutdownCmd, "[-wait_time=20s]",
+	{"shutdown", shutdownCmd, "[-wait_time=5m]",
 		"Shuts down mysqld, does not remove any file"},
 
 	{"position", positionCmd,

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -74,10 +74,16 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
 	if _, err = os.Stat(mycnf.DataDir); os.IsNotExist(err) {
 		log.Infof("mysql data dir (%s) doesn't exist, initializing", mycnf.DataDir)
-		mysqld.Init(ctx, *initDBSQLFile)
+		if err := mysqld.Init(ctx, *initDBSQLFile); err != nil {
+			log.Errorf("failed to initialize mysql data dir and start mysqld: %v", err)
+			exit.Return(1)
+		}
 	} else {
 		log.Infof("mysql data dir (%s) already exists, starting without init", mycnf.DataDir)
-		mysqld.Start(ctx)
+		if err := mysqld.Start(ctx); err != nil {
+			log.Errorf("failed to start mysqld: %v", err)
+			exit.Return(1)
+		}
 	}
 	cancel()
 

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -33,7 +33,7 @@ var (
 	mysqlSocket = flag.String("mysql_socket", "", "path to the mysql socket")
 
 	// mysqlctl init flags
-	waitTime      = flag.Duration("wait_time", 2*time.Minute, "how long to wait for mysqld startup or shutdown")
+	waitTime      = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
 	initDBSQLFile = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
 )
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -439,7 +439,7 @@ func (mysqld *Mysqld) Init(ctx context.Context, initDBSQLFile string) error {
 
 	// Start mysqld.
 	if err = mysqld.Start(ctx); err != nil {
-		log.Errorf("failed starting, check %v", mysqld.config.ErrorLogPath)
+		log.Errorf("failed starting mysqld (check %v for more info): %v", mysqld.config.ErrorLogPath, err)
 		return err
 	}
 


### PR DESCRIPTION
@alainjobart 

We had two user threads recently where the solution was to increase the wait_time to 5min.

Especially on test setups, mysqld can take a while to initialize. We'd rather wait a little longer to find out if it's truly stuck, rather than give up too soon when it's actually fine but slow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1718)
<!-- Reviewable:end -->
