### PR TITLE
Handling a corner case better.

### DIFF
--- a/go/vt/wrangler/validator.go
+++ b/go/vt/wrangler/validator.go
@@ -176,6 +176,11 @@ func normalizeIP(ip string) string {
 }
 
 func (wr *Wrangler) validateReplication(ctx context.Context, shardInfo *topo.ShardInfo, tabletMap map[topodatapb.TabletAlias]*topo.TabletInfo, results chan<- error) {
+	if shardInfo.MasterAlias == nil {
+		results <- fmt.Errorf("no master in shard record %v/%v", shardInfo.Keyspace(), shardInfo.ShardName())
+		return
+	}
+
 	masterTabletInfo, ok := tabletMap[*shardInfo.MasterAlias]
 	if !ok {
 		results <- fmt.Errorf("master %v not in tablet map", topoproto.TabletAliasString(shardInfo.MasterAlias))


### PR DESCRIPTION
If a shard has no master, fail early, instead of panicking, in validation code.

@michael-berlin @dsslater 