### PR TITLE
v3: Improve symbol resolution for subqueries

### DIFF
--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -683,6 +683,27 @@
   }
 }
 
+# subquery with join, and aliased references
+"select t.id from (select user.id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id"
+{
+  "Original": "select t.id from (select user.id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select t.id from (select user.id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id",
+    "FieldQuery": "select t.id from (select user.id from user where 1 != 1) as t join user_extra where 1 != 1",
+    "Vindex": "user_index",
+    "Values": 5
+  }
+}
+
+# subquery with join, duplicate columns
+"select t.id from (select user.id, id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id"
+"duplicate column aliases: id"
+
 # subquery in RHS of join
 "select t.id from user_extra join (select id from user where id = 5) as t on t.id = user_extra.user_id"
 {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -49,6 +49,60 @@
 "select id from user group by col"
 "symbol col not found"
 
+# HAVING references base name of a column
+"select user.col1 from user having col1 = 2"
+{
+  "Original": "select user.col1 from user having col1 = 2",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select user.col1 from user having col1 = 2",
+    "FieldQuery": "select user.col1 from user where 1 != 1"
+  }
+}
+
+# HAVING references base name of non-existent column
+"select user.col1 from user having col2 = 2"
+"symbol col2 not found"
+
+# ambiguous symbol reference
+"select user.col1, user_extra.col1 from user join user_extra having col1 = 2"
+"ambiguous symbol reference: col1"
+
+# non-ambiguous symbol reference
+"select user.col1, user_extra.col1 from user join user_extra having user_extra.col1 = 2"
+{
+  "Original": "select user.col1, user_extra.col1 from user join user_extra having user_extra.col1 = 2",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user.col1 from user",
+      "FieldQuery": "select user.col1 from user where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user_extra.col1 from user_extra having user_extra.col1 = 2",
+      "FieldQuery": "select user_extra.col1 from user_extra where 1 != 1"
+    },
+    "Cols": [
+      -1,
+      1
+    ]
+  }
+}
+
 # HAVING multi-route
 "select user.col1 as a, user.col2, user_extra.col3 from user join user_extra having 1 = 1 and a = 1 and a = user.col2 and user_extra.col3 = 1"
 {

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -28,6 +28,21 @@
   }
 }
 
+# unqualified '*' expression for simple route
+"select * from user"
+{
+  "Original": "select * from user",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select * from user",
+    "FieldQuery": "select * from user where 1 != 1"
+  }
+}
+
 # RHS route referenced
 "select user_extra.id from user join user_extra"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -99,7 +99,7 @@
 "unsupported: complex join and group by"
 
 # Group by references outer query
-"select id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 group by id)"
+"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 group by aa)"
 "unsupported: subquery references outer query in group by"
 
 # Group by and scatter
@@ -111,7 +111,7 @@
 "unsupported: subqueries in group by expression"
 
 # Order by references outer query
-"select id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 order by id)"
+"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 order by aa)"
 "unsupported: subquery references outer query in order by"
 
 # Order by uses complex expression

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -96,6 +96,13 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema VSchema)
 			if colsyms.Vindex == nil {
 				continue
 			}
+			// Check if a colvindex of the same name already exists.
+			// Dups are not allowed in subqueries in this situation.
+			for _, colVindex := range table.ColumnVindexes {
+				if colVindex.Column.Equal(cistring.CIString(colsyms.Alias)) {
+					return nil, fmt.Errorf("duplicate column aliases: %v", colsyms.Alias)
+				}
+			}
 			table.ColumnVindexes = append(table.ColumnVindexes, &vindexes.ColumnVindex{
 				Column: cistring.CIString(colsyms.Alias),
 				Vindex: colsyms.Vindex,

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -279,18 +279,30 @@ func (t *tabsym) FindVindex(name sqlparser.ColIdent) vindexes.Vindex {
 // a tabsym, colsym also contains a backpointer to the symtab,
 // and a pointer to the route that would compute or fetch this value.
 // In the future, it could point to primitives other than a route.
-// A colsym may not have an alias, in which case, it cannot be referenced
-// by ohter parts of the query.
 // If the expression is a plain column reference, then the 'Underlying' field
 // is set to the column it refers. If the referenced column has a Vindex,
 // the Vindex field is also accordingly set.
 type colsym struct {
-	Alias         sqlparser.ColIdent
+	// Alias will represent the unqualified symbol name for that expression.
+	// If the statement provides an explicit alias, that name will be used.
+	// Otherwise, one will be generated. If the expression is a simple
+	// column, then the base name of the column will be used as the alias.
+	Alias sqlparser.ColIdent
+
+	// QualfiedName will represent the fully qualified column name,
+	// if the expression is a simple column reference. If the column
+	// expression does not reference a table (or alias), a fully
+	// qualified name will be generated based on the table alias
+	// the column references.
+	// Alias or QualifiedName or both could be blank if such names
+	// could not be generated. If so, those expressions cannot be
+	// referenced by other clauses of the SQL statement.
 	QualifiedName sqlparser.ColIdent
-	route         *route
-	symtab        *symtab
-	Underlying    colref
-	Vindex        vindexes.Vindex
+
+	route      *route
+	symtab     *symtab
+	Underlying colref
+	Vindex     vindexes.Vindex
 }
 
 // newColsym builds a colsym for the specified route and symtab.


### PR DESCRIPTION
We found a situation where subqueries that used FQ column names
would cause V3 code to be confused about their vindexes. For
example, a query like:
select ... from (select t.id from t) as t1...
would end up creating a vindex named "t.id". But a reference
to t1.id would fail to match against "t.id" because the string
comparison would fail.

This PR fixes the issue by creating aliases named "id" along with
fully qualified names as "t.id", which would allow any kind of
reference to correctly find the columns referenced.

This behavior still doesn't fully match MySQL's behavior. However,
it comes closer, while still preserving SQL name resolution rules.
The particular use case where we deviate is as follows:
select id as foo from t having id = 1
MySQL allows the above construct. However, we'll fail because you
can reference that expression either as 'foo' or 't.id', but not
as 'id'.

Implementation notes:
The colsym already had two values to match against. I have now changed
the meaning of those:
1. The Alias is the alias of the column. If one is not provided,
then we assign the base name of the column. Previously we used to
assign the FQ name.
2. The ExprName (now renamed to QualifiedName) always contains
the FQ name. This used to have a value only if there was already
an alias provided.

The matching logic has been changed accordingly. Some new errors
have been added to handle possible ambiquities that can now happen
because we match using base names. Otherwise, most things should
work like before.