### PR TITLE
2pc: WIP

### DIFF
--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -9,16 +9,17 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/sync2"
+	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/logutil"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	"github.com/youtube/vitess/go/vt/tableacl/acl"
+	"golang.org/x/net/context"
 )
 
 // QueryEngine implements the core functionality of tabletserver.
@@ -151,9 +152,7 @@ func NewQueryEngine(checker MySQLChecker, config Config) *QueryEngine {
 		prepCap = 0
 	}
 	qe.preparedPool = NewTxPreparedPool(prepCap)
-
-	// twoPC depends on txPool for some of its operations.
-	qe.twoPC = NewTwoPC(qe.txPool)
+	qe.twoPC = NewTwoPC()
 	qe.consolidator = sync2.NewConsolidator()
 	http.Handle(config.DebugURLPrefix+"/consolidations", qe.consolidator)
 	qe.streamQList = NewQueryList()
@@ -245,6 +244,48 @@ func (qe *QueryEngine) IsMySQLReachable() bool {
 	}
 	conn.Close()
 	return true
+}
+
+// PrepareFromRedo replays and prepares the transactions
+// from the redo log. This is called when a tablet becomes
+// a master.
+func (qe *QueryEngine) PrepareFromRedo() error {
+	ctx := context.Background()
+	var allErr concurrency.AllErrorRecorder
+	readConn, err := qe.connPool.Get(ctx)
+	if err != nil {
+		return err
+	}
+	defer readConn.Recycle()
+	transactions, err := qe.twoPC.ReadPrepared(ctx, readConn)
+	if err != nil {
+		return err
+	}
+
+outer:
+	for dtid, tx := range transactions {
+		conn, err := qe.txPool.LocalBegin(ctx)
+		if err != nil {
+			allErr.RecordError(err)
+			continue
+		}
+		for _, stmt := range tx {
+			_, err := conn.Exec(ctx, stmt, 1, false)
+			if err != nil {
+				allErr.RecordError(err)
+				qe.txPool.LocalConclude(ctx, conn)
+				continue outer
+			}
+		}
+		// We should not use the external Prepare because
+		// we don't want to write again to the redo log.
+		err = qe.preparedPool.Put(conn, dtid)
+		if err != nil {
+			allErr.RecordError(err)
+			continue
+		}
+	}
+	return allErr.Error()
 }
 
 // WaitForTxEmpty must be called before calling Close.

--- a/go/vt/tabletserver/query_engine.go
+++ b/go/vt/tabletserver/query_engine.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/sync2"
@@ -16,10 +17,10 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/logutil"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	"github.com/youtube/vitess/go/vt/tableacl/acl"
-	"golang.org/x/net/context"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // QueryEngine implements the core functionality of tabletserver.

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -1066,6 +1066,7 @@ const (
 	noFlags      executorFlags = 0
 	enableStrict               = 1 << iota
 	enableStrictTableAcl
+	smallTxPool
 )
 
 // newTestQueryExecutor uses a package level variable testTabletServer defined in tabletserver_test.go
@@ -1076,7 +1077,11 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	config.DebugURLPrefix = fmt.Sprintf("/debug-%d-", randID)
 	config.PoolNamePrefix = fmt.Sprintf("Pool-%d-", randID)
 	config.PoolSize = 100
-	config.TransactionCap = 100
+	if flags&smallTxPool > 0 {
+		config.TransactionCap = 3
+	} else {
+		config.TransactionCap = 100
+	}
 	config.EnablePublishStats = false
 	config.EnableAutoCommit = true
 

--- a/go/vt/tabletserver/tx_executor.go
+++ b/go/vt/tabletserver/tx_executor.go
@@ -7,8 +7,11 @@ package tabletserver
 import (
 	"time"
 
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/trace"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // TxExecutor is used for executing a transactional request.
@@ -76,7 +79,7 @@ func (txe *TxExecutor) CommitPrepared(dtid string) error {
 	}
 	// We have to use a context that will never give up,
 	// even if the original context expires.
-	ctx := context.Background()
+	ctx := trace.CopySpan(context.Background(), txe.ctx)
 	defer txe.qe.txPool.LocalConclude(ctx, conn)
 	err := txe.qe.twoPC.DeleteRedo(ctx, conn, dtid)
 	if err != nil {

--- a/go/vt/tabletserver/tx_executor.go
+++ b/go/vt/tabletserver/tx_executor.go
@@ -32,6 +32,12 @@ func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 	}
 	conn := v.(*TxConnection)
 
+	// If no queries were executed, we just rollback.
+	if len(conn.Queries) == 0 {
+		txe.qe.txPool.LocalCommit(txe.ctx, conn)
+		return nil
+	}
+
 	err = txe.qe.preparedPool.Put(conn, dtid)
 	if err != nil {
 		txe.qe.txPool.localRollback(txe.ctx, conn)
@@ -68,13 +74,16 @@ func (txe *TxExecutor) CommitPrepared(dtid string) error {
 	if conn == nil {
 		return nil
 	}
-	defer txe.qe.txPool.LocalConclude(txe.ctx, conn)
-	err := txe.qe.twoPC.DeleteRedo(txe.ctx, conn, dtid)
+	// We have to use a context that will never give up,
+	// even if the original context expires.
+	ctx := context.Background()
+	defer txe.qe.txPool.LocalConclude(ctx, conn)
+	err := txe.qe.twoPC.DeleteRedo(ctx, conn, dtid)
 	if err != nil {
 		// TODO(sougou): raise alarms & mark as defunct.
 		return err
 	}
-	err = txe.qe.txPool.LocalCommit(txe.ctx, conn)
+	err = txe.qe.txPool.LocalCommit(ctx, conn)
 	if err != nil {
 		// TODO(sougou): raise alarms & mark as defunct.
 		return err
@@ -116,11 +125,9 @@ func (txe *TxExecutor) RollbackPrepared(dtid string, originalID int64) error {
 	err = txe.qe.txPool.LocalCommit(txe.ctx, localConn)
 
 returnConn:
-	conn := txe.qe.preparedPool.Get(dtid)
-	if conn == nil {
-		return nil
+	if conn := txe.qe.preparedPool.Get(dtid); conn != nil {
+		txe.qe.txPool.LocalConclude(txe.ctx, conn)
 	}
-	txe.qe.txPool.LocalConclude(txe.ctx, conn)
 	if originalID != 0 {
 		txe.qe.txPool.Rollback(txe.ctx, originalID)
 	}

--- a/go/vt/tabletserver/tx_executor_test.go
+++ b/go/vt/tabletserver/tx_executor_test.go
@@ -5,22 +5,35 @@
 package tabletserver
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
 	"golang.org/x/net/context"
 )
 
-func TestTxExecutorPrepare(t *testing.T) {
-	db := setUpQueryExecutorTest()
-	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, noFlags, db)
+func TestTxExecutorEmptyPrepare(t *testing.T) {
+	txe, tsv, _ := newTestTxExecutor()
 	defer tsv.StopService()
-	txe := newTestTxExecutor(ctx, tsv)
 	txid := newTransaction(tsv)
-	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
-	db.AddQueryPattern("delete from `_vt`\\.redo_log_transaction where dtid =.*", &sqltypes.Result{})
-	db.AddQueryPattern("delete from `_vt`\\.redo_log_statement where dtid =.*", &sqltypes.Result{})
+	err := txe.Prepare(txid, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	// Nothing should be prepared.
+	if len(txe.qe.preparedPool.conns) != 0 {
+		t.Errorf("len(txe.qe.preparedPool.conns): %d, want 0", len(txe.qe.preparedPool.conns))
+	}
+}
+
+func TestTxExecutorPrepare(t *testing.T) {
+	txe, tsv, _ := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
 	err := txe.Prepare(txid, "aa")
 	if err != nil {
 		t.Error(err)
@@ -29,18 +42,87 @@ func TestTxExecutorPrepare(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	// A retry should still succeed.
+	err = txe.RollbackPrepared("aa", 1)
+	if err != nil {
+		t.Error(err)
+	}
+	// A retry  with no original id should also succeed.
+	err = txe.RollbackPrepared("aa", 0)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTxExecutorPrepareNotInTx(t *testing.T) {
+	txe, tsv, _ := newTestTxExecutor()
+	defer tsv.StopService()
+	err := txe.Prepare(0, "aa")
+	want := "not_in_tx: prepare failed for transaction 0: not found"
+	if err == nil || err.Error() != want {
+		t.Errorf("Prepare err: %v, want %s", err, want)
+	}
+}
+
+func TestTxExecutorPreparePoolFail(t *testing.T) {
+	txe, tsv, _ := newTestTxExecutor()
+	defer tsv.StopService()
+	txid1 := newTxForPrep(tsv)
+	txid2 := newTxForPrep(tsv)
+	err := txe.Prepare(txid1, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	defer txe.RollbackPrepared("aa", 0)
+	err = txe.Prepare(txid2, "bb")
+	want := "prepared transactions exceeded limit"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Prepare err: %v, must contain %s", err, want)
+	}
+}
+
+func TestTxExecutorPrepareRedoBeginFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	db.AddRejectedQuery("begin", errors.New("begin fail"))
+	err := txe.Prepare(txid, "aa")
+	defer txe.RollbackPrepared("aa", 0)
+	want := "error: error: begin fail"
+	if err == nil || err.Error() != want {
+		t.Errorf("Prepare err: %v, want %s", err, want)
+	}
+}
+
+func TestTxExecutorPrepareRedoFail(t *testing.T) {
+	txe, tsv, _ := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	err := txe.Prepare(txid, "bb")
+	defer txe.RollbackPrepared("bb", 0)
+	want := "is not supported"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Prepare err: %v, must contain %s", err, want)
+	}
+}
+
+func TestTxExecutorPrepareRedoCommitFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	db.AddRejectedQuery("commit", errors.New("commit fail"))
+	err := txe.Prepare(txid, "aa")
+	defer txe.RollbackPrepared("aa", 0)
+	want := "error: error: commit fail"
+	if err == nil || err.Error() != want {
+		t.Errorf("Prepare err: %v, want %s", err, want)
+	}
 }
 
 func TestTxExecutorCommit(t *testing.T) {
-	db := setUpQueryExecutorTest()
-	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, noFlags, db)
+	txe, tsv, _ := newTestTxExecutor()
 	defer tsv.StopService()
-	txe := newTestTxExecutor(ctx, tsv)
-	txid := newTransaction(tsv)
-	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
-	db.AddQueryPattern("delete from `_vt`\\.redo_log_transaction where dtid =.*", &sqltypes.Result{})
-	db.AddQueryPattern("delete from `_vt`\\.redo_log_statement where dtid =.*", &sqltypes.Result{})
+	txid := newTxForPrep(tsv)
 	err := txe.Prepare(txid, "aa")
 	if err != nil {
 		t.Error(err)
@@ -49,13 +131,105 @@ func TestTxExecutorCommit(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	// Commiting an absent transaction should succeed.
+	err = txe.CommitPrepared("bb")
+	if err != nil {
+		t.Error(err)
+	}
 }
 
-func newTestTxExecutor(ctx context.Context, tsv *TabletServer) *TxExecutor {
+func TestTxExecutorCommitRedoFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	// Allow all additions to redo logs to succeed
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
+	err := txe.Prepare(txid, "bb")
+	if err != nil {
+		t.Error(err)
+	}
+	defer txe.RollbackPrepared("bb", 0)
+	err = txe.CommitPrepared("bb")
+	want := "is not supported"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Prepare err: %v, must contain %s", err, want)
+	}
+}
+
+func TestTxExecutorCommitRedoCommitFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	err := txe.Prepare(txid, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	defer txe.RollbackPrepared("aa", 0)
+	db.AddRejectedQuery("commit", errors.New("commit fail"))
+	err = txe.CommitPrepared("aa")
+	want := "error: error: commit fail"
+	if err == nil || err.Error() != want {
+		t.Errorf("Prepare err: %v, want %s", err, want)
+	}
+}
+
+func TestTxExecutorRollbackBeginFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	err := txe.Prepare(txid, "aa")
+	if err != nil {
+		t.Error(err)
+	}
+	db.AddRejectedQuery("begin", errors.New("begin fail"))
+	err = txe.RollbackPrepared("aa", txid)
+	want := "error: error: begin fail"
+	if err == nil || err.Error() != want {
+		t.Errorf("Prepare err: %v, want %s", err, want)
+	}
+}
+
+func TestTxExecutorRollbackRedoFail(t *testing.T) {
+	txe, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	txid := newTxForPrep(tsv)
+	// Allow all additions to redo logs to succeed
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction.*", &sqltypes.Result{})
+	err := txe.Prepare(txid, "bb")
+	if err != nil {
+		t.Error(err)
+	}
+	err = txe.RollbackPrepared("bb", txid)
+	want := "is not supported"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Prepare err: %v, must contain %s", err, want)
+	}
+}
+
+func newTestTxExecutor() (txe *TxExecutor, tsv *TabletServer, db *fakesqldb.DB) {
+	db = setUpQueryExecutorTest()
+	ctx := context.Background()
 	logStats := newLogStats("TestTxExecutor", ctx)
+	tsv = newTestTabletServer(ctx, smallTxPool, db)
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction\\(dtid, state, resolution, time_created\\) values \\('aa', 'Prepared', null,.*", &sqltypes.Result{})
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_statement.*", &sqltypes.Result{})
+	db.AddQuery("delete from `_vt`.redo_log_transaction where dtid = 'aa'", &sqltypes.Result{})
+	db.AddQuery("delete from `_vt`.redo_log_statement where dtid = 'aa'", &sqltypes.Result{})
+	db.AddQuery("update test_table set name = 2 where pk in (1) /* _stream test_table (pk ) (1 ); */", &sqltypes.Result{})
 	return &TxExecutor{
 		ctx:      ctx,
 		logStats: logStats,
 		qe:       tsv.qe,
+	}, tsv, db
+}
+
+// newTxForPrep creates a non-empty transaction.
+func newTxForPrep(tsv *TabletServer) int64 {
+	txid := newTransaction(tsv)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	_, err := tsv.Execute(context.Background(), &target, "update test_table set name = 2 where pk = 1", nil, txid, nil)
+	if err != nil {
+		panic(err)
 	}
+	return txid
 }

--- a/go/vt/tabletserver/tx_prep_pool.go
+++ b/go/vt/tabletserver/tx_prep_pool.go
@@ -22,7 +22,7 @@ type TxPreparedPool struct {
 // NewTxPreparedPool creates a new TxPreparedPool.
 func NewTxPreparedPool(capacity int) *TxPreparedPool {
 	return &TxPreparedPool{
-		conns:    make(map[string]*TxConnection),
+		conns:    make(map[string]*TxConnection, capacity),
 		capacity: capacity,
 	}
 }

--- a/go/vt/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/tabletserver/tx_prep_pool_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 )
 
+func TestEmptyPrep(t *testing.T) {
+	pp := NewTxPreparedPool(0)
+	want := "prepared transactions exceeded limit: 0"
+	err := pp.Put(nil, "aa")
+	if err == nil || err.Error() != want {
+		t.Errorf("Put err: %v, want %s", err, want)
+	}
+}
+
 func TestPrepPut(t *testing.T) {
 	pp := NewTxPreparedPool(2)
 	err := pp.Put(nil, "aa")


### PR DESCRIPTION
* More tests for Prepare, full coverage.
* Changed commit to use background context so it never times out.
* Changed Rollback to not return early under some conditions.
* Prepare from redo logs implemented, but more tests needed.
* TabletServer implementation of Prepare.
* Fix error handling in TabletServer.
* TwoPC doesn't depend on TxPool any more.
* Transactions with no statements are rolled back as no-op.

The TabletServer state transition has some complications:
* SetServingType is currently just a flag flip. But it can
leave unresolved prepared transactions. This needs to be handled
correctly.
* For normal transitions out of master (or shutdown), prepared
transactions have to be rolled back because they will be
resurrected elsewhere. The current implementation waits
for prepared transactions to be resolved.
* For resharding, we'll need a special shutdown that waits
for prepared transactions to be resolved.
* If we allow CommitPrepared during shut down, it can cause
a race condition with the code that rolls back prepared transactions.
We need to add synchronization to prevent this.

We'll resolve the TabletServer issues in subsequent PRs.