### PR TITLE
worker: Restart streaming queries on a different tablet if the first …

### DIFF
--- a/go/vt/tabletmanager/binlog_players.go
+++ b/go/vt/tabletmanager/binlog_players.go
@@ -305,8 +305,9 @@ func (bpc *BinlogPlayerController) Iteration() (err error) {
 
 	// Find the server list from the health check.
 	// Note: We cannot use tsc.GetHealthyTabletStats() here because it does
-	// not return non-serving tablets. However, we might replicate from
-	// these as well.
+	// not return non-serving tablets. We must include non-serving tablets because
+	// REPLICA source tablets may not be serving anymore because their traffic was
+	// already migrated to the destination shards.
 	addrs := discovery.RemoveUnhealthyTablets(bpc.tabletStatsCache.GetTabletStats(bpc.sourceShard.Keyspace, bpc.sourceShard.Shard, topodatapb.TabletType_REPLICA))
 	if len(addrs) == 0 {
 		return fmt.Errorf("can't find any healthy source tablet for %v %v %v", bpc.cell, bpc.sourceShard.String(), topodatapb.TabletType_REPLICA)

--- a/go/vt/tabletserver/queryservice/fakes/stream_health_query_service.go
+++ b/go/vt/tabletserver/queryservice/fakes/stream_health_query_service.go
@@ -83,6 +83,18 @@ func (q *StreamHealthQueryService) AddHealthResponseWithSecondsBehindMaster(repl
 	}
 }
 
+// AddHealthResponseWithNotServing adds a faked health response to the
+// buffer channel. Only "Serving" is different in this message.
+func (q *StreamHealthQueryService) AddHealthResponseWithNotServing() {
+	q.healthResponses <- &querypb.StreamHealthResponse{
+		Target:  proto.Clone(&q.target).(*querypb.Target),
+		Serving: false,
+		RealtimeStats: &querypb.RealtimeStats{
+			SecondsBehindMaster: DefaultSecondsBehindMaster,
+		},
+	}
+}
+
 // UpdateType changes the type of the query service.
 // Only newly sent health messages will use the new type.
 func (q *StreamHealthQueryService) UpdateType(tabletType topodatapb.TabletType) {

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -564,7 +564,8 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 					scw.tableStatusList.threadStarted(tableIndex)
 
 					// Start streaming from the source tablets.
-					rr, err := NewRestartableResultReader(ctx, scw.wr.Logger(), scw.wr.TopoServer(), scw.sourceAliases[shardIndex], td, chunk)
+					tp := newSingleTabletProvider(ctx, scw.wr.TopoServer(), scw.sourceAliases[shardIndex])
+					rr, err := NewRestartableResultReader(ctx, scw.wr.Logger(), tp, td, chunk)
 					if err != nil {
 						processError("NewRestartableResultReader failed: %v", err)
 						return

--- a/go/vt/worker/tablet_provider.go
+++ b/go/vt/worker/tablet_provider.go
@@ -1,0 +1,86 @@
+package worker
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/discovery"
+	"github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/topo/topoproto"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// tabletProvider defines an interface to pick a tablet for reading data.
+type tabletProvider interface {
+	// getTablet returns a tablet.
+	getTablet() (*topodatapb.Tablet, error)
+
+	// returnTablet must be called after the tablet is no longer used and e.g.
+	// TabletTracker.Untrack() should get called for it.
+	returnTablet(*topodata.Tablet)
+
+	// description returns a string which can be used in error messages e.g.
+	// the name of the keyspace and the shard.
+	description() string
+}
+
+// singleTabletProvider implements the tabletProvider interface and always
+// returns the one tablet which was set at creation.
+type singleTabletProvider struct {
+	ctx   context.Context
+	ts    topo.Server
+	alias *topodatapb.TabletAlias
+}
+
+func newSingleTabletProvider(ctx context.Context, ts topo.Server, alias *topodatapb.TabletAlias) *singleTabletProvider {
+	return &singleTabletProvider{ctx, ts, alias}
+}
+
+func (p *singleTabletProvider) getTablet() (*topodatapb.Tablet, error) {
+	shortCtx, cancel := context.WithTimeout(p.ctx, *remoteActionsTimeout)
+	tablet, err := p.ts.GetTablet(shortCtx, p.alias)
+	cancel()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve tablet alias: %v err: %v", topoproto.TabletAliasString(p.alias), err)
+	}
+	return tablet.Tablet, err
+}
+
+func (p *singleTabletProvider) returnTablet(*topodata.Tablet) {}
+
+func (p *singleTabletProvider) description() string {
+	return topoproto.TabletAliasString(p.alias)
+}
+
+// shardTabletProvider returns a random healthy RDONLY tablet for a given
+// keyspace and shard. It uses the HealthCheck module to retrieve the tablets.
+type shardTabletProvider struct {
+	tsc      *discovery.TabletStatsCache
+	tracker  *TabletTracker
+	keyspace string
+	shard    string
+}
+
+func newShardTabletProvider(tsc *discovery.TabletStatsCache, tracker *TabletTracker, keyspace, shard string) *shardTabletProvider {
+	return &shardTabletProvider{tsc, tracker, keyspace, shard}
+}
+
+func (p *shardTabletProvider) getTablet() (*topodatapb.Tablet, error) {
+	// Pick any healthy serving tablet.
+	tablets := p.tsc.GetHealthyTabletStats(p.keyspace, p.shard, topodatapb.TabletType_RDONLY)
+	if len(tablets) == 0 {
+		return nil, fmt.Errorf("%v: no healthy RDONLY tablets available", p.description())
+	}
+	return p.tracker.Track(tablets), nil
+}
+
+func (p *shardTabletProvider) returnTablet(t *topodatapb.Tablet) {
+	p.tracker.Untrack(t.Alias)
+}
+
+func (p *shardTabletProvider) description() string {
+	return topoproto.KeyspaceShardString(p.keyspace, p.shard)
+}

--- a/go/vt/worker/tablet_tracker.go
+++ b/go/vt/worker/tablet_tracker.go
@@ -37,7 +37,7 @@ func NewTabletTracker() *TabletTracker {
 // Track will pick the least used tablet from "stats", increment its usage by 1
 // and return it.
 // "stats" must not be empty.
-func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.TabletAlias {
+func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.Tablet {
 	if len(stats) == 0 {
 		panic("stats must not be empty")
 	}
@@ -49,7 +49,7 @@ func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.TabletAli
 		key := topoproto.TabletAliasString(stat.Tablet.Alias)
 		if _, ok := t.usedTablets[key]; !ok {
 			t.usedTablets[key] = 1
-			return stat.Tablet.Alias
+			return stat.Tablet
 		}
 	}
 
@@ -60,7 +60,7 @@ func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.TabletAli
 			key := topoproto.TabletAliasString(stat.Tablet.Alias)
 			if key == aliasString {
 				t.usedTablets[key]++
-				return stat.Tablet.Alias
+				return stat.Tablet
 			}
 		}
 	}

--- a/go/vt/worker/tablet_tracker_test.go
+++ b/go/vt/worker/tablet_tracker_test.go
@@ -42,19 +42,19 @@ func TestTabletsInUse(t *testing.T) {
 func TestTrackUntrack(t *testing.T) {
 	tt := NewTabletTracker()
 	// ts1 will be used because no tablet is in use yet and ts1 is the first.
-	if got, want := tt.Track(allTs), ts1.Tablet.Alias; !proto.Equal(got, want) {
+	if got, want := tt.Track(allTs), ts1.Tablet; !proto.Equal(got, want) {
 		t.Fatalf("Track(%v) = %v, want = %v", allTs, got, want)
 	}
 
 	// ts1 is already in use once, use ts2 now.
-	if got, want := tt.Track(allTs), ts2.Tablet.Alias; !proto.Equal(got, want) {
+	if got, want := tt.Track(allTs), ts2.Tablet; !proto.Equal(got, want) {
 		t.Fatalf("Track(%v) = %v, want = %v", allTs, got, want)
 	}
 
 	// ts2 is no longer in use after Untrack().
 	tt.Untrack(ts2.Tablet.Alias)
 	// ts2 instead of ts1 will be used because ts1 has a higher use count.
-	if got, want := tt.Track(allTs), ts2.Tablet.Alias; !proto.Equal(got, want) {
+	if got, want := tt.Track(allTs), ts2.Tablet; !proto.Equal(got, want) {
 		t.Fatalf("Track(%v) = %v, want = %v", allTs, got, want)
 	}
 }

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
 	"github.com/youtube/vitess/go/vt/tabletserver/grpcqueryservice"
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice/fakes"
+	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"github.com/youtube/vitess/go/vt/wrangler/testlib"
 	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
@@ -125,14 +126,14 @@ func TestVerticalSplitClone(t *testing.T) {
 	}
 	sourceRdonlyShqs := fakes.NewStreamHealthQueryService(sourceRdonly.Target())
 	sourceRdonlyShqs.AddDefaultHealthResponse()
-	sourceRdonlyQs := newTestQueryService(t, sourceRdonly.Target(), sourceRdonlyShqs, 0, 1, sourceRdonly.Tablet.Alias.Uid, true /* omitKeyspaceID */)
+	sourceRdonlyQs := newTestQueryService(t, sourceRdonly.Target(), sourceRdonlyShqs, 0, 1, topoproto.TabletAliasString(sourceRdonly.Tablet.Alias), true /* omitKeyspaceID */)
 	sourceRdonlyQs.addGeneratedRows(verticalSplitCloneTestMin, verticalSplitCloneTestMax)
 	grpcqueryservice.Register(sourceRdonly.RPCServer, sourceRdonlyQs)
 
 	// Set up destination rdonly which will be used as input for the diff during the clone.
 	destRdonlyShqs := fakes.NewStreamHealthQueryService(destRdonly.Target())
 	destRdonlyShqs.AddDefaultHealthResponse()
-	destRdonlyQs := newTestQueryService(t, destRdonly.Target(), destRdonlyShqs, 0, 1, destRdonly.Tablet.Alias.Uid, true /* omitKeyspaceID */)
+	destRdonlyQs := newTestQueryService(t, destRdonly.Target(), destRdonlyShqs, 0, 1, topoproto.TabletAliasString(destRdonly.Tablet.Alias), true /* omitKeyspaceID */)
 	// This tablet is empty and does not return any rows.
 	grpcqueryservice.Register(destRdonly.RPCServer, destRdonlyQs)
 

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -70,6 +70,13 @@ var (
 	statsOfflineUpdatesCounters = stats.NewCounters("WorkerOfflineUpdatesCounters")
 	// statsOfflineUpdatesCounters tracks for every table how many rows were deleted.
 	statsOfflineDeletesCounters = stats.NewCounters("WorkerOfflineDeletesCounters")
+
+	// statsStreamingQueryRestartsCounters tracks for every tablet alias how often
+	// a streaming query was succesfully established there.
+	statsStreamingQueryCounters = stats.NewCounters("StreamingQueryCounters")
+	// statsStreamingQueryErrorsCounters tracks for every tablet alias how often
+	// a (previously successfully established) streaming query did error.
+	statsStreamingQueryErrorsCounters = stats.NewCounters("StreamingQueryErrorsCounters")
 )
 
 const (
@@ -91,6 +98,8 @@ func resetVars() {
 	statsOfflineInsertsCounters.Reset()
 	statsOfflineUpdatesCounters.Reset()
 	statsOfflineDeletesCounters.Reset()
+	statsStreamingQueryCounters.Reset()
+	statsStreamingQueryErrorsCounters.Reset()
 }
 
 // checkDone returns ctx.Err() iff ctx.Done().


### PR DESCRIPTION
…retry failed.

This is necessary when a tablet is temporary taken out of service.

I've added two integration tests in split_clone_test.go to cover the new functionality.

Other changes:
- Added stat variables for started and errored streaming queries.
- Fake query service uses the alias instead of the UID to make it easier to access the new stat vars by alias.
- The fake query service now supports an error callback to run code before an error is returned.
- TestSplitCloneV2_Offline_RestartStreamingQuery: Tightened the test by using only one source tablet and verifying the stat vars.
- Unified the clone code to always use a common prefix "table=%v chunk=%v" within the chunk pipeline.

@alainjobart 