### PR TITLE
worker: Fix that the number of threads in the status was off by one.

### DIFF
--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -722,7 +722,7 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 		if err != nil {
 			return err
 		}
-		tableStatusList.setThreadCount(tableIndex, len(chunks)-1)
+		tableStatusList.setThreadCount(tableIndex, len(chunks))
 
 		for _, c := range chunks {
 			sourceWaitGroup.Add(1)


### PR DESCRIPTION
The old chunk generator code generated "threads+1" chunks. The new code generates "threads" chunks instead. I forgot to adjust the number of threads for the table status.

@alainjobart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1848)
<!-- Reviewable:end -->
