### PR TITLE
tabletserver: enforce AUTOCOMMIT mode

### DIFF
--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -105,19 +105,35 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 	return nil
 }
 
-var getModeSQL = "select @@global.sql_mode"
+var (
+	getModeSQL    = "select @@global.sql_mode"
+	getAutocommit = "select @@autocommit"
+)
 
-// VerifyStrict is a helper method to verify mysql is running with
-// sql_mode = STRICT_TRANS_TABLES.
-func (dbc *DBConnection) VerifyStrict() bool {
+// VerifyMode is a helper method to verify mysql is running with
+// sql_mode = STRICT_TRANS_TABLES and autocommit=ON.
+func (dbc *DBConnection) VerifyMode() error {
 	qr, err := dbc.ExecuteFetch(getModeSQL, 2, false)
 	if err != nil {
-		return false
+		return fmt.Errorf("could not verify mode: %v", err)
 	}
-	if len(qr.Rows) == 0 {
-		return false
+	if len(qr.Rows) != 1 {
+		return fmt.Errorf("incorrect rowcount received for %s: %d", getModeSQL, len(qr.Rows))
 	}
-	return strings.Contains(qr.Rows[0][0].String(), "STRICT_TRANS_TABLES")
+	if !strings.Contains(qr.Rows[0][0].String(), "STRICT_TRANS_TABLES") {
+		return fmt.Errorf("require sql_mode to be STRICT_TRANS_TABLES: got %s", qr.Rows[0][0].String())
+	}
+	qr, err = dbc.ExecuteFetch(getAutocommit, 2, false)
+	if err != nil {
+		return fmt.Errorf("could not verify mode: %v", err)
+	}
+	if len(qr.Rows) != 1 {
+		return fmt.Errorf("incorrect rowcount received for %s: %d", getAutocommit, len(qr.Rows))
+	}
+	if !strings.Contains(qr.Rows[0][0].String(), "1") {
+		return fmt.Errorf("require autocommit to be 1: got %s", qr.Rows[0][0].String())
+	}
+	return nil
 }
 
 // NewDBConnection returns a new DBConnection based on the ConnParams

--- a/go/vt/tabletserver/dbconn.go
+++ b/go/vt/tabletserver/dbconn.go
@@ -142,9 +142,9 @@ func (dbc *DBConn) streamOnce(ctx context.Context, query string, callback func(*
 	return dbc.conn.ExecuteStreamFetch(query, callback, streamBufferSize)
 }
 
-// VerifyStrict returns true if MySQL is in STRICT mode.
-func (dbc *DBConn) VerifyStrict() bool {
-	return dbc.conn.VerifyStrict()
+// VerifyMode returns an error if the connection mode is incorrect.
+func (dbc *DBConn) VerifyMode() error {
+	return dbc.conn.VerifyMode()
 }
 
 // Close closes the DBConn.

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -1020,6 +1020,12 @@ func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
 				{sqltypes.MakeString([]byte("STRICT_TRANS_TABLES"))},
 			},
 		},
+		"select @@autocommit": {
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeString([]byte("1"))},
+			},
+		},
 		baseShowTables: {
 			RowsAffected: 2,
 			Rows: [][]sqltypes.Value{

--- a/go/vt/tabletserver/schema_info.go
+++ b/go/vt/tabletserver/schema_info.go
@@ -152,8 +152,10 @@ func (si *SchemaInfo) Open(dbaParams *sqldb.ConnParams, strictMode bool) {
 	conn := getOrPanic(ctx, si.connPool)
 	defer conn.Recycle()
 
-	if strictMode && !conn.VerifyStrict() {
-		panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not verify strict mode"))
+	if strictMode {
+		if err := conn.VerifyMode(); err != nil {
+			panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, err.Error()))
+		}
 	}
 
 	tableData, err := conn.Exec(ctx, baseShowTables, maxTableCount, false)

--- a/go/vt/tabletserver/schema_info_test.go
+++ b/go/vt/tabletserver/schema_info_test.go
@@ -557,6 +557,12 @@ func getSchemaInfoTestSupportedQueries() map[string]*sqltypes.Result {
 				{sqltypes.MakeString([]byte("STRICT_TRANS_TABLES"))},
 			},
 		},
+		"select @@autocommit": {
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeString([]byte("1"))},
+			},
+		},
 		baseShowTables: {
 			RowsAffected: 3,
 			Rows: [][]sqltypes.Value{

--- a/go/vt/tabletserver/tabletserver_test.go
+++ b/go/vt/tabletserver/tabletserver_test.go
@@ -1377,6 +1377,12 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				{sqltypes.MakeString([]byte("STRICT_TRANS_TABLES"))},
 			},
 		},
+		"select @@autocommit": {
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeString([]byte("1"))},
+			},
+		},
 		"select * from test_table where 1 != 1": {
 			Fields: getTestTableFields(),
 		},


### PR DESCRIPTION
@alainjobart or @enisoc 
VTTablet will not work correctly if AUTOCOMMIT was OFF. This is
because it uses connection pools. If AUTOCOMMIT is OFF, MySQL
will start a transaction at the beginning, which will create a
snapshot of the database that will never change for the rest
of the life's connection. If AUTOCOMMIT was ON, then there's
an implicit commit after every read, which will reset the snapshot
view.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1802)
<!-- Reviewable:end -->
