### PR TITLE
vtworker: Revert --destination_pack_count to 10.

### DIFF
--- a/go/vt/worker/defaults.go
+++ b/go/vt/worker/defaults.go
@@ -8,10 +8,13 @@ import "github.com/youtube/vitess/go/vt/throttler"
 
 const (
 	defaultSourceReaderCount = 10
-	// defaultDestinationPackCount is the number of rows which will be aggreated
-	// into one transaction. Note that higher values will increase memory
-	// consumption in vtworker, vttablet and mysql.
-	defaultDestinationPackCount    = 1000
+	// defaultDestinationPackCount is the number of StreamExecute responses which
+	// will be aggreated into one transaction. See the vttablet flag
+	// "-queryserver-config-stream-buffer-size" for the size (in bytes) of a
+	// StreamExecute response. As of 06/2015, the default for it was 32 kB.
+	// Note that higher values for this flag --destination_pack_count will
+	// increase memory consumption in vtworker, vttablet and mysql.
+	defaultDestinationPackCount    = 10
 	defaultMinTableSizeForSplit    = 1024 * 1024
 	defaultDestinationWriterCount  = 20
 	defaultMinHealthyRdonlyTablets = 2


### PR DESCRIPTION
In commit 2e43353cb1688970198ba3f167042eec9684caa5 we increased the value from 10 to 1000 because we thought it refers to rows (how many to aggregate in one transaction during the resharding copy). However, this is not the case. Instead, it's the number of StreamExecute responses whose size defaults to 32 kB. Aggregating 1000 * 32 kB results into too large transactions and might actually OOM MySQL. Therefore, we revert to the previous value 10.

@alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1766)
<!-- Reviewable:end -->
