### PR TITLE
Allow to wait for all tablets to be propagated to TabletStatsCache

### DIFF
--- a/go/vt/discovery/fake_healthcheck.go
+++ b/go/vt/discovery/fake_healthcheck.go
@@ -50,6 +50,10 @@ func (fhc *FakeHealthCheck) SetListener(listener HealthCheckStatsListener, sendD
 	fhc.listener = listener
 }
 
+// WaitForInitialStatsUpdates is not implemented.
+func (fhc *FakeHealthCheck) WaitForInitialStatsUpdates() {
+}
+
 // AddTablet adds the tablet and calls the listener.
 func (fhc *FakeHealthCheck) AddTablet(tablet *topodatapb.Tablet, name string) {
 	key := TabletToMapKey(tablet)

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -174,7 +174,10 @@ type HealthCheck interface {
 	// AddTablet() call were propagated to the listener via corresponding
 	// StatsUpdate() calls. Note that code path from AddTablet() to
 	// corresponding StatsUpdate() is asynchronous but not cancelable, thus
-	// this function is also non-cancelable and can't return error.
+	// this function is also non-cancelable and can't return error. Also
+	// note that all AddTablet() calls should happen before calling this
+	// method. WaitForInitialStatsUpdates won't wait for StatsUpdate() calls
+	// corresponding to AddTablet() calls made during its execution.
 	WaitForInitialStatsUpdates()
 	// GetConnection returns the TabletConn of the given tablet.
 	GetConnection(key string) tabletconn.TabletConn

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -84,6 +84,10 @@ type TopologyWatcher struct {
 	// mu protects all variables below
 	mu      sync.Mutex
 	tablets map[string]*tabletInfo
+	// Whether first load of the topology data is done.
+	firstLoadDone bool
+	// Channel that is closed when the initial loading of topology data is done.
+	firstLoadChan chan interface{}
 }
 
 // NewTopologyWatcher returns a TopologyWatcher that monitors all
@@ -98,6 +102,7 @@ func NewTopologyWatcher(topoServer topo.Server, tr TabletRecorder, cell string, 
 		sem:             make(chan int, topoReadConcurrency),
 		tablets:         make(map[string]*tabletInfo),
 	}
+	tw.firstLoadChan = make(chan interface{})
 	tw.ctx, tw.cancelFunc = context.WithCancel(context.Background())
 	tw.wg.Add(1)
 	go tw.watch()
@@ -172,7 +177,29 @@ func (tw *TopologyWatcher) loadTablets() {
 		}
 	}
 	tw.tablets = newTablets
+	if !tw.firstLoadDone {
+		tw.firstLoadDone = true
+		close(tw.firstLoadChan)
+	}
 	tw.mu.Unlock()
+}
+
+// WaitForInitialTopology waits until the watcher reads all of the topology data
+// for the first time and transfers the information to TabletRecorder via its
+// AddTablet() method.
+func (tw *TopologyWatcher) WaitForInitialTopology() error {
+	tw.mu.Lock()
+	firstLoadDone := tw.firstLoadDone
+	tw.mu.Unlock()
+	if !firstLoadDone {
+		select {
+		case <-tw.ctx.Done():
+			return tw.ctx.Err()
+		case <-tw.firstLoadChan:
+			// First load is done, normally return from the function.
+		}
+	}
+	return nil
 }
 
 // Stop stops the watcher. It does not clean up the tablets added to TabletRecorder.

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -84,9 +84,9 @@ type TopologyWatcher struct {
 	// mu protects all variables below
 	mu      sync.Mutex
 	tablets map[string]*tabletInfo
-	// Whether first load of the topology data is done.
+	// firstLoadDone is true when first load of the topology data is done.
 	firstLoadDone bool
-	// Channel that is closed when the initial loading of topology data is done.
+	// firstLoadChan is closed when the initial loading of topology data is done.
 	firstLoadChan chan struct{}
 }
 

--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -99,6 +99,13 @@ func (shardSwap *shardSchemaSwap) startHealthWatchers() error {
 			discovery.DefaultTopoReadConcurrency)
 		shardSwap.tabletWatchers = append(shardSwap.tabletWatchers, watcher)
 	}
+	for _, watcher := range shardSwap.tabletWatchers {
+		err := watcher.WaitForInitialTopology()
+		if err != nil {
+			return err
+		}
+	}
+	shardSwap.tabletHealthCheck.WaitForInitialStatsUpdates()
 	return nil
 }
 

--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -100,8 +100,7 @@ func (shardSwap *shardSchemaSwap) startHealthWatchers() error {
 		shardSwap.tabletWatchers = append(shardSwap.tabletWatchers, watcher)
 	}
 	for _, watcher := range shardSwap.tabletWatchers {
-		err := watcher.WaitForInitialTopology()
-		if err != nil {
+		if err := watcher.WaitForInitialTopology(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This change adds method TopologyWatcher.WaitForInitialTopology() that will wait
until the initial topology data is read and propagated to TabletRecorder through
AddTablet() method. This also adds HealthCheck.WaitForInitialStatsUpdates()
method which will wait until information about all tablets added via AddTablet()
method is propagated to the listener through StatsUpdate() method.

This will allow resharding and schema swap code to be sure that after they
created the topology watchers all tablets has been propagated to
TabletStatsCache (or other health check listener).

The schema swap code is modified here to use these new methods. This code is not
tested (because schema swap code is not fully ready yet), but serves as an
example of how these new methods can be used.