### PR TITLE
Fix TabletStatsCache to properly cache topology info.

### DIFF
--- a/go/vt/vtctld/tablet_stats_cache.go
+++ b/go/vt/vtctld/tablet_stats_cache.go
@@ -94,10 +94,10 @@ func (c *tabletStatsCache) StatsUpdate(stats *discovery.TabletStats) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	keyspace := stats.Target.Keyspace
-	shard := stats.Target.Shard
+	keyspace := stats.Tablet.Keyspace
+	shard := stats.Tablet.Shard
 	cell := stats.Tablet.Alias.Cell
-	tabletType := stats.Target.TabletType
+	tabletType := stats.Tablet.Type
 
 	aliasKey := tabletToMapKey(stats)
 	ts, ok := c.statusesByAlias[aliasKey]


### PR DESCRIPTION
After https://github.com/youtube/vitess/pull/2138 the notifications by
HealthCheck have changed so that the very first notification about tablet
happens with empty Target field. But TabletStatsCache code was reading info
about keyspace/shard/type of a tablet from Target field and then assumed that
the info didn't change later for a tablet with the same alias (until
notification with Down=false). To fix that I'm reading these values from Tablet
field instead of Target because Tablet is always populated.

Fixes #2164.