### PR TITLE
worker: Include context error when the retry context is up.

### DIFF
--- a/go/vt/worker/executor.go
+++ b/go/vt/worker/executor.go
@@ -143,7 +143,7 @@ func (e *executor) fetchWithRetries(ctx context.Context, command string) error {
 			if retryCtx.Err() == context.DeadlineExceeded {
 				return fmt.Errorf("failed to connect to destination tablet %v after retrying for %v", tabletString, retryDuration)
 			}
-			return fmt.Errorf("interrupted while trying to run %v on tablet %v", command, tabletString)
+			return fmt.Errorf("interrupted (context error: %v) while trying to run %v on tablet %v", retryCtx.Err(), command, tabletString)
 		case <-time.After(*executeFetchRetryTime):
 			// Retry 30s after the failure using the current master seen by the HealthCheck.
 		}

--- a/go/vt/worker/restartable_result_reader.go
+++ b/go/vt/worker/restartable_result_reader.go
@@ -233,7 +233,7 @@ func (r *RestartableResultReader) nextWithRetries() (*sqltypes.Result, error) {
 			if retryCtx.Err() == context.DeadlineExceeded {
 				return nil, fmt.Errorf("%v: failed to restart the streaming connection after retrying for %v", r.tp.description(), *retryDuration)
 			}
-			return nil, fmt.Errorf("%v: interrupted while trying to restart the streaming connection (%.1f minutes elapsed so far)", r.tp.description(), time.Now().Sub(start).Minutes())
+			return nil, fmt.Errorf("%v: interrupted (context error: %v) while trying to restart the streaming connection (%.1f minutes elapsed so far)", r.tp.description(), retryCtx.Err(), time.Now().Sub(start).Minutes())
 		case <-time.After(*executeFetchRetryTime):
 			// Make a pause between the retries to avoid hammering the servers.
 		}


### PR DESCRIPTION
Including the context error makes it easier to e.g. filter out log lines which contain "context canceled". This way, it's simpler to find the original error and ignore the error of the other threads which were canceled as a consequence.