### PR TITLE
PullApprove: Convert default settings from v1 to v2 as well.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,8 +1,12 @@
 version: 2
-approve_by_comment: true
-approve_regex: ':lgtm:|^(LGTM|lgtm)'
-reject_regex: '^Rejected'
-reset_on_push: false
+
+group_defaults:
+  approve_by_comment:
+    enabled: true
+    approve_regex: ':lgtm:|^(LGTM|lgtm)'
+  reset_on_push:
+    enabled: false
+
 groups:
   vitess-eng:
     required: 1


### PR DESCRIPTION
Other changes:
- Remove "reject_regex" because it's not mentioned in the v2 documentation and we didn't use it anyway.