### PR TITLE
Making DeleteShard a bit more resilient.

### DIFF
--- a/go/vt/wrangler/shard.go
+++ b/go/vt/wrangler/shard.go
@@ -114,6 +114,10 @@ func (wr *Wrangler) SetShardTabletControl(ctx context.Context, keyspace, shard s
 func (wr *Wrangler) DeleteShard(ctx context.Context, keyspace, shard string, recursive bool) error {
 	shardInfo, err := wr.ts.GetShard(ctx, keyspace, shard)
 	if err != nil {
+		if err == topo.ErrNoNode {
+			wr.Logger().Infof("Shard %v/%v doesn't seem to exist, cleaning up any potential leftover", keyspace, shard)
+			return wr.ts.DeleteShard(ctx, keyspace, shard)
+		}
 		return err
 	}
 


### PR DESCRIPTION
If we can't read the Shard record, some leftover files might still be in
there. So we try to delete the shard anyway.