### PR TITLE
Fix bug in passing conditional test_flags in vtctld k8s template.

### DIFF
--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -49,8 +49,7 @@ spec:
               -service_map 'grpc-vtctl'
               -topo_implementation etcd
               -etcd_global_addrs http://etcd-global:4001
-              {{test_flags}}
-              {{backup_flags}}" vitess
+              {{backup_flags}} {{test_flags}}" vitess
       volumes:
         - name: syslog
           hostPath: {path: /dev/log}


### PR DESCRIPTION
@thompsonja 

When test_flags were empty that resulted in an empty line in the template.
Kubernetes seem to have special treatment for that and it resulted in a new line
after the -etcd_global_addrs flag before the backup flags. And that resulted in
vtctld not seeing the backup flags at all (new line == next command).
For some reason putting test_flags and backup_flags on the same line in that
order resulted in the same behavior (when test_flags is empty the line has extra
space in the beginning of the line and Kubernetes inserts new line before it),
so I'm reversing their order.

The bug was introduced by https://github.com/youtube/vitess/pull/1809, in the
commit https://github.com/youtube/vitess/commit/3d82402706.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1833)
<!-- Reviewable:end -->
