### PR TITLE
Bind variables optimizations.

### DIFF
--- a/go/cmd/vtgateclienttest/goclienttest/echo.go
+++ b/go/cmd/vtgateclienttest/goclienttest/echo.go
@@ -64,11 +64,10 @@ var (
 
 	bindVars = map[string]interface{}{
 		"int":   123,
-		"float": 2.0,
+		"float": 2.1,
 		"bytes": []byte{1, 2, 3},
 	}
-	bindVarsEcho = "map[bytes:[1 2 3] float:2 int:123]"
-	bindVarsP3   = map[string]*querypb.BindVariable{
+	bindVarsP3 = map[string]*querypb.BindVariable{
 		"int": {
 			Type:  querypb.Type_INT64,
 			Value: []byte{'1', '2', '3'},
@@ -126,7 +125,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 	checkEcho(t, "Execute", qr, err, map[string]string{
 		"callerId":   callerIDEcho,
 		"query":      echoPrefix + query,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"keyspace":   connectionKeyspace,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
@@ -139,7 +138,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":      echoPrefix + query,
 		"keyspace":   keyspace,
 		"shards":     shardsEcho,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
 		"extras":     extrasEcho,
@@ -151,7 +150,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":       echoPrefix + query,
 		"keyspace":    keyspace,
 		"keyspaceIds": keyspaceIDsEcho,
-		"bindVars":    bindVarsEcho,
+		"bindVars":    bindVarsP3Echo,
 		"tabletType":  tabletTypeEcho,
 		"options":     optionsEcho,
 		"extras":      extrasEcho,
@@ -163,7 +162,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":      echoPrefix + query,
 		"keyspace":   keyspace,
 		"keyRanges":  keyRangesEcho,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
 		"extras":     extrasEcho,
@@ -176,7 +175,7 @@ func testEchoExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"keyspace":         keyspace,
 		"entityColumnName": "column1",
 		"entityIds":        entityKeyspaceIDsEcho,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"tabletType":       tabletTypeEcho,
 		"options":          optionsEcho,
 		"extras":           extrasEcho,
@@ -242,7 +241,7 @@ func testEchoStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 	checkEcho(t, "StreamExecute", qr, err, map[string]string{
 		"callerId":   callerIDEcho,
 		"query":      echoPrefix + query,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"keyspace":   connectionKeyspace,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
@@ -258,7 +257,7 @@ func testEchoStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":      echoPrefix + query,
 		"keyspace":   keyspace,
 		"shards":     shardsEcho,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
 	})
@@ -273,7 +272,7 @@ func testEchoStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":       echoPrefix + query,
 		"keyspace":    keyspace,
 		"keyspaceIds": keyspaceIDsEcho,
-		"bindVars":    bindVarsEcho,
+		"bindVars":    bindVarsP3Echo,
 		"tabletType":  tabletTypeEcho,
 		"options":     optionsEcho,
 	})
@@ -288,7 +287,7 @@ func testEchoStreamExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":      echoPrefix + query,
 		"keyspace":   keyspace,
 		"keyRanges":  keyRangesEcho,
-		"bindVars":   bindVarsEcho,
+		"bindVars":   bindVarsP3Echo,
 		"tabletType": tabletTypeEcho,
 		"options":    optionsEcho,
 	})
@@ -309,7 +308,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 	checkEcho(t, "Execute", qr, err, map[string]string{
 		"callerId":         callerIDEcho,
 		"query":            echoPrefix + query,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"keyspace":         connectionKeyspace,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
@@ -323,7 +322,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":            echoPrefix + query,
 		"keyspace":         keyspace,
 		"shards":           shardsEcho,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
 		"notInTransaction": "false",
@@ -336,7 +335,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":            echoPrefix + query,
 		"keyspace":         keyspace,
 		"keyspaceIds":      keyspaceIDsEcho,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
 		"notInTransaction": "false",
@@ -349,7 +348,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"query":            echoPrefix + query,
 		"keyspace":         keyspace,
 		"keyRanges":        keyRangesEcho,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
 		"notInTransaction": "false",
@@ -363,7 +362,7 @@ func testEchoTransactionExecute(t *testing.T, conn *vtgateconn.VTGateConn) {
 		"keyspace":         keyspace,
 		"entityColumnName": "column1",
 		"entityIds":        entityKeyspaceIDsEcho,
-		"bindVars":         bindVarsEcho,
+		"bindVars":         bindVarsP3Echo,
 		"tabletType":       tabletTypeEcho,
 		"session":          sessionEcho,
 		"notInTransaction": "false",

--- a/go/vt/tabletserver/querytypes/proto3.go
+++ b/go/vt/tabletserver/querytypes/proto3.go
@@ -228,25 +228,7 @@ func Proto3ToBindVariables(bv map[string]*querypb.BindVariable) (map[string]inte
 		if v == nil {
 			continue
 		}
-		if v.Type == sqltypes.Tuple {
-			list := make([]interface{}, len(v.Values))
-			for i, lv := range v.Values {
-				v, err := sqltypes.ValueFromBytes(lv.Type, lv.Value)
-				if err != nil {
-					return nil, err
-				}
-				// TODO(sougou): Change this to just v.
-				list[i] = v.ToNative()
-			}
-			result[k] = list
-		} else {
-			v, err := sqltypes.ValueFromBytes(v.Type, v.Value)
-			if err != nil {
-				return nil, err
-			}
-			// TODO(sougou): Change this to just v.
-			result[k] = v.ToNative()
-		}
+		result[k] = v
 	}
 	return result, nil
 }

--- a/go/vt/tabletserver/querytypes/proto3_test.go
+++ b/go/vt/tabletserver/querytypes/proto3_test.go
@@ -314,39 +314,23 @@ func TestProto3ToBindVariables(t *testing.T) {
 		in   *querypb.BindVariable
 		out  interface{}
 	}{{
-		name: "Int16",
+		name: "value set",
 		in: &querypb.BindVariable{
 			Type:  sqltypes.Int16,
 			Value: []byte("-1"),
 		},
-		out: int64(-1),
-	}, {
-		name: "Uint16",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.Uint16,
-			Value: []byte("1"),
+		out: &querypb.BindVariable{
+			Type:  sqltypes.Int16,
+			Value: []byte("-1"),
 		},
-		out: uint64(1),
-	}, {
-		name: "Float64",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.Float64,
-			Value: []byte("1.5"),
-		},
-		out: float64(1.5),
-	}, {
-		name: "VarChar",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.VarChar,
-			Value: []byte("aa"),
-		},
-		out: []byte("aa"),
 	}, {
 		name: "Null",
 		in: &querypb.BindVariable{
 			Type: sqltypes.Null,
 		},
-		out: nil,
+		out: &querypb.BindVariable{
+			Type: sqltypes.Null,
+		},
 	}, {
 		name: "nil",
 		in:   nil,
@@ -370,7 +354,23 @@ func TestProto3ToBindVariables(t *testing.T) {
 				},
 			},
 		},
-		out: []interface{}{int64(1), []byte("aa"), float64(1.5)},
+		out: &querypb.BindVariable{
+			Type: sqltypes.Tuple,
+			Values: []*querypb.Value{
+				{
+					Type:  sqltypes.Int64,
+					Value: []byte("1"),
+				},
+				{
+					Type:  sqltypes.VarChar,
+					Value: []byte("aa"),
+				},
+				{
+					Type:  sqltypes.Float64,
+					Value: []byte("1.5"),
+				},
+			},
+		},
 	}}
 	for _, tcase := range testcases {
 		p3 := map[string]*querypb.BindVariable{
@@ -382,56 +382,6 @@ func TestProto3ToBindVariables(t *testing.T) {
 		}
 		if !reflect.DeepEqual(bv["bv"], tcase.out) {
 			t.Errorf("Mismatch on %v: %+v, want %+v", tcase.name, bv["bv"], tcase.out)
-		}
-	}
-}
-
-func TestProto3ToBindVariablesErrors(t *testing.T) {
-	testcases := []struct {
-		name string
-		in   *querypb.BindVariable
-		out  string
-	}{{
-		name: "Int64",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.Int64,
-			Value: []byte("aa"),
-		},
-		out: `strconv.ParseInt: parsing "aa": invalid syntax`,
-	}, {
-		name: "Uint64",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.Uint64,
-			Value: []byte("-1"),
-		},
-		out: `strconv.ParseUint: parsing "-1": invalid syntax`,
-	}, {
-		name: "Float64",
-		in: &querypb.BindVariable{
-			Type:  sqltypes.Float64,
-			Value: []byte("aa"),
-		},
-		out: `strconv.ParseFloat: parsing "aa": invalid syntax`,
-	}, {
-		name: "Tuple",
-		in: &querypb.BindVariable{
-			Type: sqltypes.Tuple,
-			Values: []*querypb.Value{
-				{
-					Type:  sqltypes.Int64,
-					Value: []byte("aa"),
-				},
-			},
-		},
-		out: `strconv.ParseInt: parsing "aa": invalid syntax`,
-	}}
-	for _, tcase := range testcases {
-		p3 := map[string]*querypb.BindVariable{
-			"bv": tcase.in,
-		}
-		_, err := Proto3ToBindVariables(p3)
-		if err == nil || err.Error() != tcase.out {
-			t.Errorf("Error: %v, want %v", err, tcase.out)
 		}
 	}
 }

--- a/go/vt/tabletserver/tabletconntest/fakequeryservice.go
+++ b/go/vt/tabletserver/tabletconntest/fakequeryservice.go
@@ -309,7 +309,10 @@ func (f *FakeQueryService) ReadTransaction(ctx context.Context, target *querypb.
 const ExecuteQuery = "executeQuery"
 
 var ExecuteBindVars = map[string]interface{}{
-	"bind1": int64(1114444),
+	"bind1": &querypb.BindVariable{
+		Type:  querypb.Type_INT64,
+		Value: []byte("1114444"),
+	},
 }
 
 const ExecuteTransactionID int64 = 678
@@ -374,7 +377,10 @@ func (f *FakeQueryService) Execute(ctx context.Context, target *querypb.Target, 
 const StreamExecuteQuery = "streamExecuteQuery"
 
 var StreamExecuteBindVars = map[string]interface{}{
-	"bind1": int64(93848000),
+	"bind1": &querypb.BindVariable{
+		Type:  querypb.Type_INT64,
+		Value: []byte("93848000"),
+	},
 }
 
 var StreamExecuteQueryResult1 = sqltypes.Result{
@@ -443,13 +449,19 @@ var ExecuteBatchQueries = []querytypes.BoundQuery{
 	{
 		Sql: "executeBatchQueries1",
 		BindVariables: map[string]interface{}{
-			"bind1": int64(43),
+			"bind1": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("43"),
+			},
 		},
 	},
 	{
 		Sql: "executeBatchQueries2",
 		BindVariables: map[string]interface{}{
-			"bind2": int64(72),
+			"bind2": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("72"),
+			},
 		},
 	},
 }
@@ -530,7 +542,10 @@ func (f *FakeQueryService) ExecuteBatch(ctx context.Context, target *querypb.Tar
 var SplitQueryBoundQuery = querytypes.BoundQuery{
 	Sql: "splitQuery",
 	BindVariables: map[string]interface{}{
-		"bind1": int64(43),
+		"bind1": &querypb.BindVariable{
+			Type:  querypb.Type_INT64,
+			Value: []byte("43"),
+		},
 	},
 }
 
@@ -541,8 +556,14 @@ var SplitQueryQuerySplitList = []querytypes.QuerySplit{
 	{
 		Sql: "splitQuery",
 		BindVariables: map[string]interface{}{
-			"bind1":       int64(43),
-			"keyspace_id": int64(3333),
+			"bind1": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("43"),
+			},
+			"keyspace_id": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("3333"),
+			},
 		},
 		RowCount: 4456,
 	},
@@ -556,7 +577,10 @@ const SplitQueryV2SplitCount = 372
 var SplitQueryV2BoundQuery = querytypes.BoundQuery{
 	Sql: "splitQuery",
 	BindVariables: map[string]interface{}{
-		"bind1": int64(43),
+		"bind1": &querypb.BindVariable{
+			Type:  querypb.Type_INT64,
+			Value: []byte("43"),
+		},
 	},
 }
 
@@ -567,8 +591,14 @@ var SplitQueryQueryV2SplitList = []querytypes.QuerySplit{
 	{
 		Sql: "splitQuery",
 		BindVariables: map[string]interface{}{
-			"bind1":       int64(43),
-			"keyspace_id": int64(3333),
+			"bind1": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("43"),
+			},
+			"keyspace_id": &querypb.BindVariable{
+				Type:  querypb.Type_INT64,
+				Value: []byte("3333"),
+			},
 		},
 		RowCount: 4456,
 	},

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -264,7 +264,10 @@ var execMap = map[string]struct {
 		execQuery: &queryExecute{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"v1": int64(0),
+				"v1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			TabletType: topodatapb.TabletType_RDONLY,
 			Session:    nil,
@@ -276,7 +279,10 @@ var execMap = map[string]struct {
 		execQuery: &queryExecute{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"v1": int64(0),
+				"v1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			TabletType: topodatapb.TabletType_MASTER,
 			Session:    session1,
@@ -300,7 +306,10 @@ var execSpecificShardMap = map[string]struct {
 			queryExecute: queryExecute{
 				SQL: "request1SpecificShard",
 				BindVariables: map[string]interface{}{
-					"v1": int64(0),
+					"v1": &querypb.BindVariable{
+						Type:  querypb.Type_INT64,
+						Value: []byte("0"),
+					},
 				},
 				TabletType: topodatapb.TabletType_RDONLY,
 				Session:    nil,
@@ -316,7 +325,10 @@ var execSpecificShardMap = map[string]struct {
 			queryExecute: queryExecute{
 				SQL: "txRequestSpecificShard",
 				BindVariables: map[string]interface{}{
-					"v1": int64(0),
+					"v1": &querypb.BindVariable{
+						Type:  querypb.Type_INT64,
+						Value: []byte("0"),
+					},
 				},
 				TabletType: topodatapb.TabletType_MASTER,
 				Session:    session1,

--- a/go/vt/vtgate/topo_utils_test.go
+++ b/go/vt/vtgate/topo_utils_test.go
@@ -160,8 +160,13 @@ func TestBoundShardQueriesToScatterBatchRequest(t *testing.T) {
 					"ks1:0": {
 						Queries: []querytypes.BoundQuery{
 							{
-								Sql:           "q1",
-								BindVariables: map[string]interface{}{"q1var": int64(1)},
+								Sql: "q1",
+								BindVariables: map[string]interface{}{
+									"q1var": &querypb.BindVariable{
+										Type:  sqltypes.Int64,
+										Value: []byte("1"),
+									},
+								},
 							},
 						},
 						Keyspace:      "ks1",
@@ -171,11 +176,21 @@ func TestBoundShardQueriesToScatterBatchRequest(t *testing.T) {
 					"ks1:1": {
 						Queries: []querytypes.BoundQuery{
 							{
-								Sql:           "q1",
-								BindVariables: map[string]interface{}{"q1var": int64(1)},
+								Sql: "q1",
+								BindVariables: map[string]interface{}{
+									"q1var": &querypb.BindVariable{
+										Type:  sqltypes.Int64,
+										Value: []byte("1"),
+									},
+								},
 							}, {
-								Sql:           "q2",
-								BindVariables: map[string]interface{}{"q2var": int64(2)},
+								Sql: "q2",
+								BindVariables: map[string]interface{}{
+									"q2var": &querypb.BindVariable{
+										Type:  sqltypes.Int64,
+										Value: []byte("2"),
+									},
+								},
 							},
 						},
 						Keyspace:      "ks1",
@@ -185,8 +200,13 @@ func TestBoundShardQueriesToScatterBatchRequest(t *testing.T) {
 					"ks2:1": {
 						Queries: []querytypes.BoundQuery{
 							{
-								Sql:           "q3",
-								BindVariables: map[string]interface{}{"q3var": int64(3)},
+								Sql: "q3",
+								BindVariables: map[string]interface{}{
+									"q3var": &querypb.BindVariable{
+										Type:  sqltypes.Int64,
+										Value: []byte("3"),
+									},
+								},
 							},
 						},
 						Keyspace:      "ks2",
@@ -218,8 +238,13 @@ func TestBoundShardQueriesToScatterBatchRequest(t *testing.T) {
 					"ks1:0": {
 						Queries: []querytypes.BoundQuery{
 							{
-								Sql:           "q1",
-								BindVariables: map[string]interface{}{"q1var": int64(1)},
+								Sql: "q1",
+								BindVariables: map[string]interface{}{
+									"q1var": &querypb.BindVariable{
+										Type:  sqltypes.Int64,
+										Value: []byte("1"),
+									},
+								},
 							},
 						},
 						Keyspace:      "ks1",

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -1964,7 +1964,10 @@ var execMap = map[string]struct {
 		execQuery: &queryExecute{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace:   "connection_ks",
 			TabletType: topodatapb.TabletType_RDONLY,
@@ -1973,7 +1976,10 @@ var execMap = map[string]struct {
 		shardQuery: &queryExecuteShards{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace:   "ks",
 			Shards:     []string{"1", "2"},
@@ -1983,7 +1989,10 @@ var execMap = map[string]struct {
 		keyspaceIDQuery: &queryExecuteKeyspaceIds{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace: "ks",
 			KeyspaceIds: [][]byte{
@@ -1995,7 +2004,10 @@ var execMap = map[string]struct {
 		keyRangeQuery: &queryExecuteKeyRanges{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace: "ks",
 			KeyRanges: []*topodatapb.KeyRange{
@@ -2010,7 +2022,10 @@ var execMap = map[string]struct {
 		entityIdsQuery: &queryExecuteEntityIds{
 			SQL: "request1",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace:         "ks",
 			EntityColumnName: "column",
@@ -2212,7 +2227,10 @@ var execMap = map[string]struct {
 		execQuery: &queryExecute{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace:   "connection_ks",
 			TabletType: topodatapb.TabletType_MASTER,
@@ -2221,7 +2239,10 @@ var execMap = map[string]struct {
 		shardQuery: &queryExecuteShards{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			TabletType: topodatapb.TabletType_MASTER,
 			Keyspace:   "",
@@ -2231,7 +2252,10 @@ var execMap = map[string]struct {
 		keyspaceIDQuery: &queryExecuteKeyspaceIds{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace: "ks",
 			KeyspaceIds: [][]byte{
@@ -2243,7 +2267,10 @@ var execMap = map[string]struct {
 		keyRangeQuery: &queryExecuteKeyRanges{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace: "ks",
 			KeyRanges: []*topodatapb.KeyRange{
@@ -2258,7 +2285,10 @@ var execMap = map[string]struct {
 		entityIdsQuery: &queryExecuteEntityIds{
 			SQL: "txRequest",
 			BindVariables: map[string]interface{}{
-				"bind1": int64(0),
+				"bind1": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("0"),
+				},
 			},
 			Keyspace:         "ks",
 			EntityColumnName: "column",
@@ -2395,7 +2425,10 @@ var splitQueryRequest = &querySplitQuery{
 	Keyspace: "ks",
 	SQL:      "in for SplitQuery",
 	BindVariables: map[string]interface{}{
-		"bind1": int64(43),
+		"bind1": &querypb.BindVariable{
+			Type:  querypb.Type_INT64,
+			Value: []byte("43"),
+		},
 	},
 	SplitColumn: "split_column",
 	SplitCount:  13,
@@ -2405,7 +2438,10 @@ var splitQueryV2Request = &querySplitQueryV2{
 	Keyspace: "ks2",
 	SQL:      "in for SplitQueryV2",
 	BindVariables: map[string]interface{}{
-		"bind2": int64(43),
+		"bind2": &querypb.BindVariable{
+			Type:  querypb.Type_INT64,
+			Value: []byte("43"),
+		},
 	},
 	SplitColumns:        []string{"split_column1", "split_column2"},
 	SplitCount:          145,

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -92,8 +92,7 @@ public abstract class RpcClientTest {
 
   private static final Map<String, Object> BIND_VARS = new ImmutableMap.Builder<String, Object>()
       .put("int", 123).put("float", 2.5).put("bytes", new byte[] {1, 2, 3}).build();
-  private static final String BIND_VARS_ECHO = "map[bytes:[1 2 3] float:2.5 int:123]";
-  private static final String BIND_VARS_ECHO_P3 =
+  private static final String BIND_VARS_ECHO =
       "map[bytes:type:VARBINARY value:\"\\001\\002\\003\"  float:type:FLOAT64 value:\"2.5\"  int:type:INT64 value:\"123\" ]";
 
   private static final String SESSION_ECHO = "in_transaction:true ";
@@ -187,7 +186,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(SHARDS_ECHO, echo.get("shards"));
-    Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
+    Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals("true", echo.get("asTransaction"));
 
@@ -199,7 +198,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(KEYSPACE_IDS_ECHO, echo.get("keyspaceIds"));
-    Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
+    Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals("true", echo.get("asTransaction"));
   }
@@ -313,7 +312,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(SHARDS_ECHO, echo.get("shards"));
-    Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
+    Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("asTransaction"));
@@ -326,7 +325,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(KEYSPACE_IDS_ECHO, echo.get("keyspaceIds"));
-    Assert.assertEquals(BIND_VARS_ECHO_P3, echo.get("bindVars"));
+    Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("asTransaction"));

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -185,7 +185,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         // Check NULL vs. empty string.
@@ -198,7 +198,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$SHARDS_ECHO, $echo['shards']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->executeKeyspaceIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -206,7 +206,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEYSPACE_IDS_ECHO, $echo['keyspaceIds']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->executeKeyRanges($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEY_RANGES, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -214,7 +214,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEY_RANGES_ECHO, $echo['keyRanges']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->executeEntityIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$ENTITY_COLUMN_NAME, self::$ENTITY_KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -223,7 +223,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$ENTITY_COLUMN_NAME, $echo['entityColumnName']);
         $this->assertEquals(self::$ENTITY_KEYSPACE_IDS_ECHO, $echo['entityIds']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $results = $conn->executeBatchShards($ctx, array(
@@ -260,7 +260,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->streamExecuteShards($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$SHARDS, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -268,7 +268,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$SHARDS_ECHO, $echo['shards']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->streamExecuteKeyspaceIds($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEYSPACE_IDS, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -276,7 +276,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEYSPACE_IDS_ECHO, $echo['keyspaceIds']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
 
         $echo = $this->getEcho($conn->streamExecuteKeyRanges($ctx, self::$ECHO_QUERY, self::$KEYSPACE, self::$KEY_RANGES, self::$BIND_VARS, self::$TABLET_TYPE));
@@ -284,7 +284,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEY_RANGES_ECHO, $echo['keyRanges']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
     }
 
@@ -299,7 +299,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$CALLER_ID_ECHO, $echo['callerId']);
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
         $this->assertEquals('false', $echo['notInTransaction']);
@@ -309,7 +309,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$SHARDS_ECHO, $echo['shards']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
         $this->assertEquals('false', $echo['notInTransaction']);
@@ -319,7 +319,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEYSPACE_IDS_ECHO, $echo['keyspaceIds']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
         $this->assertEquals('false', $echo['notInTransaction']);
@@ -329,7 +329,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$ECHO_QUERY, $echo['query']);
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$KEY_RANGES_ECHO, $echo['keyRanges']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
         $this->assertEquals('false', $echo['notInTransaction']);
@@ -340,7 +340,7 @@ class VTGateConnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(self::$KEYSPACE, $echo['keyspace']);
         $this->assertEquals(self::$ENTITY_COLUMN_NAME, $echo['entityColumnName']);
         $this->assertEquals(self::$ENTITY_KEYSPACE_IDS_ECHO, $echo['entityIds']);
-        $this->assertEquals(self::$BIND_VARS_ECHO, $echo['bindVars']);
+        $this->assertEquals(self::$BIND_VARS_ECHO_P3, $echo['bindVars']);
         $this->assertEquals(self::$TABLET_TYPE_ECHO, $echo['tabletType']);
         $this->assertEquals(self::$SESSION_ECHO, $echo['session']);
         $this->assertEquals('false', $echo['notInTransaction']);

--- a/py/vtdb/vtgate_client_testsuite.py
+++ b/py/vtdb/vtgate_client_testsuite.py
@@ -465,11 +465,10 @@ class TestEcho(TestPythonClientBase):
       'bytes': '\x01\x02\x03',
       'bool': True,
   }
-  bind_variables_echo = 'map[bool:1 bytes:[1 2 3] float:2.1 int:123]'
-  bind_variables_p3_echo = ('map[bool:type:INT64 value:"1"  '
-                            'bytes:type:VARBINARY value:"\\001\\002\\003"  '
-                            'float:type:FLOAT64 value:"2.1"  '
-                            'int:type:INT64 value:"123" ]')
+  bind_variables_echo = ('map[bool:type:INT64 value:"1"  '
+                         'bytes:type:VARBINARY value:"\\001\\002\\003"  '
+                         'float:type:FLOAT64 value:"2.1"  '
+                         'int:type:INT64 value:"123" ]')
 
   caller_id = vtgate_client.CallerID(
       principal='test_principal',
@@ -605,7 +604,7 @@ class TestEcho(TestPythonClientBase):
         'query': self.echo_prefix+self.query_echo,
         'keyspace': self.keyspace,
         'shards': self.shards_echo,
-        'bindVars': self.bind_variables_p3_echo,
+        'bindVars': self.bind_variables_echo,
         'tabletType': self.tablet_type_echo,
         'asTransaction': 'true',
     })
@@ -628,7 +627,7 @@ class TestEcho(TestPythonClientBase):
         'query': self.echo_prefix+self.query_echo,
         'keyspace': self.keyspace,
         'keyspaceIds': self.keyspace_ids_echo,
-        'bindVars': self.bind_variables_p3_echo,
+        'bindVars': self.bind_variables_echo,
         'tabletType': self.tablet_type_echo,
         'asTransaction': 'true',
     })


### PR DESCRIPTION
Now all places that use bind variables also support *querypb.BindVariable. That way, when a query comes in, we just keep the original variable.

We can't change the type of the map yet, as we use some custom types in tabletserver to expand primary keys, for instance.
