### PR TITLE
wrangler: Fix flaky unit test caused by Go map randomization.

### DIFF
--- a/go/vt/wrangler/testlib/migrate_served_types_test.go
+++ b/go/vt/wrangler/testlib/migrate_served_types_test.go
@@ -160,7 +160,7 @@ func TestMigrateServedTypes(t *testing.T) {
 
 	// migrate will error if the overlapping shards have no "SourceShard" entry
 	// and we cannot decide which shard is the source or the destination.
-	if err := vp.Run([]string{"MigrateServedTypes", "ks/0", "rdonly"}); err == nil || !strings.Contains(err.Error(), "neither Shard '-80' nor Shard '0' have a 'SourceShards' entry. Did you successfully run vtworker SplitClone before? Or did you already migrate the MASTER type?") {
+	if err := vp.Run([]string{"MigrateServedTypes", "ks/0", "rdonly"}); err == nil || !strings.Contains(err.Error(), "' have a 'SourceShards' entry. Did you successfully run vtworker SplitClone before? Or did you already migrate the MASTER type?") {
 		t.Fatalf("MigrateServedType(rdonly) should fail if no 'SourceShards' entry is present: %v", err)
 	}
 


### PR DESCRIPTION
This was introduced in https://github.com/youtube/vitess/pull/2098.