### PR TITLE
[Docs] GettingStarted - More specific link to appropriate docker reference material

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -30,7 +30,7 @@ vitess@32f187ef9351:/vt/src/github.com/youtube/vitess$ make build
 Now you can proceed to [start a Vitess cluster](#start-a-vitess-cluster) inside
 the Docker container you just started. Note that if you want to access the
 servers from outside the container, you'll need to expose the ports as described
-in the [Docker user guide](https://docs.docker.com/userguide/).
+in the [Docker Engine Reference Guide](https://docs.docker.com/engine/reference/run/#/expose-incoming-ports).
 
 For local testing, you can also access the servers on the local IP address
 created for the container by Docker:


### PR DESCRIPTION
I updated the GettingStarted page to include a more specific link to the docker engine run reference specifically for exposing ports. 

Would it be helpful to also include an example for exposing ports 15000-15999?