### PR TITLE
java: Add getRawValue(String columnLabel) to Row class.

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
@@ -5,12 +5,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
-
 import com.youtube.vitess.mysql.DateTime;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Query.Type;
-
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLDataException;
@@ -21,24 +19,21 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * Type-converting wrapper around raw
- * {@link com.youtube.vitess.proto.Query.Row} proto.
+ * Type-converting wrapper around raw {@link com.youtube.vitess.proto.Query.Row} proto.
  *
- * <p>Usually you get Row objects from a {@link Cursor}, which builds
- * them by combining {@link com.youtube.vitess.proto.Query.Row} with
- * the list of {@link Field}s from the corresponding
+ * <p>
+ * Usually you get Row objects from a {@link Cursor}, which builds them by combining
+ * {@link com.youtube.vitess.proto.Query.Row} with the list of {@link Field}s from the corresponding
  * {@link com.youtube.vitess.proto.Query.QueryResult}.
  *
- * <p>Methods on {@code Row} are intended to be compatible with those on
- * {@link java.sql.ResultSet} where possible.
- * This means {@code columnIndex} values start at 1 for the first column,
- * and {@code columnLabel} values are case-insensitive. If multiple columns
- * have the same case-insensitive {@code columnLabel}, the earliest one will
- * be returned.
+ * <p>
+ * Methods on {@code Row} are intended to be compatible with those on {@link java.sql.ResultSet}
+ * where possible. This means {@code columnIndex} values start at 1 for the first column, and
+ * {@code columnLabel} values are case-insensitive. If multiple columns have the same
+ * case-insensitive {@code columnLabel}, the earliest one will be returned.
  */
 @NotThreadSafe
 public class Row {
@@ -46,21 +41,21 @@ public class Row {
   private final List<ByteString> values;
   private final Query.Row rawRow;
   /**
-   * Remembers whether the column referenced by the last {@code get*()} was
-   * MySQL {@code NULL}.
+   * Remembers whether the column referenced by the last {@code get*()} was MySQL {@code NULL}.
    *
-   * <p>Although {@link Row} is not supposed to be used by multiple threads,
-   * we defensively declare {@code lastGetWasNull} as {@code volatile} since
-   * {@link Cursor} in general is used in asynchronous callbacks.
+   * <p>
+   * Although {@link Row} is not supposed to be used by multiple threads, we defensively declare
+   * {@code lastGetWasNull} as {@code volatile} since {@link Cursor} in general is used in
+   * asynchronous callbacks.
    */
   private volatile boolean lastGetWasNull;
 
   /**
-   * Construct a Row from {@link com.youtube.vitess.proto.Query.Row}
-   * proto with a pre-built {@link FieldMap}.
+   * Construct a Row from {@link com.youtube.vitess.proto.Query.Row} proto with a pre-built
+   * {@link FieldMap}.
    *
-   * <p>{@link Cursor} uses this to share a {@link FieldMap}
-   * among multiple rows.
+   * <p>
+   * {@link Cursor} uses this to share a {@link FieldMap} among multiple rows.
    */
   public Row(FieldMap fieldMap, Query.Row rawRow) {
     this.fieldMap = fieldMap;
@@ -80,14 +75,14 @@ public class Row {
   /**
    * Construct a Row manually (not from proto).
    *
-   * <p>The primary purpose of this Row class is to wrap the
-   * {@link com.youtube.vitess.proto.Query.Row} proto, which stores values
-   * in a packed format. However, when writing tests you may want to create
-   * a Row from unpacked data.
+   * <p>
+   * The primary purpose of this Row class is to wrap the {@link com.youtube.vitess.proto.Query.Row}
+   * proto, which stores values in a packed format. However, when writing tests you may want to
+   * create a Row from unpacked data.
    *
-   * <p>Note that {@link #getRowProto()} will return null in this case,
-   * so a Row created in this way can't be used with code that requires
-   * access to the raw row proto.
+   * <p>
+   * Note that {@link #getRowProto()} will return null in this case, so a Row created in this way
+   * can't be used with code that requires access to the raw row proto.
    */
   @VisibleForTesting
   public Row(List<Field> fields, List<ByteString> values) {
@@ -150,6 +145,15 @@ public class Row {
 
   /**
    * Returns the raw {@link ByteString} for a column.
+   * 
+   * @param columnLabel case-insensitive column label
+   */
+  public ByteString getRawValue(String columnLabel) throws SQLException {
+    return getRawValue(findColumn(columnLabel));
+  }
+
+  /**
+   * Returns the raw {@link ByteString} for a column.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -166,8 +170,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(String,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(String,Class)}.
    *
    * @param columnLabel case-insensitive column label
    */
@@ -178,8 +183,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(int,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(int,Class)}.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -219,8 +225,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(String,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(String,Class)}.
    *
    * @param columnLabel case-insensitive column label
    */
@@ -231,8 +238,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(int,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(int,Class)}.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -244,8 +252,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(String,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(String,Class)}.
    *
    * @param columnLabel case-insensitive column label
    */
@@ -256,8 +265,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(int,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(int,Class)}.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -269,8 +279,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(String,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(String,Class)}.
    *
    * @param columnLabel case-insensitive column label
    */
@@ -281,8 +292,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(int,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(int,Class)}.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -428,13 +440,8 @@ public class Row {
     }
     Field field = fieldMap.get(columnIndex);
     if (field.getType() != Type.TIMESTAMP && field.getType() != Type.DATETIME) {
-      throw new SQLDataException(
-          "type mismatch, expected: "
-              + Type.TIMESTAMP
-              + " or "
-              + Type.DATETIME
-              + ", actual: "
-              + field.getType());
+      throw new SQLDataException("type mismatch, expected: " + Type.TIMESTAMP + " or "
+          + Type.DATETIME + ", actual: " + field.getType());
     }
     try {
       return DateTime.parseTimestamp(rawValue.toStringUtf8(), cal);
@@ -474,8 +481,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(String,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(String,Class)}.
    *
    * @param columnLabel case-insensitive column label
    */
@@ -486,8 +494,9 @@ public class Row {
   /**
    * Returns the column value, or 0 if the value is SQL NULL.
    *
-   * <p>To distinguish between 0 and SQL NULL, use either {@link #wasNull()}
-   * or {@link #getObject(int,Class)}.
+   * <p>
+   * To distinguish between 0 and SQL NULL, use either {@link #wasNull()} or
+   * {@link #getObject(int,Class)}.
    *
    * @param columnIndex 1-based column number (0 is invalid)
    */
@@ -499,15 +508,20 @@ public class Row {
   /**
    * Returns the column value, cast to the specified type.
    *
-   * <p>This can be used as an alternative to getters that return primitive
-   * types, if you need to distinguish between 0 and SQL NULL. For example:
+   * <p>
+   * This can be used as an alternative to getters that return primitive types, if you need to
+   * distinguish between 0 and SQL NULL. For example:
    *
-   * <blockquote><pre>
+   * <blockquote>
+   * 
+   * <pre>
    * Long value = row.getObject(0, Long.class);
    * if (value == null) {
    *   // The value was SQL NULL, not 0.
    * }
-   * </pre></blockquote>
+   * </pre>
+   * 
+   * </blockquote>
    *
    * @param columnIndex 1-based column number (0 is invalid)
    * @throws SQLDataException if the type doesn't match the actual value.
@@ -525,15 +539,20 @@ public class Row {
   /**
    * Returns the column value, cast to the specified type.
    *
-   * <p>This can be used as an alternative to getters that return primitive
-   * types, if you need to distinguish between 0 and SQL NULL. For example:
+   * <p>
+   * This can be used as an alternative to getters that return primitive types, if you need to
+   * distinguish between 0 and SQL NULL. For example:
    *
-   * <blockquote><pre>
+   * <blockquote>
+   * 
+   * <pre>
    * Long value = row.getObject("col0", Long.class);
    * if (value == null) {
    *   // The value was SQL NULL, not 0.
    * }
-   * </pre></blockquote>
+   * </pre>
+   * 
+   * </blockquote>
    *
    * @param columnLabel case-insensitive column label
    * @throws SQLDataException if the type doesn't match the actual value.
@@ -545,17 +564,20 @@ public class Row {
   /**
    * Reports whether the last column read had a value of SQL NULL.
    *
-   * <p>Getter methods that return primitive types, such as {@link #getLong(int)},
-   * will return 0 if the value is SQL NULL. To distinguish 0 from SQL NULL,
-   * you can call {@code wasNull()} immediately after retrieving the value.
+   * <p>
+   * Getter methods that return primitive types, such as {@link #getLong(int)}, will return 0 if the
+   * value is SQL NULL. To distinguish 0 from SQL NULL, you can call {@code wasNull()} immediately
+   * after retrieving the value.
    *
-   * <p>Note that this is not thread-safe: the value of {@code wasNull()} is only
-   * trustworthy if there are no concurrent calls on this {@code Row} between the
-   * call to {@code get*()} and the call to {@code wasNull()}.
+   * <p>
+   * Note that this is not thread-safe: the value of {@code wasNull()} is only trustworthy if there
+   * are no concurrent calls on this {@code Row} between the call to {@code get*()} and the call to
+   * {@code wasNull()}.
    *
-   * <p>As an alternative to {@code wasNull()}, you can use {@link #getObject(int,Class)}
-   * (e.g. {@code getObject(0, Long.class)} instead of {@code getLong(0)}) to get a
-   * wrapped {@code Long} value that will be {@code null} if the column value was SQL NULL.
+   * <p>
+   * As an alternative to {@code wasNull()}, you can use {@link #getObject(int,Class)} (e.g.
+   * {@code getObject(0, Long.class)} instead of {@code getLong(0)}) to get a wrapped {@code Long}
+   * value that will be {@code null} if the column value was SQL NULL.
    *
    * @throws SQLException
    */
@@ -640,7 +662,8 @@ public class Row {
   /**
    * Extract cell values from the single-buffer wire format.
    *
-   * <p>See the docs for the {@code Row} message in {@code query.proto}.
+   * <p>
+   * See the docs for the {@code Row} message in {@code query.proto}.
    */
   private static List<ByteString> extractValues(List<Long> lengths, ByteString buf) {
     List<ByteString> list = new ArrayList<ByteString>(lengths.size());

--- a/java/client/src/test/java/com/youtube/vitess/client/cursor/CursorTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/cursor/CursorTest.java
@@ -2,16 +2,9 @@ package com.youtube.vitess.client.cursor;
 
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
-
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Query.QueryResult;
-
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
@@ -21,6 +14,10 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.TimeZone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CursorTest {
@@ -28,14 +25,12 @@ public class CursorTest {
 
   @Test
   public void testFindColumn() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(Field.newBuilder().setName("col1").build())
-                    .addFields(Field.newBuilder().setName("COL2").build()) // case-insensitive
-                    .addFields(Field.newBuilder().setName("col1").build()) // duplicate
-                    .addFields(Field.newBuilder().setName("col4").build()) // skip duplicate
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(
+        QueryResult.newBuilder().addFields(Field.newBuilder().setName("col1").build())
+            .addFields(Field.newBuilder().setName("COL2").build()) // case-insensitive
+            .addFields(Field.newBuilder().setName("col1").build()) // duplicate
+            .addFields(Field.newBuilder().setName("col4").build()) // skip duplicate
+            .build())) {
       Assert.assertEquals(1, cursor.findColumn("col1")); // should return first col1
       Assert.assertEquals(2, cursor.findColumn("Col2")); // should be case-insensitive
       Assert.assertEquals(4, cursor.findColumn("col4")); // index should skip over duplicate
@@ -44,27 +39,15 @@ public class CursorTest {
 
   @Test
   public void testGetInt() throws Exception {
-    List<Query.Type> types =
-        Arrays.asList(
-            Query.Type.INT8,
-            Query.Type.UINT8,
-            Query.Type.INT16,
-            Query.Type.UINT16,
-            Query.Type.INT24,
-            Query.Type.UINT24,
-            Query.Type.INT32);
+    List<Query.Type> types = Arrays.asList(Query.Type.INT8, Query.Type.UINT8, Query.Type.INT16,
+        Query.Type.UINT16, Query.Type.INT24, Query.Type.UINT24, Query.Type.INT32);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("12345".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("12345")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("12345".length()).addLengths(-1) // SQL NULL
+              .setValues(ByteString.copyFromUtf8("12345")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(12345, row.getInt("col1"));
@@ -79,19 +62,13 @@ public class CursorTest {
 
   @Test
   public void testGetULong() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(
-                        Field.newBuilder().setName("col1").setType(Query.Type.UINT64).build())
-                    .addFields(
-                        Field.newBuilder().setName("null").setType(Query.Type.UINT64).build())
-                    .addRows(
-                        Query.Row.newBuilder()
-                            .addLengths("18446744073709551615".length())
-                            .addLengths(-1) // SQL NULL
-                            .setValues(ByteString.copyFromUtf8("18446744073709551615")))
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.UINT64).build())
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.UINT64).build())
+        .addRows(Query.Row.newBuilder().addLengths("18446744073709551615".length()).addLengths(-1) // SQL
+                                                                                                   // NULL
+            .setValues(ByteString.copyFromUtf8("18446744073709551615")))
+        .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(UnsignedLong.fromLongBits(-1), row.getULong("col1"));
@@ -105,17 +82,12 @@ public class CursorTest {
   public void testGetString() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.ENUM, Query.Type.SET);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("val123".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("val123")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("val123".length()).addLengths(-1) // SQL NULL
+              .setValues(ByteString.copyFromUtf8("val123")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals("val123", row.getString("col1"));
@@ -130,17 +102,12 @@ public class CursorTest {
   public void testGetLong() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.UINT32, Query.Type.INT64);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("12345".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("12345")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("12345".length()).addLengths(-1) // SQL NULL
+              .setValues(ByteString.copyFromUtf8("12345")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(12345L, row.getLong("col1"));
@@ -155,19 +122,12 @@ public class CursorTest {
 
   @Test
   public void testGetDouble() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(
-                        Field.newBuilder().setName("col1").setType(Query.Type.FLOAT64).build())
-                    .addFields(
-                        Field.newBuilder().setName("null").setType(Query.Type.FLOAT64).build())
-                    .addRows(
-                        Query.Row.newBuilder()
-                            .addLengths("2.5".length())
-                            .addLengths(-1) // SQL NULL
-                            .setValues(ByteString.copyFromUtf8("2.5")))
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.FLOAT64).build())
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.FLOAT64).build())
+        .addRows(Query.Row.newBuilder().addLengths("2.5".length()).addLengths(-1) // SQL NULL
+            .setValues(ByteString.copyFromUtf8("2.5")))
+        .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(2.5, row.getDouble("col1"), 0.01);
@@ -181,19 +141,12 @@ public class CursorTest {
 
   @Test
   public void testGetFloat() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(
-                        Field.newBuilder().setName("col1").setType(Query.Type.FLOAT32).build())
-                    .addFields(
-                        Field.newBuilder().setName("null").setType(Query.Type.FLOAT32).build())
-                    .addRows(
-                        Query.Row.newBuilder()
-                            .addLengths("2.5".length())
-                            .addLengths(-1) // SQL NULL
-                            .setValues(ByteString.copyFromUtf8("2.5")))
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.FLOAT32).build())
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.FLOAT32).build())
+        .addRows(Query.Row.newBuilder().addLengths("2.5".length()).addLengths(-1) // SQL NULL
+            .setValues(ByteString.copyFromUtf8("2.5")))
+        .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(2.5f, row.getFloat("col1"), 0.01f);
@@ -209,17 +162,13 @@ public class CursorTest {
   public void testGetDate() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.DATE);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("2008-01-02".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("2008-01-02")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("2008-01-02".length()).addLengths(-1) // SQL
+                                                                                           // NULL
+              .setValues(ByteString.copyFromUtf8("2008-01-02")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(Date.valueOf("2008-01-02"), row.getObject("col1"));
@@ -234,17 +183,12 @@ public class CursorTest {
 
   @Test
   public void testGetTime() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(Field.newBuilder().setName("col1").setType(Query.Type.TIME).build())
-                    .addFields(Field.newBuilder().setName("null").setType(Query.Type.TIME).build())
-                    .addRows(
-                        Query.Row.newBuilder()
-                            .addLengths("12:34:56".length())
-                            .addLengths(-1) // SQL NULL
-                            .setValues(ByteString.copyFromUtf8("12:34:56")))
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.TIME).build())
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.TIME).build())
+        .addRows(Query.Row.newBuilder().addLengths("12:34:56".length()).addLengths(-1) // SQL NULL
+            .setValues(ByteString.copyFromUtf8("12:34:56")))
+        .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(Time.valueOf("12:34:56"), row.getObject("col1"));
@@ -260,22 +204,18 @@ public class CursorTest {
   public void testGetTimestamp() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.DATETIME, Query.Type.TIMESTAMP);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("2008-01-02 14:15:16.123456".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("2008-01-02 14:15:16.123456")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("2008-01-02 14:15:16.123456".length())
+              .addLengths(-1) // SQL NULL
+              .setValues(ByteString.copyFromUtf8("2008-01-02 14:15:16.123456")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertEquals(Timestamp.valueOf("2008-01-02 14:15:16.123456"), row.getObject("col1"));
-        Assert.assertEquals(
-            Timestamp.valueOf("2008-01-02 14:15:16.123456"), row.getTimestamp("col1"));
+        Assert.assertEquals(Timestamp.valueOf("2008-01-02 14:15:16.123456"),
+            row.getTimestamp("col1"));
         Timestamp ts = new Timestamp(1199283316000L);
         ts.setNanos(123456000);
         Assert.assertEquals(ts, row.getTimestamp("col1", GMT));
@@ -288,27 +228,16 @@ public class CursorTest {
 
   @Test
   public void testGetBytes() throws Exception {
-    List<Query.Type> types =
-        Arrays.asList(
-            Query.Type.TEXT,
-            Query.Type.BLOB,
-            Query.Type.VARCHAR,
-            Query.Type.VARBINARY,
-            Query.Type.CHAR,
-            Query.Type.BINARY,
-            Query.Type.BIT);
+    List<Query.Type> types = Arrays.asList(Query.Type.TEXT, Query.Type.BLOB, Query.Type.VARCHAR,
+        Query.Type.VARBINARY, Query.Type.CHAR, Query.Type.BINARY, Query.Type.BIT);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("hello world".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("hello world")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("hello world".length()).addLengths(-1) // SQL
+                                                                                            // NULL
+              .setValues(ByteString.copyFromUtf8("hello world")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
         Assert.assertArrayEquals("hello world".getBytes("UTF-8"), row.getBytes("col1"));
@@ -323,21 +252,17 @@ public class CursorTest {
   public void testGetBigDecimal() throws Exception {
     List<Query.Type> types = Arrays.asList(Query.Type.DECIMAL);
     for (Query.Type type : types) {
-      try (Cursor cursor =
-              new SimpleCursor(
-                  QueryResult.newBuilder()
-                      .addFields(Field.newBuilder().setName("col1").setType(type).build())
-                      .addFields(Field.newBuilder().setName("null").setType(type).build())
-                      .addRows(
-                          Query.Row.newBuilder()
-                              .addLengths("1234.56789".length())
-                              .addLengths(-1) // SQL NULL
-                              .setValues(ByteString.copyFromUtf8("1234.56789")))
-                      .build())) {
+      try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+          .addFields(Field.newBuilder().setName("col1").setType(type).build())
+          .addFields(Field.newBuilder().setName("null").setType(type).build())
+          .addRows(Query.Row.newBuilder().addLengths("1234.56789".length()).addLengths(-1) // SQL
+                                                                                           // NULL
+              .setValues(ByteString.copyFromUtf8("1234.56789")))
+          .build())) {
         Row row = cursor.next();
         Assert.assertNotNull(row);
-        Assert.assertEquals(
-            new BigDecimal(BigInteger.valueOf(123456789), 5), row.getBigDecimal("col1"));
+        Assert.assertEquals(new BigDecimal(BigInteger.valueOf(123456789), 5),
+            row.getBigDecimal("col1"));
         Assert.assertFalse(row.wasNull());
         Assert.assertEquals(null, row.getBigDecimal("null"));
         Assert.assertTrue(row.wasNull());
@@ -347,17 +272,12 @@ public class CursorTest {
 
   @Test
   public void testGetShort() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(Field.newBuilder().setName("col1").setType(Query.Type.YEAR).build())
-                    .addFields(Field.newBuilder().setName("null").setType(Query.Type.YEAR).build())
-                    .addRows(
-                        Query.Row.newBuilder()
-                            .addLengths("1234".length())
-                            .addLengths(-1) // SQL NULL
-                            .setValues(ByteString.copyFromUtf8("1234")))
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.YEAR).build())
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.YEAR).build())
+        .addRows(Query.Row.newBuilder().addLengths("1234".length()).addLengths(-1) // SQL NULL
+            .setValues(ByteString.copyFromUtf8("1234")))
+        .build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(1234, row.getShort("col1"));
@@ -370,16 +290,25 @@ public class CursorTest {
   }
 
   @Test
+  public void testGetRawValue() throws Exception {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("col1").setType(Query.Type.INT32).build())
+        .addRows(Query.Row.newBuilder().addLengths("12345".length())
+            .setValues(ByteString.copyFromUtf8("12345")))
+        .build())) {
+      Row row = cursor.next();
+      Assert.assertNotNull(row);
+      Assert.assertEquals(ByteString.copyFromUtf8("12345"), row.getRawValue("col1"));
+      Assert.assertEquals(ByteString.copyFromUtf8("12345"), row.getRawValue(1));
+    }
+  }
+
+  @Test
   public void testNull() throws Exception {
-    try (Cursor cursor =
-            new SimpleCursor(
-                QueryResult.newBuilder()
-                    .addFields(
-                        Field.newBuilder().setName("null").setType(Query.Type.NULL_TYPE).build())
-                    .addRows(
-                        Query.Row.newBuilder().addLengths(-1) // SQL NULL
-                        )
-                    .build())) {
+    try (Cursor cursor = new SimpleCursor(QueryResult.newBuilder()
+        .addFields(Field.newBuilder().setName("null").setType(Query.Type.NULL_TYPE).build())
+        .addRows(Query.Row.newBuilder().addLengths(-1) // SQL NULL
+        ).build())) {
       Row row = cursor.next();
       Assert.assertNotNull(row);
       Assert.assertEquals(null, row.getObject("null"));


### PR DESCRIPTION
@thompsonja 

As requested by a user, this just adds a convenient wrapper around `getRawValue(findColumn(...))`, to make it match other `get*()` methods that come in such pairs.

Sorry about the formatting changes. I just use the Google auto-formatter, and apparently they changed the settings.