### PR TITLE
Exposing BeginExecute* calls in QueryService.

### DIFF
--- a/go/vt/tabletserver/queryservice/fakes/error_query_service.go
+++ b/go/vt/tabletserver/queryservice/fakes/error_query_service.go
@@ -49,6 +49,16 @@ func (e *ErrorQueryService) ExecuteBatch(ctx context.Context, target *querypb.Ta
 	return nil, fmt.Errorf("ErrorQueryService does not implement any method")
 }
 
+// BeginExecute is part of QueryService interface
+func (e *ErrorQueryService) BeginExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("ErrorQueryService does not implement any method")
+}
+
+// BeginExecuteBatch is part of QueryService interface
+func (e *ErrorQueryService) BeginExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	return nil, 0, fmt.Errorf("ErrorQueryService does not implement any method")
+}
+
 // SplitQuery is part of QueryService interface
 // TODO(erez): Remove once the migration to SplitQuery V2 is done.
 func (e *ErrorQueryService) SplitQuery(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error) {

--- a/go/vt/tabletserver/queryservice/queryservice.go
+++ b/go/vt/tabletserver/queryservice/queryservice.go
@@ -32,8 +32,10 @@ type QueryService interface {
 	StreamExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, sendReply func(*sqltypes.Result) error) error
 	ExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error)
 
-	// Combo methods: if err != nil, the transactionID may still
-	// be non-zero, and needs to be propagated back.
+	// Combo methods, they also return the transactionID from the
+	// Begin part. If err != nil, the transactionID may still be
+	// non-zero, and needs to be propagated back (like for a DB
+	// Integrity Error)
 	BeginExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error)
 	BeginExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error)
 

--- a/go/vt/tabletserver/queryservice/queryservice.go
+++ b/go/vt/tabletserver/queryservice/queryservice.go
@@ -28,10 +28,14 @@ type QueryService interface {
 	Rollback(ctx context.Context, target *querypb.Target, transactionID int64) error
 
 	// Query execution
-
 	Execute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, transactionID int64) (*sqltypes.Result, error)
 	StreamExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, sendReply func(*sqltypes.Result) error) error
 	ExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool, transactionID int64) ([]sqltypes.Result, error)
+
+	// Combo methods: if err != nil, the transactionID may still
+	// be non-zero, and needs to be propagated back.
+	BeginExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error)
+	BeginExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error)
 
 	// SplitQuery is a map reduce helper function
 	// TODO(erez): Remove this and rename the following func to SplitQuery

--- a/go/vt/tabletserver/queryservice/queryservice_testing/mock_queryservice.go
+++ b/go/vt/tabletserver/queryservice/queryservice_testing/mock_queryservice.go
@@ -95,6 +95,30 @@ func (_mr *_MockQueryServiceRecorder) ExecuteBatch(arg0, arg1, arg2, arg3, arg4 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ExecuteBatch", arg0, arg1, arg2, arg3, arg4)
 }
 
+func (_m *MockQueryService) BeginExecute(ctx context.Context, target *query.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error) {
+	ret := _m.ctrl.Call(_m, "BeginExecute", ctx, target, sql, bindVariables)
+	ret0, _ := ret[0].(*sqltypes.Result)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockQueryServiceRecorder) BeginExecute(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BeginExecute", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockQueryService) BeginExecuteBatch(ctx context.Context, target *query.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	ret := _m.ctrl.Call(_m, "BeginExecuteBatch", ctx, target, queries, asTransaction)
+	ret0, _ := ret[0].([]sqltypes.Result)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockQueryServiceRecorder) BeginExecuteBatch(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BeginExecuteBatch", arg0, arg1, arg2, arg3)
+}
+
 func (_m *MockQueryService) SplitQuery(ctx context.Context, target *query.Target, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error) {
 	ret := _m.ctrl.Call(_m, "SplitQuery", ctx, target, sql, bindVariables, splitColumn, splitCount)
 	ret0, _ := ret[0].([]querytypes.QuerySplit)

--- a/go/vt/tabletserver/tabletconntest/fakequeryservice.go
+++ b/go/vt/tabletserver/tabletconntest/fakequeryservice.go
@@ -384,6 +384,28 @@ var SplitQueryQueryV2SplitList = []querytypes.QuerySplit{
 	},
 }
 
+// BeginExecute combines Begin and Execute.
+func (f *FakeQueryService) BeginExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error) {
+	transactionID, err := f.Begin(ctx, target)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	result, err := f.Execute(ctx, target, sql, bindVariables, transactionID)
+	return result, transactionID, err
+}
+
+// BeginExecuteBatch combines Begin and ExecuteBatch.
+func (f *FakeQueryService) BeginExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	transactionID, err := f.Begin(ctx, target)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	results, err := f.ExecuteBatch(ctx, target, queries, asTransaction, transactionID)
+	return results, transactionID, err
+}
+
 // SplitQuery is part of the queryservice.QueryService interface
 func (f *FakeQueryService) SplitQuery(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error) {
 	if f.HasError {

--- a/go/vt/vtgate/l2vtgate/l2vtgate.go
+++ b/go/vt/vtgate/l2vtgate/l2vtgate.go
@@ -109,6 +109,16 @@ func (l *L2VTGate) ExecuteBatch(ctx context.Context, target *querypb.Target, que
 	return l.gateway.ExecuteBatch(ctx, target.Keyspace, target.Shard, target.TabletType, queries, asTransaction, transactionID)
 }
 
+// BeginExecute is part of the queryservice.QueryService interface
+func (l *L2VTGate) BeginExecute(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}) (*sqltypes.Result, int64, error) {
+	return l.gateway.BeginExecute(ctx, target.Keyspace, target.Shard, target.TabletType, sql, bindVariables)
+}
+
+// BeginExecuteBatch is part of the queryservice.QueryService interface
+func (l *L2VTGate) BeginExecuteBatch(ctx context.Context, target *querypb.Target, queries []querytypes.BoundQuery, asTransaction bool) ([]sqltypes.Result, int64, error) {
+	return l.gateway.BeginExecuteBatch(ctx, target.Keyspace, target.Shard, target.TabletType, queries, asTransaction)
+}
+
 // SplitQuery is part of the queryservice.QueryService interface
 func (l *L2VTGate) SplitQuery(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]interface{}, splitColumn string, splitCount int64) ([]querytypes.QuerySplit, error) {
 	return l.gateway.SplitQuery(ctx, target.Keyspace, target.Shard, target.TabletType, sql, bindVariables, splitColumn, splitCount)


### PR DESCRIPTION
That way when a l2vtgate gets a BeginExecute* call, it is not converted
into 2 calls (Begin and then Execute). So it stays one call when going
through l2vtgate to vttablet.

@michael-berlin @enisoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1900)
<!-- Reviewable:end -->
