### PR TITLE
Add connection-wide default keyspace for VTGateV3 queries.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f94639fdd21d6d8c0d4303d1f31a2ac7",
-    "content-hash": "54e74f04ae871f8c990be820ed4d2404",
+    "hash": "0cd710cc0ecaf561decfc222218510ab",
+    "content-hash": "5ab396f6457dc803b81cb295390ba83f",
     "packages": [
         {
             "name": "datto/protobuf-php",
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/stanley-cheung/Protobuf-PHP.git",
-                "reference": "b0a40f3150e5cd5b002f1cb16c021f4a59e20d6d"
+                "reference": "dbbe0846ee99e9579a0e5b09abf03e671614f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stanley-cheung/Protobuf-PHP/zipball/b0a40f3150e5cd5b002f1cb16c021f4a59e20d6d",
-                "reference": "b0a40f3150e5cd5b002f1cb16c021f4a59e20d6d",
+                "url": "https://api.github.com/repos/stanley-cheung/Protobuf-PHP/zipball/dbbe0846ee99e9579a0e5b09abf03e671614f0a8",
+                "reference": "dbbe0846ee99e9579a0e5b09abf03e671614f0a8",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +59,7 @@
             "support": {
                 "source": "https://github.com/stanley-cheung/Protobuf-PHP/tree/master"
             },
-            "time": "2015-12-10 06:02:49"
+            "time": "2016-05-18 22:11:39"
         },
         {
             "name": "firebase/php-jwt",
@@ -106,16 +106,16 @@
         },
         {
             "name": "google/auth",
-            "version": "dev-master",
+            "version": "v0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/google/google-auth-library-php.git",
-                "reference": "45c5e62244995d4dae51aa379894401ebe992b4d"
+                "reference": "f3288860ce7b3076a6768e4ff7b85e0f6100e221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/google/google-auth-library-php/zipball/45c5e62244995d4dae51aa379894401ebe992b4d",
-                "reference": "45c5e62244995d4dae51aa379894401ebe992b4d",
+                "url": "https://api.github.com/repos/google/google-auth-library-php/zipball/f3288860ce7b3076a6768e4ff7b85e0f6100e221",
+                "reference": "f3288860ce7b3076a6768e4ff7b85e0f6100e221",
                 "shasum": ""
             },
             "require": {
@@ -149,7 +149,7 @@
                 "google",
                 "oauth2"
             ],
-            "time": "2016-02-24 18:00:02"
+            "time": "2016-03-03 02:03:58"
         },
         {
             "name": "grpc/grpc",
@@ -157,16 +157,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/grpc/grpc.git",
-                "reference": "22648b7f7c83d80b71ac312864f760775f8d5abd"
+                "reference": "768c769acef173ef6ba4fc076e782607816c5ab9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc/zipball/22648b7f7c83d80b71ac312864f760775f8d5abd",
-                "reference": "22648b7f7c83d80b71ac312864f760775f8d5abd",
+                "url": "https://api.github.com/repos/grpc/grpc/zipball/768c769acef173ef6ba4fc076e782607816c5ab9",
+                "reference": "768c769acef173ef6ba4fc076e782607816c5ab9",
                 "shasum": ""
             },
             "require": {
-                "google/auth": "dev-master",
+                "datto/protobuf-php": "dev-master",
+                "google/auth": "v0.7",
                 "php": ">=5.5.0"
             },
             "type": "library",
@@ -184,7 +185,7 @@
             "keywords": [
                 "rpc"
             ],
-            "time": "2016-02-23 02:54:24"
+            "time": "2016-04-29 18:06:37"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -192,12 +193,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "739b9c8378c462943c42fee5353453ab4164ed8e"
+                "reference": "b1a96f6134f69cb41f8538d3a6491f4bb1dbab78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/739b9c8378c462943c42fee5353453ab4164ed8e",
-                "reference": "739b9c8378c462943c42fee5353453ab4164ed8e",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b1a96f6134f69cb41f8538d3a6491f4bb1dbab78",
+                "reference": "b1a96f6134f69cb41f8538d3a6491f4bb1dbab78",
                 "shasum": ""
             },
             "require": {
@@ -246,20 +247,20 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-02-17 21:09:10"
+            "time": "2016-05-08 19:39:56"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "dev-master",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "976e0f50981f845dcee1c25bfcac2304a7bb5583"
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/976e0f50981f845dcee1c25bfcac2304a7bb5583",
-                "reference": "976e0f50981f845dcee1c25bfcac2304a7bb5583",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
                 "shasum": ""
             },
             "require": {
@@ -297,7 +298,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-02-26 22:29:15"
+            "time": "2016-05-18 16:56:05"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -412,7 +413,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "datto/protobuf-php": 20,
-        "google/auth": 20,
         "grpc/grpc": 20
     },
     "prefer-stable": false,

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
@@ -17,18 +17,27 @@ import java.util.Map;
 /**
  * A synchronous wrapper around a VTGate connection.
  *
- * <p>This is a wrapper around the asynchronous {@link VTGateConn} class
- * that converts all methods to synchronous.
+ * <p>
+ * This is a wrapper around the asynchronous {@link VTGateConn} class that converts all methods to
+ * synchronous.
  */
 public class VTGateBlockingConn implements Closeable {
   private final VTGateConn conn;
 
   /**
-   * Creates a new {@link VTGateConn} with the given {@link RpcClient}
-   * and wraps it in a synchronous API.
+   * Creates a new {@link VTGateConn} with the given {@link RpcClient} and wraps it in a synchronous
+   * API.
    */
   public VTGateBlockingConn(RpcClient client) {
     conn = new VTGateConn(client);
+  }
+
+  /**
+   * Creates a new {@link VTGateConn} with the given {@link RpcClient} and wraps it in a synchronous
+   * API.
+   */
+  public VTGateBlockingConn(RpcClient client, String keyspace) {
+    conn = new VTGateConn(client, keyspace);
   }
 
   /**
@@ -43,67 +52,40 @@ public class VTGateBlockingConn implements Closeable {
     return conn.execute(ctx, query, bindVars, tabletType).checkedGet();
   }
 
-  public Cursor executeShards(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<String> shards,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
+  public Cursor executeShards(Context ctx, String query, String keyspace, Iterable<String> shards,
+      Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
     return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
   }
 
-  public Cursor executeKeyspaceIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<byte[]> keyspaceIds,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor executeKeyspaceIds(Context ctx, String query, String keyspace,
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
         .checkedGet();
   }
 
-  public Cursor executeKeyRanges(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<? extends KeyRange> keyRanges,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor executeKeyRanges(Context ctx, String query, String keyspace,
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
         .checkedGet();
   }
 
-  public Cursor executeEntityIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      String entityColumnName,
-      Map<byte[], ?> entityKeyspaceIds,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
-    return conn.executeEntityIds(
-            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType)
-        .checkedGet();
+  public Cursor executeEntityIds(Context ctx, String query, String keyspace,
+      String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
+    return conn.executeEntityIds(ctx, query, keyspace, entityColumnName, entityKeyspaceIds,
+        bindVars, tabletType).checkedGet();
   }
 
   /**
    * Execute multiple keyspace ID queries as a batch.
    *
    * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
-   * the batch queries.
+   *        the batch queries.
    */
-  public List<Cursor> executeBatchShards(
-      Context ctx,
-      Iterable<? extends BoundShardQuery> queries,
-      TabletType tabletType,
-      boolean asTransaction)
-      throws SQLException {
+  public List<Cursor> executeBatchShards(Context ctx, Iterable<? extends BoundShardQuery> queries,
+      TabletType tabletType, boolean asTransaction) throws SQLException {
     return conn.executeBatchShards(ctx, queries, tabletType, asTransaction).checkedGet();
   }
 
@@ -111,52 +93,32 @@ public class VTGateBlockingConn implements Closeable {
    * Execute multiple keyspace ID queries as a batch.
    *
    * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
-   * the batch queries.
+   *        the batch queries.
    */
-  public List<Cursor> executeBatchKeyspaceIds(
-      Context ctx,
-      Iterable<? extends BoundKeyspaceIdQuery> queries,
-      TabletType tabletType,
-      boolean asTransaction)
-      throws SQLException {
+  public List<Cursor> executeBatchKeyspaceIds(Context ctx,
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      boolean asTransaction) throws SQLException {
     return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction).checkedGet();
   }
 
-  public Cursor streamExecute(
-      Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
-      throws SQLException {
+  public Cursor streamExecute(Context ctx, String query, Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
     return conn.streamExecute(ctx, query, bindVars, tabletType);
   }
 
-  public Cursor streamExecuteShards(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<String> shards,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
+  public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
     return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType);
   }
 
-  public Cursor streamExecuteKeyspaceIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<byte[]> keyspaceIds,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType);
   }
 
-  public Cursor streamExecuteKeyRanges(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<? extends KeyRange> keyRanges,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType);
   }
@@ -165,14 +127,8 @@ public class VTGateBlockingConn implements Closeable {
     return new VTGateBlockingTx(conn.begin(ctx).checkedGet());
   }
 
-  public List<SplitQueryResponse.Part> splitQuery(
-      Context ctx,
-      String keyspace,
-      String query,
-      Map<String, ?> bindVars,
-      String splitColumn,
-      long splitCount)
-      throws SQLException {
+  public List<SplitQueryResponse.Part> splitQuery(Context ctx, String keyspace, String query,
+      Map<String, ?> bindVars, String splitColumn, long splitCount) throws SQLException {
     return conn.splitQuery(ctx, keyspace, query, bindVars, splitColumn, splitCount).checkedGet();
   }
 

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -51,62 +51,77 @@ import javax.annotation.Nullable;
 /**
  * An asynchronous VTGate connection.
  *
- * <p>See the
- * <a href="https://github.com/youtube/vitess/blob/master/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java">VitessClientExample</a>
+ * <p>
+ * See the <a href=
+ * "https://github.com/youtube/vitess/blob/master/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java">VitessClientExample</a>
  * for a usage example.
  *
- * <p>All non-streaming calls on {@code VTGateConn} are asynchronous.
- * Use {@link VTGateBlockingConn} if you want synchronous calls.
+ * <p>
+ * All non-streaming calls on {@code VTGateConn} are asynchronous. Use {@link VTGateBlockingConn} if
+ * you want synchronous calls.
  */
 public final class VTGateConn implements Closeable {
   private final RpcClient client;
+  private final String keyspace;
 
+  /**
+   * Creates a VTGateConn with no default keyspace.
+   * 
+   * <p>
+   * In this mode, methods like {@code execute()} and {@code streamExecute()} that don't have a
+   * per-call {@code keyspace} parameter will use VSchema to resolve the keyspace for any unprefixed
+   * table names. Note that this only works if the table name is unique across all keyspaces.
+   */
   public VTGateConn(RpcClient client) {
     this.client = checkNotNull(client);
+    this.keyspace = "";
   }
 
-  public SQLFuture<Cursor> execute(
-      Context ctx, String query, @Nullable Map<String, ?> bindVars, TabletType tabletType)
-      throws SQLException {
+  /**
+   * Creates a VTGateConn with a default keyspace.
+   * 
+   * <p>
+   * The given {@code keyspace} will be used as the connection-wide default for {@code execute()}
+   * and {@code streamExecute()} calls, since those do not specify the keyspace for each call. Like
+   * the connection-wide default database of a MySQL connection, individual queries can still refer
+   * to other keyspaces by prefixing table names. For example:
+   * {@code "SELECT ... FROM keyspace.table ..."}
+   */
+  public VTGateConn(RpcClient client, String keyspace) {
+    this.client = checkNotNull(client);
+    this.keyspace = checkNotNull(keyspace);
+  }
+
+  public SQLFuture<Cursor> execute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
     ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setTabletType(checkNotNull(tabletType));
+        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
-    return new SQLFuture<Cursor>(
-        Futures.transformAsync(
-            client.execute(ctx, requestBuilder.build()),
-            new AsyncFunction<ExecuteResponse, Cursor>() {
-              @Override
-              public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
-                Proto.checkError(response.getError());
-                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-              }
-            }));
+    return new SQLFuture<Cursor>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
+        new AsyncFunction<ExecuteResponse, Cursor>() {
+          @Override
+          public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
+            Proto.checkError(response.getError());
+            return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+          }
+        }));
   }
 
-  public SQLFuture<Cursor> executeShards(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<String> shards,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
+  public SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     ExecuteShardsRequest.Builder requestBuilder =
-        ExecuteShardsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllShards(checkNotNull(shards))
+        ExecuteShardsRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
             .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<Cursor>(
-        Futures.transformAsync(
-            client.executeShards(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteShardsResponse, Cursor>() {
               @Override
               public ListenableFuture<Cursor> apply(ExecuteShardsResponse response)
@@ -117,27 +132,20 @@ public final class VTGateConn implements Closeable {
             }));
   }
 
-  public SQLFuture<Cursor> executeKeyspaceIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<byte[]> keyspaceIds,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
+  public SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query, String keyspace,
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
-    ExecuteKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteKeyspaceIdsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllKeyspaceIds(
-                Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-            .setTabletType(checkNotNull(tabletType));
+    ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyspaceIds(
+            Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<Cursor>(
-        Futures.transformAsync(
-            client.executeKeyspaceIds(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
               @Override
               public ListenableFuture<Cursor> apply(ExecuteKeyspaceIdsResponse response)
@@ -148,26 +156,18 @@ public final class VTGateConn implements Closeable {
             }));
   }
 
-  public SQLFuture<Cursor> executeKeyRanges(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<? extends KeyRange> keyRanges,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
-    ExecuteKeyRangesRequest.Builder requestBuilder =
-        ExecuteKeyRangesRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllKeyRanges(checkNotNull(keyRanges))
-            .setTabletType(checkNotNull(tabletType));
+  public SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
+      Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
+    ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<Cursor>(
-        Futures.transformAsync(
-            client.executeKeyRanges(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
               @Override
               public ListenableFuture<Cursor> apply(ExecuteKeyRangesResponse response)
@@ -178,30 +178,20 @@ public final class VTGateConn implements Closeable {
             }));
   }
 
-  public SQLFuture<Cursor> executeEntityIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      String entityColumnName,
-      Map<byte[], ?> entityKeyspaceIds,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
-    ExecuteEntityIdsRequest.Builder requestBuilder =
-        ExecuteEntityIdsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .setEntityColumnName(checkNotNull(entityColumnName))
-            .addAllEntityKeyspaceIds(
-                Iterables.transform(
-                    entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-            .setTabletType(checkNotNull(tabletType));
+  public SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
+      String entityColumnName, Map<byte[], ?> entityKeyspaceIds, @Nullable Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
+    ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace))
+        .setEntityColumnName(checkNotNull(entityColumnName)).addAllEntityKeyspaceIds(Iterables
+            .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<Cursor>(
-        Futures.transformAsync(
-            client.executeEntityIds(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
               @Override
               public ListenableFuture<Cursor> apply(ExecuteEntityIdsResponse response)
@@ -216,32 +206,26 @@ public final class VTGateConn implements Closeable {
    * Execute multiple keyspace ID queries as a batch.
    *
    * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
-   * the batch queries.
+   *        the batch queries.
    */
-  public SQLFuture<List<Cursor>> executeBatchShards(
-      Context ctx,
-      Iterable<? extends BoundShardQuery> queries,
-      TabletType tabletType,
-      boolean asTransaction)
+  public SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType, boolean asTransaction)
       throws SQLException {
     ExecuteBatchShardsRequest.Builder requestBuilder =
-        ExecuteBatchShardsRequest.newBuilder()
-            .addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType))
-            .setAsTransaction(asTransaction);
+        ExecuteBatchShardsRequest.newBuilder().addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<List<Cursor>>(
-        Futures.transformAsync(
-            client.executeBatchShards(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
               @Override
               public ListenableFuture<List<Cursor>> apply(ExecuteBatchShardsResponse response)
                   throws Exception {
                 Proto.checkError(response.getError());
-                return Futures.<List<Cursor>>immediateFuture(
-                    Proto.toCursorList(response.getResultsList()));
+                return Futures
+                    .<List<Cursor>>immediateFuture(Proto.toCursorList(response.getResultsList()));
               }
             }));
   }
@@ -250,104 +234,76 @@ public final class VTGateConn implements Closeable {
    * Execute multiple keyspace ID queries as a batch.
    *
    * @param asTransaction If true, automatically create a transaction (per shard) that encloses all
-   * the batch queries.
+   *        the batch queries.
    */
-  public SQLFuture<List<Cursor>> executeBatchKeyspaceIds(
-      Context ctx,
-      Iterable<? extends BoundKeyspaceIdQuery> queries,
-      TabletType tabletType,
-      boolean asTransaction)
-      throws SQLException {
+  public SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      boolean asTransaction) throws SQLException {
     ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteBatchKeyspaceIdsRequest.newBuilder()
-            .addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType))
-            .setAsTransaction(asTransaction);
+        ExecuteBatchKeyspaceIdsRequest.newBuilder().addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<List<Cursor>>(
-        Futures.transformAsync(
-            client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {
               @Override
               public ListenableFuture<List<Cursor>> apply(ExecuteBatchKeyspaceIdsResponse response)
                   throws Exception {
                 Proto.checkError(response.getError());
-                return Futures.<List<Cursor>>immediateFuture(
-                    Proto.toCursorList(response.getResultsList()));
+                return Futures
+                    .<List<Cursor>>immediateFuture(Proto.toCursorList(response.getResultsList()));
               }
             }));
   }
 
-  public Cursor streamExecute(
-      Context ctx, String query, @Nullable Map<String, ?> bindVars, TabletType tabletType)
-      throws SQLException {
+  public Cursor streamExecute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
     StreamExecuteRequest.Builder requestBuilder =
-        StreamExecuteRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setTabletType(checkNotNull(tabletType));
+        StreamExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new StreamCursor(client.streamExecute(ctx, requestBuilder.build()));
   }
 
-  public Cursor streamExecuteShards(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<String> shards,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
-    StreamExecuteShardsRequest.Builder requestBuilder =
-        StreamExecuteShardsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllShards(checkNotNull(shards))
-            .setTabletType(checkNotNull(tabletType));
+    StreamExecuteShardsRequest.Builder requestBuilder = StreamExecuteShardsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new StreamCursor(client.streamExecuteShards(ctx, requestBuilder.build()));
   }
 
-  public Cursor streamExecuteKeyspaceIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<byte[]> keyspaceIds,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
+  public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
-    StreamExecuteKeyspaceIdsRequest.Builder requestBuilder =
-        StreamExecuteKeyspaceIdsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllKeyspaceIds(
-                Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-            .setTabletType(checkNotNull(tabletType));
+    StreamExecuteKeyspaceIdsRequest.Builder requestBuilder = StreamExecuteKeyspaceIdsRequest
+        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyspaceIds(
+            Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new StreamCursor(client.streamExecuteKeyspaceIds(ctx, requestBuilder.build()));
   }
 
-  public Cursor streamExecuteKeyRanges(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<? extends KeyRange> keyRanges,
-      @Nullable Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
-    StreamExecuteKeyRangesRequest.Builder requestBuilder =
-        StreamExecuteKeyRangesRequest.newBuilder()
-            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace))
-            .addAllKeyRanges(checkNotNull(keyRanges))
-            .setTabletType(checkNotNull(tabletType));
+  public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
+      Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
+    StreamExecuteKeyRangesRequest.Builder requestBuilder = StreamExecuteKeyRangesRequest
+        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType));
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
@@ -359,40 +315,30 @@ public final class VTGateConn implements Closeable {
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
-    return new SQLFuture<VTGateTx>(
-        Futures.transformAsync(
-            client.begin(ctx, requestBuilder.build()),
-            new AsyncFunction<BeginResponse, VTGateTx>() {
-              @Override
-              public ListenableFuture<VTGateTx> apply(BeginResponse response) throws Exception {
-                return Futures.<VTGateTx>immediateFuture(
-                    new VTGateTx(client, response.getSession()));
-              }
-            }));
+    return new SQLFuture<VTGateTx>(Futures.transformAsync(client.begin(ctx, requestBuilder.build()),
+        new AsyncFunction<BeginResponse, VTGateTx>() {
+          @Override
+          public ListenableFuture<VTGateTx> apply(BeginResponse response) throws Exception {
+            return Futures
+                .<VTGateTx>immediateFuture(new VTGateTx(client, response.getSession(), keyspace));
+          }
+        }));
   }
 
   // TODO(erez): Migrate to SplitQueryV2 after it's stable.
-  public SQLFuture<List<SplitQueryResponse.Part>> splitQuery(
-      Context ctx,
-      String keyspace,
-      String query,
-      @Nullable Map<String, ?> bindVars,
-      String splitColumn,
-      long splitCount)
+  public SQLFuture<List<SplitQueryResponse.Part>> splitQuery(Context ctx, String keyspace,
+      String query, @Nullable Map<String, ?> bindVars, String splitColumn, long splitCount)
       throws SQLException {
     SplitQueryRequest.Builder requestBuilder =
-        SplitQueryRequest.newBuilder()
-            .setKeyspace(checkNotNull(keyspace))
+        SplitQueryRequest.newBuilder().setKeyspace(checkNotNull(keyspace))
             .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .addSplitColumn(checkNotNull(splitColumn))
-            .setSplitCount(splitCount)
+            .addSplitColumn(checkNotNull(splitColumn)).setSplitCount(splitCount)
             .setUseSplitQueryV2(false);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     return new SQLFuture<List<SplitQueryResponse.Part>>(
-        Futures.transformAsync(
-            client.splitQuery(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.splitQuery(ctx, requestBuilder.build()),
             new AsyncFunction<SplitQueryResponse, List<SplitQueryResponse.Part>>() {
               @Override
               public ListenableFuture<List<SplitQueryResponse.Part>> apply(
@@ -407,8 +353,7 @@ public final class VTGateConn implements Closeable {
     GetSrvKeyspaceRequest.Builder requestBuilder =
         GetSrvKeyspaceRequest.newBuilder().setKeyspace(checkNotNull(keyspace));
     return new SQLFuture<SrvKeyspace>(
-        Futures.transformAsync(
-            client.getSrvKeyspace(ctx, requestBuilder.build()),
+        Futures.transformAsync(client.getSrvKeyspace(ctx, requestBuilder.build()),
             new AsyncFunction<GetSrvKeyspaceResponse, SrvKeyspace>() {
               @Override
               public ListenableFuture<SrvKeyspace> apply(GetSrvKeyspaceResponse response)

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -41,265 +41,207 @@ import java.util.Map;
 /**
  * An asynchronous VTGate transaction session.
  *
- * <p>Because {@code VTGateTx} manages a session cookie, only one operation can be in flight
- * at a time on a given instance. The methods are {@code synchronized} only because the
- * session cookie is updated asynchronously when the RPC response comes back.
+ * <p>
+ * Because {@code VTGateTx} manages a session cookie, only one operation can be in flight at a time
+ * on a given instance. The methods are {@code synchronized} only because the session cookie is
+ * updated asynchronously when the RPC response comes back.
  *
- * <p>After calling any method that returns a {@link SQLFuture}, you must wait for that future to
- * complete before calling any other methods on that {@code VTGateTx} instance.
- * An {@link IllegalStateException} will be thrown if this constraint is violated.
+ * <p>
+ * After calling any method that returns a {@link SQLFuture}, you must wait for that future to
+ * complete before calling any other methods on that {@code VTGateTx} instance. An
+ * {@link IllegalStateException} will be thrown if this constraint is violated.
  *
- * <p>All operations on {@code VTGateTx} are asynchronous, including those whose ultimate
- * return type is {@link Void}, such as {@link #commit(Context)} and {@link #rollback(Context)}.
- * You must still wait for the futures returned by these methods to complete and check the
- * error on them (such as by calling {@code checkedGet()} before you can assume the operation
- * has finished successfully.
+ * <p>
+ * All operations on {@code VTGateTx} are asynchronous, including those whose ultimate return type
+ * is {@link Void}, such as {@link #commit(Context)} and {@link #rollback(Context)}. You must still
+ * wait for the futures returned by these methods to complete and check the error on them (such as
+ * by calling {@code checkedGet()} before you can assume the operation has finished successfully.
  *
- * <p>If you prefer a synchronous API, you can use {@link VTGateBlockingConn#begin(Context)},
- * which returns a {@link VTGateBlockingTx} instead.
+ * <p>
+ * If you prefer a synchronous API, you can use {@link VTGateBlockingConn#begin(Context)}, which
+ * returns a {@link VTGateBlockingTx} instead.
  */
 public class VTGateTx {
   private final RpcClient client;
+  private final String keyspace;
   private Session session;
   private SQLFuture<?> lastCall;
 
-  VTGateTx(RpcClient client, Session session) {
+  VTGateTx(RpcClient client, Session session, String keyspace) {
     this.client = checkNotNull(client);
+    this.keyspace = checkNotNull(keyspace);
     setSession(checkNotNull(session));
   }
 
-  public synchronized SQLFuture<Cursor> execute(
-      Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
-      throws SQLException {
+  public synchronized SQLFuture<Cursor> execute(Context ctx, String query, Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
     checkCallIsAllowed("execute");
     ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder()
-            .setQuery(Proto.bindQuery(query, bindVars))
-            .setTabletType(tabletType)
-            .setSession(session);
+        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
+            .setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Cursor> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.execute(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteResponse, Cursor>() {
-                  @Override
-                  public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteResponse response) throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<Cursor> executeShards(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<String> shards,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
+  public synchronized SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
     checkCallIsAllowed("executeShards");
-    ExecuteShardsRequest.Builder requestBuilder =
-        ExecuteShardsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(query, bindVars))
-            .setKeyspace(keyspace)
-            .addAllShards(shards)
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteShardsRequest.Builder requestBuilder = ExecuteShardsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllShards(shards)
+        .setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Cursor> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeShards(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteShardsResponse, Cursor>() {
-                  @Override
-                  public ListenableFuture<Cursor> apply(ExecuteShardsResponse response)
-                      throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteShardsResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteShardsResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<Cursor> executeKeyspaceIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<byte[]> keyspaceIds,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public synchronized SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query,
+      String keyspace, Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     checkCallIsAllowed("executeKeyspaceIds");
-    ExecuteKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteKeyspaceIdsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(query, bindVars))
-            .setKeyspace(keyspace)
-            .addAllKeyspaceIds(Iterables.transform(keyspaceIds, Proto.BYTE_ARRAY_TO_BYTE_STRING))
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
+        .addAllKeyspaceIds(Iterables.transform(keyspaceIds, Proto.BYTE_ARRAY_TO_BYTE_STRING))
+        .setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
-    SQLFuture<Cursor> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeKeyspaceIds(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
-                  @Override
-                  public ListenableFuture<Cursor> apply(ExecuteKeyspaceIdsResponse response)
-                      throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                  }
-                }));
+    SQLFuture<Cursor> call = new SQLFuture<>(
+        Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteKeyspaceIdsResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<Cursor> executeKeyRanges(
-      Context ctx,
-      String query,
-      String keyspace,
-      Iterable<? extends KeyRange> keyRanges,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
+  public synchronized SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
       throws SQLException {
     checkCallIsAllowed("executeKeyRanges");
-    ExecuteKeyRangesRequest.Builder requestBuilder =
-        ExecuteKeyRangesRequest.newBuilder()
-            .setQuery(Proto.bindQuery(query, bindVars))
-            .setKeyspace(keyspace)
-            .addAllKeyRanges(keyRanges)
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
+        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllKeyRanges(keyRanges)
+        .setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Cursor> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeKeyRanges(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
-                  @Override
-                  public ListenableFuture<Cursor> apply(ExecuteKeyRangesResponse response)
-                      throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteKeyRangesResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<Cursor> executeEntityIds(
-      Context ctx,
-      String query,
-      String keyspace,
-      String entityColumnName,
-      Map<byte[], ?> entityKeyspaceIds,
-      Map<String, ?> bindVars,
-      TabletType tabletType)
-      throws SQLException {
+  public synchronized SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
+      String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
+      TabletType tabletType) throws SQLException {
     checkCallIsAllowed("executeEntityIds");
-    ExecuteEntityIdsRequest.Builder requestBuilder =
-        ExecuteEntityIdsRequest.newBuilder()
-            .setQuery(Proto.bindQuery(query, bindVars))
-            .setKeyspace(keyspace)
-            .setEntityColumnName(entityColumnName)
-            .addAllEntityKeyspaceIds(
-                Iterables.transform(
-                    entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
+        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
+        .setEntityColumnName(entityColumnName).addAllEntityKeyspaceIds(Iterables
+            .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
+        .setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Cursor> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeEntityIds(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
-                  @Override
-                  public ListenableFuture<Cursor> apply(ExecuteEntityIdsResponse response)
-                      throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
+              @Override
+              public ListenableFuture<Cursor> apply(ExecuteEntityIdsResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures.<Cursor>immediateFuture(new SimpleCursor(response.getResult()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<List<Cursor>> executeBatchShards(
-      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType)
-      throws SQLException {
+  public synchronized SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType) throws SQLException {
     checkCallIsAllowed("executeBatchShards");
-    ExecuteBatchShardsRequest.Builder requestBuilder =
-        ExecuteBatchShardsRequest.newBuilder()
-            .addAllQueries(queries)
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteBatchShardsRequest.Builder requestBuilder = ExecuteBatchShardsRequest.newBuilder()
+        .addAllQueries(queries).setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
-    SQLFuture<List<Cursor>> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeBatchShards(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
-                  @Override
-                  public ListenableFuture<List<Cursor>> apply(ExecuteBatchShardsResponse response)
-                      throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<List<Cursor>>immediateFuture(
-                        Proto.toCursorList(response.getResultsList()));
-                  }
-                }));
+    SQLFuture<List<Cursor>> call = new SQLFuture<>(
+        Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
+              @Override
+              public ListenableFuture<List<Cursor>> apply(ExecuteBatchShardsResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures
+                    .<List<Cursor>>immediateFuture(Proto.toCursorList(response.getResultsList()));
+              }
+            }));
     lastCall = call;
     return call;
   }
 
-  public synchronized SQLFuture<List<Cursor>> executeBatchKeyspaceIds(
-      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType)
-      throws SQLException {
+  public synchronized SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType) throws SQLException {
     checkCallIsAllowed("executeBatchKeyspaceIds");
-    ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteBatchKeyspaceIdsRequest.newBuilder()
-            .addAllQueries(queries)
-            .setTabletType(tabletType)
-            .setSession(session);
+    ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder = ExecuteBatchKeyspaceIdsRequest
+        .newBuilder().addAllQueries(queries).setTabletType(tabletType).setSession(session);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
-    SQLFuture<List<Cursor>> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
-                new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {
-                  @Override
-                  public ListenableFuture<List<Cursor>> apply(
-                      ExecuteBatchKeyspaceIdsResponse response) throws Exception {
-                    setSession(response.getSession());
-                    Proto.checkError(response.getError());
-                    return Futures.<List<Cursor>>immediateFuture(
-                        Proto.toCursorList(response.getResultsList()));
-                  }
-                }));
+    SQLFuture<List<Cursor>> call = new SQLFuture<>(
+        Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
+            new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {
+              @Override
+              public ListenableFuture<List<Cursor>> apply(ExecuteBatchKeyspaceIdsResponse response)
+                  throws Exception {
+                setSession(response.getSession());
+                Proto.checkError(response.getError());
+                return Futures
+                    .<List<Cursor>>immediateFuture(Proto.toCursorList(response.getResultsList()));
+              }
+            }));
     lastCall = call;
     return call;
   }
@@ -311,16 +253,14 @@ public class VTGateTx {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Void> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.commit(ctx, requestBuilder.build()),
-                new AsyncFunction<CommitResponse, Void>() {
-                  @Override
-                  public ListenableFuture<Void> apply(CommitResponse response) throws Exception {
-                    setSession(null);
-                    return Futures.<Void>immediateFuture(null);
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.commit(ctx, requestBuilder.build()),
+            new AsyncFunction<CommitResponse, Void>() {
+              @Override
+              public ListenableFuture<Void> apply(CommitResponse response) throws Exception {
+                setSession(null);
+                return Futures.<Void>immediateFuture(null);
+              }
+            }));
     lastCall = call;
     return call;
   }
@@ -332,16 +272,14 @@ public class VTGateTx {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
     SQLFuture<Void> call =
-        new SQLFuture<>(
-            Futures.transformAsync(
-                client.rollback(ctx, requestBuilder.build()),
-                new AsyncFunction<RollbackResponse, Void>() {
-                  @Override
-                  public ListenableFuture<Void> apply(RollbackResponse response) throws Exception {
-                    setSession(null);
-                    return Futures.<Void>immediateFuture(null);
-                  }
-                }));
+        new SQLFuture<>(Futures.transformAsync(client.rollback(ctx, requestBuilder.build()),
+            new AsyncFunction<RollbackResponse, Void>() {
+              @Override
+              public ListenableFuture<Void> apply(RollbackResponse response) throws Exception {
+                setSession(null);
+                return Futures.<Void>immediateFuture(null);
+              }
+            }));
     lastCall = call;
     return call;
   }
@@ -349,10 +287,8 @@ public class VTGateTx {
   protected synchronized void checkCallIsAllowed(String call) throws SQLException {
     // Calls are not allowed to overlap.
     if (lastCall != null && !lastCall.isDone()) {
-      throw new IllegalStateException(
-          "Can't call "
-              + call
-              + "() on a VTGateTx instance until the last asynchronous call is done.");
+      throw new IllegalStateException("Can't call " + call
+          + "() on a VTGateTx instance until the last asynchronous call is done.");
     }
     // All calls must occur within a valid transaction.
     if (session == null || !session.getInTransaction()) {

--- a/php/src/Vitess/VTGateConn.php
+++ b/php/src/Vitess/VTGateConn.php
@@ -6,13 +6,38 @@ class VTGateConn
 
     /**
      *
-     * @var RpcClient
+     * @var RpcClient The underlying RPC client.
      */
     protected $client;
 
-    public function __construct(RpcClient $client)
+    /**
+     *
+     * @var string The connection-wide keyspace for execute() calls.
+     */
+    protected $keyspace;
+
+    /**
+     * Create a VTGateConn.
+     *
+     * If specified, the given keyspace will be used as the connection-wide
+     * default for execute() and streamExecute() calls, since those do not
+     * specify the keyspace for each call. Like the connection-wide default
+     * database of a MySQL connection, individual queries can still refer to
+     * other keyspaces by prefixing table names. For example:
+     * "SELECT ... FROM keyspace.table ..."
+     *
+     * If the default keyspace name is left empty, Vitess will use VSchema to
+     * look up the keyspace for each unprefixed table name. Note that this only
+     * works if the table name is unique across all keyspaces.
+     *
+     * @param RpcClient $client
+     * @param string $keyspace
+     *            The connection-wide keyspace for execute() calls.
+     */
+    public function __construct(RpcClient $client, $keyspace = '')
     {
         $this->client = $client;
+        $this->keyspace = $keyspace;
     }
 
     public function execute(Context $ctx, $query, array $bind_vars, $tablet_type)
@@ -20,6 +45,7 @@ class VTGateConn
         $request = new Proto\Vtgate\ExecuteRequest();
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
+        $request->setKeyspace($this->keyspace);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }
@@ -144,6 +170,7 @@ class VTGateConn
         $request = new Proto\Vtgate\StreamExecuteRequest();
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
+        $request->setKeyspace($this->keyspace);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }
@@ -201,7 +228,7 @@ class VTGateConn
         }
 
         $response = $this->client->begin($ctx, $request);
-        return new VTGateTx($this->client, $response->getSession());
+        return new VTGateTx($this->client, $response->getSession(), $this->keyspace);
     }
 
     // TODO(erez): Migrate to SplitQueryV2 after it's stable.

--- a/php/src/Vitess/VTGateTx.php
+++ b/php/src/Vitess/VTGateTx.php
@@ -8,10 +8,13 @@ class VTGateTx
 
     protected $session;
 
-    public function __construct($client, $session)
+    protected $keyspace;
+
+    public function __construct($client, $session, $keyspace = '')
     {
         $this->client = $client;
         $this->session = $session;
+        $this->keyspace = $keyspace;
     }
 
     private function inTransaction()
@@ -29,6 +32,7 @@ class VTGateTx
         $request->setSession($this->session);
         $request->setQuery(ProtoUtils::BoundQuery($query, $bind_vars));
         $request->setTabletType($tablet_type);
+        $request->setKeyspace($this->keyspace);
         if ($ctx->getCallerId()) {
             $request->setCallerId($ctx->getCallerId());
         }

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -154,7 +154,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->ctx = Context::getDefault()->withDeadlineAfter(5.0)->withCallerId(self::$CALLER_ID);
-        $this->conn = new VTGateConn(self::$client);
+        $this->conn = new VTGateConn(self::$client, self::$KEYSPACE);
     }
 
     private function getEcho($result)
@@ -176,6 +176,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $echo = $this->getEcho($conn->execute($ctx, self::$ECHO_QUERY, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
+        $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
@@ -250,6 +251,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $echo = $this->getEcho($conn->streamExecute($ctx, self::$ECHO_QUERY, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
+        $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
@@ -288,6 +290,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $echo = $this->getEcho($tx->execute($ctx, self::$ECHO_QUERY, self::$BIND_VARS, self::$TABLET_TYPE));
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
+        $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);


### PR DESCRIPTION
@alainjobart 

This makes it possible to specify a per-connection default keyspace for VTGateV3 queries, causing vtgate to assume that keyspace for unqualified table names, rather than using VSchema to look them up. This allows the app to unambiguously refer to tables whose names are not unique across keyspaces, without having to write fully-qualified `keyspace.table` names in the queries themselves.

Note that the JDBC and PDO wrappers will need to be updated to make use of the new constructors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1725)
<!-- Reviewable:end -->
