### PR TITLE
sqldb: remove obsolete mysql-new-conn-count var

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"expvar"
 	"flag"
 	"time"
 
@@ -133,7 +132,6 @@ func main() {
 		// FIXME(alainjobart): stop vtgate
 	})
 	servenv.OnClose(func() {
-		log.Infof("Total count of new connections to MySQL: %v", expvar.Get("mysql-new-connection-count"))
 		// We will still use the topo server during lameduck period
 		// to update our state, so closing it in OnClose()
 		topo.CloseServers()

--- a/go/sqldb/conn.go
+++ b/go/sqldb/conn.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/stats"
 
 	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -26,9 +25,6 @@ var (
 	// mu protects conns.
 	mu    sync.Mutex
 	conns = make(map[string]NewConnFunc)
-	// Keep track of the total number of connections opened to MySQL. This is mainly
-	// useful for tests, where we use this to approximate the number of ports that we used.
-	connCount = stats.NewInt("mysql-new-connection-count")
 )
 
 // Conn defines the behavior for the low level db connection
@@ -88,7 +84,6 @@ func Register(name string, fn NewConnFunc) {
 
 // Connect returns a sqldb.Conn using the default connection creation function.
 func Connect(params ConnParams) (Conn, error) {
-	connCount.Add(1)
 	// Use a lock-free fast path for default.
 	if params.Engine == "" {
 		return defaultConn(params)


### PR DESCRIPTION
@alainjobart 
This variable was used for some one-time troubleshooting.
It's otherwise not useful because there are alternate ways
of counting the number of mysql connections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1794)
<!-- Reviewable:end -->
