### PR TITLE
discovery: Guarantee that HealthCheck stops calling the listener after HealthCheck.Close() returned.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -780,14 +780,20 @@ func (hc *HealthCheckImpl) CacheStatus() TabletsCacheStatusList {
 // anymore.
 func (hc *HealthCheckImpl) Close() error {
 	hc.mu.Lock()
-	defer hc.mu.Unlock()
 	close(hc.closeChan)
 	for _, hcc := range hc.addrToConns {
 		hcc.cancelFunc()
 	}
-	hc.wg.Wait()
 	hc.addrToConns = make(map[string]*healthCheckConn)
 	hc.targetToTablets = make(map[string]map[string]map[topodatapb.TabletType][]*topodatapb.Tablet)
+	// Release the lock early or a pending checkHealthCheckTimeout cannot get a
+	// read lock on it.
+	hc.mu.Unlock()
+
+	// Wait for the checkHealthCheckTimeout Go routine and each Go routine per
+	// tablet.
+	hc.wg.Wait()
+
 	return nil
 }
 


### PR DESCRIPTION
@guoliang100 

You can ignore the first two commits. They're identical to https://github.com/youtube/vitess/pull/1724 since this PR is based on that PR.

**Description:**

Without this change, it's difficult to synchronize the shutdown of a listener implementation and HealthCheck.

For example, a listener implementation could send to a channel for every update. But the shutdown of the listener implementation will close that channel and future sends to it will panic. Therefore, a HealthCheck.Close() must guarantee the user that the listener won't be called anymore when it returned. After that, the listener can shut down itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1726)
<!-- Reviewable:end -->
