### PR TITLE
b/31470937: remove keyrange blacklisting rules

### DIFF
--- a/test/legacy_resharding.py
+++ b/test/legacy_resharding.py
@@ -245,27 +245,6 @@ primary key (name)
                         'msg-range2-%d' % i, 0xE000000000000000 + base + i,
                         should_be_here=False)
 
-  def _test_keyrange_constraints(self):
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          "insert into resharding1(id, msg, custom_ksid_col) "
-          " values(1, 'msg', :custom_ksid_col)",
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          "update resharding1 set msg = 'msg' where id = 1",
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          'delete from resharding1 where id = 1',
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-
   def test_resharding(self):
     utils.run_vtctl(['CreateKeyspace',
                      '--sharding_column_name', 'bad_column',
@@ -325,7 +304,6 @@ primary key (name)
     # create the tables
     self._create_schema()
     self._insert_startup_values()
-    self._test_keyrange_constraints()
 
     # run a health check on source replicas so they respond to discovery
     # (for binlog players) and on the source rdonlys (for workers)

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -311,27 +311,6 @@ primary key (name)
                         'msg-range2-%d' % i, 0xE000000000000000 + base + i,
                         should_be_here=False)
 
-  def _test_keyrange_constraints(self):
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          "insert into resharding1(id, msg, custom_ksid_col) "
-          " values(1, 'msg', :custom_ksid_col)",
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          "update resharding1 set msg = 'msg' where id = 1",
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-    with self.assertRaisesRegexp(
-        Exception, '.*enforce custom_ksid_col range.*'):
-      shard_0_master.execute(
-          'delete from resharding1 where id = 1',
-          bindvars={'custom_ksid_col': 0x9000000000000000},
-      )
-
   def test_resharding(self):
     # we're going to reparent and swap these two
     global shard_2_master, shard_2_replica1
@@ -396,7 +375,6 @@ primary key (name)
     # create the tables
     self._create_schema()
     self._insert_startup_values()
-    self._test_keyrange_constraints()
 
     # run a health check on source replicas so they respond to discovery
     # (for binlog players) and on the source rdonlys (for workers)


### PR DESCRIPTION
The keyrange blacklisting rules conflict with v3 queries
because they fail if the sharding column name is specified in the topo.
We've decided to get rid of the rules because there are sufficient
checks and balances elsewhere to ensure that queries are not misrouted.