### PR TITLE
vtcombo: Allow vtctl GetSchema and other DBA commands.

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -26,7 +26,7 @@ func (mysqld *Mysqld) GetSchema(dbName string, tables, excludeTables []string, i
 	sd := &tabletmanagerdatapb.SchemaDefinition{}
 
 	// get the database creation command
-	qr, fetchErr := mysqld.FetchSuperQuery(ctx, "SHOW CREATE DATABASE IF NOT EXISTS "+dbName)
+	qr, fetchErr := mysqld.FetchSuperQuery(ctx, fmt.Sprintf("SHOW CREATE DATABASE IF NOT EXISTS `%s`", dbName))
 	if fetchErr != nil {
 		return nil, fetchErr
 	}
@@ -72,7 +72,7 @@ func (mysqld *Mysqld) GetSchema(dbName string, tables, excludeTables []string, i
 			}
 		}
 
-		qr, fetchErr := mysqld.FetchSuperQuery(ctx, "SHOW CREATE TABLE "+dbName+"."+tableName)
+		qr, fetchErr := mysqld.FetchSuperQuery(ctx, fmt.Sprintf("SHOW CREATE TABLE `%s`.`%s`", dbName, tableName))
 		if fetchErr != nil {
 			return nil, fetchErr
 		}
@@ -138,7 +138,7 @@ func (mysqld *Mysqld) GetColumns(dbName, table string) ([]string, error) {
 		return nil, err
 	}
 	defer conn.Recycle()
-	qr, err := conn.ExecuteFetch(fmt.Sprintf("select * from %v.%v where 1=0", dbName, table), 0, true)
+	qr, err := conn.ExecuteFetch(fmt.Sprintf("SELECT * FROM `%s`.`%s` WHERE 1=0", dbName, table), 0, true)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (mysqld *Mysqld) GetPrimaryKeyColumns(dbName, table string) ([]string, erro
 		return nil, err
 	}
 	defer conn.Recycle()
-	qr, err := conn.ExecuteFetch(fmt.Sprintf("show index from %v.%v", dbName, table), 100, true)
+	qr, err := conn.ExecuteFetch(fmt.Sprintf("SHOW INDEX FROM `%v`.`%v`", dbName, table), 100, true)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (mysqld *Mysqld) ApplySchemaChange(dbName string, change *tmutils.SchemaCha
 	}
 
 	// add a 'use XXX' in front of the SQL
-	sql = "USE " + dbName + ";\n" + sql
+	sql = fmt.Sprintf("USE `%s`;\n%s", dbName, sql)
 
 	// execute the schema change using an external mysql process
 	// (to benefit from the extra commands in mysql cli)

--- a/py/vttest/vt_processes.py
+++ b/py/vttest/vt_processes.py
@@ -132,6 +132,9 @@ class VtcomboProcess(VtProcess):
         '-db-config-app-charset', charset,
         '-db-config-app-uname', mysql_db.username(),
         '-db-config-app-pass', mysql_db.password(),
+        '-db-config-dba-charset', charset,
+        '-db-config-dba-uname', mysql_db.username(),
+        '-db-config-dba-pass', mysql_db.password(),
         '-proto_topo', text_format.MessageToString(topology, as_one_line=True),
         '-mycnf_server_id', '1',
         '-mycnf_socket_file', mysql_db.unix_socket(),
@@ -142,11 +145,14 @@ class VtcomboProcess(VtProcess):
       self.extraparams.extend(['-web_dir', web_dir])
     if mysql_db.unix_socket():
       self.extraparams.extend(
-          ['-db-config-app-unixsocket', mysql_db.unix_socket()])
+          ['-db-config-app-unixsocket', mysql_db.unix_socket(),
+           '-db-config-dba-unixsocket', mysql_db.unix_socket()])
     else:
       self.extraparams.extend(
           ['-db-config-app-host', mysql_db.hostname(),
-           '-db-config-app-port', str(mysql_db.port())])
+           '-db-config-app-port', str(mysql_db.port()),
+           '-db-config-dba-host', mysql_db.hostname(),
+           '-db-config-dba-port', str(mysql_db.port())])
 
 
 vtcombo_process = None


### PR DESCRIPTION
@michael-berlin 

Previously vtcombo was only set up to allow app-user connections. Now it also allows dba-user connections, which enables some admin commands to work with vtcombo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1816)
<!-- Reviewable:end -->
