### PR TITLE
Introduce _vt.shard_metadata table.

### DIFF
--- a/config/init_db.sql
+++ b/config/init_db.sql
@@ -20,6 +20,18 @@ DROP DATABASE IF EXISTS test;
 
 # Vitess-internal database.
 CREATE DATABASE IF NOT EXISTS _vt;
+# Note that definitions of local_metadata and shard_metadata should be the same
+# as in production which is defined in go/vt/mysqlctl/metadata_tables.go.
+CREATE TABLE IF NOT EXISTS _vt.local_metadata (
+  name VARCHAR(255) NOT NULL,
+  value VARCHAR(255) NOT NULL,
+  PRIMARY KEY (name)
+  ) ENGINE=InnoDB;
+CREATE TABLE IF NOT EXISTS _vt.shard_metadata (
+  name VARCHAR(255) NOT NULL,
+  value MEDIUMBLOB NOT NULL,
+  PRIMARY KEY (name)
+  ) ENGINE=InnoDB;
 
 # Admin user with all privileges.
 GRANT ALL ON *.* TO 'vt_dba'@'localhost';

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -621,7 +621,7 @@ func Restore(
 	}
 	if toRestore < 0 {
 		logger.Errorf("No backup to restore on BackupStorage for directory %v. Starting up empty.", dir)
-		if err = populateLocalMetadata(mysqld, localMetadata); err == nil {
+		if err = populateMetadataTables(mysqld, localMetadata); err == nil {
 			err = ErrNoBackup
 		}
 		return replication.Position{}, err
@@ -635,7 +635,7 @@ func Restore(
 		}
 		if !ok {
 			logger.Infof("Auto-restore is enabled, but mysqld already contains data. Assuming vttablet was just restarted.")
-			if err = populateLocalMetadata(mysqld, localMetadata); err == nil {
+			if err = populateMetadataTables(mysqld, localMetadata); err == nil {
 				err = ErrExistingDB
 			}
 			return replication.Position{}, err
@@ -685,7 +685,7 @@ func Restore(
 	// Populate local_metadata before starting without --skip-networking,
 	// so it's there before we start announcing ourselves.
 	logger.Infof("Restore: populating local_metadata")
-	err = populateLocalMetadata(mysqld, localMetadata)
+	err = populateMetadataTables(mysqld, localMetadata)
 	if err != nil {
 		return replication.Position{}, err
 	}

--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/net/context"
 
 	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -254,6 +255,11 @@ func (wr *Wrangler) CopySchemaShard(ctx context.Context, sourceTabletAlias *topo
 		return err
 	}
 
+	err = wr.copyShardMetadata(ctx, sourceTabletAlias, destShardInfo.MasterAlias)
+	if err != nil {
+		return err
+	}
+
 	diffs, err := wr.compareSchemas(ctx, sourceTabletAlias, destShardInfo.MasterAlias, tables, excludeTables, includeViews)
 	if err != nil {
 		return fmt.Errorf("CopySchemaShard failed because schemas could not be compared initially: %v", err)
@@ -303,6 +309,43 @@ func (wr *Wrangler) CopySchemaShard(ctx context.Context, sourceTabletAlias *topo
 	reloadCtx, cancel := context.WithTimeout(ctx, waitSlaveTimeout)
 	defer cancel()
 	wr.ReloadSchemaShard(reloadCtx, destKeyspace, destShard, destMasterPos)
+	return nil
+}
+
+// copyShardMetadata copies contents of _vt.shard_metadata table from the source
+// tablet to the destination tablet. It's assumed that destination tablet is a
+// master and binlogging is not turned off when INSERT statements are executed.
+func (wr *Wrangler) copyShardMetadata(ctx context.Context, srcTabletAlias *topodatapb.TabletAlias, destTabletAlias *topodatapb.TabletAlias) error {
+	presenceResult, err := wr.ExecuteFetchAsDba(ctx, srcTabletAlias, "SELECT 1 FROM information_schema.tables WHERE table_schema = '_vt' AND table_name = 'shard_metadata'", 1, false, false)
+	if err != nil {
+		return err
+	}
+	if len(presenceResult.Rows) == 0 {
+		log.Infof("_vt.shard_metadata doesn't exist on the source tablet %v, skipping its copy.", topoproto.TabletAliasString(srcTabletAlias))
+		return nil
+	}
+
+	dataProto, err := wr.ExecuteFetchAsDba(ctx, srcTabletAlias, "SELECT name, value FROM _vt.shard_metadata", 100, false, false)
+	if err != nil {
+		return err
+	}
+	data := sqltypes.Proto3ToResult(dataProto)
+	for _, row := range data.Rows {
+		name := row[0]
+		value := row[1]
+		queryBuf := bytes.Buffer{}
+		queryBuf.WriteString("INSERT INTO _vt.shard_metadata (name, value) VALUES (")
+		name.EncodeSQL(&queryBuf)
+		queryBuf.WriteByte(',')
+		value.EncodeSQL(&queryBuf)
+		queryBuf.WriteString(") ON DUPLICATE KEY UPDATE value = ")
+		value.EncodeSQL(&queryBuf)
+
+		_, err := wr.ExecuteFetchAsDba(ctx, destTabletAlias, queryBuf.String(), 0, false, false)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/go/vt/wrangler/testlib/backup_test.go
+++ b/go/vt/wrangler/testlib/backup_test.go
@@ -41,6 +41,7 @@ func TestBackupRestore(t *testing.T) {
 	db.AddQuery("BEGIN", &sqltypes.Result{})
 	db.AddQuery("COMMIT", &sqltypes.Result{})
 	db.AddQueryPattern(`SET @@session\.sql_log_bin = .*`, &sqltypes.Result{})
+	db.AddQueryPattern(`CREATE TABLE IF NOT EXISTS _vt\.shard_metadata .*`, &sqltypes.Result{})
 	db.AddQueryPattern(`CREATE TABLE IF NOT EXISTS _vt\.local_metadata .*`, &sqltypes.Result{})
 	db.AddQueryPattern(`INSERT INTO _vt\.local_metadata .*`, &sqltypes.Result{})
 

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -308,7 +308,7 @@ class Tablet(object):
     rows = self.mquery('', 'show databases')
     for row in rows:
       dbname = row[0]
-      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys']:
+      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys', '_vt']:
         continue
       self.drop_db(dbname)
 

--- a/test/worker.py
+++ b/test/worker.py
@@ -384,6 +384,9 @@ class TestBaseSplitClone(unittest.TestCase, base_sharding.BaseShardingTest):
         t.reset_replication()
         t.set_semi_sync_enabled(master=False)
         t.clean_dbs()
+        # _vt.blp_checkpoint should be dropped to avoid interference between
+        # test cases
+        t.mquery('', 'drop table if exists _vt.blp_checkpoint')
         t.kill_vttablet()
         # we allow failures here as some tablets will be gone sometimes
         # (the master tablets after an emergency reparent)


### PR DESCRIPTION
This table will contain a per-shard metadata information similarly to how
_vt.local_metadata contains local per-tablet metadata information. It will be
used later by online schema swap process. This table will be replicated and
changed only on the master. As an exception to that rule creation of the table
is added to the vttablet startup code to make sure that it's created during
vttablet version update.

Copying of the contents of _vt.shard_metadata table is added to horizontal
resharding procedure to make sure that the contents of the table is consistent
across all shards of a single keyspace in cases when we are resharding only part
of the source keyspace leaving another part intact. The check for existence of
_vt.shard_metadata is still added to CopySchemaShard e.g. for a case when new
vtworker code will work with older vttablet code.

I've modified init_db.sql to create both _vt.shard_metadata and
_vt.local_metadata tables because it's just logically correct to have them both
in the tests since they will exist both in production. Tests are also adjusted
to not clobber the _vt database when not needed since resharding code now
depends on _vt.shard_metadata table existence.

@alainjobart @michael-berlin 