### PR TITLE
2pc: TwoPC type and sekeletal structure

### DIFF
--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -153,6 +153,8 @@ func initTabletMap(ts topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlctl
 						dbname = fmt.Sprintf("vt_%v_%v", keyspace, shard)
 					}
 					dbcfgs.App.DbName = dbname
+					// Override SidecarDBName because there will be one for each db.
+					dbcfgs.SidecarDBName = "_" + dbname
 
 					replicas := int(kpb.ReplicaCount)
 					if replicas == 0 {

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -18,7 +18,9 @@ import (
 
 // We keep a global singleton for the db configs, and that's the one
 // the flags will change
-var dbConfigs DBConfigs
+var dbConfigs = DBConfigs{
+	SidecarDBName: "_vt",
+}
 
 // DBConfigFlag describes which flags we need
 type DBConfigFlag int
@@ -102,15 +104,17 @@ func MysqlParams(cp *sqldb.ConnParams) (sqldb.ConnParams, error) {
 }
 
 // DBConfigs is all we need for a smart tablet server:
-// - DBConfig for the query engine, running for the specified keyspace / shard
+// - App access with db name for serving app queries
 // - Dba access for any dba-type operation (db creation, replication, ...)
 // - Filtered access for filtered replication
 // - Replication access to change master
+// - SidecarDBName for storing operational metadata
 type DBConfigs struct {
-	App      sqldb.ConnParams
-	Dba      sqldb.ConnParams
-	Filtered sqldb.ConnParams
-	Repl     sqldb.ConnParams
+	App           sqldb.ConnParams
+	Dba           sqldb.ConnParams
+	Filtered      sqldb.ConnParams
+	Repl          sqldb.ConnParams
+	SidecarDBName string
 }
 
 func (dbcfgs *DBConfigs) String() string {

--- a/go/vt/tabletserver/endtoend/framework/server.go
+++ b/go/vt/tabletserver/endtoend/framework/server.go
@@ -34,7 +34,8 @@ var (
 // once at the beginning of the test.
 func StartServer(connParams sqldb.ConnParams) error {
 	dbcfgs := dbconfigs.DBConfigs{
-		App: connParams,
+		App:           connParams,
+		SidecarDBName: "_vt",
 	}
 
 	mysqld := mysqlctl.NewMysqld(

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -1007,6 +1007,13 @@ func checkPlanID(
 
 func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
 	return map[string]*sqltypes.Result{
+		// queries for twopc
+		sqlTurnoffBinlog:                                     {},
+		fmt.Sprintf(sqlCreateSidecarDB, "_vt"):               {},
+		fmt.Sprintf(sqlCreateTableRedoLogTransaction, "_vt"): {},
+		fmt.Sprintf(sqlCreateTableRedoLogStatement, "_vt"):   {},
+		fmt.Sprintf(sqlCreateTableTransaction, "_vt"):        {},
+		fmt.Sprintf(sqlCreateTableParticipant, "_vt"):        {},
 		// queries for schema info
 		"select unix_timestamp()": {
 			RowsAffected: 1,

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -231,7 +231,7 @@ func (tsv *TabletServer) IsServing() bool {
 }
 
 // InitDBConfig inititalizes the db config variables for TabletServer. You must call this function before
-// calling StartService or SetServingType.
+// calling SetServingType.
 func (tsv *TabletServer) InitDBConfig(target querypb.Target, dbconfigs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) error {
 	tsv.mu.Lock()
 	defer tsv.mu.Unlock()

--- a/go/vt/tabletserver/tabletserver_test.go
+++ b/go/vt/tabletserver/tabletserver_test.go
@@ -6,6 +6,7 @@ package tabletserver
 
 import (
 	"expvar"
+	"fmt"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -1368,6 +1369,13 @@ func checkTabletServerState(t *testing.T, tsv *TabletServer, expectState int64) 
 
 func getSupportedQueries() map[string]*sqltypes.Result {
 	return map[string]*sqltypes.Result{
+		// queries for twopc
+		sqlTurnoffBinlog:                                     {},
+		fmt.Sprintf(sqlCreateSidecarDB, "_vt"):               {},
+		fmt.Sprintf(sqlCreateTableRedoLogTransaction, "_vt"): {},
+		fmt.Sprintf(sqlCreateTableRedoLogStatement, "_vt"):   {},
+		fmt.Sprintf(sqlCreateTableTransaction, "_vt"):        {},
+		fmt.Sprintf(sqlCreateTableParticipant, "_vt"):        {},
 		// queries for schema info
 		"select unix_timestamp()": {
 			RowsAffected: 1,

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -93,7 +93,8 @@ func (util *testUtils) newMysqld(dbconfigs *dbconfigs.DBConfigs) mysqlctl.MysqlD
 
 func (util *testUtils) newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {
 	return dbconfigs.DBConfigs{
-		App: sqldb.ConnParams{Engine: db.Name},
+		App:           sqldb.ConnParams{Engine: db.Name},
+		SidecarDBName: "_vt",
 	}
 }
 

--- a/go/vt/tabletserver/twopc.go
+++ b/go/vt/tabletserver/twopc.go
@@ -1,0 +1,94 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"fmt"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/vt/dbconnpool"
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+const (
+	sqlTurnoffBinlog   = "set @@session.sql_log_bin = 0"
+	sqlCreateSidecarDB = "create database if not exists `%s`"
+
+	sqlCreateTableRedoLogTransaction = `create table if not exists ` + "`%s`" + `.redo_log_transaction(
+  dtid varbinary(512),
+  state enum('Prepared', 'Resolved'),
+  resolution enum ('Committed', 'RolledBack'),
+  time_created bigint,
+  primary key(dtid),
+  index state_time_idx(state, time_created)
+	) engine=InnoDB`
+
+	sqlCreateTableRedoLogStatement = `create table if not exists ` + "`%s`" + `.redo_log_statement(
+  dtid varbinary(512),
+  id bigint,
+  statement mediumblob,
+  primary key(dtid, id)
+	) engine=InnoDB`
+
+	sqlCreateTableTransaction = `create table if not exists ` + "`%s`" + `.transaction(
+  dtid varbinary(512),
+  state enum('Prepare', 'Commit', 'Rollback'),
+  time_created bigint,
+  time_updated bigint,
+  primary key(dtid)
+	) engine=InnoDB`
+
+	sqlCreateTableParticipant = `create table if not exists ` + "`%s`" + `.participant(
+  dtid varbinary(512),
+	id bigint,
+	keyspace varchar(256),
+	shard varchar(256),
+  primary key(dtid, id)
+	) engine=InnoDB`
+)
+
+// TwoPC performs 2PC metadata management (MM) functions.
+type TwoPC struct {
+	txpool        *TxPool
+	sidecarDBName string
+}
+
+// NewTwoPC creates a TwoPC variable. It requires a TxPool to
+// perform its operations.
+func NewTwoPC(txpool *TxPool) *TwoPC {
+	return &TwoPC{
+		txpool: txpool,
+	}
+}
+
+// Open starts the 2PC MM service. If the metadata database or tables
+// are not present, they are created.
+func (tpc *TwoPC) Open(sidecardbname string, dbaparams *sqldb.ConnParams) {
+	tpc.sidecarDBName = sidecardbname
+	conn, err := dbconnpool.NewDBConnection(dbaparams, stats.NewTimings(""))
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+	statements := []string{
+		sqlTurnoffBinlog,
+		fmt.Sprintf(sqlCreateSidecarDB, tpc.sidecarDBName),
+		fmt.Sprintf(sqlCreateTableRedoLogTransaction, tpc.sidecarDBName),
+		fmt.Sprintf(sqlCreateTableRedoLogStatement, tpc.sidecarDBName),
+		fmt.Sprintf(sqlCreateTableTransaction, tpc.sidecarDBName),
+		fmt.Sprintf(sqlCreateTableParticipant, tpc.sidecarDBName),
+	}
+	for _, s := range statements {
+		if _, err := conn.ExecuteFetch(s, 0, false); err != nil {
+			panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, err.Error()))
+		}
+	}
+}
+
+// Close shuts down the 2PC MM service.
+func (tpc *TwoPC) Close() {
+	tpc.sidecarDBName = ""
+}

--- a/test/vttest_sample_test.py
+++ b/test/vttest_sample_test.py
@@ -76,6 +76,7 @@ class TestMysqlctl(unittest.TestCase):
                                          'vttest_schema'),
             '--web_dir', environment.vttop + '/web/vtctld',
            ]
+    print args
     sp = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     config = json.loads(sp.stdout.readline())
 

--- a/test/vttest_sample_test.py
+++ b/test/vttest_sample_test.py
@@ -76,7 +76,6 @@ class TestMysqlctl(unittest.TestCase):
                                          'vttest_schema'),
             '--web_dir', environment.vttop + '/web/vtctld',
            ]
-    print args
     sp = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
     config = json.loads(sp.stdout.readline())
 


### PR DESCRIPTION
This PR creates the skeletal TwoPC service in vttablet,
and incorporates itself into vttablet. All the MM functionality
will go into this. It currently depends on TxPool. More dependencies
may be added as needed.

Notes to reviewers:
* SidecarDBName: Please suggest alternate name if you don't like it.
* I've split the transaction table into two just like we did the
redo_log tables, which deviates from the original design.