### PR TITLE
Fix work of vttablet with non-empty vt_dba password.

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -476,7 +476,7 @@ func (mysqld *Mysqld) Init(ctx context.Context, initDBSQLFile string) error {
 		return fmt.Errorf("can't open init_db_sql_file (%v): %v", initDBSQLFile, err)
 	}
 	defer sqlFile.Close()
-	if err := mysqld.executeMysqlScript("root", "", sqlFile); err != nil {
+	if err := mysqld.executeMysqlScript(&sqldb.ConnParams{Uname: "root", Pass: ""}, sqlFile); err != nil {
 		return fmt.Errorf("can't run init_db_sql_file (%v): %v", initDBSQLFile, err)
 	}
 
@@ -687,12 +687,12 @@ func deleteTopDir(dir string) (removalErr error) {
 
 // executeMysqlCommands executes some SQL commands,
 // using the mysql command line tool.
-func (mysqld *Mysqld) executeMysqlCommands(user, password, sql string) error {
-	return mysqld.executeMysqlScript(user, password, strings.NewReader(sql))
+func (mysqld *Mysqld) executeMysqlCommands(connParams *sqldb.ConnParams, sql string) error {
+	return mysqld.executeMysqlScript(connParams, strings.NewReader(sql))
 }
 
 // executeMysqlScript executes a .sql script file with the mysql command line tool.
-func (mysqld *Mysqld) executeMysqlScript(user, password string, sql io.Reader) error {
+func (mysqld *Mysqld) executeMysqlScript(connParams *sqldb.ConnParams, sql io.Reader) error {
 	dir, err := vtenv.VtMysqlRoot()
 	if err != nil {
 		return err
@@ -701,10 +701,10 @@ func (mysqld *Mysqld) executeMysqlScript(user, password string, sql io.Reader) e
 	if err != nil {
 		return err
 	}
-	arg := []string{"--batch", "-u", user, "-S", mysqld.config.SocketFile}
-	if password != "" {
+	arg := []string{"--batch", "-u", connParams.Uname, "-S", mysqld.config.SocketFile}
+	if connParams.Pass != "" {
 		// -p must be omitted entirely if empty, or else it will prompt.
-		arg = append(arg, "-p"+password)
+		arg = append(arg, "-p"+connParams.Pass)
 	}
 	env := []string{
 		"LD_LIBRARY_PATH=" + path.Join(dir, "lib/mysql"),

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -230,7 +230,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 			initialCopySQL += s + ";\n"
 		}
 	}
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, initialCopySQL); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba, initialCopySQL); err != nil {
 		return nil, err
 	}
 
@@ -245,7 +245,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 		sql := "SET sql_log_bin = 0;\n"
 		sql += "USE _vt_preflight;\n"
 		sql += change
-		if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, sql); err != nil {
+		if err = mysqld.executeMysqlCommands(mysqld.dba, sql); err != nil {
 			return nil, err
 		}
 
@@ -261,7 +261,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 	// and clean up the extra database
 	dropSQL := "SET sql_log_bin = 0;\n"
 	dropSQL += "DROP DATABASE _vt_preflight;\n"
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, dropSQL); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba, dropSQL); err != nil {
 		return nil, err
 	}
 
@@ -313,7 +313,7 @@ func (mysqld *Mysqld) ApplySchemaChange(dbName string, change *tmutils.SchemaCha
 
 	// execute the schema change using an external mysql process
 	// (to benefit from the extra commands in mysql cli)
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, sql); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba, sql); err != nil {
 		return nil, err
 	}
 

--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -230,7 +230,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 			initialCopySQL += s + ";\n"
 		}
 	}
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, initialCopySQL); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, initialCopySQL); err != nil {
 		return nil, err
 	}
 
@@ -245,7 +245,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 		sql := "SET sql_log_bin = 0;\n"
 		sql += "USE _vt_preflight;\n"
 		sql += change
-		if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, sql); err != nil {
+		if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, sql); err != nil {
 			return nil, err
 		}
 
@@ -261,7 +261,7 @@ func (mysqld *Mysqld) PreflightSchemaChange(dbName string, changes []string) ([]
 	// and clean up the extra database
 	dropSQL := "SET sql_log_bin = 0;\n"
 	dropSQL += "DROP DATABASE _vt_preflight;\n"
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, dropSQL); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, dropSQL); err != nil {
 		return nil, err
 	}
 
@@ -313,7 +313,7 @@ func (mysqld *Mysqld) ApplySchemaChange(dbName string, change *tmutils.SchemaCha
 
 	// execute the schema change using an external mysql process
 	// (to benefit from the extra commands in mysql cli)
-	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, sql); err != nil {
+	if err = mysqld.executeMysqlCommands(mysqld.dba.Uname, mysqld.dba.Pass, sql); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Apparently the --password flag on mysql and mysqladmin is in some way special
and it doesn't accept the value of password separeted from the flag by a space,
it requires it to be passed via '=' (--password=value). Another way to pass the
password is via short flag -p again with password following the flag without
space and without '='. I chose that method of passing password since it would
be consistent with flags -u and -S.

Also fixing the problem introduced in
https://github.com/youtube/vitess/pull/2148 when executeMysqlScript() would pass
vt_dba password even if it tries to connect as a different user.

Fixes #2154.