### PR TITLE
Disable Native AIO for MySQL 5.6+ flavor.

### DIFF
--- a/config/mycnf/master_mysql56.cnf
+++ b/config/mycnf/master_mysql56.cnf
@@ -4,4 +4,9 @@ gtid_mode = ON
 log_bin
 log_slave_updates
 enforce_gtid_consistency
+
+# Ignore relay logs on disk at startup.
 relay_log_recovery
+
+# Native AIO tends to run into aio-max-nr limit during test startup.
+innodb_use_native_aio = 0


### PR DESCRIPTION
@pivanof 

It causes startup problems for tests that run a lot of mysqld instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1804)
<!-- Reviewable:end -->
