### PR TITLE
Convert Java vttest helper to new proto_topo format.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ site_integration_test:
 	go run test.go -docker=false -tag=site_test
 
 java_test:
-	go install ./go/cmd/vtgateclienttest
+	go install ./go/cmd/vtgateclienttest ./go/cmd/vtcombo
 	mvn -f java/pom.xml clean verify
 
 php_test:

--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -208,6 +208,7 @@ func initTabletMapProto(ts topo.Server, topoProto string, mysqld mysqlctl.MysqlD
 	var uid uint32 = 1
 	for _, kpb := range tpb.Keyspaces {
 		keyspace := kpb.Name
+		vs := formal.Keyspaces[keyspace]
 
 		// First parse the ShardingColumnType.
 		// Note if it's empty, we will return 'UNSET'.
@@ -239,7 +240,9 @@ func initTabletMapProto(ts topo.Server, topoProto string, mysqld mysqlctl.MysqlD
 			}); err != nil {
 				return fmt.Errorf("CreateKeyspace(%v) failed: %v", keyspace, err)
 			}
-
+			if err := ts.SaveVSchema(ctx, keyspace, &vs); err != nil {
+				return fmt.Errorf("SaveVSchema failed: %v", err)
+			}
 		} else {
 			// create a regular keyspace
 			if err := ts.CreateKeyspace(ctx, keyspace, &topodatapb.Keyspace{
@@ -247,6 +250,9 @@ func initTabletMapProto(ts topo.Server, topoProto string, mysqld mysqlctl.MysqlD
 				ShardingColumnType: sct,
 			}); err != nil {
 				return fmt.Errorf("CreateKeyspace(%v) failed: %v", keyspace, err)
+			}
+			if err := ts.SaveVSchema(ctx, keyspace, &vs); err != nil {
+				return fmt.Errorf("SaveVSchema failed: %v", err)
 			}
 
 			// iterate through the shards

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -84,6 +84,7 @@
             <include>topodata.proto</include>
             <include>vtgate.proto</include>
             <include>vtrpc.proto</include>
+            <include>vttest.proto</include>
           </includes>
         </configuration>
         <executions>

--- a/java/client/src/test/java/com/youtube/vitess/client/TestEnv.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/TestEnv.java
@@ -2,6 +2,8 @@ package com.youtube.vitess.client;
 
 import org.apache.commons.io.FileUtils;
 
+import vttest.Vttest.VTTestTopology;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -12,17 +14,17 @@ import java.util.List;
  * Helper class to hold the configurations for VtGate setup used in integration tests
  */
 public class TestEnv {
-  private String topology;
+  private VTTestTopology topology;
   private String keyspace;
   private String outputPath;
   private Process pythonScriptProcess;
   private int port;
 
-  public void setTopology(String topology) {
+  public void setTopology(VTTestTopology topology) {
     this.topology = topology;
   }
 
-  public String getTopology() {
+  public VTTestTopology getTopology() {
     return this.topology;
   }
 
@@ -63,8 +65,8 @@ public class TestEnv {
     command.add(vtTop + "/py/vttest/run_local_database.py");
     command.add("--port");
     command.add(Integer.toString(port));
-    command.add("--topology");
-    command.add(getTopology());
+    command.add("--proto_topo");
+    command.add(getTopology().toString());
     command.add("--schema_dir");
     command.add(schemaDir);
     command.add("--vschema");

--- a/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
@@ -11,6 +11,8 @@ import org.apache.log4j.Logger;
 import org.joda.time.Duration;
 import org.junit.Assert;
 
+import vttest.Vttest.VTTestTopology;
+
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
@@ -72,7 +74,7 @@ public class TestUtil {
     testEnv.clearTestOutput();
   }
 
-  public static TestEnv getTestEnv(String keyspace, String topology) {
+  public static TestEnv getTestEnv(String keyspace, VTTestTopology topology) {
     String testEnvClass = System.getProperty(PROPERTY_KEY_CLIENT_TEST_ENV);
     try {
       Class<?> clazz = Class.forName(testEnvClass);

--- a/java/hadoop/src/test/java/com/youtube/vitess/hadoop/MapReduceIT.java
+++ b/java/hadoop/src/test/java/com/youtube/vitess/hadoop/MapReduceIT.java
@@ -22,6 +22,10 @@ import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
+import vttest.Vttest.Keyspace;
+import vttest.Vttest.Shard;
+import vttest.Vttest.VTTestTopology;
+
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.sql.SQLException;
@@ -182,7 +186,10 @@ public class MapReduceIT extends HadoopTestCase {
    * Create env with two shards each having a master, replica, and rdonly.
    */
   static TestEnv getTestEnv() {
-    String topology = "test_keyspace/-80:test_keyspace_0,test_keyspace/80-:test_keyspace_1";
+    Keyspace keyspace = Keyspace.newBuilder().setName("test_keyspace")
+        .addShards(Shard.newBuilder().setName("-80").build())
+        .addShards(Shard.newBuilder().setName("80-").build()).build();
+    VTTestTopology topology = VTTestTopology.newBuilder().addKeyspaces(keyspace).build();
     TestEnv env = TestUtil.getTestEnv("test_keyspace", topology);
     return env;
   }


### PR DESCRIPTION
@alainjobart 

The MapReduce test I added started failing after merging into master. It turns out the new vtcombo code path for topo_proto wasn't saving VSchema. After fixing that, I figured I'll go ahead and convert the Java stuff to generate the proto natively, rather than relying on run_local_database.py to convert it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1734)
<!-- Reviewable:end -->
