### PR TITLE
2pc: Prepare core functionality.

### DIFF
--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -643,6 +643,7 @@ func (tsv *TabletServer) Commit(ctx context.Context, target *querypb.Target, tra
 		target, false, true,
 		func(ctx context.Context, logStats *LogStats) error {
 			defer tsv.qe.queryServiceStats.QueryStats.Record("COMMIT", time.Now())
+			logStats.TransactionID = transactionID
 			return tsv.qe.txPool.Commit(ctx, transactionID)
 		},
 	)
@@ -656,6 +657,7 @@ func (tsv *TabletServer) Rollback(ctx context.Context, target *querypb.Target, t
 		target, false, true,
 		func(ctx context.Context, logStats *LogStats) error {
 			defer tsv.qe.queryServiceStats.QueryStats.Record("ROLLBACK", time.Now())
+			logStats.TransactionID = transactionID
 			return tsv.qe.txPool.Rollback(ctx, transactionID)
 		},
 	)

--- a/go/vt/tabletserver/tx_executor.go
+++ b/go/vt/tabletserver/tx_executor.go
@@ -1,0 +1,129 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"time"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+	"golang.org/x/net/context"
+)
+
+// TxExecutor is used for executing a transactional request.
+type TxExecutor struct {
+	ctx      context.Context
+	logStats *LogStats
+	qe       *QueryEngine
+}
+
+// Prepare performs a prepare on a connection including the redo log work.
+// If there is any failure, an error is returned. No cleanup is performed.
+// A subsequent call to RollbackPrepared, which is required by the 2PC
+// protocol, will perform all the cleanup.
+func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
+	defer txe.qe.queryServiceStats.QueryStats.Record("PREPARE", time.Now())
+	txe.logStats.TransactionID = transactionID
+
+	v, err := txe.qe.txPool.activePool.Get(transactionID, "for prepare")
+	if err != nil {
+		return NewTabletError(vtrpcpb.ErrorCode_NOT_IN_TX, "prepare failed for transaction %d: %v", transactionID, err)
+	}
+	conn := v.(*TxConnection)
+
+	err = txe.qe.preparedPool.Put(conn, dtid)
+	if err != nil {
+		txe.qe.txPool.localRollback(txe.ctx, conn)
+		return NewTabletError(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, "prepare failed for transaction %d: %v", transactionID, err)
+	}
+
+	localConn, err := txe.qe.txPool.LocalBegin(txe.ctx)
+	if err != nil {
+		return err
+	}
+	defer txe.qe.txPool.LocalConclude(txe.ctx, localConn)
+
+	err = txe.qe.twoPC.SaveRedo(txe.ctx, localConn, dtid, conn.Queries)
+	if err != nil {
+		return err
+	}
+
+	err = txe.qe.txPool.LocalCommit(txe.ctx, localConn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CommitPrepared commits a prepared transaction. If the operation
+// fails, an error counter is incremented and the transaction is
+// marked as defunct in the redo log. If the marking fails, a
+// different error counter is incremented indicating a more
+// severe condition.
+func (txe *TxExecutor) CommitPrepared(dtid string) error {
+	defer txe.qe.queryServiceStats.QueryStats.Record("COMMIT_PREPARED", time.Now())
+	conn := txe.qe.preparedPool.Get(dtid)
+	if conn == nil {
+		return nil
+	}
+	defer txe.qe.txPool.LocalConclude(txe.ctx, conn)
+	err := txe.qe.twoPC.DeleteRedo(txe.ctx, conn, dtid)
+	if err != nil {
+		// TODO(sougou): raise alarms & mark as defunct.
+		return err
+	}
+	err = txe.qe.txPool.LocalCommit(txe.ctx, conn)
+	if err != nil {
+		// TODO(sougou): raise alarms & mark as defunct.
+		return err
+	}
+	return nil
+}
+
+// RollbackPrepared rolls back a prepared transaction. This function handles
+// the case of an incomplete prepare.
+//
+// If the prepare completely failed, it will just rollback the original
+// transaction identified by originalID.
+//
+// If the connection was moved to the prepared pool, but redo log
+// creation failed, then it will rollback that transaction and
+// return the conn to the txPool.
+//
+// If prepare was fully successful, it will also delete the redo log.
+// If the redo log deletion fails, it returns an error indicating that
+// a retry is needed.
+//
+// In recovery mode, the original transaction id will not be available.
+// If so, it must be set to 0, and the function will not attempt that
+// step. If the original transaction is still alive, the transaction
+// killer will be the one to eventually roll it back.
+func (txe *TxExecutor) RollbackPrepared(dtid string, originalID int64) error {
+	defer txe.qe.queryServiceStats.QueryStats.Record("ROLLBACK_PREPARED", time.Now())
+	localConn, err := txe.qe.txPool.LocalBegin(txe.ctx)
+	if err != nil {
+		goto returnConn
+	}
+	defer txe.qe.txPool.LocalConclude(txe.ctx, localConn)
+
+	err = txe.qe.twoPC.DeleteRedo(txe.ctx, localConn, dtid)
+	if err != nil {
+		goto returnConn
+	}
+
+	err = txe.qe.txPool.LocalCommit(txe.ctx, localConn)
+
+returnConn:
+	conn := txe.qe.preparedPool.Get(dtid)
+	if conn == nil {
+		return nil
+	}
+	txe.qe.txPool.LocalConclude(txe.ctx, conn)
+	if originalID != 0 {
+		txe.qe.txPool.Rollback(txe.ctx, originalID)
+	}
+
+	return err
+}

--- a/go/vt/tabletserver/tx_executor_test.go
+++ b/go/vt/tabletserver/tx_executor_test.go
@@ -1,0 +1,61 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"golang.org/x/net/context"
+)
+
+func TestTxExecutorPrepare(t *testing.T) {
+	db := setUpQueryExecutorTest()
+	ctx := context.Background()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+	txe := newTestTxExecutor(ctx, tsv)
+	txid := newTransaction(tsv)
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
+	db.AddQueryPattern("delete from `_vt`\\.redo_log_transaction where dtid =.*", &sqltypes.Result{})
+	db.AddQueryPattern("delete from `_vt`\\.redo_log_statement where dtid =.*", &sqltypes.Result{})
+	err := txe.Prepare(txid, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	err = txe.RollbackPrepared("aa", 1)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTxExecutorCommit(t *testing.T) {
+	db := setUpQueryExecutorTest()
+	ctx := context.Background()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+	txe := newTestTxExecutor(ctx, tsv)
+	txid := newTransaction(tsv)
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
+	db.AddQueryPattern("delete from `_vt`\\.redo_log_transaction where dtid =.*", &sqltypes.Result{})
+	db.AddQueryPattern("delete from `_vt`\\.redo_log_statement where dtid =.*", &sqltypes.Result{})
+	err := txe.Prepare(txid, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	err = txe.CommitPrepared("aa")
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func newTestTxExecutor(ctx context.Context, tsv *TabletServer) *TxExecutor {
+	logStats := newLogStats("TestTxExecutor", ctx)
+	return &TxExecutor{
+		ctx:      ctx,
+		logStats: logStats,
+		qe:       tsv.qe,
+	}
+}

--- a/go/vt/tabletserver/tx_prep_pool.go
+++ b/go/vt/tabletserver/tx_prep_pool.go
@@ -5,6 +5,7 @@
 package tabletserver
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -14,26 +15,25 @@ import (
 // is done by TxPool.
 type TxPreparedPool struct {
 	mu       sync.Mutex
-	conns    map[string]*DBConn
+	conns    map[string]*TxConnection
 	capacity int
 }
 
 // NewTxPreparedPool creates a new TxPreparedPool.
 func NewTxPreparedPool(capacity int) *TxPreparedPool {
 	return &TxPreparedPool{
-		conns:    make(map[string]*DBConn),
+		conns:    make(map[string]*TxConnection),
 		capacity: capacity,
 	}
 }
 
 // Put adds the connection to the pool. It returns an error
 // if the pool is full, and panics on duplicate key.
-func (pp *TxPreparedPool) Put(c *DBConn, dtid string) error {
+func (pp *TxPreparedPool) Put(c *TxConnection, dtid string) error {
 	pp.mu.Lock()
 	defer pp.mu.Unlock()
 	if _, ok := pp.conns[dtid]; ok {
-		// This should never happen.
-		panic("duplicate DTID in Prepare: " + dtid)
+		return errors.New("duplicate DTID in Prepare: " + dtid)
 	}
 	if len(pp.conns) >= pp.capacity {
 		return fmt.Errorf("prepared transactions exceeded limit: %d", pp.capacity)
@@ -44,7 +44,7 @@ func (pp *TxPreparedPool) Put(c *DBConn, dtid string) error {
 
 // Get returns the connection and removes it from the pool.
 // If the connection is not found, it returns nil.
-func (pp *TxPreparedPool) Get(dtid string) *DBConn {
+func (pp *TxPreparedPool) Get(dtid string) *TxConnection {
 	pp.mu.Lock()
 	defer pp.mu.Unlock()
 	c := pp.conns[dtid]

--- a/go/vt/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/tabletserver/tx_prep_pool_test.go
@@ -9,12 +9,6 @@ import (
 )
 
 func TestPrepPut(t *testing.T) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatalf("panic expected")
-		}
-	}()
 	pp := NewTxPreparedPool(2)
 	err := pp.Put(nil, "aa")
 	if err != nil {
@@ -29,13 +23,16 @@ func TestPrepPut(t *testing.T) {
 	if err == nil || err.Error() != want {
 		t.Errorf("Put err: %v, want %s", err, want)
 	}
-	// This should panic.
-	pp.Put(nil, "aa")
+	err = pp.Put(nil, "aa")
+	want = "duplicate DTID in Prepare: aa"
+	if err == nil || err.Error() != want {
+		t.Errorf("Put err: %v, want %s", err, want)
+	}
 }
 
 func TestPrepGet(t *testing.T) {
 	pp := NewTxPreparedPool(2)
-	conn := &DBConn{}
+	conn := &TxConnection{}
 	pp.Put(conn, "aa")
 	got := pp.Get("bb")
 	if got != nil {


### PR DESCRIPTION
* Local transaction support in TxPool.
* TxPreparedPool uses TxConnection instead of DBConn.
* Additional tests in sqlparser for 2pc usage pattern.
* Prepared pool is not part of txPool. Logic between them
is managed at a higher level. TxConnection remains active
in TxPool while it's tracked in TxPreparedPool.
* Added redo log functionality in TwoPC.
* TxExecutor for doing transaction work, just like QueryExecutor.
* Some tests for TxExecutor. More will be added.