### PR TITLE
misc: Add two commit hooks for handling the internal bug number in commit messages.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -205,10 +205,12 @@ else
     rm -r mock-1.0.1
 fi
 
-# create pre-commit hooks
-echo "creating git pre-commit hooks"
+# Create the Git hooks.
+echo "creating git hooks"
 mkdir -p $VTTOP/.git/hooks
 ln -sf $VTTOP/misc/git/pre-commit $VTTOP/.git/hooks/pre-commit
+ln -sf $VTTOP/misc/git/prepare-commit-msg.bugnumber $VTTOP/.git/hooks/prepare-commit-msg
+ln -sf $VTTOP/misc/git/commit-msg.bugnumber $VTTOP/.git/hooks/commit-msg
 
 # Download chromedriver
 echo "Installing selenium and chromedriver"

--- a/misc/git/commit-msg.bugnumber
+++ b/misc/git/commit-msg.bugnumber
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script is run during "git commit" after the commit message was entered.
+#
+# If it does not find a BUG=<bug number> line in this commit or previous new
+# commits from this branch, it prompts the user to add one.
+# <bug number> refers to a Google internal bug number. Therefore, the script
+# prompts only users who have @google.com in their Git configured email.
+
+bug_marker="BUG="
+
+# Return early if a bug marker is already present:
+# a) Check current commit message.
+msg_file="$1"
+if grep -qE "^${bug_marker}[0-9]{8,}$|\bb\/[0-9]{8,}\b" "$msg_file"; then
+  exit 0
+fi
+# b) Check other commits in the branch as well.
+if [[ -n "$(git log --no-merges -E --grep="^${bug_marker}[0-9]{8,}$|\bb\/[0-9]{8,}\b" master..)" ]]; then
+  exit 0
+fi
+
+# No bug number found. Ask user to input a bug number.
+
+# git doesn't give us access to user input, so let's steal it.
+exec < /dev/tty
+if [[ $? -ne 0 ]]; then
+  # non-interactive shell (e.g. called from Eclipse). Give up here.
+  exit 0
+fi
+
+git_email=$(git config --get user.email)
+if [[ "$git_email" != *@google.com ]]; then
+  # This script applies only to internal developers.
+  exit 0
+fi
+
+echo "No ${bug_marker}<bug number> marker was found in this or previous commits in this branch."
+echo
+echo "As an internal developer, please always try to add a bug number to your commits."
+echo
+while [[ -z "$bug" ]]; do
+  read -r -p 'You can enter a bug number now: [press enter to skip] '
+  if [[ -z "$REPLY" ]]; then
+    bug="skipped"
+    break
+  fi
+  # Example: 28221285
+  if [[ "$REPLY" =~ ^[0-9]{8,}$ ]]; then
+    bug="$REPLY"
+    break
+  fi
+
+  echo "You entered an invalid bug number: $REPLY"
+  echo
+  echo "Please try again. Do not enter anything to skip this step."
+done
+if [[ "$bug" == "skipped" ]]; then
+  exit 0
+fi
+
+# Add the bug number to the commit message.
+bug_marker_line="${bug_marker}$bug"
+echo >> "$msg_file"
+echo "$bug_marker_line" >> "$msg_file"

--- a/misc/git/prepare-commit-msg.bugnumber
+++ b/misc/git/prepare-commit-msg.bugnumber
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script is run during "git commit" before the commit message editor
+# is shown.
+#
+# It automatically adds a BUG=<bug numer> line to the default commit
+# message if the branch name starts with "b<bug numer>".
+# Note that <bug number> refers to a Google internal bug number.
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+# Examples: 28221285, b28221285, 28221285_feature, b28221285_feature
+if [[ "$branch" =~ ^b?([0-9]{8,}) ]]; then
+  bug=${BASH_REMATCH[1]}
+fi
+
+if [[ -z "$bug" ]]; then
+  # No bug found in branch name. Exit early.
+  exit 0
+fi
+
+bug_marker_line="BUG=$bug"
+bug_url="b/${bug}"
+
+# Check current commit message (e.g. in case of an --amend).
+msg_file="$1"
+if grep -q "$bug_marker_line" "$msg_file"; then
+  exit 0
+fi
+
+# Check other commits in the branch as well.
+if [[ -n "$(git log --no-merges -E --grep="^$bug_marker_line$|$bug_url" master..)" ]]; then
+  echo "Note: Bug number found in branch name ($bug) but not adding it to this commit message because previous commits already include it."
+  exit 0
+fi
+
+# Add the bug number to the commit message.
+type="$2"
+# TODO(mberlin): React on other types as well?
+# https://git-scm.com/docs/githooks lists these types:
+# template, merge, squash
+if [[ -z "$type" || "$type" == "commit" || "$type" == "message" ]]; then
+  echo >> "$msg_file"
+  echo "$bug_marker_line" >> "$msg_file"
+fi


### PR DESCRIPTION
1. pre-commit-msg hook:

If a branch is named "b<bug number>", the bug marker B=<bug number> will be automatically added to the commit message.
1. commit-msg hook:

If no bug number is found in the branch, "git commit" will prompt the user for one after they entered the commit message.

This hook applies only to internal developers (i.e. people with a @google.com email address).

Both scripts return early if any commit in the feature branch already has a B=<bug number> marker.

Ironically, this commit does not contain a bug marker yet :)
