### PR TITLE
Fixing update_stream.py for MySQL 5.6.

### DIFF
--- a/test/update_stream.py
+++ b/test/update_stream.py
@@ -348,9 +348,9 @@ class TestUpdateStream(unittest.TestCase):
 
   def test_event_token(self):
     """Checks the background binlog monitor thread works."""
-    replica_position = _get_repl_current_position()
     timeout = 10
     while True:
+      replica_position = _get_repl_current_position()
       value = None
       v = utils.get_vars(replica_tablet.port)
       if 'EventTokenPosition' in v:
@@ -366,7 +366,8 @@ class TestUpdateStream(unittest.TestCase):
                         'EventTokenTimestamp is too recent: %d > %d' %(ts, now))
         break
       timeout = utils.wait_step(
-          'EventTokenPosition must be up to date but got %s' % value, timeout)
+          'EventTokenPosition must be up to date but got %s (expected %s)' %
+          (value, replica_position), timeout)
 
     # With vttablet up to date, test a vttablet query returns the EventToken.
     qr = replica_tablet.execute('select * from vt_insert_test',
@@ -617,6 +618,8 @@ class TestUpdateStream(unittest.TestCase):
       logging.debug('_test_timestamp_start: got event: %s @ %d',
                     str(event), resume_timestamp)
       # we might get a couple extra events from the rotation, ignore these.
+      if not event.statements:
+        continue
       if event.statements[0].category == 0:  # Statement.Category.Error
         continue
       self.assertEqual(event.statements[0].table_name, 'vt_b',


### PR DESCRIPTION
Also fixing a flakiness, a test was reading a value that may not be
final. Now we re-read it every time.