### PR TITLE
vtgateclienttest: Test Unicode in query echo.

### DIFF
--- a/go/cmd/vtgateclienttest/goclienttest/echo.go
+++ b/go/cmd/vtgateclienttest/goclienttest/echo.go
@@ -22,7 +22,7 @@ import (
 var (
 	echoPrefix = "echo://"
 
-	query    = "test query"
+	query    = "test query with unicode: \u6211\u80fd\u541e\u4e0b\u73bb\u7483\u800c\u4e0d\u50b7\u8eab\u9ad4"
 	keyspace = "test_keyspace"
 
 	shards     = []string{"-80", "80-"}
@@ -104,7 +104,7 @@ var (
 	optionsEcho = "exclude_field_names:true include_event_token:true compare_event_token:<" + eventTokenEcho + "> "
 	extrasEcho  = "event_token:<" + eventTokenEcho + "> fresher:true "
 
-	updateStreamEcho = "map[callerId:" + callerIDEcho + " event:" + eventTokenEcho + " keyRange:" + keyRangeZeroEcho + " keyspace:conn_ks shard:echo://test query tabletType:REPLICA timestamp:0]"
+	updateStreamEcho = "map[callerId:" + callerIDEcho + " event:" + eventTokenEcho + " keyRange:" + keyRangeZeroEcho + " keyspace:conn_ks shard:echo://" + query + " tabletType:REPLICA timestamp:0]"
 )
 
 // testEcho exercises the test cases provided by the "echo" service.

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -65,7 +65,7 @@ public abstract class RpcClientTest {
           .put("aborted", SQLRecoverableException.class)
           .put("unknown error", SQLNonTransientException.class).build();
 
-  private static final String QUERY = "test query";
+  private static final String QUERY = "test query with unicode: \u6211\u80fd\u541e\u4e0b\u73bb\u7483\u800c\u4e0d\u50b7\u8eab\u9ad4";
   private static final String KEYSPACE = "test_keyspace";
 
   private static final List<String> SHARDS = Arrays.asList("-80", "80-");

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -11,7 +11,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
 
     private static $client;
 
-    private static $ECHO_QUERY = 'echo://test query';
+    private static $ECHO_QUERY = "echo://test query with utf-8: \xe6\x88\x91\xe8\x83\xbd\xe5\x90\x9e\xe4\xb8\x8b\xe7\x8e\xbb\xe7\x92\x83\xe8\x80\x8c\xe4\xb8\x8d\xe5\x82\xb7\xe8\xba\xab\xe9\xab\x94";
 
     private static $ERROR_PREFIX = 'error://';
 

--- a/py/vtdb/vtgate_client_testsuite.py
+++ b/py/vtdb/vtgate_client_testsuite.py
@@ -434,8 +434,14 @@ class TestEcho(TestPythonClientBase):
 
   echo_prefix = 'echo://'
 
-  query = 'test query with bind variables: :int :float :bytes'
-  query_echo = 'test query with bind variables: :int :float :bytes'
+  query = (
+      u'test query with bind variables: :int :float :bytes, unicode: '
+      u'\u6211\u80fd\u541e\u4e0b\u73bb\u7483\u800c\u4e0d\u50b7\u8eab\u9ad4'
+      ).encode('utf-8')
+  query_echo = (
+      u'test query with bind variables: :int :float :bytes, unicode: '
+      u'\u6211\u80fd\u541e\u4e0b\u73bb\u7483\u800c\u4e0d\u50b7\u8eab\u9ad4'
+      ).encode('utf-8')
   keyspace = 'test_keyspace'
 
   shards = ['-80', '80-']


### PR DESCRIPTION
In languages with native support, insert Unicode and encode to UTF-8.
In others, directly insert UTF-8. Check that the echo is unmangled.