### PR TITLE
Using int64 for python bool type (instead of int8).

### DIFF
--- a/py/vtdb/proto3_encoding.py
+++ b/py/vtdb/proto3_encoding.py
@@ -93,7 +93,7 @@ def convert_value(value, proto_value, allow_lists=False):
     allow_lists: allows the use of python lists.
   """
   if isinstance(value, bool):
-    proto_value.type = query_pb2.INT8
+    proto_value.type = query_pb2.INT64
     proto_value.value = str(int(value))
   elif isinstance(value, int):
     proto_value.type = query_pb2.INT64

--- a/test/python_client_test.py
+++ b/test/python_client_test.py
@@ -495,7 +495,7 @@ class TestEcho(TestPythonClientBase):
       'bool': True,
   }
   bind_variables_echo = 'map[bool:1 bytes:[1 2 3] float:2.1 int:123]'
-  bind_variables_p3_echo = ('map[bool:type:INT8 value:"1"  '
+  bind_variables_p3_echo = ('map[bool:type:INT64 value:"1"  '
                             'bytes:type:VARBINARY value:"\\001\\002\\003"  '
                             'float:type:FLOAT64 value:"2.1"  '
                             'int:type:INT64 value:"123" ]')


### PR DESCRIPTION
(some old clients don't support int8).