### PR TITLE
Fixing test/cache_invalidation.py for MySQL 5.6

### DIFF
--- a/go/mysql/vtmysql_internals.h
+++ b/go/mysql/vtmysql_internals.h
@@ -39,8 +39,8 @@ unsigned long cli_safe_read(MYSQL *mysql);
 
 // st_mysql_methods and simple_command are declared in mysql.h in
 // Google MySQL 5.1 (VERSION_ID=501xx), but were moved to sql_common.h in
-// MariaDB (VERSION_ID=1000xx) and MySQL 5.6 (VERSION_ID=506xx).
-#if MYSQL_VERSION_ID >= 50600 // MySQL version >= 5.6
+// MariaDB (VERSION_ID=1000xx) and MySQL 5.5 (VERSION_ID=505xx).
+#if MYSQL_VERSION_ID >= 50500 // MySQL version >= 5.5
 
 typedef struct st_mysql_methods
 {

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -33,6 +33,7 @@ func (fakeEvent) IsGTID() bool                          { return false }
 func (fakeEvent) IsRotate() bool                        { return false }
 func (fakeEvent) IsIntVar() bool                        { return false }
 func (fakeEvent) IsRand() bool                          { return false }
+func (fakeEvent) IsPreviousGTIDs() bool                 { return false }
 func (fakeEvent) HasGTID(replication.BinlogFormat) bool { return true }
 func (fakeEvent) Timestamp() uint32                     { return 1407805592 }
 func (fakeEvent) Format() (replication.BinlogFormat, error) {
@@ -40,6 +41,9 @@ func (fakeEvent) Format() (replication.BinlogFormat, error) {
 }
 func (fakeEvent) GTID(replication.BinlogFormat) (replication.GTID, error) {
 	return replication.MariadbGTID{Domain: 0, Server: 62344, Sequence: 0xd}, nil
+}
+func (fakeEvent) PreviousGTIDs(replication.BinlogFormat) (replication.Position, error) {
+	return replication.Position{}, errors.New("not a PreviousGTIDs")
 }
 func (fakeEvent) IsBeginGTID(replication.BinlogFormat) bool { return false }
 func (fakeEvent) Query(replication.BinlogFormat) (replication.Query, error) {

--- a/go/vt/mysqlctl/binlog_event.go
+++ b/go/vt/mysqlctl/binlog_event.go
@@ -119,6 +119,11 @@ func (ev binlogEvent) IsRand() bool {
 	return ev.Type() == 13
 }
 
+// IsPreviousGTIDs implements BinlogEvent.IsPreviousGTIDs().
+func (ev binlogEvent) IsPreviousGTIDs() bool {
+	return ev.Type() == 35
+}
+
 // Format implements BinlogEvent.Format().
 //
 // Expected format (L = total length of event data):

--- a/go/vt/mysqlctl/mysql_flavor_mariadb.go
+++ b/go/vt/mysqlctl/mysql_flavor_mariadb.go
@@ -251,6 +251,11 @@ func (ev mariadbBinlogEvent) GTID(f replication.BinlogFormat) (replication.GTID,
 	}, nil
 }
 
+// PreviousGTIDs implements BinlogEvent.PreviousGTIDs().
+func (ev mariadbBinlogEvent) PreviousGTIDs(f replication.BinlogFormat) (replication.Position, error) {
+	return replication.Position{}, fmt.Errorf("MariaDB should not provide PREVIOUS_GTIDS_EVENT events")
+}
+
 // StripChecksum implements BinlogEvent.StripChecksum().
 func (ev mariadbBinlogEvent) StripChecksum(f replication.BinlogFormat) (replication.BinlogEvent, []byte, error) {
 	switch f.ChecksumAlgorithm {

--- a/go/vt/mysqlctl/mysql_flavor_mysql56.go
+++ b/go/vt/mysqlctl/mysql_flavor_mysql56.go
@@ -211,6 +211,18 @@ func (ev mysql56BinlogEvent) GTID(f replication.BinlogFormat) (replication.GTID,
 	return replication.Mysql56GTID{Server: sid, Sequence: gno}, nil
 }
 
+// PreviousGTIDs implements BinlogEvent.PreviousGTIDs().
+func (ev mysql56BinlogEvent) PreviousGTIDs(f replication.BinlogFormat) (replication.Position, error) {
+	data := ev.Bytes()[f.HeaderLength:]
+	set, err := replication.NewMysql56GTIDSetFromSIDBlock(data)
+	if err != nil {
+		return replication.Position{}, err
+	}
+	return replication.Position{
+		GTIDSet: set,
+	}, nil
+}
+
 // StripChecksum implements BinlogEvent.StripChecksum().
 func (ev mysql56BinlogEvent) StripChecksum(f replication.BinlogFormat) (replication.BinlogEvent, []byte, error) {
 	switch f.ChecksumAlgorithm {

--- a/go/vt/mysqlctl/replication/binlog_event.go
+++ b/go/vt/mysqlctl/replication/binlog_event.go
@@ -54,6 +54,8 @@ type BinlogEvent interface {
 	// because it's a GTID_EVENT (MariaDB, MySQL 5.6), or because it is some
 	// arbitrary event type that has a GTID in the header (Google MySQL).
 	HasGTID(BinlogFormat) bool
+	// IsPreviousGTIDs returns true if this event is a PREVIOUS_GTIDS_EVENT.
+	IsPreviousGTIDs() bool
 
 	// Timestamp returns the timestamp from the event header.
 	Timestamp() uint32
@@ -78,6 +80,9 @@ type BinlogEvent interface {
 	// Rand returns the two seed values for a RAND_EVENT.
 	// This is only valid if IsRand() returns true.
 	Rand(BinlogFormat) (uint64, uint64, error)
+	// PreviousGTIDs returns the Position from the event.
+	// This is only valid if IsPreviousGTIDs() returns true.
+	PreviousGTIDs(BinlogFormat) (Position, error)
 
 	// StripChecksum returns the checksum and a modified event with the checksum
 	// stripped off, if any. If there is no checksum, it returns the same event

--- a/go/vt/mysqlctl/replication/mysql56_gtid_set_test.go
+++ b/go/vt/mysqlctl/replication/mysql56_gtid_set_test.go
@@ -437,7 +437,17 @@ func TestMysql56GTIDSetSIDBlock(t *testing.T) {
 		// sid2: interval 1 end
 		6, 0, 0, 0, 0, 0, 0, 0,
 	}
-	if got := input.SIDBlock(); !reflect.DeepEqual(got, want) {
+	got := input.SIDBlock()
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("%#v.SIDBlock() = %#v, want %#v", input, got, want)
+	}
+
+	// Testing the conversion back.
+	set, err := NewMysql56GTIDSetFromSIDBlock(want)
+	if err != nil {
+		t.Fatalf("Reconstructing Mysql56GTIDSet from SID block failed: %v", err)
+	}
+	if !reflect.DeepEqual(set, input) {
+		t.Errorf("NewMysql56GTIDSetFromSIDBlock(%#v) = %#v, want %#v", want, set, input)
 	}
 }

--- a/test/cache_invalidation.py
+++ b/test/cache_invalidation.py
@@ -264,7 +264,7 @@ class InvalidatorThread(threading.Thread):
             self.timestamp)
 
   def invalidate(self, table_name, row_id, token):
-    logging.debug('Invalidating %s(%d):', table_name, row_id)
+    logging.debug('Invalidating %s(%d) - %s:', table_name, row_id, token)
     version, cache_event_token, _ = self.cache.gets(table_name, row_id)
     if version is None:
       logging.debug('  no entry in cache, saving event_token')


### PR DESCRIPTION
In the process:
- fixing binlog replay starting from a timestamp: we just cannot skip
  the events at a lower level, as the binlogs may contain format event,
  binlog GTID set events, and so on. We need to parse them all.
- adding support for MySQL 5.6 PREVIOUS_GTIDS_EVENT event. It contains a
  SIDBlock, adding parsing for that (we already had code to generate it,
  as it's used to start replication from a GTIDSet).
- Some code in vtmysql_internals.h was incorrectly compiling for MySQL
  5.6 and higher, when it should have been 5.5.