### PR TITLE
v3: implement new symbol rules for ORDER BY

### DIFF
--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -174,6 +174,23 @@
 "select id, col from user having col in (select user_extra.col, user.id as user_id from user join user_extra on user.id = user_extra.user_id having user_id = notthere)"
 "symbol notthere not found"
 
+# ORDER BY, reference col from local table.
+"select col from user where id = 5 order by aa"
+{
+  "Original": "select col from user where id = 5 order by aa",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select col from user where id = 5 order by aa asc",
+    "FieldQuery": "select col from user where 1 != 1",
+    "Vindex": "user_index",
+    "Values": 5
+  }
+}
+
 # ORDER BY uses column numbers
 "select col from user where id = 1 order by 1"
 {
@@ -363,6 +380,10 @@
   }
 }
 
+# Order by, verify outer symtab is searched according to its own context.
+"select u.id from user u having u.id in (select col2 from user where user.id = u.id order by u.col)"
+"symbol u.col not found"
+
 # Order by, qualified '*' expression, name mismatched.
 "select user.* from user where id = 5 order by e.col"
 "symbol e.col not found"
@@ -370,10 +391,6 @@
 # Order by, invalid column number
 "select col from user order by 1.1"
 "error parsing order by clause: 1.1"
-
-# Order by, invalid column name
-"select col from user order by aa"
-"symbol aa not found"
 
 # Order by, out of range column number
 "select col from user order by 2"

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -70,6 +70,9 @@ func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 // are readjusted on push-down to match the numbers of the individual
 // queries.
 func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
+	s := bldr.Symtab().SetState(symtabOrderBy)
+	defer bldr.Symtab().SetState(s)
+
 	if orderBy == nil {
 		return nil
 	}


### PR DESCRIPTION
This change addresses #2254. The ORDER BY clause is allowed
to reference columns in the FROM clause that are not necessarily
present in the SELECT expressions.