### PR TITLE
b/29618677: limit max concurrent requests

### DIFF
--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -49,6 +49,7 @@ func init() {
 	flag.StringVar(&qsConfig.DebugURLPrefix, "debug-url-prefix", DefaultQsConfig.DebugURLPrefix, "debug url prefix, vttablet will report various system debug pages and this config controls the prefix of these debug urls")
 	flag.StringVar(&qsConfig.PoolNamePrefix, "pool-name-prefix", DefaultQsConfig.PoolNamePrefix, "pool name prefix, vttablet has several pools and each of them has a name. This config specifies the prefix of these pool names")
 	flag.BoolVar(&qsConfig.EnableAutoCommit, "enable-autocommit", DefaultQsConfig.EnableAutoCommit, "if the flag is on, a DML outsides a transaction will be auto committed.")
+	flag.IntVar(&qsConfig.MaxConcurrentRequests, "max_concurrent_requests", DefaultQsConfig.MaxConcurrentRequests, "Limit the number of allowed concurrent requests to this amount")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -59,28 +60,29 @@ func Init() {
 
 // Config contains all the configuration for query service
 type Config struct {
-	PoolSize             int
-	StreamPoolSize       int
-	TransactionCap       int
-	TransactionTimeout   float64
-	MaxResultSize        int
-	MaxDMLRows           int
-	StreamBufferSize     int
-	QueryCacheSize       int
-	SchemaReloadTime     float64
-	QueryTimeout         float64
-	TxPoolTimeout        float64
-	IdleTimeout          float64
-	StrictMode           bool
-	StrictTableAcl       bool
-	TerseErrors          bool
-	EnablePublishStats   bool
-	EnableAutoCommit     bool
-	EnableTableAclDryRun bool
-	StatsPrefix          string
-	DebugURLPrefix       string
-	PoolNamePrefix       string
-	TableAclExemptACL    string
+	PoolSize              int
+	StreamPoolSize        int
+	TransactionCap        int
+	TransactionTimeout    float64
+	MaxResultSize         int
+	MaxDMLRows            int
+	StreamBufferSize      int
+	QueryCacheSize        int
+	SchemaReloadTime      float64
+	QueryTimeout          float64
+	TxPoolTimeout         float64
+	IdleTimeout           float64
+	StrictMode            bool
+	StrictTableAcl        bool
+	TerseErrors           bool
+	EnablePublishStats    bool
+	EnableAutoCommit      bool
+	EnableTableAclDryRun  bool
+	StatsPrefix           string
+	DebugURLPrefix        string
+	PoolNamePrefix        string
+	TableAclExemptACL     string
+	MaxConcurrentRequests int
 }
 
 // DefaultQsConfig is the default value for the query service config.
@@ -91,28 +93,29 @@ type Config struct {
 // great (the overhead makes the final packets on the wire about twice
 // bigger than this).
 var DefaultQsConfig = Config{
-	PoolSize:             16,
-	StreamPoolSize:       750,
-	TransactionCap:       20,
-	TransactionTimeout:   30,
-	MaxResultSize:        10000,
-	MaxDMLRows:           500,
-	QueryCacheSize:       5000,
-	SchemaReloadTime:     30 * 60,
-	QueryTimeout:         0,
-	TxPoolTimeout:        1,
-	IdleTimeout:          30 * 60,
-	StreamBufferSize:     32 * 1024,
-	StrictMode:           true,
-	StrictTableAcl:       false,
-	TerseErrors:          false,
-	EnablePublishStats:   true,
-	EnableAutoCommit:     false,
-	EnableTableAclDryRun: false,
-	StatsPrefix:          "",
-	DebugURLPrefix:       "/debug",
-	PoolNamePrefix:       "",
-	TableAclExemptACL:    "",
+	PoolSize:              16,
+	StreamPoolSize:        750,
+	TransactionCap:        20,
+	TransactionTimeout:    30,
+	MaxResultSize:         10000,
+	MaxDMLRows:            500,
+	QueryCacheSize:        5000,
+	SchemaReloadTime:      30 * 60,
+	QueryTimeout:          0,
+	TxPoolTimeout:         1,
+	IdleTimeout:           30 * 60,
+	StreamBufferSize:      32 * 1024,
+	StrictMode:            true,
+	StrictTableAcl:        false,
+	TerseErrors:           false,
+	EnablePublishStats:    true,
+	EnableAutoCommit:      false,
+	EnableTableAclDryRun:  false,
+	StatsPrefix:           "",
+	DebugURLPrefix:        "/debug",
+	PoolNamePrefix:        "",
+	TableAclExemptACL:     "",
+	MaxConcurrentRequests: 100000,
 }
 
 var qsConfig Config


### PR DESCRIPTION
@alainjobart @enisoc 
There was previously no limit on how many concurrent requests
VTTablet could accept. This change allows you to set such a limit
to prevent too many requests from OOMing the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1882)
<!-- Reviewable:end -->
