### PR TITLE
Update k8s end2end tests. Add backup/drain tests.

### DIFF
--- a/test/end2end/backup_test.py
+++ b/test/end2end/backup_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+"""Tests backup/restore when a tablet is restarted."""
+
+import json
+import os
+import random
+import time
+
+import logging
+
+from vtdb import keyrange
+from vttest import sharding_utils
+import base_end2end_test
+
+
+def tearDownModule():
+  pass
+
+
+class BackupTest(base_end2end_test.BaseEnd2EndTest):
+
+  _WAIT_FOR_HEALTHY_DEADLINE = 600  # seconds
+  _WAIT_FOR_SCHEMA_VALIDATION_DEADLINE = 120  # seconds
+  _WAIT_FOR_TYPE_RETRIES = 90
+
+  @classmethod
+  def setUpClass(cls):
+    super(BackupTest, cls).setUpClass()
+
+    # number of backup iterations
+    cls.num_backups = int(cls.test_params.get('num_backups', '1'))
+
+    # number of insert statements
+    cls.num_inserts = int(cls.test_params.get('num_inserts', '100'))
+
+  def setUp(self):
+    """Updates schema, adding a table and populating it with data."""
+    super(BackupTest, self).setUp()
+    os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'cpp'
+    os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION'] = '2'
+    self.table_name = 'vt_insert_test'
+
+    self.env.delete_table(self.table_name)
+    self.env.create_table(
+        self.table_name,
+        validate_deadline_s=self._WAIT_FOR_SCHEMA_VALIDATION_DEADLINE)
+
+    for keyspace, num_shards in zip(self.env.keyspaces, self.env.num_shards):
+      for shard_name in sharding_utils.get_shard_names(num_shards):
+        logging.info('Inserting %d rows into %s',
+                     self.num_inserts, self.table_name)
+        kr = keyrange.KeyRange('') if num_shards == 1 else keyrange.KeyRange(
+            shard_name)
+
+        master_tablet = self.env.get_current_master_name(keyspace, shard_name)
+        master_cell = self.env.get_tablet_cell(master_tablet)
+        conn = self.env.get_vtgate_conn(master_cell)
+        cursor = conn.cursor(tablet_type='master', keyspace=keyspace,
+                             keyranges=[kr], writable=True)
+        for i in xrange(self.num_inserts):
+          cursor.begin()
+          cursor.execute(
+              'insert into %s (msg, keyspace_id) values (:msg, :keyspace_id)' %
+              self.table_name, {'msg': 'test %d' % i, 'keyspace_id': 0})
+          cursor.commit()
+        cursor.close()
+        logging.info('Data insertion complete')
+
+  def tearDown(self):
+    self.env.delete_table(self.table_name)
+    super(BackupTest, self).tearDown()
+
+  def perform_backup(self, tablets):
+    """Backup specific tablets.
+
+    Args:
+      tablets: List of tablet names to be backed up
+    """
+    for tablet in tablets:
+      self.env.backup(tablet)
+
+  def perform_restore(self, tablets, num_shards):
+    """Restore tablets by restarting the alloc.
+
+    Args:
+      tablets: List of tablet names to be restored
+      num_shards: Number of shards for the specific keyspace (int)
+    """
+    # First call restart alloc on all tablets being restored
+    for tablet in tablets:
+      self.env.restart_mysql_task(tablet, 'mysql', is_alloc=True)
+
+    # Wait for the tablets to be unhealthy
+    for tablet_name in tablets:
+      logging.info('Waiting for tablet %s to be unhealthy', tablet_name)
+      for _ in xrange(self._WAIT_FOR_TYPE_RETRIES):
+        if not self.env.is_tablet_healthy(tablet_name):
+          logging.info('Tablet %s is now unhealthy', tablet_name)
+          break
+        time.sleep(1)
+      else:
+        logging.info('Timed out, tablet %s is not unhealthy', tablet_name)
+
+    # Wait for the tablet to be healthy according to vttablet health
+    for tablet_name in tablets:
+      logging.info('Waiting for tablet %s to be healthy', tablet_name)
+      for _ in xrange(self._WAIT_FOR_TYPE_RETRIES):
+        if self.env.is_tablet_healthy(tablet_name):
+          logging.info('Tablet %s is now healthy', tablet_name)
+          break
+        time.sleep(1)
+      else:
+        logging.info('Timed out, tablet %s is still unhealthy', tablet_name)
+
+      logging.info('Waiting for tablet %s to enter serving state', tablet_name)
+      self.env.poll_for_varz(
+          tablet_name, ['TabletStateName'], 'TabletStateName == SERVING',
+          timeout=300.0,
+          condition_fn=lambda v: v['TabletStateName'] == 'SERVING')
+      logging.info('Done')
+      count = json.loads(self.env.vtctl_helper.execute_vtctl_command(
+          ['ExecuteFetchAsDba', '-json', tablet_name,
+           'select * from %s' % self.table_name]))['rows_affected']
+      logging.info('Select count: %d', count)
+      self.assertEquals(count, self.num_inserts)
+
+  def test_backup(self):
+    logging.info('Performing %s backup cycles', self.num_backups)
+    for attempt in xrange(self.num_backups):
+      logging.info('Backup iteration %d of %d', attempt + 1, self.num_backups)
+      for keyspace, num_shards in zip(self.env.keyspaces, self.env.num_shards):
+        backup_tablets = []
+        for shard in xrange(num_shards):
+          # Pick a random replica tablet in each shard
+          tablets = self.env.get_tablet_types_for_shard(
+              keyspace, sharding_utils.get_shard_name(shard, num_shards))
+          available_tablets = [x for x in tablets if x[1] == 'replica']
+          self.assertNotEqual(len(available_tablets), 0,
+                              'No available tablets found to backup!')
+          tablet_to_backup_name = random.choice(available_tablets)[0]
+          backup_tablets.append(tablet_to_backup_name)
+
+        self.perform_backup(backup_tablets)
+        self.perform_restore(backup_tablets, num_shards)
+
+
+if __name__ == '__main__':
+  base_end2end_test.main()
+

--- a/test/end2end/base_end2end_test.py
+++ b/test/end2end/base_end2end_test.py
@@ -5,8 +5,6 @@ import optparse
 import unittest
 import sys
 
-import utils
-
 _options = None
 
 
@@ -60,6 +58,7 @@ class BaseEnd2EndTest(unittest.TestCase):
 
 
 def main():
+  import utils
   parser = optparse.OptionParser(usage='usage: %prog [options] [test_names]')
   parser.add_option('-e', '--environment_type', help='Environment type',
                     default=None)

--- a/test/end2end/base_environment.py
+++ b/test/end2end/base_environment.py
@@ -4,7 +4,10 @@ Contains functions that all environments should implement along with functions
 common to all environments.
 """
 
+# pylint: disable=unused-argument
+
 import json
+import random
 from vttest import sharding_utils
 
 
@@ -58,6 +61,21 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'Destroy unsupported in this environment')
 
+  def create_table(self, table_name, schema=None, validate_deadline_s=60):
+    schema = schema or (
+        'create table %s (id bigint auto_increment, msg varchar(64), '
+        'keyspace_id bigint(20) unsigned NOT NULL, primary key (id)) '
+        'Engine=InnoDB' % table_name)
+    for keyspace in self.keyspaces:
+      self.vtctl_helper.execute_vtctl_command(
+          ['ApplySchema', '-sql', schema, keyspace])
+
+  def delete_table(self, table_name):
+    for keyspace in self.keyspaces:
+      self.vtctl_helper.execute_vtctl_command(
+          ['ApplySchema', '-sql', 'drop table if exists %s' % table_name,
+           keyspace])
+
   def get_vtgate_conn(self, cell):
     """Gets a connection to a vtgate in a particular cell.
 
@@ -73,17 +91,12 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'Get VTGate Conn unsupported in this environment')
 
-  def restart_mysql_task(
-      self, cell, keyspace, shard, task_num, dbtype, task_name, is_alloc=False):
+  def restart_mysql_task(self, tablet_name, task_name, is_alloc=False):
     """Restart a job within the mysql alloc or the whole alloc itself.
 
     Args:
-      cell: cell value containing the vttablet alloc to restart (string).
-      keyspace: keyspace (string).
-      shard: shard number (int).
-      task_num: which vttablet alloc task to restart (int).
-      dbtype: which dbtype to restart (replica | rdonly) (string).
-      task_name: Name of specific  task (droid, vttablet, mysql, etc.)
+      tablet_name: tablet associated with the mysql instance (string).
+      task_name: Name of specific task (droid, vttablet, mysql, etc.)
       is_alloc: True to restart entire alloc
 
     Returns:
@@ -94,6 +107,25 @@ class BaseEnvironment(object):
     """
     raise VitessEnvironmentError(
         'Restart MySQL task unsupported in this environment')
+
+  def restart_vtgate(self, cell=None, task_num=None):
+    """Restarts a vtgate task.
+
+    If cell and task_num are unspecified, restarts a random task in a random
+    cell.
+
+    Args:
+      cell: cell containing the vtgate task to restart (string).
+      task_num: which vtgate task to restart (int).
+
+    Returns:
+      return val for restart
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'Restart vtgate unsupported in this environment')
 
   def wait_for_good_failover_status(
       self, keyspace, shard_name, failover_completion_timeout_s=60):
@@ -115,14 +147,22 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'Wait for good failover status unsupported in this environment')
 
-  def wait_for_healthy_tablets(self):
+  def wait_for_healthy_tablets(self, deadline_s=300):
     """Wait until all tablets report healthy status.
+
+    Args:
+      deadline_s: Deadline timeout (seconds) (int)
 
     Raises:
       VitessEnvironmentError: Raised if unsupported
     """
     raise VitessEnvironmentError(
         'Wait for healthy tablets unsupported in this environment')
+
+  def is_tablet_healthy(self, tablet_name):
+    vttablet_stream_health = json.loads(self.vtctl_helper.execute_vtctl_command(
+        ['VtTabletStreamHealth', tablet_name]))
+    return 'health_error' not in vttablet_stream_health['realtime_stats']
 
   def get_next_master(self, keyspace, shard_name, cross_cell=False):
     """Determine what instance to select as the next master.
@@ -171,14 +211,13 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'Get tablet task number unsupported in this environment')
 
-  def external_reparent(self, keyspace, new_cell, shard, new_task_num):
+  def external_reparent(self, keyspace, shard_name, new_master_name):
     """Perform a reparent through external means (Orchestrator, etc.).
 
     Args:
       keyspace: name of the keyspace to reparent (string)
-      new_cell: new master cell (string)
-      shard: 0 based shard index to reparent (int)
-      new_task_num: 0 based task num to become next master (int)
+      shard_name: shard name (string)
+      new_master_name: tablet name of the tablet to become master (string)
 
     Raises:
       VitessEnvironmentError: Raised if unsupported
@@ -186,9 +225,52 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'External reparent unsupported in this environment')
 
-  def internal_reparent(self, keyspace, new_master_uid, emergency=False):
-    raise VitessEnvironmentError(
-        'Internal reparent unsupported in this environment')
+  def internal_reparent_available(self):
+    """Checks if the environment can do a vtctl reparent."""
+    return 'PlannedReparentShard' in (
+        self.vtctl_helper.execute_vtctl_command(['help']))
+
+  def automatic_reparent_available(self):
+    """Checks if the environment can automatically reparent."""
+    return False
+
+  def explicit_external_reparent_available(self):
+    """Checks if the environment can explicitly reparent via external tools."""
+    return False
+
+  def internal_reparent(self, keyspace, shard_name, new_master_name,
+                        emergency=False):
+    """Performs an internal reparent through vtctl.
+
+    Args:
+      keyspace: name of the keyspace to reparent (string)
+      shard_name: string representation of the shard to reparent (e.g. '-80')
+      new_master_name: Name of the new master tablet (string)
+      emergency: True to perform an emergency reparent (bool)
+    """
+    reparent_type = (
+        'EmergencyReparentShard' if emergency else 'PlannedReparentShard')
+    self.vtctl_helper.execute_vtctl_command(
+        [reparent_type, '%s/%s' % (keyspace, shard_name), new_master_name])
+    self.vtctl_helper.execute_vtctl_command(['RebuildKeyspaceGraph', keyspace])
+
+  def get_current_master_cell(self, keyspace):
+    """Obtains current master cell.
+
+    This gets the master cell for the first shard in the keyspace, and assumes
+    that all shards share the same master.
+
+    Args:
+      keyspace: name of the keyspace to get the master cell for (string)
+
+    Returns:
+      master cell name (string)
+    """
+    num_shards = self.num_shards[self.keyspaces.index(keyspace)]
+    first_shard_name = sharding_utils.get_shard_name(0, num_shards)
+    first_shard_master_tablet = (
+        self.get_current_master_name(keyspace, first_shard_name))
+    return self.get_tablet_cell(first_shard_master_tablet)
 
   def get_current_master_name(self, keyspace, shard_name):
     """Obtains current master's tablet name (cell-uid).
@@ -204,6 +286,34 @@ class BaseEnvironment(object):
         ['GetShard', '{0}/{1}'.format(keyspace, shard_name)]))
     master_alias = shard_info['master_alias']
     return '%s-%s' % (master_alias['cell'], master_alias['uid'])
+
+  def get_random_tablet(self, keyspace=None, shard_name=None, cell=None,
+                        tablet_type=None, task_number=None):
+    """Get a random tablet name.
+
+    Args:
+      keyspace: name of the keyspace to get information on the master
+      shard_name: shard to select tablet from (None for random) (string)
+      cell: cell to select tablet from (None for random) (string)
+      tablet_type: type of tablet to select (None for random) (string)
+      task_number: a specific task number (None for random) (int)
+
+    Returns:
+      random tablet name (cell-uid) (string)
+    """
+    keyspace = keyspace or random.choice(self.keyspaces)
+    shard_name = shard_name or (
+        sharding_utils.get_shard_name(
+            random.randint(0, self.shards[self.keyspaces.index(keyspace)])))
+    cell = cell or random.choice(self.cells)
+    tablets = [t.split(' ') for t in self.vtctl_helper.execute_vtctl_command(
+        ['ListShardTablets', '%s/%s' % (keyspace, shard_name)]).split('\n')]
+    cell_tablets = [t for t in tablets if self.get_tablet_cell(t[0]) == cell]
+    if task_number:
+      return cell_tablets[task_number][0]
+    if tablet_type:
+      return random.choice([t[0] for t in cell_tablets if t[3] == tablet_type])
+    return random.choice(cell_tablets)[0]
 
   def get_tablet_cell(self, tablet_name):
     """Get the cell of a tablet.
@@ -226,6 +336,18 @@ class BaseEnvironment(object):
       Tablet's uid. (int)
     """
     return int(tablet_name.split('-')[-1])
+
+  def get_tablet_keyspace(self, tablet_name):
+    """Get the keyspace of a tablet.
+
+    Args:
+      tablet_name: Name of the tablet, including cell prefix. (string)
+
+    Returns:
+      Tablet's keyspace. (string)
+    """
+    return json.loads(self.vtctl_helper.execute_vtctl_command(
+        ['GetTablet', tablet_name]))['keyspace']
 
   def get_tablet_shard(self, tablet_name):
     """Get the shard of a tablet.
@@ -299,3 +421,97 @@ class BaseEnvironment(object):
     for shard_name in sharding_utils.get_shard_names(num_shards):
       tablet_info += self.get_tablet_types_for_shard(keyspace, shard_name)
     return tablet_info
+
+  def backup(self, tablet_name):
+    """Wait until all tablets report healthy status.
+
+    Args:
+      tablet_name: Name of tablet to backup. (string)
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'Backup unsupported in this environment')
+
+  def drain_tablet(self, tablet_name, duration_s=600):
+    """Add a drain from a tablet.
+
+    Args:
+      tablet_name: vttablet to drain (string).
+      duration_s: how long to have the drain exist for, in seconds (int).
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'drain unsupported in this environment')
+
+  def is_tablet_drained(self, tablet_name):
+    """Checks whether a tablet is drained.
+
+    Args:
+      tablet_name: vttablet to drain (string).
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'is tablet drained unsupported in this environment')
+
+  def undrain_tablet(self, tablet_name):
+    """Remove a drain from a tablet.
+
+    Args:
+      tablet_name: vttablet name to undrain (string).
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'undrain unsupported in this environment')
+
+  def is_tablet_undrained(self, tablet_name):
+    """Checks whether a tablet is undrained.
+
+    Args:
+      tablet_name: vttablet to undrain (string).
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'is tablet undrained unsupported in this environment')
+
+  def poll_for_varz(self, tablet_name, varz, condition_msg, timeout=60.0,
+                    condition_fn=None, converter=str):
+    """Polls for varz to exist, or match specific conditions, within a timeout.
+
+    Args:
+      tablet_name: the name of the process that we're trying to poll vars from.
+      varz: name of the vars to fetch from varz
+      condition_msg: string describing the conditions that we're polling for,
+        used for error messaging.
+      timeout: number of seconds that we should attempt to poll for.
+      condition_fn: a function that takes the var as input, and returns a truthy
+        value if it matches the success conditions.
+      converter: function to convert varz value
+
+    Raises:
+      TestError: if the varz conditions aren't met within the given timeout
+
+    Returns:
+      dict of requested varz
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported
+    """
+    raise VitessEnvironmentError(
+        'Polling for varz unsupported in this environment')
+
+  def truncate_usertable(self, keyspace, shard, table=None):
+    tablename = table or self.tablename
+    master_tablet = self.get_current_master_name(keyspace, shard)
+    self.vtctl_helper.execute_vtctl_command(
+        ['ExecuteFetchAsDba', master_tablet, 'truncate %s' % tablename])
+

--- a/test/end2end/base_environment.py
+++ b/test/end2end/base_environment.py
@@ -28,16 +28,16 @@ class BaseEnvironment(object):
       **kwargs: kwargs parameterizing the environment.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Create unsupported in this environment')
+        'create unsupported in this environment')
 
   def use_named(self, instance_name):
     """Populate this instance based on a pre-existing environment.
 
     Args:
-      instance_name: Name of the existing environment instance (string)
+      instance_name: Name of the existing environment instance (string).
     """
     self.master_capable_tablets = {}
     for keyspace, num_shards in zip(self.keyspaces, self.num_shards):
@@ -59,7 +59,7 @@ class BaseEnvironment(object):
       VitessEnvironmentError: Raised if unsupported
     """
     raise VitessEnvironmentError(
-        'Destroy unsupported in this environment')
+        'destroy unsupported in this environment')
 
   def create_table(self, table_name, schema=None, validate_deadline_s=60):
     schema = schema or (
@@ -80,33 +80,33 @@ class BaseEnvironment(object):
     """Gets a connection to a vtgate in a particular cell.
 
     Args:
-      cell: cell to obtain a vtgate connection from (string)
+      cell: cell to obtain a vtgate connection from (string).
 
     Returns:
       A vtgate connection.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Get VTGate Conn unsupported in this environment')
+        'get_vtgate_conn unsupported in this environment')
 
   def restart_mysql_task(self, tablet_name, task_name, is_alloc=False):
     """Restart a job within the mysql alloc or the whole alloc itself.
 
     Args:
       tablet_name: tablet associated with the mysql instance (string).
-      task_name: Name of specific task (droid, vttablet, mysql, etc.)
-      is_alloc: True to restart entire alloc
+      task_name: Name of specific task (droid, vttablet, mysql, etc.).
+      is_alloc: True to restart entire alloc.
 
     Returns:
-      return restart return val
+      return restart return val.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Restart MySQL task unsupported in this environment')
+        'restart_mysql_task unsupported in this environment')
 
   def restart_vtgate(self, cell=None, task_num=None):
     """Restarts a vtgate task.
@@ -119,13 +119,13 @@ class BaseEnvironment(object):
       task_num: which vtgate task to restart (int).
 
     Returns:
-      return val for restart
+      return val for restart.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Restart vtgate unsupported in this environment')
+        'restart_vtgate unsupported in this environment')
 
   def wait_for_good_failover_status(
       self, keyspace, shard_name, failover_completion_timeout_s=60):
@@ -137,27 +137,27 @@ class BaseEnvironment(object):
     status is 'OFF'.
 
     Args:
-      keyspace: Name of the keyspace to reparent (string)
-      shard_name: name of the shard to verify (e.g. '-80') (string)
-      failover_completion_timeout_s: Failover completion timeout (int)
+      keyspace: Name of the keyspace to reparent (string).
+      shard_name: name of the shard to verify (e.g. '-80') (string).
+      failover_completion_timeout_s: Failover completion timeout (int).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Wait for good failover status unsupported in this environment')
+        'wait_for_good_failover_status unsupported in this environment')
 
   def wait_for_healthy_tablets(self, deadline_s=300):
     """Wait until all tablets report healthy status.
 
     Args:
-      deadline_s: Deadline timeout (seconds) (int)
+      deadline_s: Deadline timeout (seconds) (int).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Wait for healthy tablets unsupported in this environment')
+        'wait_for_healthy_tablets unsupported in this environment')
 
   def is_tablet_healthy(self, tablet_name):
     vttablet_stream_health = json.loads(self.vtctl_helper.execute_vtctl_command(
@@ -176,7 +176,7 @@ class BaseEnvironment(object):
       cross_cell: Whether the desired reparent is to another cell (bool).
 
     Returns:
-      Tuple of cell, task num, tablet uid (string, int, string)
+      Tuple of cell, task num, tablet uid (string, int, string).
     """
     num_tasks = self.keyspace_alias_to_num_instances_dict[keyspace]['replica']
     current_master = self.get_current_master_name(keyspace, shard_name)
@@ -200,30 +200,30 @@ class BaseEnvironment(object):
     """Gets a tablet's 0 based task number.
 
     Args:
-      tablet_name: Name of the tablet (string)
+      tablet_name: Name of the tablet (string).
 
     Returns:
       0 based task number (int).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Get tablet task number unsupported in this environment')
+        'get_tablet_task_number unsupported in this environment')
 
   def external_reparent(self, keyspace, shard_name, new_master_name):
     """Perform a reparent through external means (Orchestrator, etc.).
 
     Args:
-      keyspace: name of the keyspace to reparent (string)
-      shard_name: shard name (string)
-      new_master_name: tablet name of the tablet to become master (string)
+      keyspace: name of the keyspace to reparent (string).
+      shard_name: shard name (string).
+      new_master_name: tablet name of the tablet to become master (string).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'External reparent unsupported in this environment')
+        'external_reparent unsupported in this environment')
 
   def internal_reparent_available(self):
     """Checks if the environment can do a vtctl reparent."""
@@ -243,10 +243,10 @@ class BaseEnvironment(object):
     """Performs an internal reparent through vtctl.
 
     Args:
-      keyspace: name of the keyspace to reparent (string)
-      shard_name: string representation of the shard to reparent (e.g. '-80')
-      new_master_name: Name of the new master tablet (string)
-      emergency: True to perform an emergency reparent (bool)
+      keyspace: name of the keyspace to reparent (string).
+      shard_name: string representation of the shard to reparent (e.g. '-80').
+      new_master_name: Name of the new master tablet (string).
+      emergency: True to perform an emergency reparent (bool).
     """
     reparent_type = (
         'EmergencyReparentShard' if emergency else 'PlannedReparentShard')
@@ -261,10 +261,10 @@ class BaseEnvironment(object):
     that all shards share the same master.
 
     Args:
-      keyspace: name of the keyspace to get the master cell for (string)
+      keyspace: name of the keyspace to get the master cell for (string).
 
     Returns:
-      master cell name (string)
+      master cell name (string).
     """
     num_shards = self.num_shards[self.keyspaces.index(keyspace)]
     first_shard_name = sharding_utils.get_shard_name(0, num_shards)
@@ -276,11 +276,11 @@ class BaseEnvironment(object):
     """Obtains current master's tablet name (cell-uid).
 
     Args:
-      keyspace: name of the keyspace to get information on the master
-      shard_name: string representation of the shard in question (e.g. '-80')
+      keyspace: name of the keyspace to get information on the master.
+      shard_name: string representation of the shard in question (e.g. '-80').
 
     Returns:
-      master tablet name (cell-uid) (string)
+      master tablet name (cell-uid) (string).
     """
     shard_info = json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetShard', '{0}/{1}'.format(keyspace, shard_name)]))
@@ -292,14 +292,14 @@ class BaseEnvironment(object):
     """Get a random tablet name.
 
     Args:
-      keyspace: name of the keyspace to get information on the master
-      shard_name: shard to select tablet from (None for random) (string)
-      cell: cell to select tablet from (None for random) (string)
-      tablet_type: type of tablet to select (None for random) (string)
-      task_number: a specific task number (None for random) (int)
+      keyspace: name of the keyspace to get information on the master.
+      shard_name: shard to select tablet from (None for random) (string).
+      cell: cell to select tablet from (None for random) (string).
+      tablet_type: type of tablet to select (None for random) (string).
+      task_number: a specific task number (None for random) (int).
 
     Returns:
-      random tablet name (cell-uid) (string)
+      random tablet name (cell-uid) (string).
     """
     keyspace = keyspace or random.choice(self.keyspaces)
     shard_name = shard_name or (
@@ -319,10 +319,10 @@ class BaseEnvironment(object):
     """Get the cell of a tablet.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      Tablet's cell. (string)
+      Tablet's cell (string).
     """
     return tablet_name.split('-')[0]
 
@@ -330,10 +330,10 @@ class BaseEnvironment(object):
     """Get the uid of a tablet.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      Tablet's uid. (int)
+      Tablet's uid (int).
     """
     return int(tablet_name.split('-')[-1])
 
@@ -341,10 +341,10 @@ class BaseEnvironment(object):
     """Get the keyspace of a tablet.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      Tablet's keyspace. (string)
+      Tablet's keyspace (string).
     """
     return json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))['keyspace']
@@ -353,10 +353,10 @@ class BaseEnvironment(object):
     """Get the shard of a tablet.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      Tablet's shard. (string)
+      Tablet's shard (string).
     """
     return json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))['shard']
@@ -365,10 +365,10 @@ class BaseEnvironment(object):
     """Get the current type of the tablet as reported via vtctl.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      Current tablet type (e.g. spare, replica, rdonly). (string)
+      Current tablet type (e.g. spare, replica, rdonly) (string).
     """
     return json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))['type']
@@ -377,10 +377,10 @@ class BaseEnvironment(object):
     """Get the ip and port of the tablet as reported via vtctl.
 
     Args:
-      tablet_name: Name of the tablet, including cell prefix. (string)
+      tablet_name: Name of the tablet, including cell prefix (string).
 
     Returns:
-      ip:port (string)
+      ip:port (string).
     """
     tablet_info = json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))
@@ -390,11 +390,11 @@ class BaseEnvironment(object):
     """Get the types for all tablets in a shard.
 
     Args:
-      keyspace: Name of keyspace to get tablet information on. (string)
-      shard_name: single shard to obtain tablet types from (string)
+      keyspace: Name of keyspace to get tablet information on (string).
+      shard_name: single shard to obtain tablet types from (string).
 
     Returns:
-      List of pairs of tablet's name and type
+      List of pairs of tablet's name and type.
     """
     tablet_info = []
     raw_tablets = self.vtctl_helper.execute_vtctl_command(
@@ -411,11 +411,11 @@ class BaseEnvironment(object):
     """Get the types for all tablets in a keyspace.
 
     Args:
-      keyspace: Name of keyspace to get tablet information on. (string)
-      num_shards: number of shards in the keyspace. (int)
+      keyspace: Name of keyspace to get tablet information on (string).
+      num_shards: number of shards in the keyspace (int).
 
     Returns:
-      List of pairs of tablet's name and type
+      List of pairs of tablet's name and type.
     """
     tablet_info = []
     for shard_name in sharding_utils.get_shard_names(num_shards):
@@ -426,13 +426,13 @@ class BaseEnvironment(object):
     """Wait until all tablets report healthy status.
 
     Args:
-      tablet_name: Name of tablet to backup. (string)
+      tablet_name: Name of tablet to backup (string).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Backup unsupported in this environment')
+        'backup unsupported in this environment')
 
   def drain_tablet(self, tablet_name, duration_s=600):
     """Add a drain from a tablet.
@@ -442,10 +442,10 @@ class BaseEnvironment(object):
       duration_s: how long to have the drain exist for, in seconds (int).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'drain unsupported in this environment')
+        'drain_tablet unsupported in this environment')
 
   def is_tablet_drained(self, tablet_name):
     """Checks whether a tablet is drained.
@@ -454,10 +454,10 @@ class BaseEnvironment(object):
       tablet_name: vttablet to drain (string).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'is tablet drained unsupported in this environment')
+        'is_tablet_drained unsupported in this environment')
 
   def undrain_tablet(self, tablet_name):
     """Remove a drain from a tablet.
@@ -466,10 +466,10 @@ class BaseEnvironment(object):
       tablet_name: vttablet name to undrain (string).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'undrain unsupported in this environment')
+        'undrain_tablet unsupported in this environment')
 
   def is_tablet_undrained(self, tablet_name):
     """Checks whether a tablet is undrained.
@@ -478,10 +478,10 @@ class BaseEnvironment(object):
       tablet_name: vttablet to undrain (string).
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'is tablet undrained unsupported in this environment')
+        'is_tablet_undrained unsupported in this environment')
 
   def poll_for_varz(self, tablet_name, varz, condition_msg, timeout=60.0,
                     condition_fn=None, converter=str):
@@ -489,25 +489,25 @@ class BaseEnvironment(object):
 
     Args:
       tablet_name: the name of the process that we're trying to poll vars from.
-      varz: name of the vars to fetch from varz
+      varz: name of the vars to fetch from varz.
       condition_msg: string describing the conditions that we're polling for,
         used for error messaging.
       timeout: number of seconds that we should attempt to poll for.
       condition_fn: a function that takes the var as input, and returns a truthy
         value if it matches the success conditions.
-      converter: function to convert varz value
+      converter: function to convert varz value.
 
     Raises:
-      TestError: if the varz conditions aren't met within the given timeout
+      TestError: if the varz conditions aren't met within the given timeout.
 
     Returns:
-      dict of requested varz
+      dict of requested varz.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported
+      VitessEnvironmentError: Raised if unsupported.
     """
     raise VitessEnvironmentError(
-        'Polling for varz unsupported in this environment')
+        'poll_for_varz unsupported in this environment')
 
   def truncate_usertable(self, keyspace, shard, table=None):
     tablename = table or self.tablename

--- a/test/end2end/drain_test.py
+++ b/test/end2end/drain_test.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+"""Tests that the topology updates when performing drains."""
+
+import json
+import os
+import random
+import time
+
+import logging
+import base_end2end_test
+from vtdb import keyrange
+from vttest import sharding_utils
+
+
+def tearDownModule():
+  pass
+
+
+class DrainTest(base_end2end_test.BaseEnd2EndTest):
+
+  @classmethod
+  def setUpClass(cls):
+    super(DrainTest, cls).setUpClass()
+
+    # number of drain iterations
+    cls.num_drains = int(cls.test_params.get('num_drains', '10'))
+
+    # seconds to wait for adding/removing a drain to take effect
+    cls.drain_timeout_threshold = (
+        int(cls.test_params.get('drain_timeout_threshold', '90')))
+
+    cls.num_inserts = int(cls.test_params.get('num_inserts', 100))
+
+  @classmethod
+  def tearDownClass(cls):
+    for keyspace, num_shards in zip(cls.env.keyspaces, cls.env.num_shards):
+      for shard_name in sharding_utils.get_shard_names(num_shards):
+        drained_tablets = [x[0] for x in cls.env.get_tablet_types_for_shard(
+            keyspace, shard_name) if x[1] == 'drained']
+        for tablet in drained_tablets:
+          logging.info('Undraining tablet %s', tablet)
+          cls.env.undrain_tablet(tablet)
+
+  def insert_rows(self, keyspace, num_rows, starting_index=0):
+    logging.info('Inserting %d rows into %s', num_rows, self.table_name)
+    master_cell = self.env.get_current_master_cell(keyspace)
+    conn = self.env.get_vtgate_conn(master_cell)
+    cursor = conn.cursor(tablet_type='master', keyspace=keyspace,
+                         keyranges=[keyrange.KeyRange('')], writable=True)
+
+    for i in xrange(starting_index, starting_index + num_rows):
+      cursor.begin()
+      cursor.execute(
+          'insert into %s (msg, keyspace_id) values (:msg, :keyspace_id)' %
+          self.table_name, {'msg': 'test %d' % i, 'keyspace_id': 0})
+      cursor.commit()
+    cursor.close()
+    logging.info('Data insertion complete')
+
+  def read_rows(self, keyspace, num_reads, num_rows, cell,
+                tablet_type='replica'):
+    logging.info('Reading %d rows from %s', num_reads, self.table_name)
+
+    conn = self.env.get_vtgate_conn(cell)
+    cursor = conn.cursor(
+        tablet_type=tablet_type, keyspace=keyspace,
+        keyranges=[keyrange.KeyRange('')])
+
+    for i in [random.randint(0, num_rows - 1) for _ in xrange(num_reads)]:
+      cursor.execute(
+          'select * from %s where msg = "test %d"' % (self.table_name, i), {})
+    cursor.close()
+    logging.info('Data reads complete')
+
+  def get_row_count(self, tablet_name):
+    fetch = self.env.vtctl_helper.execute_vtctl_command(
+        ['ExecuteFetchAsDba', '-json', tablet_name,
+         'select count(*) from %s' % self.table_name])
+    return json.loads(fetch)['rows'][0][0]
+
+  def get_tablet_to_drain(self, keyspace, num_shards):
+    # obtain information on all tablets in a keyspace
+    keyspace_tablets = self.env.get_all_tablet_types(keyspace, num_shards)
+
+    # filter only the tablets whose type we care about.
+    available_tablets = [x for x in keyspace_tablets if x[1] == 'replica']
+    self.assertNotEqual(len(available_tablets), 0,
+                        'No available tablets found to drain!')
+
+    # choose a tablet randomly and get its name
+    tablet_to_drain_info = random.choice(available_tablets)
+    return str(tablet_to_drain_info[0])
+
+  def wait_for_drained_tablet(self, tablet_to_drain):
+    # Check tablet type until the tablet becomes drained
+    drain_added_time = time.time()
+    while time.time() - drain_added_time < self.drain_timeout_threshold:
+      if self.env.is_tablet_drained(tablet_to_drain):
+        logging.info('Tablet %s is now drained (took %f seconds)',
+                     tablet_to_drain, time.time() - drain_added_time)
+        break
+      time.sleep(1)
+    else:
+      logging.info('Timed out waiting for tablet %s to go drained!',
+                   tablet_to_drain)
+
+  def wait_for_undrained_tablet(self, tablet_to_drain):
+    # Check tablet type until the tablet is no longer drained
+    drain_removed_time = time.time()
+    while time.time() - drain_removed_time < self.drain_timeout_threshold:
+      if self.env.is_tablet_undrained(tablet_to_drain):
+        logging.info('Tablet %s is now undrained (took %f seconds)',
+                     tablet_to_drain, time.time() - drain_removed_time)
+        break
+      time.sleep(1)
+    else:
+      logging.info('Timed out waiting for tablet %s to be undrained!',
+                   tablet_to_drain)
+
+  def setUp(self):
+    super(DrainTest, self).setUp()
+    os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'cpp'
+    os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION_VERSION'] = '2'
+    self.table_name = 'vt_insert_test'
+
+    self.env.delete_table(self.table_name)
+    self.env.create_table(self.table_name)
+
+  def test_drain(self):
+    """Drain tablets and verify topology is updated.
+
+    Each iteration drains a random tablet in each keyspace.  Once it is verified
+    that the tablet is unhealthy, the drain is removed and it is verified that
+    the tablet returns to a healthy state.
+    """
+    logging.info('Performing %s drain cycles', self.num_drains)
+    for attempt in xrange(self.num_drains):
+      logging.info('Drain iteration %d of %d', attempt + 1, self.num_drains)
+      for keyspace, num_shards in zip(self.env.keyspaces, self.env.num_shards):
+        tablet_to_drain = self.get_tablet_to_drain(keyspace, num_shards)
+        num_rows0 = self.get_row_count(tablet_to_drain)
+        self.env.drain_tablet(tablet_to_drain)
+        self.wait_for_drained_tablet(tablet_to_drain)
+        self.insert_rows(keyspace, self.num_inserts,
+                         starting_index=self.num_inserts * attempt)
+        num_rows1 = self.get_row_count(tablet_to_drain)
+        self.assertEquals(num_rows0, num_rows1)
+        query_count0 = self.env.poll_for_varz(
+            tablet_to_drain, ['Queries'], ' ')['Queries']['TotalCount']
+        self.read_rows(
+            keyspace, self.num_inserts, self.num_inserts * (attempt + 1),
+            self.env.get_tablet_cell(tablet_to_drain))
+        self.env.undrain_tablet(tablet_to_drain)
+        self.wait_for_undrained_tablet(tablet_to_drain)
+        query_count1 = self.env.poll_for_varz(
+            tablet_to_drain, ['Queries'], ' ')['Queries']['TotalCount']
+        logging.info('%s total query count before/after reads: %d/%d',
+                     tablet_to_drain, query_count0, query_count1)
+        self.assertEquals(query_count0, query_count1)
+
+
+if __name__ == '__main__':
+  base_end2end_test.main()
+

--- a/test/end2end/k8s_environment.py
+++ b/test/end2end/k8s_environment.py
@@ -5,8 +5,10 @@ import getpass
 import logging
 import os
 import subprocess
+import tempfile
 import time
 
+from vtproto import topodata_pb2
 from vtdb import vtgate_client
 import base_environment
 import protocols_flavor
@@ -101,16 +103,12 @@ class K8sEnvironment(base_environment.BaseEnvironment):
 
     start_time = time.time()
     self.vtgate_addrs = {}
-    self.vtgate_conns = {}
     for cell in self.cells:
-      self.vtgate_addr = ''
-      while time.time() - start_time < 60 and not self.vtgate_addr:
+      vtgate_addr = ''
+      while time.time() - start_time < 60 and not vtgate_addr:
         vtgate_addr = subprocess.check_output(
             get_address_params + ['vtgate-%s' % cell], stderr=subprocess.STDOUT)
-      self.vtgate_addrs[cell] = '%s:15001' % vtgate_addr
-      self.vtgate_conns[cell] = vtgate_client.connect(
-          protocols_flavor.protocols_flavor().vtgate_python_protocol(),
-          self.vtgate_addrs[cell], 60)
+      self.vtgate_addrs[cell] = '%s:15991' % vtgate_addr
     super(K8sEnvironment, self).use_named(instance_name)
 
   def create(self, **kwargs):
@@ -163,11 +161,100 @@ class K8sEnvironment(base_environment.BaseEnvironment):
       logging.info(cluster_down_output)
 
   def get_vtgate_conn(self, cell):
-    return self.vtgate_conns[cell]
+    return vtgate_client.connect(
+        protocols_flavor.protocols_flavor().vtgate_python_protocol(),
+        self.vtgate_addrs[cell], 60)
+
+  def restart_mysql_task(self, tablet_name, task_name, is_alloc=False):
+    # Kubernetes strips leading 0s from uid when creating pod names
+    uid = str(self.get_tablet_uid(tablet_name)).lstrip('0')
+    vttablet_pod_name = 'vttablet-%s' % uid
+
+    # Generate temp file with current k8s pod config. Many of these steps
+    # can be deleted once StatefulSet is implemented and vttablets are
+    # controlled via replication controller.
+    tmpfile = None
+    tmpfile = tempfile.NamedTemporaryFile()
+    subprocess.Popen(['kubectl', 'get', 'pod', vttablet_pod_name,
+                      '--namespace=%s' % self.cluster_name, '-o', 'json'],
+                     stdout=tmpfile)
+    tmpfile.flush()
+    tmpfile.seek(0)
+
+    # Actually delete the pod and wait for it to be deleted.
+    os.system('kubectl delete pod %s --namespace=%s' % (
+        vttablet_pod_name, self.cluster_name))
+    start_time = time.time()
+    while time.time() - start_time < 120:
+      logging.info('Waiting for pod %s to be deleted', vttablet_pod_name)
+      pods = subprocess.check_output(
+          ['kubectl', 'get', 'pods', '--namespace=%s' % self.cluster_name])
+      if vttablet_pod_name not in pods:
+        logging.info('Pod deleted.')
+        break
+      time.sleep(5)
+
+    logging.info('Sleeping...')
+    time.sleep(60)
+
+    # Create the pod again.
+    os.system('cat %s | kubectl create -f -' % tmpfile.name)
+    while time.time() - start_time < 120:
+      logging.info('Waiting for pod %s to be running', vttablet_pod_name)
+      pod = subprocess.check_output(
+          ['kubectl', 'get', 'pod', '--namespace=%s' % self.cluster_name,
+           vttablet_pod_name, '-o', 'json'])
+      try:
+        if json.loads(pod)['status']['phase'] == 'Running':
+          logging.info('Pod is running')
+          break
+      except ValueError:
+        pass
+      time.sleep(5)
+    return 0
 
   def wait_for_good_failover_status(
       self, keyspace, shard_name, failover_completion_timeout_s=60):
     return 0
+
+  def poll_for_varz(self, tablet_name, varz, condition_msg, timeout=60.0,
+                    condition_fn=None, converter=str):
+    """Polls for varz to exist, or match specific conditions, within a timeout.
+
+    Args:
+      tablet_name: the name of the process that we're trying to poll vars from.
+      varz: name of the vars to fetch from varz
+      condition_msg: string describing the conditions that we're polling for,
+        used for error messaging.
+      timeout: number of seconds that we should attempt to poll for.
+      condition_fn: a function that takes the var as input, and returns a truthy
+        value if it matches the success conditions.
+      converter: function to convert varz value
+
+    Raises:
+      VitessEnvironmentError: Raised if the varz conditions aren't met within
+        the given timeout
+
+    Returns:
+      dict of requested varz
+    """
+    start_time = time.time()
+    while True:
+      if (time.time() - start_time) >= timeout:
+        raise base_environment.VitessEnvironmentError(
+            'Timed out polling for varz; condition "%s" not met' % (
+                condition_msg))
+      hostname = self.get_tablet_ip_port(tablet_name)
+      tablet_pod = 'vttablet-%s' % self.get_tablet_uid(tablet_name)
+      host_varz = subprocess.check_output([
+          'kubectl', 'exec', '-ti', tablet_pod,
+          '--namespace=%s' % self.cluster_name,
+          'curl', '%s/debug/vars' % hostname])
+      if not host_varz:
+        continue
+      host_varz = json.loads(host_varz)
+      if condition_fn is None or condition_fn(host_varz):
+        return host_varz
 
   def wait_for_healthy_tablets(self):
     return 0
@@ -176,6 +263,16 @@ class K8sEnvironment(base_environment.BaseEnvironment):
     tablet_info = json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))
     return tablet_info['alias']['uid'] % 100
+
+  def automatic_reparent_available(self):
+    """Checks if the environment can automatically reparent."""
+    p1 = subprocess.Popen(
+        ['kubectl', 'get', 'pods', '--namespace=%s' % self.cluster_name],
+        stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(
+        ['grep', 'orchestrator'], stdin=p1.stdout, stdout=subprocess.PIPE)
+    output = p2.communicate()[0]
+    return bool(output)
 
   def internal_reparent(self, keyspace, shard_name, new_master_uid,
                         emergency=False):
@@ -186,3 +283,23 @@ class K8sEnvironment(base_environment.BaseEnvironment):
          '-new_master', new_master_uid])
     self.vtctl_helper.execute_vtctl_command(['RebuildKeyspaceGraph', keyspace])
     return 0, 'No output'
+
+  def backup(self, tablet_name):
+    logging.info('Backing up tablet %s', tablet_name)
+    self.vtctl_helper.execute_vtctl_command(['Backup', tablet_name])
+
+  def drain_tablet(self, tablet_name, duration_s=600):
+    self.vtctl_helper.execute_vtctl_command(['StopSlave', tablet_name])
+    self.vtctl_helper.execute_vtctl_command(
+        ['ChangeSlaveType', tablet_name, 'drained'])
+
+  def is_tablet_drained(self, tablet_name):
+    return self.get_tablet_type(tablet_name) == topodata_pb2.DRAINED
+
+  def undrain_tablet(self, tablet_name):
+    self.vtctl_helper.execute_vtctl_command(
+        ['ChangeSlaveType', tablet_name, 'replica'])
+    self.vtctl_helper.execute_vtctl_command(['StartSlave', tablet_name])
+
+  def is_tablet_undrained(self, tablet_name):
+    return not self.is_tablet_drained(tablet_name)

--- a/test/end2end/reparent_test.py
+++ b/test/end2end/reparent_test.py
@@ -116,7 +116,8 @@ class ReparentTest(base_end2end_test.BaseEnd2EndTest):
             logging.info('Reparent took %f seconds', duration)
             break
         except (IndexError, KeyError, vtctl_helper.VtctlClientError) as e:
-          logging.info(e)
+          logging.info(
+              'While waiting for reparent, got the following error: %s', e)
       else:
         self.fail('Timed out waiting for reparent on %s/%s' % (
             keyspace, shard_name))

--- a/test/end2end/vtctl_helper.py
+++ b/test/end2end/vtctl_helper.py
@@ -5,10 +5,7 @@ executed.  This should help reduce flakiness in the sandbox.
 """
 
 import logging
-import os
-import re
 import subprocess
-import tempfile
 import time
 
 from vtctl import vtctl_client
@@ -62,7 +59,8 @@ class VtctlHelper(object):
         if expect_fail:
           logging.info('Expected vtctl error, got: %s', e.message or e.output)
           raise VtctlClientError('Caught an expected vtctl error')
-        logging.info('Vtctl error: %s', e.message or e.output)
+        logging.info('Vtctl error (vtctl %s): %s',
+                     ' '.join(args), e.message or e.output)
       time.sleep(5)
     raise VtctlClientError('Timed out on vtctl_client execute_vtctl_command')
 


### PR DESCRIPTION
Other updates:
- Moved util import in base_end2end_test.py to main(), as importing it has side effects that are easier to avoid if I swap out main() in subclasses.
- Update environments to support common functionalities in tests, like creating/deleting tables, reparenting functions, etc.
- Added functions to the environments so they can specify whether reparents are allowed via vtctl (by checking if ReparentShard exists), are automated (like via Orchestrator), etc.