### PR TITLE
Remove throttled logging for filtered replication unfriendly queries.

### DIFF
--- a/go/vt/sqlannotation/sqlannotation.go
+++ b/go/vt/sqlannotation/sqlannotation.go
@@ -16,11 +16,9 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/youtube/vitess/go/stats"
-	"github.com/youtube/vitess/go/vt/logutil"
 )
 
 const (
@@ -29,7 +27,6 @@ const (
 
 var (
 	filteredReplicationUnfriendlyStatementsCount = stats.NewInt("FilteredReplicationUnfriendlyStatementsCount")
-	filteredReplicationUnfriendlyStatementLogger = logutil.NewThrottledLogger("FilteredReplicationUnfriendlyStatement", 5*time.Second)
 )
 
 // AnnotateIfDML annotates 'sql' based on 'keyspaceIDs'
@@ -46,7 +43,6 @@ func AnnotateIfDML(sql string, keyspaceIDs [][]byte) string {
 		return AddKeyspaceID(sql, keyspaceIDs[0], "")
 	}
 	filteredReplicationUnfriendlyStatementsCount.Add(1)
-	filteredReplicationUnfriendlyStatementLogger.Warningf("filtered-replication-unfriendly SQL statement detected: %q", sql)
 	return sql + filteredReplicationUnfriendlyAnnotation
 }
 


### PR DESCRIPTION
It resulted into logspam for unsharded keyspaces.

No need to LGTM. Change was already approved internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/1901)
<!-- Reviewable:end -->
