### PR TITLE
Change the way modification of Node and broadcasting of changes works.

### DIFF
--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -171,7 +171,8 @@ func (schemaSwap *Swap) Run(ctx context.Context, manager *workflow.Manager, work
 	schemaSwap.topoServer = topo.GetServer()
 	schemaSwap.tabletClient = tmclient.NewTabletManagerClient()
 
-	rootUINode := workflow.NewToplevelNode(workflowInfo, schemaSwap)
+	rootUINode := workflow.NewNode()
+	rootUINode.AttachToWorkflow(workflowInfo, schemaSwap)
 	rootUINode.State = workflowpb.WorkflowState_Running
 	rootUINode.Display = workflow.NodeDisplayIndeterminate
 	rootUINode.Message = fmt.Sprintf("Schema swap is executed on the keyspace %s", schemaSwap.keyspace)

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -50,7 +50,7 @@ func TestLongPolling(t *testing.T) {
 		workflow: tw,
 
 		Name:        "name",
-		Path:        "/uuid1",
+		PathName:    "uuid1",
 		Children:    []*Node{},
 		LastChanged: 143,
 	}
@@ -96,9 +96,8 @@ func TestLongPolling(t *testing.T) {
 	}
 
 	// Send an update, make sure we see it.
-	n.Modify(func() {
-		n.Name = "name2"
-	})
+	n.Name = "name2"
+	n.BroadcastChanges(false /* updateChildren */)
 
 	u.Path = "/workflow/poll/1"
 	resp, err = http.Get(u.String())

--- a/go/vt/workflow/node_test.go
+++ b/go/vt/workflow/node_test.go
@@ -49,12 +49,11 @@ func TestNodeManagerWithRoot(t *testing.T) {
 	}
 
 	// Add a root level node, make sure we get notified.
-	// Can't really use NewToplevelNode because it takes a WorkflowInfo.
 	n := &Node{
 		workflow: tw,
 
 		Name:        "name",
-		Path:        "/uuid1",
+		PathName:    "uuid1",
 		Children:    []*Node{},
 		LastChanged: time.Now().Unix(),
 	}
@@ -67,9 +66,8 @@ func TestNodeManagerWithRoot(t *testing.T) {
 	}
 
 	// Modify root node, make sure we get notified.
-	n.Modify(func() {
-		n.Name = "name2"
-	})
+	n.Name = "name2"
+	n.BroadcastChanges(false /* updateChildren */)
 	result, ok = <-notifications
 	if !ok ||
 		!strings.Contains(string(result), `"name":"name2"`) ||

--- a/go/vt/workflow/websocket_test.go
+++ b/go/vt/workflow/websocket_test.go
@@ -50,7 +50,7 @@ func TestWebSocket(t *testing.T) {
 		workflow: tw,
 
 		Name:        "name",
-		Path:        "/uuid1",
+		PathName:    "uuid1",
 		Children:    []*Node{},
 		LastChanged: 143,
 	}
@@ -87,9 +87,8 @@ func TestWebSocket(t *testing.T) {
 	}
 
 	// Send an update, make sure we see it.
-	n.Modify(func() {
-		n.Name = "name2"
-	})
+	n.Name = "name2"
+	n.BroadcastChanges(false /* updateChildren */)
 	_, tree, err = c.ReadMessage()
 	if err != nil {
 		t.Fatalf("WebSocket update read failed: %v", err)


### PR DESCRIPTION
This change clearly separates the data owned by user of workflow API and data
owned by the workflow library itself. After this separation user can change the
data owned by it at any time and in any way it wants, but then it will need to
call the BroadcastChanges() method to copy that data into workflow library and
broadcast it to browsers.
This eliminates Node.Modify() method which was a pretty awkward callback-based
method of modifying the Node data. It highly limited what the API users could
do, and besides that it would race with any other Node changes that could be
done at the same time. This also fixes the problem when a Node couldn't be
updated in the UI without updating its children as well. Now that can be done if
BroadcastChanges() method is called with updateChildren = false.