### PR TITLE
Bump minimum Go version from 1.5 to 1.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: go
 go:
-  - 1.5
+  - 1.7
 addons:
   apt:
     sources:

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -73,7 +73,7 @@ OS X 10.11 (El Capitan) should work as well, the installation instructions are b
 
 In addition, Vitess requires the software and libraries listed below.
 
-1.  [Install Go 1.5+](http://golang.org/doc/install).
+1.  [Install Go 1.7+](http://golang.org/doc/install).
 
 2.  Install [MariaDB 10.0](https://downloads.mariadb.org/) or
     [MySQL 5.6](http://dev.mysql.com/downloads/mysql). You can use any

--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -9,13 +9,13 @@ The `kubectl` steps will apply to any Kubernetes cluster.
 
 ## Prerequisites
 
-To complete the exercise in this guide, you must locally install Go 1.5+,
+To complete the exercise in this guide, you must locally install Go 1.7+,
 Vitess' `vtctlclient` tool, and Google Cloud SDK. The
 following sections explain how to set these up in your environment.
 
-### Install Go 1.5+
+### Install Go 1.7+
 
-You need to install [Go 1.5+](http://golang.org/doc/install) to build the
+You need to install [Go 1.7+](http://golang.org/doc/install) to build the
 `vtctlclient` tool, which issues commands to Vitess.
 
 After installing Go, make sure your `GOPATH` environment

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,4 +1,4 @@
-FROM golang:1.5
+FROM golang:1.7
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
bootstrap.sh is currently failing in our Travis CI tests because "golint" dropped support for Go 1.5.

While we're at it, let's upgrade to 1.7 instead of 1.6. (After all, 1.7 also comes with a significant speed improvement.)