### PR TITLE
worker: Reduce log spam for per chunk log lines which occur on the ha…

### DIFF
--- a/go/vt/worker/restartable_result_reader.go
+++ b/go/vt/worker/restartable_result_reader.go
@@ -13,6 +13,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	log "github.com/golang/glog"
+
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
@@ -130,7 +132,7 @@ func (r *RestartableResultReader) startStream() (bool, error) {
 
 	alias := topoproto.TabletAliasString(r.tablet.Alias)
 	statsStreamingQueryCounters.Add(alias, 1)
-	r.logger.Infof("tablet=%v table=%v chunk=%v: Starting to stream rows using query '%v'.", alias, r.td.Name, r.chunk, r.query)
+	log.V(2).Infof("tablet=%v table=%v chunk=%v: Starting to stream rows using query '%v'.", alias, r.td.Name, r.chunk, r.query)
 	return false, nil
 }
 

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -10,6 +10,8 @@ import (
 	"math/rand"
 	"time"
 
+	log "github.com/golang/glog"
+
 	"github.com/youtube/vitess/go/vt/discovery"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
@@ -58,7 +60,7 @@ func waitForHealthyRdonlyTablets(ctx context.Context, wr *wrangler.Wrangler, tsc
 
 	start := time.Now()
 	deadlineForLog, _ := busywaitCtx.Deadline()
-	wr.Logger().Infof("Waiting for enough healthy RDONLY tablets to become available in (%v,%v/%v). required: %v Waiting up to %.1f seconds.",
+	log.V(2).Infof("Waiting for enough healthy RDONLY tablets to become available in (%v,%v/%v). required: %v Waiting up to %.1f seconds.",
 		cell, keyspace, shard, minHealthyRdonlyTablets, deadlineForLog.Sub(time.Now()).Seconds())
 
 	// Wait for at least one RDONLY tablet initially before checking the list.
@@ -91,7 +93,7 @@ func waitForHealthyRdonlyTablets(ctx context.Context, wr *wrangler.Wrangler, tsc
 		case <-timer.C:
 		}
 	}
-	wr.Logger().Infof("At least %v healthy RDONLY tablets are available in (%v,%v/%v) (required: %v). Took %.1f seconds to find this out.",
+	log.V(2).Infof("At least %v healthy RDONLY tablets are available in (%v,%v/%v) (required: %v). Took %.1f seconds to find this out.",
 		len(healthyTablets), cell, keyspace, shard, minHealthyRdonlyTablets, time.Now().Sub(start).Seconds())
 	return healthyTablets, nil
 }


### PR DESCRIPTION
…ppy path.

The spam got worse when we switched from 10 to 1000 chunks.

It's logged to V2 to the log file only and will e.g. no longer show up in the web interface status page or on the stream returned by the RPC.