### PR TITLE
A couple of reparent fixes.

### DIFF
--- a/go/vt/mysqlctl/reparent.go
+++ b/go/vt/mysqlctl/reparent.go
@@ -19,28 +19,47 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	// replicationPositionSize is the maximum size of the
+	// replication_position column in the _vt.reparent_journal
+	// table. A row has a maximum size of 65535 bytes. So we want
+	// to stay under that. Note we also specify the character set
+	// and collation of the replication_position column, as we
+	// know we only use latin1 characters.
+	replicationPositionSize = 64000
+)
+
 // CreateReparentJournal returns the commands to execute to create
 // the _vt.reparent_journal table. It is safe to run these commands
 // even if the table already exists.
+//
+// If the table was created by Vitess version 2.0, the following command
+// may need to be run:
+// ALTER TABLE _vt.reparent_journal MODIFY COLUMN replication_position VARCHAR(64000) CHARACTER SET latin1 COLLATE latin1_bin;
 func CreateReparentJournal() []string {
 	return []string{
 		"CREATE DATABASE IF NOT EXISTS _vt",
-		`CREATE TABLE IF NOT EXISTS _vt.reparent_journal (
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS _vt.reparent_journal (
   time_created_ns BIGINT UNSIGNED NOT NULL,
   action_name VARCHAR(250) NOT NULL,
   master_alias VARCHAR(32) NOT NULL,
-  replication_position VARCHAR(250) DEFAULT NULL,
-  PRIMARY KEY (time_created_ns)) ENGINE=InnoDB`}
+  replication_position VARCHAR(%v) DEFAULT NULL,
+  PRIMARY KEY (time_created_ns))
+ENGINE=InnoDB CHARACTER SET latin1 COLLATE latin1_bin`, replicationPositionSize)}
 }
 
 // PopulateReparentJournal returns the SQL command to use to populate
 // the _vt.reparent_journal table, as well as the time_created_ns
 // value used.
 func PopulateReparentJournal(timeCreatedNS int64, actionName, masterAlias string, pos replication.Position) string {
+	posStr := replication.EncodePosition(pos)
+	if len(posStr) > replicationPositionSize {
+		posStr = posStr[:replicationPositionSize]
+	}
 	return fmt.Sprintf("INSERT INTO _vt.reparent_journal "+
 		"(time_created_ns, action_name, master_alias, replication_position) "+
 		"VALUES (%v, '%v', '%v', '%v')",
-		timeCreatedNS, actionName, masterAlias, replication.EncodePosition(pos))
+		timeCreatedNS, actionName, masterAlias, posStr)
 }
 
 // queryReparentJournal returns the SQL query to use to query the database

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -216,6 +216,11 @@ func (wr *Wrangler) initShardMasterLocked(ctx context.Context, ev *events.Repare
 		return err
 	}
 
+	// Create a cancelable context for the following RPCs.
+	// If error conditions happen, we can cancel all outgoing RPCs.
+	replCtx, replCancel := context.WithCancel(ctx)
+	defer replCancel()
+
 	// Now tell the new master to insert the reparent_journal row,
 	// and tell everybody else to become a slave of the new master,
 	// and wait for the row in the reparent_journal table.
@@ -233,14 +238,14 @@ func (wr *Wrangler) initShardMasterLocked(ctx context.Context, ev *events.Repare
 			go func(alias topodatapb.TabletAlias, tabletInfo *topo.TabletInfo) {
 				defer wgMaster.Done()
 				wr.logger.Infof("populating reparent journal on new master %v", topoproto.TabletAliasString(&alias))
-				masterErr = wr.tmc.PopulateReparentJournal(ctx, tabletInfo.Tablet, now, initShardMasterOperation, &alias, rp)
+				masterErr = wr.tmc.PopulateReparentJournal(replCtx, tabletInfo.Tablet, now, initShardMasterOperation, &alias, rp)
 			}(alias, tabletInfo)
 		} else {
 			wgSlaves.Add(1)
 			go func(alias topodatapb.TabletAlias, tabletInfo *topo.TabletInfo) {
 				defer wgSlaves.Done()
 				wr.logger.Infof("initializing slave %v", topoproto.TabletAliasString(&alias))
-				if err := wr.tmc.InitSlave(ctx, tabletInfo.Tablet, masterElectTabletAlias, rp, now); err != nil {
+				if err := wr.tmc.InitSlave(replCtx, tabletInfo.Tablet, masterElectTabletAlias, rp, now); err != nil {
 					rec.RecordError(fmt.Errorf("Tablet %v InitSlave failed: %v", topoproto.TabletAliasString(&alias), err))
 				}
 			}(alias, tabletInfo)
@@ -248,9 +253,13 @@ func (wr *Wrangler) initShardMasterLocked(ctx context.Context, ev *events.Repare
 	}
 
 	// After the master is done, we can update the shard record
-	// (note with semi-sync, it also means at least one slave is done)
+	// (note with semi-sync, it also means at least one slave is done).
 	wgMaster.Wait()
 	if masterErr != nil {
+		// The master failed, there is no way the
+		// slaves will work.  So we cancel them all.
+		wr.logger.Warningf("master failed to PopulateReparentJournal, canceling slaves")
+		replCancel()
 		wgSlaves.Wait()
 		return fmt.Errorf("failed to PopulateReparentJournal on master: %v", masterErr)
 	}
@@ -377,6 +386,11 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 		return fmt.Errorf("master-elect tablet %v failed to catch up with replication or be upgraded to master: %v", topoproto.TabletAliasString(masterElectTabletAlias), err)
 	}
 
+	// Create a cancelable context for the following RPCs.
+	// If error conditions happen, we can cancel all outgoing RPCs.
+	replCtx, replCancel := context.WithCancel(ctx)
+	defer replCancel()
+
 	// Go through all the tablets:
 	// - new master: populate the reparent journal
 	// - everybody else: reparent to new master, wait for row
@@ -392,7 +406,7 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 			go func(alias topodatapb.TabletAlias, tabletInfo *topo.TabletInfo) {
 				defer wgMaster.Done()
 				wr.logger.Infof("populating reparent journal on new master %v", topoproto.TabletAliasString(&alias))
-				masterErr = wr.tmc.PopulateReparentJournal(ctx, tabletInfo.Tablet, now, plannedReparentShardOperation, &alias, rp)
+				masterErr = wr.tmc.PopulateReparentJournal(replCtx, tabletInfo.Tablet, now, plannedReparentShardOperation, &alias, rp)
 			}(alias, tabletInfo)
 		} else {
 			wgSlaves.Add(1)
@@ -401,7 +415,7 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 				wr.logger.Infof("setting new master on slave %v", topoproto.TabletAliasString(&alias))
 				// also restart replication on old master
 				forceStartSlave := topoproto.TabletAliasEqual(&alias, oldMasterTabletInfo.Alias)
-				if err := wr.tmc.SetMaster(ctx, tabletInfo.Tablet, masterElectTabletAlias, now, forceStartSlave); err != nil {
+				if err := wr.tmc.SetMaster(replCtx, tabletInfo.Tablet, masterElectTabletAlias, now, forceStartSlave); err != nil {
 					rec.RecordError(fmt.Errorf("Tablet %v SetMaster failed: %v", topoproto.TabletAliasString(&alias), err))
 					return
 				}
@@ -413,6 +427,10 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 	// (note with semi-sync, it also means at least one slave is done)
 	wgMaster.Wait()
 	if masterErr != nil {
+		// The master failed, there is no way the
+		// slaves will work.  So we cancel them all.
+		wr.logger.Warningf("master failed to PopulateReparentJournal, canceling slaves")
+		replCancel()
 		wgSlaves.Wait()
 		return fmt.Errorf("failed to PopulateReparentJournal on master: %v", masterErr)
 	}
@@ -425,8 +443,7 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 		return fmt.Errorf("failed to update shard master record: %v", err)
 	}
 
-	// Wait for the slaves to complete. If some of them fail, we
-	// will rebuild the shard serving graph anyway
+	// Wait for the slaves to complete.
 	wgSlaves.Wait()
 	if err := rec.Error(); err != nil {
 		wr.Logger().Errorf("Some slaves failed to reparent: %v", err)
@@ -649,6 +666,11 @@ func (wr *Wrangler) emergencyReparentShardLocked(ctx context.Context, ev *events
 		return fmt.Errorf("master-elect tablet %v failed to be upgraded to master: %v", topoproto.TabletAliasString(masterElectTabletAlias), err)
 	}
 
+	// Create a cancelable context for the following RPCs.
+	// If error conditions happen, we can cancel all outgoing RPCs.
+	replCtx, replCancel := context.WithCancel(ctx)
+	defer replCancel()
+
 	// Reset replication on all slaves to point to the new master, and
 	// insert test row in the new master.
 	// Go through all the tablets:
@@ -666,7 +688,7 @@ func (wr *Wrangler) emergencyReparentShardLocked(ctx context.Context, ev *events
 			go func(alias topodatapb.TabletAlias, tabletInfo *topo.TabletInfo) {
 				defer wgMaster.Done()
 				wr.logger.Infof("populating reparent journal on new master %v", topoproto.TabletAliasString(&alias))
-				masterErr = wr.tmc.PopulateReparentJournal(ctx, tabletInfo.Tablet, now, emergencyReparentShardOperation, &alias, rp)
+				masterErr = wr.tmc.PopulateReparentJournal(replCtx, tabletInfo.Tablet, now, emergencyReparentShardOperation, &alias, rp)
 			}(alias, tabletInfo)
 		} else {
 			wgSlaves.Add(1)
@@ -677,7 +699,7 @@ func (wr *Wrangler) emergencyReparentShardLocked(ctx context.Context, ev *events
 				if status, ok := statusMap[alias]; ok {
 					forceStartSlave = status.SlaveIoRunning || status.SlaveSqlRunning
 				}
-				if err := wr.tmc.SetMaster(ctx, tabletInfo.Tablet, masterElectTabletAlias, now, forceStartSlave); err != nil {
+				if err := wr.tmc.SetMaster(replCtx, tabletInfo.Tablet, masterElectTabletAlias, now, forceStartSlave); err != nil {
 					rec.RecordError(fmt.Errorf("Tablet %v SetMaster failed: %v", topoproto.TabletAliasString(&alias), err))
 				}
 			}(alias, tabletInfo)
@@ -688,6 +710,10 @@ func (wr *Wrangler) emergencyReparentShardLocked(ctx context.Context, ev *events
 	// (note with semi-sync, it also means at least one slave is done)
 	wgMaster.Wait()
 	if masterErr != nil {
+		// The master failed, there is no way the
+		// slaves will work.  So we cancel them all.
+		wr.logger.Warningf("master failed to PopulateReparentJournal, canceling slaves")
+		replCancel()
 		wgSlaves.Wait()
 		return fmt.Errorf("failed to PopulateReparentJournal on master: %v", masterErr)
 	}

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -296,13 +296,14 @@ class Tablet(object):
     self.drop_db(name)
     self.mquery('', 'create database %s' % name)
 
-  def clean_dbs(self):
+  def clean_dbs(self, include_vt=False):
     logging.debug('mysql(%s): removing all databases', self.tablet_uid)
     rows = self.mquery('', 'show databases')
     for row in rows:
       dbname = row[0]
-      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys',
-                    '_vt']:
+      if dbname in ['information_schema', 'performance_schema', 'mysql', 'sys']:
+        continue
+      if dbname == '_vt' and not include_vt:
         continue
       self.drop_db(dbname)
 


### PR DESCRIPTION
1. If the master fails, cancel all slaves. Instead of waiting for them to timeout, which can take hours.
2. fix access to _vt.reparent_journal.