### PR TITLE
Moving three methods out of sqldb.Conn.

### DIFF
--- a/go/sqldb/conn.go
+++ b/go/sqldb/conn.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 
-	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
@@ -31,9 +30,6 @@ var (
 type Conn interface {
 	// ExecuteFetch executes the query on the connection
 	ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error)
-	// ExecuteFetchMap returns a map from column names to cell data for a query
-	// that should return exactly 1 row.
-	ExecuteFetchMap(query string) (map[string]string, error)
 	// ExecuteStreamFetch starts a streaming query to db server. Use FetchNext
 	// on the Connection until it returns nil or error
 	ExecuteStreamFetch(query string) error
@@ -56,11 +52,6 @@ type Conn interface {
 	ReadPacket() ([]byte, error)
 	// SendCommand sends a raw command to the db server.
 	SendCommand(command uint32, data []byte) error
-	// GetCharset returns the current numerical values of the per-session character
-	// set variables.
-	GetCharset() (cs *binlogdatapb.Charset, err error)
-	// SetCharset changes the per-session character set variables.
-	SetCharset(cs *binlogdatapb.Charset) error
 }
 
 // RegisterDefault registers the default connection function.

--- a/go/sqldb/utils.go
+++ b/go/sqldb/utils.go
@@ -1,0 +1,80 @@
+package sqldb
+
+import (
+	"fmt"
+	"strconv"
+
+	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
+)
+
+// This file contains utility methods for Conn objects.
+
+// ExecuteFetchMap returns a map from column names to cell data for a query
+// that should return exactly 1 row.
+func ExecuteFetchMap(conn Conn, query string) (map[string]string, error) {
+	qr, err := conn.ExecuteFetch(query, 1, true)
+	if err != nil {
+		return nil, err
+	}
+	if len(qr.Rows) != 1 {
+		return nil, fmt.Errorf("query %#v returned %d rows, expected 1", query, len(qr.Rows))
+	}
+	if len(qr.Fields) != len(qr.Rows[0]) {
+		return nil, fmt.Errorf("query %#v returned %d column names, expected %d", query, len(qr.Fields), len(qr.Rows[0]))
+	}
+
+	rowMap := make(map[string]string)
+	for i, value := range qr.Rows[0] {
+		rowMap[qr.Fields[i].Name] = value.String()
+	}
+	return rowMap, nil
+}
+
+// GetCharset returns the current numerical values of the per-session character
+// set variables.
+func GetCharset(conn Conn) (*binlogdatapb.Charset, error) {
+	// character_set_client
+	row, err := ExecuteFetchMap(conn, "SHOW COLLATION WHERE `charset`=@@session.character_set_client AND `default`='Yes'")
+	if err != nil {
+		return nil, err
+	}
+	client, err := strconv.ParseInt(row["Id"], 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	// collation_connection
+	row, err = ExecuteFetchMap(conn, "SHOW COLLATION WHERE `collation`=@@session.collation_connection")
+	if err != nil {
+		return nil, err
+	}
+	connection, err := strconv.ParseInt(row["Id"], 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	// collation_server
+	row, err = ExecuteFetchMap(conn, "SHOW COLLATION WHERE `collation`=@@session.collation_server")
+	if err != nil {
+		return nil, err
+	}
+	server, err := strconv.ParseInt(row["Id"], 10, 16)
+	if err != nil {
+		return nil, err
+	}
+
+	return &binlogdatapb.Charset{
+		Client: int32(client),
+		Conn:   int32(connection),
+		Server: int32(server),
+	}, nil
+}
+
+// SetCharset changes the per-session character set variables.
+func SetCharset(conn Conn, cs *binlogdatapb.Charset) error {
+	sql := fmt.Sprintf(
+		"SET @@session.character_set_client=%d, @@session.collation_connection=%d, @@session.collation_server=%d",
+		cs.Client, cs.Conn, cs.Server)
+	_, err := conn.ExecuteFetch(sql, 1, false)
+	return err
+}

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/golang/glog"
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/mysqlctl/replication"
@@ -118,7 +119,7 @@ func (bls *Streamer) Stream(ctx context.Context) (err error) {
 	// general doesn't support servers with different default charsets, so we
 	// treat it as a configuration error.
 	if bls.clientCharset != nil {
-		cs, err := bls.conn.GetCharset()
+		cs, err := sqldb.GetCharset(bls.conn)
 		if err != nil {
 			return fmt.Errorf("can't get charset to check binlog stream: %v", err)
 		}

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -257,7 +257,7 @@ func (blp *BinlogPlayer) processTransaction(tx *binlogdatapb.BinlogTransaction) 
 				// proceeds, but in Vitess-land this usually means a misconfigured
 				// server or a misbehaving client, so we spam the logs with warnings.
 				log.Warningf("BinlogPlayer changing charset from %v to %v for statement %d in transaction %v", blp.currentCharset, stmtCharset, i, *tx)
-				err = dbClient.dbConn.SetCharset(stmtCharset)
+				err = sqldb.SetCharset(dbClient.dbConn, stmtCharset)
 				if err != nil {
 					return false, fmt.Errorf("can't set charset for statement %d in transaction %v: %v", i, *tx, err)
 				}
@@ -362,7 +362,7 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 	// to check that they match. The streamer will also only send per-statement
 	// charset data if that statement's charset is different from what we specify.
 	if dbClient, ok := blp.dbClient.(*DBClient); ok {
-		blp.defaultCharset, err = dbClient.dbConn.GetCharset()
+		blp.defaultCharset, err = sqldb.GetCharset(dbClient.dbConn)
 		if err != nil {
 			return fmt.Errorf("can't get charset to request binlog stream: %v", err)
 		}
@@ -376,7 +376,7 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 				return
 			}
 			log.Infof("restoring original charset %v", blp.defaultCharset)
-			if csErr := dbClient.dbConn.SetCharset(blp.defaultCharset); csErr != nil {
+			if csErr := sqldb.SetCharset(dbClient.dbConn, blp.defaultCharset); csErr != nil {
 				log.Errorf("can't restore original charset %v: %v", blp.defaultCharset, csErr)
 			}
 		}()


### PR DESCRIPTION
They operate on the sqldb.Conn, but they shouldn't be part of the
interface, as noone will override them.

@sougou I found that during my previous changes. Duplicate code for nothing. :)