### PR TITLE
Issue #2190: Set default timeout for queries

### DIFF
--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -93,14 +93,14 @@ type Config struct {
 // bigger than this).
 var DefaultQsConfig = Config{
 	PoolSize:             16,
-	StreamPoolSize:       750,
+	StreamPoolSize:       200,
 	TransactionCap:       20,
 	TransactionTimeout:   30,
 	MaxResultSize:        10000,
 	MaxDMLRows:           500,
 	QueryCacheSize:       5000,
 	SchemaReloadTime:     30 * 60,
-	QueryTimeout:         0,
+	QueryTimeout:         30,
 	TxPoolTimeout:        1,
 	IdleTimeout:          30 * 60,
 	StreamBufferSize:     32 * 1024,

--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -1682,9 +1682,13 @@ func Rand() int64 {
 	return rand.Int63()
 }
 
-// withTimeout returns a context based on whether the timeout is 0 or not.
+// withTimeout returns a context based on the specified timeout.
+// If the context is the background context or if timeout is 0, the
+// original context is returned as is.
+// TODO(sougou): cleanup code that treats background context as
+// special case.
 func withTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	if timeout == 0 {
+	if timeout == 0 || ctx == context.Background() {
 		return ctx, func() {}
 	}
 	return context.WithTimeout(ctx, timeout)

--- a/go/vt/tabletserver/tabletserver_test.go
+++ b/go/vt/tabletserver/tabletserver_test.go
@@ -909,8 +909,7 @@ func TestTabletServerBeginFail(t *testing.T) {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
-	ctx := context.Background()
-	ctx, cancel := withTimeout(ctx, 1*time.Nanosecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 	tsv.Begin(ctx, &target)
 	_, err = tsv.Begin(ctx, &target)


### PR DESCRIPTION
The default no-timeout value for queries has burnt a few people,
especially because queries can hold transactions hostage in spite
of a transaction timeout. With a default timeout, long-running queries
will eventually get killed, allowing for shutdown workflows to complete
gracefully as expected.
