### PR TITLE
Add missing kill_sub_processes call to webdriver tests

### DIFF
--- a/test/vtctld2_web_status_test.py
+++ b/test/vtctld2_web_status_test.py
@@ -41,9 +41,10 @@ def tearDownModule():
   if utils.options.skip_teardown:
     return
   utils.remove_tmp_files()
+  utils.kill_sub_processes()
 
 
-class TestVtctldWeb(unittest.TestCase):
+class TestVtctld2WebStatus(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):

--- a/test/vtctld2_web_test.py
+++ b/test/vtctld2_web_test.py
@@ -40,9 +40,10 @@ def tearDownModule():
   if utils.options.skip_teardown:
     return
   utils.remove_tmp_files()
+  utils.kill_sub_processes()
 
 
-class TestVtctldWeb(unittest.TestCase):
+class TestVtctld2Web(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):

--- a/test/vtctld_web_test.py
+++ b/test/vtctld_web_test.py
@@ -38,6 +38,7 @@ def tearDownModule():
   if utils.options.skip_teardown:
     return
   utils.remove_tmp_files()
+  utils.kill_sub_processes()
 
 
 class TestVtctldWeb(unittest.TestCase):


### PR DESCRIPTION
This will ensure that the Xvfb process is killed. This will allow webdriver tests on Travis to complete normally again.

@michael-berlin 