### PR TITLE
Add the rest of schema swap code.

### DIFF
--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -1,6 +1,7 @@
 package schemaswap
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -18,6 +19,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctl"
+	"github.com/youtube/vitess/go/vt/wrangler"
 )
 
 var (
@@ -25,6 +27,17 @@ var (
 		"time to wait after a retryable error happened in the schema swap process")
 	adminQueryTimeout = flag.Duration("schema_swap_admin_query_timeout", 30*time.Second,
 		"timeout for SQL queries used to save and retrieve meta information for schema swap process")
+	backupConcurrency = flag.Int("schema_swap_backup_concurrency", 4,
+		"number of simultaneous compression/checksum jobs to run for seed backup during schema swap")
+	reparentTimeout = flag.Duration("schema_swap_reparent_timeout", 30*time.Second,
+		"timeout to wait for slaves when doing reparent during schema swap")
+)
+
+const (
+	lastStartedMetadataName  = "LastStartedSchemaSwap"
+	lastFinishedMetadataName = "LastFinishedSchemaSwap"
+	currentSQLMetadataName   = "CurrentSchemaSwapSQL"
+	lastAppliedMetadataName  = "LastAppliedSchemaSwap"
 )
 
 // Swap contains meta-information and methods controlling schema swap process as a whole.
@@ -43,6 +56,8 @@ type Swap struct {
 	// tabletClient is the client implementation used by the schema swap process to control
 	// all tablets in the keyspace.
 	tabletClient tmclient.TabletManagerClient
+	// allShards is a list of schema swap objects for each shard in the keyspace.
+	allShards []*shardSchemaSwap
 }
 
 // shardSchemaSwap contains data related to schema swap happening on a specific shard.
@@ -73,6 +88,290 @@ type shardSchemaSwap struct {
 	// variable is set to nil when nothing is waited on at the moment. The variable is
 	// protected by allTabletsLock.
 	healthWaitingChannel *chan interface{}
+}
+
+// shardSwapMetadata contains full metadata about schema swaps on a certain shard.
+type shardSwapMetadata struct {
+	shardName string
+	err       error
+	// IDs of last started and last finished schema swap on the shard
+	lastStartedSwap, lastFinishedSwap uint64
+	// currentSQL is the SQL of the currentlr running schema swap (if there is any)
+	currentSQL string
+}
+
+// Run is the main entry point of the schema swap process. It drives the process from start
+// to finish, including possible restart of already started process. In the latter case the
+// method should be just called again and it will pick up already started process. The only
+// input argument is the SQL statements that comprise the schema change that needs to be
+// pushed using the schema swap process.
+func (schemaSwap *Swap) Run(sql string) error {
+	err := schemaSwap.createShardObjects()
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.initializeSwap(sql)
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.startHealthWatchers()
+		})
+	// Note: this defer statement is before the error is checked because some shards may
+	// succeed while others fail. We should try to stop health watching on all shards no
+	// matter if there was some failure or not.
+	defer schemaSwap.stopAllHealthWatchers()
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.applySeedSchemaChange(sql)
+		})
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.takeSeedBackup()
+		})
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.propagateToNonMasterTablets()
+		})
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.propagateToMaster()
+		})
+	if err != nil {
+		return err
+	}
+	return schemaSwap.finalizeSwap()
+}
+
+// runOnAllShards is a helper method that executes the passed function for all shards in parallel.
+// The method returns no error if the function succeeds on all shards. If on any of the shards
+// the function fails then the method returns error. If several shards return error then only one
+// of them is returned.
+func (schemaSwap *Swap) runOnAllShards(shardFunc func(shard *shardSchemaSwap) error) error {
+	errorChannel := make(chan error)
+	for _, shardSwap := range schemaSwap.allShards {
+		go func(shard *shardSchemaSwap) {
+			err := shardFunc(shard)
+			errorChannel <- err
+		}(shardSwap)
+	}
+	var overallErr error
+	cntErrsReceived := 0
+	for cntErrsReceived != len(schemaSwap.allShards) {
+		err := <-errorChannel
+		if err != nil {
+			overallErr = err
+		}
+		cntErrsReceived++
+	}
+	close(errorChannel)
+	return overallErr
+}
+
+// createShardObjects creates per-shard swap objects for all shards in the keyspace.
+func (schemaSwap *Swap) createShardObjects() error {
+	shardsList, err := schemaSwap.topoServer.FindAllShardsInKeyspace(schemaSwap.ctx, schemaSwap.keyspace)
+	if err != nil {
+		return err
+	}
+	for _, shardInfo := range shardsList {
+		shardSwap := &shardSchemaSwap{
+			parent: schemaSwap,
+			shard:  shardInfo.ShardName(),
+		}
+		schemaSwap.allShards = append(schemaSwap.allShards, shardSwap)
+	}
+	return nil
+}
+
+// stopAllHealthWatchers stops watching for health on each shard. It's separated into a separate
+// function mainly to make "defer" statement where it's used simpler.
+func (schemaSwap *Swap) stopAllHealthWatchers() {
+	schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			shard.stopHealthWatchers()
+			return nil
+		})
+}
+
+// initializeSwap starts the schema swap process. If there is already a schema swap process started
+// the the method just picks up that. Otherwise it starts a new one and writes into the database that
+// the process was started.
+func (schemaSwap *Swap) initializeSwap(sql string) error {
+	metadataChannel := make(chan *shardSwapMetadata)
+	for _, shard := range schemaSwap.allShards {
+		go shard.readShardMetadata(metadataChannel)
+	}
+	var initError error
+	var cntDataReceived int
+	for cntDataReceived != len(schemaSwap.allShards) {
+		metadata := <-metadataChannel
+		cntDataReceived++
+		if metadata.lastStartedSwap == metadata.lastFinishedSwap {
+			// The shard doesn't have schema swap started yet.
+			nextSwapID := metadata.lastFinishedSwap + 1
+			if schemaSwap.swapID == 0 {
+				schemaSwap.swapID = nextSwapID
+			} else if schemaSwap.swapID != nextSwapID {
+				initError = fmt.Errorf(
+					"Next schema swap id on shard %v should be %v, while for other shard(s) it should be %v",
+					metadata.shardName, nextSwapID, schemaSwap.swapID)
+			}
+		} else if metadata.lastStartedSwap < metadata.lastFinishedSwap {
+			initError = fmt.Errorf(
+				"Bad swap metadata on shard %v: LastFinishedSchemaSwap=%v is greater than LastStartedSchemaSwap=%v",
+				metadata.shardName, metadata.lastFinishedSwap, metadata.lastStartedSwap)
+		} else if schemaSwap.swapID != 0 && schemaSwap.swapID != metadata.lastStartedSwap {
+			initError = fmt.Errorf(
+				"Shard %v has an already started schema swap with an id %v, while for other shard(s) id should be equal to %v",
+				metadata.shardName, metadata.lastStartedSwap, schemaSwap.swapID)
+		} else if metadata.currentSQL != sql {
+			initError = fmt.Errorf("Shard %v has an already started schema swap with a different set of SQL statements", metadata.shardName)
+		} else {
+			schemaSwap.swapID = metadata.lastStartedSwap
+		}
+	}
+	close(metadataChannel)
+	if initError != nil {
+		return initError
+	}
+	initError = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.writeStartedSwap(sql)
+		})
+	return initError
+}
+
+// finalizeSwap finishes the completed swap process by verifying that it's actually complete
+// and then modifying the database to register the completion.
+func (schemaSwap *Swap) finalizeSwap() error {
+	err := schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.verifySwapApplied()
+		})
+	if err != nil {
+		return err
+	}
+	err = schemaSwap.runOnAllShards(
+		func(shard *shardSchemaSwap) error {
+			return shard.writeFinishedSwap()
+		})
+	return err
+}
+
+// getMasterTablet returns the tablet that is currently master on the shard.
+func (shardSwap *shardSchemaSwap) getMasterTablet() (*topodatapb.Tablet, error) {
+	topoServer := shardSwap.parent.topoServer
+	shardInfo, err := topoServer.GetShard(shardSwap.parent.ctx, shardSwap.parent.keyspace, shardSwap.shard)
+	if err != nil {
+		return nil, err
+	}
+	tabletInfo, err := topoServer.GetTablet(shardSwap.parent.ctx, shardInfo.MasterAlias)
+	if err != nil {
+		return nil, err
+	}
+	return tabletInfo.Tablet, nil
+}
+
+// readShardMetadata reads info about schema swaps on this shard from _vt.shard_metadata table.
+func (shardSwap *shardSchemaSwap) readShardMetadata(metadataChannel chan *shardSwapMetadata) {
+	metadata := &shardSwapMetadata{shardName: shardSwap.shard}
+	defer func() { metadataChannel <- metadata }()
+
+	tablet, err := shardSwap.getMasterTablet()
+	if err != nil {
+		metadata.err = err
+		return
+	}
+	query := fmt.Sprintf(
+		"SELECT name, value FROM _vt.shard_metadata WHERE name in ('%s', '%s', '%s')",
+		lastStartedMetadataName, lastFinishedMetadataName, currentSQLMetadataName)
+	queryResult, err := shardSwap.executeAdminQuery(tablet, query, 3 /* maxRows */)
+	if err != nil {
+		metadata.err = err
+		return
+	}
+	for _, row := range queryResult.Rows {
+		switch row[0].String() {
+		case lastStartedMetadataName:
+			swapID, err := row[1].ParseUint64()
+			if err != nil {
+				log.Warningf("Could not parse value of last started schema swap id ('%s'), ignoring the value: %v", row[1].String(), err)
+			} else {
+				metadata.lastStartedSwap = swapID
+			}
+		case lastFinishedMetadataName:
+			swapID, err := row[1].ParseUint64()
+			if err != nil {
+				log.Warningf("Could not parse value of last finished schema swap id ('%s'), ignoring the value: %v", row[1].String(), err)
+			} else {
+				metadata.lastFinishedSwap = swapID
+			}
+		case currentSQLMetadataName:
+			metadata.currentSQL = row[1].String()
+		}
+	}
+}
+
+// writeStartedSwap registers in the _vt.shard_metadata table in the database the information
+// about the new schema swap process being started.
+func (shardSwap *shardSchemaSwap) writeStartedSwap(sql string) error {
+	tablet, err := shardSwap.getMasterTablet()
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf(
+		"INSERT INTO _vt.shard_metadata (name, value) VALUES ('%s', '%d') ON DUPLICATE KEY UPDATE value = '%d'",
+		lastStartedMetadataName, shardSwap.parent.swapID, shardSwap.parent.swapID)
+	_, err = shardSwap.executeAdminQuery(tablet, query, 0 /* maxRows */)
+	if err != nil {
+		return err
+	}
+	queryBuf := bytes.Buffer{}
+	queryBuf.WriteString("INSERT INTO _vt.shard_metadata (name, value) VALUES ('")
+	queryBuf.WriteString(currentSQLMetadataName)
+	queryBuf.WriteString("',")
+	sqlValue, err := sqltypes.BuildValue(sql)
+	if err != nil {
+		return err
+	}
+	sqlValue.EncodeSQL(&queryBuf)
+	queryBuf.WriteString(") ON DUPLICATE KEY UPDATE value = ")
+	sqlValue.EncodeSQL(&queryBuf)
+	_, err = shardSwap.executeAdminQuery(tablet, queryBuf.String(), 0 /* maxRows */)
+	return err
+}
+
+// writeFinishedSwap registers in the _vt.shard_metadata table in the database that the schema
+// swap process has finished.
+func (shardSwap *shardSchemaSwap) writeFinishedSwap() error {
+	tablet, err := shardSwap.getMasterTablet()
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf(
+		"INSERT INTO _vt.shard_metadata (name, value) VALUES ('%s', '%d') ON DUPLICATE KEY UPDATE value = '%d'",
+		lastFinishedMetadataName, shardSwap.parent.swapID, shardSwap.parent.swapID)
+	_, err = shardSwap.executeAdminQuery(tablet, query, 0 /* maxRows */)
+	if err != nil {
+		return err
+	}
+	query = fmt.Sprintf("DELETE FROM _vt.shard_metadata WHERE name = '%s'", currentSQLMetadataName)
+	_, err = shardSwap.executeAdminQuery(tablet, query, 0 /* maxRows */)
+	return err
 }
 
 // startHealthWatchers launches the topology watchers and health checking to monitor
@@ -239,25 +538,35 @@ func (array orderTabletsForSwap) Less(i, j int) bool {
 	return tabletSortIndex(&array[i]) < tabletSortIndex(&array[j])
 }
 
+// executeAdminQuery executes a query on a given tablet as 'allprivs' user. The query is executed
+// using timeout value from --schema_swap_admin_query_timeout flag.
+func (shardSwap *shardSchemaSwap) executeAdminQuery(tablet *topodatapb.Tablet, query string, maxRows int) (*sqltypes.Result, error) {
+	sqlCtx, cancelSQLCtx := context.WithTimeout(shardSwap.parent.ctx, *adminQueryTimeout)
+	defer cancelSQLCtx()
+
+	sqlResultProto, err := shardSwap.parent.tabletClient.ExecuteFetchAsAllPrivs(
+		sqlCtx,
+		tablet,
+		[]byte(query),
+		maxRows,
+		false /* reloadSchema */)
+	if err != nil {
+		return nil, err
+	}
+	return sqltypes.Proto3ToResult(sqlResultProto), nil
+}
+
 // isSwapApplied verifies whether the schema swap was already applied to the tablet. It's
 // considered to be applied if _vt.local_metadata table has the swap id in the row titled
 // 'LastAppliedSchemaSwap'.
 func (shardSwap *shardSchemaSwap) isSwapApplied(tablet *topodatapb.Tablet) (bool, error) {
-	sqlCtx, cancelSQLCtx := context.WithTimeout(shardSwap.parent.ctx, *adminQueryTimeout)
-	defer cancelSQLCtx()
-
-	swapIDProto, err := shardSwap.parent.tabletClient.ExecuteFetchAsDba(
-		sqlCtx,
+	swapIDResult, err := shardSwap.executeAdminQuery(
 		tablet,
-		true, /* usePool */
-		[]byte("SELECT value FROM _vt.local_metadata WHERE name = 'LastAppliedSchemaSwap'"),
-		1,     /* maxRows */
-		false, /* disableBinlogs */
-		false /* reloadSchema */)
+		fmt.Sprintf("SELECT value FROM _vt.local_metadata WHERE name = '%s'", lastAppliedMetadataName),
+		1 /* maxRows */)
 	if err != nil {
 		return false, err
 	}
-	swapIDResult := sqltypes.Proto3ToResult(swapIDProto)
 	if len(swapIDResult.Rows) == 0 {
 		// No such row means we need to apply the swap.
 		return false, nil
@@ -269,12 +578,12 @@ func (shardSwap *shardSchemaSwap) isSwapApplied(tablet *topodatapb.Tablet) (bool
 	return swapID == shardSwap.parent.swapID, nil
 }
 
-// findNextTablet searches for the next tablet where we need to apply the schema swap. The
+// findNextTabletToSwap searches for the next tablet where we need to apply the schema swap. The
 // tablets are processed in the order described on tabletSortIndex() function above. If
 // it hits any error while searching for the tablet it returns it to the caller. If the
 // only tablet that's left without schema swap applied is the master then the function
 // returns nil as the tablet and nil as the error.
-func (shardSwap *shardSchemaSwap) findNextTablet() (*topodatapb.Tablet, error) {
+func (shardSwap *shardSchemaSwap) findNextTabletToSwap() (*topodatapb.Tablet, error) {
 	tabletList := shardSwap.getTabletList()
 	sort.Sort(orderTabletsForSwap(tabletList))
 	for _, tabletStats := range tabletList {
@@ -291,6 +600,143 @@ func (shardSwap *shardSchemaSwap) findNextTablet() (*topodatapb.Tablet, error) {
 		}
 	}
 	return nil, fmt.Errorf("Something is wrong! Cannot find master on shard %v", shardSwap.shard)
+}
+
+// applySeedSchemaChange chooses a healthy tablet as a schema swap seed and applies the schema change
+// on it. In the choice of the seed tablet any RDONLY tablet is preferred, but if there are no healthy
+// RDONLY tablets the REPLICA one is chosen. If there are any non-MASTER tablets indicating that the
+// schema swap was already applied on them, then the method assumes that it's the seed tablet from the
+// already started process and doesn't try to apply the schema change on any other tablet.
+func (shardSwap *shardSchemaSwap) applySeedSchemaChange(sql string) error {
+	tabletList := shardSwap.getTabletList()
+	sort.Sort(orderTabletsForSwap(tabletList))
+	for _, tabletStats := range tabletList {
+		swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
+		if err != nil {
+			return err
+		}
+		if swapApplied && tabletStats.Tablet.Type != topodatapb.TabletType_MASTER {
+			return nil
+		}
+	}
+	seedTablet := tabletList[0].Tablet
+	if seedTablet.Type == topodatapb.TabletType_MASTER {
+		return fmt.Errorf("The only candidate for a schema swap seed is the master %v. Aborting the swap.", seedTablet)
+	}
+	// Draining the tablet for it to not be used for execution of user queries.
+	savedSeedType := seedTablet.Type
+	err := shardSwap.parent.tabletClient.ChangeType(shardSwap.parent.ctx, seedTablet, topodatapb.TabletType_DRAINED)
+	if err != nil {
+		return err
+	}
+	_, err = shardSwap.parent.topoServer.UpdateTabletFields(shardSwap.parent.ctx, seedTablet.Alias,
+		func(tablet *topodatapb.Tablet) error {
+			tablet.Tags["drain_reason"] = "Drained as online schema swap seed"
+			return nil
+		})
+	if err != nil {
+		// This is not a critical error, we'll just log it.
+		log.Errorf("Got error trying to set drain_reason on tablet %v: %v", seedTablet.Alias, err)
+	}
+	// TODO: Add support for multi-statement schema swaps.
+	_, err = shardSwap.parent.tabletClient.ExecuteFetchAsDba(
+		shardSwap.parent.ctx,
+		seedTablet,
+		true, /* usePool */
+		[]byte(sql),
+		0,    /* maxRows */
+		true, /* disableBinlogs */
+		true /* reloadSchema */)
+	if err != nil {
+		return err
+	}
+	updateAppliedSwapQuery := fmt.Sprintf(
+		"INSERT INTO _vt.local_metadata (name, value) VALUES ('%s', '%d') ON DUPLICATE KEY UPDATE value = '%d'",
+		lastAppliedMetadataName, shardSwap.parent.swapID, shardSwap.parent.swapID)
+	_, err = shardSwap.parent.tabletClient.ExecuteFetchAsDba(
+		shardSwap.parent.ctx,
+		seedTablet,
+		true, /* usePool */
+		[]byte(updateAppliedSwapQuery),
+		0,    /* maxRows */
+		true, /* disableBinlogs */
+		false /* reloadSchema */)
+	if err != nil {
+		return err
+	}
+
+	// Undraining the tablet, returing it to the same type as it was before.
+	_, err = shardSwap.parent.topoServer.UpdateTabletFields(shardSwap.parent.ctx, seedTablet.Alias,
+		func(tablet *topodatapb.Tablet) error {
+			delete(tablet.Tags, "drain_reason")
+			return nil
+		})
+	if err != nil {
+		// This is not a critical error, we'll just log it.
+		log.Errorf("Got error trying to set drain_reason on tablet %v: %v", seedTablet.Alias, err)
+	}
+	err = shardSwap.parent.tabletClient.ChangeType(shardSwap.parent.ctx, seedTablet, savedSeedType)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// takeSeedBackup takes backup on the seed tablet. The method assumes that the seed tablet is any tablet that
+// has info that schema swap was already applied on it. This way the function can be re-used if the seed backup
+// is lost somewhere half way through the schema swap process.
+func (shardSwap *shardSchemaSwap) takeSeedBackup() error {
+	tabletList := shardSwap.getTabletList()
+	sort.Sort(orderTabletsForSwap(tabletList))
+	var seedTablet *topodatapb.Tablet
+	for _, tabletStats := range tabletList {
+		swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
+		if err != nil {
+			return err
+		}
+		if swapApplied && tabletStats.Tablet.Type != topodatapb.TabletType_MASTER {
+			seedTablet = tabletStats.Tablet
+			break
+		}
+	}
+	if seedTablet == nil {
+		return fmt.Errorf("Cannot find the seed tablet on shard %v", shardSwap.shard)
+	}
+
+	eventStream, err := shardSwap.parent.tabletClient.Backup(shardSwap.parent.ctx, seedTablet, *backupConcurrency)
+	if err != nil {
+		return err
+	}
+waitForBackup:
+	for {
+		event, err := eventStream.Recv()
+		switch err {
+		case nil:
+			log.Infof("Backup process on tablet %v: %v", seedTablet.Alias, logutil.EventString(event))
+		case io.EOF:
+			break waitForBackup
+		default:
+			return err
+		}
+	}
+
+	return shardSwap.waitForTabletToBeHealthy(seedTablet)
+}
+
+// verifySwapApplied checks that all tablets in the shard have schema swap applied on them.
+func (shardSwap *shardSchemaSwap) verifySwapApplied() error {
+	tabletList := shardSwap.getTabletList()
+	for _, tabletStats := range tabletList {
+		swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
+		if err != nil {
+			return err
+		}
+		if !swapApplied {
+			return fmt.Errorf("Schema swap was not applied on tablet %v", tabletStats.Tablet.Alias)
+		}
+	}
+	return nil
 }
 
 // swapOnTablet performs the schema swap on the provided tablet and then waits for it
@@ -323,6 +769,13 @@ waitForRestore:
 		return fmt.Errorf("Restore from backup cannot pick up new schema. Backup from tablet with new schema needs to be taken.")
 	}
 
+	return shardSwap.waitForTabletToBeHealthy(tablet)
+}
+
+// waitForTabletToBeHealthy waits until the given tablet becomes healthy and caught up with
+// replication. If the tablet is already healthy and caught up when this method is called then
+// it returns immediately.
+func (shardSwap *shardSchemaSwap) waitForTabletToBeHealthy(tablet *topodatapb.Tablet) error {
 	waitChannel, err := shardSwap.startWaitingOnUnhealthyTablet(tablet)
 	if err != nil {
 		return err
@@ -344,7 +797,7 @@ waitForRestore:
 // old schema, everything else is verified to have schema swap applied.
 func (shardSwap *shardSchemaSwap) propagateToNonMasterTablets() error {
 	for {
-		tablet, err := shardSwap.findNextTablet()
+		tablet, err := shardSwap.findNextTabletToSwap()
 		if err == nil {
 			if tablet == nil {
 				return nil
@@ -367,4 +820,29 @@ func (shardSwap *shardSchemaSwap) propagateToNonMasterTablets() error {
 			// Waiting is done going to the next loop.
 		}
 	}
+}
+
+// propagateToMaster propagates the schema change to the master. If the master already has
+// the schema change applied then the method does nothing.
+func (shardSwap *shardSchemaSwap) propagateToMaster() error {
+	masterTablet, err := shardSwap.getMasterTablet()
+	if err != nil {
+		return err
+	}
+	swapApplied, err := shardSwap.isSwapApplied(masterTablet)
+	if swapApplied {
+		return nil
+	}
+	wr := wrangler.New(logutil.NewConsoleLogger(), shardSwap.parent.topoServer, shardSwap.parent.tabletClient)
+	err = wr.PlannedReparentShard(
+		shardSwap.parent.ctx,
+		shardSwap.parent.keyspace,
+		shardSwap.shard,
+		nil,                /* masterElectTabletAlias */
+		masterTablet.Alias, /* avoidMasterAlias */
+		*reparentTimeout)
+	if err != nil {
+		return err
+	}
+	return shardSwap.swapOnTablet(masterTablet)
 }


### PR DESCRIPTION
This code is still not tested besides simple compilation, but it is representing
now the full schema swap process from the beginning to the end. The code also
is not well-versed on handling different errors, so it mostly represents only
the happy path of the process.

Next up after this will be wiring the code into a way to call it and actually
testing it.