### PR TITLE
2pc: TabletServer workflows

### DIFF
--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -409,13 +409,15 @@ func (tsv *TabletServer) serveNewType() (err error) {
 			err = x.(error)
 		}
 	}()
-	if tsv.target.TabletType != topodatapb.TabletType_MASTER {
-		tsv.startReplicationStreamer()
+	if tsv.target.TabletType == topodatapb.TabletType_MASTER {
 		err = tsv.qe.PrepareFromRedo()
 		if err != nil {
 			// TODO(sougou): raise alarms.
 			log.Errorf("Could not prepare transactions: %v", err)
 		}
+	} else {
+		tsv.qe.RollbackTransactions()
+		tsv.startReplicationStreamer()
 	}
 	tsv.transition(StateServing)
 	return nil

--- a/go/vt/tabletserver/twopc.go
+++ b/go/vt/tabletserver/twopc.go
@@ -131,9 +131,6 @@ func (tpc *TwoPC) SaveRedo(ctx context.Context, conn *TxConnection, dtid string,
 		return err
 	}
 
-	if len(queries) == 0 {
-		return nil
-	}
 	rows := make([][]sqltypes.Value, len(queries))
 	for i, query := range queries {
 		rows[i] = []sqltypes.Value{

--- a/go/vt/tabletserver/twopc_test.go
+++ b/go/vt/tabletserver/twopc_test.go
@@ -1,0 +1,100 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestReadPrepared(t *testing.T) {
+	// Reuse code from tx_executor_test.
+	_, tsv, db := newTestTxExecutor()
+	defer tsv.StopService()
+	tpc := tsv.qe.twoPC
+	ctx := context.Background()
+
+	conn, err := tsv.qe.connPool.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Recycle()
+
+	db.AddQuery(tpc.readPrepared, &sqltypes.Result{})
+	got, err := tpc.ReadPrepared(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string][]string{}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadPrepared: %#v, want %#v", got, want)
+	}
+
+	db.AddQuery(tpc.readPrepared, &sqltypes.Result{
+		Rows: [][]sqltypes.Value{{
+			sqltypes.MakeString([]byte("dtid0")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt01")),
+		}},
+	})
+	got, err = tpc.ReadPrepared(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = map[string][]string{"dtid0": {"stmt01"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadPrepared: %#v, want %#v", got, want)
+	}
+
+	db.AddQuery(tpc.readPrepared, &sqltypes.Result{
+		Rows: [][]sqltypes.Value{{
+			sqltypes.MakeString([]byte("dtid0")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt01")),
+		}, {
+			sqltypes.MakeString([]byte("dtid0")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt02")),
+		}},
+	})
+	got, err = tpc.ReadPrepared(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = map[string][]string{"dtid0": {"stmt01", "stmt02"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadPrepared: %#v, want %#v", got, want)
+	}
+
+	db.AddQuery(tpc.readPrepared, &sqltypes.Result{
+		Rows: [][]sqltypes.Value{{
+			sqltypes.MakeString([]byte("dtid0")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt01")),
+		}, {
+			sqltypes.MakeString([]byte("dtid0")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt02")),
+		}, {
+			sqltypes.MakeString([]byte("dtid1")),
+			sqltypes.MakeString([]byte("")),
+			sqltypes.MakeString([]byte("stmt11")),
+		}},
+	})
+	got, err = tpc.ReadPrepared(ctx, conn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = map[string][]string{
+		"dtid0": {"stmt01", "stmt02"},
+		"dtid1": {"stmt11"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReadPrepared: %#v, want %#v", got, want)
+	}
+}

--- a/go/vt/tabletserver/tx_executor.go
+++ b/go/vt/tabletserver/tx_executor.go
@@ -37,7 +37,7 @@ func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 
 	// If no queries were executed, we just rollback.
 	if len(conn.Queries) == 0 {
-		txe.qe.txPool.LocalCommit(txe.ctx, conn)
+		txe.qe.txPool.LocalConclude(txe.ctx, conn)
 		return nil
 	}
 

--- a/go/vt/tabletserver/tx_prep_pool.go
+++ b/go/vt/tabletserver/tx_prep_pool.go
@@ -51,3 +51,15 @@ func (pp *TxPreparedPool) Get(dtid string) *TxConnection {
 	delete(pp.conns, dtid)
 	return c
 }
+
+// GetAll removes all connections and returns them as a list.
+func (pp *TxPreparedPool) GetAll() []*TxConnection {
+	pp.mu.Lock()
+	defer pp.mu.Unlock()
+	conns := make([]*TxConnection, 0, len(pp.conns))
+	for _, c := range pp.conns {
+		conns = append(conns, c)
+	}
+	pp.conns = make(map[string]*TxConnection, pp.capacity)
+	return conns
+}

--- a/go/vt/tabletserver/tx_prep_pool_test.go
+++ b/go/vt/tabletserver/tx_prep_pool_test.go
@@ -56,3 +56,18 @@ func TestPrepGet(t *testing.T) {
 		t.Errorf("Get(aa): %v, want nil", got)
 	}
 }
+
+func TestPrepGetAll(t *testing.T) {
+	pp := NewTxPreparedPool(2)
+	conn1 := &TxConnection{}
+	conn2 := &TxConnection{}
+	pp.Put(conn1, "aa")
+	pp.Put(conn2, "bb")
+	got := pp.GetAll()
+	if len(got) != 2 {
+		t.Errorf("GetAll len: %d, want 2", len(got))
+	}
+	if len(pp.conns) != 0 {
+		t.Errorf("len(pp.conns): %d, want 0", len(pp.conns))
+	}
+}


### PR DESCRIPTION
All previously mentioned tabletserver workflow issues
are addressed now.
* A master->non-master transition immediately rolls back all
transactions including the prepared ones. This addresses the case
where MySQL was externally reparented.
* A master->shutdown transition waits till all transactions are
resolved. This addresses the reparent caused by the resharding
workflow. We don't want to shut down with unresolved transactions.
This code path is also used for normal reparents, where this behavior
is also acceptable.
* There is no race condition between state transition code and other
transactional commands. When we transition between two serving types,
we don't allow any requests until the transactions are rolled back.
During shutdown, we allow transactional statements, but the transition
code only waits for transactions to be resolved. So, there's no race
in either situation.