### PR TITLE
throttler: memory: Round values up instead of down.

### DIFF
--- a/go/vt/throttler/memory.go
+++ b/go/vt/throttler/memory.go
@@ -87,7 +87,9 @@ func (m *memory) markGood(rate int64) error {
 }
 
 func (m *memory) markBad(rate int64, now time.Time) error {
-	rate = m.roundDown(rate)
+	// Bad rates are rounded up instead of down to not be too extreme on the
+	// reduction and account for some margin of error.
+	rate = m.roundUp(rate)
 
 	// Ignore higher bad rates than the current one.
 	if m.bad != 0 && rate >= m.bad {
@@ -160,4 +162,12 @@ func (m *memory) lowestBad() int64 {
 
 func (m *memory) roundDown(rate int64) int64 {
 	return rate / int64(m.bucketSize) * int64(m.bucketSize)
+}
+
+func (m *memory) roundUp(rate int64) int64 {
+	ceil := rate / int64(m.bucketSize) * int64(m.bucketSize)
+	if rate%int64(m.bucketSize) != 0 {
+		ceil += int64(m.bucketSize)
+	}
+	return ceil
 }

--- a/go/vt/throttler/memory_test.go
+++ b/go/vt/throttler/memory_test.go
@@ -36,9 +36,9 @@ func TestMemory(t *testing.T) {
 	if got := m.lowestBad(); got != 0 {
 		t.Fatalf("lowestBad should return zero value when no bad rate is recorded yet: got = %v", got)
 	}
-	m.markBad(301, sinceZero(0))
-	if got := m.lowestBad(); got != want300 {
-		t.Fatalf("bad rate was not recorded: got = %v, want = %v", got, want300)
+	m.markBad(300, sinceZero(0))
+	if got, want := m.lowestBad(), want300; got != want {
+		t.Fatalf("bad rate was not recorded: got = %v, want = %v", got, want)
 	}
 	if got := m.highestGood(); got != want200 {
 		t.Fatalf("new lower bad rate did not invalidate previous good rates: got = %v, want = %v", got, want200)
@@ -60,7 +60,8 @@ func TestMemory(t *testing.T) {
 		t.Fatalf("good rates beyond the lowest bad rate must be ignored: got = %v, want = %v", got, want200)
 	}
 
-	m.markBad(201, sinceZero(0))
+	// 199 will be rounded up to 200.
+	m.markBad(199, sinceZero(0))
 	if got := m.lowestBad(); got != want200 {
 		t.Fatalf("bad rate was not updated: got = %v, want = %v", got, want200)
 	}


### PR DESCRIPTION
This way we account for some error of margin and newly recorded bad rates result in a less severe drop of the adjusted throttler rate.