### PR TITLE
examples/kubernetes: Clean up unnecessary variables in scripts

### DIFF
--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -5,7 +5,13 @@
 # KUBECTL='gcloud container kubectl' for a while. Now that most of our
 # use cases just need KUBECTL=kubectl, we'll make that the default.
 KUBECTL=${KUBECTL:-kubectl}
+
+# Kuberentes namespace for Vitess and components.
 VITESS_NAME=${VITESS_NAME:-'default'}
+
+# CELLS should be a comma separated list of cells
+# the first cell listed will become local to vtctld.
+CELLS=${CELLS:-'test'}
 
 # This should match the nodePort in vtctld-service.yaml
 VTCTLD_PORT=${VTCTLD_PORT:-30001}

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -8,7 +8,7 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME=-'default'}
+VITESS_NAME=${VITESS_NAME:-'default'}
 CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -8,7 +8,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
 CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 

--- a/examples/kubernetes/etcd-down.sh
+++ b/examples/kubernetes/etcd-down.sh
@@ -8,7 +8,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 
 # Delete replication controllers

--- a/examples/kubernetes/etcd-up.sh
+++ b/examples/kubernetes/etcd-up.sh
@@ -14,7 +14,6 @@ script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
 replicas=${ETCD_REPLICAS:-3}
-CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 
 for cell in 'global' $cells; do

--- a/examples/kubernetes/etcd-up.sh
+++ b/examples/kubernetes/etcd-up.sh
@@ -14,7 +14,6 @@ script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
 replicas=${ETCD_REPLICAS:-3}
-VITESS_NAME=${VITESS_NAME:-'default'}
 CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 

--- a/examples/kubernetes/guestbook-down.sh
+++ b/examples/kubernetes/guestbook-down.sh
@@ -4,8 +4,6 @@
 
 set -e
 
-VITESS_NAME=${VITESS_NAME:-'default'}
-
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 

--- a/examples/kubernetes/guestbook-up.sh
+++ b/examples/kubernetes/guestbook-up.sh
@@ -7,8 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
-
 echo "Creating guestbook service..."
 $KUBECTL create --namespace=$VITESS_NAME -f guestbook-service.yaml
 

--- a/examples/kubernetes/orchestrator-down.sh
+++ b/examples/kubernetes/orchestrator-down.sh
@@ -7,8 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
-
 echo "Stopping orchestrator replicationcontroller..."
 $KUBECTL delete replicationcontroller orchestrator --namespace=$VITESS_NAME
 

--- a/examples/kubernetes/orchestrator-up.sh
+++ b/examples/kubernetes/orchestrator-up.sh
@@ -7,8 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
-
 echo "Creating orchestrator service and replicationcontroller..."
 sed_script=""
 for var in service_type; do

--- a/examples/kubernetes/vtctld-down.sh
+++ b/examples/kubernetes/vtctld-down.sh
@@ -7,8 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
-
 echo "Stopping vtctld replicationcontroller..."
 $KUBECTL delete replicationcontroller vtctld --namespace=$VITESS_NAME
 

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -9,7 +9,6 @@ source $script_root/env.sh
 
 service_type=${VTCTLD_SERVICE_TYPE:-'ClusterIP'}
 cell='test'
-VITESS_NAME=${VITESS_NAME:-'default'}
 TEST_MODE=${TEST_MODE:-'0'}
 
 test_flags=`[[ $TEST_MODE -gt 0 ]] && echo '-enable_queries' || echo ''`

--- a/examples/kubernetes/vtctld-up.sh
+++ b/examples/kubernetes/vtctld-up.sh
@@ -8,7 +8,7 @@ script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
 service_type=${VTCTLD_SERVICE_TYPE:-'ClusterIP'}
-cell='test'
+cell=(`echo $CELLS | tr ',' ' '`) # ref to cell will get first element
 TEST_MODE=${TEST_MODE:-'0'}
 
 test_flags=`[[ $TEST_MODE -gt 0 ]] && echo '-enable_queries' || echo ''`

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -7,7 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 
 for cell in $cells; do

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -7,7 +7,6 @@ set -e
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
-VITESS_NAME=${VITESS_NAME:-'default'}
 CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
 

--- a/examples/kubernetes/vtgate-down.sh
+++ b/examples/kubernetes/vtgate-down.sh
@@ -4,12 +4,12 @@
 
 set -e
 
+script_root=`dirname "${BASH_SOURCE}"`
+source $script_root/env.sh
+
 VITESS_NAME=${VITESS_NAME:-'default'}
 CELLS=${CELLS:-'test'}
 cells=`echo $CELLS | tr ',' ' '`
-
-script_root=`dirname "${BASH_SOURCE}"`
-source $script_root/env.sh
 
 for cell in $cells; do
   echo "Stopping vtgate replicationcontroller in cell $cell..."

--- a/examples/kubernetes/vtgate-up.sh
+++ b/examples/kubernetes/vtgate-up.sh
@@ -11,7 +11,6 @@ VTGATE_REPLICAS=${VTGATE_REPLICAS:-3}
 VTDATAROOT_VOLUME=${VTDATAROOT_VOLUME:-''}
 VTGATE_TEMPLATE=${VTGATE_TEMPLATE:-'vtgate-controller-template.yaml'}
 CELLS=${CELLS:-'test'}
-VITESS_NAME=${VITESS_NAME:-'default'}
 
 vtdataroot_volume='emptyDir: {}'
 if [ -n "$VTDATAROOT_VOLUME" ]; then

--- a/examples/kubernetes/vtgate-up.sh
+++ b/examples/kubernetes/vtgate-up.sh
@@ -10,7 +10,6 @@ source $script_root/env.sh
 VTGATE_REPLICAS=${VTGATE_REPLICAS:-3}
 VTDATAROOT_VOLUME=${VTDATAROOT_VOLUME:-''}
 VTGATE_TEMPLATE=${VTGATE_TEMPLATE:-'vtgate-controller-template.yaml'}
-CELLS=${CELLS:-'test'}
 
 vtdataroot_volume='emptyDir: {}'
 if [ -n "$VTDATAROOT_VOLUME" ]; then

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -14,7 +14,6 @@ trap stop_vtctld_forward EXIT
 VTCTLD_ADDR="localhost:$vtctld_forward_port"
 
 # Delete the pods for all shards
-CELLS=${CELLS:-'test'}
 keyspace='test_keyspace'
 SHARDS=${SHARDS:-'0'}
 TABLETS_PER_SHARD=${TABLETS_PER_SHARD:-5}

--- a/examples/kubernetes/vttablet-down.sh
+++ b/examples/kubernetes/vttablet-down.sh
@@ -19,7 +19,6 @@ keyspace='test_keyspace'
 SHARDS=${SHARDS:-'0'}
 TABLETS_PER_SHARD=${TABLETS_PER_SHARD:-5}
 UID_BASE=${UID_BASE:-100}
-VITESS_NAME=${VITESS_NAME:-'default'}
 
 num_shards=`echo $SHARDS | tr "," " " | wc -w`
 uid_base=$UID_BASE

--- a/examples/kubernetes/vttablet-up.sh
+++ b/examples/kubernetes/vttablet-up.sh
@@ -8,7 +8,6 @@ script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
 
 # Create the pods for shard-0
-CELLS=${CELLS:-'test'}
 keyspace='test_keyspace'
 SHARDS=${SHARDS:-'0'}
 TABLETS_PER_SHARD=${TABLETS_PER_SHARD:-5}

--- a/examples/kubernetes/vttablet-up.sh
+++ b/examples/kubernetes/vttablet-up.sh
@@ -18,7 +18,6 @@ UID_BASE=${UID_BASE:-100}
 VTTABLET_TEMPLATE=${VTTABLET_TEMPLATE:-'vttablet-pod-template.yaml'}
 VTDATAROOT_VOLUME=${VTDATAROOT_VOLUME:-''}
 RDONLY_COUNT=${RDONLY_COUNT:-2}
-VITESS_NAME=${VITESS_NAME:-'default'}
 
 vtdataroot_volume='emptyDir: {}'
 if [ -n "$VTDATAROOT_VOLUME" ]; then


### PR DESCRIPTION
`VITESS_NAME` is already defined in [`env.sh`](examples/kubernetes/env.sh#L8) making this statement unreachable.

Unreachable code should still be correct code though? 😛 

Despite being unreachable, since this is an example script, I'm assuming it's best to keep that for clarity in case someone copy/pastes without sourcing from `env.sh`.