### PR TITLE
automation: Always reset the used vtworker after the command returned.

### DIFF
--- a/go/vt/automation/split_diff_task.go
+++ b/go/vt/automation/split_diff_task.go
@@ -16,6 +16,11 @@ type SplitDiffTask struct {
 
 // Run is part of the Task interface.
 func (t *SplitDiffTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
+	// Run a "Reset" first to clear the state of a previous finished command.
+	// This reset is best effort. We ignore the output and error of it.
+	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
+	ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
+
 	args := []string{"SplitDiff"}
 	if excludeTables := parameters["exclude_tables"]; excludeTables != "" {
 		args = append(args, "--exclude_tables="+excludeTables)
@@ -24,13 +29,8 @@ func (t *SplitDiffTask) Run(parameters map[string]string) ([]*automationpb.TaskC
 		args = append(args, "--min_healthy_rdonly_tablets="+minHealthyRdonlyTablets)
 	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["keyspace"], parameters["dest_shard"]))
-	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
-	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
-	if err == nil {
-		// Ignore output and error of the Reset.
-		ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
-	}
+	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 	return nil, output, err
 }
 

--- a/go/vt/automation/vertical_split_clone_task.go
+++ b/go/vt/automation/vertical_split_clone_task.go
@@ -17,6 +17,11 @@ type VerticalSplitCloneTask struct {
 
 // Run is part of the Task interface.
 func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
+	// Run a "Reset" first to clear the state of a previous finished command.
+	// This reset is best effort. We ignore the output and error of it.
+	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
+	ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
+
 	// TODO(mberlin): Add parameters for the following options?
 	//                        '--source_reader_count', '1',
 	//                        '--destination_writer_count', '1',
@@ -50,13 +55,8 @@ func (t *VerticalSplitCloneTask) Run(parameters map[string]string) ([]*automatio
 		args = append(args, "--max_replication_lag="+maxReplicationLag)
 	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["dest_keyspace"], parameters["shard"]))
-	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
-	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
-	if err == nil {
-		// Ignore output and error of the Reset.
-		ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
-	}
+	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 	return nil, output, err
 }
 

--- a/go/vt/automation/vertical_split_diff_task.go
+++ b/go/vt/automation/vertical_split_diff_task.go
@@ -17,18 +17,18 @@ type VerticalSplitDiffTask struct {
 
 // Run is part of the Task interface.
 func (t *VerticalSplitDiffTask) Run(parameters map[string]string) ([]*automationpb.TaskContainer, string, error) {
+	// Run a "Reset" first to clear the state of a previous finished command.
+	// This reset is best effort. We ignore the output and error of it.
+	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
+	ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
+
 	args := []string{"VerticalSplitDiff"}
 	if minHealthyRdonlyTablets := parameters["min_healthy_rdonly_tablets"]; minHealthyRdonlyTablets != "" {
 		args = append(args, "--min_healthy_rdonly_tablets="+minHealthyRdonlyTablets)
 	}
 	args = append(args, topoproto.KeyspaceShardString(parameters["dest_keyspace"], parameters["shard"]))
-	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 
-	// TODO(mberlin): Remove explicit reset when vtworker supports it implicility.
-	if err == nil {
-		// Ignore output and error of the Reset.
-		ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], []string{"Reset"})
-	}
+	output, err := ExecuteVtworker(context.TODO(), parameters["vtworker_endpoint"], args)
 	return nil, output, err
 }
 


### PR DESCRIPTION
Before this change, we triggered a reset only when the command was successful.