### PR TITLE
Allow to override the default gRPC max message size.

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -43,6 +43,10 @@ var (
 	// GRPCCA is the CA to use if TLS is enabled
 	GRPCCA *string
 
+	// GRPCMaxMessageSize is the maximum message size which the gRPC server will
+	// accept. Larger messages will be rejected.
+	GRPCMaxMessageSize *int
+
 	// GRPCServer is the global server to serve gRPC.
 	GRPCServer *grpc.Server
 )
@@ -100,6 +104,15 @@ func createGRPCServer() {
 		creds := credentials.NewTLS(config)
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
+	// Override the default max message size (which is 4 MiB in gRPC 1.0.0).
+	// Large messages can occur when users try to insert very big rows. If they
+	// hit the limit, they'll see the following error:
+	// grpc: received message length XXXXXXX exceeding the max size 4194304
+	// Note: For gRPC 1.0.0 it's sufficient to set the limit on the server only
+	// because it's not enforced on the client side.
+	if GRPCMaxMessageSize != nil {
+		opts = append(opts, grpc.MaxMsgSize(*GRPCMaxMessageSize))
+	}
 
 	GRPCServer = grpc.NewServer(opts...)
 }
@@ -127,6 +140,9 @@ func RegisterGRPCFlags() {
 	GRPCCert = flag.String("grpc_cert", "", "certificate to use, requires grpc_key, enables TLS")
 	GRPCKey = flag.String("grpc_key", "", "key to use, requires grpc_cert, enables TLS")
 	GRPCCA = flag.String("grpc_ca", "", "ca to use, requires TLS, and enforces client cert check")
+	// Note: We're using 4 MiB as default value because that's the default in the
+	// gRPC 1.0.0 Go server.
+	GRPCMaxMessageSize = flag.Int("grpc_max_message_size", 4*1024*1024, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
 }
 
 // GRPCCheckServiceMap returns if we should register a gRPC service


### PR DESCRIPTION
Such large messages can occur when users try to insert very big rows. If they hit the limit, they'll see the following error:

grpc: received message length XXXXXXX exceeding the max size 4194304