### PR TITLE
Add handling of easily fixable errors in schema swap.

### DIFF
--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -37,7 +37,8 @@ var (
 	reparentTimeout = flag.Duration("schema_swap_reparent_timeout", 30*time.Second,
 		"timeout to wait for slaves when doing reparent during schema swap")
 
-	errOnlyMasterLeft = errors.New("Only master is left to swap schema")
+	errOnlyMasterLeft   = errors.New("Only master is left to swap schema")
+	errNoBackupWithSwap = errors.New("Restore from backup cannot pick up new schema")
 )
 
 const (
@@ -59,6 +60,13 @@ type Swap struct {
 	workflowManager *workflow.Manager
 	// rootUINode is the root node in workflow UI representing this schema swap.
 	rootUINode *workflow.Node
+	// uiLogger is the logger collecting logs that will be displayed in the UI.
+	uiLogger *logutil.MemoryLogger
+
+	// retryMutex is a mutex protecting access to retryChannel and to Actions in rootUINode.
+	retryMutex sync.Mutex
+	// retryChannel is a channel that gets closed when Retry button is pressed.
+	retryChannel chan struct{}
 
 	// keyspace is the name of the keyspace on which schema swap process operates.
 	keyspace string
@@ -91,8 +99,15 @@ type shardSchemaSwap struct {
 	shardUINode       *workflow.Node
 	applySchemaUINode *workflow.Node
 	backupUINode      *workflow.Node
-	propagateUINode   *workflow.Node
+	propagationUINode *workflow.Node
 	reparentUINode    *workflow.Node
+
+	// shardUILogger is the logger collecting logs that will be displayed in the UI
+	// for the whole shard.
+	shardUILogger *logutil.MemoryLogger
+	// propagationUILogger is the logger collecting logs that will be displayed in the UI
+	// for the propagation task.
+	propagationUILogger *logutil.MemoryLogger
 
 	// numTabletsTotal is the total number of tablets in the shard.
 	numTabletsTotal int
@@ -183,6 +198,7 @@ func (*SwapWorkflowFactory) Instantiate(workflowProto *workflowpb.Workflow, root
 		keyspace:   data.Keyspace,
 		sql:        data.SQL,
 		rootUINode: rootNode,
+		uiLogger:   logutil.NewMemoryLogger(),
 	}, nil
 }
 
@@ -193,24 +209,82 @@ func (schemaSwap *Swap) Run(ctx context.Context, manager *workflow.Manager, work
 	schemaSwap.topoServer = topo.GetServer()
 	schemaSwap.tabletClient = tmclient.NewTabletManagerClient()
 
-	err := schemaSwap.executeSwap()
-	if err != nil {
+	log.Infof("Starting schema swap on keyspace %v with the following SQL: %v", schemaSwap.keyspace, schemaSwap.sql)
+
+	for {
+		err := schemaSwap.executeSwap()
+		if err == nil {
+			return nil
+		}
+		// If context is cancelled then return right away, otherwise move on to allow
+		// user to retry.
+		select {
+		case <-schemaSwap.ctx.Done():
+			return err
+		default:
+		}
+
+		schemaSwap.retryMutex.Lock()
+		retryAction := &workflow.Action{
+			Name:  "Retry",
+			State: workflow.ActionStateEnabled,
+			Style: workflow.ActionStyleWaiting,
+		}
+		schemaSwap.rootUINode.Actions = []*workflow.Action{retryAction}
+		schemaSwap.rootUINode.Listener = schemaSwap
+		schemaSwap.retryChannel = make(chan struct{})
+		schemaSwap.retryMutex.Unlock()
+		// setUIMessage broadcasts changes to rootUINode.
 		schemaSwap.setUIMessage(fmt.Sprintf("Error: %v", err))
+
+		select {
+		case <-schemaSwap.retryChannel:
+			schemaSwap.setUIMessage("Retrying schema swap after an error")
+			continue
+		case <-schemaSwap.ctx.Done():
+			schemaSwap.closeRetryChannel()
+			schemaSwap.setUIMessage("Schema swap is stopped")
+			return schemaSwap.ctx.Err()
+		}
 	}
-	return err
 }
 
-// Run is the main entry point of the schema swap process. It drives the process from start
+// closeRetryChannel closes the retryChannel and empties the Actions list in the rootUINode
+// to indicate that the channel is closed and Retry action is not waited for anymore.
+func (schemaSwap *Swap) closeRetryChannel() {
+	schemaSwap.retryMutex.Lock()
+	defer schemaSwap.retryMutex.Unlock()
+
+	if len(schemaSwap.rootUINode.Actions) != 0 {
+		schemaSwap.rootUINode.Actions = []*workflow.Action{}
+		close(schemaSwap.retryChannel)
+	}
+}
+
+// Action is a part of workflow.ActionListener interface. It registers "Retry" actions
+// from UI.
+func (schemaSwap *Swap) Action(ctx context.Context, path, name string) error {
+	if name != "Retry" {
+		return fmt.Errorf("Unknown action on schema swap: %v", name)
+	}
+	schemaSwap.closeRetryChannel()
+	schemaSwap.rootUINode.BroadcastChanges(false /* updateChildren */)
+	return nil
+}
+
+// executeSwap is the main entry point of the schema swap process. It drives the process from start
 // to finish, including possible restart of already started process. In the latter case the
 // method should be just called again and it will pick up already started process. The only
 // input argument is the SQL statements that comprise the schema change that needs to be
 // pushed using the schema swap process.
 func (schemaSwap *Swap) executeSwap() error {
 	schemaSwap.setUIMessage("Initializing schema swap")
-	if err := schemaSwap.createShardObjects(); err != nil {
-		return err
+	if len(schemaSwap.allShards) == 0 {
+		if err := schemaSwap.createShardObjects(); err != nil {
+			return err
+		}
+		schemaSwap.rootUINode.BroadcastChanges(true /* updateChildren */)
 	}
-	schemaSwap.rootUINode.BroadcastChanges(true /* updateChildren */)
 	if err := schemaSwap.initializeSwap(); err != nil {
 		return err
 	}
@@ -225,6 +299,7 @@ func (schemaSwap *Swap) executeSwap() error {
 	if errHealthWatchers != nil {
 		return errHealthWatchers
 	}
+
 	schemaSwap.setUIMessage("Applying schema change on seed tablets")
 	err := schemaSwap.runOnAllShards(
 		func(shard *shardSchemaSwap) error {
@@ -284,6 +359,9 @@ func (schemaSwap *Swap) executeSwap() error {
 
 // setUIMessage updates message on the schema swap's root UI node and broadcasts changes.
 func (schemaSwap *Swap) setUIMessage(message string) {
+	log.Infof("Schema swap on keyspace %v: %v", schemaSwap.keyspace, message)
+	schemaSwap.uiLogger.Infof(message)
+	schemaSwap.rootUINode.Log = schemaSwap.uiLogger.String()
 	schemaSwap.rootUINode.Message = message
 	schemaSwap.rootUINode.BroadcastChanges(false /* updateChildren */)
 }
@@ -329,7 +407,7 @@ func (schemaSwap *Swap) createShardObjects() error {
 				Name:     "Take seed backup",
 				PathName: "backup",
 			},
-			propagateUINode: &workflow.Node{
+			propagationUINode: &workflow.Node{
 				Name:     "Propagate backup",
 				PathName: "propagate",
 			},
@@ -337,12 +415,14 @@ func (schemaSwap *Swap) createShardObjects() error {
 				Name:     "Reparent from old master",
 				PathName: "reparent",
 			},
+			shardUILogger:       logutil.NewMemoryLogger(),
+			propagationUILogger: logutil.NewMemoryLogger(),
 		}
 		schemaSwap.rootUINode.Children = append(schemaSwap.rootUINode.Children, shardSwap.shardUINode)
 		shardSwap.shardUINode.Children = []*workflow.Node{
 			shardSwap.applySchemaUINode,
 			shardSwap.backupUINode,
-			shardSwap.propagateUINode,
+			shardSwap.propagationUINode,
 			shardSwap.reparentUINode,
 		}
 		schemaSwap.allShards = append(schemaSwap.allShards, shardSwap)
@@ -373,60 +453,71 @@ func (schemaSwap *Swap) initializeSwap() error {
 	waitGroup.Wait()
 
 	var recorder concurrency.AllErrorRecorder
+	var lastFinishedSwapID uint64
 	for i, metadata := range metadataList {
 		if metadata.err != nil {
 			recorder.RecordError(metadata.err)
-		} else if metadata.lastStartedSwap == metadata.lastFinishedSwap {
-			// The shard doesn't have schema swap started yet.
-			nextSwapID := metadata.lastFinishedSwap + 1
-			if schemaSwap.swapID == 0 {
-				schemaSwap.swapID = nextSwapID
-			} else if schemaSwap.swapID != nextSwapID {
-				recorder.RecordError(fmt.Errorf(
-					"Next schema swap id on shard %v should be %v, while for other shard(s) it should be %v",
-					schemaSwap.allShards[i].shardName, nextSwapID, schemaSwap.swapID))
-			}
-		} else if metadata.lastStartedSwap < metadata.lastFinishedSwap {
+		} else if metadata.lastStartedSwap < metadata.lastFinishedSwap || metadata.lastStartedSwap > metadata.lastFinishedSwap+1 {
 			recorder.RecordError(fmt.Errorf(
-				"Bad swap metadata on shard %v: LastFinishedSchemaSwap=%v is greater than LastStartedSchemaSwap=%v",
+				"Bad swap metadata on shard %v: LastFinishedSchemaSwap=%v, LastStartedSchemaSwap=%v",
 				schemaSwap.allShards[i].shardName, metadata.lastFinishedSwap, metadata.lastStartedSwap))
-		} else if schemaSwap.swapID != 0 && schemaSwap.swapID != metadata.lastStartedSwap {
-			recorder.RecordError(fmt.Errorf(
-				"Shard %v has an already started schema swap with an id %v, while for other shard(s) id should be equal to %v",
-				schemaSwap.allShards[i].shardName, metadata.lastStartedSwap, schemaSwap.swapID))
-		} else if metadata.currentSQL != schemaSwap.sql {
-			recorder.RecordError(fmt.Errorf(
-				"Shard %v has an already started schema swap with a different set of SQL statements",
-				schemaSwap.allShards[i].shardName))
-		} else {
-			schemaSwap.swapID = metadata.lastStartedSwap
+		} else if metadata.lastStartedSwap != metadata.lastFinishedSwap {
+			if metadata.currentSQL != schemaSwap.sql {
+				recorder.RecordError(fmt.Errorf(
+					"Shard %v has an already started schema swap with a different set of SQL statements",
+					schemaSwap.allShards[i].shardName))
+			}
+		}
+		if lastFinishedSwapID == 0 || metadata.lastFinishedSwap < lastFinishedSwapID {
+			lastFinishedSwapID = metadata.lastFinishedSwap
 		}
 	}
 	if recorder.HasErrors() {
 		return recorder.Error()
 	}
 
-	return schemaSwap.runOnAllShards(
-		func(shard *shardSchemaSwap) error {
-			return shard.writeStartedSwap()
-		})
+	schemaSwap.swapID = lastFinishedSwapID + 1
+	var haveNotStartedSwap, haveFinishedSwap bool
+	for i, metadata := range metadataList {
+		if metadata.lastStartedSwap == metadata.lastFinishedSwap {
+			// The shard doesn't have schema swap started yet or it's already finished.
+			if schemaSwap.swapID != metadata.lastFinishedSwap && schemaSwap.swapID != metadata.lastFinishedSwap+1 {
+				recorder.RecordError(fmt.Errorf(
+					"Shard %v has last finished swap id euqal to %v which doesn't align with swap id for the keyspace equal to %v",
+					schemaSwap.allShards[i].shardName, metadata.lastFinishedSwap, schemaSwap.swapID))
+			} else if schemaSwap.swapID == metadata.lastFinishedSwap {
+				haveFinishedSwap = true
+			} else {
+				haveNotStartedSwap = true
+			}
+		} else if schemaSwap.swapID != metadata.lastStartedSwap {
+			recorder.RecordError(fmt.Errorf(
+				"Shard %v has an already started schema swap with an id %v, while for the keyspace it should be equal to %v",
+				schemaSwap.allShards[i].shardName, metadata.lastStartedSwap, schemaSwap.swapID))
+		}
+	}
+	if haveNotStartedSwap && haveFinishedSwap {
+		recorder.RecordError(errors.New("impossible state: there are shards with finished swap and shards where swap was not started"))
+	}
+	if recorder.HasErrors() {
+		return recorder.Error()
+	}
+
+	if haveNotStartedSwap {
+		return schemaSwap.runOnAllShards(
+			func(shard *shardSchemaSwap) error {
+				return shard.writeStartedSwap()
+			})
+	}
+	return nil
 }
 
-// finalizeSwap finishes the completed swap process by verifying that it's actually complete
-// and then modifying the database to register the completion.
+// finalizeSwap finishes the completed swap process by modifying the database to register the completion.
 func (schemaSwap *Swap) finalizeSwap() error {
-	err := schemaSwap.runOnAllShards(
-		func(shard *shardSchemaSwap) error {
-			return shard.verifySwapApplied()
-		})
-	if err != nil {
-		return err
-	}
-	err = schemaSwap.runOnAllShards(
+	return schemaSwap.runOnAllShards(
 		func(shard *shardSchemaSwap) error {
 			return shard.writeFinishedSwap()
 		})
-	return err
 }
 
 // setShardInProgress changes the way shard looks in the UI. Either it's "in progress" (has
@@ -448,11 +539,22 @@ func (shardSwap *shardSchemaSwap) markStepInProgress(uiNode *workflow.Node) {
 	uiNode.BroadcastChanges(false /* updateChildren */)
 }
 
+// addShardLog prints the message into logs and adds it into logs displayed in UI on the
+// shard node.
+func (shardSwap *shardSchemaSwap) addShardLog(message string) {
+	log.Infof("Shard %v: %v", shardSwap.shardName, message)
+	shardSwap.shardUILogger.Infof(message)
+	shardSwap.shardUINode.Log = shardSwap.shardUILogger.String()
+	shardSwap.shardUINode.BroadcastChanges(false /* updateChildren */)
+}
+
 // markStepDone marks one step of the shard schema swap workflow as finished successfully
 // or with an error.
-func (shardSwap *shardSchemaSwap) markStepDone(uiNode *workflow.Node, err error) {
-	if err != nil {
-		uiNode.Message = fmt.Sprintf("Error: %v", err)
+func (shardSwap *shardSchemaSwap) markStepDone(uiNode *workflow.Node, err *error) {
+	if *err != nil {
+		msg := fmt.Sprintf("Error: %v", *err)
+		shardSwap.addShardLog(msg)
+		uiNode.Message = msg
 	}
 	uiNode.State = workflowpb.WorkflowState_Done
 	uiNode.Display = workflow.NodeDisplayNone
@@ -519,13 +621,6 @@ func (shardSwap *shardSchemaSwap) writeStartedSwap() error {
 	if err != nil {
 		return err
 	}
-	query := fmt.Sprintf(
-		"INSERT INTO _vt.shard_metadata (name, value) VALUES ('%s', '%d') ON DUPLICATE KEY UPDATE value = '%d'",
-		lastStartedMetadataName, shardSwap.parent.swapID, shardSwap.parent.swapID)
-	_, err = shardSwap.executeAdminQuery(tablet, query, 0 /* maxRows */)
-	if err != nil {
-		return err
-	}
 	queryBuf := bytes.Buffer{}
 	queryBuf.WriteString("INSERT INTO _vt.shard_metadata (name, value) VALUES ('")
 	queryBuf.WriteString(currentSQLMetadataName)
@@ -538,6 +633,13 @@ func (shardSwap *shardSchemaSwap) writeStartedSwap() error {
 	queryBuf.WriteString(") ON DUPLICATE KEY UPDATE value = ")
 	sqlValue.EncodeSQL(&queryBuf)
 	_, err = shardSwap.executeAdminQuery(tablet, queryBuf.String(), 0 /* maxRows */)
+	if err != nil {
+		return err
+	}
+	query := fmt.Sprintf(
+		"INSERT INTO _vt.shard_metadata (name, value) VALUES ('%s', '%d') ON DUPLICATE KEY UPDATE value = '%d'",
+		lastStartedMetadataName, shardSwap.parent.swapID, shardSwap.parent.swapID)
+	_, err = shardSwap.executeAdminQuery(tablet, query, 0 /* maxRows */)
 	return err
 }
 
@@ -801,7 +903,27 @@ func (shardSwap *shardSchemaSwap) findNextTabletToSwap() (*topodatapb.Tablet, er
 			return tabletStats.Tablet, nil
 		}
 	}
+	shardSwap.numTabletsSwapped = numTabletsSwapped
 	return nil, nil
+}
+
+// undrainSeedTablet undrains the tablet that was used to apply seed schema change,
+// and returns it to the same type as it was before.
+func (shardSwap *shardSchemaSwap) undrainSeedTablet(seedTablet *topodatapb.Tablet, tabletType topodatapb.TabletType) error {
+	_, err := shardSwap.parent.topoServer.UpdateTabletFields(shardSwap.parent.ctx, seedTablet.Alias,
+		func(tablet *topodatapb.Tablet) error {
+			delete(tablet.Tags, "drain_reason")
+			return nil
+		})
+	if err != nil {
+		// This is not a critical error, we'll just log it.
+		log.Errorf("Got error trying to set drain_reason on tablet %v: %v", seedTablet.Alias, err)
+	}
+	err = shardSwap.parent.tabletClient.ChangeType(shardSwap.parent.ctx, seedTablet, tabletType)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // applySeedSchemaChange chooses a healthy tablet as a schema swap seed and applies the schema change
@@ -811,7 +933,7 @@ func (shardSwap *shardSchemaSwap) findNextTabletToSwap() (*topodatapb.Tablet, er
 // already started process and doesn't try to apply the schema change on any other tablet.
 func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 	shardSwap.markStepInProgress(shardSwap.applySchemaUINode)
-	defer shardSwap.markStepDone(shardSwap.applySchemaUINode, err)
+	defer shardSwap.markStepDone(shardSwap.applySchemaUINode, &err)
 
 	tabletList := shardSwap.getTabletList()
 	sort.Sort(orderTabletsForSwap(tabletList))
@@ -826,8 +948,10 @@ func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 	}
 	seedTablet := tabletList[0].Tablet
 	if seedTablet.Type == topodatapb.TabletType_MASTER {
-		return fmt.Errorf("The only candidate for a schema swap seed is the master %v. Aborting the swap.", seedTablet)
+		return fmt.Errorf("the only candidate for a schema swap seed is the master %v, aborting", seedTablet)
 	}
+	shardSwap.addShardLog(fmt.Sprintf("Applying schema change on the seed tablet %v", seedTablet.Alias))
+
 	// Draining the tablet for it to not be used for execution of user queries.
 	savedSeedType := seedTablet.Type
 	err = shardSwap.parent.tabletClient.ChangeType(shardSwap.parent.ctx, seedTablet, topodatapb.TabletType_DRAINED)
@@ -846,6 +970,7 @@ func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 		// This is not a critical error, we'll just log it.
 		log.Errorf("Got error trying to set drain_reason on tablet %v: %v", seedTablet.Alias, err)
 	}
+
 	// TODO: Add support for multi-statement schema swaps.
 	_, err = shardSwap.parent.tabletClient.ExecuteFetchAsDba(
 		shardSwap.parent.ctx,
@@ -856,6 +981,10 @@ func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 		true, /* disableBinlogs */
 		true /* reloadSchema */)
 	if err != nil {
+		if undrainErr := shardSwap.undrainSeedTablet(seedTablet, savedSeedType); undrainErr != nil {
+			// We won't return error of undraining because we already have error of SQL execution.
+			log.Errorf("Got error undraining seed tablet: %v", undrainErr)
+		}
 		return err
 	}
 	updateAppliedSwapQuery := fmt.Sprintf(
@@ -870,24 +999,18 @@ func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 		true, /* disableBinlogs */
 		false /* reloadSchema */)
 	if err != nil {
+		if undrainErr := shardSwap.undrainSeedTablet(seedTablet, savedSeedType); undrainErr != nil {
+			// We won't return error of undraining because we already have error of SQL execution.
+			log.Errorf("Got error undraining seed tablet: %v", undrainErr)
+		}
 		return err
 	}
 
-	// Undraining the tablet, returing it to the same type as it was before.
-	_, err = shardSwap.parent.topoServer.UpdateTabletFields(shardSwap.parent.ctx, seedTablet.Alias,
-		func(tablet *topodatapb.Tablet) error {
-			delete(tablet.Tags, "drain_reason")
-			return nil
-		})
-	if err != nil {
-		// This is not a critical error, we'll just log it.
-		log.Errorf("Got error trying to set drain_reason on tablet %v: %v", seedTablet.Alias, err)
-	}
-	err = shardSwap.parent.tabletClient.ChangeType(shardSwap.parent.ctx, seedTablet, savedSeedType)
-	if err != nil {
+	if err = shardSwap.undrainSeedTablet(seedTablet, savedSeedType); err != nil {
 		return err
 	}
 
+	shardSwap.addShardLog("Schema applied on the seed tablet")
 	return nil
 }
 
@@ -896,25 +1019,31 @@ func (shardSwap *shardSchemaSwap) applySeedSchemaChange() (err error) {
 // is lost somewhere half way through the schema swap process.
 func (shardSwap *shardSchemaSwap) takeSeedBackup() (err error) {
 	shardSwap.markStepInProgress(shardSwap.backupUINode)
-	defer shardSwap.markStepDone(shardSwap.backupUINode, err)
+	defer shardSwap.markStepDone(shardSwap.backupUINode, &err)
 
 	tabletList := shardSwap.getTabletList()
 	sort.Sort(orderTabletsForSwap(tabletList))
 	var seedTablet *topodatapb.Tablet
-	for _, tabletStats := range tabletList {
-		swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
-		if err != nil {
-			return err
+	for seedTablet == nil {
+		for _, tabletStats := range tabletList {
+			swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
+			if err != nil {
+				return err
+			}
+			if swapApplied && tabletStats.Tablet.Type != topodatapb.TabletType_MASTER {
+				seedTablet = tabletStats.Tablet
+				break
+			}
 		}
-		if swapApplied && tabletStats.Tablet.Type != topodatapb.TabletType_MASTER {
-			seedTablet = tabletStats.Tablet
-			break
+		if seedTablet == nil {
+			shardSwap.addShardLog("Cannot find the seed tablet to take backup.")
+			if err := shardSwap.applySeedSchemaChange(); err != nil {
+				return err
+			}
 		}
-	}
-	if seedTablet == nil {
-		return fmt.Errorf("Cannot find the seed tablet on shard %v", shardSwap.shardName)
 	}
 
+	shardSwap.addShardLog(fmt.Sprintf("Taking backup on the seed tablet %v", seedTablet.Alias))
 	eventStream, err := shardSwap.parent.tabletClient.Backup(shardSwap.parent.ctx, seedTablet, *backupConcurrency)
 	if err != nil {
 		return err
@@ -932,28 +1061,14 @@ waitForBackup:
 		}
 	}
 
+	shardSwap.addShardLog(fmt.Sprintf("Waiting for the seed tablet %v to become healthy", seedTablet.Alias))
 	return shardSwap.waitForTabletToBeHealthy(seedTablet)
-}
-
-// verifySwapApplied checks that all tablets in the shard have schema swap applied on them.
-func (shardSwap *shardSchemaSwap) verifySwapApplied() error {
-	tabletList := shardSwap.getTabletList()
-	for _, tabletStats := range tabletList {
-		swapApplied, err := shardSwap.isSwapApplied(tabletStats.Tablet)
-		if err != nil {
-			return err
-		}
-		if !swapApplied {
-			return fmt.Errorf("Schema swap was not applied on tablet %v", tabletStats.Tablet.Alias)
-		}
-	}
-	return nil
 }
 
 // swapOnTablet performs the schema swap on the provided tablet and then waits for it
 // to become healthy and to catch up with replication.
 func (shardSwap *shardSchemaSwap) swapOnTablet(tablet *topodatapb.Tablet) error {
-	log.Infof("Restoring tablet %v from backup", tablet.Alias)
+	shardSwap.addPropagationLog(fmt.Sprintf("Restoring tablet %v from backup", tablet.Alias))
 	eventStream, err := shardSwap.parent.tabletClient.RestoreFromBackup(shardSwap.parent.ctx, tablet)
 	if err != nil {
 		return err
@@ -977,9 +1092,11 @@ waitForRestore:
 		return err
 	}
 	if !swapApplied {
-		return fmt.Errorf("Restore from backup cannot pick up new schema. Backup from tablet with new schema needs to be taken.")
+		shardSwap.addPropagationLog(fmt.Sprintf("Tablet %v is restored but doesn't have schema swap applied", tablet.Alias))
+		return errNoBackupWithSwap
 	}
 
+	shardSwap.addPropagationLog(fmt.Sprintf("Waiting for tablet %v to become healthy", tablet.Alias))
 	return shardSwap.waitForTabletToBeHealthy(tablet)
 }
 
@@ -992,7 +1109,6 @@ func (shardSwap *shardSchemaSwap) waitForTabletToBeHealthy(tablet *topodatapb.Ta
 		return err
 	}
 	if waitChannel != nil {
-		log.Infof("Waiting for tablet %v to catch up with replication", tablet.Alias)
 		select {
 		case <-shardSwap.parent.ctx.Done():
 			return shardSwap.parent.ctx.Err()
@@ -1006,22 +1122,54 @@ func (shardSwap *shardSchemaSwap) waitForTabletToBeHealthy(tablet *topodatapb.Ta
 // updatePropagationProgressUI updates the progress bar in the workflow UI to reflect appropriate
 // percentage in line with how many tablets have schema swapped already.
 func (shardSwap *shardSchemaSwap) updatePropagationProgressUI() {
-	shardSwap.propagateUINode.ProgressMessage = fmt.Sprintf("%v/%v", shardSwap.numTabletsSwapped, shardSwap.numTabletsTotal)
+	shardSwap.propagationUINode.ProgressMessage = fmt.Sprintf("%v/%v", shardSwap.numTabletsSwapped, shardSwap.numTabletsTotal)
 	if shardSwap.numTabletsTotal == 0 {
-		shardSwap.propagateUINode.Progress = 0
+		shardSwap.propagationUINode.Progress = 0
 	} else {
-		shardSwap.propagateUINode.Progress = shardSwap.numTabletsSwapped * 100 / shardSwap.numTabletsTotal
+		shardSwap.propagationUINode.Progress = shardSwap.numTabletsSwapped * 100 / shardSwap.numTabletsTotal
 	}
-	shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
+	shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
+}
+
+// markPropagationInProgress marks the propagation step of the shard schema swap workflow as running.
+func (shardSwap *shardSchemaSwap) markPropagationInProgress() {
+	shardSwap.propagationUINode.Message = ""
+	shardSwap.propagationUINode.State = workflowpb.WorkflowState_Running
+	shardSwap.propagationUINode.Display = workflow.NodeDisplayDeterminate
+	shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
+}
+
+// addPropagationLog prints the message to logs, adds it to logs displayed in the UI on the "Propagate to all tablets"
+// node and adds the message to the logs displayed on the overall shard node, so that everything happening to this
+// shard was visible in one log.
+func (shardSwap *shardSchemaSwap) addPropagationLog(message string) {
+	shardSwap.propagationUILogger.Infof(message)
+	shardSwap.propagationUINode.Log = shardSwap.propagationUILogger.String()
+	shardSwap.propagationUINode.Message = message
+	shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
+	shardSwap.addShardLog(message)
+}
+
+// markPropagationDone marks the propagation step of the shard schema swap workflow as finished successfully
+// or with an error.
+func (shardSwap *shardSchemaSwap) markPropagationDone(err *error) {
+	if *err != nil {
+		msg := fmt.Sprintf("Error: %v", *err)
+		shardSwap.addPropagationLog(msg)
+		shardSwap.propagationUINode.Message = msg
+		shardSwap.propagationUINode.State = workflowpb.WorkflowState_Done
+	} else if shardSwap.numTabletsSwapped == shardSwap.numTabletsTotal {
+		shardSwap.propagationUINode.State = workflowpb.WorkflowState_Done
+	}
+	shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
 }
 
 // propagateToNonMasterTablets propagates the schema change to all non-master tablets
 // in the shard. When it returns nil it means that only master can remain left with the
 // old schema, everything else is verified to have schema swap applied.
-func (shardSwap *shardSchemaSwap) propagateToAllTablets(withMasterReparent bool) error {
-	shardSwap.propagateUINode.Message = ""
-	shardSwap.propagateUINode.State = workflowpb.WorkflowState_Running
-	shardSwap.propagateUINode.Display = workflow.NodeDisplayDeterminate
+func (shardSwap *shardSchemaSwap) propagateToAllTablets(withMasterReparent bool) (err error) {
+	shardSwap.markPropagationInProgress()
+	defer shardSwap.markPropagationDone(&err)
 
 	for {
 		shardSwap.updatePropagationProgressUI()
@@ -1033,9 +1181,6 @@ func (shardSwap *shardSchemaSwap) propagateToAllTablets(withMasterReparent bool)
 			if withMasterReparent {
 				err = shardSwap.reparentFromMaster(tablet)
 				if err != nil {
-					shardSwap.propagateUINode.State = workflowpb.WorkflowState_Done
-					shardSwap.propagateUINode.Message = fmt.Sprintf("Error: %v", err)
-					shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
 					return err
 				}
 			} else {
@@ -1044,36 +1189,36 @@ func (shardSwap *shardSchemaSwap) propagateToAllTablets(withMasterReparent bool)
 		}
 		if err == nil {
 			if tablet == nil {
-				shardSwap.propagateUINode.State = workflowpb.WorkflowState_Done
-				shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
+				shardSwap.propagationUINode.Message = ""
+				shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
 				return nil
 			}
 			err = shardSwap.swapOnTablet(tablet)
 			if err == nil {
 				shardSwap.numTabletsSwapped++
-				log.Infof("Schema is successfully swapped on tablet %v.", tablet.Alias)
+				shardSwap.addPropagationLog(fmt.Sprintf("Schema is successfully swapped on tablet %v.", tablet.Alias))
 				continue
 			}
-			log.Infof("Error swapping schema on tablet %v: %v", tablet.Alias, err)
+			if err == errNoBackupWithSwap {
+				if err := shardSwap.takeSeedBackup(); err != nil {
+					return err
+				}
+				continue
+			}
+			shardSwap.addPropagationLog(fmt.Sprintf("Error swapping schema on tablet %v: %v", tablet.Alias, err))
 		} else {
-			log.Infof("Error searching for next tablet to swap schema on: %v.", err)
+			shardSwap.addPropagationLog(fmt.Sprintf("Error searching for next tablet to swap schema on: %v.", err))
 		}
 
-		msg := fmt.Sprintf("Sleeping for %v seconds.", *delayBetweenErrors)
-		log.Infof(msg)
-		shardSwap.propagateUINode.Message = msg
-		shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
+		shardSwap.addPropagationLog(fmt.Sprintf("Sleeping for %v seconds.", *delayBetweenErrors))
 		select {
 		case <-shardSwap.parent.ctx.Done():
-			shardSwap.propagateUINode.State = workflowpb.WorkflowState_Done
-			shardSwap.propagateUINode.Message = fmt.Sprintf("Error: %v", shardSwap.parent.ctx.Err())
-			shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
 			return shardSwap.parent.ctx.Err()
 		case <-time.After(*delayBetweenErrors):
 			// Waiting is done going to the next loop.
 		}
-		shardSwap.propagateUINode.Message = ""
-		shardSwap.propagateUINode.BroadcastChanges(false /* updateChildren */)
+		shardSwap.propagationUINode.Message = ""
+		shardSwap.propagationUINode.BroadcastChanges(false /* updateChildren */)
 	}
 }
 
@@ -1081,8 +1226,9 @@ func (shardSwap *shardSchemaSwap) propagateToAllTablets(withMasterReparent bool)
 // the schema change applied then the method does nothing.
 func (shardSwap *shardSchemaSwap) reparentFromMaster(masterTablet *topodatapb.Tablet) (err error) {
 	shardSwap.markStepInProgress(shardSwap.reparentUINode)
-	defer shardSwap.markStepDone(shardSwap.reparentUINode, err)
+	defer shardSwap.markStepDone(shardSwap.reparentUINode, &err)
 
+	shardSwap.addShardLog(fmt.Sprintf("Reparenting away from master %v", masterTablet.Alias))
 	wr := wrangler.New(logutil.NewConsoleLogger(), shardSwap.parent.topoServer, shardSwap.parent.tabletClient)
 	err = wr.PlannedReparentShard(
 		shardSwap.parent.ctx,


### PR DESCRIPTION
I'm adding handling of the following problems:
- vtctld died during schema swap initialization or finalization;
- schema change have failed (the tablet needs to be undrained);
- seed backup disappeared before it was propagated everywhere;
- seed replica disappeared before seed backup is taken.

I'm also adding a "Retry" button to the workflow to be able to retry the swap
after any other problems that were deemed retriable or got fixed by an operator.
I'm also adding an extensive logging of all operations that are being done both
to the vtctld logs and to the workflow UI to be easily viewable.

On the way I'm also fixing a few bugs in error handling that I found during
testing.