### PR TITLE
Adding Percona 5.7 docker image

### DIFF
--- a/Dockerfile.percona57
+++ b/Dockerfile.percona57
@@ -1,0 +1,12 @@
+FROM vitess/bootstrap:percona57
+
+# Re-copy sources from working tree
+USER root
+COPY . /vt/src/github.com/youtube/vitess
+
+# Fix permissions
+RUN chown -R vitess:vitess /vt
+USER vitess
+
+# Build Vitess
+RUN make build

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ php_proto:
 	docker rm vitess_php-proto
 
 # This rule builds the bootstrap images for all flavors.
-DOCKER_IMAGES_FOR_TEST = mariadb mysql56 mysql57 percona
+DOCKER_IMAGES_FOR_TEST = mariadb mysql56 mysql57 percona percona57
 DOCKER_IMAGES = common $(DOCKER_IMAGES_FOR_TEST)
 docker_bootstrap:
 	for i in $(DOCKER_IMAGES); do echo "image: $$i"; docker/bootstrap/build.sh $$i || exit 1; done
@@ -169,6 +169,10 @@ docker_base_percona:
 	chmod -R o=g *
 	docker build -f Dockerfile.percona -t vitess/base:percona .
 
+docker_base_percona57:
+	chmod -R o=g *
+	docker build -f Dockerfile.percona57 -t vitess/base:percona57 .
+
 docker_base_mariadb:
 	chmod -R o=g *
 	docker build -f Dockerfile.mariadb -t vitess/base:mariadb .
@@ -184,6 +188,9 @@ docker_lite_mariadb: docker_base_mariadb
 
 docker_lite_percona: docker_base_percona
 	cd docker/lite && ./build.sh percona
+
+docker_lite_percona57: docker_base_percona57
+	cd docker/lite && ./build.sh percona57
 
 docker_guestbook:
 	cd examples/kubernetes/guestbook && ./build.sh

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -1,0 +1,23 @@
+FROM vitess/bootstrap:common
+
+# Install Percona 5.7
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net \
+        --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A && \
+    add-apt-repository 'deb http://repo.percona.com/apt jessie main' && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-5.7 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        percona-server-server-5.7 libperconaserverclient18.1-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Bootstrap Vitess
+WORKDIR /vt/src/github.com/youtube/vitess
+USER vitess
+# Required by e2e test dependencies e.g. test/environment.py.
+ENV USER vitess
+ENV MYSQL_FLAVOR MySQL56
+RUN ./bootstrap.sh --skip_root_installs

--- a/docker/lite/Dockerfile.percona57
+++ b/docker/lite/Dockerfile.percona57
@@ -1,0 +1,37 @@
+# This image is only meant to be built from within the build.sh script.
+FROM debian:jessie
+
+# Install dependencies
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net \
+        --recv-keys 430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A && \
+    echo 'deb http://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/mysql.list && \
+    { \
+        echo debconf debconf/frontend select Noninteractive; \
+        echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \
+        echo percona-server-server-5.7 percona-server-server/root_password_again password 'unused'; \
+    } | debconf-set-selections && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        percona-server-server-5.7 libperconaserverclient18.1 bzip2 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTTOP /vt/src/github.com/youtube/vitess
+ENV VTROOT /vt
+ENV GOTOP $VTTOP/go
+ENV VTDATAROOT $VTROOT/vtdataroot
+ENV GOBIN $VTROOT/bin
+ENV GOPATH $VTROOT
+ENV PATH $VTROOT/bin:$PATH
+ENV VT_MYSQL_ROOT /usr
+ENV PKG_CONFIG_PATH $VTROOT/lib
+
+# Copy binaries (placed by build.sh)
+COPY lite/vt /vt
+
+# Create vitess user
+RUN groupadd -r vitess && useradd -r -g vitess vitess && \
+    mkdir -p /vt/vtdataroot && chown -R vitess:vitess /vt
+
+# Create mount point for actual data (e.g. MySQL data dir)
+VOLUME /vt/vtdataroot


### PR DESCRIPTION
We use percona 5.7 at our shop (instead of MySQL or Maria 5.7) so I wanted push this back upstream so that vitess had support for percona version 5.7 as well.