### PR TITLE
sqlannotation fixes

### DIFF
--- a/go/vt/sqlannotation/sqlannotation_test.go
+++ b/go/vt/sqlannotation/sqlannotation_test.go
@@ -45,21 +45,22 @@ func verifyParseError(t *testing.T, sql string) {
 	}
 }
 
+var IsDMLTests = []struct {
+	sql   string
+	isDML bool
+}{
+	{"   update ...", true},
+	{"UPDATE ...", true},
+	{"\n\t    delete ...", true},
+	{"insert ...", true},
+	{"select ...", false},
+	{"    select ...", false},
+	{"", false},
+	{" ", false},
+}
+
 func TestIsDML(t *testing.T) {
-	tests := []struct {
-		sql   string
-		isDML bool
-	}{
-		{"   update ...", true},
-		{"UPDATE ...", true},
-		{" \n  delete ...", true},
-		{"insert ...", true},
-		{"select ...", false},
-		{"    select ...", false},
-		{"", false},
-		{" ", false},
-	}
-	for _, test := range tests {
+	for _, test := range IsDMLTests {
 		if dml := IsDML(test.sql); dml != test.isDML {
 			t.Errorf("IsDML(%q) = %t, got %t", test.sql, dml, test.isDML)
 		}
@@ -87,5 +88,11 @@ func BenchmarkExtractKeySpaceIDReplicationUnfriendly(b *testing.B) {
 func BenchmarkExtractKeySpaceIDNothing(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		ExtractKeySpaceID("DML")
+	}
+}
+
+func BenchmarkIsDML(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		IsDML("UPDATE ultimatequestion set answer=42 where question = 'What do you get if you multiply six by nine?'")
 	}
 }


### PR DESCRIPTION
* reinstating a varz lost in CL 127386781
* adding a benchmark for IsDML
* adding throttled logging of filtered-replication-unfriendly statements
* adding a tab character to IsDML tests

NOTE: Changes were already LGTM'd internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1874)
<!-- Reviewable:end -->
