### PR TITLE
S3 Backup Storage Plugin

### DIFF
--- a/go/cmd/vtctl/plugin_s3backupstorage.go
+++ b/go/cmd/vtctl/plugin_s3backupstorage.go
@@ -1,0 +1,5 @@
+package main
+
+import (
+	_ "github.com/youtube/vitess/go/vt/mysqlctl/s3backupstorage"
+)

--- a/go/cmd/vtctld/plugin_s3backupstorage.go
+++ b/go/cmd/vtctld/plugin_s3backupstorage.go
@@ -1,0 +1,5 @@
+package main
+
+import (
+	_ "github.com/youtube/vitess/go/vt/mysqlctl/s3backupstorage"
+)

--- a/go/cmd/vttablet/plugin_s3backupstorage.go
+++ b/go/cmd/vttablet/plugin_s3backupstorage.go
@@ -1,0 +1,5 @@
+package main
+
+import (
+	_ "github.com/youtube/vitess/go/vt/mysqlctl/s3backupstorage"
+)

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -1,0 +1,265 @@
+// Package s3backupstorage implements the BackupStorage interface for AWS S3
+package s3backupstorage
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/youtube/vitess/go/vt/concurrency"
+	"github.com/youtube/vitess/go/vt/mysqlctl/backupstorage"
+)
+
+var (
+	// AWS API region
+	region = flag.String("s3_backup_aws_region", "us-east-1", "AWS region to use")
+
+	// bucket is where the backups will go.
+	bucket = flag.String("s3_backup_storage_bucket", "", "S3 bucket to use for backups")
+
+	// root is a prefix added to all object names.
+	root = flag.String("s3_backup_storage_root", "", "root prefix for all backup-related object names")
+
+	// path component delimiter
+	delimiter = "/"
+)
+
+type S3BackupHandle struct {
+	client    *s3.S3
+	bs        *S3BackupStorage
+	dir       string
+	name      string
+	readOnly  bool
+	errors    concurrency.AllErrorRecorder
+	waitGroup sync.WaitGroup
+}
+
+func (bh *S3BackupHandle) Directory() string {
+	return bh.dir
+}
+
+func (bh *S3BackupHandle) Name() string {
+	return bh.name
+}
+
+func (bh *S3BackupHandle) AddFile(filename string) (io.WriteCloser, error) {
+	if bh.readOnly {
+		return nil, fmt.Errorf("AddFile cannot be called on read-only backup")
+	}
+
+	reader, writer := io.Pipe()
+	bh.waitGroup.Add(1)
+
+	go func() {
+		defer bh.waitGroup.Done()
+		uploader := s3manager.NewUploaderWithClient(bh.client)
+		object := objName(bh.dir, bh.name, filename)
+		_, err := uploader.Upload(&s3manager.UploadInput{
+			Bucket: bucket,
+			Key:    object,
+			Body:   reader,
+		})
+		if err != nil {
+			reader.CloseWithError(err)
+			bh.errors.RecordError(err)
+		}
+	}()
+
+	return writer, nil
+}
+
+func (bh *S3BackupHandle) EndBackup() error {
+	if bh.readOnly {
+		return fmt.Errorf("EndBackup cannot be called on read-only backup")
+	}
+	bh.waitGroup.Wait()
+	return bh.errors.Error()
+}
+
+func (bh *S3BackupHandle) AbortBackup() error {
+	if bh.readOnly {
+		return fmt.Errorf("AbortBackup cannot be called on read-only backup")
+	}
+	return bh.bs.RemoveBackup(bh.dir, bh.name)
+}
+
+func (bh *S3BackupHandle) ReadFile(filename string) (io.ReadCloser, error) {
+	if !bh.readOnly {
+		return nil, fmt.Errorf("ReadFile cannot be called on read-write backup")
+	}
+	object := objName(bh.dir, bh.name, filename)
+	out, err := bh.client.GetObject(&s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    object,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.Body, nil
+}
+
+var _ backupstorage.BackupHandle = (*S3BackupHandle)(nil)
+
+type S3BackupStorage struct {
+	_client *s3.S3
+	mu      sync.Mutex
+}
+
+func (bs *S3BackupStorage) ListBackups(dir string) ([]backupstorage.BackupHandle, error) {
+	c, err := bs.client()
+	if err != nil {
+		return nil, err
+	}
+
+	searchPrefix := objName(dir, "")
+	query := &s3.ListObjectsV2Input{
+		Bucket:    bucket,
+		Delimiter: &delimiter,
+		Prefix:    searchPrefix,
+	}
+
+	var subdirs []string
+	for {
+		ojbs, err := c.ListObjectsV2(query)
+		if err != nil {
+			return nil, err
+		}
+		for _, prefix := range ojbs.CommonPrefixes {
+			subdir := strings.TrimPrefix(*prefix.Prefix, *searchPrefix)
+			subdir = strings.TrimSuffix(subdir, delimiter)
+			subdirs = append(subdirs, subdir)
+		}
+
+		if ojbs.NextContinuationToken == nil {
+			break
+		}
+		query.ContinuationToken = ojbs.NextContinuationToken
+	}
+
+	// Backups must be returned in order, oldest first.
+	sort.Strings(subdirs)
+
+	result := make([]backupstorage.BackupHandle, 0, len(subdirs))
+	for _, subdir := range subdirs {
+		result = append(result, &S3BackupHandle{
+			client:   c,
+			bs:       bs,
+			dir:      dir,
+			name:     subdir,
+			readOnly: true,
+		})
+	}
+	return result, nil
+}
+
+func (bs *S3BackupStorage) StartBackup(dir, name string) (backupstorage.BackupHandle, error) {
+	c, err := bs.client()
+	if err != nil {
+		return nil, err
+	}
+
+	return &S3BackupHandle{
+		client:   c,
+		bs:       bs,
+		dir:      dir,
+		name:     name,
+		readOnly: false,
+	}, nil
+}
+
+func (bs *S3BackupStorage) RemoveBackup(dir, name string) error {
+	c, err := bs.client()
+	if err != nil {
+		return err
+	}
+
+	query := &s3.ListObjectsV2Input{
+		Bucket: bucket,
+		Prefix: objName(dir, ""),
+	}
+
+	for {
+		objs, err := c.ListObjectsV2(query)
+		if err != nil {
+			return err
+		}
+
+		objIds := make([]*s3.ObjectIdentifier, 0, len(objs.Contents))
+		for _, obj := range objs.Contents {
+			objIds = append(objIds, &s3.ObjectIdentifier{
+				Key: obj.Key,
+			})
+		}
+
+		quiet := true // return less in the Delete response
+		out, err := c.DeleteObjects(&s3.DeleteObjectsInput{
+			Bucket: bucket,
+			Delete: &s3.Delete{
+				Objects: objIds,
+				Quiet:   &quiet,
+			},
+		})
+
+		if err != nil {
+			return err
+		}
+
+		for _, objError := range out.Errors {
+			return fmt.Errorf(objError.String())
+		}
+
+		if objs.NextContinuationToken == nil {
+			break
+		}
+
+		query.ContinuationToken = objs.NextContinuationToken
+	}
+
+	return nil
+}
+
+func (bs *S3BackupStorage) Close() error {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	bs._client = nil
+	return nil
+}
+
+var _ backupstorage.BackupStorage = (*S3BackupStorage)(nil)
+
+func (bs *S3BackupStorage) client() (*s3.S3, error) {
+	bs.mu.Lock()
+	defer bs.mu.Unlock()
+	if bs._client == nil {
+		bs._client = s3.New(session.New(), &aws.Config{Region: aws.String(*region)})
+
+		if len(*bucket) == 0 {
+			return nil, fmt.Errorf("-s3_backup_storage_bucket required")
+		}
+
+		if _, err := bs._client.HeadBucket(&s3.HeadBucketInput{Bucket: bucket}); err != nil {
+			return nil, err
+		}
+	}
+	return bs._client, nil
+}
+
+func objName(parts ...string) *string {
+	res := ""
+	if *root != "" {
+		res += *root + delimiter
+	}
+	res += strings.Join(parts, delimiter)
+	return &res
+}
+
+func init() {
+	backupstorage.BackupStorageMap["s3"] = &S3BackupStorage{}
+}

--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -1,4 +1,10 @@
-// Package s3backupstorage implements the BackupStorage interface for AWS S3
+// Package s3backupstorage implements the BackupStorage interface for AWS S3.
+//
+// AWS access credentials are configured via standard AWS means, such as:
+// - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables
+// - credentials file at ~/.aws/credentials
+// - if running on an EC2 instance, an IAM role
+// See details at http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs
 package s3backupstorage
 
 import (
@@ -127,20 +133,20 @@ func (bs *S3BackupStorage) ListBackups(dir string) ([]backupstorage.BackupHandle
 
 	var subdirs []string
 	for {
-		ojbs, err := c.ListObjectsV2(query)
+		objs, err := c.ListObjectsV2(query)
 		if err != nil {
 			return nil, err
 		}
-		for _, prefix := range ojbs.CommonPrefixes {
+		for _, prefix := range objs.CommonPrefixes {
 			subdir := strings.TrimPrefix(*prefix.Prefix, *searchPrefix)
 			subdir = strings.TrimSuffix(subdir, delimiter)
 			subdirs = append(subdirs, subdir)
 		}
 
-		if ojbs.NextContinuationToken == nil {
+		if objs.NextContinuationToken == nil {
 			break
 		}
-		query.ContinuationToken = ojbs.NextContinuationToken
+		query.ContinuationToken = objs.NextContinuationToken
 	}
 
 	// Backups must be returned in order, oldest first.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,10 @@
 	"ignore": "",
 	"package": [
 		{
+			"path": "context",
+			"revision": ""
+		},
+		{
 			"checksumSHA1": "N4ulLWtRPfGRJcNYgwD2sFSpXAQ=",
 			"path": "github.com/aws/aws-sdk-go/aws",
 			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
@@ -245,6 +249,24 @@
 			"versionExact": "v2.0.0"
 		},
 		{
+			"checksumSHA1": "39c+shSLmvturiMmkG4MjIFQQB4=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+			"revisionTime": "2015-11-05T21:09:06Z"
+		},
+		{
+			"checksumSHA1": "a2yC46a1qsJomgY6rb+FkTFiqmE=",
+			"path": "github.com/davecgh/go-spew/spew/testdata",
+			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+			"revisionTime": "2015-11-05T21:09:06Z"
+		},
+		{
+			"checksumSHA1": "mTTCsIV4p/hC4wIcGKAcOus2hlo=",
+			"path": "github.com/go-ini/ini",
+			"revision": "72ba3e6b9e6b87e0c74c9a7a4dc86e8dd8ba4355",
+			"revisionTime": "2016-06-01T19:11:21Z"
+		},
+		{
 			"checksumSHA1": "yUc84k7cfnRi9AlPFuRo77Y18Og=",
 			"path": "github.com/golang/glog",
 			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
@@ -317,12 +339,30 @@
 			"revisionTime": "2016-04-13T04:01:00Z"
 		},
 		{
+			"checksumSHA1": "d22rgDYcZ/l1RPHtCokJRHAh0QI=",
+			"path": "github.com/gopherjs/gopherjs/js",
+			"revision": "a727a4a1dd2f292e948cebe6ec9aef1a7863f145",
+			"revisionTime": "2016-06-12T21:17:59Z"
+		},
+		{
 			"checksumSHA1": "fe0NspvyJjx6DhmTjIpO0zmR+kg=",
 			"path": "github.com/influxdb/influxdb/client",
 			"revision": "afde71eb1740fd763ab9450e1f700ba0e53c36d0",
 			"revisionTime": "2014-12-28T19:15:54Z",
 			"version": "=v0.8.8",
 			"versionExact": "v0.8.8"
+		},
+		{
+			"checksumSHA1": "TDeiKiCXvRCyaC5uBryv5Av5SMk=",
+			"path": "github.com/jmespath/go-jmespath",
+			"revision": "0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74",
+			"revisionTime": "2016-02-02T18:50:14Z"
+		},
+		{
+			"checksumSHA1": "T4PaLboFtj3ClK/pPvbiHxYwJd0=",
+			"path": "github.com/jtolds/gls",
+			"revision": "8ddce2a84170772b95dd5d576c48d517b22cac63",
+			"revisionTime": "2016-01-05T22:08:40Z"
 		},
 		{
 			"checksumSHA1": "09mQOEtlqUoIz/sXFWA/vY1lEPw=",
@@ -343,16 +383,100 @@
 			"revisionTime": "2016-01-15T11:10:02Z"
 		},
 		{
+			"checksumSHA1": "RZOdTSZN/PgcTqko5LzIAzw+UT4=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "Gv/ks20dikzPV0cMqy8Pz9aZJGU=",
+			"path": "github.com/smartystreets/assertions",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "HccvnpX9rsFv9SzBK3U9jYC3Sr4=",
+			"path": "github.com/smartystreets/assertions/internal/go-render/render",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "lpuRmiGuFG4JN6U1edndsQhVDYY=",
+			"path": "github.com/smartystreets/assertions/internal/oglematchers",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "Kvzrrb7AvTf+3R9FGPrOoHcTqHg=",
+			"path": "github.com/smartystreets/assertions/internal/oglemock",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "fqmDhb1Vu5Ian6bKOIK/qKHbfDY=",
+			"path": "github.com/smartystreets/assertions/internal/oglemock/sample/mock_io",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "28/fJ0iD7Syn7KW0twO2/096hO8=",
+			"path": "github.com/smartystreets/assertions/internal/ogletest",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "4PhmMvV0Nu/3QGu+f4wezosML04=",
+			"path": "github.com/smartystreets/assertions/internal/ogletest/srcutil",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "Lq4IjivEPadH4fnuG/3uXyMZHEQ=",
+			"path": "github.com/smartystreets/assertions/internal/reqtrace",
+			"revision": "40711f7748186bbf9c99977cd89f21ce1a229447",
+			"revisionTime": "2016-04-22T19:53:51Z"
+		},
+		{
+			"checksumSHA1": "KYSYYlW1zv3HfpbNSLJpDYj5rJE=",
+			"path": "github.com/smartystreets/goconvey/convey",
+			"revision": "c53abc99456fa3402dd33c15ee51c3e545e04a3f",
+			"revisionTime": "2016-05-23T15:31:47Z"
+		},
+		{
+			"checksumSHA1": "2x3M0H7g69Yul0dydYqLklCFDDA=",
+			"path": "github.com/smartystreets/goconvey/convey/gotest",
+			"revision": "c53abc99456fa3402dd33c15ee51c3e545e04a3f",
+			"revisionTime": "2016-05-23T15:31:47Z"
+		},
+		{
+			"checksumSHA1": "/Vf/BK8DEzagv141VuY7P1UtI40=",
+			"path": "github.com/smartystreets/goconvey/convey/reporting",
+			"revision": "c53abc99456fa3402dd33c15ee51c3e545e04a3f",
+			"revisionTime": "2016-05-23T15:31:47Z"
+		},
+		{
+			"checksumSHA1": "9x9U6gHs3Rd8ENYSIHXgTazYiEA=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "8d64eb7173c7753d6419fd4a9caf057398611364",
+			"revisionTime": "2016-05-24T23:42:29Z"
+		},
+		{
+			"checksumSHA1": "r6WTJyDUKCuA7ICt8cRLjoJpdoY=",
+			"path": "github.com/stretchr/testify/require",
+			"revision": "8d64eb7173c7753d6419fd4a9caf057398611364",
+			"revisionTime": "2016-05-24T23:42:29Z"
+		},
+		{
 			"checksumSHA1": "N5zDlkYc/+g7EwjB3GyHkYfOJAI=",
 			"path": "golang.org/x/crypto/ssh/terminal",
 			"revision": "1777f3ba8c1fed80fcaec3317e3aaa4f627764d2",
 			"revisionTime": "2016-03-18T12:12:46Z"
 		},
 		{
-			"checksumSHA1": "WMRVWZKfmpPuAD9paJXp1YmQFEY=",
+			"checksumSHA1": "88lxkrVVZyBqOBOFnNMBwEexiLY=",
 			"path": "golang.org/x/net/context",
-			"revision": "fb93926129b8ec0056f2f458b1f519654814edf0",
-			"revisionTime": "2016-04-12T22:48:50Z"
+			"revision": "3f122ce3dbbe488b7e6a8bdb26f41edec852a40b",
+			"revisionTime": "2016-06-09T04:57:12Z"
 		},
 		{
 			"checksumSHA1": "eiQWDBulU3IQDIrb6SbQ3ySr2YU=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,240 @@
 	"ignore": "",
 	"package": [
 		{
+			"checksumSHA1": "N4ulLWtRPfGRJcNYgwD2sFSpXAQ=",
+			"path": "github.com/aws/aws-sdk-go/aws",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "AWg3FBA1NTPdIVZipaQf/rGx38o=",
+			"path": "github.com/aws/aws-sdk-go/aws/awserr",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "6YvMGcO1vw1iDoTD5jCYxTKVHyE=",
+			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "RsYlRfQceaAgqjIrExwNsb/RBEM=",
+			"path": "github.com/aws/aws-sdk-go/aws/client",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "2kisALlB2/LZkxlucVvCm+1/mZ8=",
+			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "CC8BP+QNXIs3MprvuXAT6j5oQfs=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "Yh3b24h9uG8ztCuGrzBWB3YwVVo=",
+			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "t9z4goehHyiGgU85snZcFogywwk=",
+			"path": "github.com/aws/aws-sdk-go/aws/defaults",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "2HqBdkS1hmV6tRoCWENP7zhP76c=",
+			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "bMHwuHjff/XMmSc7F4+CvL4vXHU=",
+			"path": "github.com/aws/aws-sdk-go/aws/request",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "JZWWt+LwSsUHDHqRyBRLf1BAT4s=",
+			"path": "github.com/aws/aws-sdk-go/aws/session",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "pKrneJCsQv3jpiSlOlxN9PxcnhQ=",
+			"path": "github.com/aws/aws-sdk-go/awstesting",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "fY/HE8hjs/8eAK3FLmh0LJFF8No=",
+			"path": "github.com/aws/aws-sdk-go/awstesting/mock",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "EH5bYi2J/M/U8nmx+3Ewai/NCzc=",
+			"path": "github.com/aws/aws-sdk-go/awstesting/unit",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "zQ53hIbmk6OBHojC2TqZARrsrIU=",
+			"path": "github.com/aws/aws-sdk-go/private/endpoints",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "YVb6IGbsYv0bBxIflqDLow+vnmY=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "NI2ZiJtAQv5o4YZoAIao5B0rmx0=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "a5aOQgdCqa6fuvy8DUVVHX4Twe4=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "RrKQN1AA4e++Pyqs6LcywNDSdoo=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "To+gA82eBcwtQqzqvHD+okUyARk=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "5xzix1R8prUyWxgLnzUQoxTsfik=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "TW/7U+/8ormL7acf6z2rv2hDD+s=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "Z81MalpRsgsuIuCUxdFKGSfTDBk=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "tsiQbBV6UTqr/VonrgRckifNzQ0=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "LsCIsjbzX2r3n/AhpNJvAC5ueNA=",
+			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "Ot2E8+egDx6PSPD/04bbhbrg4EQ=",
+			"path": "github.com/aws/aws-sdk-go/private/signer/v4",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "01b4hmyUzoReoOyEDylDinWBSdA=",
+			"path": "github.com/aws/aws-sdk-go/private/util",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "QbEoYQYx91JTBRjDy+uyerMim+Y=",
+			"path": "github.com/aws/aws-sdk-go/private/waiter",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "oy2zeRJtv/QKoxLydB08WNC//24=",
+			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "h2l8keT0CEGgtAPZUA2B3X9RClI=",
+			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "AGYBxJu7YAAplQ3+7PslNh5+OlY=",
+			"path": "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "q4h5Zm8v/fpffGN8Wd4AydQQd+0=",
+			"path": "github.com/aws/aws-sdk-go/service/ec2",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "P4i4PADyOyNEX0AnckWvTAAGIg8=",
+			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "gDdKNPqYwkkWAMuIIzkVNzwLeIA=",
+			"path": "github.com/aws/aws-sdk-go/service/kinesis",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "raPOxmCZf3/yShL6qANx++69SOo=",
+			"path": "github.com/aws/aws-sdk-go/service/route53",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "/HK8ojiNI+Ipag1MzNslSZpDr90=",
+			"path": "github.com/aws/aws-sdk-go/service/s3",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "HBr74u7wII+7Xu4wb12f5+fDi5k=",
+			"path": "github.com/aws/aws-sdk-go/service/s3/s3iface",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
+			"checksumSHA1": "0rTtw/kZllvakNne2tUwIqpLMhM=",
+			"path": "github.com/aws/aws-sdk-go/service/s3/s3manager",
+			"revision": "2e1a49c71fb7d8f6b7e8cca2259ed9b68d9b97ce",
+			"revisionTime": "2016-06-13T21:28:44Z"
+		},
+		{
 			"checksumSHA1": "uHYYdl624/j2tsU9fFFN62wZ2JM=",
 			"path": "github.com/coreos/go-etcd/etcd",
 			"revision": "f02171fbd43c7b9b53ce8679b03235a1ef3c7b12",


### PR DESCRIPTION
Implements backup storage on S3 via official aws go sdk.

The code is heavily based on (or copy-pasta'd from) the GCS & Ceph backup plugin.

Review notes:
- The vendored dependencies were fetched as github.com/aws/aws-sdk-go/... It may be possible to bring in a smaller subset.
- Acess is meant to be configured via standard AWS envs/files, which is why there's no config beyond region and bucket (http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs). Should this be documented somewhere? Our deployment uses IAM roles to let the workers access the bucket transparently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1799)
<!-- Reviewable:end -->
