### PR TITLE
tabletserver: schema info should use dba creds

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -214,7 +214,7 @@ func (qe *QueryEngine) Open(dbconfigs dbconfigs.DBConfigs) {
 	}
 
 	start := time.Now()
-	qe.schemaInfo.Open(&appParams, &dbaParams, strictMode)
+	qe.schemaInfo.Open(&dbaParams, strictMode)
 	log.Infof("Time taken to load the schema: %v", time.Now().Sub(start))
 
 	qe.connPool.Open(&appParams, &dbaParams)

--- a/go/vt/tabletserver/schema_info.go
+++ b/go/vt/tabletserver/schema_info.go
@@ -143,9 +143,9 @@ func NewSchemaInfo(
 }
 
 // Open initializes the current SchemaInfo for service by loading the necessary info from the specified database.
-func (si *SchemaInfo) Open(appParams, dbaParams *sqldb.ConnParams, strictMode bool) {
+func (si *SchemaInfo) Open(dbaParams *sqldb.ConnParams, strictMode bool) {
 	ctx := context.Background()
-	si.connPool.Open(appParams, dbaParams)
+	si.connPool.Open(dbaParams, dbaParams)
 	// Get time first because it needs a connection from the pool.
 	curTime := si.mysqlTime(ctx)
 

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -30,7 +30,6 @@ func TestSchemaInfoStrictMode(t *testing.T) {
 	}
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
 	t.Log(schemaInfo)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
@@ -38,7 +37,7 @@ func TestSchemaInfoStrictMode(t *testing.T) {
 			"connection cannot verify strict mode",
 		vtrpcpb.ErrorCode_INTERNAL_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 }
 
 func TestSchemaInfoOpenFailedDueToMissMySQLTime(t *testing.T) {
@@ -51,14 +50,13 @@ func TestSchemaInfoOpenFailedDueToMissMySQLTime(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because of it could not get MySQL time",
 		vtrpcpb.ErrorCode_UNKNOWN_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 }
 
 func TestSchemaInfoOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
@@ -71,14 +69,13 @@ func TestSchemaInfoOpenFailedDueToIncorrectMysqlRowNum(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because of incorrect MySQL row number",
 		vtrpcpb.ErrorCode_UNKNOWN_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 }
 
 func TestSchemaInfoOpenFailedDueToInvalidTimeFormat(t *testing.T) {
@@ -91,14 +88,13 @@ func TestSchemaInfoOpenFailedDueToInvalidTimeFormat(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because it could not get MySQL time",
 		vtrpcpb.ErrorCode_UNKNOWN_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 }
 
 func TestSchemaInfoOpenFailedDueToExecErr(t *testing.T) {
@@ -111,14 +107,13 @@ func TestSchemaInfoOpenFailedDueToExecErr(t *testing.T) {
 		RowsAffected: math.MaxUint64,
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because conn.Exec failed",
 		vtrpcpb.ErrorCode_UNKNOWN_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 }
 
 func TestSchemaInfoOpenFailedDueToTableInfoErr(t *testing.T) {
@@ -137,14 +132,13 @@ func TestSchemaInfoOpenFailedDueToTableInfoErr(t *testing.T) {
 		RowsAffected: math.MaxUint64,
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
 	defer handleAndVerifyTabletError(
 		t,
 		"schema info Open should fail because NewTableInfo failed",
 		vtrpcpb.ErrorCode_INTERNAL_ERROR,
 	)
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 }
 
 func TestSchemaInfoReload(t *testing.T) {
@@ -154,9 +148,8 @@ func TestSchemaInfoReload(t *testing.T) {
 	}
 	idleTimeout := 10 * time.Second
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, idleTimeout, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 	// this new table does not exist
 	newTable := "test_table_04"
@@ -238,9 +231,8 @@ func TestSchemaInfoCreateOrUpdateTableFailedDuetoExecErr(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, true)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 	defer schemaInfo.Close()
 	originalSchemaErrorCount := schemaInfo.queryServiceStats.InternalErrors.Counts()["Schema"]
 	// should silently fail: no errors returned, but increment a counter
@@ -267,9 +259,8 @@ func TestSchemaInfoCreateOrUpdateTable(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 	schemaInfo.CreateOrUpdateTable(context.Background(), "test_table_01")
 	schemaInfo.Close()
 }
@@ -288,9 +279,8 @@ func TestSchemaInfoDropTable(t *testing.T) {
 		},
 	})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, false)
+	schemaInfo.Open(&dbaParams, false)
 	tableInfo := schemaInfo.GetTable(existingTable)
 	if tableInfo == nil {
 		t.Fatalf("table: %s should exist", existingTable)
@@ -309,9 +299,8 @@ func TestSchemaInfoGetPlanPanicDuetoEmptyQuery(t *testing.T) {
 		db.AddQuery(query, result)
 	}
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 
 	ctx := context.Background()
@@ -330,9 +319,8 @@ func TestSchemaInfoQueryCacheFailDueToInvalidCacheSize(t *testing.T) {
 		db.AddQuery(query, result)
 	}
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 	defer handleAndVerifyTabletError(
 		t,
@@ -354,9 +342,8 @@ func TestSchemaInfoQueryCache(t *testing.T) {
 	db.AddQuery("select * from test_table_02 where 1 != 1", &sqltypes.Result{})
 
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, 10*time.Second, true)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 
 	ctx := context.Background()
@@ -382,9 +369,8 @@ func TestSchemaInfoExportVars(t *testing.T) {
 		db.AddQuery(query, result)
 	}
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, true)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 	expvar.Do(func(kv expvar.KeyValue) {
 		_ = kv.Value.String()
@@ -398,9 +384,8 @@ func TestUpdatedMysqlStats(t *testing.T) {
 	}
 	idleTimeout := 10 * time.Second
 	schemaInfo := newTestSchemaInfo(10, 10*time.Second, idleTimeout, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 	// Add new table
 	tableName := "mysql_stats_test_table"
@@ -471,9 +456,8 @@ func TestSchemaInfoStatsURL(t *testing.T) {
 	query := "select * from test_table_01"
 	db.AddQuery("select * from test_table_01 where 1 != 1", &sqltypes.Result{})
 	schemaInfo := newTestSchemaInfo(10, 1*time.Second, 1*time.Second, false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
 	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	schemaInfo.Open(&appParams, &dbaParams, true)
+	schemaInfo.Open(&dbaParams, true)
 	defer schemaInfo.Close()
 	// warm up cache
 	ctx := context.Background()


### PR DESCRIPTION
@alainjobart 
b/28999540
SchemaInfo should not be blocked by permission while performing
its functions. So, it should use dba creds instead of app creds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1748)
<!-- Reviewable:end -->
