### PR TITLE
Add possibility to do reparent away from a certain tablet.

### DIFF
--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -97,7 +97,7 @@ func TestPlannedReparentShard(t *testing.T) {
 	defer goodSlave2.StopActionLoop(t)
 
 	// run PlannedReparentShard
-	if err := vp.Run([]string{"PlannedReparentShard", "-wait_slave_timeout", "10s", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, topoproto.TabletAliasString(newMaster.Tablet.Alias)}); err != nil {
+	if err := vp.Run([]string{"PlannedReparentShard", "-wait_slave_timeout", "10s", "-keyspace_shard", newMaster.Tablet.Keyspace + "/" + newMaster.Tablet.Shard, "-new_master", topoproto.TabletAliasString(newMaster.Tablet.Alias)}); err != nil {
 		t.Fatalf("PlannedReparentShard failed: %v", err)
 	}
 

--- a/test/backup.py
+++ b/test/backup.py
@@ -226,8 +226,9 @@ class TestBackup(unittest.TestCase):
     self._check_data(tablet_replica2, 2, 'replica2 tablet getting data')
 
     # Promote replica2 to master.
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/0',
-                     tablet_replica2.tablet_alias])
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/0',
+                     '-new_master', tablet_replica2.tablet_alias])
 
     # insert more data on replica2 (current master)
     self._insert_data(tablet_replica2, 3)
@@ -266,8 +267,9 @@ class TestBackup(unittest.TestCase):
     self._insert_data(tablet_master, 2)
 
     # reparent to replica1
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/0',
-                     tablet_replica1.tablet_alias])
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/0',
+                     '-new_master', tablet_replica1.tablet_alias])
 
     # insert more data on new master
     self._insert_data(tablet_replica1, 3)

--- a/test/end2end/k8s_environment.py
+++ b/test/end2end/k8s_environment.py
@@ -182,6 +182,7 @@ class K8sEnvironment(base_environment.BaseEnvironment):
     reparent_command = (
         'EmergencyReparentShard' if emergency else 'PlannedReparentShard')
     self.vtctl_helper.execute_vtctl_command(
-        [reparent_command, '%s/%s' % (keyspace, shard_name), new_master_uid])
+        [reparent_command, '-keyspace_shard', '%s/%s' % (keyspace, shard_name),
+         '-new_master', new_master_uid])
     self.vtctl_helper.execute_vtctl_command(['RebuildKeyspaceGraph', keyspace])
     return 0, 'No output'

--- a/test/reparent.py
+++ b/test/reparent.py
@@ -164,14 +164,16 @@ class TestReparent(unittest.TestCase):
     # Perform a planned reparent operation, will try to contact
     # the current master and fail somewhat quickly
     _, stderr = utils.run_vtctl(['-wait-time', '5s',
-                                 'PlannedReparentShard', 'test_keyspace/0',
-                                 tablet_62044.tablet_alias],
+                                 'PlannedReparentShard',
+                                 '-keyspace_shard', 'test_keyspace/0',
+                                 '-new_master', tablet_62044.tablet_alias],
                                 expect_fail=True)
     self.assertIn('DemoteMaster failed', stderr)
 
     # Run forced reparent operation, this should now proceed unimpeded.
-    utils.run_vtctl(['EmergencyReparentShard', 'test_keyspace/0',
-                     tablet_62044.tablet_alias], auto_log=True)
+    utils.run_vtctl(['EmergencyReparentShard',
+                     '-keyspace_shard', 'test_keyspace/0',
+                     '-new_master', tablet_62044.tablet_alias], auto_log=True)
 
     utils.validate_topology()
     self._check_master_tablet(tablet_62044)
@@ -231,8 +233,9 @@ class TestReparent(unittest.TestCase):
     self._check_master_tablet(tablet_62344)
 
     # Perform a graceful reparent operation to another cell.
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/' + shard_id,
-                     tablet_31981.tablet_alias], auto_log=True)
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/' + shard_id,
+                     '-new_master', tablet_31981.tablet_alias], auto_log=True)
     utils.validate_topology()
 
     self._check_master_tablet(tablet_31981)
@@ -303,8 +306,9 @@ class TestReparent(unittest.TestCase):
     self.assertIn('master', lines[0])  # master first
 
     # Perform a graceful reparent operation.
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/' + shard_id,
-                     tablet_62044.tablet_alias], auto_log=True)
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/' + shard_id,
+                     '-new_master', tablet_62044.tablet_alias], auto_log=True)
     utils.validate_topology()
 
     self._check_master_tablet(tablet_62044)
@@ -376,11 +380,81 @@ class TestReparent(unittest.TestCase):
     tablet_31981.kill_vttablet()
 
     # Perform a graceful reparent operation.
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/' + shard_id,
-                     tablet_62044.tablet_alias])
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/' + shard_id,
+                     '-new_master', tablet_62044.tablet_alias])
     self._check_master_tablet(tablet_62044)
 
     tablet.kill_tablets([tablet_62344, tablet_62044, tablet_41983])
+
+  def test_reparent_avoid(self):
+    utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
+
+    # create the database so vttablets start, as they are serving
+    tablet_62344.create_db('vt_test_keyspace')
+    tablet_62044.create_db('vt_test_keyspace')
+    tablet_31981.create_db('vt_test_keyspace')
+
+    # Start up a master mysql and vttablet
+    tablet_62344.init_tablet('master', 'test_keyspace', '0', start=True,
+                             wait_for_start=False)
+
+    # Create a few slaves for testing reparenting. Won't be healthy
+    # as replication is not running.
+    tablet_62044.init_tablet('replica', 'test_keyspace', '0', start=True,
+                             wait_for_start=False)
+    tablet_31981.init_tablet('replica', 'test_keyspace', '0', start=True,
+                             wait_for_start=False)
+    tablet_62344.wait_for_vttablet_state('SERVING')
+    for t in [tablet_62044, tablet_31981]:
+      t.wait_for_vttablet_state('NOT_SERVING')
+
+    utils.validate_topology()
+
+    # Force the slaves to reparent assuming that all the datasets are
+    # identical.
+    for t in [tablet_62344, tablet_62044, tablet_31981]:
+      t.reset_replication()
+    utils.run_vtctl(['InitShardMaster', 'test_keyspace/0',
+                     tablet_62344.tablet_alias], auto_log=True)
+
+    utils.validate_topology(ping_tablets=True)
+    self._check_master_tablet(tablet_62344)
+
+    # Perform a reparent operation with avoid_master pointing to non-master. It
+    # should succeed without doing anything.
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/0',
+                     '-avoid_master', tablet_62044.tablet_alias], auto_log=True)
+
+    utils.validate_topology()
+    self._check_master_tablet(tablet_62344)
+
+    # Perform a reparent operation with avoid_master pointing to master.
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/0',
+                     '-avoid_master', tablet_62344.tablet_alias], auto_log=True)
+
+    utils.validate_topology()
+    # 62044 is in the same cell and 31981 is in a different cell, so we must
+    # land on 62044
+    self._check_master_tablet(tablet_62044)
+
+    # If we kill the tablet in the same cell as master then reparent
+    # -avoid_master will fail.
+    tablet_62344.kill_vttablet()
+    _, stderr = utils.run_vtctl(['PlannedReparentShard',
+                                 '-keyspace_shard', 'test_keyspace/0',
+                                 '-avoid_master', tablet_62044.tablet_alias],
+                                auto_log=True,
+                                expect_fail=True)
+    self.assertIn('cannot find a tablet to reparent to', stderr)
+
+    utils.validate_topology()
+    self._check_master_tablet(tablet_62044)
+
+    tablet.kill_tablets([tablet_62344, tablet_62044, tablet_41983,
+                         tablet_31981])
 
   # assume a different entity is doing the reparent, and telling us it was done
   def test_reparent_from_outside(self):
@@ -555,8 +629,8 @@ class TestReparent(unittest.TestCase):
 
     # Perform a graceful reparent operation. It will fail as one tablet is down.
     _, stderr = utils.run_vtctl(['PlannedReparentShard',
-                                 'test_keyspace/' + shard_id,
-                                 tablet_62044.tablet_alias],
+                                 '-keyspace_shard', 'test_keyspace/' + shard_id,
+                                 '-new_master', tablet_62044.tablet_alias],
                                 expect_fail=True)
     self.assertIn('TabletManager.SetMaster on test_nj-0000041983 error', stderr)
 

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -775,8 +775,9 @@ primary key (name)
 
     # reparent shard_2 to shard_2_replica1, then insert more data and
     # see it flow through still
-    utils.run_vtctl(['PlannedReparentShard', 'test_keyspace/80-c0',
-                     shard_2_replica1.tablet_alias])
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'test_keyspace/80-c0',
+                     '-new_master', shard_2_replica1.tablet_alias])
 
     # update our test variables to point at the new master
     shard_2_master, shard_2_replica1 = shard_2_replica1, shard_2_master

--- a/test/worker.py
+++ b/test/worker.py
@@ -496,11 +496,11 @@ class TestBaseSplitCloneResiliency(TestBaseSplitClone):
 
       # Reparent away from the old masters.
       utils.run_vtctl(
-          ['PlannedReparentShard', 'test_keyspace/-80',
-           shard_0_replica.tablet_alias], auto_log=True)
+          ['PlannedReparentShard', '-keyspace_shard', 'test_keyspace/-80',
+           '-new_master', shard_0_replica.tablet_alias], auto_log=True)
       utils.run_vtctl(
-          ['PlannedReparentShard', 'test_keyspace/80-',
-           shard_1_replica.tablet_alias], auto_log=True)
+          ['PlannedReparentShard', '-keyspace_shard', 'test_keyspace/80-',
+           '-new_master', shard_1_replica.tablet_alias], auto_log=True)
 
     else:
       # NOTE: There is a race condition around this:
@@ -523,11 +523,11 @@ class TestBaseSplitCloneResiliency(TestBaseSplitClone):
       logging.debug('Worker is in copy state, starting reparent now')
 
       utils.run_vtctl(
-          ['PlannedReparentShard', 'test_keyspace/-80',
-           shard_0_replica.tablet_alias], auto_log=True)
+          ['PlannedReparentShard', '-keyspace_shard', 'test_keyspace/-80',
+           '-new_master', shard_0_replica.tablet_alias], auto_log=True)
       utils.run_vtctl(
-          ['PlannedReparentShard', 'test_keyspace/80-',
-           shard_1_replica.tablet_alias], auto_log=True)
+          ['PlannedReparentShard', '-keyspace_shard', 'test_keyspace/80-',
+           '-new_master', shard_1_replica.tablet_alias], auto_log=True)
 
     utils.wait_procs([workerclient_proc])
 


### PR DESCRIPTION
This modifies PlannedReparentShard vtctl command and adds to it -avoid_master
flag to be able to do reparent to any tablet other than the specified one. The
reparent will be done to another tablet in the same cell as the current master
on the shard if the shard has the master. If the shard doesn't have the master
then the choice of the new master will be done without cell restriction. If the
flag -avoid_master will contain an alias of a tablet that is not the current
master for the shard then the PlannedReparentShard will succeed without doing
anything.

To make the reparent command's parameters more consistent I've also changed the
way the new master is specified -- it will be done now through -new_master flag.
Again for consistency reasons that change is done both for PlannedReparentShard
and EmergencyReparentShard commands. But then with that change made I needed to
do another change to be able to have the command line of PlannedReparentShard
and EmergencyReparentShard in the same order as it was (i.e. keyspace/shard
first and new master after that) -- I've converted keyspace/shard into its own
flag -keyspace_shard as well (because flags must go before the positional
parameters). Both PlannedReparentShard and EmergencyReparentShard still support
the old command line syntax (<keyspace/shard> <tablet alias>), but to be able to
phase that out I've converted all usages of these commands in our tests to the
new syntax.