### PR TITLE
docker: Always set USER environment variable to "vitess".

### DIFF
--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -10,5 +10,7 @@ RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db 
 # Bootstrap Vitess
 WORKDIR /vt/src/github.com/youtube/vitess
 USER vitess
+# Required by e2e test dependencies e.g. test/environment.py.
+ENV USER vitess
 ENV MYSQL_FLAVOR MariaDB
 RUN ./bootstrap.sh --skip_root_installs

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -10,5 +10,7 @@ RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
 # Bootstrap Vitess
 WORKDIR /vt/src/github.com/youtube/vitess
 USER vitess
+# Required by e2e test dependencies e.g. test/environment.py.
+ENV USER vitess
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh --skip_root_installs

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -10,5 +10,7 @@ RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
 # Bootstrap Vitess
 WORKDIR /vt/src/github.com/youtube/vitess
 USER vitess
+# Required by e2e test dependencies e.g. test/environment.py.
+ENV USER vitess
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh --skip_root_installs

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -17,5 +17,7 @@ RUN apt-key adv --keyserver ha.pool.sks-keyservers.net \
 # Bootstrap Vitess
 WORKDIR /vt/src/github.com/youtube/vitess
 USER vitess
+# Required by e2e test dependencies e.g. test/environment.py.
+ENV USER vitess
 ENV MYSQL_FLAVOR MySQL56
 RUN ./bootstrap.sh --skip_root_installs

--- a/docker/bootstrap/README.md
+++ b/docker/bootstrap/README.md
@@ -8,6 +8,7 @@ The `vitess/bootstrap` image comes in different flavors:
 * `vitess/bootstrap:common` - dependencies that are common to all flavors
 * `vitess/bootstrap:mariadb` - bootstrap image for MariaDB
 * `vitess/bootstrap:mysql56` - bootstrap image for MySQL 5.6
+* `vitess/bootstrap:mysql57` - bootstrap image for MySQL 5.7
 * `vitess/bootstrap:percona` - bootstrap image for Percona Server
 
 **NOTE: Unlike the base image that builds Vitess itself, this bootstrap image
@@ -39,6 +40,8 @@ Makefile target to build every flavor:
     ``` sh
     vitess$ ./test.go -pull=false -flavor=mariadb
     vitess$ ./test.go -pull=false -flavor=mysql56
+    vitess$ ./test.go -pull=false -flavor=mysql57
+    vitess$ ./test.go -pull=false -flavor=percona
     ...
     ```
 
@@ -48,6 +51,8 @@ Makefile target to build every flavor:
     $ docker push vitess/bootstrap:common
     $ docker push vitess/bootstrap:mariadb
     $ docker push vitess/bootstrap:mysql56
+    $ docker push vitess/bootstrap:mysql57
+    $ docker push vitess/bootstrap:percona
     ...
     ```
 

--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -22,7 +22,7 @@ fi
 # Mirror permissions to "other" from the owning group (for which we assume it has at least rX permissions).
 chmod -R o=g .
 
-args="$args -e USER=vitess -v /dev/log:/dev/log"
+args="$args -v /dev/log:/dev/log"
 args="$args -v $PWD:/tmp/src"
 
 # Share maven dependency cache so they don't have to be redownloaded every time.


### PR DESCRIPTION
@enisoc 

Fixes problems when the wrapper script docker/test/run.sh is not used.

Reported here: #1721

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1729)
<!-- Reviewable:end -->
