### PR TITLE
Check for overridden database name before restoring.

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -413,13 +413,14 @@ func backupFiles(mysqld MysqlDaemon, logger logutil.Logger, bh backupstorage.Bac
 	return nil
 }
 
-// checkNoDB makes sure there is no vt_ db already there. Used by Restore,
-// we do not wnat to destroy an existing DB.
-// Returns true iff the condition is satisfied (there's no DB).
+// checkNoDB makes sure there is no user data already there.
+// Used by Restore, as we do not want to destroy an existing DB.
+// The user's database name must be given since we ignore all others.
+// Returns true iff the specified DB either doesn't exist, or has no tables.
 // Returns (false, nil) if the check succeeds but the condition is not
-// satisfied (there is a DB).
+// satisfied (there is a DB with tables).
 // Returns non-nil error if one occurs while trying to perform the check.
-func checkNoDB(ctx context.Context, mysqld MysqlDaemon) (bool, error) {
+func checkNoDB(ctx context.Context, mysqld MysqlDaemon, dbName string) (bool, error) {
 	// Wait for mysqld to be ready, in case it was launched in parallel with us.
 	if err := mysqld.Wait(ctx); err != nil {
 		return false, err
@@ -431,8 +432,7 @@ func checkNoDB(ctx context.Context, mysqld MysqlDaemon) (bool, error) {
 	}
 
 	for _, row := range qr.Rows {
-		if strings.HasPrefix(row[0].String(), "vt_") {
-			dbName := row[0].String()
+		if row[0].String() == dbName {
 			tableQr, err := mysqld.FetchSuperQuery(ctx, "SHOW TABLES FROM "+dbName)
 			if err != nil {
 				return false, fmt.Errorf("checkNoDB failed: %v", err)
@@ -585,7 +585,8 @@ func Restore(
 	hookExtraEnv map[string]string,
 	localMetadata map[string]string,
 	logger logutil.Logger,
-	deleteBeforeRestore bool) (replication.Position, error) {
+	deleteBeforeRestore bool,
+	dbName string) (replication.Position, error) {
 
 	// find the right backup handle: most recent one, with a MANIFEST
 	logger.Infof("Restore: looking for a suitable backup to restore")
@@ -629,7 +630,7 @@ func Restore(
 
 	if !deleteBeforeRestore {
 		logger.Infof("Restore: checking no existing data is present")
-		ok, err := checkNoDB(ctx, mysqld)
+		ok, err := checkNoDB(ctx, mysqld, dbName)
 		if err != nil {
 			return replication.Position{}, err
 		}

--- a/go/vt/tabletmanager/restore.go
+++ b/go/vt/tabletmanager/restore.go
@@ -60,7 +60,7 @@ func (agent *ActionAgent) restoreDataLocked(ctx context.Context, logger logutil.
 	localMetadata := agent.getLocalMetadataValues(originalType)
 	tablet := agent.Tablet()
 	dir := fmt.Sprintf("%v/%v", tablet.Keyspace, tablet.Shard)
-	pos, err := mysqlctl.Restore(ctx, agent.MysqlDaemon, dir, *restoreConcurrency, agent.hookExtraEnv(), localMetadata, logger, deleteBeforeRestore)
+	pos, err := mysqlctl.Restore(ctx, agent.MysqlDaemon, dir, *restoreConcurrency, agent.hookExtraEnv(), localMetadata, logger, deleteBeforeRestore, topoproto.TabletDbName(tablet))
 	switch err {
 	case nil:
 		// Reconnect to master.


### PR DESCRIPTION
Before restoring, we use checkNoDB() to make sure there isn't any
existing data. There are some internal tables that exist even on an
empty tablet, so we use a whitelist to check only for user data.

Previously, we assumed the user's database would start with "vt_" since
we default to using "vt_{keyspace}". If the `-init_db_name_override`
flag had been used to set a database name that didn't start with "vt_",
it could result in unnecessary restores upon vttablet restarts.

Now we check for the overridden database name instead if one is set.