### PR TITLE
test: Temporarily disable the webdriver test for the new vtctld2.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -207,32 +207,6 @@ echo "creating git pre-commit hooks"
 mkdir -p $VTTOP/.git/hooks
 ln -sf $VTTOP/misc/git/pre-commit $VTTOP/.git/hooks/pre-commit
 
-# Download node
-node_ver=v6.3.1
-node_dist=$VTROOT/dist/node
-if [[ -x $node_dist/bin/node && `$node_dist/bin/node -v` == "$node_ver" ]]; then
-  echo "skipping nodejs download. remove $node_dist to force redownload."
-else
-  echo "Downloading nodejs"
-  rm -rf $node_dist
-  curl -sL https://nodejs.org/dist/$node_ver/node-$node_ver-linux-x64.tar.xz > node_linux64.xz
-  tar xf node_linux64.xz -C $VTROOT/dist
-  mv $VTROOT/dist/node-$node_ver-linux-x64 $node_dist
-  rm node_linux64.xz
-fi
-
-echo "Installing dependencies for building web UI"
-angular_cli_dir=$VTROOT/dist/angular-cli
-web_dir2=$VTTOP/web/vtctld2
-rm -rf $angular_cli_dir
-cd $VTROOT/dist && git clone https://github.com/angular/angular-cli.git --quiet
-cd $angular_cli_dir && git checkout 3dcd49bc625db36dd9f539cf9ce2492107e0258c --quiet
-cd $angular_cli_dir && $node_dist/bin/npm link --silent
-$node_dist/bin/npm install -g bower --silent
-cd $web_dir2 && $node_dist/bin/npm install --silent
-cd $web_dir2 && $node_dist/bin/npm link angular-cli --silent
-cd $web_dir2 && $node_dist/bin/bower install --silent
-
 # Download chromedriver
 echo "Installing selenium and chromedriver"
 selenium_dist=$VTROOT/dist/selenium

--- a/test.go
+++ b/test.go
@@ -357,7 +357,7 @@ func main() {
 	} else {
 		// Since we're sharing the working dir, do the build once for all tests.
 		log.Printf("Running make build...")
-		if out, err := exec.Command("make", "build", "build_web").CombinedOutput(); err != nil {
+		if out, err := exec.Command("make", "build").CombinedOutput(); err != nil {
 			log.Fatalf("make build failed: %v\n%s", err, out)
 		}
 	}

--- a/test/config.json
+++ b/test/config.json
@@ -370,7 +370,7 @@
 			"File": "vtctld2_web_test.py",
 			"Args": [],
 			"Command": [],
-			"Manual": false,
+			"Manual": true,
 			"Shard": 4,
 			"RetryMax": 0,
 			"Tags": [

--- a/tools/bootstrap_web.sh
+++ b/tools/bootstrap_web.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2016, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+# This script is used to install dependencies for compiling
+# the code of our upcoming Angular 2 based vtctld UI.
+#
+# Regular users should not have to run it. Run bootstrap.sh (located in the
+# repository root) instead.
+
+# TODO(mberlin): Merge this back into bootstrap.sh once we support caching the
+#                dependencies on Travis and local disk.
+
+# Download node
+node_ver=v6.3.1
+node_dist=$VTROOT/dist/node
+if [[ -x $node_dist/bin/node && `$node_dist/bin/node -v` == "$node_ver" ]]; then
+  echo "skipping nodejs download. remove $node_dist to force redownload."
+else
+  echo "Downloading nodejs"
+  rm -rf $node_dist
+  curl -sL https://nodejs.org/dist/$node_ver/node-$node_ver-linux-x64.tar.xz > node_linux64.xz
+  tar xf node_linux64.xz -C $VTROOT/dist
+  mv $VTROOT/dist/node-$node_ver-linux-x64 $node_dist
+  rm node_linux64.xz
+fi
+
+echo "Installing dependencies for building web UI"
+angular_cli_dir=$VTROOT/dist/angular-cli
+web_dir2=$VTTOP/web/vtctld2
+rm -rf $angular_cli_dir
+cd $VTROOT/dist && git clone https://github.com/angular/angular-cli.git --quiet
+cd $angular_cli_dir && git checkout 3dcd49bc625db36dd9f539cf9ce2492107e0258c --quiet
+cd $angular_cli_dir && $node_dist/bin/npm link --silent
+$node_dist/bin/npm install -g bower --silent
+cd $web_dir2 && $node_dist/bin/npm install --silent
+cd $web_dir2 && $node_dist/bin/npm link angular-cli --silent
+cd $web_dir2 && $node_dist/bin/bower install --silent


### PR DESCRIPTION
The test requires many dependencies which prolong the current test duration by up to 10 minutes on Travis.

Once we figured out how to cache the dependencies both on Travis and our local machines, we can re-enable the test.

Instead of commenting the code for installing the dependencies, I've moved it to bootstrap_web.sh for now.