### PR TITLE
publish-site.sh: Ignore /web/ dir when validating generated HTML.

### DIFF
--- a/publish-site.sh
+++ b/publish-site.sh
@@ -67,7 +67,7 @@ rm -rf vitess.io
 
 # pre-commit checks
 set +e
-list=$(find . -name '*.html' ! -path '*/vendor/*' | xargs grep -lE '^\s*([\-\*]|\d\.) ')
+list=$(find . -name '*.html' ! -path '*/vendor/*' ! -path '*/web/*' | xargs grep -lE '^\s*([\-\*]|\d\.) ')
 if [ -n "$list" ]; then
   echo
   echo "ERROR: The following pages appear to contain bulleted lists that weren't properly converted."


### PR DESCRIPTION
@michael-berlin 

Git-ignored files can remain there after switching to the gh-pages branch, although they aren't part of the vitess.io site. We should exclude those from the pre-commit checks of publish-site.sh.