### PR TITLE
test: worker.py: Unflake test_webinterface test.

### DIFF
--- a/test/worker.py
+++ b/test/worker.py
@@ -588,6 +588,11 @@ class TestVtworkerWebinterface(unittest.TestCase):
         raise Exception('Should have thrown an HTTPError for the redirect.')
       except urllib2.HTTPError as e:
         self.assertEqual(e.code, 307)
+      # Wait for the Ping command to finish.
+      utils.poll_for_vars(
+          'vtworker', self.worker_port,
+          'WorkerState == done',
+          condition_fn=lambda v: v.get('WorkerState') == 'done')
       # Verify that the command logged something and its available at /status.
       status = urllib2.urlopen(worker_base_url + '/status').read()
       self.assertIn(


### PR DESCRIPTION
The test was flaky when the "Ping" command (issued through the web interface) was still being executed while we already assumed that it was done. This happened very rarely e.g. 1 out of 1000 times.

@enisoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1824)
<!-- Reviewable:end -->
