### PR TITLE
Migrate PullApprove configuration from v1 to v2.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,25 +1,26 @@
+version: 2
 approve_by_comment: true
 approve_regex: ':lgtm:|^(LGTM|lgtm)'
 reject_regex: '^Rejected'
 reset_on_push: false
-reviewers:
-  name: vitess-eng
-  required: 1
-  members:
-  - alainjobart
-  - alainjobart-bot
-  - AndyDiamondstein
-  - dumbunny
-  - enisoc
-  - enisoc-bot
-  - erzel
-  - erzel-bot
-  - mberlin-bot
-  - michael-berlin
-  - sougou
-  - sougou-bot
-  - thompsonja
-  - thompsonja-bot
-  - pivanof
-  - pivanof-bot
+groups:
+  vitess-eng:
+    required: 1
+    users:
+      - alainjobart
+      - alainjobart-bot
+      - AndyDiamondstein
+      - dumbunny
+      - enisoc
+      - enisoc-bot
+      - erzel
+      - erzel-bot
+      - mberlin-bot
+      - michael-berlin
+      - sougou
+      - sougou-bot
+      - thompsonja
+      - thompsonja-bot
+      - pivanof
+      - pivanof-bot
 


### PR DESCRIPTION
I've followed https://docs.pullapprove.com/migrating-to-v2/ to do so.

We're migrating because v2 is required to recognize GitHub review approvals as LGTM. See https://github.com/pullapprove/support/issues/98#issuecomment-256448778