### PR TITLE
Removing vtgate_python_types in tests.

### DIFF
--- a/test/grpc_protocols_flavor.py
+++ b/test/grpc_protocols_flavor.py
@@ -42,9 +42,6 @@ class GRpcProtocolsFlavor(protocols_flavor.ProtocolsFlavor):
   def vtgate_python_protocol(self):
     return 'grpc'
 
-  def vtgate_python_types(self):
-    return 'proto3'
-
   def client_error_exception_type(self):
     return face.AbortionError
 

--- a/test/protocols_flavor.py
+++ b/test/protocols_flavor.py
@@ -54,10 +54,6 @@ class ProtocolsFlavor(object):
     """The protocol to use to talk to vtgate with python clients."""
     raise NotImplementedError('Not implemented in the base class')
 
-  def vtgate_python_types(self):
-    """Returns either 'proto3' or 'mysql' for the enum types."""
-    raise NotImplementedError('Not implemented in the base class')
-
   def client_error_exception_type(self):
     """The exception type the RPC client implementation returns for errors."""
     raise NotImplementedError('Not implemented in the base class')

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -9,12 +9,11 @@ import urllib
 import environment
 import keyspace_util
 import utils
-from protocols_flavor import protocols_flavor
-
 
 from vtdb import dbexceptions
 from vtdb import vtgate_cursor
 from vtdb import vtgate_client
+
 
 shard_0_master = None
 shard_1_master = None
@@ -312,14 +311,11 @@ def get_connection(timeout=10.0):
 
 class TestVTGateFunctions(unittest.TestCase):
 
+  int_type = 265
+  string_type = 6165
+
   def setUp(self):
     self.master_tablet = shard_1_master
-    if protocols_flavor().vtgate_python_types() == 'proto3':
-      self.int_type = 265
-      self.string_type = 6165
-    else:
-      self.int_type = 8L
-      self.string_type = 253L
 
   def execute_on_master(self, vtgate_conn, sql, bind_vars):
     return vtgate_conn._execute(


### PR DESCRIPTION
We only use proto3 now.