### PR TITLE
zktopo: Translate Zookeeper's "bad version" error into the generic "b…

### DIFF
--- a/go/vt/zktopo/cell.go
+++ b/go/vt/zktopo/cell.go
@@ -19,7 +19,7 @@ This file contains the cell management methods of zktopo.Server
 func (zkts *Server) GetKnownCells(ctx context.Context) ([]string, error) {
 	cellsWithGlobal, err := zk.ZkKnownCells()
 	if err != nil {
-		return cellsWithGlobal, err
+		return cellsWithGlobal, convertError(err)
 	}
 	cells := make([]string, 0, len(cellsWithGlobal))
 	for _, cell := range cellsWithGlobal {

--- a/go/vt/zktopo/error.go
+++ b/go/vt/zktopo/error.go
@@ -1,0 +1,39 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package zktopo
+
+import (
+	"github.com/youtube/vitess/go/vt/topo"
+	"golang.org/x/net/context"
+	"launchpad.net/gozk/zookeeper"
+)
+
+// Error codes returned by the zookeeper Go client:
+// http://bazaar.launchpad.net/~gozk/gozk/trunk/view/head:/zk.go
+func convertError(err error) error {
+	switch typeErr := err.(type) {
+	case *zookeeper.Error:
+		switch typeErr.Code {
+		case zookeeper.ZBADVERSION:
+			return topo.ErrBadVersion
+		case zookeeper.ZNONODE:
+			return topo.ErrNoNode
+		case zookeeper.ZNODEEXISTS:
+			return topo.ErrNodeExists
+		case zookeeper.ZNOTEMPTY:
+			return topo.ErrNotEmpty
+		case zookeeper.ZOPERATIONTIMEOUT:
+			return topo.ErrTimeout
+		}
+	default:
+		switch err {
+		case context.Canceled:
+			return topo.ErrInterrupted
+		case context.DeadlineExceeded:
+			return topo.ErrTimeout
+		}
+	}
+	return err
+}

--- a/go/vt/zktopo/lock.go
+++ b/go/vt/zktopo/lock.go
@@ -27,7 +27,7 @@ func (zkts *Server) lockForAction(ctx context.Context, actionDir, contents strin
 	// create the action path
 	actionPath, err := zkts.zconn.Create(actionDir, contents, zookeeper.SEQUENCE|zookeeper.EPHEMERAL, zookeeper.WorldACL(zk.PERM_FILE))
 	if err != nil {
-		return "", err
+		return "", convertError(err)
 	}
 
 	// get the timeout from the context
@@ -99,7 +99,7 @@ func (zkts *Server) unlockForAction(lockPath, results string) error {
 	actionLogPath := strings.Replace(lockPath, "/action/", "/actionlog/", 1)
 	if _, err := zk.CreateRecursive(zkts.zconn, actionLogPath, results, 0, zookeeper.WorldACL(zookeeper.PERM_ALL)); err != nil {
 		log.Warningf("Cannot create actionlog path %v (check the permissions with 'zk stat'), will keep the lock, use 'zk rm' to clear the lock", actionLogPath)
-		return err
+		return convertError(err)
 	}
 
 	// and delete the action

--- a/go/vt/zktopo/replication_graph.go
+++ b/go/vt/zktopo/replication_graph.go
@@ -34,7 +34,7 @@ func (zkts *Server) UpdateShardReplicationFields(ctx context.Context, cell, keys
 	// create the parent directory to be sure it's here
 	zkDir := path.Join("/zk", cell, "vt", "replication", keyspace)
 	if _, err := zk.CreateRecursive(zkts.zconn, zkDir, "", 0, zookeeper.WorldACL(zookeeper.PERM_ALL)); err != nil && !zookeeper.IsError(err, zookeeper.ZNODEEXISTS) {
-		return err
+		return convertError(err)
 	}
 
 	// now update the data
@@ -58,10 +58,7 @@ func (zkts *Server) UpdateShardReplicationFields(ctx context.Context, cell, keys
 	}
 	err := zkts.zconn.RetryChange(zkPath, 0, zookeeper.WorldACL(zookeeper.PERM_ALL), f)
 	if err != nil {
-		if zookeeper.IsError(err, zookeeper.ZNONODE) {
-			err = topo.ErrNoNode
-		}
-		return err
+		return convertError(err)
 	}
 	return nil
 }
@@ -71,10 +68,7 @@ func (zkts *Server) GetShardReplication(ctx context.Context, cell, keyspace, sha
 	zkPath := shardReplicationPath(cell, keyspace, shard)
 	data, _, err := zkts.zconn.Get(zkPath)
 	if err != nil {
-		if zookeeper.IsError(err, zookeeper.ZNONODE) {
-			err = topo.ErrNoNode
-		}
-		return nil, err
+		return nil, convertError(err)
 	}
 
 	sr := &topodatapb.ShardReplication{}
@@ -90,10 +84,7 @@ func (zkts *Server) DeleteShardReplication(ctx context.Context, cell, keyspace, 
 	zkPath := shardReplicationPath(cell, keyspace, shard)
 	err := zkts.zconn.Delete(zkPath, -1)
 	if err != nil {
-		if zookeeper.IsError(err, zookeeper.ZNONODE) {
-			err = topo.ErrNoNode
-		}
-		return err
+		return convertError(err)
 	}
 	return nil
 }
@@ -103,10 +94,7 @@ func (zkts *Server) DeleteKeyspaceReplication(ctx context.Context, cell, keyspac
 	zkPath := keyspaceReplicationPath(cell, keyspace)
 	err := zkts.zconn.Delete(zkPath, -1)
 	if err != nil {
-		if zookeeper.IsError(err, zookeeper.ZNONODE) {
-			err = topo.ErrNoNode
-		}
-		return err
+		return convertError(err)
 	}
 	return nil
 }

--- a/go/vt/zktopo/server.go
+++ b/go/vt/zktopo/server.go
@@ -59,7 +59,7 @@ func (zkts *Server) PurgeActions(zkActionPath string, canBePurged func(data stri
 
 	children, _, err := zkts.zconn.Children(zkActionPath)
 	if err != nil {
-		return err
+		return convertError(err)
 	}
 
 	sort.Strings(children)
@@ -95,7 +95,7 @@ func (zkts *Server) PruneActionLogs(zkActionLogPath string, keepCount int) (prun
 	// get sorted list of children
 	children, _, err := zkts.zconn.Children(zkActionLogPath)
 	if err != nil {
-		return 0, err
+		return 0, convertError(err)
 	}
 	sort.Strings(children)
 

--- a/go/vt/zktopo/vschema.go
+++ b/go/vt/zktopo/vschema.go
@@ -13,7 +13,6 @@ import (
 	"launchpad.net/gozk/zookeeper"
 
 	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
-	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/zk"
 )
 
@@ -33,7 +32,7 @@ func (zkts *Server) SaveVSchema(ctx context.Context, keyspace string, vschema *v
 	}
 	vschemaPath := path.Join(GlobalKeyspacesPath, keyspace, vschemaPath)
 	_, err = zk.CreateOrUpdate(zkts.zconn, vschemaPath, string(data), 0, zookeeper.WorldACL(zookeeper.PERM_ALL), true)
-	return err
+	return convertError(err)
 }
 
 // GetVSchema fetches the JSON vschema from the topo.
@@ -41,10 +40,7 @@ func (zkts *Server) GetVSchema(ctx context.Context, keyspace string) (*vschemapb
 	vschemaPath := path.Join(GlobalKeyspacesPath, keyspace, vschemaPath)
 	data, _, err := zkts.zconn.Get(vschemaPath)
 	if err != nil {
-		if zookeeper.IsError(err, zookeeper.ZNONODE) {
-			return nil, topo.ErrNoNode
-		}
-		return nil, err
+		return nil, convertError(err)
 	}
 	var vs vschemapb.Keyspace
 	err = json.Unmarshal([]byte(data), &vs)


### PR DESCRIPTION
…ad node version" error.

Fixes flaky e2e tests e.g. tablet startup in worker.py failed with this error:

E0610 16:24:15.788787   32332 vttablet.go:125] agent.InitTablet failed: couldn't add tablet's cell to shard record: zookeeper: set "/zk/global/vt/keyspaces/test_keyspace/shards/80-": bad version

I've replaced all previous per-function translations with a call to the new function convertError(err). This structure is identical to the etcdtopo code.

I didn't edit code which did already return very specific error messages e.g. in lock.go and server.go.

@enisoc @alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1785)
<!-- Reviewable:end -->
