### PR TITLE
bugs: b/28851938, b/28888701

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -28,9 +28,7 @@ import (
 )
 
 const (
-	// NOTE(szopa): maxSize used to be 1 << 30, but that causes
-	// compiler errors in some situations.
-	maxSize = 1 << 20
+	maxSize = 1 << 30
 )
 
 func init() {

--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	maxSize = 1 << 30
+	maxSize = 1 << 32
 )
 
 func init() {

--- a/go/vt/tabletserver/queryz.go
+++ b/go/vt/tabletserver/queryz.go
@@ -137,7 +137,10 @@ func queryzHandler(si *SchemaInfo, w http.ResponseWriter, r *http.Request) {
 			Reason: plan.Reason,
 		}
 		Value.Count, Value.tm, Value.Rows, Value.Errors = plan.Stats()
-		timepq := time.Duration(int64(Value.tm) / Value.Count)
+		var timepq time.Duration
+		if Value.Count != 0 {
+			timepq = time.Duration(int64(Value.tm) / Value.Count)
+		}
 		if timepq < 10*time.Millisecond {
 			Value.Color = "low"
 		} else if timepq < 100*time.Millisecond {


### PR DESCRIPTION
@dumbunny @mattharden 
The mysql API bug seems to trigger for very large data sizes,
likely greater than 1<<20. This is because we make go think
that those slices can't be bigger than that value.

The other fix is to prevent a divide by 0 error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1720)
<!-- Reviewable:end -->
