### PR TITLE
vttablet: Show true current health status.

### DIFF
--- a/go/cmd/vttablet/status.go
+++ b/go/cmd/vttablet/status.go
@@ -150,18 +150,19 @@ No binlog player is running.
 type healthStatus struct {
 	Records []interface{}
 	Config  template.HTML
+	current *tabletmanager.HealthRecord
 }
 
 func (hs *healthStatus) CurrentClass() string {
-	if len(hs.Records) > 0 {
-		return hs.Records[0].(*tabletmanager.HealthRecord).Class()
+	if hs.current != nil {
+		return hs.current.Class()
 	}
 	return "unknown"
 }
 
 func (hs *healthStatus) CurrentHTML() template.HTML {
-	if len(hs.Records) > 0 {
-		return hs.Records[0].(*tabletmanager.HealthRecord).HTML()
+	if hs.current != nil {
+		return hs.current.HTML()
 	}
 	return template.HTML("unknown")
 }
@@ -189,6 +190,7 @@ func addStatusParts(qsc tabletserver.Controller) {
 		return &healthStatus{
 			Records: agent.History.Records(),
 			Config:  tabletmanager.ConfigHTML(),
+			current: agent.History.Latest().(*tabletmanager.HealthRecord),
 		}
 	})
 	qsc.AddStatusPart()

--- a/go/history/history_test.go
+++ b/go/history/history_test.go
@@ -38,6 +38,39 @@ func TestHistory(t *testing.T) {
 	}
 }
 
+func TestLatest(t *testing.T) {
+	h := New(4)
+
+	// Add first value.
+	h.Add(mod10(1))
+	if got, want := int(h.Records()[0].(mod10)), 1; got != want {
+		t.Errorf("h.Records()[0] = %v, want %v", got, want)
+	}
+	if got, want := int(h.Latest().(mod10)), 1; got != want {
+		t.Errorf("h.Latest() = %v, want %v", got, want)
+	}
+
+	// Add value that isn't a "duplicate".
+	h.Add(mod10(2))
+	if got, want := int(h.Records()[0].(mod10)), 2; got != want {
+		t.Errorf("h.Records()[0] = %v, want %v", got, want)
+	}
+	if got, want := int(h.Latest().(mod10)), 2; got != want {
+		t.Errorf("h.Latest() = %v, want %v", got, want)
+	}
+
+	// Add value that IS a "duplicate".
+	h.Add(mod10(12))
+	// Records()[0] doesn't change.
+	if got, want := int(h.Records()[0].(mod10)), 2; got != want {
+		t.Errorf("h.Records()[0] = %v, want %v", got, want)
+	}
+	// Latest() does change.
+	if got, want := int(h.Latest().(mod10)), 12; got != want {
+		t.Errorf("h.Latest() = %v, want %v", got, want)
+	}
+}
+
 type duplic int
 
 func (d duplic) IsDuplicate(other interface{}) bool {
@@ -51,4 +84,10 @@ func TestIsEquivalent(t *testing.T) {
 	if got, want := len(q.Records()), 1; got != want {
 		t.Errorf("len(q.Records())=%v, want %v", got, want)
 	}
+}
+
+type mod10 int
+
+func (m mod10) IsDuplicate(other interface{}) bool {
+	return m%10 == other.(mod10)%10
 }


### PR DESCRIPTION
We were actually showing the most recent entry in the deduplicated
history. Since deduplication was changed to ignore replication lag,
the lag reported under "Current status" on the vttablet status page
wasn't actually current.