### PR TITLE
Adding binary vindex

### DIFF
--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-// Binary is a vindex that hashes binary bits to a keyspace id.
+// Binary is a vindex that converts binary bits to a keyspace id.
 type Binary struct {
 	name string
 }
@@ -22,7 +22,7 @@ func (vind *Binary) String() string {
 
 // Cost returns the cost as 1.
 func (vind *Binary) Cost() int {
-	return 1
+	return 0
 }
 
 // Verify returns true if id maps to ksid.
@@ -52,7 +52,7 @@ func (*Binary) ReverseMap(_ VCursor, ksid []byte) (interface{}, error) {
 	if ksid == nil {
 		return nil, fmt.Errorf("Binary.ReverseMap: is nil")
 	}
-	return ([]byte(ksid)), nil
+	return []byte(ksid), nil
 }
 
 func init() {

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -1,0 +1,60 @@
+package vindexes
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Binary is a vindex that hashes binary bits to a keyspace id.
+type Binary struct {
+	name string
+}
+
+// NewBinary creates a new Binary.
+func NewBinary(name string, _ map[string]string) (Vindex, error) {
+	return &Binary{name: name}, nil
+}
+
+// String returns the name of the vindex.
+func (vind *Binary) String() string {
+	return vind.name
+}
+
+// Cost returns the cost as 1.
+func (vind *Binary) Cost() int {
+	return 1
+}
+
+// Verify returns true if id maps to ksid.
+func (vind *Binary) Verify(_ VCursor, id interface{}, ksid []byte) (bool, error) {
+	data, err := getBytes(id)
+	if err != nil {
+		return false, fmt.Errorf("Binary.Verify: %v", err)
+	}
+	return bytes.Compare(data, ksid) == 0, nil
+}
+
+// Map returns the corresponding keyspace id values for the given ids.
+func (vind *Binary) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
+	out := make([][]byte, 0, len(ids))
+	for _, id := range ids {
+		data, err := getBytes(id)
+		if err != nil {
+			return nil, fmt.Errorf("Binary.Map :%v", err)
+		}
+		out = append(out, data)
+	}
+	return out, nil
+}
+
+// ReverseMap returns the associated id for the ksid.
+func (*Binary) ReverseMap(_ VCursor, ksid []byte) (interface{}, error) {
+	if ksid == nil {
+		return nil, fmt.Errorf("Binary.ReverseMap: is nil")
+	}
+	return ([]byte(ksid)), nil
+}
+
+func init() {
+	Register("binary", NewBinary)
+}

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -1,0 +1,62 @@
+package vindexes
+
+import (
+	"testing"
+	"bytes"
+	"fmt"
+)
+
+var binOnlyVindex Vindex
+
+func init() {
+	binOnlyVindex, _ = CreateVindex("binary", "vch", nil)
+}
+
+func TestBinaryCost(t *testing.T) {
+	if binOnlyVindex.Cost() != 1 {
+		t.Errorf("Cost(): %d, want 1", binOnlyVindex.Cost())
+	}
+}
+
+func TestBinary(t *testing.T) {
+	tcases := []struct {
+		in, out []byte
+	}{{
+		in:  []byte("test"),
+		out: []byte("test"),
+	}, {
+		in:  []byte("test2"),
+		out: []byte("test2"),
+	}, {
+		in:  []byte("test3"),
+		out: []byte("test3"),
+	}}
+	for _, tcase := range tcases {
+		got, err := binOnlyVindex.(Unique).Map(nil, []interface{}{tcase.in})
+		if err != nil {
+			t.Error(err)
+		}
+		out := []byte(got[0])
+		fmt.Print(bytes.Compare(tcase.in, out))
+		if bytes.Compare(tcase.in, out) != 0 {
+			t.Errorf("Map(%#v): %#v, want %#v", tcase.in, out, tcase.out)
+		}
+		ok, err := binOnlyVindex.Verify(nil, tcase.in, tcase.out)
+		if err != nil {
+			t.Error(err)
+		}
+		if !ok {
+			t.Errorf("Verify(%#v): false, want true", tcase.in)
+		}
+	}
+}
+
+func TestBinaryReverseMap(t *testing.T) {
+	got, err := binOnlyVindex.(Reversible).ReverseMap(nil, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
+	if err != nil {
+		t.Error(err)
+	}
+	if bytes.Compare(got.([]byte), []byte("\x00\x00\x00\x00\x00\x00\x00\x01")) != 0 {
+		t.Errorf("ReverseMap(): %+v, want %+v", got, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
+	}
+}

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -13,8 +13,8 @@ func init() {
 }
 
 func TestBinaryCost(t *testing.T) {
-	if binOnlyVindex.Cost() != 1 {
-		t.Errorf("Cost(): %d, want 1", binOnlyVindex.Cost())
+	if binOnlyVindex.Cost() != 0 {
+		t.Errorf("Cost(): %d, want 0", binOnlyVindex.Cost())
 	}
 }
 

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -3,7 +3,6 @@ package vindexes
 import (
 	"testing"
 	"bytes"
-	"fmt"
 )
 
 var binOnlyVindex Vindex


### PR DESCRIPTION
This is to have a feature to directly map binary shard keys to vindex instead of md5ing it. This will help to know where the data is located just by looking at the shard key. In this case, we have a time based UUID binary which ensures random distribution and avoiding hotspots on a specific shard. Had a detailed discussion on the same before with @sougou and @enisoc .

Thanks
Amit