### PR TITLE
Adding support for proto bind variables.

### DIFF
--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/hack"
+
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
@@ -99,6 +100,8 @@ func BuildValue(goval interface{}) (v Value, err error) {
 		v = MakeTrusted(Datetime, []byte(goval.Format("2006-01-02 15:04:05")))
 	case Value:
 		v = goval
+	case *querypb.BindVariable:
+		return ValueFromBytes(goval.Type, goval.Value)
 	default:
 		return v, fmt.Errorf("unexpected type %T: %v", goval, goval)
 	}

--- a/go/vt/sqlparser/parsed_query_test.go
+++ b/go/vt/sqlparser/parsed_query_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 func TestParsedQuery(t *testing.T) {
@@ -47,6 +49,13 @@ func TestParsedQuery(t *testing.T) {
 				"id": make([]int, 1),
 			},
 			"unexpected type []int: [0]",
+		}, {
+			"simple sqltypes.Value",
+			"select * from a where id1 = :id1",
+			map[string]interface{}{
+				"id1": sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+			},
+			"select * from a where id1 = 1",
 		}, {
 			"list inside bind vars",
 			"select * from a where id in (:vals)",
@@ -171,6 +180,78 @@ func TestParsedQuery(t *testing.T) {
 				},
 			},
 			"values don't match column count",
+		}, {
+			"simple *querypb.BindVariable",
+			"select * from a where id1 = :id",
+			map[string]interface{}{
+				"id": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("123"),
+				},
+			},
+			"select * from a where id1 = 123",
+		}, {
+			"null *querypb.BindVariable",
+			"select * from a where id1 = :id",
+			map[string]interface{}{
+				"id": &querypb.BindVariable{
+					Type: querypb.Type_NULL_TYPE,
+				},
+			},
+			"select * from a where id1 = null",
+		}, {
+			"tuple *querypb.BindVariable",
+			"select * from a where id in ::vals",
+			map[string]interface{}{
+				"vals": &querypb.BindVariable{
+					Type: querypb.Type_TUPLE,
+					Values: []*querypb.Value{
+						{
+							Type:  querypb.Type_INT64,
+							Value: []byte("1"),
+						},
+						{
+							Type:  querypb.Type_VARCHAR,
+							Value: []byte("aa"),
+						},
+					},
+				},
+			},
+			"select * from a where id in (1, 'aa')",
+		}, {
+			"list bind vars 0 arguments",
+			"select * from a where id in ::vals",
+			map[string]interface{}{
+				"vals": &querypb.BindVariable{
+					Type: querypb.Type_TUPLE,
+				},
+			},
+			"empty list supplied for vals",
+		}, {
+			"non-list bind var supplied",
+			"select * from a where id in ::vals",
+			map[string]interface{}{
+				"vals": &querypb.BindVariable{
+					Type:  querypb.Type_INT64,
+					Value: []byte("1"),
+				},
+			},
+			"unexpected list arg type *querypb.BindVariable(INT64) for key vals",
+		}, {
+			"list bind var for non-list",
+			"select * from a where id = :vals",
+			map[string]interface{}{
+				"vals": &querypb.BindVariable{
+					Type: querypb.Type_TUPLE,
+					Values: []*querypb.Value{
+						{
+							Type:  querypb.Type_INT64,
+							Value: []byte("1"),
+						},
+					},
+				},
+			},
+			"unexpected arg type *querypb.BindVariable(TUPLE) for key vals",
 		},
 	}
 

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -61,7 +61,7 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 			case rune:
 				buf.WriteRune(v)
 			default:
-				panic(fmt.Sprintf("unexpected type %T", v))
+				panic(fmt.Sprintf("unexpected TrackedBuffer type %T", v))
 			}
 		case 's':
 			switch v := values[fieldnum].(type) {
@@ -70,7 +70,7 @@ func (buf *TrackedBuffer) Myprintf(format string, values ...interface{}) {
 			case string:
 				buf.WriteString(v)
 			default:
-				panic(fmt.Sprintf("unexpected type %T", v))
+				panic(fmt.Sprintf("unexpected TrackedBuffer type %T", v))
 			}
 		case 'v':
 			node := values[fieldnum].(SQLNode)

--- a/go/vt/tabletserver/codex.go
+++ b/go/vt/tabletserver/codex.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/schema"
 	"github.com/youtube/vitess/go/vt/sqlparser"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // buildValueList builds the set of PK reference rows used to drive the next query.

--- a/go/vt/tabletserver/query_rules_test.go
+++ b/go/vt/tabletserver/query_rules_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
 
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
@@ -356,12 +357,34 @@ var bvtestcases = []BindVarTestCase{
 	{BindVarCond{"a", true, true, QRNoOp, nil}, 1, false},
 	{BindVarCond{"a", false, true, QRNoOp, nil}, 1, true},
 
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_INT24,
+		Value: []byte{'1'},
+	}, false},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_INT32,
+		Value: []byte{'1', '0'},
+	}, true},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'1', '0'},
+	}, true},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'-', '1', '0'},
+	}, false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int(10), true},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int8(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int8(10), true},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int16(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int32(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int64(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint(10), true},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint8(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint8(10), true},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint16(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint32(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, uint64(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, int8(-1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcuint64(10)}, "abc", true},
@@ -391,12 +414,33 @@ var bvtestcases = []BindVarTestCase{
 	{BindVarCond{"a", true, true, QRLessEqual, bvcuint64(10)}, int8(11), false},
 	{BindVarCond{"a", true, true, QRLessEqual, bvcuint64(10)}, int8(-1), true},
 
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_INT24,
+		Value: []byte{'1'},
+	}, false},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_INT32,
+		Value: []byte{'1', '0'},
+	}, true},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'1', '0'},
+	}, true},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'-', '1', '0'},
+	}, false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int8(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int8(10), true},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int16(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int32(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, int64(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint(0xFFFFFFFFFFFFFFFF), false},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint8(10), true},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint16(1), false},
+	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint32(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint64(1), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, uint64(0xFFFFFFFFFFFFFFFF), false},
 	{BindVarCond{"a", true, true, QREqual, bvcint64(10)}, "abc", true},
@@ -426,6 +470,14 @@ var bvtestcases = []BindVarTestCase{
 	{BindVarCond{"a", true, true, QRLessEqual, bvcint64(10)}, int8(11), false},
 	{BindVarCond{"a", true, true, QRLessEqual, bvcint64(10)}, uint64(0xFFFFFFFFFFFFFFFF), false},
 
+	{BindVarCond{"a", true, true, QREqual, bvcstring("b")}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'a'},
+	}, false},
+	{BindVarCond{"a", true, true, QREqual, bvcstring("b")}, &querypb.BindVariable{
+		Type:  querypb.Type_VARCHAR,
+		Value: []byte{'b'},
+	}, true},
 	{BindVarCond{"a", true, true, QREqual, bvcstring("b")}, "a", false},
 	{BindVarCond{"a", true, true, QREqual, bvcstring("b")}, "b", true},
 	{BindVarCond{"a", true, true, QREqual, bvcstring("b")}, "c", false},

--- a/go/vt/tabletserver/querytypes/proto3_test.go
+++ b/go/vt/tabletserver/querytypes/proto3_test.go
@@ -267,7 +267,7 @@ func TestBindVariablesToProto3Errors(t *testing.T) {
 	}{{
 		name: "chan",
 		in:   make(chan bool),
-		out:  "key: bv: unexpected type chan bool",
+		out:  "key: bv: bindVariableToValue: unexpected type chan bool",
 	}, {
 		name: "empty []interface{}",
 		in:   []interface{}{},
@@ -295,7 +295,7 @@ func TestBindVariablesToProto3Errors(t *testing.T) {
 	}, {
 		name: "chan in []interface{}",
 		in:   []interface{}{make(chan bool)},
-		out:  "key: bv: unexpected type chan bool",
+		out:  "key: bv: bindVariableToValue: unexpected type chan bool",
 	}}
 	for _, tcase := range testcases {
 		bv := map[string]interface{}{

--- a/go/vt/vtgate/router_dml_test.go
+++ b/go/vt/vtgate/router_dml_test.go
@@ -116,7 +116,7 @@ func TestUpdateEqualFail(t *testing.T) {
 	_, err = routerExec(router, "update user set a=2 where id = :id", map[string]interface{}{
 		"id": "aa",
 	})
-	want = `execUpdateEqual: hash.Map: getNumber: strconv.ParseUint: parsing "aa": invalid syntax`
+	want = `execUpdateEqual: hash.Map: parseString: strconv.ParseUint: parsing "aa": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("routerExec: %v, want %v", err, want)
 	}
@@ -275,7 +275,7 @@ func TestDeleteEqualFail(t *testing.T) {
 	_, err = routerExec(router, "delete from user where id = :id", map[string]interface{}{
 		"id": "aa",
 	})
-	want = `execDeleteEqual: hash.Map: getNumber: strconv.ParseUint: parsing "aa": invalid syntax`
+	want = `execDeleteEqual: hash.Map: parseString: strconv.ParseUint: parsing "aa": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("routerExec: %v, want %v", err, want)
 	}
@@ -644,7 +644,7 @@ func TestInsertFail(t *testing.T) {
 	}
 
 	_, err = routerExec(router, "insert into music_extra_reversed(music_id, user_id) values (1, 'aa')", nil)
-	want = `execInsertSharded: hash.Verify: getNumber: strconv.ParseUint: parsing "aa": invalid syntax`
+	want = `execInsertSharded: hash.Verify: parseString: strconv.ParseUint: parsing "aa": invalid syntax`
 	if err == nil || err.Error() != want {
 		t.Errorf("routerExec: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/binarymd5.go
+++ b/go/vt/vtgate/vindexes/binarymd5.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
-
-	"github.com/youtube/vitess/go/sqltypes"
 )
 
 // BinaryMD5 is a vindex that hashes binary bits to a keyspace id.
@@ -56,16 +54,6 @@ func binHashKey(key interface{}) ([]byte, error) {
 		return nil, err
 	}
 	return binHash(source), nil
-}
-
-func getBytes(key interface{}) ([]byte, error) {
-	switch v := key.(type) {
-	case []byte:
-		return v, nil
-	case sqltypes.Value:
-		return v.Raw(), nil
-	}
-	return nil, fmt.Errorf("unexpected data type for binHash: %T", key)
 }
 
 func binHash(source []byte) []byte {

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -11,9 +11,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"strconv"
-
-	"github.com/youtube/vitess/go/sqltypes"
 )
 
 // Hash defines vindex that hashes an int64 to a KeyspaceId
@@ -63,41 +60,6 @@ func (vind *Hash) Verify(_ VCursor, id interface{}, ksid []byte) (bool, error) {
 // ReverseMap returns the id from ksid.
 func (vind *Hash) ReverseMap(_ VCursor, ksid []byte) (interface{}, error) {
 	return vunhash(ksid)
-}
-
-func getNumber(v interface{}) (int64, error) {
-	if val, ok := v.([]byte); ok {
-		v = string(val)
-	}
-	if val, ok := v.(sqltypes.Value); ok {
-		v = val.String()
-	}
-
-	switch v := v.(type) {
-	case int:
-		return int64(v), nil
-	case int32:
-		return int64(v), nil
-	case int64:
-		return v, nil
-	case uint:
-		return int64(v), nil
-	case uint32:
-		return int64(v), nil
-	case uint64:
-		return int64(v), nil
-	case string:
-		signed, err := strconv.ParseInt(v, 0, 64)
-		if err == nil {
-			return signed, nil
-		}
-		unsigned, err := strconv.ParseUint(v, 0, 64)
-		if err == nil {
-			return int64(unsigned), nil
-		}
-		return 0, fmt.Errorf("getNumber: %v", err)
-	}
-	return 0, fmt.Errorf("unexpected type for %v: %T", v, v)
 }
 
 var block3DES cipher.Block

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -74,7 +74,7 @@ func TestNumericStaticMapMapBadData(t *testing.T) {
 	}
 
 	_, err = numericStaticMap.(Unique).Map(nil, []interface{}{1.1})
-	want := `NumericStaticMap.Map: unexpected type for 1.1: float64`
+	want := `NumericStaticMap.Map: getNumber: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("NumericStaticMap.Map: %v, want %v", err, want)
 	}
@@ -102,7 +102,7 @@ func TestNumericStaticMapVerifyBadData(t *testing.T) {
 	}
 
 	_, err = numericStaticMap.Verify(nil, 1.1, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
-	want := `NumericStaticMap.Verify: unexpected type for 1.1: float64`
+	want := `NumericStaticMap.Verify: getNumber: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numericStaticMap.Map: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -55,7 +55,7 @@ func TestNumericMap(t *testing.T) {
 
 func TestNumericMapBadData(t *testing.T) {
 	_, err := numeric.(Unique).Map(nil, []interface{}{1.1})
-	want := `Numeric.Map: unexpected type for 1.1: float64`
+	want := `Numeric.Map: getNumber: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)
 	}
@@ -73,7 +73,7 @@ func TestNumericVerify(t *testing.T) {
 
 func TestNumericVerifyBadData(t *testing.T) {
 	_, err := numeric.Verify(nil, 1.1, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
-	want := `Numeric.Verify: unexpected type for 1.1: float64`
+	want := `Numeric.Verify: getNumber: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/utils.go
+++ b/go/vt/vtgate/vindexes/utils.go
@@ -1,0 +1,96 @@
+package vindexes
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// parseString takes a string and tries to extract a number from it.
+func parseString(s string) (int64, error) {
+	signed, err := strconv.ParseInt(s, 0, 64)
+	if err == nil {
+		return signed, nil
+	}
+	unsigned, err := strconv.ParseUint(s, 0, 64)
+	if err == nil {
+		return int64(unsigned), nil
+	}
+	return 0, fmt.Errorf("parseString: %v", err)
+}
+
+// parseValue handles the type + value parameters.
+func parseValue(typ querypb.Type, val []byte) (int64, error) {
+	if sqltypes.IsSigned(typ) {
+		signed, err := strconv.ParseInt(string(val), 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parseValue: %v", err)
+		}
+		return signed, nil
+	}
+	if sqltypes.IsUnsigned(typ) {
+		unsigned, err := strconv.ParseUint(string(val), 0, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parseValue: %v", err)
+		}
+		return int64(unsigned), nil
+	}
+	if sqltypes.IsText(typ) || sqltypes.IsBinary(typ) {
+		return parseString(string(val))
+	}
+	return 0, fmt.Errorf("parseValue: incompatible type %v", typ)
+}
+
+// getNumber extracts a number from a bind variable.
+// It handles most bind variable types gracefully.
+func getNumber(v interface{}) (int64, error) {
+	switch v := v.(type) {
+	case int:
+		return int64(v), nil
+	case int8:
+		return int64(v), nil
+	case int16:
+		return int64(v), nil
+	case int32:
+		return int64(v), nil
+	case int64:
+		return v, nil
+	case uint:
+		return int64(v), nil
+	case uint8:
+		return int64(v), nil
+	case uint16:
+		return int64(v), nil
+	case uint32:
+		return int64(v), nil
+	case uint64:
+		return int64(v), nil
+	case []byte:
+		return parseString(string(v))
+	case string:
+		return parseString(v)
+	case sqltypes.Value:
+		return parseValue(v.Type(), v.Raw())
+	case *querypb.BindVariable:
+		return parseValue(v.Type, v.Value)
+	}
+	return 0, fmt.Errorf("getNumber: unexpected type for %v: %T", v, v)
+}
+
+// getBytes returns the raw bytes for a value.
+func getBytes(key interface{}) ([]byte, error) {
+	switch v := key.(type) {
+	case string:
+		return []byte(v), nil
+	case []byte:
+		return v, nil
+	case sqltypes.Value:
+		return v.Raw(), nil
+	case *querypb.BindVariable:
+		return v.Value, nil
+	}
+	return nil, fmt.Errorf("unexpected data type for getBytes: %T", key)
+}

--- a/go/vt/vtgate/vindexes/utils_test.go
+++ b/go/vt/vtgate/vindexes/utils_test.go
@@ -1,0 +1,140 @@
+package vindexes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestGetNumber(t *testing.T) {
+	tcases := []struct {
+		in  interface{}
+		out string
+	}{{
+		in:  []byte{'1', '2', '3'},
+		out: "123",
+	}, {
+		in:  sqltypes.MakeTrusted(querypb.Type_UINT64, []byte{'1', '2', '3'}),
+		out: "123",
+	}, {
+		in:  int(12),
+		out: "12",
+	}, {
+		in:  int8(12),
+		out: "12",
+	}, {
+		in:  int16(12),
+		out: "12",
+	}, {
+		in:  int32(12),
+		out: "12",
+	}, {
+		in:  int64(-12),
+		out: "-12",
+	}, {
+		in:  uint(125),
+		out: "125",
+	}, {
+		in:  uint8(125),
+		out: "125",
+	}, {
+		in:  uint16(125),
+		out: "125",
+	}, {
+		in:  uint32(124),
+		out: "124",
+	}, {
+		in:  uint64(123),
+		out: "123",
+	}, {
+		in:  "1234",
+		out: "1234",
+	}, {
+		in:  "18446744073709551606", // 2^64-10
+		out: "-10",
+	}, {
+		in:  "not a number",
+		out: `parseString: strconv.ParseUint: parsing "not a number": invalid syntax`,
+	}, {
+		in: &querypb.BindVariable{
+			Type:  querypb.Type_INT64,
+			Value: []byte{'-', '1', '2', '3'},
+		},
+		out: "-123",
+	}, {
+		in: &querypb.BindVariable{
+			Type:  querypb.Type_UINT64,
+			Value: []byte{'1', '2', '3'},
+		},
+		out: "123",
+	}, {
+		in: &querypb.BindVariable{
+			Type:  querypb.Type_VARCHAR,
+			Value: []byte{'1', '2', '3'},
+		},
+		out: "123",
+	}, {
+		in: &querypb.BindVariable{
+			Type:  querypb.Type_VARBINARY,
+			Value: []byte{'1', '2', '3'},
+		},
+		out: "123",
+	}, {
+		in: &querypb.BindVariable{
+			Type: querypb.Type_TUPLE,
+		},
+		out: "parseValue: incompatible type TUPLE",
+	}}
+	for _, tcase := range tcases {
+		n, err := getNumber(tcase.in)
+		got := ""
+		if err != nil {
+			got = err.Error()
+		} else {
+			got = fmt.Sprintf("%v", n)
+		}
+		if got != tcase.out {
+			t.Errorf("getNumber(%v) got %v %v expected %v", tcase.in, n, err, tcase.out)
+		}
+	}
+}
+
+func TestGetBytes(t *testing.T) {
+	tcases := []struct {
+		in  interface{}
+		out string
+	}{{
+		in:  []byte{'1', '2', '3'},
+		out: "123",
+	}, {
+		in:  "1234",
+		out: "1234",
+	}, {
+		in:  sqltypes.MakeTrusted(querypb.Type_UINT64, []byte{'1', '2', '3'}),
+		out: "123",
+	}, {
+		in: &querypb.BindVariable{
+			Type:  querypb.Type_VARBINARY,
+			Value: []byte{'1', '2', '3'},
+		},
+		out: "123",
+	}, {
+		in:  65,
+		out: "unexpected data type for getBytes: int",
+	}}
+	for _, tcase := range tcases {
+		b, err := getBytes(tcase.in)
+		got := ""
+		if err != nil {
+			got = err.Error()
+		} else {
+			got = string(b)
+		}
+		if got != tcase.out {
+			t.Errorf("getBytes(%v) got %v %v expected %v", tcase.in, b, err, tcase.out)
+		}
+	}
+}


### PR DESCRIPTION
Note we do not use that support yet. It will be enabled in a separate
commit. Right now, we just handle querypb.BindVariable as a type in the
map[string]interface used with bind variables.

In the process, handling a bunch more types and adding tests for the
handling functions:
- Simplifying bindVariableToValue.
- Making vindexes.getNumber and getBytes better, with more tests.
- Also adding more types and test cases for query rules.