### PR TITLE
vtctl: Add command "RefreshStateByShard".

### DIFF
--- a/doc/vtctlReference.md
+++ b/doc/vtctlReference.md
@@ -1824,6 +1824,7 @@ Blocks until the specified shard has caught up with the filtered replication of 
 * [InitTablet](#inittablet)
 * [Ping](#ping)
 * [RefreshState](#refreshstate)
+* [RefreshStateByShard](#refreshstatebyshard)
 * [ReparentTablet](#reparenttablet)
 * [RestoreFromBackup](#restorefrombackup)
 * [RunHealthCheck](#runhealthcheck)
@@ -2102,6 +2103,30 @@ Reloads the tablet record on the specified tablet.
 #### Errors
 
 * The <code>&lt;tablet alias&gt;</code> argument is required for the <code>&lt;RefreshState&gt;</code> command. This error occurs if the command is not called with exactly one argument.
+
+
+### RefreshStateByShard
+
+Runs 'RefreshState' on all tablets in the given shard.
+
+#### Example
+
+<pre class="command-example">RefreshStateByShard [-cells=c1,c2,...] &lt;keyspace/shard&gt;</pre>
+
+#### Flags
+
+| Name | Type | Definition |
+| :-------- | :--------- | :--------- |
+| cells | string | Specifies a comma-separated list of cells whose tablets are included. If empty, all cells are considered. |
+
+
+#### Arguments
+
+* <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitepace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
+
+#### Errors
+
+* The <code>&lt;keyspace/shard&gt;</code> argument is required for the <code>&lt;RefreshStateByShard&gt;</code> command. This error occurs if the command is not called with exactly one argument.
 
 
 ### ReparentTablet

--- a/test/tabletmanager.py
+++ b/test/tabletmanager.py
@@ -118,9 +118,12 @@ class TestTabletManager(unittest.TestCase):
         len(query_result['fields']), 2,
         'expected 2 fields in vt_select_test: %s' % str(query_result))
 
-    # check Ping / RefreshState
+    # check Ping / RefreshState / RefreshStateByShard
     utils.run_vtctl(['Ping', tablet_62344.tablet_alias])
     utils.run_vtctl(['RefreshState', tablet_62344.tablet_alias])
+    utils.run_vtctl(['RefreshStateByShard', 'test_keyspace/0'])
+    utils.run_vtctl(['RefreshStateByShard', '--cells=test_nj',
+                     'test_keyspace/0'])
 
     # Quickly check basic actions.
     utils.run_vtctl(['SetReadOnly', tablet_62344.tablet_alias])


### PR DESCRIPTION
This command allows to run "RefreshState" on all tablets for a given shard.

This is useful in the following cases:

* when tablets must be refreshed after a blacklist rule was removed
* manually refreshing tablets e.g. when filtered replication was enabled or disabled

B=31752251