### PR TITLE
Refactoring vtgatev2_test a bit.

### DIFF
--- a/py/vtdb/grpc_vtgate_client.py
+++ b/py/vtdb/grpc_vtgate_client.py
@@ -79,7 +79,13 @@ class GRPCVTGateConnection(vtgate_client.VTGateClient,
     to it will just close the channel.
     """
     if self.session and self.session.in_transaction:
-      self.rollback()
+      # If the endpoint is not responding, this would exception out,
+      # just when we want to not connect to the endpoint any more.
+      # Let's swallow that exception.
+      try:
+        self.rollback()
+      except dbexceptions.TimeoutError:
+        pass
     self.stub = None
 
   def is_closed(self):


### PR DESCRIPTION
Not restarting processes when we don't have to.
Closing vtgate connections when not used.
Not waiting for SERVING state (when the start_vttablet does it already).
Killing vtgate explicitely at the end to avoid spam.

Execution time went from 210s to 145s on my WS.

Also swallowing execptions on the rollback() in close() for GRPC vtgate
client. We want to close that connection after all.

@dumbunny @guoliang100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1765)
<!-- Reviewable:end -->
