### PR TITLE
k8s: Add Helm chart for Vitess

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,12 @@
+# Helm Charts
+
+This directory contains [Helm](https://github.com/kubernetes/helm)
+charts for running [Vitess](http://vitess.io) on
+[Kubernetes](http://kubernetes.io).
+
+Note that this is not in the `examples` directory because these are the
+sources for canonical packages that we plan to publish to the official
+[Kubernetes Charts Repository](https://github.com/kubernetes/charts).
+However, you may also find them useful as a starting point for creating
+customized charts for your site, or other general-purpose charts for
+common cluster variations.

--- a/helm/vitess/.gitignore
+++ b/helm/vitess/.gitignore
@@ -1,0 +1,2 @@
+# Don't check in site-local customizations.
+site-values.yaml

--- a/helm/vitess/.helmignore
+++ b/helm/vitess/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/vitess/Chart.yaml
+++ b/helm/vitess/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+name: vitess
+version: 0.1.0
+description: Single-Chart Vitess Cluster
+keywords:
+  - vitess
+  - mysql
+  - sql
+  - database
+  - shard
+home: http://vitess.io
+sources:
+  - https://github.com/youtube/vitess
+maintainers:
+  - name: Vitess Project
+    email: vitess@googlegroups.com
+icon: http://vitess.io/images/vitess_logomark_cropped.svg

--- a/helm/vitess/README.md
+++ b/helm/vitess/README.md
@@ -1,0 +1,26 @@
+# Vitess
+
+[Vitess](http://vitess.io) is a database clustering system for horizontal
+scaling of MySQL. It is an open-source project started at YouTube,
+and has been used there since 2011.
+
+## Introduction
+
+This chart creates a Vitess cluster on Kubernetes in a single
+[release](https://github.com/kubernetes/helm/blob/master/docs/glossary.md#release).
+It currently includes all dependencies (e.g. etcd) and Vitess components
+(vtctld, vtgate, vttablet) inline (in `templates/`) rather than as sub-charts.
+
+**WARNING: This chart should be considered Alpha.
+Upgrading a release of this chart may or may not delete all your data.**
+
+## Installing the Chart
+
+```console
+vitess/helm$ helm install ./vitess
+```
+
+## Configuration
+
+See the comments in `values.yaml` for descriptions of the parameters.
+

--- a/helm/vitess/templates/_etcd.tpl
+++ b/helm/vitess/templates/_etcd.tpl
@@ -1,0 +1,149 @@
+{{- define "etcd" -}}
+{{- $ := index . 0 -}}
+{{- $cell := index . 1 -}}
+{{- with (index . 2) -}}
+{{- $0 := $.Values.etcd -}}
+{{- $replicas := .replicas | default $0.replicas -}}
+# etcd
+# Regular service for load balancing client connections.
+kind: Service
+apiVersion: v1
+metadata:
+  name: "etcd-{{$cell.name}}"
+  labels:
+    component: etcd
+    cell: {{$cell.name | quote}}
+    app: vitess
+spec:
+  ports:
+    - port: 4001
+  selector:
+    component: etcd
+    cell: {{$cell.name | quote}}
+    app: vitess
+---
+# Headless service for etcd cluster bootstrap.
+kind: Service
+apiVersion: v1
+metadata:
+  name: "etcd-{{$cell.name}}-srv"
+  labels:
+    component: etcd
+    cell: {{$cell.name | quote}}
+    app: vitess
+spec:
+  clusterIP: None
+  ports:
+    - name: etcd-server
+      port: 7001
+  selector:
+    component: etcd
+    cell: {{$cell.name | quote}}
+    app: vitess
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: "etcd-{{$cell.name}}"
+spec:
+  replicas: {{$replicas}}
+  template:
+    metadata:
+      labels:
+        component: etcd
+        cell: {{$cell.name | quote}}
+        app: vitess
+    spec:
+      volumes:
+        - name: certs
+          hostPath: { path: {{$.Values.certsPath | quote}} }
+      containers:
+        - name: etcd
+          image: {{.image | default $0.image | quote}}
+          volumeMounts:
+            - name: certs
+              readOnly: true
+              # Mount root certs from the host OS into the location
+              # expected for our container OS (Debian):
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+          resources:
+{{ toYaml (.resources | default $0.resources) | indent 12 }}
+          command:
+            - bash
+            - "-c"
+            - |
+              set -ex
+
+              ipaddr=$(hostname -i)
+              peer_url="http://$ipaddr:7001"
+              client_url="http://$ipaddr:4001"
+
+              export ETCD_NAME=$HOSTNAME
+              export ETCD_DATA_DIR=/vt/vtdataroot/etcd-$ETCD_NAME
+              export ETCD_STRICT_RECONFIG_CHECK=true
+              export ETCD_ADVERTISE_CLIENT_URLS=$client_url
+              export ETCD_INITIAL_ADVERTISE_PEER_URLS=$peer_url
+              export ETCD_LISTEN_CLIENT_URLS=$client_url
+              export ETCD_LISTEN_PEER_URLS=$peer_url
+
+              if [ -d $ETCD_DATA_DIR ]; then
+                # We've been restarted with an intact datadir.
+                # Just run without trying to do any bootstrapping.
+                echo "Resuming with existing data dir: $ETCD_DATA_DIR"
+              else
+                # This is the first run for this member.
+
+                # If there's already a functioning cluster, join it.
+                echo "Checking for existing cluster by trying to join..."
+                if result=$(etcdctl -C http://etcd-{{$cell.name}}:4001 member add $ETCD_NAME $peer_url); then
+                  [[ "$result" =~ ETCD_INITIAL_CLUSTER=\"([^\"]*)\" ]] && \
+                  export ETCD_INITIAL_CLUSTER="${BASH_REMATCH[1]}"
+                  export ETCD_INITIAL_CLUSTER_STATE=existing
+                  echo "Joining existing cluster: $ETCD_INITIAL_CLUSTER"
+                else
+                  # Join failed. Assume we're trying to bootstrap.
+
+                  # First register with global topo, if we aren't global.
+                  if [ "{{$cell.name}}" != "global" ]; then
+                    echo "Registering cell "{{$cell.name}}" with global etcd..."
+                    until etcdctl -C "http://etcd-global:4001" \
+                        set "/vt/cells/{{$cell.name}}" "http://etcd-{{$cell.name}}:4001"; do
+                      echo "[$(date)] waiting for global etcd to register cell '{{$cell.name}}'"
+                      sleep 1
+                    done
+                  fi
+
+                  # Use DNS to bootstrap.
+
+                  # First wait for the desired number of replicas to show up.
+                  echo "Waiting for {{$replicas}} replicas in SRV record for etcd-{{$cell.name}}-srv..."
+                  until [ $(getsrv etcd-server tcp etcd-{{$cell.name}}-srv | wc -l) -eq {{$replicas}} ]; do
+                    echo "[$(date)] waiting for {{$replicas}} entries in SRV record for etcd-{{$cell.name}}-srv"
+                    sleep 1
+                  done
+
+                  export ETCD_DISCOVERY_SRV=etcd-{{$cell.name}}-srv
+                  echo "Bootstrapping with DNS discovery:"
+                  getsrv etcd-server tcp etcd-{{$cell.name}}-srv
+                fi
+              fi
+
+              # We've set up the env as we want it. Now run.
+              exec etcd
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - bash
+                  - "-c"
+                  - |
+                    # Find our member ID.
+                    members=$(etcdctl -C http://etcd-{{$cell.name}}:4001 member list)
+                    if [[ "$members" =~ ^([0-9a-f]+):\ name=$HOSTNAME ]]; then
+                      member_id=${BASH_REMATCH[1]}
+                      echo "Removing $HOSTNAME ($member_id) from etcd-{{$cell.name}} cluster..."
+                      etcdctl -C http://etcd-{{$cell.name}}:4001 member remove $member_id
+                    fi
+{{- end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/_helpers.tpl
+++ b/helm/vitess/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+# Helper templates
+
+# Format a flag map into a command line,
+# as expected by the golang 'flag' package.
+# Boolean flags must be given a value, such as "true" or "false".
+{{- define "format-flags" -}}
+{{- range $key, $value := . -}}
+-{{$key}}={{$value | quote}}
+{{end -}}
+{{- end -}}
+
+# Format a list of flag maps into a command line.
+{{- define "format-flags-all" -}}
+{{- range . }}{{template "format-flags" .}}{{end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -1,0 +1,53 @@
+{{- define "orchestrator" -}}
+{{- $ := index . 0 -}}
+{{- $cell := index . 1 -}}
+{{- with index . 2 -}}
+{{- $0 := $.Values.orchestrator -}}
+# Orchestrator service
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator
+  labels:
+    component: orchestrator
+    app: vitess
+spec:
+  ports:
+    - port: 80
+      targetPort: 3000
+  selector:
+    component: orchestrator
+    app: vitess
+---
+# Orchestrator replication controller
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: orchestrator
+spec:
+  replicas: {{.replicas | default $0.replicas}}
+  template:
+    metadata:
+      labels:
+        component: orchestrator
+        app: vitess
+    spec:
+      containers:
+        - name: orchestrator
+          image: {{.image | default $0.image | quote}}
+          livenessProbe:
+            httpGet:
+              path: "/"
+              port: 3000
+            initialDelaySeconds: 300
+            timeoutSeconds: 30
+          resources:
+{{ toYaml (.resources | default $0.resources) | indent 12 }}
+        - name: mysql
+          image: {{.image | default $0.image | quote}}
+          resources:
+{{ toYaml (.mysqlResources | default $0.mysqlResources) | indent 12 }}
+          command: ["mysqld"]
+{{- end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
         - name: vtctld
-          image: {{.image | default $0.image}}
+          image: {{.image | default $0.image | quote}}
           livenessProbe:
             httpGet:
               path: /debug/vars

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -1,0 +1,92 @@
+{{- define "vtctld" -}}
+{{- $ := index . 0 -}}
+{{- $cell := index . 1 -}}
+{{- with index . 2 -}}
+{{- $0 := $.Values.vtctld -}}
+# vtctld
+kind: Service
+apiVersion: v1
+metadata:
+  name: vtctld
+  labels:
+    component: vtctld
+    app: vitess
+spec:
+  ports:
+    - name: web
+      port: 15000
+    - name: grpc
+      port: 15999
+  selector:
+    component: vtctld
+    app: vitess
+  type: {{.serviceType | default $0.serviceType}}
+---
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: vtctld
+spec:
+  replicas: {{.replicas | default $0.replicas}}
+  template:
+    metadata:
+      labels:
+        component: vtctld
+        app: vitess
+    spec:
+      containers:
+        - name: vtctld
+          image: {{.image | default $0.image}}
+          livenessProbe:
+            httpGet:
+              path: /debug/vars
+              port: 15000
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: syslog
+              mountPath: /dev/log
+            - name: vtdataroot
+              mountPath: /vt/vtdataroot
+            - name: certs
+              readOnly: true
+              # Mount root certs from the host OS into the location
+              # expected for our container OS (Debian):
+              mountPath: /etc/ssl/certs/ca-certificates.crt
+          resources:
+{{ toYaml (.resources | default $0.resources) | indent 12 }}
+          command:
+            - bash
+            - "-c"
+            - |
+              set -ex
+              mkdir -p $VTDATAROOT/tmp
+              chown -R vitess /vt
+
+              exec su -p -c "$(tr '\n' ' ' <<END_OF_COMMAND
+                exec /vt/bin/vtctld
+                  -cell {{$cell.name | quote}}
+                  -web_dir "$VTTOP/web/vtctld"
+                  -web_dir2 "$VTTOP/web/vtctld2/app"
+                  -workflow_manager_init
+                  -workflow_manager_use_election
+                  -log_dir "$VTDATAROOT/tmp"
+                  -alsologtostderr
+                  -port 15000
+                  -grpc_port 15999
+                  -service_map "grpc-vtctl"
+                  -topo_implementation "etcd"
+                  -etcd_global_addrs "http://etcd-global:4001"
+{{ include "format-flags-all" (tuple $.Values.backupFlags $0.extraFlags .extraFlags) | indent 18 }}
+              END_OF_COMMAND
+              )" vitess
+      volumes:
+        - name: syslog
+          hostPath: {path: /dev/log}
+        - name: vtdataroot
+          emptyDir: {}
+        - name: certs
+          hostPath: { path: {{$.Values.certsPath | quote}} }
+{{- end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: vtgate
-          image: {{.image | default $0.image}}
+          image: {{.image | default $0.image | quote}}
           livenessProbe:
             httpGet:
               path: /debug/vars

--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -1,0 +1,87 @@
+{{- define "vtgate" -}}
+{{- $ := index . 0 -}}
+{{- $cell := index . 1 -}}
+{{- with index . 2 -}}
+{{- $0 := $.Values.vtgate -}}
+# vtgate
+kind: Service
+apiVersion: v1
+metadata:
+  name: vtgate-{{$cell.name}}
+  labels:
+    component: vtgate
+    cell: {{$cell.name}}
+    app: vitess
+spec:
+  ports:
+    - name: web
+      port: 15001
+    - name: grpc
+      port: 15991
+  selector:
+    component: vtgate
+    cell: {{$cell.name}}
+    app: vitess
+  type: {{.serviceType | default $0.serviceType}}
+---
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: vtgate-{{$cell.name}}
+spec:
+  replicas: {{.replicas | default $0.replicas}}
+  template:
+    metadata:
+      labels:
+        component: vtgate
+        cell: {{$cell.name}}
+        app: vitess
+    spec:
+      containers:
+        - name: vtgate
+          image: {{.image | default $0.image}}
+          livenessProbe:
+            httpGet:
+              path: /debug/vars
+              port: 15001
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: syslog
+              mountPath: /dev/log
+            - name: vtdataroot
+              mountPath: /vt/vtdataroot
+          resources:
+{{ toYaml (.resources | default $0.resources) | indent 12 }}
+          command:
+            - bash
+            - "-c"
+            - |
+              set -ex
+              mkdir -p $VTDATAROOT/tmp &&
+              chown -R vitess /vt &&
+
+              exec su -p -c "$(tr '\n' ' ' <<END_OF_COMMAND
+                exec /vt/bin/vtgate
+                  -topo_implementation "etcd"
+                  -etcd_global_addrs "http://etcd-global:4001"
+                  -log_dir "$VTDATAROOT/tmp"
+                  -alsologtostderr
+                  -port 15001
+                  -grpc_port 15991
+                  -service_map "grpc-vtgateservice"
+                  -cells_to_watch {{$cell.name | quote}}
+                  -tablet_types_to_wait "MASTER,REPLICA"
+                  -gateway_implementation "discoverygateway"
+                  -cell {{$cell.name | quote}}
+{{ include "format-flags-all" (tuple $0.extraFlags .extraFlags) | indent 18 }}
+              END_OF_COMMAND
+              )" vitess
+      volumes:
+        - name: syslog
+          hostPath: {path: /dev/log}
+        - name: vtdataroot
+          emptyDir: {}
+{{- end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: vttablet
-      image: {{.image | default $0.image}}
+      image: {{.image | default $0.image | quote}}
       livenessProbe:
         httpGet:
           path: /debug/vars
@@ -92,7 +92,7 @@ spec:
           END_OF_COMMAND
           )" vitess
     - name: mysql
-      image: {{.image | default $0.image}}
+      image: {{.image | default $0.image | quote}}
       volumeMounts:
         - name: syslog
           mountPath: /dev/log

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -1,0 +1,148 @@
+{{- define "vttablet" -}}
+{{- $ := index . 0 -}}
+{{- $cell := index . 1 -}}
+{{- $keyspace := index . 2 -}}
+{{- $shard := index . 3 -}}
+{{- $tablet := index . 4 -}}
+{{- $index := index . 5 -}}
+{{- with index . 6 -}}
+{{- $0 := $.Values.vttablet -}}
+{{- $uid := add $tablet.uidBase $index -}}
+{{- $alias := printf "%s-%d" $cell.name $uid -}}
+# vttablet
+kind: Pod
+apiVersion: v1
+metadata:
+  name: "vttablet-{{$uid}}"
+  labels:
+    component: vttablet
+    keyspace: {{$keyspace.name | quote}}
+    shard: {{$shard.name | quote}}
+    tablet: {{$alias | quote}}
+    app: vitess
+spec:
+  containers:
+    - name: vttablet
+      image: {{.image | default $0.image}}
+      livenessProbe:
+        httpGet:
+          path: /debug/vars
+          port: 15002
+        initialDelaySeconds: 60
+        timeoutSeconds: 10
+      volumeMounts:
+        - name: syslog
+          mountPath: /dev/log
+        - name: vtdataroot
+          mountPath: /vt/vtdataroot
+        - name: certs
+          readOnly: true
+          # Mount root certs from the host OS into the location
+          # expected for our container OS (Debian):
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+      resources:
+{{ toYaml (.resources | default $0.resources) | indent 8 }}
+      ports:
+        - name: web
+          containerPort: 15002
+        - name: grpc
+          containerPort: 16002
+      command:
+        - bash
+        - "-c"
+        - |
+          set -ex
+          mkdir -p $VTDATAROOT/tmp
+          chown -R vitess /vt
+
+          exec su -p -c "$(tr '\n' ' ' <<END_OF_COMMAND
+            exec /vt/bin/vttablet
+              -topo_implementation "etcd"
+              -etcd_global_addrs "http://etcd-global:4001"
+              -log_dir "$VTDATAROOT/tmp"
+              -alsologtostderr
+              -port 15002
+              -grpc_port 16002
+              -service_map "grpc-queryservice,grpc-tabletmanager,grpc-updatestream"
+              -tablet-path {{$alias | quote}}
+              -tablet_hostname "$(hostname -i)"
+              -init_keyspace {{$keyspace.name | quote}}
+              -init_shard {{$shard.name | quote}}
+              -init_tablet_type {{$tablet.type | quote}}
+              -health_check_interval "5s"
+              -mysqlctl_socket "$VTDATAROOT/mysqlctl.sock"
+              -db-config-app-uname "vt_app"
+              -db-config-app-dbname "vt_{{$keyspace.name}}"
+              -db-config-app-charset "utf8"
+              -db-config-dba-uname "vt_dba"
+              -db-config-dba-dbname "vt_{{$keyspace.name}}"
+              -db-config-dba-charset "utf8"
+              -db-config-repl-uname "vt_repl"
+              -db-config-repl-dbname "vt_{{$keyspace.name}}"
+              -db-config-repl-charset "utf8"
+              -db-config-filtered-uname "vt_filtered"
+              -db-config-filtered-dbname "vt_{{$keyspace.name}}"
+              -db-config-filtered-charset "utf8"
+              -enable_semi_sync
+              -enable_replication_reporter
+              -orc_api_url "http://orchestrator/api"
+              -orc_discover_interval "5m"
+              -restore_from_backup
+{{ include "format-flags-all" (tuple $.Values.backupFlags $0.extraFlags .extraFlags) | indent 14 }}
+          END_OF_COMMAND
+          )" vitess
+    - name: mysql
+      image: {{.image | default $0.image}}
+      volumeMounts:
+        - name: syslog
+          mountPath: /dev/log
+        - name: vtdataroot
+          mountPath: /vt/vtdataroot
+      resources:
+{{ toYaml (.mysqlResources | default $0.mysqlResources) | indent 8 }}
+      command:
+        - sh
+        - "-c"
+        - |
+          set -ex
+          mkdir -p $VTDATAROOT/tmp
+          chown -R vitess /vt
+
+          exec su -p -c "$(tr '\n' ' ' <<END_OF_COMMAND
+            exec /vt/bin/mysqlctld
+              -log_dir "$VTDATAROOT/tmp"
+              -alsologtostderr
+              -tablet_uid {{$uid}}
+              -socket_file "$VTDATAROOT/mysqlctl.sock"
+              -db-config-app-uname "vt_app"
+              -db-config-app-dbname "vt_{{$keyspace.name}}"
+              -db-config-app-charset "utf8"
+              -db-config-allprivs-uname "vt_allprivs"
+              -db-config-allprivs-dbname "vt_{{$keyspace.name}}"
+              -db-config-allprivs-charset "utf8"
+              -db-config-dba-uname "vt_dba"
+              -db-config-dba-dbname "vt_{{$keyspace.name}}"
+              -db-config-dba-charset "utf8"
+              -db-config-repl-uname "vt_repl"
+              -db-config-repl-dbname "vt_{{$keyspace.name}}"
+              -db-config-repl-charset "utf8"
+              -db-config-filtered-uname "vt_filtered"
+              -db-config-filtered-dbname "vt_{{$keyspace.name}}"
+              -db-config-filtered-charset "utf8"
+              -init_db_sql_file "$VTROOT/config/init_db.sql"
+{{ include "format-flags-all" (tuple $0.mysqlctlExtraFlags .mysqlctlExtraFlags) | indent 14 }}
+          END_OF_COMMAND
+          )" vitess
+      env:
+        - name: EXTRA_MY_CNF
+          value: {{.extraMyCnf | default $0.extraMyCnf | quote}}
+  volumes:
+    - name: syslog
+      hostPath: {path: /dev/log}
+    - name: vtdataroot
+{{ toYaml (.dataVolume | default $0.dataVolume) | indent 6 }}
+    - name: certs
+      hostPath: { path: {{$.Values.certsPath | quote}} }
+{{- end -}}
+{{- end -}}
+

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -6,6 +6,8 @@
 {{ with $cell.vtctld }}{{ include "vtctld" (tuple $ $cell .) }}{{ end }}
 ---
 {{ with $cell.vtgate }}{{ include "vtgate" (tuple $ $cell .) }}{{ end }}
+---
+{{ with $cell.orchestrator }}{{ include "orchestrator" (tuple $ $cell .) }}{{ end }}
 
 # Tablets for keyspaces
 {{ range $keyspace := $cell.keyspaces }}

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -1,0 +1,26 @@
+# Create requested resources in each cell.
+{{ range $cell := $.Values.topology.cells }}
+---
+{{ with $cell.etcd }}{{ include "etcd" (tuple $ $cell .) }}{{ end }}
+---
+{{ with $cell.vtctld }}{{ include "vtctld" (tuple $ $cell .) }}{{ end }}
+---
+{{ with $cell.vtgate }}{{ include "vtgate" (tuple $ $cell .) }}{{ end }}
+
+# Tablets for keyspaces
+{{ range $keyspace := $cell.keyspaces }}
+{{ range $shard := $keyspace.shards }}
+{{ range $tablet := $shard.tablets }}
+
+# This inner-most loop is a hack because we don't yet use StatefulSet:
+{{ range $index := until (atoi (print $tablet.vttablet.replicas)) }}
+---
+{{ with $tablet.vttablet }}{{ include "vttablet" (tuple $ $cell $keyspace $shard $tablet $index .) }}{{ end }}
+{{ end }}
+
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{ end }}
+

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -1,0 +1,97 @@
+# This file contains default values for vitess.
+#
+# You can override these defaults when installing:
+#   helm install -f site-values.yaml .
+#
+# The contents of site-values.yaml will be merged into this default config.
+# It's not necessary to copy the defaults into site-values.yaml.
+#
+# For command-line flag maps like backupFlags or extraFlags,
+# use 'flag_name: true|false' to enable or disable a boolean flag.
+
+# The main topology map declares what resources should be created.
+# Values for each component (etcd, vtctld, ...) that are not specified here
+# will be taken from defaults defined below.
+topology:
+  cells:
+    - name: "global"
+      etcd:
+        replicas: 3
+    - name: "test"
+      etcd:
+        replicas: 3
+      vtctld:
+        replicas: 1
+      vtgate:
+        replicas: 3
+      keyspaces:
+        - name: "test_keyspace"
+          shards:
+            - name: "0"
+              tablets:
+                - type: "replica"
+                  uidBase: 100
+                  vttablet:
+                    replicas: 3
+                - type: "rdonly"
+                  uidBase: 103
+                  vttablet:
+                    replicas: 2
+
+# Backup flags will be applied to components that need them.
+# These are defined globally since all components should agree.
+backupFlags:
+  backup_storage_implementation: "gcs"
+  gcs_backup_storage_bucket: ""
+
+# Default values for etcd resources defined in 'topology'.
+etcd:
+  image: "vitess/etcd:v2.0.13-lite"
+  resources:
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
+
+# Default values for vtctld resources defined in 'topology'.
+vtctld:
+  serviceType: "ClusterIP"
+  image: "vitess/lite:latest"
+  resources:
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
+
+# Default values for vtgate resources defined in 'topology'.
+vtgate:
+  serviceType: "ClusterIP"
+  image: "vitess/lite:latest"
+  resources:
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+# Default values for vttablet resources defined in 'topology'.
+vttablet:
+  image: "vitess/lite:latest"
+  dataVolume:
+    emptyDir: {}
+  resources:
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+  mysqlResources:
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+  extraMyCnf: "/vt/config/mycnf/master_mysql56.cnf"
+
+# Uncomment one of the following lines to configure the location
+# of the root certificates file on your host OS.
+# We need this so we can import it into the container OS.
+#
+# If your host OS is Fedora/RHEL:
+#certsPath: "/etc/pki/tls/certs/ca-bundle.crt"
+#
+# If your host OS is Debian/Ubuntu/Gentoo:
+certsPath: "/etc/ssl/certs/ca-certificates.crt"
+

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -17,6 +17,9 @@ topology:
     - name: "global"
       etcd:
         replicas: 3
+      orchestrator:
+        # NOTE: Our config currently only supports 1 orchestrator replica.
+        replicas: 1
     - name: "test"
       etcd:
         replicas: 3
@@ -50,6 +53,18 @@ etcd:
   resources:
     limits:
       memory: "128Mi"
+      cpu: "100m"
+
+# Default values for orchestrator resources defined in 'topology'.
+orchestrator:
+  image: "vitess/orchestrator:latest"
+  resources:
+    limits:
+      memory: "512Mi"
+      cpu: "100m"
+  mysqlResources:
+    limits:
+      memory: "512Mi"
       cpu: "100m"
 
 # Default values for vtctld resources defined in 'topology'.


### PR DESCRIPTION
@thompsonja 

This is mostly a direct translation of `examples/kubernetes`,
which I expect can be replaced by this after some more tweaks
and doc updates.

In particular, this still does not use new features like Deployment,
and tablets are not protected by any controllers. I plan to start
incorporating these new features, potentially as options so this chart
can still work on clusters that don't have k8s Alpha features enabled.