### PR TITLE
docker: Run govendor sync in common bootstrap image.

### DIFF
--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -87,6 +87,12 @@ COPY travis /vt/src/github.com/youtube/vitess/travis
 COPY composer.json composer.lock /vt/src/github.com/youtube/vitess/
 COPY vendor/vendor.json /vt/src/github.com/youtube/vitess/vendor/
 
+# Download vendored Go dependencies
+RUN cd /vt/src/github.com/youtube/vitess && \
+    go get -u github.com/kardianos/govendor && \
+    govendor sync && \
+    rm -rf /vt/.cache
+
 # Install gRPC (and protobuf) as root
 RUN export MAKEFLAGS="-j$(nproc)" && \
     cd /vt/dist && \


### PR DESCRIPTION
@michael-berlin 

This way, when 'sync' runs in the flavor images, it will see the
checksums already match and finish much faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1803)
<!-- Reviewable:end -->
