### PR TITLE
worker: SplitClone: Do not overwrite the state in waitForTablets().

### DIFF
--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -551,8 +551,6 @@ func (scw *SplitCloneWorker) findDestinationMasters(ctx context.Context) error {
 // waitForTablets waits for enough serving tablets in the given
 // shard (which can be used as input during the diff).
 func (scw *SplitCloneWorker) waitForTablets(ctx context.Context, shardInfos []*topo.ShardInfo, timeout time.Duration) error {
-	scw.setState(WorkerStateFindTargets)
-
 	var wg sync.WaitGroup
 	rec := concurrency.AllErrorRecorder{}
 	for _, si := range shardInfos {


### PR DESCRIPTION
This unflakes the worker.py test which requires to observe vtworker in the clone state such that it can run the reparent.

The issue was introduced in https://github.com/youtube/vitess/pull/1858 where waitForTablets() was added as part of the clone phase.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1860)
<!-- Reviewable:end -->
