### PR TITLE
Removing flag that combines begin+execute.

### DIFF
--- a/go/vt/tabletserver/grpctabletconn/conn_test.go
+++ b/go/vt/tabletserver/grpctabletconn/conn_test.go
@@ -44,17 +44,4 @@ func TestGRPCTabletConn(t *testing.T) {
 			"grpc": int32(port),
 		},
 	}, service)
-
-	// run it again with combo enabled
-	t.Log("Enabling combo Begin / Execute{,Batch}")
-	*combo = true
-	tabletconntest.TestSuite(t, protocolName, &topodatapb.Tablet{
-		Keyspace: tabletconntest.TestTarget.Keyspace,
-		Shard:    tabletconntest.TestTarget.Shard,
-		Type:     tabletconntest.TestTarget.TabletType,
-		Hostname: host,
-		PortMap: map[string]int32{
-			"grpc": int32(port),
-		},
-	}, service)
 }

--- a/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
+++ b/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
@@ -72,10 +72,6 @@ func TestGRPCDiscovery(t *testing.T) {
 
 	// run the test suite.
 	TestSuite(t, "discovery-grpc", dg, service)
-
-	// run it again with vtgate combining Begin and Execute
-	flag.Set("tablet_grpc_combine_begin_execute", "true")
-	TestSuite(t, "discovery-grpc-combo", dg, service)
 }
 
 // TestL2VTGateDiscovery tests the l2vtgate gateway with a gRPC

--- a/test/utils.py
+++ b/test/utils.py
@@ -547,7 +547,6 @@ class VtGate(object):
         '-log_dir', environment.vtlogroot,
         '-srv_topo_cache_ttl', cache_ttl,
         '-tablet_protocol', protocols_flavor().tabletconn_protocol(),
-        '-tablet_grpc_combine_begin_execute',
     ]
     if l2vtgates:
       args.extend([
@@ -741,7 +740,6 @@ class L2VtGate(object):
         '-healthcheck_conn_timeout', healthcheck_conn_timeout,
         '-tablet_protocol', protocols_flavor().tabletconn_protocol(),
         '-gateway_implementation', vtgate_gateway_flavor().flavor(),
-        '-tablet_grpc_combine_begin_execute',
     ]
     args.extend(vtgate_gateway_flavor().flags(cell=cell, tablets=tablets))
     if tablet_types_to_wait:


### PR DESCRIPTION
It is now the default. The RPC endpoints exist since before 2.0 GA was released.