### PR TITLE
Translate not_in_tx error in Java and PHP clients.

### DIFF
--- a/go/cmd/vtgateclienttest/goclienttest/errors.go
+++ b/go/cmd/vtgateclienttest/goclienttest/errors.go
@@ -30,6 +30,7 @@ var (
 		"integrity error":   vtrpcpb.ErrorCode_INTEGRITY_ERROR,
 		"transient error":   vtrpcpb.ErrorCode_TRANSIENT_ERROR,
 		"unauthenticated":   vtrpcpb.ErrorCode_UNAUTHENTICATED,
+		"aborted":           vtrpcpb.ErrorCode_NOT_IN_TX,
 		"unknown error":     vtrpcpb.ErrorCode_UNKNOWN_ERROR,
 	}
 )

--- a/go/cmd/vtgateclienttest/services/errors.go
+++ b/go/cmd/vtgateclienttest/services/errors.go
@@ -105,6 +105,11 @@ func trimmedRequestToError(received string) error {
 			vtrpcpb.ErrorCode_UNAUTHENTICATED,
 			errors.New("vtgate test client forced error: unauthenticated"),
 		)
+	case "aborted":
+		return vterrors.FromError(
+			vtrpcpb.ErrorCode_NOT_IN_TX,
+			errors.New("vtgate test client forced error: aborted"),
+		)
 	case "unknown error":
 		return vterrors.FromError(
 			vtrpcpb.ErrorCode_UNKNOWN_ERROR,

--- a/java/client/src/main/java/com/youtube/vitess/client/Proto.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/Proto.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
-
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.SimpleCursor;
 import com.youtube.vitess.proto.Query;
@@ -16,19 +15,18 @@ import com.youtube.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
 import com.youtube.vitess.proto.Vtgate.BoundShardQuery;
 import com.youtube.vitess.proto.Vtgate.ExecuteEntityIdsRequest.EntityId;
 import com.youtube.vitess.proto.Vtrpc.RPCError;
-
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLInvalidAuthorizationSpecException;
 import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 
 /**
@@ -63,6 +61,8 @@ public class Proto {
           throw new SQLTransientException(error.toString(), sqlState, errno);
         case UNAUTHENTICATED:
           throw new SQLInvalidAuthorizationSpecException(error.toString(), sqlState, errno);
+        case NOT_IN_TX:
+          throw new SQLRecoverableException(error.toString(), sqlState, errno);
         default:
           throw new SQLNonTransientException("Vitess RPC error: " + error.toString(), sqlState,
               errno);

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -2,7 +2,6 @@ package com.youtube.vitess.client;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
-
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
 import com.youtube.vitess.proto.Query.Field;
@@ -14,18 +13,13 @@ import com.youtube.vitess.proto.Topodata.SrvKeyspace.KeyspacePartition;
 import com.youtube.vitess.proto.Topodata.TabletType;
 import com.youtube.vitess.proto.Vtgate.SplitQueryResponse;
 import com.youtube.vitess.proto.Vtrpc.CallerID;
-
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLInvalidAuthorizationSpecException;
 import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientException;
@@ -33,6 +27,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * RpcClientTest tests a given implementation of RpcClient against a mock vtgate server
@@ -64,6 +62,7 @@ public abstract class RpcClientTest {
           .put("integrity error", SQLIntegrityConstraintViolationException.class)
           .put("transient error", SQLTransientException.class)
           .put("unauthenticated", SQLInvalidAuthorizationSpecException.class)
+          .put("aborted", SQLRecoverableException.class)
           .put("unknown error", SQLNonTransientException.class).build();
 
   private static final String QUERY = "test query";
@@ -348,14 +347,13 @@ public abstract class RpcClientTest {
 
   @Test
   public void testGetSrvKeyspace() throws Exception {
-    SrvKeyspace expected = SrvKeyspace.newBuilder().addPartitions(KeyspacePartition.newBuilder()
-        .setServedType(TabletType.REPLICA)
-        .addShardReferences(ShardReference.newBuilder().setName("shard0")
-            .setKeyRange(KeyRange.newBuilder()
-                .setStart(ByteString.copyFrom(new byte[] {0x40, 0, 0, 0, 0, 0, 0, 0}))
+    SrvKeyspace expected = SrvKeyspace.newBuilder()
+        .addPartitions(KeyspacePartition.newBuilder().setServedType(TabletType.REPLICA)
+            .addShardReferences(ShardReference.newBuilder().setName("shard0").setKeyRange(KeyRange
+                .newBuilder().setStart(ByteString.copyFrom(new byte[] {0x40, 0, 0, 0, 0, 0, 0, 0}))
                 .setEnd(ByteString.copyFrom(new byte[] {(byte) 0x80, 0, 0, 0, 0, 0, 0, 0})).build())
+                .build())
             .build())
-        .build())
         .setShardingColumnName("sharding_column_name")
         .setShardingColumnType(KeyspaceIdType.UINT64).addServedFrom(SrvKeyspace.ServedFrom
             .newBuilder().setTabletType(TabletType.MASTER).setKeyspace("other_keyspace").build())

--- a/java/grpc-client/src/main/java/com/youtube/vitess/client/grpc/GrpcClient.java
+++ b/java/grpc-client/src/main/java/com/youtube/vitess/client/grpc/GrpcClient.java
@@ -3,7 +3,6 @@ package com.youtube.vitess.client.grpc;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.Proto;
 import com.youtube.vitess.client.RpcClient;
@@ -44,21 +43,19 @@ import com.youtube.vitess.proto.Vtgate.StreamExecuteShardsResponse;
 import com.youtube.vitess.proto.grpc.VitessGrpc;
 import com.youtube.vitess.proto.grpc.VitessGrpc.VitessFutureStub;
 import com.youtube.vitess.proto.grpc.VitessGrpc.VitessStub;
-
-import org.joda.time.Duration;
-
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.SQLInvalidAuthorizationSpecException;
 import java.sql.SQLNonTransientException;
+import java.sql.SQLRecoverableException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientException;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.Duration;
 
 /**
  * GrpcClient is a gRPC-based implementation of Vitess Rpcclient.
@@ -82,64 +79,50 @@ public class GrpcClient implements RpcClient {
   @Override
   public ListenableFuture<ExecuteResponse> execute(Context ctx, ExecuteRequest request)
       throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).execute(request),
-        Exception.class,
+    return Futures.catchingAsync(getFutureStub(ctx).execute(request), Exception.class,
         new ExceptionConverter<ExecuteResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteShardsResponse> executeShards(
-      Context ctx, ExecuteShardsRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeShards(request),
-        Exception.class,
+  public ListenableFuture<ExecuteShardsResponse> executeShards(Context ctx,
+      ExecuteShardsRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeShards(request), Exception.class,
         new ExceptionConverter<ExecuteShardsResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteKeyspaceIdsResponse> executeKeyspaceIds(
-      Context ctx, ExecuteKeyspaceIdsRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeKeyspaceIds(request),
-        Exception.class,
+  public ListenableFuture<ExecuteKeyspaceIdsResponse> executeKeyspaceIds(Context ctx,
+      ExecuteKeyspaceIdsRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeKeyspaceIds(request), Exception.class,
         new ExceptionConverter<ExecuteKeyspaceIdsResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteKeyRangesResponse> executeKeyRanges(
-      Context ctx, ExecuteKeyRangesRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeKeyRanges(request),
-        Exception.class,
+  public ListenableFuture<ExecuteKeyRangesResponse> executeKeyRanges(Context ctx,
+      ExecuteKeyRangesRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeKeyRanges(request), Exception.class,
         new ExceptionConverter<ExecuteKeyRangesResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteEntityIdsResponse> executeEntityIds(
-      Context ctx, ExecuteEntityIdsRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeEntityIds(request),
-        Exception.class,
+  public ListenableFuture<ExecuteEntityIdsResponse> executeEntityIds(Context ctx,
+      ExecuteEntityIdsRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeEntityIds(request), Exception.class,
         new ExceptionConverter<ExecuteEntityIdsResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteBatchShardsResponse> executeBatchShards(
-      Context ctx, ExecuteBatchShardsRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeBatchShards(request),
-        Exception.class,
+  public ListenableFuture<ExecuteBatchShardsResponse> executeBatchShards(Context ctx,
+      ExecuteBatchShardsRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeBatchShards(request), Exception.class,
         new ExceptionConverter<ExecuteBatchShardsResponse>());
   }
 
   @Override
-  public ListenableFuture<ExecuteBatchKeyspaceIdsResponse> executeBatchKeyspaceIds(
-      Context ctx, ExecuteBatchKeyspaceIdsRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).executeBatchKeyspaceIds(request),
-        Exception.class,
-        new ExceptionConverter<ExecuteBatchKeyspaceIdsResponse>());
+  public ListenableFuture<ExecuteBatchKeyspaceIdsResponse> executeBatchKeyspaceIds(Context ctx,
+      ExecuteBatchKeyspaceIdsRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).executeBatchKeyspaceIds(request),
+        Exception.class, new ExceptionConverter<ExecuteBatchKeyspaceIdsResponse>());
   }
 
   @Override
@@ -157,8 +140,8 @@ public class GrpcClient implements RpcClient {
   }
 
   @Override
-  public StreamIterator<QueryResult> streamExecuteShards(
-      Context ctx, StreamExecuteShardsRequest request) throws SQLException {
+  public StreamIterator<QueryResult> streamExecuteShards(Context ctx,
+      StreamExecuteShardsRequest request) throws SQLException {
     GrpcStreamAdapter<StreamExecuteShardsResponse, QueryResult> adapter =
         new GrpcStreamAdapter<StreamExecuteShardsResponse, QueryResult>() {
           @Override
@@ -171,8 +154,8 @@ public class GrpcClient implements RpcClient {
   }
 
   @Override
-  public StreamIterator<QueryResult> streamExecuteKeyspaceIds(
-      Context ctx, StreamExecuteKeyspaceIdsRequest request) throws SQLException {
+  public StreamIterator<QueryResult> streamExecuteKeyspaceIds(Context ctx,
+      StreamExecuteKeyspaceIdsRequest request) throws SQLException {
     GrpcStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult> adapter =
         new GrpcStreamAdapter<StreamExecuteKeyspaceIdsResponse, QueryResult>() {
           @Override
@@ -185,8 +168,8 @@ public class GrpcClient implements RpcClient {
   }
 
   @Override
-  public StreamIterator<QueryResult> streamExecuteKeyRanges(
-      Context ctx, StreamExecuteKeyRangesRequest request) throws SQLException {
+  public StreamIterator<QueryResult> streamExecuteKeyRanges(Context ctx,
+      StreamExecuteKeyRangesRequest request) throws SQLException {
     GrpcStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult> adapter =
         new GrpcStreamAdapter<StreamExecuteKeyRangesResponse, QueryResult>() {
           @Override
@@ -201,45 +184,35 @@ public class GrpcClient implements RpcClient {
   @Override
   public ListenableFuture<BeginResponse> begin(Context ctx, BeginRequest request)
       throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).begin(request),
-        Exception.class,
+    return Futures.catchingAsync(getFutureStub(ctx).begin(request), Exception.class,
         new ExceptionConverter<BeginResponse>());
   }
 
   @Override
   public ListenableFuture<CommitResponse> commit(Context ctx, CommitRequest request)
       throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).commit(request),
-        Exception.class,
+    return Futures.catchingAsync(getFutureStub(ctx).commit(request), Exception.class,
         new ExceptionConverter<CommitResponse>());
   }
 
   @Override
   public ListenableFuture<RollbackResponse> rollback(Context ctx, RollbackRequest request)
       throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).rollback(request),
-        Exception.class,
+    return Futures.catchingAsync(getFutureStub(ctx).rollback(request), Exception.class,
         new ExceptionConverter<RollbackResponse>());
   }
 
   @Override
   public ListenableFuture<SplitQueryResponse> splitQuery(Context ctx, SplitQueryRequest request)
       throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).splitQuery(request),
-        Exception.class,
+    return Futures.catchingAsync(getFutureStub(ctx).splitQuery(request), Exception.class,
         new ExceptionConverter<SplitQueryResponse>());
   }
 
   @Override
-  public ListenableFuture<GetSrvKeyspaceResponse> getSrvKeyspace(
-      Context ctx, GetSrvKeyspaceRequest request) throws SQLException {
-    return Futures.catchingAsync(
-        getFutureStub(ctx).getSrvKeyspace(request),
-        Exception.class,
+  public ListenableFuture<GetSrvKeyspaceResponse> getSrvKeyspace(Context ctx,
+      GetSrvKeyspaceRequest request) throws SQLException {
+    return Futures.catchingAsync(getFutureStub(ctx).getSrvKeyspace(request), Exception.class,
         new ExceptionConverter<GetSrvKeyspaceResponse>());
   }
 
@@ -264,6 +237,8 @@ public class GrpcClient implements RpcClient {
           return new SQLInvalidAuthorizationSpecException(sre.toString(), sqlState, errno, sre);
         case UNAVAILABLE:
           return new SQLTransientException(sre.toString(), sqlState, errno, sre);
+        case ABORTED:
+          return new SQLRecoverableException(sre.toString(), sqlState, errno, sre);
         default: // Covers e.g. UNKNOWN.
           String advice = "";
           if (e.getCause() instanceof java.nio.channels.ClosedChannelException) {

--- a/php/src/Vitess/Error/Aborted.php
+++ b/php/src/Vitess/Error/Aborted.php
@@ -1,0 +1,6 @@
+<?php
+namespace Vitess\Error;
+
+class Aborted extends \Vitess\Exception
+{
+}

--- a/php/src/Vitess/Grpc/Client.php
+++ b/php/src/Vitess/Grpc/Client.php
@@ -139,6 +139,8 @@ class Client implements \Vitess\RpcClient
                     throw new \Vitess\Error\Unauthenticated($status->details);
                 case \Grpc\STATUS_UNAVAILABLE:
                     throw new \Vitess\Error\Transient($status->details);
+                case \Grpc\STATUS_ABORTED:
+                    throw new \Vitess\Error\Aborted($status->details);
                 default:
                     throw new \Vitess\Exception("{$status->code}: {$status->details}");
             }

--- a/php/src/Vitess/ProtoUtils.php
+++ b/php/src/Vitess/ProtoUtils.php
@@ -28,6 +28,7 @@ class ProtoUtils
      * @throws Error\Integrity
      * @throws Error\Transient
      * @throws Error\Unauthenticated
+     * @throws Error\Aborted
      * @throws Exception
      */
     public static function checkError($response)
@@ -47,6 +48,8 @@ class ProtoUtils
                     throw new Error\Transient($error->getMessage());
                 case ErrorCode::UNAUTHENTICATED:
                     throw new Error\Unauthenticated($error->getMessage());
+                case ErrorCode::NOT_IN_TX:
+                    throw new Error\Aborted($error->getMessage());
                 default:
                     throw new Exception($error->getCode() . ': ' . $error->getMessage());
             }

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -23,6 +23,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         'integrity error' => 'Vitess\Error\Integrity',
         'transient error' => 'Vitess\Error\Transient',
         'unauthenticated' => 'Vitess\Error\Unauthenticated',
+        'aborted' => 'Vitess\Error\Aborted',
         'unknown error' => 'Vitess\Exception'
     );
 


### PR DESCRIPTION
@alainjobart 

According to the mapping defined in Vitess, NOT_IN_TX translates to gRPC
canonical code ABORTED:

https://github.com/grpc/grpc-go/blob/9e3a674ceba65708273cf1cd8e71a1bdce68107b/codes/codes.go#L115

In Java, this corresponds to SQLRecoverableException, meaning your
transaction is no longer valid and you must start over from the
beginning:

https://docs.oracle.com/javase/7/docs/api/java/sql/SQLRecoverableException.html

Thus by catching SQLRecoverableException, you can find out when your transaction session cookie is no longer valid, as in https://github.com/youtube/vitess/pull/1966.