### PR TITLE
Revert "b/29618677: limit max concurrent requests"

### DIFF
--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -49,7 +49,6 @@ func init() {
 	flag.StringVar(&qsConfig.DebugURLPrefix, "debug-url-prefix", DefaultQsConfig.DebugURLPrefix, "debug url prefix, vttablet will report various system debug pages and this config controls the prefix of these debug urls")
 	flag.StringVar(&qsConfig.PoolNamePrefix, "pool-name-prefix", DefaultQsConfig.PoolNamePrefix, "pool name prefix, vttablet has several pools and each of them has a name. This config specifies the prefix of these pool names")
 	flag.BoolVar(&qsConfig.EnableAutoCommit, "enable-autocommit", DefaultQsConfig.EnableAutoCommit, "if the flag is on, a DML outsides a transaction will be auto committed.")
-	flag.IntVar(&qsConfig.MaxConcurrentRequests, "max_concurrent_requests", DefaultQsConfig.MaxConcurrentRequests, "Limit the number of allowed concurrent requests to this amount")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -60,29 +59,28 @@ func Init() {
 
 // Config contains all the configuration for query service
 type Config struct {
-	PoolSize              int
-	StreamPoolSize        int
-	TransactionCap        int
-	TransactionTimeout    float64
-	MaxResultSize         int
-	MaxDMLRows            int
-	StreamBufferSize      int
-	QueryCacheSize        int
-	SchemaReloadTime      float64
-	QueryTimeout          float64
-	TxPoolTimeout         float64
-	IdleTimeout           float64
-	StrictMode            bool
-	StrictTableAcl        bool
-	TerseErrors           bool
-	EnablePublishStats    bool
-	EnableAutoCommit      bool
-	EnableTableAclDryRun  bool
-	StatsPrefix           string
-	DebugURLPrefix        string
-	PoolNamePrefix        string
-	TableAclExemptACL     string
-	MaxConcurrentRequests int
+	PoolSize             int
+	StreamPoolSize       int
+	TransactionCap       int
+	TransactionTimeout   float64
+	MaxResultSize        int
+	MaxDMLRows           int
+	StreamBufferSize     int
+	QueryCacheSize       int
+	SchemaReloadTime     float64
+	QueryTimeout         float64
+	TxPoolTimeout        float64
+	IdleTimeout          float64
+	StrictMode           bool
+	StrictTableAcl       bool
+	TerseErrors          bool
+	EnablePublishStats   bool
+	EnableAutoCommit     bool
+	EnableTableAclDryRun bool
+	StatsPrefix          string
+	DebugURLPrefix       string
+	PoolNamePrefix       string
+	TableAclExemptACL    string
 }
 
 // DefaultQsConfig is the default value for the query service config.
@@ -93,29 +91,28 @@ type Config struct {
 // great (the overhead makes the final packets on the wire about twice
 // bigger than this).
 var DefaultQsConfig = Config{
-	PoolSize:              16,
-	StreamPoolSize:        750,
-	TransactionCap:        20,
-	TransactionTimeout:    30,
-	MaxResultSize:         10000,
-	MaxDMLRows:            500,
-	QueryCacheSize:        5000,
-	SchemaReloadTime:      30 * 60,
-	QueryTimeout:          0,
-	TxPoolTimeout:         1,
-	IdleTimeout:           30 * 60,
-	StreamBufferSize:      32 * 1024,
-	StrictMode:            true,
-	StrictTableAcl:        false,
-	TerseErrors:           false,
-	EnablePublishStats:    true,
-	EnableAutoCommit:      false,
-	EnableTableAclDryRun:  false,
-	StatsPrefix:           "",
-	DebugURLPrefix:        "/debug",
-	PoolNamePrefix:        "",
-	TableAclExemptACL:     "",
-	MaxConcurrentRequests: 100000,
+	PoolSize:             16,
+	StreamPoolSize:       750,
+	TransactionCap:       20,
+	TransactionTimeout:   30,
+	MaxResultSize:        10000,
+	MaxDMLRows:           500,
+	QueryCacheSize:       5000,
+	SchemaReloadTime:     30 * 60,
+	QueryTimeout:         0,
+	TxPoolTimeout:        1,
+	IdleTimeout:          30 * 60,
+	StreamBufferSize:     32 * 1024,
+	StrictMode:           true,
+	StrictTableAcl:       false,
+	TerseErrors:          false,
+	EnablePublishStats:   true,
+	EnableAutoCommit:     false,
+	EnableTableAclDryRun: false,
+	StatsPrefix:          "",
+	DebugURLPrefix:       "/debug",
+	PoolNamePrefix:       "",
+	TableAclExemptACL:    "",
 }
 
 var qsConfig Config

--- a/go/vt/tabletserver/endtoend/config_test.go
+++ b/go/vt/tabletserver/endtoend/config_test.go
@@ -128,34 +128,6 @@ func TestPoolSize(t *testing.T) {
 	}
 }
 
-func TestMaxConcurrency(t *testing.T) {
-	defer framework.Server.SetMaxConcurrentRequests(framework.Server.MaxConcurrentRequests())
-	framework.Server.SetMaxConcurrentRequests(1)
-
-	var err1, err2 error
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		_, err1 = framework.NewClient().Execute("select sleep(0.5) from dual", nil)
-		wg.Done()
-	}()
-	// The queries have to be different so consolidator doesn't kick in.
-	go func() {
-		_, err2 = framework.NewClient().Execute("select sleep(0.49) from dual", nil)
-		wg.Done()
-	}()
-	wg.Wait()
-
-	err := err1
-	if err == nil {
-		err = err2
-	}
-	want := "Concurrent requests exceeded max"
-	if err == nil || !strings.Contains(err1.Error(), want) {
-		t.Errorf("Exec: %v, at least one should contain %s", err, want)
-	}
-}
-
 func TestQueryCache(t *testing.T) {
 	defer framework.Server.SetQueryCacheCap(framework.Server.QueryCacheCap())
 	framework.Server.SetQueryCacheCap(1)

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -86,14 +86,13 @@ type TabletServer struct {
 	// for health checks. This does not affect how queries are served.
 	// target specifies the primary target type, and also allow specifies
 	// secondary types that should be additionally allowed.
-	mu           sync.Mutex
-	state        int64
-	lameduck     sync2.AtomicInt32
-	target       querypb.Target
-	alsoAllow    []topodatapb.TabletType
-	requests     sync.WaitGroup
-	begins       sync.WaitGroup
-	requestCount sync2.AtomicInt64
+	mu        sync.Mutex
+	state     int64
+	lameduck  sync2.AtomicInt32
+	target    querypb.Target
+	alsoAllow []topodatapb.TabletType
+	requests  sync.WaitGroup
+	begins    sync.WaitGroup
 
 	// The following variables should be initialized only once
 	// before starting the tabletserver. For backward compatibility,
@@ -1153,10 +1152,6 @@ verifyTarget:
 	return NewTabletError(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, "No target")
 
 ok:
-	if tsv.requestCount.Get() >= int64(tsv.config.MaxConcurrentRequests) {
-		return NewTabletError(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, "Concurrent requests exceeded max: %d", tsv.config.MaxConcurrentRequests)
-	}
-	tsv.requestCount.Add(1)
 	tsv.requests.Add(1)
 	// If it's a begin, we should make the shutdown code
 	// wait for the call to end before it waits for tx empty.
@@ -1168,11 +1163,10 @@ ok:
 
 // endRequest unregisters the current request (a waitgroup) as done.
 func (tsv *TabletServer) endRequest(isBegin bool) {
+	tsv.requests.Done()
 	if isBegin {
 		tsv.begins.Done()
 	}
-	tsv.requests.Done()
-	tsv.requestCount.Add(-1)
 }
 
 func (tsv *TabletServer) registerDebugHealthHandler() {
@@ -1297,18 +1291,6 @@ func (tsv *TabletServer) SetMaxDMLRows(val int) {
 // MaxDMLRows returns the max result size.
 func (tsv *TabletServer) MaxDMLRows() int {
 	return int(tsv.qe.maxDMLRows.Get())
-}
-
-// SetMaxConcurrentRequests sets the max concurrent requests to the new value.
-// This function is not thread safe.
-func (tsv *TabletServer) SetMaxConcurrentRequests(val int) {
-	tsv.config.MaxConcurrentRequests = val
-}
-
-// MaxConcurrentRequests returns the max concurrent requests value.
-// This function is not thread safe.
-func (tsv *TabletServer) MaxConcurrentRequests() int {
-	return tsv.config.MaxConcurrentRequests
 }
 
 func init() {


### PR DESCRIPTION
@alainjobart @enisoc 
This reverts commit 1466c4b024c6423f27cd3ebb5b4ce7d52d59d855.
The fix was found to be ineffective because the OOM was at the
grpc level. We'll need to follow up with grpc team on this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1887)
<!-- Reviewable:end -->
