### PR TITLE
Freeing up connections in tmclient.

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -769,3 +769,6 @@ func (itmc *internalTabletManagerClient) Backup(ctx context.Context, tablet *top
 func (itmc *internalTabletManagerClient) RestoreFromBackup(ctx context.Context, tablet *topodatapb.Tablet) (logutil.EventStream, error) {
 	return nil, fmt.Errorf("not implemented in vtcombo")
 }
+
+func (itmc *internalTabletManagerClient) Close() {
+}

--- a/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
+++ b/go/vt/tabletmanager/agentrpctest/test_agent_rpc.go
@@ -1307,4 +1307,6 @@ func Run(t *testing.T, client tmclient.TabletManagerClient, tablet *topodatapb.T
 	// Backup / restore related methods
 	agentRPCTestBackupPanic(ctx, t, client, tablet)
 	agentRPCTestRestoreFromBackupPanic(ctx, t, client, tablet)
+
+	client.Close()
 }

--- a/go/vt/tabletmanager/faketmclient/fake_client.go
+++ b/go/vt/tabletmanager/faketmclient/fake_client.go
@@ -284,3 +284,11 @@ func (client *FakeTabletManagerClient) Backup(ctx context.Context, tablet *topod
 func (client *FakeTabletManagerClient) RestoreFromBackup(ctx context.Context, tablet *topodatapb.Tablet) (logutil.EventStream, error) {
 	return &eofEventStream{}, nil
 }
+
+//
+// Management related methods
+//
+
+// Close is part of the tmclient.TabletManagerClient interface.
+func (client *FakeTabletManagerClient) Close() {
+}

--- a/go/vt/tabletmanager/grpctmclient/client.go
+++ b/go/vt/tabletmanager/grpctmclient/client.go
@@ -750,6 +750,7 @@ func (client *Client) RestoreFromBackup(ctx context.Context, tablet *topodatapb.
 // Close is part of the tmclient.TabletManagerClient interface.
 func (client *Client) Close() {
 	client.mu.Lock()
+	defer client.mu.Unlock()
 	for _, c := range client.rpcClientMap {
 		close(c)
 		for ch := range c {
@@ -757,5 +758,4 @@ func (client *Client) Close() {
 		}
 	}
 	client.rpcClientMap = nil
-	client.mu.Unlock()
 }

--- a/go/vt/tabletmanager/tmclient/rpc_client_api.go
+++ b/go/vt/tabletmanager/tmclient/rpc_client_api.go
@@ -185,6 +185,14 @@ type TabletManagerClient interface {
 
 	// RestoreFromBackup deletes local data and restores database from backup
 	RestoreFromBackup(ctx context.Context, tablet *topodatapb.Tablet) (logutil.EventStream, error)
+
+	//
+	// Management methods
+	//
+
+	// Close will be called when this TabletManagerClient won't be
+	// used any more. It can be used to free any resource.
+	Close()
 }
 
 // TabletManagerClientFactory is the factory method to create

--- a/go/vt/vtctl/grpcvtctlserver/server.go
+++ b/go/vt/vtctl/grpcvtctlserver/server.go
@@ -49,7 +49,9 @@ func (s *VtctlServer) ExecuteVtctlCommand(args *vtctldatapb.ExecuteVtctlCommandR
 	logger := logutil.NewTeeLogger(logstream, logutil.NewConsoleLogger())
 
 	// create the wrangler
-	wr := wrangler.New(logger, s.ts, tmclient.NewTabletManagerClient())
+	tmc := tmclient.NewTabletManagerClient()
+	defer tmc.Close()
+	wr := wrangler.New(logger, s.ts, tmc)
 
 	// execute the command
 	return vtctl.RunCommand(stream.Context(), wr, args.Args)


### PR DESCRIPTION
Adding a Close method, using it to free up resources used by the
tmclient inside vtctld.

@michael-berlin there is only one place where we need to call Close inside vtctld. The worker one is a global instance that's never closed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1883)
<!-- Reviewable:end -->
