### PR TITLE
Remove WHERE filters from the full-scan queries.

### DIFF
--- a/go/vt/tabletserver/splitquery/full_scan_algorithm.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm.go
@@ -18,8 +18,8 @@ import (
 //                           WHERE :prev_boundary <= (<split_columns>)
 //                           ORDER BY <split_columns>
 //                           LIMIT <num_rows_per_query_part>, 1
-// where <split_columns> denotes the ordered list of split columns, and <table> is the
-// value of the FROM and WHERE clauses of the input query, respectfully.
+// where <split_columns> denotes the ordered list of split columns and <table> is the
+// value of the FROM clause.
 // The 'prev_boundary' bind variable holds a tuple consisting of split column values.
 // It is updated after each iteration with the result of the query. In the query executed in the
 // first iteration (the initial query) the term ':prev_boundary <= (<split_columns>)' is
@@ -28,8 +28,8 @@ import (
 // consisting of the result of each query in order.
 //
 // Actually, the code below differs slightly from the above description: the lexicographial tuple
-// inequality in the query above is actually re-written to use only scalar comparisons since MySQL
-// does not optimize queries involving tuple inequalities, correctly. Instead of using a single
+// inequality in the query above is re-written to use only scalar comparisons since MySQL
+// does not optimize queries involving tuple inequalities correctly. Instead of using a single
 // tuple bind variable: 'prev_boundary', the code uses a list of scalar bind-variables--one for each
 // element of the tuple. The bind variable storing the tuple element corresponding to a
 // split-column named 'x' is called <prevBindVariablePrefix><x>, where prevBindVariablePrefix is

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm.go
@@ -109,7 +109,7 @@ func (a *FullScanAlgorithm) populatePrevTupleInBindVariables(
 // the Sql field of the result will be:
 // "SELECT sc_1,sc_2,...,sc_n FROM <table>
 //                            ORDER BY <split_columns>
-//                            LIMIT splitParams.numRowsPerQueryPart-1, 1",
+//                            LIMIT splitParams.numRowsPerQueryPart, 1",
 // The BindVariables field of the result will contain a deep-copy of splitParams.BindVariables.
 func buildInitialQuery(splitParams *SplitParams) *querytypes.BoundQuery {
 	resultSelectAST := buildInitialQueryAST(splitParams)
@@ -128,7 +128,7 @@ func buildInitialQueryAST(splitParams *SplitParams) *sqlparser.Select {
 	resultSelectAST := *splitParams.selectAST
 	resultSelectAST.Where = nil
 	resultSelectAST.SelectExprs = convertColumnsToSelectExprs(splitParams.splitColumns)
-	resultSelectAST.Limit = buildLimitClause(splitParams.numRowsPerQueryPart-1, 1)
+	resultSelectAST.Limit = buildLimitClause(splitParams.numRowsPerQueryPart, 1)
 	resultSelectAST.OrderBy = buildOrderByClause(splitParams.splitColumns)
 	return &resultSelectAST
 }

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm.go
@@ -126,6 +126,7 @@ func buildInitialQueryAST(splitParams *SplitParams) *sqlparser.Select {
 			*splitParams))
 	}
 	resultSelectAST := *splitParams.selectAST
+	resultSelectAST.Where = nil
 	resultSelectAST.SelectExprs = convertColumnsToSelectExprs(splitParams.splitColumns)
 	resultSelectAST.Limit = buildLimitClause(splitParams.numRowsPerQueryPart, 1)
 	resultSelectAST.OrderBy = buildOrderByClause(splitParams.splitColumns)

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
@@ -31,7 +31,7 @@ func TestMultipleBoundaries(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{
@@ -45,7 +45,7 @@ func TestMultipleBoundaries(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(1),
 			"_splitquery_prev_user_id": int64(1),
@@ -63,7 +63,7 @@ func TestMultipleBoundaries(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(2),
 			"_splitquery_prev_user_id": int64(10),
@@ -109,7 +109,7 @@ func TestSmallNumberOfRows(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{Rows: [][]sqltypes.Value{}}, nil)
@@ -148,7 +148,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{
@@ -162,7 +162,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 999, 1",
+			" limit 1000, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(1),
 			"_splitquery_prev_user_id": int64(1),

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
@@ -30,7 +30,6 @@ func TestMultipleBoundaries(t *testing.T) {
 	mockSQLExecuter := splitquery_testing.NewMockSQLExecuter(mockCtrl)
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where int_col > 5"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{})
@@ -42,9 +41,9 @@ func TestMultipleBoundaries(t *testing.T) {
 		nil)
 	expectedCall2 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where (int_col > 5) and"+
-			" (:_splitquery_prev_id < id or"+
-			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id))"+
+			" where"+
+			" :_splitquery_prev_id < id or"+
+			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{
@@ -60,9 +59,9 @@ func TestMultipleBoundaries(t *testing.T) {
 	expectedCall2.After(expectedCall1)
 	expectedCall3 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where (int_col > 5) and"+
-			" (:_splitquery_prev_id < id or"+
-			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id))"+
+			" where"+
+			" :_splitquery_prev_id < id or"+
+			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{
@@ -109,7 +108,6 @@ func TestSmallNumberOfRows(t *testing.T) {
 	mockSQLExecuter := splitquery_testing.NewMockSQLExecuter(mockCtrl)
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where int_col > 5"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{})
@@ -149,7 +147,6 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 	mockSQLExecuter := splitquery_testing.NewMockSQLExecuter(mockCtrl)
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where int_col > 5"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{})
@@ -161,9 +158,9 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 		nil)
 	expectedCall2 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
-			" where (int_col > 5) and"+
-			" (:_splitquery_prev_id < id or"+
-			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id))"+
+			" where"+
+			" :_splitquery_prev_id < id or"+
+			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
 			" limit 1000, 1",
 		map[string]interface{}{

--- a/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
+++ b/go/vt/tabletserver/splitquery/full_scan_algorithm_test.go
@@ -31,7 +31,7 @@ func TestMultipleBoundaries(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{
@@ -45,7 +45,7 @@ func TestMultipleBoundaries(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(1),
 			"_splitquery_prev_user_id": int64(1),
@@ -63,7 +63,7 @@ func TestMultipleBoundaries(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(2),
 			"_splitquery_prev_user_id": int64(10),
@@ -109,7 +109,7 @@ func TestSmallNumberOfRows(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{Rows: [][]sqltypes.Value{}}, nil)
@@ -148,7 +148,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 	expectedCall1 := mockSQLExecuter.EXPECT().SQLExecute(
 		"select id, user_id from test_table"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{})
 	expectedCall1.Return(
 		&sqltypes.Result{
@@ -162,7 +162,7 @@ func TestSQLExecuterReturnsError(t *testing.T) {
 			" :_splitquery_prev_id < id or"+
 			" (:_splitquery_prev_id = id and :_splitquery_prev_user_id <= user_id)"+
 			" order by id asc, user_id asc"+
-			" limit 1000, 1",
+			" limit 999, 1",
 		map[string]interface{}{
 			"_splitquery_prev_id":      int64(1),
 			"_splitquery_prev_user_id": int64(1),


### PR DESCRIPTION
Some WHERE clauses are very sparse WRT the PK, causing some
split queries to scan most or all of the table. The full scan
algorithm is more stable with no WHERE filters.

@erzel: Does this work for you?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/2157)
<!-- Reviewable:end -->
