### PR TITLE
vtctl: MigrateServedTypes: Wait for several seconds for the old table…

### DIFF
--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -5,6 +5,7 @@
 package testlib
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
@@ -43,6 +44,10 @@ func checkShardSourceShards(t *testing.T, ts topo.Server, shard string, expected
 }
 
 func TestMigrateServedTypes(t *testing.T) {
+	// TODO(b/26388813): Remove the next two lines once vtctl WaitForDrain is integrated in the vtctl MigrateServed* commands.
+	flag.Set("wait_for_drain_sleep_rdonly", "0s")
+	flag.Set("wait_for_drain_sleep_replica", "0s")
+
 	db := fakesqldb.Register()
 	ts := zktestserver.New(t, []string{"cell1", "cell2"})
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())

--- a/test/utils.py
+++ b/test/utils.py
@@ -868,6 +868,10 @@ def run_vtctl_vtctl(clargs, auto_log=False, expect_fail=False,
   args.extend(['-throttler_client_protocol',
                protocols_flavor().throttler_client_protocol()])
   args.extend(['-vtgate_protocol', protocols_flavor().vtgate_protocol()])
+  # TODO(b/26388813): Remove the next two lines once vtctl WaitForDrain is
+  #                   integrated in the vtctl MigrateServed* commands.
+  args.extend(['--wait_for_drain_sleep_rdonly', '0s'])
+  args.extend(['--wait_for_drain_sleep_replica', '0s'])
 
   if auto_log:
     args.append('--stderrthreshold=%s' % get_log_level())
@@ -1235,6 +1239,10 @@ class Vtctld(object):
         protocols_flavor().throttler_client_protocol(),
         '-vtgate_protocol', protocols_flavor().vtgate_protocol(),
     ] + environment.topo_server().flags()
+    # TODO(b/26388813): Remove the next two lines once vtctl WaitForDrain is
+    #                   integrated in the vtctl MigrateServed* commands.
+    args.extend(['--wait_for_drain_sleep_rdonly', '0s'])
+    args.extend(['--wait_for_drain_sleep_replica', '0s'])
     if enable_schema_change_dir:
       args += [
           '--schema_change_dir', self.schema_change_dir,


### PR DESCRIPTION
…ts to be drained before disabling their query service.

During a resharding, vtgate traffic is migrated from the old tablets to
the new tablets for each tablet type (RDONLY, REPLICA, MASTER).

Before this change, the query service of the old tablets was shut down
immediately and vtgate did serve errors until it noticed that it should
use the new tablets instead.

This is not necessary for RDONLY and REPLICA tablets where it is okay to
keep serving from old tablets for a limited time. (The MASTER is not
migrated yet and the old RDONLY and REPLICA tablets still get the latest
changes from the old MASTER.)

Therefore, we're waiting for some time now before we shutdown the query
service. During this time, the keyspace remains locked.

This change is a short-term solution. In the near future, it will be
replaced with the "vtctl WaitForDrain" command which actively watches
the QPS on all tablets and stops waiting once the QPS went to zero or a
timeout is reached.