### PR TITLE
schemamanager: Fix the fake for PreflightSchema.

### DIFF
--- a/go/vt/schemamanager/schemamanager_test.go
+++ b/go/vt/schemamanager/schemamanager_test.go
@@ -247,10 +247,11 @@ func (client *fakeTabletManagerClient) PreflightSchema(ctx context.Context, tabl
 	var result []*tabletmanagerdatapb.SchemaChangeResult
 	for _, change := range changes {
 		scr, ok := client.preflightSchemas[change]
-		if !ok {
+		if ok {
+			result = append(result, scr)
+		} else {
 			result = append(result, &tabletmanagerdatapb.SchemaChangeResult{})
 		}
-		result = append(result, scr)
 	}
 	return result, nil
 }


### PR DESCRIPTION
When no fake result was registered for an SQL, it did return two instead of one messages.

@alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1770)
<!-- Reviewable:end -->
