### PR TITLE
2pc watchdog and related work

### DIFF
--- a/go/vt/tabletserver/config.go
+++ b/go/vt/tabletserver/config.go
@@ -50,6 +50,9 @@ func init() {
 	flag.StringVar(&qsConfig.DebugURLPrefix, "debug-url-prefix", DefaultQsConfig.DebugURLPrefix, "debug url prefix, vttablet will report various system debug pages and this config controls the prefix of these debug urls")
 	flag.StringVar(&qsConfig.PoolNamePrefix, "pool-name-prefix", DefaultQsConfig.PoolNamePrefix, "pool name prefix, vttablet has several pools and each of them has a name. This config specifies the prefix of these pool names")
 	flag.BoolVar(&qsConfig.EnableAutoCommit, "enable-autocommit", DefaultQsConfig.EnableAutoCommit, "if the flag is on, a DML outsides a transaction will be auto committed.")
+	flag.BoolVar(&qsConfig.TwoPCEnable, "twopc_enable", DefaultQsConfig.TwoPCEnable, "if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.")
+	flag.StringVar(&qsConfig.TwoPCCoordinatorAddress, "twopc_coordinator_address", DefaultQsConfig.TwoPCCoordinatorAddress, "address of the (VTGate) process(es) that will be used to notify of abandoned transactions.")
+	flag.Float64Var(&qsConfig.TwoPCAbandonAge, "twopc_abandon_age", DefaultQsConfig.TwoPCAbandonAge, "time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.")
 }
 
 // Init must be called after flag.Parse, and before doing any other operations.
@@ -60,28 +63,31 @@ func Init() {
 
 // Config contains all the configuration for query service
 type Config struct {
-	PoolSize             int
-	StreamPoolSize       int
-	TransactionCap       int
-	TransactionTimeout   float64
-	MaxResultSize        int
-	MaxDMLRows           int
-	StreamBufferSize     int
-	QueryCacheSize       int
-	SchemaReloadTime     float64
-	QueryTimeout         float64
-	TxPoolTimeout        float64
-	IdleTimeout          float64
-	StrictMode           bool
-	StrictTableAcl       bool
-	TerseErrors          bool
-	EnablePublishStats   bool
-	EnableAutoCommit     bool
-	EnableTableAclDryRun bool
-	StatsPrefix          string
-	DebugURLPrefix       string
-	PoolNamePrefix       string
-	TableAclExemptACL    string
+	PoolSize                int
+	StreamPoolSize          int
+	TransactionCap          int
+	TransactionTimeout      float64
+	MaxResultSize           int
+	MaxDMLRows              int
+	StreamBufferSize        int
+	QueryCacheSize          int
+	SchemaReloadTime        float64
+	QueryTimeout            float64
+	TxPoolTimeout           float64
+	IdleTimeout             float64
+	StrictMode              bool
+	StrictTableAcl          bool
+	TerseErrors             bool
+	EnablePublishStats      bool
+	EnableAutoCommit        bool
+	EnableTableAclDryRun    bool
+	StatsPrefix             string
+	DebugURLPrefix          string
+	PoolNamePrefix          string
+	TableAclExemptACL       string
+	TwoPCEnable             bool
+	TwoPCCoordinatorAddress string
+	TwoPCAbandonAge         float64
 }
 
 // DefaultQsConfig is the default value for the query service config.
@@ -92,28 +98,31 @@ type Config struct {
 // great (the overhead makes the final packets on the wire about twice
 // bigger than this).
 var DefaultQsConfig = Config{
-	PoolSize:             16,
-	StreamPoolSize:       200,
-	TransactionCap:       20,
-	TransactionTimeout:   30,
-	MaxResultSize:        10000,
-	MaxDMLRows:           500,
-	QueryCacheSize:       5000,
-	SchemaReloadTime:     30 * 60,
-	QueryTimeout:         30,
-	TxPoolTimeout:        1,
-	IdleTimeout:          30 * 60,
-	StreamBufferSize:     32 * 1024,
-	StrictMode:           true,
-	StrictTableAcl:       false,
-	TerseErrors:          false,
-	EnablePublishStats:   true,
-	EnableAutoCommit:     false,
-	EnableTableAclDryRun: false,
-	StatsPrefix:          "",
-	DebugURLPrefix:       "/debug",
-	PoolNamePrefix:       "",
-	TableAclExemptACL:    "",
+	PoolSize:                16,
+	StreamPoolSize:          200,
+	TransactionCap:          20,
+	TransactionTimeout:      30,
+	MaxResultSize:           10000,
+	MaxDMLRows:              500,
+	QueryCacheSize:          5000,
+	SchemaReloadTime:        30 * 60,
+	QueryTimeout:            30,
+	TxPoolTimeout:           1,
+	IdleTimeout:             30 * 60,
+	StreamBufferSize:        32 * 1024,
+	StrictMode:              true,
+	StrictTableAcl:          false,
+	TerseErrors:             false,
+	EnablePublishStats:      true,
+	EnableAutoCommit:        false,
+	EnableTableAclDryRun:    false,
+	StatsPrefix:             "",
+	DebugURLPrefix:          "/debug",
+	PoolNamePrefix:          "",
+	TableAclExemptACL:       "",
+	TwoPCEnable:             false,
+	TwoPCCoordinatorAddress: "",
+	TwoPCAbandonAge:         0,
 }
 
 var qsConfig Config

--- a/go/vt/tabletserver/endtoend/framework/server.go
+++ b/go/vt/tabletserver/endtoend/framework/server.go
@@ -10,12 +10,16 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/tabletserver"
+	"github.com/youtube/vitess/go/vt/vtgate/fakerpcvtgateconn"
+	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 )
 
 var (
@@ -27,12 +31,23 @@ var (
 	Server *tabletserver.TabletServer
 	// ServerAddress is the http URL for the server.
 	ServerAddress string
+	// ResolveChan is the channel that sends dtids that are to be resolved.
+	ResolveChan = make(chan string, 1)
 )
 
 // StartServer starts the server and initializes
 // all the global variables. This function should only be called
 // once at the beginning of the test.
 func StartServer(connParams sqldb.ConnParams) error {
+	// Setup a fake vtgate server.
+	protocol := "resolveTest"
+	*vtgateconn.VtgateProtocol = protocol
+	vtgateconn.RegisterDialer(protocol, func(context.Context, string, time.Duration) (vtgateconn.Impl, error) {
+		return &txResolver{
+			FakeVTGateConn: fakerpcvtgateconn.FakeVTGateConn{},
+		}, nil
+	})
+
 	dbcfgs := dbconfigs.DBConfigs{
 		App:           connParams,
 		SidecarDBName: "_vt",
@@ -49,6 +64,9 @@ func StartServer(connParams sqldb.ConnParams) error {
 	BaseConfig = tabletserver.DefaultQsConfig
 	BaseConfig.EnableAutoCommit = true
 	BaseConfig.StrictTableAcl = true
+	BaseConfig.TwoPCEnable = true
+	BaseConfig.TwoPCAbandonAge = 1
+	BaseConfig.TwoPCCoordinatorAddress = "fake"
 
 	Target = querypb.Target{
 		Keyspace:   "vttest",
@@ -60,13 +78,13 @@ func StartServer(connParams sqldb.ConnParams) error {
 	Server.Register()
 	err := Server.StartService(Target, dbcfgs, mysqld)
 	if err != nil {
-		return fmt.Errorf("could not start service: %v\n", err)
+		return fmt.Errorf("could not start service: %v", err)
 	}
 
 	// Start http service.
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
-		return fmt.Errorf("could not start listener: %v\n", err)
+		return fmt.Errorf("could not start listener: %v", err)
 	}
 	ServerAddress = fmt.Sprintf("http://%s", ln.Addr().String())
 	go http.Serve(ln, nil)
@@ -84,4 +102,17 @@ func StartServer(connParams sqldb.ConnParams) error {
 // StopServer must be called once all the tests are done.
 func StopServer() {
 	Server.StopService()
+}
+
+// txReolver transmits dtids to be resolved through ResolveChan.
+type txResolver struct {
+	fakerpcvtgateconn.FakeVTGateConn
+}
+
+func (conn *txResolver) ResolveTransaction(ctx context.Context, dtid string) error {
+	select {
+	case ResolveChan <- dtid:
+	default:
+	}
+	return nil
 }

--- a/go/vt/tabletserver/twopc.go
+++ b/go/vt/tabletserver/twopc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 
@@ -71,6 +72,8 @@ const (
 
 // TwoPC performs 2PC metadata management (MM) functions.
 type TwoPC struct {
+	readPool *ConnPool
+
 	insertRedoTx   *sqlparser.ParsedQuery
 	insertRedoStmt *sqlparser.ParsedQuery
 	updateRedoTx   *sqlparser.ParsedQuery
@@ -85,19 +88,20 @@ type TwoPC struct {
 	deleteParticipants *sqlparser.ParsedQuery
 	readTransaction    *sqlparser.ParsedQuery
 	readParticipants   *sqlparser.ParsedQuery
+	readAbandoned      *sqlparser.ParsedQuery
 }
 
 // NewTwoPC creates a TwoPC variable.
-func NewTwoPC() *TwoPC {
-	return &TwoPC{}
+func NewTwoPC(readPool *ConnPool) *TwoPC {
+	return &TwoPC{readPool: readPool}
 }
 
-// Open starts the 2PC MM service. If the metadata database or tables
+// Init initializes TwoPC. If the metadata database or tables
 // are not present, they are created.
-func (tpc *TwoPC) Open(sidecarDBName string, dbaparams *sqldb.ConnParams) {
+func (tpc *TwoPC) Init(sidecarDBName string, dbaparams *sqldb.ConnParams) error {
 	conn, err := dbconnpool.NewDBConnection(dbaparams, stats.NewTimings(""))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer conn.Close()
 	statements := []string{
@@ -111,7 +115,7 @@ func (tpc *TwoPC) Open(sidecarDBName string, dbaparams *sqldb.ConnParams) {
 	}
 	for _, s := range statements {
 		if _, err := conn.ExecuteFetch(s, 0, false); err != nil {
-			panic(NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, err.Error()))
+			return NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, err.Error())
 		}
 	}
 	tpc.insertRedoTx = buildParsedQuery(
@@ -152,16 +156,26 @@ func (tpc *TwoPC) Open(sidecarDBName string, dbaparams *sqldb.ConnParams) {
 	tpc.readParticipants = buildParsedQuery(
 		"select keyspace, shard from `%s`.participant where dtid = %a",
 		sidecarDBName, ":dtid")
+	tpc.readAbandoned = buildParsedQuery(
+		"select dtid, time_created from `%s`.transaction where time_created < %a",
+		sidecarDBName, ":time_created")
+	return nil
+}
+
+// Open starts the TwoPC service.
+func (tpc *TwoPC) Open(dbconfigs dbconfigs.DBConfigs) {
+	tpc.readPool.Open(&dbconfigs.App, &dbconfigs.Dba)
+}
+
+// Close closes the TwoPC service.
+func (tpc *TwoPC) Close() {
+	tpc.readPool.Close()
 }
 
 func buildParsedQuery(in string, vars ...interface{}) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.Myprintf(in, vars...)
 	return buf.ParsedQuery()
-}
-
-// Close shuts down the 2PC MM service.
-func (tpc *TwoPC) Close() {
 }
 
 // SaveRedo saves the statements in the redo log using the supplied connection.
@@ -214,7 +228,13 @@ func (tpc *TwoPC) DeleteRedo(ctx context.Context, conn *TxConnection, dtid strin
 }
 
 // ReadAllRedo returns all the prepared transactions from the redo logs.
-func (tpc *TwoPC) ReadAllRedo(ctx context.Context, conn *DBConn) (prepared map[string][]string, failed []string, err error) {
+func (tpc *TwoPC) ReadAllRedo(ctx context.Context) (prepared map[string][]string, failed []string, err error) {
+	conn, err := tpc.readPool.Get(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer conn.Recycle()
+
 	qr, err := conn.Exec(ctx, tpc.readAllRedo, 10000, false)
 	if err != nil {
 		return nil, nil, err
@@ -305,7 +325,13 @@ func (tpc *TwoPC) DeleteTransaction(ctx context.Context, conn *TxConnection, dti
 }
 
 // ReadTransaction returns the metadata for the transaction.
-func (tpc *TwoPC) ReadTransaction(ctx context.Context, conn *DBConn, dtid string) (*querypb.TransactionMetadata, error) {
+func (tpc *TwoPC) ReadTransaction(ctx context.Context, dtid string) (*querypb.TransactionMetadata, error) {
+	conn, err := tpc.readPool.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+
 	result := &querypb.TransactionMetadata{}
 	bindVars := map[string]interface{}{
 		"dtid": dtid,
@@ -351,6 +377,33 @@ func (tpc *TwoPC) ReadTransaction(ctx context.Context, conn *DBConn, dtid string
 	}
 	result.Participants = participants
 	return result, nil
+}
+
+// ReadAbandoned returns the list of abandoned transactions
+// and their associated start time.
+func (tpc *TwoPC) ReadAbandoned(ctx context.Context, abandonTime time.Time) (map[string]time.Time, error) {
+	conn, err := tpc.readPool.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Recycle()
+
+	bindVars := map[string]interface{}{
+		"time_created": int64(abandonTime.UnixNano()),
+	}
+	qr, err := tpc.read(ctx, conn, tpc.readAbandoned, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	txs := make(map[string]time.Time, len(qr.Rows))
+	for _, row := range qr.Rows {
+		t, err := strconv.ParseInt(row[1].String(), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		txs[row[0].String()] = time.Unix(0, t)
+	}
+	return txs, nil
 }
 
 func (tpc *TwoPC) exec(ctx context.Context, conn *TxConnection, pq *sqlparser.ParsedQuery, bindVars map[string]interface{}) (*sqltypes.Result, error) {

--- a/go/vt/tabletserver/twopc_test.go
+++ b/go/vt/tabletserver/twopc_test.go
@@ -16,7 +16,7 @@ func TestReadAllRedo(t *testing.T) {
 	// Reuse code from tx_executor_test.
 	_, tsv, db := newTestTxExecutor()
 	defer tsv.StopService()
-	tpc := tsv.qe.twoPC
+	tpc := tsv.te.twoPC
 	ctx := context.Background()
 
 	conn, err := tsv.qe.connPool.Get(ctx)
@@ -26,7 +26,7 @@ func TestReadAllRedo(t *testing.T) {
 	defer conn.Recycle()
 
 	db.AddQuery(tpc.readAllRedo, &sqltypes.Result{})
-	prepared, failed, err := tpc.ReadAllRedo(ctx, conn)
+	prepared, failed, err := tpc.ReadAllRedo(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestReadAllRedo(t *testing.T) {
 			sqltypes.MakeString([]byte("stmt01")),
 		}},
 	})
-	prepared, failed, err = tpc.ReadAllRedo(ctx, conn)
+	prepared, failed, err = tpc.ReadAllRedo(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestReadAllRedo(t *testing.T) {
 			sqltypes.MakeString([]byte("stmt02")),
 		}},
 	})
-	prepared, failed, err = tpc.ReadAllRedo(ctx, conn)
+	prepared, failed, err = tpc.ReadAllRedo(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func TestReadAllRedo(t *testing.T) {
 			sqltypes.MakeString([]byte("stmt11")),
 		}},
 	})
-	prepared, failed, err = tpc.ReadAllRedo(ctx, conn)
+	prepared, failed, err = tpc.ReadAllRedo(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,7 +149,7 @@ func TestReadAllRedo(t *testing.T) {
 			sqltypes.MakeString([]byte("stmt31")),
 		}},
 	})
-	prepared, failed, err = tpc.ReadAllRedo(ctx, conn)
+	prepared, failed, err = tpc.ReadAllRedo(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/tabletserver/tx_engine.go
+++ b/go/vt/tabletserver/tx_engine.go
@@ -1,0 +1,237 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tabletserver
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/timer"
+	"github.com/youtube/vitess/go/vt/concurrency"
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
+)
+
+// TxEngine handles transactions.
+type TxEngine struct {
+	isOpen, twopcEnabled bool
+	coordinatorAddress   string
+	abandonAge           time.Duration
+	ticks                *timer.Timer
+
+	txPool       *TxPool
+	preparedPool *TxPreparedPool
+	twoPC        *TwoPC
+
+	queryServiceStats *QueryServiceStats
+}
+
+// NewTxEngine creates a new TxEngine.
+func NewTxEngine(checker MySQLChecker, config Config, queryServiceStats *QueryServiceStats) *TxEngine {
+	te := &TxEngine{}
+	te.txPool = NewTxPool(
+		config.PoolNamePrefix+"TransactionPool",
+		config.StatsPrefix,
+		config.TransactionCap,
+		time.Duration(config.TransactionTimeout*1e9),
+		time.Duration(config.IdleTimeout*1e9),
+		config.EnablePublishStats,
+		queryServiceStats,
+		checker,
+	)
+	te.queryServiceStats = queryServiceStats
+	te.twopcEnabled = config.TwoPCEnable
+	if te.twopcEnabled {
+		if config.TwoPCCoordinatorAddress == "" {
+			log.Error("Coordinator address not specified: Disabling 2PC")
+			te.twopcEnabled = false
+		}
+		if config.TwoPCAbandonAge <= 0 {
+			log.Error("2PC abandon age not specified: Disabling 2PC")
+			te.twopcEnabled = false
+		}
+	}
+	te.coordinatorAddress = config.TwoPCCoordinatorAddress
+	te.abandonAge = time.Duration(config.TwoPCAbandonAge * 1e9)
+	te.ticks = timer.NewTimer(te.abandonAge / 2)
+
+	// Set the prepared pool capacity to something lower than
+	// tx pool capacity. Those spare connections are needed to
+	// perform metadata state change operations. Without this,
+	// the system can deadlock if all connections get moved to
+	// the TxPreparedPool.
+	te.preparedPool = NewTxPreparedPool(config.TransactionCap - 2)
+	readPool := NewConnPool(
+		config.PoolNamePrefix+"TxReadPool",
+		3,
+		time.Duration(config.IdleTimeout*1e9),
+		config.EnablePublishStats,
+		queryServiceStats,
+		checker,
+	)
+	te.twoPC = NewTwoPC(readPool)
+	return te
+}
+
+// Init must be called once when vttablet starts for setting
+// up the metadata tables.
+func (te *TxEngine) Init(dbconfigs dbconfigs.DBConfigs) error {
+	if te.twopcEnabled {
+		return te.twoPC.Init(dbconfigs.SidecarDBName, &dbconfigs.Dba)
+	}
+	return nil
+}
+
+// Open opens the TxEngine. If 2pc is enabled, it restores
+// all previously prepared transactions from the redo log.
+func (te *TxEngine) Open(dbconfigs dbconfigs.DBConfigs) {
+	if te.isOpen {
+		return
+	}
+	te.txPool.Open(&dbconfigs.App, &dbconfigs.Dba)
+	if !te.twopcEnabled {
+		te.isOpen = true
+		return
+	}
+
+	te.twoPC.Open(dbconfigs)
+	if err := te.prepareFromRedo(); err != nil {
+		// If this operation fails, we choose to raise an alert and
+		// continue anyway. Serving traffic is considered more important
+		// than blocking everything for the sake of a few transactions.
+		te.queryServiceStats.InternalErrors.Add("TwopcResurrection", 1)
+		log.Errorf("Could not prepare transactions: %v", err)
+	}
+	te.startWatchdog()
+	te.isOpen = true
+}
+
+// Close closes the TxEngine. If the immediate flag is on,
+// then all current transactions are immediately rolled back.
+// Otherwise, the function waits for all current transactions
+// to conclude.
+func (te *TxEngine) Close(immediate bool) {
+	if !te.isOpen {
+		return
+	}
+	// Shut down functions are idempotent.
+	// No need to check if 2pc is enabled.
+	te.stopWatchdog()
+	if immediate {
+		te.rollbackTransactions()
+	}
+	te.txPool.WaitForEmpty()
+	te.txPool.Close()
+	te.twoPC.Close()
+	te.isOpen = false
+}
+
+// prepareFromRedo replays and prepares the transactions
+// from the redo log. It also loads previously failed transactions
+// into the reserved list.
+// TODO(sougou): Make this function set the lastId for tx pool to be
+// greater than all those used by dtids. This will prevent dtid
+// collisions.
+func (te *TxEngine) prepareFromRedo() error {
+	ctx := context.Background()
+	var allErr concurrency.AllErrorRecorder
+	prepared, failed, err := te.twoPC.ReadAllRedo(ctx)
+	if err != nil {
+		return err
+	}
+
+outer:
+	for dtid, tx := range prepared {
+		conn, err := te.txPool.LocalBegin(ctx)
+		if err != nil {
+			allErr.RecordError(err)
+			continue
+		}
+		for _, stmt := range tx {
+			conn.RecordQuery(stmt)
+			_, err := conn.Exec(ctx, stmt, 1, false)
+			if err != nil {
+				allErr.RecordError(err)
+				te.txPool.LocalConclude(ctx, conn)
+				continue outer
+			}
+		}
+		// We should not use the external Prepare because
+		// we don't want to write again to the redo log.
+		err = te.preparedPool.Put(conn, dtid)
+		if err != nil {
+			allErr.RecordError(err)
+			continue
+		}
+	}
+	for _, dtid := range failed {
+		te.preparedPool.SetFailed(dtid)
+	}
+	log.Infof("Prepared %d transactions, and registered %d failures.", len(prepared), len(failed))
+	return allErr.Error()
+}
+
+// rollbackTransactions rolls back all open transactions
+// including the prepared ones.
+// This is used for transitioning from a master to a non-master
+// serving type.
+func (te *TxEngine) rollbackTransactions() {
+	ctx := context.Background()
+	// The order of rollbacks is currently not material because
+	// we don't allow new statements or commits during
+	// this function. In case of any such change, this will
+	// have to be revisited.
+	te.txPool.RollbackNonBusy(ctx)
+	for _, c := range te.preparedPool.FetchAll() {
+		te.txPool.LocalConclude(ctx, c)
+	}
+}
+
+// startWatchdog starts the watchdog goroutine, which looks for abandoned
+// transactions and calls the notifier on them.
+func (te *TxEngine) startWatchdog() {
+	te.ticks.Start(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), te.abandonAge/4)
+		defer cancel()
+		txs, err := te.twoPC.ReadAbandoned(ctx, time.Now().Add(-te.abandonAge))
+		if err != nil {
+			// TODO(sougou): increment error counter.
+			log.Errorf("Error reading transactions for 2pc watchdog: %v", err)
+			return
+		}
+		if len(txs) == 0 {
+			return
+		}
+
+		coordConn, err := vtgateconn.Dial(ctx, te.coordinatorAddress, te.abandonAge/4, "")
+		if err != nil {
+			// TODO(sougou): increment error counter.
+			log.Errorf("error connecting to coordinator '%v': %v", te.coordinatorAddress, err)
+			return
+		}
+		defer coordConn.Close()
+
+		var wg sync.WaitGroup
+		for tx := range txs {
+			wg.Add(1)
+			go func(dtid string) {
+				defer wg.Done()
+				if err := coordConn.ResolveTransaction(ctx, dtid); err != nil {
+					// TODO(sougou): increment error counter.
+					log.Errorf("Error notifying for dtid %s: %v", dtid, err)
+				}
+			}(tx)
+		}
+		wg.Wait()
+	})
+}
+
+// stopWatchdog stops the watchdog goroutine.
+func (te *TxEngine) stopWatchdog() {
+	te.ticks.Stop()
+}

--- a/go/vt/tabletserver/tx_executor_test.go
+++ b/go/vt/tabletserver/tx_executor_test.go
@@ -9,12 +9,16 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/vtgate/fakerpcvtgateconn"
+	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 	"github.com/youtube/vitess/go/vt/vttest/fakesqldb"
-	"golang.org/x/net/context"
 )
 
 func TestTxExecutorEmptyPrepare(t *testing.T) {
@@ -26,8 +30,8 @@ func TestTxExecutorEmptyPrepare(t *testing.T) {
 		t.Error(err)
 	}
 	// Nothing should be prepared.
-	if len(txe.qe.preparedPool.conns) != 0 {
-		t.Errorf("len(txe.qe.preparedPool.conns): %d, want 0", len(txe.qe.preparedPool.conns))
+	if len(txe.te.preparedPool.conns) != 0 {
+		t.Errorf("len(txe.te.preparedPool.conns): %d, want 0", len(txe.te.preparedPool.conns))
 	}
 }
 
@@ -361,6 +365,91 @@ func TestExecutorReadTransaction(t *testing.T) {
 	}
 }
 
+// These vars and types are used only for TestExecutorResolveTransaction
+var dtidCh = make(chan string)
+
+type FakeVTGateConn struct {
+	fakerpcvtgateconn.FakeVTGateConn
+}
+
+func (conn *FakeVTGateConn) ResolveTransaction(ctx context.Context, dtid string) error {
+	dtidCh <- dtid
+	return nil
+}
+
+func TestExecutorResolveTransaction(t *testing.T) {
+	protocol := "resolveTest"
+	var save string
+	save, *vtgateconn.VtgateProtocol = *vtgateconn.VtgateProtocol, protocol
+	defer func() { *vtgateconn.VtgateProtocol = save }()
+
+	vtgateconn.RegisterDialer(protocol, func(context.Context, string, time.Duration) (vtgateconn.Impl, error) {
+		return &FakeVTGateConn{
+			FakeVTGateConn: fakerpcvtgateconn.FakeVTGateConn{},
+		}, nil
+	})
+	_, tsv, db := newShortAgeExecutor()
+	defer tsv.StopService()
+	want := "aa"
+	db.AddQueryPattern(
+		"select dtid, time_created from `_vt`\\.transaction where time_created.*",
+		&sqltypes.Result{
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeString([]byte(want)),
+				sqltypes.MakeString([]byte("1")),
+			}},
+		})
+	got := <-dtidCh
+	if got != want {
+		t.Errorf("ResolveTransaction: %s, want %s", got, want)
+	}
+}
+
+func TestNoTwopc(t *testing.T) {
+	txe, tsv, _ := newNoTwopcExecutor()
+	defer tsv.StopService()
+
+	testcases := []struct {
+		desc string
+		fun  func() error
+	}{{
+		desc: "Prepare",
+		fun:  func() error { return txe.Prepare(1, "aa") },
+	}, {
+		desc: "CommitPrepared",
+		fun:  func() error { return txe.CommitPrepared("aa") },
+	}, {
+		desc: "RollbackPrepared",
+		fun:  func() error { return txe.RollbackPrepared("aa", 1) },
+	}, {
+		desc: "CreateTransaction",
+		fun:  func() error { return txe.CreateTransaction("aa", nil) },
+	}, {
+		desc: "StartCommit",
+		fun:  func() error { return txe.StartCommit(1, "aa") },
+	}, {
+		desc: "SetRollback",
+		fun:  func() error { return txe.SetRollback("aa", 1) },
+	}, {
+		desc: "ConcludeTransaction",
+		fun:  func() error { return txe.ConcludeTransaction("aa") },
+	}, {
+		desc: "ReadTransaction",
+		fun: func() error {
+			_, err := txe.ReadTransaction("aa")
+			return err
+		},
+	}}
+
+	want := "error: 2pc is not enabled"
+	for _, tc := range testcases {
+		err := tc.fun()
+		if err == nil || err.Error() != want {
+			t.Errorf("%s: %v, want %s", tc.desc, err, want)
+		}
+	}
+}
+
 func newTestTxExecutor() (txe *TxExecutor, tsv *TabletServer, db *fakesqldb.DB) {
 	db = setUpQueryExecutorTest()
 	ctx := context.Background()
@@ -374,7 +463,38 @@ func newTestTxExecutor() (txe *TxExecutor, tsv *TabletServer, db *fakesqldb.DB) 
 	return &TxExecutor{
 		ctx:      ctx,
 		logStats: logStats,
-		qe:       tsv.qe,
+		te:       tsv.te,
+	}, tsv, db
+}
+
+// newShortAgeExecutor is same as newTestTxExecutor, but shorter transaction abandon age.
+func newShortAgeExecutor() (txe *TxExecutor, tsv *TabletServer, db *fakesqldb.DB) {
+	db = setUpQueryExecutorTest()
+	ctx := context.Background()
+	logStats := newLogStats("TestTxExecutor", ctx)
+	tsv = newTestTabletServer(ctx, smallTxPool|shortTwopcAge, db)
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_transaction\\(dtid, state, time_created\\) values \\('aa', 'Prepared',.*", &sqltypes.Result{})
+	db.AddQueryPattern("insert into `_vt`\\.redo_log_statement.*", &sqltypes.Result{})
+	db.AddQuery("delete from `_vt`.redo_log_transaction where dtid = 'aa'", &sqltypes.Result{})
+	db.AddQuery("delete from `_vt`.redo_log_statement where dtid = 'aa'", &sqltypes.Result{})
+	db.AddQuery("update test_table set name = 2 where pk in (1) /* _stream test_table (pk ) (1 ); */", &sqltypes.Result{})
+	return &TxExecutor{
+		ctx:      ctx,
+		logStats: logStats,
+		te:       tsv.te,
+	}, tsv, db
+}
+
+// newNoTwopcExecutor is same as newTestTxExecutor, but 2pc disabled.
+func newNoTwopcExecutor() (txe *TxExecutor, tsv *TabletServer, db *fakesqldb.DB) {
+	db = setUpQueryExecutorTest()
+	ctx := context.Background()
+	logStats := newLogStats("TestTxExecutor", ctx)
+	tsv = newTestTabletServer(ctx, noTwopc, db)
+	return &TxExecutor{
+		ctx:      ctx,
+		logStats: logStats,
+		te:       tsv.te,
 	}, tsv, db
 }
 

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -139,13 +139,7 @@ func (axp *TxPool) WaitForEmpty() {
 // Begin begins a transaction, and returns the associated transaction id.
 // Subsequent statements can access the connection through the transaction id.
 func (axp *TxPool) Begin(ctx context.Context) (int64, error) {
-	poolCtx := ctx
-	if deadline, ok := ctx.Deadline(); ok {
-		var cancel func()
-		poolCtx, cancel = context.WithDeadline(ctx, deadline.Add(-10*time.Millisecond))
-		defer cancel()
-	}
-	conn, err := axp.pool.Get(poolCtx)
+	conn, err := axp.pool.Get(ctx)
 	if err != nil {
 		switch err {
 		case ErrConnPoolClosed:

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -175,26 +175,6 @@ func TestTxPoolBeginAfterConnPoolClosed(t *testing.T) {
 	}
 }
 
-func TestTxPoolBeginWithShortDeadline(t *testing.T) {
-	db := fakesqldb.Register()
-	txPool := newTxPool(false)
-	appParams := sqldb.ConnParams{Engine: db.Name}
-	dbaParams := sqldb.ConnParams{Engine: db.Name}
-	txPool.Open(&appParams, &dbaParams)
-	// set pool capacity to 1
-	txPool.pool.SetCapacity(1)
-	defer txPool.Close()
-
-	// A timeout < 10ms should always fail.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
-	_, err := txPool.Begin(ctx)
-	want := "tx_pool_full: Transaction pool connection limit exceeded"
-	if err == nil || err.Error() != want {
-		t.Errorf("Begin: %v, want %s", err, want)
-	}
-}
-
 func TestTxPoolBeginWithPoolConnectionError(t *testing.T) {
 	db := fakesqldb.Register()
 	db.EnableConnFail()

--- a/go/vt/tabletserver/tx_prep_pool.go
+++ b/go/vt/tabletserver/tx_prep_pool.go
@@ -27,6 +27,10 @@ type TxPreparedPool struct {
 
 // NewTxPreparedPool creates a new TxPreparedPool.
 func NewTxPreparedPool(capacity int) *TxPreparedPool {
+	if capacity < 0 {
+		// If capacity is 0 all prepares will fail.
+		capacity = 0
+	}
 	return &TxPreparedPool{
 		conns:    make(map[string]*TxConnection, capacity),
 		reserved: make(map[string]error),


### PR DESCRIPTION
The tx pools have a different life cycle than the other
pools of QueryEngine. So, those pools are now moved to
a new TxEngine. This engine is enabled only if the tablet
is the master.

The new TxEngine now has its own read pool which will be
used for internal housekeeping. Without this, TxEngine
would have to depend on QueryEngine for a connection from
the main conn pool.

I was not able to change the TxEngine to create the metadata
tables just for the master.  This is because InitMaster gets called
with semi-sync enabled, but with no replicas pointing at
the master. This causes those DDLs to hang forever waiting
for semi-sync ack.

Watchdog functionality has been implemented on the refactored code.