### PR TITLE
examples: Remove *_protocol flags from the examples.

### DIFF
--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -47,8 +47,6 @@ spec:
               -grpc_port 15999
               -service_map 'grpc-vtctl'
               -topo_implementation etcd
-              -tablet_protocol grpc
-              -tablet_manager_protocol grpc
               -etcd_global_addrs http://etcd-global:4001
               {{backup_flags}}" vitess
       volumes:

--- a/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
+++ b/examples/kubernetes/vtgate-controller-benchmarking-template.yaml
@@ -42,7 +42,6 @@ spec:
               -alsologtostderr
               -port 15001
               -grpc_port 15991
-              -tablet_protocol grpc
               -service_map 'grpc-vtgateservice'
               -cells_to_watch {{cell}}
               -tablet_types_to_wait MASTER,REPLICA

--- a/examples/kubernetes/vtgate-controller-template.yaml
+++ b/examples/kubernetes/vtgate-controller-template.yaml
@@ -42,7 +42,6 @@ spec:
               -alsologtostderr
               -port 15001
               -grpc_port 15991
-              -tablet_protocol grpc
               -service_map 'grpc-vtgateservice'
               -cells_to_watch {{cell}}
               -tablet_types_to_wait MASTER,REPLICA

--- a/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
+++ b/examples/kubernetes/vttablet-pod-benchmarking-template.yaml
@@ -49,7 +49,6 @@ spec:
           -port {{port}}
           -grpc_port {{grpc_port}}
           -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream'
-          -binlog_player_protocol grpc
           -tablet-path {{alias}}
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}

--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -55,7 +55,6 @@ spec:
           -port {{port}}
           -grpc_port {{grpc_port}}
           -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream'
-          -binlog_player_protocol grpc
           -tablet-path {{alias}}
           -tablet_hostname $(hostname -i)
           -init_keyspace {{keyspace}}

--- a/examples/kubernetes/vtworker-pod-template.yaml
+++ b/examples/kubernetes/vtworker-pod-template.yaml
@@ -27,8 +27,6 @@ spec:
           -topo_implementation etcd
           -etcd_global_addrs http://etcd-global:4001
           -cell {{cell}}
-          -tablet_protocol grpc
-          -tablet_manager_protocol grpc
           -use_v3_resharding_mode
           {{vtworker_command}}" vitess
   restartPolicy: Never

--- a/examples/local/sharded-vtworker.sh
+++ b/examples/local/sharded-vtworker.sh
@@ -10,8 +10,6 @@ source $script_root/env.sh
 echo "Starting vtworker..."
 exec $VTROOT/bin/vtworker \
   -cell test \
-  -tablet_protocol grpc \
-  -tablet_manager_protocol grpc \
   -log_dir $VTDATAROOT/tmp \
   -alsologtostderr \
   -use_v3_resharding_mode \

--- a/examples/local/vtctld-up.sh
+++ b/examples/local/vtctld-up.sh
@@ -13,8 +13,6 @@ source $script_root/env.sh
 echo "Starting vtctld..."
 $VTROOT/bin/vtctld \
   -web_dir $VTTOP/web/vtctld \
-  -tablet_protocol grpc \
-  -tablet_manager_protocol grpc \
   -service_map 'grpc-vtctl' \
   -backup_storage_implementation file \
   -file_backup_storage_root $VTDATAROOT/backups \

--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -20,7 +20,6 @@ $VTROOT/bin/vtgate \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \
   -gateway_implementation discoverygateway \
-  -tablet_protocol grpc \
   -service_map 'grpc-vtgateservice' \
   -pid_file $VTDATAROOT/tmp/vtgate.pid \
   > $VTDATAROOT/tmp/vtgate.out 2>&1 &

--- a/examples/local/vttablet-up.sh
+++ b/examples/local/vttablet-up.sh
@@ -107,7 +107,6 @@ for uid_index in $uids; do
     -restore_from_backup \
     -port $port \
     -grpc_port $grpc_port \
-    -binlog_player_protocol grpc \
     -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
     -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
     $dbconfig_flags \


### PR DESCRIPTION
The code defaults to "grpc" for all flags now. Therefore, there's no
point in setting it explicitly to "grpc" anymore.

Only test code is still setting the flag. Verified with:

$ ack-grep -- "-[-a-zA-Z0-9_]+_protocol"

@enisoc @alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1792)
<!-- Reviewable:end -->
