### PR TITLE
2pc: implement new RecordQuery

### DIFF
--- a/go/vt/tabletserver/endtoend/transaction_test.go
+++ b/go/vt/tabletserver/endtoend/transaction_test.go
@@ -44,7 +44,7 @@ func TestCommit(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	want := []string{query}
+	want := []string{"insert into vitess_test(intval, floatval, charval, binval) values (4, null, null, null) /* _stream vitess_test (intval ) (4 ); */"}
 	if !reflect.DeepEqual(tx.Queries, want) {
 		t.Errorf("queries: %v, want %v", tx.Queries, want)
 	}
@@ -140,7 +140,7 @@ func TestRollback(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	want := []string{query}
+	want := []string{"insert into vitess_test values (4, null, null, null) /* _stream vitess_test (intval ) (4 ); */"}
 	if !reflect.DeepEqual(tx.Queries, want) {
 		t.Errorf("queries: %v, want %v", tx.Queries, want)
 	}
@@ -204,7 +204,7 @@ func TestAutoCommit(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	want := []string{query}
+	want := []string{"insert into vitess_test(intval, floatval, charval, binval) values (4, null, null, null) /* _stream vitess_test (intval ) (4 ); */"}
 	if !reflect.DeepEqual(tx.Queries, want) {
 		t.Errorf("queries: %v, want %v", tx.Queries, want)
 	}

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -35,11 +35,6 @@ type QueryExecutor struct {
 	qe            *QueryEngine
 }
 
-// poolConn is the interface implemented by users of this specialized pool.
-type poolConn interface {
-	Exec(ctx context.Context, query string, maxrows int, wantfields bool) (*sqltypes.Result, error)
-}
-
 func addUserTableQueryStats(queryServiceStats *QueryServiceStats, ctx context.Context, tableName string, queryType string, duration int64) {
 	username := callerid.GetPrincipal(callerid.EffectiveCallerIDFromContext(ctx))
 	if username == "" {
@@ -86,13 +81,12 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		// Need upfront connection for DMLs and transactions
 		conn := qre.qe.txPool.Get(qre.transactionID)
 		defer conn.Recycle()
-		conn.RecordQuery(qre.query)
 		switch qre.plan.PlanID {
 		case planbuilder.PlanPassDML:
 			if qre.qe.strictMode.Get() != 0 {
 				return nil, NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "DML too complex")
 			}
-			reply, err = qre.directFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+			reply, err = qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)
 		case planbuilder.PlanInsertPK:
 			reply, err = qre.execInsertPK(conn)
 		case planbuilder.PlanInsertSubquery:
@@ -105,7 +99,9 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 			reply, err = qre.execSQL(conn, qre.query, true)
 		case planbuilder.PlanUpsertPK:
 			reply, err = qre.execUpsertPK(conn)
-		default: // select or set in a transaction, just count as select
+		case planbuilder.PlanSet:
+			reply, err = qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)
+		default:
 			reply, err = qre.execDirect(conn)
 		}
 	} else {
@@ -158,18 +154,17 @@ func (qre *QueryExecutor) Stream(sendReply func(*sqltypes.Result) error) error {
 	qre.qe.streamQList.Add(qd)
 	defer qre.qe.streamQList.Remove(qd)
 
-	return qre.fullStreamFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, sendReply)
+	return qre.streamFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, sendReply)
 }
 
 func (qre *QueryExecutor) execDmlAutoCommit() (reply *sqltypes.Result, err error) {
 	return qre.execAsTransaction(func(conn *TxConnection) (reply *sqltypes.Result, err error) {
-		conn.RecordQuery(qre.query)
 		switch qre.plan.PlanID {
 		case planbuilder.PlanPassDML:
 			if qre.qe.strictMode.Get() != 0 {
 				return nil, NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "DML too complex")
 			}
-			reply, err = qre.directFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+			reply, err = qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)
 		case planbuilder.PlanInsertPK:
 			reply, err = qre.execInsertPK(conn)
 		case planbuilder.PlanInsertSubquery:
@@ -317,7 +312,6 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 	if t.NextVal >= t.LastVal {
 		_, err := qre.execAsTransaction(func(conn *TxConnection) (*sqltypes.Result, error) {
 			query := fmt.Sprintf("select next_id, cache, increment from `%s` where id = 0 for update", qre.plan.TableName)
-			conn.RecordQuery(query)
 			qr, err := qre.execSQL(conn, query, false)
 			if err != nil {
 				return nil, err
@@ -373,17 +367,17 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 	}, nil
 }
 
-// execDirect always sends the query to mysql
-func (qre *QueryExecutor) execDirect(conn poolConn) (*sqltypes.Result, error) {
+// execDirect is for reads inside transactions. Always send to MySQL.
+func (qre *QueryExecutor) execDirect(conn *TxConnection) (*sqltypes.Result, error) {
 	if qre.plan.Fields != nil {
-		result, err := qre.directFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+		result, err := qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, false)
 		if err != nil {
 			return nil, err
 		}
 		result.Fields = qre.plan.Fields
 		return result, nil
 	}
-	return qre.fullFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+	return qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, true, false)
 }
 
 // execSelect sends a query to mysql only if another identical query is not running. Otherwise, it waits and
@@ -404,10 +398,10 @@ func (qre *QueryExecutor) execSelect() (*sqltypes.Result, error) {
 		return nil, err
 	}
 	defer conn.Recycle()
-	return qre.fullFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+	return qre.dbConnFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, true)
 }
 
-func (qre *QueryExecutor) execInsertPK(conn poolConn) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execInsertPK(conn *TxConnection) (*sqltypes.Result, error) {
 	pkRows, err := buildValueList(qre.plan.TableInfo, qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
@@ -415,8 +409,8 @@ func (qre *QueryExecutor) execInsertPK(conn poolConn) (*sqltypes.Result, error) 
 	return qre.execInsertPKRows(conn, pkRows)
 }
 
-func (qre *QueryExecutor) execInsertSubquery(conn poolConn) (*sqltypes.Result, error) {
-	innerResult, err := qre.directFetch(conn, qre.plan.Subquery, qre.bindVars, nil)
+func (qre *QueryExecutor) execInsertSubquery(conn *TxConnection) (*sqltypes.Result, error) {
+	innerResult, err := qre.txFetch(conn, qre.plan.Subquery, qre.bindVars, nil, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -440,18 +434,18 @@ func (qre *QueryExecutor) execInsertSubquery(conn poolConn) (*sqltypes.Result, e
 	return qre.execInsertPKRows(conn, pkRows)
 }
 
-func (qre *QueryExecutor) execInsertPKRows(conn poolConn, pkRows [][]sqltypes.Value) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execInsertPKRows(conn *TxConnection, pkRows [][]sqltypes.Value) (*sqltypes.Result, error) {
 	bsc := buildStreamComment(qre.plan.TableInfo, pkRows, nil)
-	return qre.directFetch(conn, qre.plan.OuterQuery, qre.bindVars, bsc)
+	return qre.txFetch(conn, qre.plan.OuterQuery, qre.bindVars, bsc, false, true)
 }
 
-func (qre *QueryExecutor) execUpsertPK(conn poolConn) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, error) {
 	pkRows, err := buildValueList(qre.plan.TableInfo, qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
 	}
 	bsc := buildStreamComment(qre.plan.TableInfo, pkRows, nil)
-	result, err := qre.directFetch(conn, qre.plan.OuterQuery, qre.bindVars, bsc)
+	result, err := qre.txFetch(conn, qre.plan.OuterQuery, qre.bindVars, bsc, false, true)
 	if err == nil {
 		return result, nil
 	}
@@ -479,7 +473,7 @@ func (qre *QueryExecutor) execUpsertPK(conn poolConn) (*sqltypes.Result, error) 
 	return result, err
 }
 
-func (qre *QueryExecutor) execDMLPK(conn poolConn) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execDMLPK(conn *TxConnection) (*sqltypes.Result, error) {
 	pkRows, err := buildValueList(qre.plan.TableInfo, qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
@@ -487,15 +481,15 @@ func (qre *QueryExecutor) execDMLPK(conn poolConn) (*sqltypes.Result, error) {
 	return qre.execDMLPKRows(conn, qre.plan.OuterQuery, pkRows)
 }
 
-func (qre *QueryExecutor) execDMLSubquery(conn poolConn) (*sqltypes.Result, error) {
-	innerResult, err := qre.directFetch(conn, qre.plan.Subquery, qre.bindVars, nil)
+func (qre *QueryExecutor) execDMLSubquery(conn *TxConnection) (*sqltypes.Result, error) {
+	innerResult, err := qre.txFetch(conn, qre.plan.Subquery, qre.bindVars, nil, false, false)
 	if err != nil {
 		return nil, err
 	}
 	return qre.execDMLPKRows(conn, qre.plan.OuterQuery, innerResult.Rows)
 }
 
-func (qre *QueryExecutor) execDMLPKRows(conn poolConn, query *sqlparser.ParsedQuery, pkRows [][]sqltypes.Value) (*sqltypes.Result, error) {
+func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.ParsedQuery, pkRows [][]sqltypes.Value) (*sqltypes.Result, error) {
 	if len(pkRows) == 0 {
 		return &sqltypes.Result{RowsAffected: 0}, nil
 	}
@@ -521,7 +515,7 @@ func (qre *QueryExecutor) execDMLPKRows(conn poolConn, query *sqlparser.ParsedQu
 			Columns: cistring.ToStrings(qre.plan.TableInfo.Indexes[0].Columns),
 			Rows:    pkRows,
 		}
-		r, err := qre.directFetch(conn, query, qre.bindVars, bsc)
+		r, err := qre.txFetch(conn, query, qre.bindVars, bsc, false, true)
 		if err != nil {
 			return nil, err
 		}
@@ -537,7 +531,7 @@ func (qre *QueryExecutor) execSet() (*sqltypes.Result, error) {
 		return nil, err
 	}
 	defer conn.Recycle()
-	return qre.directFetch(conn, qre.plan.FullQuery, qre.bindVars, nil)
+	return qre.dbConnFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false)
 }
 
 func (qre *QueryExecutor) getConn(pool *ConnPool) (*DBConn, error) {
@@ -586,24 +580,34 @@ func (qre *QueryExecutor) qFetch(logStats *LogStats, parsedQuery *sqlparser.Pars
 	return q.Result.(*sqltypes.Result), nil
 }
 
-func (qre *QueryExecutor) directFetch(conn poolConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte) (*sqltypes.Result, error) {
+// txFetch fetches from a TxConnection.
+func (qre *QueryExecutor) txFetch(conn *TxConnection, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte, wantfields, record bool) (*sqltypes.Result, error) {
 	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, buildStreamComment)
 	if err != nil {
 		return nil, err
 	}
-	return qre.execSQL(conn, sql, false)
+	qr, err := qre.execSQL(conn, sql, wantfields)
+	if err != nil {
+		return nil, err
+	}
+	// Only record successful queries.
+	if record {
+		conn.RecordQuery(sql)
+	}
+	return qr, nil
 }
 
-// fullFetch also fetches field info
-func (qre *QueryExecutor) fullFetch(conn poolConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte) (*sqltypes.Result, error) {
+// dbConnFetch fetches from a DBConn.
+func (qre *QueryExecutor) dbConnFetch(conn *DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte, wantfields bool) (*sqltypes.Result, error) {
 	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, buildStreamComment)
 	if err != nil {
 		return nil, err
 	}
-	return qre.execSQL(conn, sql, true)
+	return qre.execSQL(conn, sql, wantfields)
 }
 
-func (qre *QueryExecutor) fullStreamFetch(conn *DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte, callback func(*sqltypes.Result) error) error {
+// streamFetch performs a streaming fetch.
+func (qre *QueryExecutor) streamFetch(conn *DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]interface{}, buildStreamComment []byte, callback func(*sqltypes.Result) error) error {
 	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, buildStreamComment)
 	if err != nil {
 		return err
@@ -620,9 +624,13 @@ func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, b
 	if buildStreamComment != nil {
 		sql = append(sql, buildStreamComment...)
 	}
-	// undo hack done by stripTrailing
 	sql = restoreTrailing(sql, bindVars)
 	return hack.String(sql), nil
+}
+
+// poolConn is an abstraction for reusing code in execSQL.
+type poolConn interface {
+	Exec(ctx context.Context, query string, maxrows int, wantfields bool) (*sqltypes.Result, error)
 }
 
 func (qre *QueryExecutor) execSQL(conn poolConn, sql string, wantfields bool) (*sqltypes.Result, error) {

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -1128,11 +1128,13 @@ func (se *splitQuerySQLExecuter) SQLExecute(
 	parsedQuery := sqlparser.GenerateParsedQuery(ast)
 
 	// We clone "bindVariables" since fullFetch() changes it.
-	return se.queryExecutor.fullFetch(
+	return se.queryExecutor.dbConnFetch(
 		se.conn,
 		parsedQuery,
 		utils.CloneBindVariables(bindVariables),
-		nil /* buildStreamComment */)
+		nil,  /* buildStreamComment */
+		true, /* wantfields */
+	)
 }
 
 // getSchemaForSplitQuery converts the given schemaInfo object into


### PR DESCRIPTION
The new RecordQuery functionality records actual DMLs sent to
MySQL. The old one used to record the requested DML. The actual
DMLs will replay more accurately when re-preparing 2pc transactions.