### PR TITLE
Test Travis/Sauce on internal PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,7 @@ env:
     - CXX=g++-4.8
     - INSTALL_GRPC_PHP="$HOME/.phpenv/lib"
     - SAUCE_USERNAME=vitess
+    - SAUCE_ACCESS_KEY=24f9fd61-d673-4387-be0c-cedf07ada340
   matrix:
     # NOTE: Travis CI schedules up to 5 tests simultaneously.
     #       All our tests should be spread out as evenly as possible across these 5 slots.


### PR DESCRIPTION
@enisoc 
Testing this PR... if the test still fails I'll probably have to update test.go to add the ability to exclude tests so I can conditionally exclude the webdriver test when TRAVIS_PULL_REQUEST != 'false'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1827)
<!-- Reviewable:end -->
