### PR TITLE
worker: SplitClone: At chunk start wait up to 2 hours for healthy sou…

### DIFF
--- a/go/vt/worker/executor.go
+++ b/go/vt/worker/executor.go
@@ -76,7 +76,7 @@ func (e *executor) fetchLoop(ctx context.Context, insertChannel chan string) err
 // executeFetchWithRetries will always get the current MASTER tablet from the
 // healthcheck instance. If no MASTER is available, it will keep retrying.
 func (e *executor) fetchWithRetries(ctx context.Context, command string) error {
-	retryDuration := 2 * time.Hour
+	retryDuration := *retryDuration
 	// We should keep retrying up until the retryCtx runs out.
 	retryCtx, retryCancel := context.WithTimeout(ctx, retryDuration)
 	defer retryCancel()

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -36,6 +36,7 @@ type Worker interface {
 }
 
 var (
+	retryDuration         = flag.Duration("retry_duration", 2*time.Hour, "Amount of time we wait before giving up on a retryable action (e.g. write to destination, waiting for healthy tablets)")
 	executeFetchRetryTime = flag.Duration("executefetch_retry_time", 30*time.Second, "Amount of time we should wait before retrying ExecuteFetch calls")
 	remoteActionsTimeout  = flag.Duration("remote_actions_timeout", time.Minute, "Amount of time to wait for remote actions (like replication stop, ...)")
 	useV3ReshardingMode   = flag.Bool("use_v3_resharding_mode", false, "True iff the workers should use V3-style resharding, which doesn't require a preset sharding key column.")


### PR DESCRIPTION
…rce and destination tablets.

Thix fixes the problem that SplitClone immediately failed when the destination tablets became unhealthy because a previous chunk pipeline inserted data too fast.

I've reused the existing timeout of 2 hours (from the destination writes) and made it configurable as global flag "--retry_duration".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1858)
<!-- Reviewable:end -->
