### PR TITLE
Replacing space with underscore in unsecure username

### DIFF
--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	unsecureClient = "unsecure grpc client"
+	unsecureClient = "unsecure_grpc_client"
 )
 
 var (

--- a/test/encrypted_transport.py
+++ b/test/encrypted_transport.py
@@ -347,7 +347,7 @@ class TestSecure(unittest.TestCase):
                          shards=['0'])
 
     # not passing any immediate caller id should fail as using
-    # the unsecure user "unsecure grpc client"
+    # the unsecure user "unsecure_grpc_client"
     cursor.set_effective_caller_id(None)
     try:
       cursor.execute('select * from vt_insert_test', {})
@@ -356,7 +356,7 @@ class TestSecure(unittest.TestCase):
       s = str(e)
       self.assertIn('table acl error', s)
       self.assertIn('cannot run PASS_SELECT on table', s)
-      self.assertIn('unsecure grpc client', s)
+      self.assertIn('unsecure_grpc_client', s)
 
     # 'vtgate client 1' is authorized to access vt_insert_test
     cursor.set_effective_caller_id(vtgate_client.CallerID(


### PR DESCRIPTION
Impact:
In vttablet debug/vars
UserTableQueryCount: {
<#table_name>.**unsecure_grpc_client**.Execute: <#count>
}
Likewise in UserTableQueryTimesNs stats

Immediate Caller will have **unsecure_grpc_client**