### PR TITLE
logutil/purge: Fix timestamp parsing for -keep_logs purge feature

### DIFF
--- a/go/vt/logutil/logutil_test.go
+++ b/go/vt/logutil/logutil_test.go
@@ -11,10 +11,9 @@ import (
 
 func TestParsing(t *testing.T) {
 
-	path := [...]string{
+	path := []string{
 		"/tmp/something.foo/zkocc.goedel.szopa.log.INFO.20130806-151006.10530",
-		"/tmp/something.foo/zkocc.goedel.szopa.test.log.ERROR.20130806-151006.10530",
-	}
+		"/tmp/something.foo/zkocc.goedel.szopa.test.log.ERROR.20130806-151006.10530"}
 
 	for _, filepath := range path {
 		ts, err := parseTimestamp(filepath)

--- a/go/vt/logutil/logutil_test.go
+++ b/go/vt/logutil/logutil_test.go
@@ -10,13 +10,21 @@ import (
 )
 
 func TestParsing(t *testing.T) {
-	ts, err := parseTimestamp("/tmp/something.foo/zkocc.goedel.szopa.log.INFO.20130806-151006.10530")
-	if err != nil {
-		t.Fatalf("parse: %v", err)
+
+	path := [...]string{
+		"/tmp/something.foo/zkocc.goedel.szopa.log.INFO.20130806-151006.10530",
+		"/tmp/something.foo/zkocc.goedel.szopa.test.log.ERROR.20130806-151006.10530",
 	}
 
-	if want := time.Date(2013, 8, 6, 15, 10, 06, 0, time.UTC); ts != want {
-		t.Errorf("timestamp: want %v, got %v", want, ts)
+	for _, filepath := range path {
+		ts, err := parseTimestamp(filepath)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		if want := time.Date(2013, 8, 6, 15, 10, 06, 0, time.Now().Location()); ts != want {
+			t.Errorf("timestamp: want %v, got %v", want, ts)
+		}
 	}
 }
 
@@ -27,7 +35,7 @@ func TestPurge(t *testing.T) {
 	}
 	defer os.RemoveAll(logDir)
 
-	now := time.Date(2013, 8, 6, 15, 10, 06, 0, time.UTC)
+	now := time.Date(2013, 8, 6, 15, 10, 06, 0, time.Now().Location())
 	files := []string{
 		"zkocc.goedel.szopa.log.INFO.20130806-121006.10530",
 		"zkocc.goedel.szopa.log.INFO.20130806-131006.10530",

--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -22,7 +22,8 @@ func parseTimestamp(filename string) (timestamp time.Time, err error) {
 	if len(parts) < 6 {
 		return time.Time{}, fmt.Errorf("malformed logfile name: %v", filename)
 	}
-	return time.Parse("20060102-150405", parts[5])
+	//return time.Parse("20060102-150405", parts[5])
+	return time.ParseInLocation("20060102-150405", parts[len(parts)-2], time.Now().Location())
 
 }
 

--- a/go/vt/logutil/purge.go
+++ b/go/vt/logutil/purge.go
@@ -22,7 +22,6 @@ func parseTimestamp(filename string) (timestamp time.Time, err error) {
 	if len(parts) < 6 {
 		return time.Time{}, fmt.Errorf("malformed logfile name: %v", filename)
 	}
-	//return time.Parse("20060102-150405", parts[5])
 	return time.ParseInLocation("20060102-150405", parts[len(parts)-2], time.Now().Location())
 
 }


### PR DESCRIPTION
Fixes #1994