### PR TITLE
worker: Log streaming query restarts to V2 and no longer as part of t…

### DIFF
--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -83,6 +83,16 @@ var (
 	// statsStreamingQueryErrorsCounters tracks for every tablet alias how often
 	// a (previously successfully established) streaming query did error.
 	statsStreamingQueryErrorsCounters = stats.NewCounters("StreamingQueryErrorsCounters")
+	// statsStreamingQueryRestartsSameTabletCounters tracks for every tablet alias
+	// how often we successfully restarted a streaming query on the first retry.
+	// This kind of restart is usually necessary when our streaming query is idle
+	// and MySQL aborts it after a timeout.
+	statsStreamingQueryRestartsSameTabletCounters = stats.NewCounters("StreamingQueryRestartsSameTabletCounters")
+	// statsStreamingQueryRestartsDifferentTablet records how many restarts were
+	// successful on the 2 (or higher) retry after the initial retry to the same
+	// tablet failed and we switched to a different tablet. In practice, this
+	// happens when a tablet did go away due to a maintenance operation.
+	statsStreamingQueryRestartsDifferentTablet = stats.NewInt("StreamingQueryRestartsDifferentTablet")
 )
 
 const (


### PR DESCRIPTION
…he vtworker output.

This avoids log spam which could occur over hundreds of restarts when a clone runs for hours.

Instead, I'm tracking the restarts through additional stat variables now.

Other changes:
- Changed logging level for log messages of non-retryable errors from INFO to ERROR.