### PR TITLE
replication_reporter: Repair replication even if slave not configured.

### DIFF
--- a/go/vt/tabletmanager/replication_reporter.go
+++ b/go/vt/tabletmanager/replication_reporter.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/health"
+	"github.com/youtube/vitess/go/vt/mysqlctl"
 )
 
 var (
@@ -35,8 +36,9 @@ func (r *replicationReporter) Report(isSlaveType, shouldQueryServiceBeRunning bo
 	}
 
 	status, statusErr := r.agent.MysqlDaemon.SlaveStatus()
-	if statusErr == nil && !status.SlaveSQLRunning && !status.SlaveIORunning {
-		// Slave is configured, but not running.
+	if statusErr == mysqlctl.ErrNotSlave ||
+		(statusErr == nil && !status.SlaveSQLRunning && !status.SlaveIORunning) {
+		// MySQL is up, but slave is either not configured or not running.
 		// Both SQL and IO threads are stopped, so it's probably either
 		// stopped on purpose, or stopped because of a mysqld restart.
 		if !r.agent.slaveStopped() {

--- a/go/vt/tabletmanager/rpc_replication.go
+++ b/go/vt/tabletmanager/rpc_replication.go
@@ -160,6 +160,9 @@ func (agent *ActionAgent) InitMaster(ctx context.Context) (string, error) {
 	}
 	defer agent.unlock()
 
+	// Initializing as master implies undoing any previous "do not replicate".
+	agent.setSlaveStopped(false)
+
 	// we need to insert something in the binlogs, so we can get the
 	// current position. Let's just use the mysqlctl.CreateReparentJournal commands.
 	cmds := mysqlctl.CreateReparentJournal()

--- a/test/backup.py
+++ b/test/backup.py
@@ -73,11 +73,11 @@ class TestBackup(unittest.TestCase):
     for t in tablet_master, tablet_replica1:
       t.create_db('vt_test_keyspace')
 
-    tablet_master.init_tablet('master', 'test_keyspace', '0', start=True,
+    tablet_master.init_tablet('replica', 'test_keyspace', '0', start=True,
                               supports_backups=True)
     tablet_replica1.init_tablet('replica', 'test_keyspace', '0', start=True,
                                 supports_backups=True)
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/0',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
                      tablet_master.tablet_alias])
 
   def tearDown(self):

--- a/test/cache_invalidation.py
+++ b/test/cache_invalidation.py
@@ -64,18 +64,17 @@ def setUpModule():
     # Start up a master mysql and vttablet
     logging.debug('Setting up tablets')
     utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
-    master_tablet.init_tablet('master', 'test_keyspace', '0', tablet_index=0)
+    master_tablet.init_tablet('replica', 'test_keyspace', '0', tablet_index=0)
     replica_tablet.init_tablet('replica', 'test_keyspace', '0', tablet_index=1)
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
-    utils.validate_topology()
     master_tablet.create_db('vt_test_keyspace')
     replica_tablet.create_db('vt_test_keyspace')
 
     master_tablet.start_vttablet(wait_for_state=None)
     replica_tablet.start_vttablet(wait_for_state=None)
-    master_tablet.wait_for_vttablet_state('SERVING')
+    master_tablet.wait_for_vttablet_state('NOT_SERVING')
     replica_tablet.wait_for_vttablet_state('NOT_SERVING')
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/0',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
                      master_tablet.tablet_alias], auto_log=True)
 
     utils.wait_for_tablet_type(replica_tablet.tablet_alias, 'replica')

--- a/test/custom_sharding.py
+++ b/test/custom_sharding.py
@@ -7,13 +7,13 @@
 import base64
 import unittest
 
-from vtproto import topodata_pb2
-
-from vtdb import vtgate_client
-
 import environment
 import tablet
 import utils
+
+from vtproto import topodata_pb2
+
+from vtdb import vtgate_client
 
 # shards need at least 1 replica for semi-sync ACK, and 1 rdonly for SplitQuery.
 shard_0_master = tablet.Tablet()
@@ -110,7 +110,7 @@ class TestCustomSharding(unittest.TestCase):
 
     # start the first shard only for now
     shard_0_master.init_tablet(
-        'master',
+        'replica',
         keyspace='test_keyspace',
         shard='0',
         tablet_index=0)
@@ -127,13 +127,9 @@ class TestCustomSharding(unittest.TestCase):
 
     for t in [shard_0_master, shard_0_replica, shard_0_rdonly]:
       t.create_db('vt_test_keyspace')
-    shard_0_master.start_vttablet(wait_for_state=None)
-    shard_0_replica.start_vttablet(wait_for_state=None)
-    shard_0_rdonly.start_vttablet(wait_for_state=None)
+      t.start_vttablet(wait_for_state=None)
 
-    for t in [shard_0_master]:
-      t.wait_for_vttablet_state('SERVING')
-    for t in [shard_0_replica, shard_0_rdonly]:
+    for t in [shard_0_master, shard_0_replica, shard_0_rdonly]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
     utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
@@ -162,7 +158,7 @@ primary key (id)
 
     # create shard 1
     shard_1_master.init_tablet(
-        'master',
+        'replica',
         keyspace='test_keyspace',
         shard='1',
         tablet_index=0)
@@ -179,13 +175,9 @@ primary key (id)
 
     for t in [shard_1_master, shard_1_replica, shard_1_rdonly]:
       t.create_db('vt_test_keyspace')
-    shard_1_master.start_vttablet(wait_for_state=None)
-    shard_1_replica.start_vttablet(wait_for_state=None)
-    shard_1_rdonly.start_vttablet(wait_for_state=None)
+      t.start_vttablet(wait_for_state=None)
 
-    for t in [shard_1_master]:
-      t.wait_for_vttablet_state('SERVING')
-    for t in [shard_1_replica, shard_1_rdonly]:
+    for t in [shard_1_master, shard_1_replica, shard_1_rdonly]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
     s = utils.run_vtctl_json(['GetShard', 'test_keyspace/1'])

--- a/test/encrypted_replication.py
+++ b/test/encrypted_replication.py
@@ -152,7 +152,7 @@ def setUpModule():
 
     utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
 
-    shard_0_master.init_tablet('master', 'test_keyspace', '0')
+    shard_0_master.init_tablet('replica', 'test_keyspace', '0')
     shard_0_slave.init_tablet('replica', 'test_keyspace', '0')
 
     # create databases so vttablet can start behaving normally
@@ -191,7 +191,7 @@ class TestSecure(unittest.TestCase):
 
   def test_secure(self):
     # start the tablets
-    shard_0_master.start_vttablet()
+    shard_0_master.start_vttablet(wait_for_state='NOT_SERVING')
     shard_0_slave.start_vttablet(wait_for_state='NOT_SERVING',
                                  repl_extra_flags={
                                      'flags': '2048',
@@ -201,9 +201,7 @@ class TestSecure(unittest.TestCase):
                                  })
 
     # Reparent using SSL (this will also check replication works)
-    for t in [shard_0_master, shard_0_slave]:
-      t.reset_replication()
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/0',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
                      shard_0_master.tablet_alias], auto_log=True)
 
 if __name__ == '__main__':

--- a/test/initial_sharding.py
+++ b/test/initial_sharding.py
@@ -212,7 +212,7 @@ index by_msg (msg)
 
     # create the keyspace with just one shard
     shard_master.init_tablet(
-        'master',
+        'replica',
         keyspace='test_keyspace',
         shard='0',
         tablet_index=0)
@@ -234,8 +234,7 @@ index by_msg (msg)
     shard_replica.start_vttablet(wait_for_state=None)
     shard_rdonly1.start_vttablet(wait_for_state=None)
 
-    shard_master.wait_for_vttablet_state('SERVING')
-    for t in [shard_replica, shard_rdonly1]:
+    for t in [shard_master, shard_replica, shard_rdonly1]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
     # reparent to make the tablets work
@@ -302,7 +301,7 @@ index by_msg (msg)
 
     # create the split shards
     shard_0_master.init_tablet(
-        'master',
+        'replica',
         keyspace='test_keyspace',
         shard='-80',
         tablet_index=0)
@@ -317,7 +316,7 @@ index by_msg (msg)
         shard='-80',
         tablet_index=2)
     shard_1_master.init_tablet(
-        'master',
+        'replica',
         keyspace='test_keyspace',
         shard='80-',
         tablet_index=0)
@@ -332,18 +331,13 @@ index by_msg (msg)
         shard='80-',
         tablet_index=2)
 
-    for t in [shard_0_master, shard_0_replica,
-              shard_1_master, shard_1_replica]:
-      t.create_db('vt_test_keyspace')
-      t.start_vttablet(wait_for_state=None)
-    for t in [shard_0_rdonly1, shard_1_rdonly1]:
+    for t in [shard_0_master, shard_0_replica, shard_0_rdonly1,
+              shard_1_master, shard_1_replica, shard_1_rdonly1]:
       t.create_db('vt_test_keyspace')
       t.start_vttablet(wait_for_state=None)
 
-    for t in [shard_0_master, shard_1_master]:
-      t.wait_for_vttablet_state('SERVING')
-    for t in [shard_0_replica, shard_0_rdonly1,
-              shard_1_replica, shard_1_rdonly1]:
+    for t in [shard_0_master, shard_0_replica, shard_0_rdonly1,
+              shard_1_master, shard_1_replica, shard_1_rdonly1]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
     utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/-80',

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -131,7 +131,7 @@ def setup_sharded_keyspace():
                    'keyspace_id', 'uint64'])
 
   shard_0_master.init_tablet(
-      'master',
+      'replica',
       keyspace=SHARDED_KEYSPACE,
       shard='-80',
       tablet_index=0)
@@ -141,7 +141,7 @@ def setup_sharded_keyspace():
       shard='-80',
       tablet_index=1)
   shard_1_master.init_tablet(
-      'master',
+      'replica',
       keyspace=SHARDED_KEYSPACE,
       shard='80-',
       tablet_index=0)
@@ -156,9 +156,7 @@ def setup_sharded_keyspace():
     t.mquery(shard_0_master.dbname, create_vt_insert_test)
     t.start_vttablet(wait_for_state=None)
 
-  for t in [shard_0_master, shard_1_master]:
-    t.wait_for_vttablet_state('SERVING')
-  for t in [shard_0_replica, shard_1_replica]:
+  for t in [shard_0_master, shard_0_replica, shard_1_master, shard_1_replica]:
     t.wait_for_vttablet_state('NOT_SERVING')
 
   utils.run_vtctl(['InitShardMaster', '-force', '%s/-80' % SHARDED_KEYSPACE,
@@ -186,7 +184,7 @@ def setup_unsharded_keyspace():
                    'keyspace_id', 'uint64'])
 
   unsharded_master.init_tablet(
-      'master',
+      'replica',
       keyspace=UNSHARDED_KEYSPACE,
       shard='0',
       tablet_index=0)
@@ -201,9 +199,7 @@ def setup_unsharded_keyspace():
     t.mquery(unsharded_master.dbname, create_vt_insert_test)
     t.start_vttablet(wait_for_state=None)
 
-  for t in [unsharded_master]:
-    t.wait_for_vttablet_state('SERVING')
-  for t in [unsharded_replica]:
+  for t in [unsharded_master, unsharded_replica]:
     t.wait_for_vttablet_state('NOT_SERVING')
 
   utils.run_vtctl(['InitShardMaster', '-force', '%s/0' % UNSHARDED_KEYSPACE,

--- a/test/keyspace_util.py
+++ b/test/keyspace_util.py
@@ -63,11 +63,8 @@ class TestEnv(object):
       for i in xrange(rdonly_count):
         self._start_tablet(keyspace, shard, 'rdonly', i)
 
-    for t in self.master_tablets:
-      t.wait_for_vttablet_state('SERVING')
     for t in self.tablets:
-      if t not in self.master_tablets:
-        t.wait_for_vttablet_state('NOT_SERVING')
+      t.wait_for_vttablet_state('NOT_SERVING')
 
     for t in self.master_tablets:
       utils.run_vtctl(['InitShardMaster', '-force', keyspace+'/'+t.shard,
@@ -104,12 +101,14 @@ class TestEnv(object):
     return t.init_mysql()
 
   def _init_tablet(self, keyspace, shard, tablet_type, index, tablet_index):
+    init_tablet_type = tablet_type
     if tablet_type == 'master':
+      init_tablet_type = 'replica'
       key = '%s.%s.%s' % (keyspace, shard, tablet_type)
     else:
       key = '%s.%s.%s.%s' % (keyspace, shard, tablet_type, index)
     t = self.tablet_map[key]
-    t.init_tablet(tablet_type, keyspace, shard, tablet_index=tablet_index)
+    t.init_tablet(init_tablet_type, keyspace, shard, tablet_index=tablet_index)
 
   def _start_tablet(self, keyspace, shard, tablet_type, index):
     """Start a tablet."""

--- a/test/legacy_resharding.py
+++ b/test/legacy_resharding.py
@@ -46,14 +46,13 @@ import struct
 import logging
 import unittest
 
-from vtproto import topodata_pb2
-
-from vtdb import keyrange_constants
-
 import base_sharding
 import environment
 import tablet
 import utils
+
+from vtproto import topodata_pb2
+from vtdb import keyrange_constants
 
 keyspace_id_type = keyrange_constants.KIT_UINT64
 pack_keyspace_id = struct.Struct('!Q').pack
@@ -255,10 +254,10 @@ primary key (name)
     utils.run_vtctl(['SetKeyspaceShardingInfo', '-force',
                      'test_keyspace', 'custom_ksid_col', keyspace_id_type])
 
-    shard_0_master.init_tablet('master', 'test_keyspace', '-80')
+    shard_0_master.init_tablet('replica', 'test_keyspace', '-80')
     shard_0_replica.init_tablet('replica', 'test_keyspace', '-80')
     shard_0_ny_rdonly.init_tablet('rdonly', 'test_keyspace', '-80')
-    shard_1_master.init_tablet('master', 'test_keyspace', '80-')
+    shard_1_master.init_tablet('replica', 'test_keyspace', '80-')
     shard_1_slave1.init_tablet('replica', 'test_keyspace', '80-')
     shard_1_slave2.init_tablet('replica', 'test_keyspace', '80-')
     shard_1_ny_rdonly.init_tablet('rdonly', 'test_keyspace', '80-')
@@ -278,21 +277,16 @@ primary key (name)
       t.create_db('vt_test_keyspace')
       t.start_vttablet(wait_for_state=None, full_mycnf_args=full_mycnf_args)
 
-    # wait for the tablets (replication is not setup, the slaves won't be
-    # healthy)
-    shard_0_master.wait_for_vttablet_state('SERVING')
-    shard_0_replica.wait_for_vttablet_state('NOT_SERVING')
-    shard_0_ny_rdonly.wait_for_vttablet_state('NOT_SERVING')
-    shard_1_master.wait_for_vttablet_state('SERVING')
-    shard_1_slave1.wait_for_vttablet_state('NOT_SERVING')
-    shard_1_slave2.wait_for_vttablet_state('NOT_SERVING')
-    shard_1_ny_rdonly.wait_for_vttablet_state('NOT_SERVING')
-    shard_1_rdonly1.wait_for_vttablet_state('NOT_SERVING')
+    # wait for the tablets (replication is not setup, they won't be healthy)
+    for t in [shard_0_master, shard_0_replica, shard_0_ny_rdonly,
+              shard_1_master, shard_1_slave1, shard_1_slave2, shard_1_ny_rdonly,
+              shard_1_rdonly1]:
+      t.wait_for_vttablet_state('NOT_SERVING')
 
     # reparent to make the tablets work
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/-80',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/-80',
                      shard_0_master.tablet_alias], auto_log=True)
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/80-',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/80-',
                      shard_1_master.tablet_alias], auto_log=True)
 
     # check the shards
@@ -313,10 +307,10 @@ primary key (name)
       utils.run_vtctl(['RunHealthCheck', t.tablet_alias])
 
     # create the split shards
-    shard_2_master.init_tablet('master', 'test_keyspace', '80-c0')
+    shard_2_master.init_tablet('replica', 'test_keyspace', '80-c0')
     shard_2_replica1.init_tablet('replica', 'test_keyspace', '80-c0')
     shard_2_replica2.init_tablet('replica', 'test_keyspace', '80-c0')
-    shard_3_master.init_tablet('master', 'test_keyspace', 'c0-')
+    shard_3_master.init_tablet('replica', 'test_keyspace', 'c0-')
     shard_3_replica.init_tablet('replica', 'test_keyspace', 'c0-')
     shard_3_rdonly1.init_tablet('rdonly', 'test_keyspace', 'c0-')
 
@@ -331,9 +325,9 @@ primary key (name)
               shard_3_master, shard_3_replica, shard_3_rdonly1]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/80-c0',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/80-c0',
                      shard_2_master.tablet_alias], auto_log=True)
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/c0-',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/c0-',
                      shard_3_master.tablet_alias], auto_log=True)
 
     # check the shards

--- a/test/master_buffering_test.py
+++ b/test/master_buffering_test.py
@@ -96,7 +96,7 @@ def setup_tablets():
   utils.run_vtctl(['SetKeyspaceShardingInfo', '-force', KEYSPACE_NAME,
                    'keyspace_id', 'uint64'])
   shard_0_master.init_tablet(
-      'master',
+      'replica',
       keyspace=KEYSPACE_NAME,
       shard='0',
       tablet_index=0)
@@ -112,12 +112,10 @@ def setup_tablets():
       t.mquery(shard_0_master.dbname, create_table)
     t.start_vttablet(wait_for_state=None)
 
-  for t in [shard_0_master]:
-    t.wait_for_vttablet_state('SERVING')
-  for t in [shard_0_replica1]:
+  for t in [shard_0_master, shard_0_replica1]:
     t.wait_for_vttablet_state('NOT_SERVING')
 
-  utils.run_vtctl(['InitShardMaster', KEYSPACE_NAME+'/0',
+  utils.run_vtctl(['InitShardMaster', '-force', KEYSPACE_NAME+'/0',
                    shard_0_master.tablet_alias], auto_log=True)
 
   for t in [shard_0_replica1]:

--- a/test/mysqlctl.py
+++ b/test/mysqlctl.py
@@ -27,7 +27,7 @@ def setUpModule():
 
     utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
 
-    master_tablet.init_tablet('master', 'test_keyspace', '0')
+    master_tablet.init_tablet('replica', 'test_keyspace', '0')
     replica_tablet.init_tablet('replica', 'test_keyspace', '0')
 
     master_tablet.create_db('vt_test_keyspace')
@@ -78,11 +78,11 @@ class TestMysqlctl(unittest.TestCase):
                                  extra_env={'MYSQL_FLAVOR': ''})
     replica_tablet.start_vttablet(wait_for_state=None,
                                   extra_env={'MYSQL_FLAVOR': ''})
-    master_tablet.wait_for_vttablet_state('SERVING')
+    master_tablet.wait_for_vttablet_state('NOT_SERVING')
     replica_tablet.wait_for_vttablet_state('NOT_SERVING')
 
     # reparent tablets, which requires flavor detection
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/0',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
                      master_tablet.tablet_alias], auto_log=True)
 
     master_tablet.kill_vttablet()

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -64,9 +64,9 @@ class TestVtctld(unittest.TestCase):
          'master:test_keyspace,replica:test_keyspace,rdonly:test_keyspace',
          'redirected_keyspace'])
 
-    shard_0_master.init_tablet('master', 'test_keyspace', '-80')
+    shard_0_master.init_tablet('replica', 'test_keyspace', '-80')
     shard_0_replica.init_tablet('replica', 'test_keyspace', '-80')
-    shard_1_master.init_tablet('master', 'test_keyspace', '80-')
+    shard_1_master.init_tablet('replica', 'test_keyspace', '80-')
     shard_1_replica.init_tablet('replica', 'test_keyspace', '80-')
 
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
@@ -83,14 +83,12 @@ class TestVtctld(unittest.TestCase):
                                    wait_for_state=None)
 
     # wait for the right states
-    for t in [shard_0_master, shard_1_master]:
-      t.wait_for_vttablet_state('SERVING')
-    for t in [shard_0_replica, shard_1_replica]:
+    for t in [shard_0_master, shard_1_master, shard_0_replica, shard_1_replica]:
       t.wait_for_vttablet_state('NOT_SERVING')
 
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/-80',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/-80',
                      shard_0_master.tablet_alias], auto_log=True)
-    utils.run_vtctl(['InitShardMaster', 'test_keyspace/80-',
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/80-',
                      shard_1_master.tablet_alias], auto_log=True)
     shard_0_replica.wait_for_vttablet_state('SERVING')
 

--- a/test/vtgatev2_test.py
+++ b/test/vtgatev2_test.py
@@ -174,7 +174,7 @@ def setup_tablets():
   utils.run_vtctl(['SetKeyspaceShardingInfo', '-force', KEYSPACE_NAME,
                    'keyspace_id', 'uint64'])
   shard_0_master.init_tablet(
-      'master',
+      'replica',
       keyspace=KEYSPACE_NAME,
       shard='-80',
       tablet_index=0)
@@ -189,7 +189,7 @@ def setup_tablets():
       shard='-80',
       tablet_index=2)
   shard_1_master.init_tablet(
-      'master',
+      'replica',
       keyspace=KEYSPACE_NAME,
       shard='80-',
       tablet_index=0)
@@ -213,15 +213,13 @@ def setup_tablets():
       t.mquery(shard_0_master.dbname, create_table)
     t.start_vttablet(wait_for_state=None)
 
-  for t in [shard_0_master, shard_1_master]:
-    t.wait_for_vttablet_state('SERVING')
-  for t in [shard_0_replica1, shard_0_replica2,
-            shard_1_replica1, shard_1_replica2]:
+  for t in [shard_0_master, shard_0_replica1, shard_0_replica2,
+            shard_1_master, shard_1_replica1, shard_1_replica2]:
     t.wait_for_vttablet_state('NOT_SERVING')
 
-  utils.run_vtctl(['InitShardMaster', KEYSPACE_NAME+'/-80',
+  utils.run_vtctl(['InitShardMaster', '-force', KEYSPACE_NAME+'/-80',
                    shard_0_master.tablet_alias], auto_log=True)
-  utils.run_vtctl(['InitShardMaster', KEYSPACE_NAME+'/80-',
+  utils.run_vtctl(['InitShardMaster', '-force', KEYSPACE_NAME+'/80-',
                    shard_1_master.tablet_alias], auto_log=True)
 
   for t in [shard_0_master, shard_0_replica1, shard_0_replica2,


### PR DESCRIPTION
It will still only attempt the repair if the global shard record has a `MasterAlias` specified.

Fixes #2162.