### PR TITLE
Always enable vttablet's backup support in tests.

### DIFF
--- a/test/tablet.py
+++ b/test/tablet.py
@@ -407,7 +407,7 @@ class Tablet(object):
       extra_args=None, extra_env=None, include_mysql_port=True,
       init_tablet_type=None, init_keyspace=None,
       init_shard=None, init_db_name_override=None,
-      supports_backups=False, grace_period='1s', enable_semi_sync=True):
+      supports_backups=True, grace_period='1s', enable_semi_sync=True):
     """Starts a vttablet process, and returns it.
 
     The process is also saved in self.proc, so it's easy to kill as well.

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -546,7 +546,9 @@ class TestTabletManager(unittest.TestCase):
     tablet_62044.init_tablet('replica', 'test_keyspace', '0',
                              include_mysql_port=False)
     for t in tablet_62344, tablet_62044:
-      t.start_vttablet(wait_for_state=None,
+      # Since MySQL is down at this point and we want the tablet to start up
+      # successfully, we have to use supports_backups=False.
+      t.start_vttablet(wait_for_state=None, supports_backups=False,
                        full_mycnf_args=True, include_mysql_port=False)
     for t in tablet_62344, tablet_62044:
       t.wait_for_vttablet_state('NOT_SERVING')
@@ -560,7 +562,8 @@ class TestTabletManager(unittest.TestCase):
     # The above notice to not fix replication should survive tablet restart.
     tablet_62044.kill_vttablet()
     tablet_62044.start_vttablet(wait_for_state='NOT_SERVING',
-                                full_mycnf_args=True, include_mysql_port=False)
+                                full_mycnf_args=True, include_mysql_port=False,
+                                supports_backups=False)
 
     # restart mysqld
     start_procs = [


### PR DESCRIPTION
Since in production vttablets are supposed to always run with backup support
enabled, it's better to run all (or most) of the tests with that support enabled
as well. The only test that actually requries the backup support to be disabled
is modified to explicitly do that.

@enisoc 