### PR TITLE
Adding keyspace to go client API.

### DIFF
--- a/doc/vtctlReference.md
+++ b/doc/vtctlReference.md
@@ -492,7 +492,7 @@ Executes the given SQL query with the provided bound variables against the vtgat
 
 #### Example
 
-<pre class="command-example">VtGateExecute -server &lt;vtgate&gt; [-bind_variables &lt;JSON map&gt;] [-connect_timeout &lt;connect timeout&gt;] [-tablet_type &lt;tablet type&gt;] [-json] &lt;sql&gt;</pre>
+<pre class="command-example">VtGateExecute -server &lt;vtgate&gt; [-bind_variables &lt;JSON map&gt;] [-connect_timeout &lt;connect timeout&gt;] [-keyspace &lt;default keyspace&gt;] [-tablet_type &lt;tablet type&gt;] [-json] &lt;sql&gt;</pre>
 
 #### Flags
 
@@ -500,6 +500,7 @@ Executes the given SQL query with the provided bound variables against the vtgat
 | :-------- | :--------- | :--------- |
 | connect_timeout | Duration | Connection timeout for vtgate client |
 | json | Boolean | Output JSON instead of human-readable table |
+| keyspace | string | default keyspace to use |
 | server | string | VtGate server to connect to |
 | tablet_type | string | tablet type to query |
 

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -33,8 +33,8 @@ in the form of :v1, :v2, etc.
 	timeout       = flag.Duration("timeout", 30*time.Second, "timeout for queries")
 	streaming     = flag.Bool("streaming", false, "use a streaming query")
 	bindVariables = newBindvars("bind_variables", "bind variables as a json list")
-	keyspace      = flag.String("keyspace", "", "Keyspace of a specific keyspace/shard to target. Disables vtgate v3.")
-	shard         = flag.String("shard", "", "Shard of a specific keyspace/shard to target. Disables vtgate v3.")
+	keyspace      = flag.String("keyspace", "", "Keyspace of a specific keyspace/shard to target. If shard is also specified, disables v3. Otherwise it's the default keyspace to use.")
+	shard         = flag.String("shard", "", "Shard of a specific keyspace/shard to target. Disables vtgate v3. Requires keyspace.")
 	jsonOutput    = flag.Bool("json", false, "Output JSON instead of human-readable table")
 )
 

--- a/go/cmd/vtgateclienttest/goclienttest/echo.go
+++ b/go/cmd/vtgateclienttest/goclienttest/echo.go
@@ -108,6 +108,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"callerId":   callerIDEcho,
 		"query":      echoPrefix + query,
 		"bindVars":   bindVarsEcho,
+		"keyspace":   connectionKeyspace,
 		"tabletType": tabletTypeEcho,
 	})
 
@@ -211,6 +212,7 @@ func testEchoStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"callerId":   callerIDEcho,
 		"query":      echoPrefix + query,
 		"bindVars":   bindVarsEcho,
+		"keyspace":   connectionKeyspace,
 		"tabletType": tabletTypeEcho,
 	})
 
@@ -273,6 +275,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"callerId":         callerIDEcho,
 		"query":            echoPrefix + query,
 		"bindVars":         bindVarsEcho,
+		"keyspace":         connectionKeyspace,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
 		"notInTransaction": "false",

--- a/go/cmd/vtgateclienttest/goclienttest/main.go
+++ b/go/cmd/vtgateclienttest/goclienttest/main.go
@@ -12,6 +12,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+const connectionKeyspace = "conn_ks"
+
 // This file contains the reference test for clients. It tests
 // all the corner cases of the API, and makes sure the go client
 // is full featured.
@@ -24,7 +26,7 @@ import (
 func TestGoClient(t *testing.T, protocol, addr string) {
 	// Create a client connecting to the server
 	ctx := context.Background()
-	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second, "conn_ks")
+	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second, connectionKeyspace)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}

--- a/go/cmd/vtgateclienttest/goclienttest/main.go
+++ b/go/cmd/vtgateclienttest/goclienttest/main.go
@@ -24,7 +24,7 @@ import (
 func TestGoClient(t *testing.T, protocol, addr string) {
 	// Create a client connecting to the server
 	ctx := context.Background()
-	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second)
+	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second, "conn_ks")
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -111,8 +111,8 @@ func (d drv) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if (c.Keyspace != "" && c.Shard == "") || (c.Keyspace == "" && c.Shard != "") {
-		return nil, fmt.Errorf("Always set both keyspace and shard or leave both empty. keyspace: %v shard: %v", c.Keyspace, c.Shard)
+	if c.Keyspace == "" && c.Shard != "" {
+		return nil, fmt.Errorf("the shard parameter requires a keyspace parameter. shard: %v", c.Shard)
 	}
 	if c.useExecuteShards() {
 		log.Infof("Sending queries only to keyspace/shard: %v/%v", c.Keyspace, c.Shard)

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -143,13 +143,21 @@ type Configuration struct {
 	// Format: hostname:port
 	Address string
 
-	// Keyspace of a specific keyspace and shard to target. Disables vtgate v3.
+	// Keyspace of a specific keyspace to target.
 	//
-	// If Keyspace and Shard are not empty, vtgate v1 instead of v3 will be used
-	// and all requests will be sent only to that particular shard.
-	// This functionality is meant for initial migrations from MySQL/MariaDB to Vitess.
+	// If Shard is also specified, vtgate v1 will be used instead
+	// of v3 (ExecuteShards and StreamExecuteShards), and all
+	// requests will be sent only to that particular shard.  This
+	// functionality is meant for initial migrations from
+	// MySQL/MariaDB to Vitess.
+	//
+	// If Shard is not specified, we will use the v3 API (Execute
+	// and StreamExecute calls), and specify this Keyspace as the
+	// default keyspace value.
 	Keyspace string
-	// Shard of a specific keyspace and shard to target. Disables vtgate v3.
+
+	// Shard of a specific keyspace and shard to target. See
+	// Keyspace comment, this will disable vtgate v3.
 	Shard string
 
 	// TabletType is the type of tablet you want to access and affects the
@@ -210,9 +218,9 @@ type conn struct {
 func (c *conn) dial() error {
 	var err error
 	if c.Protocol == "" {
-		c.vtgateConn, err = vtgateconn.Dial(context.Background(), c.Address, c.Timeout)
+		c.vtgateConn, err = vtgateconn.Dial(context.Background(), c.Address, c.Timeout, c.Keyspace)
 	} else {
-		c.vtgateConn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address, c.Timeout)
+		c.vtgateConn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address, c.Timeout, c.Keyspace)
 	}
 	return err
 }

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -129,14 +129,9 @@ func TestOpen_InvalidJson(t *testing.T) {
 	}
 }
 
-func TestOpen_KeyspaceAndShardBelongTogether(t *testing.T) {
-	_, err := drv{}.Open(`{"keyspace": "ks1"}`)
-	want := "Always set both keyspace and shard or leave both empty."
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("err: %v, want %s", err, want)
-	}
-
-	_, err = drv{}.Open(`{"shard": "0"}`)
+func TestOpen_ShardRequiresKeyspace(t *testing.T) {
+	_, err := drv{}.Open(`{"shard": "0"}`)
+	want := "the shard parameter requires a keyspace parameter. shard: 0"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("err: %v, want %s", err, want)
 	}

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -138,6 +138,7 @@ func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 	server := subFlags.String("server", "", "VtGate server to connect to")
 	bindVariables := newBindvars(subFlags)
 	connectTimeout := subFlags.Duration("connect_timeout", 30*time.Second, "Connection timeout for vtgate client")
+	keyspace := subFlags.String("keyspace", "", "default keyspace to use")
 	tabletType := subFlags.String("tablet_type", "master", "tablet type to query")
 	json := subFlags.Bool("json", false, "Output JSON instead of human-readable table")
 
@@ -152,7 +153,7 @@ func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 		return err
 	}
 
-	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout)
+	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout, *keyspace)
 	if err != nil {
 		return fmt.Errorf("error connecting to vtgate '%v': %v", *server, err)
 	}
@@ -192,7 +193,7 @@ func commandVtGateExecuteShards(ctx context.Context, wr *wrangler.Wrangler, subF
 		shards = strings.Split(*shardsStr, ",")
 	}
 
-	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout)
+	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout, "")
 	if err != nil {
 		return fmt.Errorf("error connecting to vtgate '%v': %v", *server, err)
 	}
@@ -239,7 +240,7 @@ func commandVtGateExecuteKeyspaceIds(ctx context.Context, wr *wrangler.Wrangler,
 		}
 	}
 
-	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout)
+	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout, "")
 	if err != nil {
 		return fmt.Errorf("error connecting to vtgate '%v': %v", *server, err)
 	}
@@ -269,7 +270,7 @@ func commandVtGateSplitQuery(ctx context.Context, wr *wrangler.Wrangler, subFlag
 		return fmt.Errorf("the <sql> argument is required for the VtGateSplitQuery command")
 	}
 
-	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout)
+	vtgateConn, err := vtgateconn.Dial(ctx, *server, *connectTimeout, "")
 	if err != nil {
 		return fmt.Errorf("error connecting to vtgate '%v': %v", *server, err)
 	}

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -47,7 +47,7 @@ func init() {
 		addCommand(queriesGroupName, command{
 			"VtGateExecute",
 			commandVtGateExecute,
-			"-server <vtgate> [-bind_variables <JSON map>] [-connect_timeout <connect timeout>] [-tablet_type <tablet type>] [-json] <sql>",
+			"-server <vtgate> [-bind_variables <JSON map>] [-connect_timeout <connect timeout>] [-keyspace <default keyspace>] [-tablet_type <tablet type>] [-json] <sql>",
 			"Executes the given SQL query with the provided bound variables against the vtgate server."})
 		addCommand(queriesGroupName, command{
 			"VtGateExecuteShards",

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -30,6 +30,7 @@ import (
 type queryExecute struct {
 	SQL              string
 	BindVariables    map[string]interface{}
+	Keyspace         string
 	TabletType       topodatapb.TabletType
 	Session          *vtgatepb.Session
 	NotInTransaction bool
@@ -210,7 +211,7 @@ func (conn *FakeVTGateConn) AddSplitQueryV2(
 }
 
 // Execute please see vtgateconn.Impl.Execute
-func (conn *FakeVTGateConn) Execute(ctx context.Context, sql string, bindVars map[string]interface{}, tabletType topodatapb.TabletType, session interface{}) (*sqltypes.Result, interface{}, error) {
+func (conn *FakeVTGateConn) Execute(ctx context.Context, sql string, bindVars map[string]interface{}, keyspace string, tabletType topodatapb.TabletType, session interface{}) (*sqltypes.Result, interface{}, error) {
 	var s *vtgatepb.Session
 	if session != nil {
 		s = session.(*vtgatepb.Session)
@@ -222,6 +223,7 @@ func (conn *FakeVTGateConn) Execute(ctx context.Context, sql string, bindVars ma
 	query := &queryExecute{
 		SQL:           sql,
 		BindVariables: bindVars,
+		Keyspace:      keyspace,
 		TabletType:    tabletType,
 		Session:       s,
 	}
@@ -305,7 +307,7 @@ func (a *streamExecuteAdapter) Recv() (*sqltypes.Result, error) {
 }
 
 // StreamExecute please see vtgateconn.Impl.StreamExecute
-func (conn *FakeVTGateConn) StreamExecute(ctx context.Context, sql string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (sqltypes.ResultStream, error) {
+func (conn *FakeVTGateConn) StreamExecute(ctx context.Context, sql string, bindVars map[string]interface{}, keyspace string, tabletType topodatapb.TabletType) (sqltypes.ResultStream, error) {
 	response, ok := conn.execMap[sql]
 	if !ok {
 		return nil, fmt.Errorf("no match for: %s", sql)
@@ -313,6 +315,7 @@ func (conn *FakeVTGateConn) StreamExecute(ctx context.Context, sql string, bindV
 	query := &queryExecute{
 		SQL:           sql,
 		BindVariables: bindVars,
+		Keyspace:      keyspace,
 		TabletType:    tabletType,
 	}
 	if !reflect.DeepEqual(query, response.execQuery) {

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -58,7 +58,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	}, nil
 }
 
-func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType, session interface{}) (*sqltypes.Result, interface{}, error) {
+func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[string]interface{}, keyspace string, tabletType topodatapb.TabletType, session interface{}) (*sqltypes.Result, interface{}, error) {
 	var s *vtgatepb.Session
 	if session != nil {
 		s = session.(*vtgatepb.Session)
@@ -71,6 +71,7 @@ func (conn *vtgateConn) Execute(ctx context.Context, query string, bindVars map[
 		CallerId:   callerid.EffectiveCallerIDFromContext(ctx),
 		Session:    s,
 		Query:      q,
+		Keyspace:   keyspace,
 		TabletType: tabletType,
 	}
 	response, err := conn.c.Execute(ctx, request)
@@ -255,7 +256,7 @@ func (a *streamExecuteAdapter) Recv() (*sqltypes.Result, error) {
 	return sqltypes.CustomProto3ToResult(a.fields, qr), nil
 }
 
-func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, tabletType topodatapb.TabletType) (sqltypes.ResultStream, error) {
+func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVars map[string]interface{}, keyspace string, tabletType topodatapb.TabletType) (sqltypes.ResultStream, error) {
 	q, err := querytypes.BoundQueryToProto3(query, bindVars)
 	if err != nil {
 		return nil, err
@@ -263,6 +264,7 @@ func (conn *vtgateConn) StreamExecute(ctx context.Context, query string, bindVar
 	req := &vtgatepb.StreamExecuteRequest{
 		CallerId:   callerid.EffectiveCallerIDFromContext(ctx),
 		Query:      q,
+		Keyspace:   keyspace,
 		TabletType: tabletType,
 	}
 	stream, err := conn.c.StreamExecute(ctx, req)

--- a/go/vt/vtgate/vtgateconn/vtgateconn_test.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn_test.go
@@ -21,15 +21,18 @@ func TestRegisterDialer(t *testing.T) {
 
 func TestGetDialerWithProtocol(t *testing.T) {
 	protocol := "test2"
-	c, err := DialProtocol(context.Background(), protocol, "", 0)
+	c, err := DialProtocol(context.Background(), protocol, "", 0, "")
 	if err == nil || err.Error() != "no dialer registered for VTGate protocol "+protocol {
 		t.Fatalf("protocol: %s is not registered, should return error: %v", protocol, err)
 	}
 	RegisterDialer(protocol, func(context.Context, string, time.Duration) (Impl, error) {
 		return nil, nil
 	})
-	c, err = DialProtocol(context.Background(), protocol, "", 0)
+	c, err = DialProtocol(context.Background(), protocol, "", 0, "test_ks")
 	if err != nil || c == nil {
 		t.Fatalf("dialerFunc has been registered, should not get nil: %v %v", err, c)
+	}
+	if c.keyspace != "test_ks" {
+		t.Errorf("not setting keyspace properly.")
 	}
 }

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -718,7 +718,7 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string, timeout time.Duration) (vtgateconn.Impl, error) {
 		return impl, nil
 	})
-	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0)
+	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0, "connection_ks")
 	if err != nil {
 		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
 	}
@@ -766,7 +766,7 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 
 // TestErrorSuite runs all the tests that expect errors
 func TestErrorSuite(t *testing.T, fakeServer vtgateservice.VTGateService) {
-	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0)
+	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0, "connection_ks")
 	if err != nil {
 		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
 	}
@@ -1767,6 +1767,7 @@ var execMap = map[string]struct {
 			BindVariables: map[string]interface{}{
 				"bind1": int64(0),
 			},
+			Keyspace:   "connection_ks",
 			TabletType: topodatapb.TabletType_RDONLY,
 			Session:    nil,
 		},
@@ -1875,6 +1876,7 @@ var execMap = map[string]struct {
 			BindVariables: map[string]interface{}{
 				"bind1": int64(0),
 			},
+			Keyspace:   "connection_ks",
 			TabletType: topodatapb.TabletType_RDONLY,
 			Session:    nil,
 		},
@@ -1983,6 +1985,7 @@ var execMap = map[string]struct {
 			BindVariables: map[string]interface{}{
 				"bind1": int64(0),
 			},
+			Keyspace:   "connection_ks",
 			TabletType: topodatapb.TabletType_MASTER,
 			Session:    session1,
 		},

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -44,7 +44,7 @@ func TestVitess(t *testing.T) {
 	}
 	port := int(fport.(float64))
 	ctx := context.Background()
-	conn, err := vtgateconn.DialProtocol(ctx, vtgateProtocol(), fmt.Sprintf("localhost:%d", port), 5*time.Second)
+	conn, err := vtgateconn.DialProtocol(ctx, vtgateProtocol(), fmt.Sprintf("localhost:%d", port), 5*time.Second, "")
 	if err != nil {
 		t.Error(err)
 		return

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -952,8 +952,10 @@ class TestVTGateFunctions(unittest.TestCase):
   def test_vtclient(self):
     """This test uses vtclient to send and receive various queries.
     """
+    # specify a good default keyspace for the connection here.
     utils.vtgate.vtclient(
         'insert into vt_user_extra(user_id, email) values (:v1, :v2)',
+        keyspace='user',
         bindvars=[10, 'test 10'])
 
     out, _ = utils.vtgate.vtclient(
@@ -986,6 +988,15 @@ class TestVTGateFunctions(unittest.TestCase):
         u'fields': [u'user_id', u'email'],
         u'rows': None,
         })
+
+    # check that specifying an invalid keyspace is propagated and triggers an
+    # error
+    _, err = utils.vtgate.vtclient(
+        'insert into vt_user_extra(user_id, email) values (:v1, :v2)',
+        keyspace='invalid',
+        bindvars=[10, 'test 10'],
+        raise_on_error=False)
+    self.assertIn('keyspace invalid not found in vschema', err)
 
   def test_vtctl_vtgate_execute(self):
     """This test uses 'vtctl VtGateExecute' to send and receive various queries.


### PR DESCRIPTION
It's a per connection parameter, so we don't have to send it in every
Execute() or StreamExecute() call.

@enisoc go version of the change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1727)
<!-- Reviewable:end -->
