### PR TITLE
Lower level topo server interface: Watch.

### DIFF
--- a/go/vt/etcdtopo/convert.go
+++ b/go/vt/etcdtopo/convert.go
@@ -1,0 +1,76 @@
+package etcdtopo
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
+)
+
+// This file contains utility functions to maintain backward
+// compatibility with old-style non-Backend etcd topologies. The old
+// implementations (before 2016-08-17) used to deal with explicit data
+// types. We converted them to a generic []byte and path
+// interface. But the etcd implementation was not compatible with
+// this.
+
+// dataType is an enum for possible known data types, used for
+// backward compatibility.
+type dataType int
+
+// Constants for type conversion
+const (
+	// newType is used to indicate a topology object type of
+	// anything that is added after the topo.Backend refactor,
+	// i.e. anything that doesn't require conversion between old
+	// style topologies and the new style ones. The list of enum
+	// values after this contain all types that exist at the
+	// moment (2016-08-17) and doesn't need to be expanded when
+	// something new is saved in the topology because it will be
+	// saved in the new style, not in the old one.
+	newType dataType = iota
+	srvKeyspaceType
+	srvVSchemaType
+)
+
+// rawDataFromNodeValue convert the data of the given type into an []byte.
+// It is mindful of the backward compatibility, i.e. for newer objects
+// it doesn't do anything, but for old object types that were stored in JSON
+// format in converts them to proto3 binary encoding.
+func rawDataFromNodeValue(valueType dataType, value string) ([]byte, error) {
+	var p proto.Message
+	switch valueType {
+	case srvKeyspaceType:
+		p = &topodatapb.SrvKeyspace{}
+	case srvVSchemaType:
+		p = &vschemapb.SrvVSchema{}
+	default:
+		return []byte(value), nil
+	}
+
+	if err := json.Unmarshal([]byte(value), p); err != nil {
+		return nil, err
+	}
+
+	return proto.Marshal(p)
+}
+
+// oldTypeAndFilePath returns the data type and old file path for a given path.
+func oldTypeAndFilePath(filePath string) (dataType, string) {
+	parts := strings.Split(filePath, "/")
+
+	// SrvKeyspace: local cell, /keyspaces/<keyspace>/SrvKeyspace
+	if len(parts) == 4 && parts[0] == "" && parts[1] == "keyspaces" && parts[3] == "SrvKeyspace" {
+		return srvKeyspaceType, srvKeyspaceFilePath(parts[2])
+	}
+
+	// SrvVSchema: local cell, /SrvVSchema
+	if len(parts) == 2 && parts[1] == "SrvVSchema" {
+		return srvVSchemaType, srvVSchemaFilePath()
+	}
+
+	return newType, filePath
+}

--- a/go/vt/etcdtopo/version.go
+++ b/go/vt/etcdtopo/version.go
@@ -1,0 +1,19 @@
+package etcdtopo
+
+import (
+	"fmt"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// EtcdVersion is etcd's idea of a version.
+// It implements topo.Version.
+// We use the native etcd version type, uint64.
+type EtcdVersion uint64
+
+// String is part of the topo.Version interface.
+func (v EtcdVersion) String() string {
+	return fmt.Sprintf("%v", uint64(v))
+}
+
+var _ topo.Version = (EtcdVersion)(0) // compile-time interface check

--- a/go/vt/etcdtopo/watch.go
+++ b/go/vt/etcdtopo/watch.go
@@ -1,0 +1,116 @@
+package etcdtopo
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-etcd/etcd"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+func newWatchData(valueType dataType, node *etcd.Node) *topo.WatchData {
+	bytes, err := rawDataFromNodeValue(valueType, node.Value)
+	if err != nil {
+		return &topo.WatchData{Err: err}
+	}
+
+	return &topo.WatchData{
+		Contents: bytes,
+		Version:  EtcdVersion(node.ModifiedIndex),
+	}
+}
+
+// Watch is part of the topo.Backend interface
+func (s *Server) Watch(ctx context.Context, cellName string, filePath string) (current *topo.WatchData, changes <-chan *topo.WatchData) {
+	cell, err := s.getCell(cellName)
+	if err != nil {
+		return &topo.WatchData{Err: fmt.Errorf("Watch cannot get cell: %v", err)}, nil
+	}
+
+	// Special paths where we need to be backward compatible.
+	var valueType dataType
+	valueType, filePath = oldTypeAndFilePath(filePath)
+
+	// Get the initial version of the file
+	initial, err := cell.Get(filePath, false /* sort */, false /* recursive */)
+	if err != nil {
+		// generic error
+		return &topo.WatchData{Err: convertError(err)}, nil
+	}
+	if initial.Node == nil {
+		// node doesn't exist
+		return &topo.WatchData{Err: topo.ErrNoNode}, nil
+	}
+	wd := newWatchData(valueType, initial.Node)
+	if wd.Err != nil {
+		return wd, nil
+	}
+
+	notifications := make(chan *topo.WatchData, 10)
+
+	// This watch go routine will stop if the 'stop' channel is closed.
+	// Otherwise it will try to watch everything in a loop, and send events
+	// to the 'watch' channel.
+	// In any case, the Watch call will close the 'watch' channel.
+	watchChannel := make(chan *etcd.Response)
+	stop := make(chan bool)
+	watchError := make(chan error)
+	go func() {
+		versionToWatch := initial.Node.ModifiedIndex + 1
+		if _, err := cell.Client.Watch(filePath, versionToWatch, false /* recursive */, watchChannel, stop); err != etcd.ErrWatchStoppedByUser {
+			// We didn't stop this watch, it errored out.
+			// In this case, watch was closed already, we just
+			// have to save the error.
+			// Note err can never be nil, as we only return when
+			// the watch is interrupted or broken.
+			watchError <- err
+			close(watchError)
+		}
+	}()
+
+	// This go routine is the main event handling routine:
+	// - it will stop if ctx.Done() is closed.
+	// - if it receives a notification from the watch, it will forward it
+	// to the notifications channel.
+	go func() {
+		for {
+			select {
+			case resp, ok := <-watchChannel:
+				if !ok {
+					// Watch terminated, because of an error
+					err := <-watchError
+					notifications <- &topo.WatchData{Err: err}
+					close(notifications)
+					return
+				}
+				if resp.Node == nil {
+					// Node doesn't exist any more, we can
+					// stop watching.
+					close(stop)
+					notifications <- &topo.WatchData{Err: topo.ErrNoNode}
+					close(notifications)
+					return
+				}
+
+				wd := newWatchData(valueType, resp.Node)
+				notifications <- wd
+				if wd.Err != nil {
+					// Error packing / unpacking data,
+					// stop the watch.
+					close(stop)
+					close(notifications)
+					return
+				}
+
+			case <-ctx.Done():
+				close(stop)
+				notifications <- &topo.WatchData{Err: ctx.Err()}
+				close(notifications)
+				return
+			}
+		}
+	}()
+
+	return wd, notifications
+}

--- a/go/vt/topo/backend.go
+++ b/go/vt/topo/backend.go
@@ -1,0 +1,102 @@
+package topo
+
+import "golang.org/x/net/context"
+
+// Backend defines the interface that must be implemented by topology
+// plug-ins to be used with Vitess.
+//
+// Zookeeper is a good example of an implementation, as defined in
+// go/vt/zktopo.
+//
+// This API is very generic, and file oriented.
+//
+// FIXME(alainjobart) add all parts of the API, implement them all for
+// all our current systems, and convert the higher levels to talk to
+// this API. This is a long-term project.
+type Backend interface {
+	// Directory support: NYI
+	//	MkDir(ctx context.Context, cell string, path string) error
+	//	RmDir(ctx context.Context, cell string, path string) error
+	//	ListDir(ctx context.Context, cell string, path string) ([]string, error)
+
+	// File support: NYI
+	// if version == nil, then it’s an unconditional update / delete.
+	//	Create(ctx context.Context, cell string, path string, contents []byte) error
+	//	Update(ctx context.Context, cell string, path string, contents []byte, version Version) (Version, error)
+	//	Get(ctx context.Context, cell string, path string) ([]byte, Version, error)
+	//	Delete(ctx context.Context, cell string, path string, version Version)
+
+	// Locks: NYI
+	//	Lock(ctx context.Context, cell string, dirPath string) (LockDescriptor, error)
+	//	Unlock(ctx context.Context, descriptor LockDescriptor) error
+
+	// Watch starts watching a file in the provided cell.  It
+	// returns the current value, as well as a channel to read the
+	// changes from.  If the initial read fails, or the file
+	// doesn't exist, current.Err is set, and 'changes' is nil.
+	// Otherwise current.Err is nil, and current.Contents /
+	// current.Version are accurate.
+	//
+	// The 'changes' channel may return a record with Err != nil.
+	// In that case, the channel will also be closed right after
+	// that record.  In any case, 'changes' has to be drained of
+	// all events, even when the Context is canceled.
+	//
+	// Note the 'changes' channel can return twice the same
+	// Version/Contents (for instance, if the watch is interrupted
+	// and restarted within the Backend implementation).
+	// Similarly, the 'changes' channel may skip versions / changes
+	// (that is, if value goes [A, B, C, D, E, F], the watch may only
+	// receive [A, B, F]). This should only happen for rapidly
+	// changing values though. Usually, the initial value will come
+	// back right away. And a stable value (that hasn't changed for
+	// a while) should be seen shortly.
+	//
+	// The Watch call is not guaranteed to return exactly up to
+	// date data right away. For instance, if a file is created
+	// and saved, and then a watch is set on that file, it may
+	// return ErrNoNode (as the underlying configuration service
+	// may use asynchronous caches that are not up to date
+	// yet). The only guarantee is that the watch data will
+	// eventually converge. Vitess doesn't explicitly depend on the data
+	// being correct quickly, as long as it eventually gets there.
+	//
+	// To stop the watch, just cancel the context.
+	Watch(ctx context.Context, cell string, path string) (current *WatchData, changes <-chan *WatchData)
+}
+
+// Version is an interface that describes a file version.
+type Version interface {
+	// String returns a text representation of the version.
+	String() string
+}
+
+// LockDescriptor is an interface that describes a lock.
+type LockDescriptor interface {
+	// String returns a text representation of the lock.
+	String() string
+}
+
+// WatchData is the structure returned by the Watch() API.
+// It can contain:
+// a) an error in Err if the call failed (or if the watch was terminated).
+// b) the current or new version of the data.
+type WatchData struct {
+	// Contents has the bytes that were stored by Create
+	// or Update.
+	Contents []byte
+
+	// Version contains an opaque representation of the Version
+	// of that file.
+	Version Version
+
+	// Err is set the same way for both the 'current' value
+	// returned by Watch, or the values read on the 'changes'
+	// channel. It can be:
+	// - nil, then Contents and Version are set.
+	// - ErrNoNode if the file doesn't exist.
+	// - context.Err() if context.Done() is closed (then the value
+	//   will be context.DeadlineExceeded or context.Interrupted).
+	// - any other platform-specific error.
+	Err error
+}

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -90,6 +90,15 @@ func (tee *Tee) Close() {
 }
 
 //
+// Backend API
+//
+
+// Watch is part of the topo.Backend interface
+func (tee *Tee) Watch(ctx context.Context, cell string, path string) (current *topo.WatchData, changes <-chan *topo.WatchData) {
+	return tee.primary.Watch(ctx, cell, path)
+}
+
+//
 // Cell management, global
 //
 

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -57,7 +57,14 @@ var (
 // implementation for this using zookeeper.
 //
 // Inside Google, we use Chubby.
+//
+// FIXME(alainjobart) we are deprecating this interface, to be
+// replaced with a lower level interface defined by Backend.
 type Impl interface {
+	// Impl will eventually be entirely replaced with Backend, and
+	// just disappear.
+	Backend
+
 	// topo.Server management interface.
 	Close()
 

--- a/go/vt/topo/test/faketopo/faketopo.go
+++ b/go/vt/topo/test/faketopo/faketopo.go
@@ -20,6 +20,13 @@ type FakeTopo struct{}
 // Close is part of the topo.Server interface.
 func (ft FakeTopo) Close() {}
 
+// Watch is part of the topo.Backend interface.
+func (ft FakeTopo) Watch(ctx context.Context, cell string, path string) (current *topo.WatchData, changes <-chan *topo.WatchData) {
+	return &topo.WatchData{
+		Err: errNotImplemented,
+	}, nil
+}
+
 // GetKnownCells is part of the topo.Server interface.
 func (ft FakeTopo) GetKnownCells(ctx context.Context) ([]string, error) {
 	return nil, errNotImplemented

--- a/go/vt/topo/test/testing.go
+++ b/go/vt/topo/test/testing.go
@@ -97,4 +97,10 @@ func TopoServerTestSuite(t *testing.T, factory func() topo.Impl) {
 	ts = factory()
 	checkElection(t, ts)
 	ts.Close()
+
+	t.Log("=== checkWatch")
+	ts = factory()
+	checkWatch(t, ts)
+	checkWatchInterrupt(t, ts)
+	ts.Close()
 }

--- a/go/vt/topo/test/watch.go
+++ b/go/vt/topo/test/watch.go
@@ -1,0 +1,191 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// waitForInitialValue waits for the initial value of
+// /keyspaces/test_keyspace/SrvKeyspace to appear, and match the
+// provided srvKeyspace.
+func waitForInitialValue(ctx context.Context, t *testing.T, ts topo.Impl, cell string, srvKeyspace *topodatapb.SrvKeyspace) <-chan *topo.WatchData {
+	var current *topo.WatchData
+	var changes <-chan *topo.WatchData
+	start := time.Now()
+	for {
+		current, changes = ts.Watch(ctx, cell, "/keyspaces/test_keyspace/SrvKeyspace")
+		if current.Err == topo.ErrNoNode {
+			// hasn't appeared yet
+			if time.Now().Sub(start) > 10*time.Second {
+				t.Fatalf("time out waiting for file to appear")
+			}
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if current.Err != nil {
+			t.Fatalf("watch failed: %v", current.Err)
+		}
+		// we got a valid result
+		break
+	}
+	got := &topodatapb.SrvKeyspace{}
+	if err := proto.Unmarshal(current.Contents, got); err != nil {
+		t.Fatalf("cannot proto-unmarshal data: %v", err)
+	}
+	if !proto.Equal(got, srvKeyspace) {
+		t.Fatalf("got bad data: %v expected: %v", got, srvKeyspace)
+	}
+
+	return changes
+}
+
+// checkWatch runs the tests on the Watch part of the Backend API.
+// We can't just use the full API yet, so use SrvKeyspace for now.
+func checkWatch(t *testing.T, ts topo.Impl) {
+	ctx := context.Background()
+	cell := getLocalCell(ctx, t, ts)
+
+	// start watching something that doesn't exist -> error
+	current, changes := ts.Watch(ctx, cell, "/keyspaces/test_keyspace/SrvKeyspace")
+	if current.Err != topo.ErrNoNode {
+		t.Errorf("watch on missing node didn't return ErrNoNode: %v %v", current, changes)
+	}
+
+	// create some data
+	srvKeyspace := &topodatapb.SrvKeyspace{
+		ShardingColumnName: "user_id",
+	}
+	if err := ts.UpdateSrvKeyspace(ctx, cell, "test_keyspace", srvKeyspace); err != nil {
+		t.Fatalf("UpdateSrvKeyspace(1): %v", err)
+	}
+
+	// start watching again, it should work
+	changes = waitForInitialValue(ctx, t, ts, cell, srvKeyspace)
+
+	// change the data
+	srvKeyspace.ShardingColumnName = "new_user_id"
+	if err := ts.UpdateSrvKeyspace(ctx, cell, "test_keyspace", srvKeyspace); err != nil {
+		t.Fatalf("UpdateSrvKeyspace(2): %v", err)
+	}
+
+	// Make sure we get the watch data, maybe not as first notice,
+	// but eventually. The API specifies it is possible to get duplicate
+	// notifications.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+		if wd.Err != nil {
+			t.Fatalf("watch interrupted: %v", wd.Err)
+		}
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+
+		if got.ShardingColumnName == "user_id" {
+			// extra first value, still good
+			continue
+		}
+		if got.ShardingColumnName == "new_user_id" {
+			// watch worked, good
+			break
+		}
+		t.Fatalf("got unknown SrvKeyspace: %v", got)
+	}
+
+	// remove the SrvKeyspace
+	if err := ts.DeleteSrvKeyspace(ctx, cell, "test_keyspace"); err != nil {
+		t.Fatalf("DeleteSrvKeyspace: %v", err)
+	}
+
+	// Make sure we get the ErrNoNode notification eventually.
+	// The API specifies it is possible to get duplicate
+	// notifications.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+		if wd.Err == topo.ErrNoNode {
+			// good
+			break
+		}
+		if wd.Err != nil {
+			t.Fatalf("bad error returned for deletion: %v", wd.Err)
+		}
+		// we got something, better be the right value
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+		if got.ShardingColumnName == "new_user_id" {
+			// good value
+			continue
+		}
+		t.Fatalf("got unknown SrvKeyspace waiting for deletion: %v", got)
+	}
+
+	// now the channel should be closed
+	if wd, ok := <-changes; ok {
+		t.Fatalf("got unexpected event after error: %v", wd)
+	}
+}
+
+// checkWatchInterrupt tests we can interrupt a watch.
+func checkWatchInterrupt(t *testing.T, ts topo.Impl) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cell := getLocalCell(ctx, t, ts)
+
+	// create some data
+	srvKeyspace := &topodatapb.SrvKeyspace{
+		ShardingColumnName: "user_id",
+	}
+	if err := ts.UpdateSrvKeyspace(ctx, cell, "test_keyspace", srvKeyspace); err != nil {
+		t.Fatalf("UpdateSrvKeyspace(1): %v", err)
+	}
+
+	// start watching, it should work
+	changes := waitForInitialValue(ctx, t, ts, cell, srvKeyspace)
+
+	// Now close the context, it should close the watch.
+	cancel()
+
+	// Make sure we get the context.Canceled notification eventually.
+	for {
+		wd, ok := <-changes
+		if !ok {
+			t.Fatalf("watch channel unexpectedly closed")
+		}
+		if wd.Err == context.Canceled {
+			// good
+			break
+		}
+		if wd.Err != nil {
+			t.Fatalf("bad error returned for deletion: %v", wd.Err)
+		}
+		// we got something, better be the right value
+		got := &topodatapb.SrvKeyspace{}
+		if err := proto.Unmarshal(wd.Contents, got); err != nil {
+			t.Fatalf("cannot proto-unmarshal data: %v", err)
+		}
+		if got.ShardingColumnName == "user_id" {
+			// good value
+			continue
+		}
+		t.Fatalf("got unknown SrvKeyspace waiting for deletion: %v", got)
+	}
+
+	// now the channel should be closed
+	if wd, ok := <-changes; ok {
+		t.Fatalf("got unexpected event after error: %v", wd)
+	}
+}

--- a/go/vt/zktopo/convert.go
+++ b/go/vt/zktopo/convert.go
@@ -1,0 +1,78 @@
+package zktopo
+
+import (
+	"encoding/json"
+	"path"
+	"strings"
+
+	"github.com/golang/protobuf/proto"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
+)
+
+// This file contains utility functions to maintain backward compatibility
+// with old-style non-Backend Zookeeper topologies. The old
+// implementations (before 2016-08-17) used to deal with explicit data
+// types. We converted them to a generic []byte and path
+// interface. But the zookeeper implementation was not compatible with
+// this.
+
+// dataType is an enum for possible data types, used for backward
+// compatibility.
+type dataType int
+
+// Constants for type conversion
+const (
+	// newType is used to indicate a topology object type of
+	// anything that is added after the topo.Backend refactor,
+	// i.e. anything that doesn't require conversion between old
+	// style topologies and the new style ones. The list of enum
+	// values after this contain all types that exist at the
+	// moment (2016-08-17) and doesn't need to be expanded when
+	// something new is saved in the topology because it will be
+	// saved in the new style, not in the old one.
+	newType dataType = iota
+	srvKeyspaceType
+	srvVSchemaType
+)
+
+// rawDataFromNodeValue convert the data of the given type into an []byte.
+// It is mindful of the backward compatibility, i.e. for newer objects
+// it doesn't do anything, but for old object types that were stored in JSON
+// format in converts them to proto3 binary encoding.
+func rawDataFromNodeValue(what dataType, data string) ([]byte, error) {
+	var p proto.Message
+	switch what {
+	case srvKeyspaceType:
+		p = &topodatapb.SrvKeyspace{}
+	case srvVSchemaType:
+		p = &vschemapb.SrvVSchema{}
+	default:
+		return []byte(data), nil
+	}
+
+	if err := json.Unmarshal([]byte(data), p); err != nil {
+		return nil, err
+	}
+
+	return proto.Marshal(p)
+}
+
+// oldTypeAndFilePath returns the data type and old file path for a given path.
+func oldTypeAndFilePath(cell, filePath string) (dataType, string) {
+	parts := strings.Split(filePath, "/")
+
+	// SrvKeyspace: local cell, /keyspaces/<keyspace>/SrvKeyspace
+	if len(parts) == 4 && parts[0] == "" && parts[1] == "keyspaces" && parts[3] == "SrvKeyspace" {
+		return srvKeyspaceType, zkPathForSrvKeyspace(cell, parts[2])
+	}
+
+	// SrvVSchema: local cell, /SrvVSchema
+	if len(parts) == 2 && parts[1] == "SrvVSchema" {
+		return srvVSchemaType, zkPathForSrvVSchema(cell)
+	}
+
+	// General case.
+	return newType, path.Join("/zk", cell, "vt", filePath)
+}

--- a/go/vt/zktopo/server.go
+++ b/go/vt/zktopo/server.go
@@ -115,3 +115,5 @@ func (zkts *Server) PruneActionLogs(zkActionLogPath string, keepCount int) (prun
 	}
 	return prunedCount, nil
 }
+
+var _ topo.Impl = (*Server)(nil) // compile-time interface check

--- a/go/vt/zktopo/version.go
+++ b/go/vt/zktopo/version.go
@@ -1,0 +1,19 @@
+package zktopo
+
+import (
+	"fmt"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// ZKVersion is zookeeper's idea of a version.
+// It implements topo.Version.
+// We use the native zookeeper.Stat.Version type, int32.
+type ZKVersion int32
+
+// String is part of the topo.Version interface.
+func (v ZKVersion) String() string {
+	return fmt.Sprintf("%v", int32(v))
+}
+
+var _ topo.Version = (ZKVersion)(0) // compile-time interface check

--- a/go/vt/zktopo/watch.go
+++ b/go/vt/zktopo/watch.go
@@ -1,0 +1,91 @@
+package zktopo
+
+import (
+	"fmt"
+
+	zookeeper "github.com/samuel/go-zookeeper/zk"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+func newWatchData(valueType dataType, data string, stats *zookeeper.Stat) *topo.WatchData {
+	bytes, err := rawDataFromNodeValue(valueType, data)
+	if err != nil {
+		return &topo.WatchData{Err: err}
+	}
+
+	return &topo.WatchData{
+		Contents: bytes,
+		Version:  ZKVersion(stats.Version),
+	}
+}
+
+// Watch is part of the topo.Backend interface
+func (zkts *Server) Watch(ctx context.Context, cell string, filePath string) (*topo.WatchData, <-chan *topo.WatchData) {
+	// Special paths where we need to be backward compatible.
+	var valueType dataType
+	valueType, filePath = oldTypeAndFilePath(cell, filePath)
+
+	// Get the initial value, set the initial watch
+	data, stats, watch, err := zkts.zconn.GetW(filePath)
+	if err != nil {
+		return &topo.WatchData{Err: convertError(err)}, nil
+	}
+	if stats == nil {
+		// No stats --> node doesn't exist.
+		return &topo.WatchData{Err: topo.ErrNoNode}, nil
+	}
+	wd := newWatchData(valueType, data, stats)
+	if wd.Err != nil {
+		return wd, nil
+	}
+
+	c := make(chan *topo.WatchData, 10)
+	go func() {
+		for {
+			// Act on the watch, or on context close.
+			select {
+			case event, ok := <-watch:
+				if !ok {
+					c <- &topo.WatchData{Err: fmt.Errorf("watch on %v was closed", filePath)}
+					close(c)
+					return
+				}
+
+				if event.Err != nil {
+					c <- &topo.WatchData{Err: fmt.Errorf("received a non-OK event for %v: %v", filePath, event.Err)}
+					close(c)
+					return
+				}
+
+			case <-ctx.Done():
+				// user is not interested any more
+				c <- &topo.WatchData{Err: ctx.Err()}
+				close(c)
+				return
+			}
+
+			// Get the value again, and send it, or error.
+			data, stats, watch, err = zkts.zconn.GetW(filePath)
+			if err != nil {
+				c <- &topo.WatchData{Err: convertError(err)}
+				close(c)
+				return
+			}
+			if stats == nil {
+				// No data --> node doesn't exist
+				c <- &topo.WatchData{Err: topo.ErrNoNode}
+				close(c)
+				return
+			}
+			wd := newWatchData(valueType, data, stats)
+			c <- wd
+			if wd.Err != nil {
+				close(c)
+				return
+			}
+		}
+	}()
+	return wd, c
+}


### PR DESCRIPTION
Starting a lower level topo server interface, called topo.Backend.
The idea is to switch to a path-based interface, with files being
represented by []byte. All in all simpler interface, easier to test,
and to maintain. The backward compatibility layer for existing
implementations will be annoying to maintain, but we'll eventually
migrate.

For now, only support a Watch method, with slightly different semantics:
if the node doesn't exist (which is reported as topo.ErrNoNode), or if
there is an error in the watch, returns the error and closes the watch.

@enisoc @pivanof first stab at this. Only Watch so far, I want to fix the couple associated issues with it first.