### PR TITLE
Generate protobuf files during compilation and fix the generation rules.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ _test/
 
 #pom generated file
 /java/jdbc/dependency-reduced-pom.xml
+
+# generated protobuf files
+/go/vt/.proto.tmp


### PR DESCRIPTION
@enisoc @michael-berlin 

The change achieves the following:
1. Removes generated protobuf files for Go and Python and instead adds
   generation of these files during build by adding dependency of 'build' rule
   on 'proto' rule.
2. Modifies the generation of protobuf files to be more in line of how Makefiles
   should be written. This has an additional benefit that protobuf files won't
   be regenerated if proto files did not change.
3. Modifies the generation rules to work both locally on a workstation and
   inside the docker image. Docker image doesn't have /vt/dist/grpc installed,
   so the existing rule didn't work.

Note that as a result of this a new directory go/vt/.proto.tmp will exist after
building. I believe that should be fine and won't interfere with anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1834)
<!-- Reviewable:end -->
