### PR TITLE
Making DeleteShard more resilient.

### DIFF
--- a/doc/vtctlReference.md
+++ b/doc/vtctlReference.md
@@ -1397,12 +1397,13 @@ Deletes the specified shard(s). In recursive mode, it also deletes all tablets b
 
 #### Example
 
-<pre class="command-example">DeleteShard [-recursive] &lt;keyspace/shard&gt; ...</pre>
+<pre class="command-example">DeleteShard [-recursive] [-even_if_serving] &lt;keyspace/shard&gt; ...</pre>
 
 #### Flags
 
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
+| even_if_serving | Boolean | Remove the shard even if it is serving. Use with caution. |
 | recursive | Boolean | Also delete all tablets belonging to the shard. |
 
 
@@ -2319,17 +2320,17 @@ Sends the provided action name on the specified path.
 
 ### WorkflowCreate
 
-Creates the workflow with the provided parameters. The workflow is also started, unless -nostart is specified.
+Creates the workflow with the provided parameters. The workflow is also started, unless -skip_start is specified.
 
 #### Example
 
-<pre class="command-example">WorkflowCreate [-nostart] &lt;factoryName&gt; [parameters...]</pre>
+<pre class="command-example">WorkflowCreate [-skip_start] &lt;factoryName&gt; [parameters...]</pre>
 
 #### Flags
 
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
-| start | Boolean | If set, the workflow will also be started. |
+| skip_start | Boolean | If set, the workflow will not be started. |
 
 
 #### Arguments

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -247,7 +247,7 @@ var commands = []commandGroup{
 				"[-force] [-recursive] <keyspace/shard> <cell>",
 				"Removes the cell from the shard's Cells list."},
 			{"DeleteShard", commandDeleteShard,
-				"[-recursive] <keyspace/shard> ...",
+				"[-recursive] [-even_if_serving] <keyspace/shard> ...",
 				"Deletes the specified shard(s). In recursive mode, it also deletes all tablets belonging to the shard. Otherwise, there must be no tablets left in the shard."},
 		},
 	},
@@ -1468,6 +1468,7 @@ func commandRemoveShardCell(ctx context.Context, wr *wrangler.Wrangler, subFlags
 
 func commandDeleteShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	recursive := subFlags.Bool("recursive", false, "Also delete all tablets belonging to the shard.")
+	evenIfServing := subFlags.Bool("even_if_serving", false, "Remove the shard even if it is serving. Use with caution.")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
@@ -1480,7 +1481,7 @@ func commandDeleteShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	for _, ks := range keyspaceShards {
-		err := wr.DeleteShard(ctx, ks.Keyspace, ks.Shard, *recursive)
+		err := wr.DeleteShard(ctx, ks.Keyspace, ks.Shard, *recursive, *evenIfServing)
 		switch err {
 		case nil:
 			// keep going

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -850,7 +850,7 @@ func (wr *Wrangler) DeleteKeyspace(ctx context.Context, keyspace string, recursi
 		wr.Logger().Infof("Deleting all shards (and their tablets) in keyspace %v", keyspace)
 		for _, shard := range shards {
 			wr.Logger().Infof("Recursively deleting shard %v/%v", keyspace, shard)
-			if err := wr.DeleteShard(ctx, keyspace, shard, recursive); err != nil && err != topo.ErrNoNode {
+			if err := wr.DeleteShard(ctx, keyspace, shard, true /* recursive */, true /* evenIfServing */); err != nil && err != topo.ErrNoNode {
 				// Unlike the errors below in non-recursive steps, we don't want to
 				// continue if a DeleteShard fails. If we continue and delete the
 				// keyspace, the tablet records will be orphaned, since we'll

--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -127,7 +127,7 @@ func NewFakeTablet(t *testing.T, wr *wrangler.Wrangler, cell string, uid uint32,
 	delete(tablet.PortMap, "start_http_server")
 	_, force := tablet.PortMap["force_init"]
 	delete(tablet.PortMap, "force_init")
-	if err := wr.InitTablet(context.Background(), tablet, force, true, false); err != nil {
+	if err := wr.InitTablet(context.Background(), tablet, force, true /* createShardAndKeyspace */, false /* allowUpdate */); err != nil {
 		t.Fatalf("cannot create tablet %v: %v", uid, err)
 	}
 

--- a/go/vt/wrangler/testlib/shard_test.go
+++ b/go/vt/wrangler/testlib/shard_test.go
@@ -1,0 +1,78 @@
+package testlib
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/tabletmanager/tmclient"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
+	"github.com/youtube/vitess/go/vt/wrangler"
+	"github.com/youtube/vitess/go/vt/zktopo/zktestserver"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+func TestDeleteShardCleanup(t *testing.T) {
+	ctx := context.Background()
+	db := fakesqldb.Register()
+	ts := zktestserver.New(t, []string{"cell1", "cell2"})
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+	vp := NewVtctlPipe(t, ts)
+	defer vp.Close()
+
+	// Create a master, a couple good slaves
+	master := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_MASTER, db)
+	slave := NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
+	remoteSlave := NewFakeTablet(t, wr, "cell2", 2, topodatapb.TabletType_REPLICA, db)
+
+	// Delete the ShardReplication record in cell2
+	if err := ts.DeleteShardReplication(ctx, "cell2", remoteSlave.Tablet.Keyspace, remoteSlave.Tablet.Shard); err != nil {
+		t.Fatalf("DeleteShardReplication failed: %v", err)
+	}
+
+	// Now try to delete the shard without even_if_serving or
+	// recursive flag, should fail on serving check first.
+	if err := vp.Run([]string{
+		"DeleteShard",
+		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+	}); err == nil || !strings.Contains(err.Error(), "is still serving, cannot delete it") {
+		t.Fatalf("DeleteShard() returned wrong error: %v", err)
+	}
+
+	// Now try to delete the shard with even_if_serving, but
+	// without recursive flag, should fail on existing tablets.
+	if err := vp.Run([]string{
+		"DeleteShard",
+		"-even_if_serving",
+		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+	}); err == nil || !strings.Contains(err.Error(), "use -recursive or remove them manually") {
+		t.Fatalf("DeleteShard(evenIfServing=true) returned wrong error: %v", err)
+	}
+
+	// Now try to delete the shard with even_if_serving and recursive,
+	// it should just work.
+	if err := vp.Run([]string{
+		"DeleteShard",
+		"-recursive",
+		"-even_if_serving",
+		master.Tablet.Keyspace + "/" + master.Tablet.Shard,
+	}); err != nil {
+		t.Fatalf("DeleteShard(recursive=true, evenIfServing=true) should have worked but returned: %v", err)
+	}
+
+	// Make sure all tablets are gone.
+	for _, ft := range []*FakeTablet{master, slave, remoteSlave} {
+		if _, err := ts.GetTablet(ctx, ft.Tablet.Alias); err != topo.ErrNoNode {
+			t.Errorf("tablet %v is still in topo: %v", ft.Tablet.Alias, err)
+		}
+	}
+
+	// Make sure the shard is gone.
+	if _, err := ts.GetShard(ctx, master.Tablet.Keyspace, master.Tablet.Shard); err != topo.ErrNoNode {
+		t.Errorf("shard %v/%v is still in topo: %v", master.Tablet.Keyspace, master.Tablet.Shard, err)
+	}
+}

--- a/test/keyspace_test.py
+++ b/test/keyspace_test.py
@@ -246,10 +246,12 @@ class TestKeyspace(unittest.TestCase):
     utils.run_vtctl(
         ['DeleteKeyspace', 'test_delete_keyspace'], expect_fail=True)
     # Can't delete shard if there are tablets present.
-    utils.run_vtctl(['DeleteShard', 'test_delete_keyspace/0'], expect_fail=True)
+    utils.run_vtctl(['DeleteShard', '-even_if_serving',
+                     'test_delete_keyspace/0'], expect_fail=True)
 
     # Use recursive DeleteShard to remove tablets.
-    utils.run_vtctl(['DeleteShard', '-recursive', 'test_delete_keyspace/0'])
+    utils.run_vtctl(['DeleteShard', '-even_if_serving', '-recursive',
+                     'test_delete_keyspace/0'])
     # Now non-recursive DeleteKeyspace should work.
     utils.run_vtctl(['DeleteKeyspace', 'test_delete_keyspace'])
 

--- a/test/resharding.py
+++ b/test/resharding.py
@@ -843,6 +843,11 @@ primary key (name)
     # delete the original shard
     utils.run_vtctl(['DeleteShard', 'test_keyspace/80-'], auto_log=True)
 
+    # make sure we can't delete the destination shard now that it's serving
+    _, stderr = utils.run_vtctl(['DeleteShard', 'test_keyspace/80-c0'],
+                                expect_fail=True)
+    self.assertIn('is still serving, cannot delete it', stderr)
+
     # kill everything
     tablet.kill_tablets([shard_0_master, shard_0_replica, shard_0_ny_rdonly,
                          shard_2_master, shard_2_replica1, shard_2_replica2,

--- a/test/schema.py
+++ b/test/schema.py
@@ -94,7 +94,8 @@ def _teardown_shard_2():
   tablet.kill_tablets(shard_2_tablets)
 
   utils.run_vtctl(
-      ['DeleteShard', '-recursive', 'test_keyspace/2'], auto_log=True)
+      ['DeleteShard', '-recursive', '-even_if_serving', 'test_keyspace/2'],
+      auto_log=True)
 
   for t in shard_2_tablets:
     t.reset_replication()

--- a/test/worker.py
+++ b/test/worker.py
@@ -399,7 +399,8 @@ class TestBaseSplitClone(unittest.TestCase, base_sharding.BaseShardingTest):
     utils.run_vtctl(['RebuildKeyspaceGraph', 'test_keyspace'], auto_log=True)
     for shard in ['0', '-80', '80-']:
       utils.run_vtctl(
-          ['DeleteShard', 'test_keyspace/%s' % shard], auto_log=True)
+          ['DeleteShard', '-even_if_serving', 'test_keyspace/%s' % shard],
+          auto_log=True)
 
 
 class TestBaseSplitCloneResiliency(TestBaseSplitClone):


### PR DESCRIPTION
If we can't find a ShardReplication object, fallback to reading all the
tablets in a cell (canonical tablet records) to find potential matches.

Also adding a unit test for that logic.