### PR TITLE
test: Move "unit_race" test from Travis shard 4 to 0.

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -1,3 +1,4 @@
+
 {
 	"Tests": {
 		"automation_horizontal_resharding": {
@@ -311,7 +312,7 @@
 				"unit_test_race"
 			],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 0,
 			"RetryMax": 0,
 			"Tags": []
 		},


### PR DESCRIPTION
This will balance the shards better. This test in particular takes ~3m48s.

Exampe for Shard Execution times before this change:
(see https://travis-ci.org/youtube/vitess/builds/159687311)

shard 0:  6m55s
shard 1: 11m48s
shard 2: 12m08s
shard 3: 14m46s
shard 4: 17m20s

Eventually, we could do the automatic rebalancing again :)