### PR TITLE
vtworkerclient: Remove --action_timeout.

### DIFF
--- a/go/cmd/vtworkerclient/vtworkerclient.go
+++ b/go/cmd/vtworkerclient/vtworkerclient.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -19,17 +18,14 @@ import (
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 )
 
-// The default values used by these flags cannot be taken from wrangler and
-// actionnode modules, as we don't want to depend on them at all.
 var (
-	actionTimeout = flag.Duration("action_timeout", time.Hour, "timeout for the total command")
-	server        = flag.String("server", "", "server to use for connection")
+	server = flag.String("server", "", "server to use for connection")
 )
 
 func main() {
 	flag.Parse()
 
-	ctx, cancel := context.WithTimeout(context.Background(), *actionTimeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)


### PR DESCRIPTION
The timeout flag makes sense for vtctlclient but not for vtworker RPCs which may run for days.

@alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1842)
<!-- Reviewable:end -->
