### PR TITLE
Adding vttablet background binlog watcher.

### DIFF
--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -131,8 +131,10 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 	var events <-chan replication.BinlogEvent
 	if bls.timestamp != 0 {
 		events, err = bls.conn.StartBinlogDumpFromTimestamp(ctx, bls.timestamp)
-	} else {
+	} else if !bls.startPos.IsZero() {
 		events, err = bls.conn.StartBinlogDumpFromPosition(ctx, bls.startPos)
+	} else {
+		bls.startPos, events, err = bls.conn.StartBinlogDumpFromCurrent(ctx)
 	}
 	if err != nil {
 		return err

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -269,7 +269,15 @@ func FindSlaves(mysqld MysqlDaemon) ([]string, error) {
 	for _, row := range qr.Rows {
 		// Check for prefix, since it could be "Binlog Dump GTID".
 		if strings.HasPrefix(row[colCommand].String(), binlogDumpCommand) {
-			host, _, err := netutil.SplitHostPort(row[colClientAddr].String())
+			host := row[colClientAddr].String()
+			if host == "localhost" {
+				// If we have a local binlog streamer, it will
+				// show up as being connected
+				// from 'localhost' through the local
+				// socket. Ignore it.
+				continue
+			}
+			host, _, err = netutil.SplitHostPort(host)
 			if err != nil {
 				return nil, fmt.Errorf("FindSlaves: malformed addr %v", err)
 			}

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -1164,8 +1164,9 @@ func (m *StreamHealthResponse) GetRealtimeStats() *RealtimeStats {
 	return nil
 }
 
-// UpdateStreamRequest is the payload for UpdateStream. Only one of
-// position and timestamp can be set.
+// UpdateStreamRequest is the payload for UpdateStream. At most one of
+// position and timestamp can be set. If neither is set, we will start
+// streaming from the current binlog position.
 type UpdateStreamRequest struct {
 	EffectiveCallerId *vtrpc.CallerID `protobuf:"bytes,1,opt,name=effective_caller_id,json=effectiveCallerId" json:"effective_caller_id,omitempty"`
 	ImmediateCallerId *VTGateCallerID `protobuf:"bytes,2,opt,name=immediate_caller_id,json=immediateCallerId" json:"immediate_caller_id,omitempty"`

--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -21,8 +21,9 @@ import (
 )
 
 var (
-	queryLogHandler = flag.String("query-log-stream-handler", "/debug/querylog", "URL handler for streaming queries log")
-	txLogHandler    = flag.String("transaction-log-stream-handler", "/debug/txlog", "URL handler for streaming transactions log")
+	queryLogHandler        = flag.String("query-log-stream-handler", "/debug/querylog", "URL handler for streaming queries log")
+	txLogHandler           = flag.String("transaction-log-stream-handler", "/debug/txlog", "URL handler for streaming transactions log")
+	watchReplicationStream = flag.Bool("watch_replication_stream", false, "When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to support the include_event_token ExecuteOptions.")
 )
 
 func init() {

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -468,8 +468,9 @@ message StreamHealthResponse {
   RealtimeStats realtime_stats = 4;
 }
 
-// UpdateStreamRequest is the payload for UpdateStream. Only one of
-// position and timestamp can be set.
+// UpdateStreamRequest is the payload for UpdateStream. At most one of
+// position and timestamp can be set. If neither is set, we will start
+// streaming from the current binlog position.
 message UpdateStreamRequest {
   vtrpc.CallerID effective_caller_id = 1;
   VTGateCallerID immediate_caller_id = 2;

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -301,7 +301,8 @@ class Tablet(object):
     rows = self.mquery('', 'show databases')
     for row in rows:
       dbname = row[0]
-      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys', '_vt']:
+      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys',
+                    '_vt']:
         continue
       self.drop_db(dbname)
 
@@ -427,6 +428,7 @@ class Tablet(object):
     args.extend(['-health_check_interval', '2s'])
     args.extend(['-enable_replication_reporter'])
     args.extend(['-degraded_threshold', '5s'])
+    args.extend(['-watch_replication_stream'])
     if enable_semi_sync:
       args.append('-enable_semi_sync')
     if self.use_mysqlctld:


### PR DESCRIPTION
It is enabled with the -watch_replication_stream command line
argument. It does two things:
- remember the last applied Event Token (and exposes it in vars)
- if the event is a DDL, it forces a schema reload.