### PR TITLE
Allow to use app2 and workflows in the k8s and local examples.

### DIFF
--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -29,6 +29,7 @@ cp -R base/vt/dist lite/vt/
 mkdir -p $lite/$vttop/go/cmd/vtctld
 mkdir -p $lite/$vttop/web
 cp -R base/$vttop/web/vtctld $lite/$vttop/web/
+cp -R base/$vttop/web/vtctld2 $lite/$vttop/web/
 
 mkdir -p $lite/$vttop/config
 cp -R base/$vttop/config/* $lite/$vttop/config/

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -44,6 +44,7 @@ spec:
               -web_dir $VTTOP/web/vtctld
               -web_dir2 $VTTOP/web/vtctld2/app
               -workflow_manager_init
+              -workflow_manager_use_election
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -43,6 +43,7 @@ spec:
               -cell {{cell}}
               -web_dir $VTTOP/web/vtctld
               -web_dir2 $VTTOP/web/vtctld2/app
+              -workflow_manager_init
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000

--- a/examples/kubernetes/vtctld-controller-template.yaml
+++ b/examples/kubernetes/vtctld-controller-template.yaml
@@ -42,6 +42,7 @@ spec:
               su -p -c "/vt/bin/vtctld
               -cell {{cell}}
               -web_dir $VTTOP/web/vtctld
+              -web_dir2 $VTTOP/web/vtctld2/app
               -log_dir $VTDATAROOT/tmp
               -alsologtostderr
               -port 15000

--- a/examples/local/vtctld-up.sh
+++ b/examples/local/vtctld-up.sh
@@ -17,6 +17,7 @@ $VTROOT/bin/vtctld \
   -web_dir $VTTOP/web/vtctld \
   -web_dir2 $VTTOP/web/vtctld2/app \
   -workflow_manager_init \
+  -workflow_manager_use_election \
   -service_map 'grpc-vtctl' \
   -backup_storage_implementation file \
   -file_backup_storage_root $VTDATAROOT/backups \

--- a/examples/local/vtctld-up.sh
+++ b/examples/local/vtctld-up.sh
@@ -15,7 +15,8 @@ echo "Starting vtctld..."
 $VTROOT/bin/vtctld \
   -cell $cell \
   -web_dir $VTTOP/web/vtctld \
-  -web_dir2 $VTTOP/web/vtctld2/dist \
+  -web_dir2 $VTTOP/web/vtctld2/app \
+  -workflow_manager_init \
   -service_map 'grpc-vtctl' \
   -backup_storage_implementation file \
   -file_backup_storage_root $VTDATAROOT/backups \


### PR DESCRIPTION
- Add vtctld2 app files into vitess/lite docker image used in the k8s example.
- Add flags to vtctld to use those files to render app2 and allow to use
  workflows.
- Add the same flags in the local example.