### PR TITLE
test: Re-add "php" test to the test configuration.

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -221,6 +221,18 @@
 				"site_test"
 			]
 		},
+		"php": {
+			"File": "",
+			"Args": [],
+			"Command": [
+				"make",
+				"php_test"
+			],
+			"Manual": true,
+			"Shard": 4,
+			"RetryMax": 0,
+				"Tags": []
+		},
 		"python_client": {
 			"File": "python_client_test.py",
 			"Args": [],


### PR DESCRIPTION
We temporarily disabled testing the PHP client in Travis because the PHP composer binary is constantly segfaulting and failing the tests. See: https://github.com/youtube/vitess/pull/2081

We want to keep the configuration entry such that we can still run the command manually e.g. via "./test.go -flavor=mariadb php".