### PR TITLE
Randomize MySQL server-id when initializing tablet from scratch.

### DIFF
--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -1,0 +1,82 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+This file contains common functions for cmd/mysqlctl and cmd/mysqlctld.
+*/
+
+package mysqlctl
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+)
+
+// CreateMysqld returns a Mysqld object to use for working with a MySQL
+// installation that hasn't been set up yet. This will generate a new my.cnf
+// from scratch and use that to call NewMysqld().
+func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
+	// Choose a random MySQL server-id, since this is a fresh data dir.
+	// We don't want to use the tablet UID as the MySQL server-id,
+	// because reusing server-ids is not safe.
+	//
+	// For example, if a tablet comes back with an empty data dir, it will restore
+	// from backup and then connect to the master. But if this tablet has the same
+	// server-id as before, and if this tablet was recently a master, then it can
+	// lose data by skipping binlog events due to replicate-same-server-id=FALSE,
+	// which is the default setting.
+	mysqlServerID, err := randomServerID()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't generate random MySQL server_id: %v", err)
+	}
+	mycnf := NewMycnf(tabletUID, mysqlServerID, mysqlPort)
+	if mysqlSocket != "" {
+		mycnf.SocketFile = mysqlSocket
+	}
+
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
+	}
+
+	return NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl), nil
+}
+
+// OpenMysqld returns a Mysqld object to use for working with a MySQL
+// installation that already exists. This will look for an existing my.cnf file
+// and use that to call NewMysqld().
+func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
+	mycnf, err := ReadMycnf(mycnfFile(tabletUID))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read my.cnf file: %v", err)
+	}
+
+	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
+	}
+
+	return NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App.ConnParams, &dbcfgs.Repl), nil
+}
+
+// randomServerID generates a random MySQL server_id.
+//
+// The returned ID will be in the range [100, 2^32).
+// It avoids 0 because that's reserved for mysqlbinlog dumps.
+// It also avoids 1-99 because low numbers are used for fake slave connections.
+// See NewSlaveConnection() in slave_connection.go for more on that.
+func randomServerID() (uint32, error) {
+	// rand.Int(_, max) returns a value in the range [0, max).
+	bigN, err := rand.Int(rand.Reader, big.NewInt(1<<32-100))
+	if err != nil {
+		return 0, err
+	}
+	n := bigN.Uint64()
+	// n is in the range [0, 2^32 - 100).
+	// Add back 100 to put it in the range [100, 2^32).
+	return uint32(n + 100), nil
+}

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -74,11 +74,6 @@ func TabletDir(uid uint32) string {
 	return fmt.Sprintf("%s/vt_%010d", env.VtDataRoot(), uid)
 }
 
-// SnapshotDir returns the default directory for a tablet's snapshots
-func SnapshotDir(uid uint32) string {
-	return fmt.Sprintf("%s/%s/vt_%010d", env.VtDataRoot(), snapshotDir, uid)
-}
-
 // mycnfFile returns the default location of the my.cnf file.
 func mycnfFile(uid uint32) string {
 	return path.Join(TabletDir(uid), "my.cnf")

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -36,7 +36,6 @@ const (
 	binLogDir        = "bin-logs"
 	innodbDataSubdir = "innodb/data"
 	innodbLogSubdir  = "innodb/logs"
-	snapshotDir      = "snapshot"
 )
 
 // NewMycnf fills the Mycnf structure with vt root paths and derived values.
@@ -44,11 +43,11 @@ const (
 // uid is a unique id for a particular tablet - it must be unique within the
 // tabletservers deployed within a keyspace, lest there be collisions on disk.
 // mysqldPort needs to be unique per instance per machine.
-func NewMycnf(uid uint32, mysqlPort int32) *Mycnf {
+func NewMycnf(tabletUID, mysqlServerID uint32, mysqlPort int32) *Mycnf {
 	cnf := new(Mycnf)
-	cnf.path = mycnfFile(uid)
-	tabletDir := TabletDir(uid)
-	cnf.ServerID = uid
+	cnf.path = mycnfFile(tabletUID)
+	tabletDir := TabletDir(tabletUID)
+	cnf.ServerID = mysqlServerID
 	cnf.MysqlPort = mysqlPort
 	cnf.DataDir = path.Join(tabletDir, dataDir)
 	cnf.InnodbDataHomeDir = path.Join(tabletDir, innodbDataSubdir)
@@ -57,11 +56,11 @@ func NewMycnf(uid uint32, mysqlPort int32) *Mycnf {
 	cnf.ErrorLogPath = path.Join(tabletDir, "error.log")
 	cnf.SlowLogPath = path.Join(tabletDir, "slow-query.log")
 	cnf.RelayLogPath = path.Join(tabletDir, relayLogDir,
-		fmt.Sprintf("vt-%010d-relay-bin", cnf.ServerID))
+		fmt.Sprintf("vt-%010d-relay-bin", tabletUID))
 	cnf.RelayLogIndexPath = cnf.RelayLogPath + ".index"
 	cnf.RelayLogInfoPath = path.Join(tabletDir, relayLogDir, "relay-log.info")
 	cnf.BinLogPath = path.Join(tabletDir, binLogDir,
-		fmt.Sprintf("vt-%010d-bin", cnf.ServerID))
+		fmt.Sprintf("vt-%010d-bin", tabletUID))
 	cnf.MasterInfoFile = path.Join(tabletDir, "master.info")
 	cnf.PidFile = path.Join(tabletDir, "mysql.pid")
 	cnf.TmpDir = path.Join(tabletDir, "tmp")
@@ -93,8 +92,8 @@ func (cnf *Mycnf) directoryList() []string {
 		cnf.InnodbDataHomeDir,
 		cnf.InnodbLogGroupHomeDir,
 		cnf.TmpDir,
-		path.Join(TabletDir(cnf.ServerID), relayLogDir),
-		path.Join(TabletDir(cnf.ServerID), binLogDir),
+		path.Dir(cnf.RelayLogPath),
+		path.Dir(cnf.BinLogPath),
 	}
 }
 

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -21,7 +22,7 @@ func TestMycnf(t *testing.T) {
 	dbaConfig := dbconfigs.DefaultDBConfigs.Dba
 	appConfig := dbconfigs.DefaultDBConfigs.App.ConnParams
 	replConfig := dbconfigs.DefaultDBConfigs.Repl
-	tablet0 := NewMysqld("Dba", "App", NewMycnf(0, 6802), &dbaConfig, &appConfig, &replConfig)
+	tablet0 := NewMysqld("Dba", "App", NewMycnf(11111, 22222, 6802), &dbaConfig, &appConfig, &replConfig)
 	defer tablet0.Close()
 	root, err := env.VtRoot()
 	if err != nil {
@@ -52,5 +53,13 @@ func TestMycnf(t *testing.T) {
 		t.Errorf("failed reading, err %v", err)
 	} else {
 		t.Logf("socket file %v", mycnf.SocketFile)
+	}
+	// Tablet UID should be 11111, which determines tablet/data dir.
+	if got, want := mycnf.DataDir, "/vt_0000011111/"; !strings.Contains(got, want) {
+		t.Errorf("mycnf.DataDir = %v, want *%v*", got, want)
+	}
+	// MySQL server-id should be 22222, different from Tablet UID.
+	if got, want := mycnf.ServerID, uint32(22222); got != want {
+		t.Errorf("mycnf.ServerID = %v, want %v", got, want)
 	}
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -60,7 +60,6 @@ type Mysqld struct {
 	replParams    *sqldb.ConnParams
 	dbaMysqlStats *stats.Timings
 	tabletDir     string
-	SnapshotDir   string
 
 	// mutex protects the fields below.
 	mutex         sync.Mutex
@@ -108,7 +107,6 @@ func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.Con
 		replParams:    repl,
 		dbaMysqlStats: dbaMysqlStats,
 		tabletDir:     TabletDir(config.ServerID),
-		SnapshotDir:   SnapshotDir(config.ServerID),
 	}
 }
 

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -106,7 +106,7 @@ func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.Con
 		appPool:       appPool,
 		replParams:    repl,
 		dbaMysqlStats: dbaMysqlStats,
-		tabletDir:     TabletDir(config.ServerID),
+		tabletDir:     path.Dir(config.DataDir),
 	}
 }
 

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -88,7 +88,7 @@ func (util *testUtils) newMysqld(dbconfigs *dbconfigs.DBConfigs) mysqlctl.MysqlD
 	return mysqlctl.NewMysqld(
 		"",
 		"",
-		mysqlctl.NewMycnf(0, 6802),
+		mysqlctl.NewMycnf(11111, 22222, 6802),
 		&dbconfigs.Dba,
 		&dbconfigs.App.ConnParams,
 		&dbconfigs.Repl,


### PR DESCRIPTION
@alainjobart @pivanof 

When creating a tablet from an empty data dir (mysqlctl init),
we should pick a random MySQL server-id, rather than using the tablet
UID as the server-id. This better matches the expectations of MySQL that
a server with the same server-id ought to be the same incarnation of the
data dir. Violating that expectation causes bad interactions with
features like ignoring binlog events from the same server-id (when
replicate-same-server-id=FALSE, which is the default).

If a tablet is just being restarted in-place with its data dir retained
(mysqlctl shutdown/start), then it will re-use the same server-id that
was previously generated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1783)
<!-- Reviewable:end -->
