### PR TITLE
throttler: Reset the "replica under increase test" when we leave the …

### DIFF
--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -536,6 +536,10 @@ func (m *MaxReplicationLagModule) updateRate(r *result, newState state, rate int
 	m.currentState = newState
 	m.lastRateChange = now
 	m.lastRateChangeReason = reason
+	if newState != stateIncreaseRate {
+		// Clear the replica under test from a previous increase.
+		m.replicaUnderIncreaseTest = ""
+	}
 
 	// Update result with the new state.
 	r.NewState = newState


### PR DESCRIPTION
…increase state.

Before this fix, the following sequence was not possible:

- increase by replica1
- decrease or emergency by replica2
- increase by replica2

That was because the module was still locked in to "replica1" and therefore only "replica1" could trigger the next increase.

@alainjobart 