### PR TITLE
Adding support for bool in python bind variables.

### DIFF
--- a/py/vtdb/proto3_encoding.py
+++ b/py/vtdb/proto3_encoding.py
@@ -92,7 +92,10 @@ def convert_value(value, proto_value, allow_lists=False):
     proto_value: the proto3 object, needs a type and value field.
     allow_lists: allows the use of python lists.
   """
-  if isinstance(value, int):
+  if isinstance(value, bool):
+    proto_value.type = query_pb2.INT8
+    proto_value.value = str(int(value))
+  elif isinstance(value, int):
     proto_value.type = query_pb2.INT64
     proto_value.value = str(value)
   elif isinstance(value, long):

--- a/test/python_client_test.py
+++ b/test/python_client_test.py
@@ -492,9 +492,11 @@ class TestEcho(TestPythonClientBase):
       'int': 123,
       'float': 2.1,
       'bytes': '\x01\x02\x03',
+      'bool': True,
   }
-  bind_variables_echo = 'map[bytes:[1 2 3] float:2.1 int:123]'
-  bind_variables_p3_echo = ('map[bytes:type:VARBINARY value:"\\001\\002\\003"  '
+  bind_variables_echo = 'map[bool:1 bytes:[1 2 3] float:2.1 int:123]'
+  bind_variables_p3_echo = ('map[bool:type:INT8 value:"1"  '
+                            'bytes:type:VARBINARY value:"\\001\\002\\003"  '
                             'float:type:FLOAT64 value:"2.1"  '
                             'int:type:INT64 value:"123" ]')
 


### PR DESCRIPTION
In python, isinstance(True, int) is true, resulting in a bug in our bind
variable encoding: the type would be query_pb2.INT64, but the value
would be 'True' or 'False', resulting in server errors.

Instead, now bool is special-cased, and encoded as '0' or '1' for False
and True, respectively.