### PR TITLE
Separate Workflow and ActionListener interfaces.

### DIFF
--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -172,7 +172,7 @@ func (schemaSwap *Swap) Run(ctx context.Context, manager *workflow.Manager, work
 	schemaSwap.tabletClient = tmclient.NewTabletManagerClient()
 
 	rootUINode := workflow.NewNode()
-	rootUINode.AttachToWorkflow(workflowInfo, schemaSwap)
+	rootUINode.PopulateFromWorkflow(workflowInfo)
 	rootUINode.State = workflowpb.WorkflowState_Running
 	rootUINode.Display = workflow.NodeDisplayIndeterminate
 	rootUINode.Message = fmt.Sprintf("Schema swap is executed on the keyspace %s", schemaSwap.keyspace)
@@ -183,11 +183,6 @@ func (schemaSwap *Swap) Run(ctx context.Context, manager *workflow.Manager, work
 
 	schemaSwap.rootUINode = rootUINode
 	return schemaSwap.executeSwap()
-}
-
-// Action is a part of workflow.Workflow interface. It implements UI actions with the workflow.
-func (*Swap) Action(ctx context.Context, path, name string) error {
-	return fmt.Errorf("Cannot execute action '%s', '%s' on schema swap", path, name)
 }
 
 // Run is the main entry point of the schema swap process. It drives the process from start

--- a/go/vt/workflow/long_polling_test.go
+++ b/go/vt/workflow/long_polling_test.go
@@ -47,7 +47,7 @@ func TestLongPolling(t *testing.T) {
 	// Add a node, make sure we get the update with the next poll
 	tw := &testWorkflow{}
 	n := &Node{
-		workflow: tw,
+		Listener: tw,
 
 		Name:        "name",
 		PathName:    "uuid1",

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -29,9 +29,6 @@ type Workflow interface {
 	// state (and it can checkpoint that new value by saving it
 	// into the manager's topo Server).
 	Run(ctx context.Context, manager *Manager, wi *topo.WorkflowInfo) error
-
-	// Action is called when the user requests an action on a node.
-	Action(ctx context.Context, path, name string) error
 }
 
 // Factory can create the initial version of a Workflow, or

--- a/go/vt/workflow/node_test.go
+++ b/go/vt/workflow/node_test.go
@@ -50,7 +50,7 @@ func TestNodeManagerWithRoot(t *testing.T) {
 
 	// Add a root level node, make sure we get notified.
 	n := &Node{
-		workflow: tw,
+		Listener: tw,
 
 		Name:        "name",
 		PathName:    "uuid1",

--- a/go/vt/workflow/sleep_workflow.go
+++ b/go/vt/workflow/sleep_workflow.go
@@ -70,7 +70,8 @@ func (sw *SleepWorkflow) Run(ctx context.Context, manager *Manager, wi *topo.Wor
 	sw.manager = manager
 	sw.wi = wi
 	sw.node = NewNode()
-	sw.node.AttachToWorkflow(wi, sw)
+	sw.node.PopulateFromWorkflow(wi)
+	sw.node.Listener = sw
 	sw.node.State = workflowpb.WorkflowState_Running
 	sw.node.Display = NodeDisplayDeterminate
 	sw.node.Message = "This workflow is a test workflow that just sleeps for the provided amount of time."
@@ -127,7 +128,7 @@ func (sw *SleepWorkflow) Run(ctx context.Context, manager *Manager, wi *topo.Wor
 	return nil
 }
 
-// Action is part of the workflow.Workflow interface.
+// Action is part of the workflow.ActionListener interface.
 func (sw *SleepWorkflow) Action(ctx context.Context, path, name string) error {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()

--- a/go/vt/workflow/websocket_test.go
+++ b/go/vt/workflow/websocket_test.go
@@ -47,7 +47,7 @@ func TestWebSocket(t *testing.T) {
 	// Add a node, make sure we get the update.
 	tw := &testWorkflow{}
 	n := &Node{
-		workflow: tw,
+		Listener: tw,
 
 		Name:        "name",
 		PathName:    "uuid1",


### PR DESCRIPTION
Having ActionListener separate from the Workflow itself will allow to have more
modular code on workflows that have many sub-nodes with actions on them.