### PR TITLE
Removing lots of RebuildKeyspaceGraph calls.

### DIFF
--- a/test/encrypted_replication.py
+++ b/test/encrypted_replication.py
@@ -155,8 +155,6 @@ def setUpModule():
     shard_0_master.init_tablet('master', 'test_keyspace', '0')
     shard_0_slave.init_tablet('replica', 'test_keyspace', '0')
 
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     # create databases so vttablet can start behaving normally
     shard_0_master.create_db('vt_test_keyspace')
     shard_0_slave.create_db('vt_test_keyspace')

--- a/test/encrypted_transport.py
+++ b/test/encrypted_transport.py
@@ -223,8 +223,6 @@ def setUpModule():
     shard_0_master.init_tablet('master', 'test_keyspace', '0')
     shard_0_slave.init_tablet('replica', 'test_keyspace', '0')
 
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     # create databases so vttablet can start behaving normally
     shard_0_master.create_db('vt_test_keyspace')
     shard_0_slave.create_db('vt_test_keyspace')

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -274,8 +274,6 @@ index by_msg (msg)
         shard='0',
         tablet_index=2)
 
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     for t in [shard_master, shard_replica, shard_rdonly1]:
       t.create_db('vt_test_keyspace')
 
@@ -295,7 +293,6 @@ index by_msg (msg)
     utils.wait_for_tablet_type(shard_rdonly1.tablet_alias, 'rdonly')
     for t in [shard_master, shard_replica, shard_rdonly1]:
       t.wait_for_vttablet_state('SERVING')
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
     # create the tables and add startup values
     self._create_schema()
@@ -368,8 +365,6 @@ index by_msg (msg)
         shard='80-',
         tablet_index=2)
 
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     for t in [shard_0_master, shard_0_replica,
               shard_1_master, shard_1_replica]:
       t.create_db('vt_test_keyspace')
@@ -398,8 +393,6 @@ index by_msg (msg)
                        shard_1_master, shard_1_replica, shard_1_rdonly1]
     for t in sharded_tablets:
       t.wait_for_vttablet_state('SERVING')
-
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
     # must restart vtgate after tablets are up, or else wait until 1min refresh
     # we want cache_ttl at zero so we re-read the topology for every test query.

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -151,8 +151,6 @@ def setup_sharded_keyspace():
       shard='80-',
       tablet_index=1)
 
-  utils.run_vtctl(['RebuildKeyspaceGraph', SHARDED_KEYSPACE], auto_log=True)
-
   for t in [shard_0_master, shard_0_replica, shard_1_master, shard_1_replica]:
     t.create_db('vt_test_keyspace_sharded')
     t.mquery(shard_0_master.dbname, create_vt_insert_test)
@@ -173,9 +171,9 @@ def setup_sharded_keyspace():
   for t in [shard_0_master, shard_0_replica, shard_1_master, shard_1_replica]:
     t.wait_for_vttablet_state('SERVING')
 
+  # rebuild to be sure we have the latest data
   utils.run_vtctl(
       ['RebuildKeyspaceGraph', SHARDED_KEYSPACE], auto_log=True)
-
   utils.check_srv_keyspace('test_nj', SHARDED_KEYSPACE,
                            'Partitions(master): -80 80-\n'
                            'Partitions(rdonly): -80 80-\n'
@@ -198,8 +196,6 @@ def setup_unsharded_keyspace():
       shard='0',
       tablet_index=1)
 
-  utils.run_vtctl(['RebuildKeyspaceGraph', UNSHARDED_KEYSPACE], auto_log=True)
-
   for t in [unsharded_master, unsharded_replica]:
     t.create_db('vt_test_keyspace_unsharded')
     t.mquery(unsharded_master.dbname, create_vt_insert_test)
@@ -218,8 +214,8 @@ def setup_unsharded_keyspace():
   for t in [unsharded_master, unsharded_replica]:
     t.wait_for_vttablet_state('SERVING')
 
+  # rebuild to be sure we have the right version
   utils.run_vtctl(['RebuildKeyspaceGraph', UNSHARDED_KEYSPACE], auto_log=True)
-
   utils.check_srv_keyspace('test_nj', UNSHARDED_KEYSPACE,
                            'Partitions(master): -\n'
                            'Partitions(rdonly): -\n'

--- a/test/master_buffering_test.py
+++ b/test/master_buffering_test.py
@@ -106,8 +106,6 @@ def setup_tablets():
       shard='0',
       tablet_index=1)
 
-  utils.run_vtctl(['RebuildKeyspaceGraph', KEYSPACE_NAME], auto_log=True)
-
   for t in [shard_0_master, shard_0_replica1]:
     t.create_db('vt_test_keyspace')
     for create_table in create_tables:
@@ -127,9 +125,6 @@ def setup_tablets():
 
   for t in [shard_0_master, shard_0_replica1]:
     t.wait_for_vttablet_state('SERVING')
-
-  utils.run_vtctl(
-      ['RebuildKeyspaceGraph', KEYSPACE_NAME], auto_log=True)
 
   utils.check_srv_keyspace(
       'test_nj', KEYSPACE_NAME,

--- a/test/merge_sharding.py
+++ b/test/merge_sharding.py
@@ -257,8 +257,8 @@ index by_msg (msg)
     shard_2_replica.init_tablet('replica', 'test_keyspace', '80-')
     shard_2_rdonly.init_tablet('rdonly', 'test_keyspace', '80-')
 
+    # rebuild and check SrvKeyspace
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     ks = utils.run_vtctl_json(['GetSrvKeyspace', 'test_nj', 'test_keyspace'])
     self.assertEqual(ks['sharding_column_name'], 'custom_sharding_key')
 

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -405,7 +405,6 @@ primary key (name)
     shard_1_rdonly1.init_tablet('rdonly', 'test_keyspace', '80-')
 
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-
     ks = utils.run_vtctl_json(['GetSrvKeyspace', 'test_nj', 'test_keyspace'])
     self.assertEqual(ks['sharding_column_name'], 'custom_sharding_key')
 

--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -87,7 +87,6 @@ def setUpModule():
     utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'replica')
     master_tablet.wait_for_vttablet_state('SERVING')
     replica_tablet.wait_for_vttablet_state('SERVING')
-#    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
     # reset counter so tests don't assert
     tablet.Tablet.tablets_running = 0

--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -87,7 +87,7 @@ def setUpModule():
     utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'replica')
     master_tablet.wait_for_vttablet_state('SERVING')
     replica_tablet.wait_for_vttablet_state('SERVING')
-    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
+#    utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
 
     # reset counter so tests don't assert
     tablet.Tablet.tablets_running = 0

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -203,11 +203,6 @@ class TestVerticalSplit(unittest.TestCase, base_sharding.BaseShardingTest):
     for t in replica_tablets:
       t.wait_for_vttablet_state('SERVING')
 
-#    utils.run_vtctl(
-#        ['RebuildKeyspaceGraph', 'source_keyspace'], auto_log=True)
-#    utils.run_vtctl(
-#        ['RebuildKeyspaceGraph', 'destination_keyspace'], auto_log=True)
-
   def _create_source_schema(self):
     create_table_template = '''create table %s(
 id bigint not null,

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -203,10 +203,10 @@ class TestVerticalSplit(unittest.TestCase, base_sharding.BaseShardingTest):
     for t in replica_tablets:
       t.wait_for_vttablet_state('SERVING')
 
-    utils.run_vtctl(
-        ['RebuildKeyspaceGraph', 'source_keyspace'], auto_log=True)
-    utils.run_vtctl(
-        ['RebuildKeyspaceGraph', 'destination_keyspace'], auto_log=True)
+#    utils.run_vtctl(
+#        ['RebuildKeyspaceGraph', 'source_keyspace'], auto_log=True)
+#    utils.run_vtctl(
+#        ['RebuildKeyspaceGraph', 'destination_keyspace'], auto_log=True)
 
   def _create_source_schema(self):
     create_table_template = '''create table %s(


### PR DESCRIPTION
These are not needed for the serving graph to be up to date any more.

@enisoc we talked about this at some point. Next would be the examples and local clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1745)
<!-- Reviewable:end -->
