### PR TITLE
go1.8 compliant functions in vitessdriver

### DIFF
--- a/examples/local/client.go
+++ b/examples/local/client.go
@@ -30,7 +30,7 @@ func main() {
 	timeout := 10 * time.Second
 
 	// Connect to vtgate.
-	db, err := vitessdriver.Open(*server, "master", timeout)
+	db, err := vitessdriver.Open(*server, "", "master", timeout)
 	if err != nil {
 		fmt.Printf("client error: %v\n", err)
 		os.Exit(1)
@@ -83,7 +83,7 @@ func main() {
 	// Note that this may be behind master due to replication lag.
 	fmt.Println("Reading from replica...")
 
-	dbr, err := vitessdriver.Open(*server, "replica", timeout)
+	dbr, err := vitessdriver.Open(*server, "", "replica", timeout)
 	if err != nil {
 		fmt.Printf("client error: %v\n", err)
 		os.Exit(1)

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -34,7 +34,6 @@ in the form of :v1, :v2, etc.
 	streaming     = flag.Bool("streaming", false, "use a streaming query")
 	bindVariables = newBindvars("bind_variables", "bind variables as a json list")
 	keyspace      = flag.String("keyspace", "", "Keyspace of a specific keyspace/shard to target. If shard is also specified, disables v3. Otherwise it's the default keyspace to use.")
-	shard         = flag.String("shard", "", "Shard of a specific keyspace/shard to target. Disables vtgate v3. Requires keyspace.")
 	jsonOutput    = flag.Bool("json", false, "Output JSON instead of human-readable table")
 )
 
@@ -110,7 +109,6 @@ func main() {
 		Protocol:   *vtgateconn.VtgateProtocol,
 		Address:    *server,
 		Keyspace:   *keyspace,
-		Shard:      *shard,
 		TabletType: *tabletType,
 		Timeout:    *timeout,
 		Streaming:  *streaming,

--- a/go/vt/vitessdriver/doc.go
+++ b/go/vt/vitessdriver/doc.go
@@ -42,12 +42,11 @@ VTGate is capable of breaking up your query into parts, routing them to the
 appropriate shards and combining the results, thereby giving the semblance
 of a unified database.
 
-See the vtgate v3 Features doc for an overview:
+The driver uses the V3 API which doesn't require you to specify routing
+information. You just send the query as if Vitess was a regular database.
+VTGate analyzes the query and uses additional metadata called VSchema
+to perform the necessary routing. See the vtgate v3 Features doc for an overview:
 https://github.com/youtube/vitess/blob/master/doc/VTGateV3Features.md
-
-To enable vtgate v3, you need to create a VSchema. A VSchema defines for vtgate
-the properties of your Vitess setup (e.g. what is the sharding key, which
-cross-shard indexes should be maintained, what are the AUTO_INCREMENT columns).
 
 As of 12/2015, the VSchema creation is not documented yet as we are in the
 process of simplifying the VSchema definition and the overall process for
@@ -69,7 +68,7 @@ Isolation levels
 The Vitess isolation model is different from the one exposed by a traditional database.
 Isolation levels are controlled by connection parameters instead of Go's IsolationLevel.
 You can perform master, replica or rdonly reads. Master reads give you read-after-write
-consitency. Replica and rdonly reads give you eventual consistency. Replica reads
+consistency. Replica and rdonly reads give you eventual consistency. Replica reads
 are for satisfying OLTP workloads while rdonly is for OLAP.
 
 All transactions must be sent to the master where writes are allowed.

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -264,6 +264,7 @@ func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 	if c.Streaming {
 		stream, err := c.vtgateConn.StreamExecute(ctx, query, bindVars, c.tabletTypeProto, nil)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		return newStreamingRows(stream, cancel), nil

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -12,11 +12,11 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
-	"golang.org/x/net/context"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
@@ -30,23 +30,10 @@ func init() {
 // It opens a database connection to vtgate running at "address".
 //
 // Note that this is the vtgate v3 mode and requires a loaded VSchema.
-func Open(address, tabletType string, timeout time.Duration) (*sql.DB, error) {
-	return OpenShard(address, "" /* keyspace */, "" /* shard */, tabletType, timeout)
-}
-
-// OpenShard connects to vtgate running at "address".
-//
-// Unlike Open(), all queries will target a specific shard in a given keyspace
-// ("fallback" mode to vtgate v1).
-//
-// This mode is recommended when you want to try out Vitess initially because it
-// does not require defining a VSchema. Just replace the MySQL/MariaDB driver
-// invocation in your application with the Vitess driver.
-func OpenShard(address, keyspace, shard, tabletType string, timeout time.Duration) (*sql.DB, error) {
+func Open(address, keyspace, tabletType string, timeout time.Duration) (*sql.DB, error) {
 	c := newDefaultConfiguration()
 	c.Address = address
 	c.Keyspace = keyspace
-	c.Shard = shard
 	c.TabletType = tabletType
 	c.Timeout = timeout
 	return OpenWithConfiguration(c)
@@ -56,22 +43,13 @@ func OpenShard(address, keyspace, shard, tabletType string, timeout time.Duratio
 // the results.
 //
 // The streaming mode is recommended for large results.
-func OpenForStreaming(address, tabletType string, timeout time.Duration) (*sql.DB, error) {
-	return OpenShardForStreaming(address, "" /* keyspace */, "" /* shard */, tabletType, timeout)
-}
-
-// OpenShardForStreaming is the same as OpenShard() but uses streaming RPCs to
-// retrieve the results.
-//
-// The streaming mode is recommended for large results.
-func OpenShardForStreaming(address, keyspace, shard, tabletType string, timeout time.Duration) (*sql.DB, error) {
+func OpenForStreaming(address, keyspace, tabletType string, timeout time.Duration) (*sql.DB, error) {
 	c := newDefaultConfiguration()
 	c.Address = address
 	c.Keyspace = keyspace
-	c.Shard = shard
 	c.TabletType = tabletType
-	c.Timeout = timeout
 	c.Streaming = true
+	c.Timeout = timeout
 	return OpenWithConfiguration(c)
 }
 
@@ -111,18 +89,11 @@ func (d drv) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	if c.Keyspace == "" && c.Shard != "" {
-		return nil, fmt.Errorf("the shard parameter requires a keyspace parameter. shard: %v", c.Shard)
-	}
-	if c.useExecuteShards() {
-		log.Infof("Sending queries only to keyspace/shard: %v/%v", c.Keyspace, c.Shard)
-	}
 	c.tabletTypeProto, err = topoproto.ParseTabletType(c.TabletType)
 	if err != nil {
 		return nil, err
 	}
-	err = c.dial()
-	if err != nil {
+	if err = c.dial(); err != nil {
 		return nil, err
 	}
 	return c, nil
@@ -143,22 +114,8 @@ type Configuration struct {
 	// Format: hostname:port
 	Address string
 
-	// Keyspace of a specific keyspace to target.
-	//
-	// If Shard is also specified, vtgate v1 will be used instead
-	// of v3 (ExecuteShards and StreamExecuteShards), and all
-	// requests will be sent only to that particular shard.  This
-	// functionality is meant for initial migrations from
-	// MySQL/MariaDB to Vitess.
-	//
-	// If Shard is not specified, we will use the v3 API (Execute
-	// and StreamExecute calls), and specify this Keyspace as the
-	// default keyspace value.
+	// Keyspace specifies the default keyspace.
 	Keyspace string
-
-	// Shard of a specific keyspace and shard to target. See
-	// Keyspace comment, this will disable vtgate v3.
-	Shard string
 
 	// TabletType is the type of tablet you want to access and affects the
 	// freshness of read data.
@@ -176,6 +133,7 @@ type Configuration struct {
 	Streaming bool
 
 	// Timeout after which a pending query will be aborted.
+	// TODO(sougou): deprecate once we switch to go1.8.
 	Timeout time.Duration
 }
 
@@ -204,7 +162,6 @@ func (c *Configuration) setDefaults() {
 	if c.TabletType == "" {
 		c.TabletType = "master"
 	}
-	// c.Streaming = false is enforced by Go's zero value.
 }
 
 type conn struct {
@@ -225,12 +182,12 @@ func (c *conn) dial() error {
 	return err
 }
 
-func (c *conn) useExecuteShards() bool {
-	return c.Keyspace != "" && c.Shard != ""
-}
-
 func (c *conn) Prepare(query string) (driver.Stmt, error) {
 	return &stmt{c: c, query: query}, nil
+}
+
+func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return c.Prepare(query)
 }
 
 func (c *conn) Close() error {
@@ -239,11 +196,12 @@ func (c *conn) Close() error {
 }
 
 func (c *conn) Begin() (driver.Tx, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
 	if c.Streaming {
 		return nil, errors.New("transaction not allowed for streaming connection")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	defer cancel()
 	tx, err := c.vtgateConn.Begin(ctx)
 	if err != nil {
 		return nil, err
@@ -253,27 +211,80 @@ func (c *conn) Begin() (driver.Tx, error) {
 }
 
 func (c *conn) Commit() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	return c.CommitContext(ctx)
+}
+
+func (c *conn) CommitContext(ctx context.Context) error {
 	if c.tx == nil {
 		return errors.New("commit: not in transaction")
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer func() {
-		cancel()
 		c.tx = nil
 	}()
 	return c.tx.Commit(ctx)
 }
 
 func (c *conn) Rollback() error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+	return c.RollbackContext(ctx)
+}
+
+func (c *conn) RollbackContext(ctx context.Context) error {
 	if c.tx == nil {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
 	defer func() {
-		cancel()
 		c.tx = nil
 	}()
 	return c.tx.Rollback(ctx)
+}
+
+func (c *conn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	if c.Streaming {
+		return nil, errors.New("Exec not allowed for streaming connections")
+	}
+
+	qr, err := c.exec(ctx, query, bindVarsFromValues(args))
+	if err != nil {
+		return nil, err
+	}
+	return result{int64(qr.InsertID), int64(qr.RowsAffected)}, nil
+}
+
+func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	bindVars := bindVarsFromValues(args)
+
+	if c.Streaming {
+		stream, err := c.vtgateConn.StreamExecute(ctx, query, bindVars, c.tabletTypeProto, nil)
+		if err != nil {
+			return nil, err
+		}
+		return newStreamingRows(stream, cancel), nil
+	}
+	// Do not cancel in case of a streaming query.
+	// It will be called when streamingRows is closed later.
+	defer cancel()
+
+	qr, err := c.exec(ctx, query, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	return newRows(qr), nil
+}
+
+func (c *conn) exec(ctx context.Context, query string, bindVars map[string]interface{}) (*sqltypes.Result, error) {
+	if c.tx != nil {
+		return c.tx.Execute(ctx, query, bindVars, c.tabletTypeProto, nil)
+	}
+	// Non-transactional case.
+	return c.vtgateConn.Execute(ctx, query, bindVars, c.tabletTypeProto, nil)
 }
 
 type stmt struct {
@@ -291,65 +302,14 @@ func (s *stmt) NumInput() int {
 }
 
 func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.c.Timeout)
-	defer cancel()
-
-	if s.c.Streaming {
-		return nil, errors.New("Exec not allowed for streaming connections")
-	}
-
-	qr, err := s.executeVitess(ctx, args)
-	if err != nil {
-		return nil, err
-	}
-	return result{int64(qr.InsertID), int64(qr.RowsAffected)}, nil
+	return s.c.Exec(s.query, args)
 }
 
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), s.c.Timeout)
-
-	if s.c.Streaming {
-		var stream sqltypes.ResultStream
-		var err error
-		if s.c.useExecuteShards() {
-			stream, err = s.c.vtgateConn.StreamExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletTypeProto, nil)
-		} else {
-			stream, err = s.c.vtgateConn.StreamExecute(ctx, s.query, makeBindVars(args), s.c.tabletTypeProto, nil)
-		}
-		if err != nil {
-			return nil, err
-		}
-		return newStreamingRows(stream, cancel), nil
-	}
-	// Do not cancel in case of a streaming query. It will do it itself.
-	defer cancel()
-
-	qr, err := s.executeVitess(ctx, args)
-	if err != nil {
-		return nil, err
-	}
-	return newRows(qr), nil
+	return s.c.Query(s.query, args)
 }
 
-func (s *stmt) executeVitess(ctx context.Context, args []driver.Value) (*sqltypes.Result, error) {
-	if s.c.tx != nil {
-		if s.c.useExecuteShards() {
-			return s.c.tx.ExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletTypeProto, nil)
-		}
-		return s.c.tx.Execute(ctx, s.query, makeBindVars(args), s.c.tabletTypeProto, nil)
-	}
-
-	// Non-transactional case.
-	if s.c.useExecuteShards() {
-		return s.c.vtgateConn.ExecuteShards(ctx, s.query, s.c.Keyspace, []string{s.c.Shard}, makeBindVars(args), s.c.tabletTypeProto, nil)
-	}
-	return s.c.vtgateConn.Execute(ctx, s.query, makeBindVars(args), s.c.tabletTypeProto, nil)
-}
-
-func makeBindVars(args []driver.Value) map[string]interface{} {
-	if len(args) == 0 {
-		return map[string]interface{}{}
-	}
+func bindVarsFromValues(args []driver.Value) map[string]interface{} {
 	bv := make(map[string]interface{}, len(args))
 	for i, v := range args {
 		bv[fmt.Sprintf("v%d", i+1)] = v

--- a/go/vt/vitessdriver/driver_go18.go
+++ b/go/vt/vitessdriver/driver_go18.go
@@ -1,0 +1,121 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.8
+
+// TODO(sougou): Merge this with driver.go once go1.7 is deprecated.
+// Also write tests for these new functions once go1.8 becomes mainstream.
+
+package vitessdriver
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+)
+
+var (
+	errNoIntermixing        = errors.New("named and positional arguments intermixing disallowed")
+	errIsolationUnsupported = errors.New("isolation levels are not supported")
+)
+
+// Type-check interfaces.
+var (
+	_ driver.QueryerContext   = &conn{}
+	_ driver.ExecerContext    = &conn{}
+	_ driver.StmtQueryContext = &stmt{}
+	_ driver.StmtExecContext  = &stmt{}
+)
+
+func (c *conn) BeginContext(ctx context.Context) (driver.Tx, error) {
+	if c.Streaming {
+		return nil, errors.New("transaction not allowed for streaming connection")
+	}
+	if _, ok := driver.IsolationFromContext(ctx); ok {
+		return nil, errIsolationUnsupported
+	}
+	tx, err := c.vtgateConn.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.tx = tx
+	return c, nil
+}
+
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if c.Streaming {
+		return nil, errors.New("Exec not allowed for streaming connections")
+	}
+
+	bv, err := bindVarsFromNamedValues(args)
+	if err != nil {
+		return nil, err
+	}
+	qr, err := c.exec(ctx, query, bv)
+	if err != nil {
+		return nil, err
+	}
+	return result{int64(qr.InsertID), int64(qr.RowsAffected)}, nil
+}
+
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	bv, err := bindVarsFromNamedValues(args)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.Streaming {
+		stream, err := c.vtgateConn.StreamExecute(ctx, query, bv, c.tabletTypeProto, nil)
+		if err != nil {
+			return nil, err
+		}
+		return newStreamingRows(stream, nil), nil
+	}
+
+	qr, err := c.exec(ctx, query, bv)
+	if err != nil {
+		return nil, err
+	}
+	return newRows(qr), nil
+}
+
+func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	return s.c.ExecContext(ctx, s.query, args)
+}
+
+func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	return s.c.QueryContext(ctx, s.query, args)
+}
+
+func bindVarsFromNamedValues(args []driver.NamedValue) (map[string]interface{}, error) {
+	bv := make(map[string]interface{}, len(args))
+	nameUsed := false
+	for i, v := range args {
+		if i == 0 {
+			// Determine if args are based on names or ordinals.
+			if v.Name != "" {
+				nameUsed = true
+			}
+		} else {
+			// Verify that there's no intermixing.
+			if nameUsed && v.Name == "" {
+				return nil, errNoIntermixing
+			}
+			if !nameUsed && v.Name != "" {
+				return nil, errNoIntermixing
+			}
+		}
+		if v.Name == "" {
+			bv[fmt.Sprintf("v%d", i+1)] = v.Value
+		} else {
+			if v.Name[0] == ':' || v.Name[0] == '@' {
+				bv[v.Name[1:]] = v.Value
+			} else {
+				bv[v.Name] = v.Value
+			}
+		}
+	}
+	return bv, nil
+}

--- a/go/vt/vitessdriver/driver_go18_test.go
+++ b/go/vt/vitessdriver/driver_go18_test.go
@@ -1,0 +1,112 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.8
+
+// TODO(sougou): delete go1.7 tests after 1.8 becomes mainstream.
+
+package vitessdriver
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBeginIsolation(t *testing.T) {
+	db, err := Open(testAddress, "", "master", 30*time.Second)
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+	ctx := sql.IsolationContext(context.Background(), sql.LevelReadUncommitted)
+	_, err = db.BeginContext(ctx)
+	want := errIsolationUnsupported.Error()
+	if err == nil || err.Error() != want {
+		t.Errorf("Begin: %v, want %s", err, want)
+	}
+}
+
+func TestBindVars(t *testing.T) {
+	var testcases = []struct {
+		desc   string
+		in     []driver.NamedValue
+		out    map[string]interface{}
+		outErr string
+	}{{
+		desc: "all names",
+		in: []driver.NamedValue{{
+			Name:  "n1",
+			Value: int64(0),
+		}, {
+			Name:  "n2",
+			Value: "abcd",
+		}},
+		out: map[string]interface{}{
+			"n1": int64(0),
+			"n2": "abcd",
+		},
+	}, {
+		desc: "prefixed names",
+		in: []driver.NamedValue{{
+			Name:  ":n1",
+			Value: int64(0),
+		}, {
+			Name:  "@n2",
+			Value: "abcd",
+		}},
+		out: map[string]interface{}{
+			"n1": int64(0),
+			"n2": "abcd",
+		},
+	}, {
+		desc: "all positional",
+		in: []driver.NamedValue{{
+			Ordinal: 1,
+			Value:   int64(0),
+		}, {
+			Ordinal: 2,
+			Value:   "abcd",
+		}},
+		out: map[string]interface{}{
+			"v1": int64(0),
+			"v2": "abcd",
+		},
+	}, {
+		desc: "name, then position",
+		in: []driver.NamedValue{{
+			Name:  "n1",
+			Value: int64(0),
+		}, {
+			Ordinal: 2,
+			Value:   "abcd",
+		}},
+		outErr: errNoIntermixing.Error(),
+	}, {
+		desc: "position, then name",
+		in: []driver.NamedValue{{
+			Ordinal: 1,
+			Value:   int64(0),
+		}, {
+			Name:  "n2",
+			Value: "abcd",
+		}},
+		outErr: errNoIntermixing.Error(),
+	}}
+	for _, tc := range testcases {
+		bv, err := bindVarsFromNamedValues(tc.in)
+		if bv != nil {
+			if !reflect.DeepEqual(bv, tc.out) {
+				t.Errorf("%s: %v, want %v", tc.desc, bv, tc.out)
+			}
+		} else {
+			if err == nil || err.Error() != tc.outErr {
+				t.Errorf("%s: %v, want %v", tc.desc, err, tc.outErr)
+			}
+		}
+	}
+}

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -28,14 +28,6 @@ type queryExecute struct {
 	NotInTransaction bool
 }
 
-// queryExecuteSpecificShard contains all the fields we use to test the
-// vtgate v2 fallback mode which uses vtgateconn.ExecuteShards internally.
-type queryExecuteSpecificShard struct {
-	queryExecute
-	Keyspace string
-	Shard    string
-}
-
 // Execute is part of the VTGateService interface
 func (f *fakeVTGateService) Execute(ctx context.Context, sql string, bindVariables map[string]interface{}, keyspace string, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
 	execCase, ok := execMap[sql]
@@ -61,28 +53,7 @@ func (f *fakeVTGateService) Execute(ctx context.Context, sql string, bindVariabl
 
 // ExecuteShards is part of the VTGateService interface
 func (f *fakeVTGateService) ExecuteShards(ctx context.Context, sql string, bindVariables map[string]interface{}, keyspace string, shards []string, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
-	execCase, ok := execSpecificShardMap[sql]
-	if !ok {
-		return nil, fmt.Errorf("no match for: %s", sql)
-	}
-	query := &queryExecuteSpecificShard{
-		queryExecute: queryExecute{
-			SQL:              sql,
-			BindVariables:    bindVariables,
-			TabletType:       tabletType,
-			Session:          session,
-			NotInTransaction: notInTransaction,
-		},
-		Keyspace: keyspace,
-		Shard:    shards[0],
-	}
-	if !reflect.DeepEqual(query, execCase.execQuery) {
-		return nil, fmt.Errorf("ExecuteShards request mismatch: got %+v, want %+v", query, execCase.execQuery)
-	}
-	if execCase.session != nil {
-		*session = *execCase.session
-	}
-	return execCase.result, nil
+	return nil, nil
 }
 
 // ExecuteKeyspaceIds is part of the VTGateService interface
@@ -146,38 +117,6 @@ func (f *fakeVTGateService) StreamExecute(ctx context.Context, sql string, bindV
 
 // StreamExecuteShards is part of the VTGateService interface
 func (f *fakeVTGateService) StreamExecuteShards(ctx context.Context, sql string, bindVariables map[string]interface{}, keyspace string, shards []string, tabletType topodatapb.TabletType, options *querypb.ExecuteOptions, sendReply func(*sqltypes.Result) error) error {
-	execCase, ok := execSpecificShardMap[sql]
-	if !ok {
-		return fmt.Errorf("no match for: %s", sql)
-	}
-	query := &queryExecuteSpecificShard{
-		queryExecute: queryExecute{
-			SQL:           sql,
-			BindVariables: bindVariables,
-			TabletType:    tabletType,
-		},
-		Keyspace: keyspace,
-		Shard:    shards[0],
-	}
-	if !reflect.DeepEqual(query, execCase.execQuery) {
-		return fmt.Errorf("request mismatch: got %+v, want %+v", query, execCase.execQuery)
-	}
-	if execCase.result != nil {
-		result := &sqltypes.Result{
-			Fields: execCase.result.Fields,
-		}
-		if err := sendReply(result); err != nil {
-			return err
-		}
-		for _, row := range execCase.result.Rows {
-			result := &sqltypes.Result{
-				Rows: [][]sqltypes.Value{row},
-			}
-			if err := sendReply(result); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
@@ -260,9 +199,9 @@ var execMap = map[string]struct {
 	session   *vtgatepb.Session
 	err       error
 }{
-	"request1": {
+	"request": {
 		execQuery: &queryExecute{
-			SQL: "request1",
+			SQL: "request",
 			BindVariables: map[string]interface{}{
 				"v1": int64(0),
 			},
@@ -284,45 +223,28 @@ var execMap = map[string]struct {
 		result:  &sqltypes.Result{},
 		session: session2,
 	},
-}
-
-// execSpecificShardMap is used to test the vtgate v2 fallback behavior where
-// sql.Open() was called for a specific keyspace/shard and
-// vtgateconn.ExecuteShards is used internally by the driver.
-var execSpecificShardMap = map[string]struct {
-	execQuery *queryExecuteSpecificShard
-	result    *sqltypes.Result
-	session   *vtgatepb.Session
-	err       error
-}{
-	"request1SpecificShard": {
-		execQuery: &queryExecuteSpecificShard{
-			queryExecute: queryExecute{
-				SQL: "request1SpecificShard",
-				BindVariables: map[string]interface{}{
-					"v1": int64(0),
-				},
-				TabletType: topodatapb.TabletType_RDONLY,
-				Session:    nil,
+	"requestKeyspace": {
+		execQuery: &queryExecute{
+			SQL: "requestKeyspace",
+			BindVariables: map[string]interface{}{
+				"v1": int64(0),
 			},
-			Keyspace: "ks1",
-			Shard:    "0",
+			Keyspace:   "ks",
+			TabletType: topodatapb.TabletType_RDONLY,
+			Session:    nil,
 		},
 		result:  &result1,
 		session: nil,
 	},
-	"txRequestSpecificShard": {
-		execQuery: &queryExecuteSpecificShard{
-			queryExecute: queryExecute{
-				SQL: "txRequestSpecificShard",
-				BindVariables: map[string]interface{}{
-					"v1": int64(0),
-				},
-				TabletType: topodatapb.TabletType_MASTER,
-				Session:    session1,
+	"txRequestKeyspace": {
+		execQuery: &queryExecute{
+			SQL: "txRequestKeyspace",
+			BindVariables: map[string]interface{}{
+				"v1": int64(0),
 			},
-			Keyspace: "ks1",
-			Shard:    "0",
+			Keyspace:   "ks",
+			TabletType: topodatapb.TabletType_MASTER,
+			Session:    session1,
 		},
 		result:  &sqltypes.Result{},
 		session: session2,

--- a/go/vt/vitessdriver/streaming_rows_test.go
+++ b/go/vt/vitessdriver/streaming_rows_test.go
@@ -125,6 +125,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 	c <- &packet3
 	close(c)
 	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	defer ri.Close()
 
 	wantRow := []driver.Value{
 		int64(1),

--- a/test/utils.py
+++ b/test/utils.py
@@ -625,7 +625,7 @@ class VtGate(object):
     """Returns the vars for this process."""
     return get_vars(self.port)
 
-  def vtclient(self, sql, keyspace=None, shard=None, tablet_type='master',
+  def vtclient(self, sql, keyspace=None, tablet_type='master',
                bindvars=None, streaming=False,
                verbose=False, raise_on_error=True, json_output=False):
     """Uses the vtclient binary to send a query to vtgate."""
@@ -638,8 +638,6 @@ class VtGate(object):
       args.append('-json')
     if keyspace:
       args.extend(['-keyspace', keyspace])
-    if shard:
-      args.extend(['-shard', shard])
     if bindvars:
       args.extend(['-bind_variables', json.dumps(bindvars)])
     if streaming:


### PR DESCRIPTION
I've left out the row support functions because most of them are
not supported by the protocol. The most important changes
are supported: contexts and named arguments.

* Deleted the deprecated shard specific connection support.
* Built go1.8, fixed compilation errors and added tests.
* Fixed documentation that was still stating support for v1 API.
* Fixed custom_sharding test that was relying on v1 API.
* Doc comments updated to explain isolation levels and named args.
* Code review comments addressed.