### PR TITLE
tabletserver: unify error handling and reuse boiler-plate

### DIFF
--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -53,8 +53,6 @@ func addUserTableQueryStats(queryServiceStats *QueryServiceStats, ctx context.Co
 
 // Execute performs a non-streaming query execution.
 func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
-	qre.logStats.OriginalSQL = qre.query
-	qre.logStats.BindVariables = qre.bindVars
 	qre.logStats.TransactionID = qre.transactionID
 	planName := qre.plan.PlanID.String()
 	qre.logStats.PlanType = planName

--- a/go/vt/tabletserver/tablet_error_test.go
+++ b/go/vt/tabletserver/tablet_error_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/sqldb"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
-	"golang.org/x/net/context"
 )
 
 func TestTabletErrorCode(t *testing.T) {
@@ -168,50 +167,6 @@ func TestTabletErrorRecordStats(t *testing.T) {
 	if failCounterAfter-failCounterBefore != 1 {
 		t.Fatalf("sql error with SQL error mysql.ErrOptionPreventsStatement should increase Fail error count by 1")
 	}
-}
-
-func TestTabletErrorHandleUncaughtError(t *testing.T) {
-	var err error
-	logStats := newLogStats("TestTabletErrorHandleError", context.Background())
-	queryServiceStats := NewQueryServiceStats("", false)
-	defer func() {
-		_, ok := err.(*TabletError)
-		if !ok {
-			t.Fatalf("error should be a TabletError, but got error: %v", err)
-		}
-	}()
-	defer handleError(&err, logStats, queryServiceStats)
-	panic("unknown error")
-}
-
-func TestTabletErrorHandleRetryError(t *testing.T) {
-	var err error
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, sqldb.NewSQLError(1000, "HY000", "test"))
-	logStats := newLogStats("TestTabletErrorHandleError", context.Background())
-	queryServiceStats := NewQueryServiceStats("", false)
-	defer func() {
-		_, ok := err.(*TabletError)
-		if !ok {
-			t.Fatalf("error should be a TabletError, but got error: %v", err)
-		}
-	}()
-	defer handleError(&err, logStats, queryServiceStats)
-	panic(tabletErr)
-}
-
-func TestTabletErrorHandleTxPoolFullError(t *testing.T) {
-	var err error
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, sqldb.NewSQLError(1000, "HY000", "test"))
-	logStats := newLogStats("TestTabletErrorHandleError", context.Background())
-	queryServiceStats := NewQueryServiceStats("", false)
-	defer func() {
-		_, ok := err.(*TabletError)
-		if !ok {
-			t.Fatalf("error should be a TabletError, but got error: %v", err)
-		}
-	}()
-	defer handleError(&err, logStats, queryServiceStats)
-	panic(tabletErr)
 }
 
 func TestTabletErrorLogUncaughtErr(t *testing.T) {

--- a/go/vt/tabletserver/tabletserver_test.go
+++ b/go/vt/tabletserver/tabletserver_test.go
@@ -1231,7 +1231,7 @@ func TestHandleExecUnknownError(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServer(config)
-	defer tsv.handleExecError("select * from test_table", nil, &err, logStats)
+	defer tsv.handleError("select * from test_table", nil, &err, logStats)
 	panic("unknown exec error")
 }
 
@@ -1248,7 +1248,7 @@ func TestHandleExecTabletError(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServer(config)
-	defer tsv.handleExecError("select * from test_table", nil, &err, logStats)
+	defer tsv.handleError("select * from test_table", nil, &err, logStats)
 	panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "tablet error"))
 }
 
@@ -1266,7 +1266,7 @@ func TestTerseErrorsNonSQLError(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServer(config)
 	tsv.config.TerseErrors = true
-	defer tsv.handleExecError("select * from test_table", nil, &err, logStats)
+	defer tsv.handleError("select * from test_table", nil, &err, logStats)
 	panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "tablet error"))
 }
 
@@ -1284,7 +1284,7 @@ func TestTerseErrorsBindVars(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServer(config)
 	tsv.config.TerseErrors = true
-	defer tsv.handleExecError("select * from test_table", map[string]interface{}{"a": 1}, &err, logStats)
+	defer tsv.handleError("select * from test_table", map[string]interface{}{"a": 1}, &err, logStats)
 	panic(&TabletError{
 		ErrorCode: vtrpcpb.ErrorCode_DEADLINE_EXCEEDED,
 		Message:   "msg",
@@ -1307,7 +1307,7 @@ func TestTerseErrorsNoBindVars(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServer(config)
 	tsv.config.TerseErrors = true
-	defer tsv.handleExecError("select * from test_table", nil, &err, logStats)
+	defer tsv.handleError("select * from test_table", nil, &err, logStats)
 	panic(&TabletError{
 		ErrorCode: vtrpcpb.ErrorCode_DEADLINE_EXCEEDED,
 		Message:   "msg",


### PR DESCRIPTION
* Merge handleError and handleExecError.
* Refactor tabletserver code to make all the boiler-plating
reusable. Now, only a couple of functions are using custom
setups.