### PR TITLE
vtworker: Add statistic variables for the number of rows skipped per …

### DIFF
--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -807,10 +807,10 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 	var tableStatusList *tableStatusList
 	switch state {
 	case WorkerStateCloneOnline:
-		statsCounters = []*stats.Counters{statsOnlineInsertsCounters, statsOnlineUpdatesCounters, statsOnlineDeletesCounters}
+		statsCounters = []*stats.Counters{statsOnlineInsertsCounters, statsOnlineUpdatesCounters, statsOnlineDeletesCounters, statsOnlineEqualRowsCounters}
 		tableStatusList = scw.tableStatusListOnline
 	case WorkerStateCloneOffline:
-		statsCounters = []*stats.Counters{statsOfflineInsertsCounters, statsOfflineUpdatesCounters, statsOfflineDeletesCounters}
+		statsCounters = []*stats.Counters{statsOfflineInsertsCounters, statsOfflineUpdatesCounters, statsOfflineDeletesCounters, statsOfflineEqualRowsCounters}
 		tableStatusList = scw.tableStatusListOffline
 	}
 

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/mysqlctl/replication"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
@@ -695,23 +696,12 @@ func TestSplitCloneV2_Online(t *testing.T) {
 	if err := runCommand(t, tc.wi, tc.wi.wr, args); err != nil {
 		t.Fatal(err)
 	}
-	if inserts := statsOnlineInsertsCounters.Counts()["table1"]; inserts != 100 {
-		t.Errorf("wrong number of rows inserted: got = %v, want = %v", inserts, 100)
+
+	if err := verifyOnlineCounters(100, 0, 0, 0); err != nil {
+		t.Fatalf("wrong Online counters: %v", err)
 	}
-	if updates := statsOnlineUpdatesCounters.Counts()["table1"]; updates != 0 {
-		t.Errorf("wrong number of rows updated: got = %v, want = %v", updates, 0)
-	}
-	if deletes := statsOnlineDeletesCounters.Counts()["table1"]; deletes != 0 {
-		t.Errorf("wrong number of rows deleted: got = %v, want = %v", deletes, 0)
-	}
-	if inserts := statsOfflineInsertsCounters.Counts()["table1"]; inserts != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got inserts = %v", inserts)
-	}
-	if updates := statsOfflineUpdatesCounters.Counts()["table1"]; updates != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got updates = %v", updates)
-	}
-	if deletes := statsOfflineDeletesCounters.Counts()["table1"]; deletes != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got deletes = %v", deletes)
+	if err := verifyOfflineCounters(0, 0, 0, 0); err != nil {
+		t.Fatalf("wrong Offline counters: %v", err)
 	}
 }
 
@@ -739,29 +729,19 @@ func TestSplitCloneV2_Online_Offline(t *testing.T) {
 	if err := runCommand(t, tc.wi, tc.wi.wr, args); err != nil {
 		t.Fatal(err)
 	}
-	if inserts := statsOnlineInsertsCounters.Counts()["table1"]; inserts != 100 {
-		t.Errorf("wrong number of rows inserted: got = %v, want = %v", inserts, 100)
+
+	if err := verifyOnlineCounters(100, 0, 0, 0); err != nil {
+		t.Fatalf("wrong Online counters: %v", err)
 	}
-	if updates := statsOnlineUpdatesCounters.Counts()["table1"]; updates != 0 {
-		t.Errorf("wrong number of rows updated: got = %v, want = %v", updates, 0)
-	}
-	if deletes := statsOnlineDeletesCounters.Counts()["table1"]; deletes != 0 {
-		t.Errorf("wrong number of rows deleted: got = %v, want = %v", deletes, 0)
-	}
-	if inserts := statsOfflineInsertsCounters.Counts()["table1"]; inserts != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got inserts = %v", inserts)
-	}
-	if updates := statsOfflineUpdatesCounters.Counts()["table1"]; updates != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got updates = %v", updates)
-	}
-	if deletes := statsOfflineDeletesCounters.Counts()["table1"]; deletes != 0 {
-		t.Errorf("no stats for the offline clone phase should have been modified. got deletes = %v", deletes)
+	if err := verifyOfflineCounters(0, 0, 0, 100); err != nil {
+		t.Fatalf("wrong Offline counters: %v", err)
 	}
 }
 
-// TestSplitCloneV2_Reconciliation is identical to TestSplitCloneV2_Offline,
-// but the destination has existing data which must be reconciled.
-func TestSplitCloneV2_Reconciliation(t *testing.T) {
+// TestSplitCloneV2_Offline_Reconciliation is identical to
+// TestSplitCloneV2_Offline, but the destination has existing data which must be
+// reconciled.
+func TestSplitCloneV2_Offline_Reconciliation(t *testing.T) {
 	tc := &splitCloneTestCase{t: t}
 	// We reduce the parallelism to 1 to test the order of expected
 	// insert/update/delete statements on the destination master.
@@ -784,7 +764,8 @@ func TestSplitCloneV2_Reconciliation(t *testing.T) {
 	}
 
 	for i := range []int{0, 1} {
-		// Both destination shards have the rows 100-200.
+		// The destination has rows 100-190 with the source in common.
+		// Rows 191-200 are extraenous on the destination.
 		tc.leftRdonlyQs[i].addGeneratedRows(100, 200)
 		tc.rightRdonlyQs[i].addGeneratedRows(100, 200)
 		// But some data is outdated data and must be updated.
@@ -820,23 +801,12 @@ func TestSplitCloneV2_Reconciliation(t *testing.T) {
 	if err := runCommand(t, tc.wi, tc.wi.wr, args); err != nil {
 		t.Fatal(err)
 	}
-	if inserts := statsOnlineInsertsCounters.Counts()["table1"]; inserts != 0 {
-		t.Errorf("no stats for the online clone phase should have been modified. got inserts = %v", inserts)
+
+	if err := verifyOnlineCounters(0, 0, 0, 0); err != nil {
+		t.Fatalf("wrong Online counters: %v", err)
 	}
-	if updates := statsOnlineUpdatesCounters.Counts()["table1"]; updates != 0 {
-		t.Errorf("no stats for the online clone phase should have been modified. got updates = %v", updates)
-	}
-	if deletes := statsOnlineDeletesCounters.Counts()["table1"]; deletes != 0 {
-		t.Errorf("no stats for the online clone phase should have been modified. got deletes = %v", deletes)
-	}
-	if inserts := statsOfflineInsertsCounters.Counts()["table1"]; inserts != 4 {
-		t.Errorf("wrong number of rows inserted: got = %v, want = %v", inserts, 4)
-	}
-	if updates := statsOfflineUpdatesCounters.Counts()["table1"]; updates != 4 {
-		t.Errorf("wrong number of rows updated: got = %v, want = %v", updates, 4)
-	}
-	if deletes := statsOfflineDeletesCounters.Counts()["table1"]; deletes != 10 {
-		t.Errorf("wrong number of rows deleted: got = %v, want = %v", deletes, 10)
+	if err := verifyOfflineCounters(4, 4, 10, 86); err != nil {
+		t.Fatalf("wrong Offline counters: %v", err)
 	}
 }
 
@@ -1039,4 +1009,38 @@ func TestSplitCloneV3(t *testing.T) {
 	if err := runCommand(t, tc.wi, tc.wi.wr, tc.defaultWorkerArgs); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func verifyOnlineCounters(inserts, updates, deletes, equal int64) error {
+	rec := concurrency.AllErrorRecorder{}
+	if got, want := statsOnlineInsertsCounters.Counts()["table1"], inserts; got != want {
+		rec.RecordError(fmt.Errorf("wrong online INSERTs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOnlineUpdatesCounters.Counts()["table1"], updates; got != want {
+		rec.RecordError(fmt.Errorf("wrong online UPDATEs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOnlineDeletesCounters.Counts()["table1"], deletes; got != want {
+		rec.RecordError(fmt.Errorf("wrong online DELETEs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOnlineEqualRowsCounters.Counts()["table1"], equal; got != want {
+		rec.RecordError(fmt.Errorf("wrong online equal rows count: got = %v, want = %v", got, want))
+	}
+	return rec.Error()
+}
+
+func verifyOfflineCounters(inserts, updates, deletes, equal int64) error {
+	rec := concurrency.AllErrorRecorder{}
+	if got, want := statsOfflineInsertsCounters.Counts()["table1"], inserts; got != want {
+		rec.RecordError(fmt.Errorf("wrong offline INSERTs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOfflineUpdatesCounters.Counts()["table1"], updates; got != want {
+		rec.RecordError(fmt.Errorf("wrong offline UPDATEs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOfflineDeletesCounters.Counts()["table1"], deletes; got != want {
+		rec.RecordError(fmt.Errorf("wrong offline DELETEs count: got = %v, want = %v", got, want))
+	}
+	if got, want := statsOfflineEqualRowsCounters.Counts()["table1"], equal; got != want {
+		rec.RecordError(fmt.Errorf("wrong offline equal rows count: got = %v, want = %v", got, want))
+	}
+	return rec.Error()
 }

--- a/go/vt/worker/table_status.go
+++ b/go/vt/worker/table_status.go
@@ -105,10 +105,10 @@ func (t *tableStatusList) format() ([]string, time.Time) {
 			result[i] = fmt.Sprintf("%v: copy not started (estimating %v rows)", ts.name, ts.rowCount)
 		} else if ts.threadsDone == ts.threadCount {
 			// we are done with the copy
-			result[i] = fmt.Sprintf("%v: copy done, copied %v rows", ts.name, ts.copiedRows)
+			result[i] = fmt.Sprintf("%v: copy done, processed %v rows", ts.name, ts.copiedRows)
 		} else {
 			// copy is running
-			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount)
+			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount)
 		}
 		copiedRows += ts.copiedRows
 		rowCount += ts.rowCount

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -56,6 +56,7 @@ var (
 	statsThrottledCounters = stats.NewMultiCounters("WorkerThrottledCounters", []string{"keyspace", "shardname", "thread_id"})
 	// statsStateDurations tracks for each state how much time was spent in it. Mainly used for testing.
 	statsStateDurationsNs = stats.NewCounters("WorkerStateDurations")
+
 	// statsOnlineInsertsCounters tracks for every table how many rows were
 	// inserted during the online clone (reconciliation) phase.
 	statsOnlineInsertsCounters = stats.NewCounters("WorkerOnlineInsertsCounters")
@@ -63,6 +64,9 @@ var (
 	statsOnlineUpdatesCounters = stats.NewCounters("WorkerOnlineUpdatesCounters")
 	// statsOnlineUpdatesCounters tracks for every table how many rows were deleted.
 	statsOnlineDeletesCounters = stats.NewCounters("WorkerOnlineDeletesCounters")
+	// statsOnlineEqualRowsCounters tracks for every table how many rows were equal.
+	statsOnlineEqualRowsCounters = stats.NewCounters("WorkerOnlineEqualRowsCounters")
+
 	// statsOfflineInsertsCounters tracks for every table how many rows were
 	// inserted during the online clone (reconciliation) phase.
 	statsOfflineInsertsCounters = stats.NewCounters("WorkerOfflineInsertsCounters")
@@ -70,6 +74,8 @@ var (
 	statsOfflineUpdatesCounters = stats.NewCounters("WorkerOfflineUpdatesCounters")
 	// statsOfflineUpdatesCounters tracks for every table how many rows were deleted.
 	statsOfflineDeletesCounters = stats.NewCounters("WorkerOfflineDeletesCounters")
+	// statsOfflineEqualRowsCounters tracks for every table how many rows were equal.
+	statsOfflineEqualRowsCounters = stats.NewCounters("WorkerOfflineEqualRowsCounters")
 
 	// statsStreamingQueryRestartsCounters tracks for every tablet alias how often
 	// a streaming query was succesfully established there.
@@ -92,12 +98,17 @@ func resetVars() {
 	statsState.Set("")
 	statsRetryCount.Set(0)
 	statsRetryCounters.Reset()
+
 	statsOnlineInsertsCounters.Reset()
 	statsOnlineUpdatesCounters.Reset()
 	statsOnlineDeletesCounters.Reset()
+	statsOnlineEqualRowsCounters.Reset()
+
 	statsOfflineInsertsCounters.Reset()
 	statsOfflineUpdatesCounters.Reset()
 	statsOfflineDeletesCounters.Reset()
+	statsOfflineEqualRowsCounters.Reset()
+
 	statsStreamingQueryCounters.Reset()
 	statsStreamingQueryErrorsCounters.Reset()
 }

--- a/test/base_sharding.py
+++ b/test/base_sharding.py
@@ -347,7 +347,7 @@ class BaseShardingTest(object):
     self.assertIn('%d active throttler(s)' % len(names), stdout)
 
   def verify_reconciliation_counters(self, worker_port, online_or_offline,
-                                     table, inserts, updates, deletes):
+                                     table, inserts, updates, deletes, equal):
     """Checks that the reconciliation Counters have the expected values."""
     worker_vars = utils.get_vars(worker_port)
 
@@ -368,3 +368,9 @@ class BaseShardingTest(object):
       self.assertNotIn(table, d)
     else:
       self.assertEqual(d[table], deletes)
+
+    e = worker_vars['Worker' + online_or_offline + 'EqualRowsCounters']
+    if equal == 0:
+      self.assertNotIn(table, e)
+    else:
+      self.assertEqual(e[table], equal)

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -471,7 +471,7 @@ index by_msg (msg)
         worker_rpc_port)
     utils.wait_procs([workerclient_proc])
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        3, 0, 0)
+                                        3, 0, 0, 0)
 
     # Reset vtworker such that we can run the next command.
     workerclient_proc = utils.run_vtworker_client_bg(['Reset'], worker_rpc_port)
@@ -502,9 +502,9 @@ index by_msg (msg)
         worker_rpc_port)
     utils.wait_procs([workerclient_proc])
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        2, 1, 1)
+                                        2, 1, 1, 0)
     self.verify_reconciliation_counters(worker_port, 'Offline', 'resharding1',
-                                        0, 0, 0)
+                                        0, 0, 0, 3)
     # Terminate worker daemon because it is no longer needed.
     utils.kill_sub_process(worker_proc, soft=True)
 

--- a/test/merge_sharding.py
+++ b/test/merge_sharding.py
@@ -276,7 +276,7 @@ index by_msg (msg)
         worker_rpc_port)
     utils.wait_procs([workerclient_proc])
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        2, 0, 0)
+                                        2, 0, 0, 0)
 
     # Reset vtworker such that we can run the next command.
     workerclient_proc = utils.run_vtworker_client_bg(['Reset'], worker_rpc_port)
@@ -308,9 +308,9 @@ index by_msg (msg)
     utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly.tablet_alias,
                      'rdonly'], auto_log=True)
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        1, 1, 1)
+                                        1, 1, 1, 0)
     self.verify_reconciliation_counters(worker_port, 'Offline', 'resharding1',
-                                        0, 0, 0)
+                                        0, 0, 0, 2)
     # Terminate worker daemon because it is no longer needed.
     utils.kill_sub_process(worker_proc, soft=True)
 

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -481,7 +481,7 @@ primary key (name)
         worker_rpc_port)
     utils.wait_procs([workerclient_proc])
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        2, 0, 0)
+                                        2, 0, 0, 0)
 
     # Reset vtworker such that we can run the next command.
     workerclient_proc = utils.run_vtworker_client_bg(['Reset'], worker_rpc_port)
@@ -507,7 +507,7 @@ primary key (name)
     utils.wait_procs([workerclient_proc])
     # Row 2 will be deleted from shard 2 and inserted to shard 3.
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        1, 0, 1)
+                                        1, 0, 1, 1)
     self._check_value(shard_2_master, 'resharding1', 2, 'msg2',
                       0xD000000000000000, should_be_here=False)
     self._check_value(shard_3_master, 'resharding1', 2, 'msg2',
@@ -534,7 +534,7 @@ primary key (name)
     utils.wait_procs([workerclient_proc])
     # Row 2 will be deleted from shard 3 and inserted to shard 2.
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        1, 0, 1)
+                                        1, 0, 1, 1)
     self._check_value(shard_2_master, 'resharding1', 2, 'msg2',
                       0x9000000000000000)
     self._check_value(shard_3_master, 'resharding1', 2, 'msg2',
@@ -571,9 +571,9 @@ primary key (name)
     utils.run_vtctl(['ChangeSlaveType', shard_1_rdonly1.tablet_alias,
                      'rdonly'], auto_log=True)
     self.verify_reconciliation_counters(worker_port, 'Online', 'resharding1',
-                                        1, 1, 2)
+                                        1, 1, 2, 0)
     self.verify_reconciliation_counters(worker_port, 'Offline', 'resharding1',
-                                        0, 0, 0)
+                                        0, 0, 0, 2)
     # Terminate worker daemon because it is no longer needed.
     utils.kill_sub_process(worker_proc, soft=True)
 


### PR DESCRIPTION
…table in each clone phase (online/offline).

This count is included in the total number of processed rows.

Doing so fixes the problem that the ETA calculation was wrong for subsequent online clones where many equal rows were skipped.