### PR TITLE
vtctld: Use "jsonpb" marshaler for protobuf only JSON responses.

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -1,6 +1,7 @@
 package vtctld
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -62,10 +65,42 @@ func handleCollection(collection string, getFunc func(*http.Request) (interface{
 		}
 
 		// JSON encode response.
-		data, err := json.MarshalIndent(obj, "", "  ")
-		if err != nil {
-			httpErrorf(w, r, "json error: %v", err)
-			return
+		var data []byte
+		switch obj := obj.(type) {
+		case proto.Message:
+			// We use jsonpb for protobuf messages because it is the only supported
+			// way to marshal protobuf messages to JSON.
+			// In addition to that, it's the only way to emit zero values in the JSON
+			// output.
+			// Unfortunately, it works only for protobuf messages. Therefore, we use
+			// the default marshaler for the remaining structs (which are possibly
+			// mixed protobuf and non-protobuf).
+			// TODO(mberlin): Switch "EnumAsInts" to "false" once the frontend is
+			//                updated and mixed types will use jsonpb as well.
+
+			// jsonpb may panic if the "proto.Message" is an embedded field
+			// of "obj" and "obj" has non-exported fields. Return an error then.
+			defer func() {
+				if val := recover(); val != nil {
+					httpErrorf(w, r, "jsonpb panicked: %v", val)
+					return
+				}
+			}()
+
+			// Marshal the protobuf message.
+			var b bytes.Buffer
+			m := jsonpb.Marshaler{EnumsAsInts: true, EmitDefaults: true, Indent: "  ", OrigName: true}
+			if err := m.Marshal(&b, obj); err != nil {
+				httpErrorf(w, r, "jsonpb error: %v", err)
+				return
+			}
+			data = b.Bytes()
+		default:
+			data, err = json.MarshalIndent(obj, "", "  ")
+			if err != nil {
+				httpErrorf(w, r, "json error: %v", err)
+				return
+			}
 		}
 		w.Header().Set("Content-Type", jsonContentType)
 		w.Write(data)
@@ -126,7 +161,9 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 				return ts.GetKeyspaces(ctx)
 			}
 			// Get the keyspace record.
-			return ts.GetKeyspace(ctx, keyspace)
+			k, err := ts.GetKeyspace(ctx, keyspace)
+			// Pass the embedded proto directly or jsonpb will panic.
+			return k.Keyspace, err
 			// Perform an action on a keyspace.
 		case "POST":
 			if keyspace == "" {
@@ -174,7 +211,9 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 		}
 
 		// Get the shard record.
-		return ts.GetShard(ctx, keyspace, shard)
+		si, err := ts.GetShard(ctx, keyspace, shard)
+		// Pass the embedded proto directly or jsonpb will panic.
+		return si.Shard, err
 	})
 
 	// SrvKeyspace
@@ -280,7 +319,9 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 		}
 
 		// Get the tablet record.
-		return ts.GetTablet(ctx, tabletAlias)
+		t, err := ts.GetTablet(ctx, tabletAlias)
+		// Pass the embedded proto directly or jsonpb will panic.
+		return t.Tablet, err
 	})
 
 	// Healthcheck real time status per (cell, keyspace, shard, tablet type).

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -98,7 +98,8 @@ func TestAPI(t *testing.T) {
 		// Keyspaces
 		{"GET", "keyspaces", `["ks1"]`},
 		{"GET", "keyspaces/ks1", `{
-				"sharding_column_name": "shardcol"
+				"sharding_column_name": "shardcol",
+				"sharding_column_type": 0
 			}`},
 		{"POST", "keyspaces/ks1?action=TestKeyspaceAction", `{
 				"Name": "TestKeyspaceAction",
@@ -133,11 +134,14 @@ func TestAPI(t *testing.T) {
 			]`},
 		{"GET", "tablets/cell1-100", `{
 				"alias": {"cell": "cell1", "uid": 100},
+				"hostname": "",
+				"ip": "",
 				"port_map": {"vt": 100},
 				"keyspace": "ks1",
 				"shard": "-80",
 				"key_range": {"end": "gA=="},
-				"type": 2
+				"type": 2,
+				"db_name_override": ""
 			}`},
 		{"POST", "tablets/cell1-100?action=TestTabletAction", `{
 				"Name": "TestTabletAction",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -315,6 +315,18 @@
 			"revisionTime": "2016-01-21T18:51:14Z"
 		},
 		{
+			"checksumSHA1": "nZzR5hsZaPQCTbGyICQ27/xZupw=",
+			"path": "github.com/golang/protobuf/jsonpb",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
+		},
+		{
+			"checksumSHA1": "uaSm4Hhyzl+DHL8kSt4mrZ7GBIk=",
+			"path": "github.com/golang/protobuf/jsonpb/jsonpb_test_proto",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
+		},
+		{
 			"checksumSHA1": "tqCpJbM+lI/tRCsVFcRySf0biWU=",
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "0c1f6d65b5a189c2250d10e71a5506f06f9fa0a0",
@@ -367,6 +379,30 @@
 			"path": "github.com/golang/protobuf/ptypes/any",
 			"revision": "0c1f6d65b5a189c2250d10e71a5506f06f9fa0a0",
 			"revisionTime": "2016-06-14T22:31:40Z"
+		},
+		{
+			"checksumSHA1": "8gDNKfvEupesDdOCXio3AK/XVaA=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
+		},
+		{
+			"checksumSHA1": "wtUJRtb2jtPzrEacdsA+JRxMz2k=",
+			"path": "github.com/golang/protobuf/ptypes/struct",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
+		},
+		{
+			"checksumSHA1": "sfoot+dHmmOgWZS6GJ5X79ClZM0=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
+		},
+		{
+			"checksumSHA1": "Ja4i09zIVGM3NjAcTM9uOUDKNWc=",
+			"path": "github.com/golang/protobuf/ptypes/wrappers",
+			"revision": "f592bd283e9ef86337a432eb50e592278c3d534d",
+			"revisionTime": "2016-08-17T17:41:13Z"
 		},
 		{
 			"checksumSHA1": "d22rgDYcZ/l1RPHtCokJRHAh0QI=",


### PR DESCRIPTION
@enisoc 

Unfortunately, `jsonpb` works only on pure protobuf messages :( But most of our code uses a mixture where custom structs have a protobuf message as field.

Even worse: The type switch I used in the code recognizes a custom struct  which has a protobuf message as an anonymous field as `proto.Message` as well. However, `jsonpb` then panics on the struct because it has unexported fields. See the work-around for the `GetShard()` result.