### PR TITLE
vtctl: MigrateServedTypes: Error if no "SourceShards" entry is present.

### DIFF
--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -112,6 +112,9 @@ func (wr *Wrangler) MigrateServedTypes(ctx context.Context, keyspace, shard stri
 	var sourceShards []*topo.ShardInfo
 	var destinationShards []*topo.ShardInfo
 	if len(os.Left[0].SourceShards) == 0 {
+		if len(os.Right[0].SourceShards) == 0 {
+			return fmt.Errorf("neither Shard '%v' nor Shard '%v' have a 'SourceShards' entry. Did you successfully run vtworker SplitClone before? Or did you already migrate the MASTER type?", os.Left[0].ShardName(), os.Right[0].ShardName())
+		}
 		sourceShards = os.Left
 		destinationShards = os.Right
 	} else {


### PR DESCRIPTION
This situation can occur when you e.g. run the online SplitClone only and then try to migrate types.

Note that vtctl MigrateServedFrom already has a similar check where it checks that there are three "ServedFroms" entries (one for each serving type).