### PR TITLE
b/32560113: Remove false alarm

### DIFF
--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -116,10 +116,7 @@ func (axp *TxPool) Close() {
 // or in prepared state.
 func (axp *TxPool) RollbackNonBusy(ctx context.Context) {
 	for _, v := range axp.activePool.GetOutdated(time.Duration(0), "for transition") {
-		conn := v.(*TxConnection)
-		log.Warningf("rolling back transaction for transition: %s", conn.Format(nil))
-		axp.queryServiceStats.InternalErrors.Add("StrayTransactions", 1)
-		axp.LocalConclude(ctx, conn)
+		axp.LocalConclude(ctx, v.(*TxConnection))
 	}
 }
 


### PR DESCRIPTION
RollbackNonBusy gets called if a tablet was externally reparented.
If so, it's normal for transactions to still be outstanding. So,
they should be simply rolled back without raising any alarms,