### PR TITLE
Remove stats exports names overrides from mysqlctl.NewMysqld().

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -124,7 +124,7 @@ func main() {
 	if err != nil {
 		log.Warning(err)
 	}
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl, true /* enablePublishStats */)
 	servenv.OnClose(mysqld.Close)
 
 	// tablets configuration and init

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -112,7 +112,7 @@ func main() {
 	// Create mysqld and register the health reporter (needs to be done
 	// before initializing the agent, so the initial health check
 	// done by the agent has the right reporter)
-	mysqld := mysqlctl.NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl)
+	mysqld := mysqlctl.NewMysqld(mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl, true /* enablePublishStats */)
 	servenv.OnClose(mysqld.Close)
 
 	// Depends on both query and updateStream.

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -40,7 +40,7 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfi
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl), nil
+	return NewMysqld(mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl, true /* enablePublishStats */), nil
 }
 
 // OpenMysqld returns a Mysqld object to use for working with a MySQL
@@ -57,5 +57,5 @@ func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld("Dba", "App", mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl), nil
+	return NewMysqld(mycnf, &dbcfgs.Dba, &dbcfgs.App, &dbcfgs.Repl, true /* enablePublishStats */), nil
 }

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -24,7 +24,7 @@ func TestMycnf(t *testing.T) {
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
-	tablet0 := NewMysqld("Dba", "App", cnf, &dbaConfig, &appConfig, &replConfig)
+	tablet0 := NewMysqld(cnf, &dbaConfig, &appConfig, &replConfig, true /* enablePublishStats */)
 	defer tablet0.Close()
 	root, err := env.VtRoot()
 	if err != nil {

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -69,8 +69,7 @@ type Mysqld struct {
 
 // NewMysqld creates a Mysqld object based on the provided configuration
 // and connection parameters.
-// dbaName and appName are the base for stats exports, use 'Dba' and 'App', except in tests
-func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.ConnParams) *Mysqld {
+func NewMysqld(config *Mycnf, dba, app, repl *sqldb.ConnParams, enablePublishStats bool) *Mysqld {
 	noParams := sqldb.ConnParams{}
 	if *dba == noParams {
 		dba.UnixSocket = config.SocketFile
@@ -79,9 +78,9 @@ func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.Con
 	// create and open the connection pool for dba access
 	dbaMysqlStatsName := ""
 	dbaPoolName := ""
-	if dbaName != "" {
-		dbaMysqlStatsName = "Mysql" + dbaName
-		dbaPoolName = dbaName + "ConnPool"
+	if enablePublishStats {
+		dbaMysqlStatsName = "MysqlDba"
+		dbaPoolName = "DbaConnPool"
 	}
 	dbaMysqlStats := stats.NewTimings(dbaMysqlStatsName)
 	dbaPool := dbconnpool.NewConnectionPool(dbaPoolName, *dbaPoolSize, *dbaIdleTimeout)
@@ -90,9 +89,9 @@ func NewMysqld(dbaName, appName string, config *Mycnf, dba, app, repl *sqldb.Con
 	// create and open the connection pool for app access
 	appMysqlStatsName := ""
 	appPoolName := ""
-	if appName != "" {
-		appMysqlStatsName = "Mysql" + appName
-		appPoolName = appName + "ConnPool"
+	if enablePublishStats {
+		appMysqlStatsName = "MysqlApp"
+		appPoolName = "AppConnPool"
 	}
 	appMysqlStats := stats.NewTimings(appMysqlStatsName)
 	appPool := dbconnpool.NewConnectionPool(appPoolName, *appPoolSize, *appIdleTimeout)

--- a/go/vt/tabletserver/endtoend/framework/server.go
+++ b/go/vt/tabletserver/endtoend/framework/server.go
@@ -39,12 +39,11 @@ func StartServer(connParams sqldb.ConnParams) error {
 	}
 
 	mysqld := mysqlctl.NewMysqld(
-		"Dba",
-		"App",
 		&mysqlctl.Mycnf{},
 		&dbcfgs.Dba,
 		&dbcfgs.App,
-		&dbcfgs.Repl)
+		&dbcfgs.Repl,
+		true /* enablePublishStats */)
 
 	BaseConfig = tabletserver.DefaultQsConfig
 	BaseConfig.EnableAutoCommit = true

--- a/go/vt/tabletserver/testutils_test.go
+++ b/go/vt/tabletserver/testutils_test.go
@@ -82,12 +82,11 @@ func (util *testUtils) newMysqld(dbconfigs *dbconfigs.DBConfigs) mysqlctl.MysqlD
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
 	return mysqlctl.NewMysqld(
-		"",
-		"",
 		cnf,
 		&dbconfigs.Dba,
 		&dbconfigs.App,
 		&dbconfigs.Repl,
+		false, /* enablePublishStats */
 	)
 }
 


### PR DESCRIPTION
These names overrides are always set to 'Dba' and 'App', and even the comment
before the function says that they should be set like that, so might as well
hard code them. Different values were passed only in one place -- from tests
to suppress publishing of stats. To achieve that I'm adding an extra parameter
to mysqlctl.NewMysqld() that explicitly will be for suppressing publishing of
the stats.

I want to do this to avoid blowup of number of function parameters when I add
a new type of db user.