### PR TITLE
gcsbackupstorage: Deprecate unused project name flag.

### DIFF
--- a/examples/kubernetes/configure.sh
+++ b/examples/kubernetes/configure.sh
@@ -11,14 +11,6 @@ if [ -n "$REPLY" ]; then storage="$REPLY"; fi
 case "$storage" in
 gcs)
   # Google Cloud Storage
-  project=$(gcloud config list project | grep 'project\s*=' | sed -r 's/^.*=\s*(.*)$/\1/')
-  read -p "Google Developers Console Project [$project]: "
-  if [ -n "$REPLY" ]; then project="$REPLY"; fi
-  if [ -z "$project" ]; then
-    echo "ERROR: Project name must not be empty."
-    exit 1
-  fi
-
   read -p "Google Cloud Storage bucket for Vitess backups: " bucket
   if [ -z "$bucket" ]; then
     echo "ERROR: Bucket name must not be empty."
@@ -30,7 +22,6 @@ gcs)
   echo
 
   backup_flags=$(echo -backup_storage_implementation gcs \
-                      -gcs_backup_storage_project "'$project'" \
                       -gcs_backup_storage_bucket "'$bucket'")
   ;;
 file)

--- a/go/vt/mysqlctl/gcsbackupstorage/gcs.go
+++ b/go/vt/mysqlctl/gcsbackupstorage/gcs.go
@@ -24,8 +24,7 @@ import (
 )
 
 var (
-	// project is the Google Developers Console project ID.
-	project = flag.String("gcs_backup_storage_project", "", "Google Developers Console project ID to use for backups")
+	_ = flag.String("gcs_backup_storage_project", "", "This flag is unused and deprecated. It will be removed entirely in a future release.")
 
 	// bucket is where the backups will go.
 	bucket = flag.String("gcs_backup_storage_bucket", "", "Google Cloud Storage bucket to use for backups")


### PR DESCRIPTION
The GCS API no longer requires us to specify the project name for any of
the calls we use.