### PR TITLE
Export internal changes to NumericLookupTable back.

### DIFF
--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -14,10 +14,11 @@ import (
 	"strconv"
 )
 
-// Stores the mapping of keys
+// NumericLookupTable stores the mapping of keys.
 type NumericLookupTable map[uint64]uint64
 
-// Similar to vindex Numeric but first attempts a lookup via a json file
+// NumericStaticMap is similar to vindex Numeric but first attempts a lookup via
+// a JSON file.
 type NumericStaticMap struct {
 	name   string
 	lookup NumericLookupTable

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -5,27 +5,36 @@
 package vindexes
 
 import (
-	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/testfiles"
 	"reflect"
 	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/testfiles"
 )
 
-var numericStaticMap Vindex
-
-func init() {
+func createVindex() (Vindex, error) {
 	m := make(map[string]string)
 	m["json_path"] = testfiles.Locate("vtgate/numeric_static_map_test.json")
-	numericStaticMap, _ = CreateVindex("numeric_static_map", "numericStaticMap", m)
+	return CreateVindex("numeric_static_map", "numericStaticMap", m)
 }
 
 func TestNumericStaticMapCost(t *testing.T) {
+	numericStaticMap, err := createVindex()
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+
 	if numericStaticMap.Cost() != 1 {
 		t.Errorf("Cost(): %d, want 1", numericStaticMap.Cost())
 	}
 }
 
 func TestNumericStaticMapMap(t *testing.T) {
+	numericStaticMap, err := createVindex()
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+
 	sqlVal, _ := sqltypes.BuildIntegral("8")
 	got, err := numericStaticMap.(Unique).Map(nil, []interface{}{
 		1,
@@ -59,7 +68,12 @@ func TestNumericStaticMapMap(t *testing.T) {
 }
 
 func TestNumericStaticMapMapBadData(t *testing.T) {
-	_, err := numericStaticMap.(Unique).Map(nil, []interface{}{1.1})
+	numericStaticMap, err := createVindex()
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+
+	_, err = numericStaticMap.(Unique).Map(nil, []interface{}{1.1})
 	want := `NumericStaticMap.Map: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("NumericStaticMap.Map: %v, want %v", err, want)
@@ -67,6 +81,11 @@ func TestNumericStaticMapMapBadData(t *testing.T) {
 }
 
 func TestNumericStaticMapVerify(t *testing.T) {
+	numericStaticMap, err := createVindex()
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+
 	success, err := numericStaticMap.Verify(nil, 1, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
 	if err != nil {
 		t.Error(err)
@@ -77,7 +96,12 @@ func TestNumericStaticMapVerify(t *testing.T) {
 }
 
 func TestNumericStaticMapVerifyBadData(t *testing.T) {
-	_, err := numericStaticMap.Verify(nil, 1.1, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
+	numericStaticMap, err := createVindex()
+	if err != nil {
+		t.Fatalf("failed to create vindex: %v", err)
+	}
+
+	_, err = numericStaticMap.Verify(nil, 1.1, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
 	want := `NumericStaticMap.Verify: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numericStaticMap.Map: %v, want %v", err, want)


### PR DESCRIPTION
Note: This change was already LGTM'd internally.