### PR TITLE
discovery: Prevent that SetListener gets called twice or after a tablet was added.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -141,7 +141,7 @@ func NewHealthCheck(connTimeout time.Duration, retryDelay time.Duration, healthC
 
 // HealthCheckImpl performs health checking and notifies downstream components about any changes.
 type HealthCheckImpl struct {
-	// set at construction time
+	// Immutable fields set at construction time.
 	listener           HealthCheckStatsListener
 	connTimeout        time.Duration
 	retryDelay         time.Duration
@@ -745,7 +745,6 @@ func (hc *HealthCheckImpl) Close() error {
 	hc.mu.Lock()
 	defer hc.mu.Unlock()
 	close(hc.closeChan)
-	hc.listener = nil
 	for _, hcc := range hc.addrToConns {
 		hcc.cancelFunc()
 	}


### PR DESCRIPTION
@guoliang100 

discovery: Fix datarace for "listener" field in HealthCheckImpl.

B=28616156

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1724)
<!-- Reviewable:end -->
