### PR TITLE
worker: Do not keep retrying after the first retry when an offline so…

### DIFF
--- a/go/vt/worker/fake_pool_connection_test.go
+++ b/go/vt/worker/fake_pool_connection_test.go
@@ -127,6 +127,7 @@ func (f *FakePoolConnection) deleteAllEntries() {
 	defer f.mu.Unlock()
 
 	f.expectedExecuteFetch = make([]ExpectedExecuteFetch, 0)
+	f.expectedExecuteFetchIndex = 0
 }
 
 func (f *FakePoolConnection) deleteAllEntriesAfterIndex(index int) {

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -565,7 +565,7 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 
 					// Start streaming from the source tablets.
 					tp := newSingleTabletProvider(ctx, scw.wr.TopoServer(), scw.sourceAliases[shardIndex])
-					rr, err := NewRestartableResultReader(ctx, scw.wr.Logger(), tp, td, chunk)
+					rr, err := NewRestartableResultReader(ctx, scw.wr.Logger(), tp, td, chunk, false /* allowMultipleRetries */)
 					if err != nil {
 						processError("NewRestartableResultReader failed: %v", err)
 						return


### PR DESCRIPTION
…urce tablet fails.

This is necessary to guard us against the situation that a failed offline source tablet comes back after its back and we would use it again. We must not use it in that case because its replication is no longer stopped at the point we initially took it offline.