### PR TITLE
vtcombo fixes: UpdateStream and dbname.

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -503,7 +503,7 @@ func (a *updateStreamAdapter) Recv() (*querypb.StreamEvent, error) {
 	return r, nil
 }
 
-// UpdateStream is part of tabletconn.TabletConn. Not implemented here.
+// UpdateStream is part of tabletconn.TabletConn.
 func (itc *internalTabletConn) UpdateStream(ctx context.Context, target *querypb.Target, position string, timestamp int64) (tabletconn.StreamEventReader, error) {
 	result := make(chan *querypb.StreamEvent, 10)
 	var finalErr error

--- a/py/vttest/local_database.py
+++ b/py/vttest/local_database.py
@@ -139,12 +139,11 @@ class LocalDatabase(object):
         # redirected keyspaces have no underlying database
         continue
 
-      for cell in self.topology.cells:
-        for spb in kpb.shards:
-          db_name = spb.db_name_override
-          if not db_name:
-            db_name = 'vt_%s_%s_%s' % (cell, kpb.name, spb.name)
-          cmds.append('create database `%s`' % db_name)
+      for spb in kpb.shards:
+        db_name = spb.db_name_override
+        if not db_name:
+          db_name = 'vt_%s_%s' % (kpb.name, spb.name)
+        cmds.append('create database `%s`' % db_name)
     logging.info('Creating databases')
     self.mysql_execute(cmds)
 
@@ -185,12 +184,11 @@ class LocalDatabase(object):
         cmds = self.get_sql_commands_from_file(filepath, schema_dir)
 
         # Run the cmds on each shard and cell in the keyspace.
-        for cell in self.topology.cells:
-          for spb in kpb.shards:
-            db_name = spb.db_name_override
-            if not db_name:
-              db_name = 'vt_%s_%s_%s' % (cell, kpb.name, spb.name)
-            self.mysql_execute(cmds, db_name=db_name)
+        for spb in kpb.shards:
+          db_name = spb.db_name_override
+          if not db_name:
+            db_name = 'vt_%s_%s' % (kpb.name, spb.name)
+          self.mysql_execute(cmds, db_name=db_name)
 
   def populate_with_random_data(self):
     """Populates all shards with randomly generated data."""
@@ -200,12 +198,11 @@ class LocalDatabase(object):
         # redirected keyspaces have no underlying database
         continue
 
-      for cell in self.topology.cells:
-        for spb in kpb.shards:
-          db_name = spb.db_name_override
-          if not db_name:
-            db_name = 'vt_%s_%s_%s' % (cell, kpb.name, spb.name)
-          self.populate_shard_with_random_data(db_name)
+      for spb in kpb.shards:
+        db_name = spb.db_name_override
+        if not db_name:
+          db_name = 'vt_%s_%s' % (kpb.name, spb.name)
+        self.populate_shard_with_random_data(db_name)
 
   def populate_shard_with_random_data(self, db_name):
     """Populates the given database with randomly generated data.

--- a/test/vttest_schema/default/test_table.sql
+++ b/test/vttest_schema/default/test_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE test_table (
-  `id` BIGINT(20) NOT NULL,
+  `id` BIGINT(20) UNSIGNED NOT NULL,
   `msg` VARCHAR(64),
   `keyspace_id` BIGINT(20) UNSIGNED NOT NULL,
   PRIMARY KEY (id)

--- a/test/vttest_schema/test_keyspace/test_table.sql
+++ b/test/vttest_schema/test_keyspace/test_table.sql
@@ -1,5 +1,5 @@
 CREATE TABLE test_table (
-  `id` BIGINT(20) NOT NULL,
+  `id` BIGINT(20) UNSIGNED NOT NULL,
   `msg` VARCHAR(64),
   `keyspace_id` BIGINT(20) UNSIGNED NOT NULL,
   PRIMARY KEY (id)


### PR DESCRIPTION
Plumbing UpdateStream through for vtcombo. Adding a test for it in
vttest_smaple_test.py.

Fixing the db name for vtcombo databases: it should not include the
cell. Not in practice vtgate is only connecting to the master cell, so
it didn't matter much, but this is more correct.