### PR TITLE
mysqlctl: Look for mysqld in either sbin or bin.

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -395,9 +395,10 @@ func execCmd(name string, args, env []string, dir string, input io.Reader) (cmd 
 	out, err := cmd.CombinedOutput()
 	output = string(out)
 	if err != nil {
-		err = errors.New(name + ": " + output)
+		log.Infof("execCmd: %v failed: %v", name, err)
+		err = fmt.Errorf("%v: %v, output: %v", name, err, output)
 	}
-	log.Infof("execCmd: command returned: %v", output)
+	log.Infof("execCmd: %v output: %v", name, output)
 	return cmd, output, err
 }
 


### PR DESCRIPTION
@alainjobart 

Some package systems like homebrew on OS X place mysqld in `$VT_MYSQL_ROOT/bin`, while others like Debian/Ubuntu place mysqld in `$VT_MYSQL_ROOT/sbin`.

Fixes #1864.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1876)
<!-- Reviewable:end -->
