### PR TITLE
Fix .gitignore to prevent loss of vendor contents when using git stash.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,15 @@ tags
 /Godeps/_workspace/bin
 
 # Go vendored libs
-# Match two levels deep so we can un-ignore specific repos, like below.
-/vendor/*/*/
-# Un-ignore gozk since it has local modifications.
-!/vendor/launchpad.net/gozk/
+# Ideally we would match two levels deep so we can un-ignore specific repos
+# like launchpad.net/gozk, but doing that triggers a bug in "git stash".
+# As a workaround, we ignore at the domain level.
+/vendor/*/
+# We really only want to un-ignore launchpad.net/gozk,
+# because it has local, tracked changes.
+# But we can't do that because of the bug mentioned above,
+# so we un-ignore all of launchpad.net.
+!/vendor/launchpad.net/
 
 # C build dirs
 **/build


### PR DESCRIPTION
@michael-berlin 

This is to work around a bug where 'git stash' would delete directories
that ought to be ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1782)
<!-- Reviewable:end -->
