### PR TITLE
L2VTGate improvements and end-to-end tests.

### DIFF
--- a/go/flagutil/flagutil_test.go
+++ b/go/flagutil/flagutil_test.go
@@ -29,6 +29,18 @@ func TestStringList(t *testing.T) {
 	}
 }
 
+// TestEmptyStringList verifies that an empty parameter results in an empty list
+func TestEmptyStringList(t *testing.T) {
+	var p StringListValue
+	var _ flag.Value = &p
+	if err := p.Set(""); err != nil {
+		t.Fatalf("p.Set(\"\"): %v", err)
+	}
+	if len(p) != 0 {
+		t.Fatalf("len(p) != 0: got %v", len(p))
+	}
+}
+
 type pair struct {
 	in  string
 	out map[string]string

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -270,10 +270,8 @@ func (fbs *FilterByShard) isIncluded(tablet *topodatapb.Tablet) bool {
 			// Exact match (probably a non-sharded keyspace).
 			return true
 		}
-		if kr != nil && c.keyRange != nil && key.KeyRangesIntersect(kr, c.keyRange) {
-			// There is overlap, we can just send to the destination.
-			// FIXME(alainjobart) if canonical is not entirely covered by filter,
-			// this is probably an error. We probably want key.KeyRangeIncludes(), NYI.
+		if kr != nil && c.keyRange != nil && key.KeyRangeIncludes(c.keyRange, kr) {
+			// Our filter's KeyRange includes the provided KeyRange
 			return true
 		}
 	}

--- a/go/vt/key/key.go
+++ b/go/vt/key/key.go
@@ -168,6 +168,29 @@ func KeyRangesOverlap(first, second *topodatapb.KeyRange) (*topodatapb.KeyRange,
 	return &result, nil
 }
 
+// KeyRangeIncludes returns true if the first provided KeyRange, big,
+// contains the second KeyRange, small. If they intersect, but small
+// spills out, this returns false.
+func KeyRangeIncludes(big, small *topodatapb.KeyRange) bool {
+	if big == nil {
+		// The outside one covers everything, we're good.
+		return true
+	}
+	if small == nil {
+		// The smaller one covers everything, better have the
+		// bigger one also cover everything.
+		return len(big.Start) == 0 && len(big.End) == 0
+	}
+	// Now we check small.Start >= big.Start, and small.End <= big.End
+	if len(big.Start) != 0 && bytes.Compare(small.Start, big.Start) < 0 {
+		return false
+	}
+	if len(big.End) != 0 && (len(small.End) == 0 || bytes.Compare(small.End, big.End) > 0) {
+		return false
+	}
+	return true
+}
+
 // ParseShardingSpec parses a string that describes a sharding
 // specification. a-b-c-d will be parsed as a-b, b-c, c-d. The empty
 // string may serve both as the start and end of the keyspace: -a-b-

--- a/go/vt/vtgate/gateway/l2vtgategateway.go
+++ b/go/vt/vtgate/gateway/l2vtgategateway.go
@@ -310,10 +310,9 @@ func (lg *l2VTGateGateway) getConn(keyspace, shard string) (*l2VTGateConn, error
 			// Exact match (probably a non-sharded keyspace).
 			return c, nil
 		}
-		if kr != nil && c.keyRange != nil && key.KeyRangesIntersect(kr, c.keyRange) {
-			// There is overlap, we can just send to the destination.
-			// FIXME(alainjobart) if canonical is not entirely covered by l2vtgate,
-			// this is probably an error. We probably want key.KeyRangeIncludes(), NYI.
+		if kr != nil && c.keyRange != nil && key.KeyRangeIncludes(c.keyRange, kr) {
+			// The shard KeyRange is included in this destination's
+			// KeyRange, that's the destination we want.
 			return c, nil
 		}
 	}

--- a/go/vt/vtgate/gateway/l2vtgategateway.go
+++ b/go/vt/vtgate/gateway/l2vtgategateway.go
@@ -310,7 +310,7 @@ func (lg *l2VTGateGateway) getConn(keyspace, shard string) (*l2VTGateConn, error
 			// Exact match (probably a non-sharded keyspace).
 			return c, nil
 		}
-		if key.KeyRangesIntersect(kr, c.keyRange) {
+		if kr != nil && c.keyRange != nil && key.KeyRangesIntersect(kr, c.keyRange) {
 			// There is overlap, we can just send to the destination.
 			// FIXME(alainjobart) if canonical is not entirely covered by l2vtgate,
 			// this is probably an error. We probably want key.KeyRangeIncludes(), NYI.

--- a/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
+++ b/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
@@ -67,8 +67,12 @@ func TestGRPCDiscovery(t *testing.T) {
 	ctx := context.Background()
 	defer dg.Close(ctx)
 
-	// and run the test suite.
+	// run the test suite.
 	TestSuite(t, "discovery-grpc", dg, service)
+
+	// run it again with vtgate combining Begin and Execute
+	flag.Set("tablet_grpc_combine_begin_execute", "true")
+	TestSuite(t, "discovery-grpc-combo", dg, service)
 }
 
 // TestL2VTGateDiscovery tests the l2vtgate gateway with a gRPC

--- a/test/config.json
+++ b/test/config.json
@@ -375,6 +375,17 @@
 				"site_test"
 			]
 		},
+		"vtgatev2_l2vtgate": {
+			"File": "vtgatev2_l2vtgate_test.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 1,
+			"RetryMax": 0,
+			"Tags": [
+				"site_test"
+			]
+		},
 		"vtgatev3": {
 			"File": "vtgatev3_test.py",
 			"Args": [],

--- a/test/config.json
+++ b/test/config.json
@@ -100,6 +100,17 @@
 				"worker_test"
 			]
 		},
+		"initial_sharding_l2vtgate": {
+			"File": "initial_sharding_l2vtgate.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 2,
+			"RetryMax": 0,
+			"Tags": [
+				"worker_test"
+			]
+		},
 		"legacy_resharding": {
 			"File": "legacy_resharding.py",
 			"Args": [],

--- a/test/initial_sharding_l2vtgate.py
+++ b/test/initial_sharding_l2vtgate.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+#
+# Copyright 2016, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+"""Re-runs initial_sharding.py with a l2vtgate process."""
+
+import initial_sharding
+import utils
+
+if __name__ == '__main__':
+  initial_sharding.use_l2vtgate = True
+  utils.main(initial_sharding)

--- a/test/vtgatev2_l2vtgate_test.py
+++ b/test/vtgatev2_l2vtgate_test.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+#
+# Copyright 2016, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+"""Re-runs vtgatev2_test.py with a l2vtgate process."""
+
+import vtgatev2_test
+import utils
+
+# this test is just re-running an entire vtgatev2_test.py with a
+# l2vtgate process in the middle
+if __name__ == '__main__':
+  vtgatev2_test.use_l2vtgate = True
+  utils.main(vtgatev2_test)


### PR DESCRIPTION
Adding flavors of vtgatev2_test and initial_sharding that go through l2vtgate.

In the process, I realized that with Discovery Gateway inside a l2vtgate, there was no way to filter the tablet list. Since l2vtgate processes are meant to watch a subset of tablets only, that was unfortunate, so fixed it.

@michael-berlin @enisoc whoever gets there first...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1896)
<!-- Reviewable:end -->
