### PR TITLE
Changing table matching syntax.

### DIFF
--- a/go/vt/mysqlctl/tmutils/schema_test.go
+++ b/go/vt/mysqlctl/tmutils/schema_test.go
@@ -338,7 +338,7 @@ func TestFilterTables(t *testing.T) {
 					basicTable1,
 				},
 			},
-			tables:    []string{"("},
+			tables:    []string{"/(/"},
 			wantError: errors.New("cannot compile regexp ( for table: error parsing regexp: missing closing ): `(`"),
 		},
 		{
@@ -348,8 +348,67 @@ func TestFilterTables(t *testing.T) {
 					basicTable1,
 				},
 			},
-			excludeTables: []string{"("},
+			excludeTables: []string{"/(/"},
 			wantError:     errors.New("cannot compile regexp ( for excludeTable: error parsing regexp: missing closing ): `(`"),
+		},
+		{
+			desc: "table substring doesn't match without regexp (include)",
+			input: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+					basicTable2,
+				},
+			},
+			tables: []string{basicTable1.Name[1:]},
+			want: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{},
+			},
+		},
+		{
+			desc: "table substring matches with regexp (include)",
+			input: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+					basicTable2,
+				},
+			},
+			tables: []string{"/" + basicTable1.Name[1:] + "/"},
+			want: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+				},
+			},
+		},
+		{
+			desc: "table substring doesn't match without regexp (exclude)",
+			input: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+					basicTable2,
+				},
+			},
+			excludeTables: []string{basicTable1.Name[1:]},
+			want: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+					basicTable2,
+				},
+			},
+		},
+		{
+			desc: "table substring matches with regexp (exclude)",
+			input: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable1,
+					basicTable2,
+				},
+			},
+			excludeTables: []string{"/" + basicTable1.Name[1:] + "/"},
+			want: &tabletmanagerdatapb.SchemaDefinition{
+				TableDefinitions: []*tabletmanagerdatapb.TableDefinition{
+					basicTable2,
+				},
+			},
 		},
 	}
 

--- a/go/vt/tabletmanager/binlog_players_test.go
+++ b/go/vt/tabletmanager/binlog_players_test.go
@@ -812,7 +812,7 @@ func TestBinlogPlayerMapVerticalSplit(t *testing.T) {
 				Shard:    "0",
 				Tables: []string{
 					"table1",
-					"funtables_*",
+					"/funtables_/",
 				},
 			},
 		}

--- a/go/vt/vtctl/vtctl.go
+++ b/go/vt/vtctl/vtctl.go
@@ -605,7 +605,7 @@ func commandInitTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 	}
 
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <tablet alias> and <tablet type> arguments are both required for the InitTablet command.")
+		return fmt.Errorf("the <tablet alias> and <tablet type> arguments are both required for the InitTablet command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -645,7 +645,7 @@ func commandGetTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the GetTablet command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the GetTablet command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -670,7 +670,7 @@ func commandUpdateTabletAddrs(ctx context.Context, wr *wrangler.Wrangler, subFla
 	}
 
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the UpdateTabletAddrs command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the UpdateTabletAddrs command")
 	}
 	if *ipAddr != "" && net.ParseIP(*ipAddr) == nil {
 		return fmt.Errorf("malformed address: %v", *ipAddr)
@@ -712,7 +712,7 @@ func commandDeleteTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() == 0 {
-		return fmt.Errorf("The <tablet alias> argument must be used to specify at least one tablet when calling the DeleteTablet command.")
+		return fmt.Errorf("the <tablet alias> argument must be used to specify at least one tablet when calling the DeleteTablet command")
 	}
 
 	tabletAliases, err := tabletParamsToTabletAliases(subFlags.Args())
@@ -732,7 +732,7 @@ func commandSetReadOnly(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the SetReadOnly command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the SetReadOnly command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -751,7 +751,7 @@ func commandSetReadWrite(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the SetReadWrite command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the SetReadWrite command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -810,7 +810,7 @@ func commandChangeSlaveType(ctx context.Context, wr *wrangler.Wrangler, subFlags
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <tablet alias> and <db type> arguments are required for the ChangeSlaveType command.")
+		return fmt.Errorf("the <tablet alias> and <db type> arguments are required for the ChangeSlaveType command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -842,7 +842,7 @@ func commandPing(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Flag
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the Ping command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the Ping command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -860,7 +860,7 @@ func commandRefreshState(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the RefreshState command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the RefreshState command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -879,7 +879,7 @@ func commandRefreshStateByShard(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the RefreshStateByShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the RefreshStateByShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -903,7 +903,7 @@ func commandRunHealthCheck(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the RunHealthCheck command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the RunHealthCheck command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -921,7 +921,7 @@ func commandIgnoreHealthError(ctx context.Context, wr *wrangler.Wrangler, subFla
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <tablet alias> and <ignore regexp> arguments are required for the IgnoreHealthError command.")
+		return fmt.Errorf("the <tablet alias> and <ignore regexp> arguments are required for the IgnoreHealthError command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -946,7 +946,7 @@ func commandWaitForDrain(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <tablet type> arguments are both required for the WaitForDrain command.")
+		return fmt.Errorf("the <keyspace/shard> and <tablet type> arguments are both required for the WaitForDrain command")
 	}
 	if *timeout != 0 {
 		var cancel context.CancelFunc
@@ -972,7 +972,7 @@ func commandSleep(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fla
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <tablet alias> and <duration> arguments are required for the Sleep command.")
+		return fmt.Errorf("the <tablet alias> and <duration> arguments are required for the Sleep command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -995,7 +995,7 @@ func commandBackup(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Fl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The Backup command requires the <tablet alias> argument.")
+		return fmt.Errorf("the Backup command requires the <tablet alias> argument")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -1033,7 +1033,7 @@ func commandExecuteFetchAsDba(ctx context.Context, wr *wrangler.Wrangler, subFla
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <tablet alias> and <sql command> arguments are required for the ExecuteFetchAsDba command.")
+		return fmt.Errorf("the <tablet alias> and <sql command> arguments are required for the ExecuteFetchAsDba command")
 	}
 
 	alias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -1058,7 +1058,7 @@ func commandExecuteHook(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() < 2 {
-		return fmt.Errorf("The <tablet alias> and <hook name> arguments are required for the ExecuteHook command.")
+		return fmt.Errorf("the <tablet alias> and <hook name> arguments are required for the ExecuteHook command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -1080,7 +1080,7 @@ func commandCreateShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the CreateShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the CreateShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1106,7 +1106,7 @@ func commandGetShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the GetShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the GetShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1125,7 +1125,7 @@ func commandTabletExternallyReparented(ctx context.Context, wr *wrangler.Wrangle
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the TabletExternallyReparented command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the TabletExternallyReparented command")
 	}
 
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
@@ -1145,7 +1145,7 @@ func commandValidateShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the ValidateShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ValidateShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1160,7 +1160,7 @@ func commandShardReplicationPositions(ctx context.Context, wr *wrangler.Wrangler
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the ShardReplicationPositions command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ShardReplicationPositions command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1192,7 +1192,7 @@ func commandListShardTablets(ctx context.Context, wr *wrangler.Wrangler, subFlag
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the ListShardTablets command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ListShardTablets command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1208,7 +1208,7 @@ func commandSetShardServedTypes(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <served tablet type> arguments are both required for the SetShardServedTypes command.")
+		return fmt.Errorf("the <keyspace/shard> and <served tablet type> arguments are both required for the SetShardServedTypes command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1229,14 +1229,14 @@ func commandSetShardServedTypes(ctx context.Context, wr *wrangler.Wrangler, subF
 
 func commandSetShardTabletControl(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	cellsStr := subFlags.String("cells", "", "Specifies a comma-separated list of cells to update")
-	tablesStr := subFlags.String("tables", "", "Specifies a comma-separated list of tables to replicate (used for vertical split)")
+	tablesStr := subFlags.String("tables", "", "Specifies a comma-separated list of tables to replicate (used for vertical split). Each is either an exact match, or a regular expression of the form /regexp/")
 	remove := subFlags.Bool("remove", false, "Removes cells for vertical splits. This flag requires the *tables* flag to also be set.")
 	disableQueryService := subFlags.Bool("disable_query_service", false, "Disables query service on the provided nodes")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <tablet type> arguments are both required for the SetShardTabletControl command.")
+		return fmt.Errorf("the <keyspace/shard> and <tablet type> arguments are both required for the SetShardTabletControl command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1264,7 +1264,7 @@ func commandSourceShardDelete(ctx context.Context, wr *wrangler.Wrangler, subFla
 	}
 
 	if subFlags.NArg() < 2 {
-		return fmt.Errorf("The <keyspace/shard> and <uid> arguments are both required for the SourceShardDelete command.")
+		return fmt.Errorf("the <keyspace/shard> and <uid> arguments are both required for the SourceShardDelete command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1279,12 +1279,12 @@ func commandSourceShardDelete(ctx context.Context, wr *wrangler.Wrangler, subFla
 
 func commandSourceShardAdd(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	keyRange := subFlags.String("key_range", "", "Identifies the key range to use for the SourceShard")
-	tablesStr := subFlags.String("tables", "", "Specifies a comma-separated list of tables to replicate (used for vertical split)")
+	tablesStr := subFlags.String("tables", "", "Specifies a comma-separated list of tables to replicate (used for vertical split). Each is either an exact match, or a regular expression of the form /regexp/")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 3 {
-		return fmt.Errorf("The <keyspace/shard>, <uid>, and <source keyspace/shard> arguments are all required for the SourceShardAdd command.")
+		return fmt.Errorf("the <keyspace/shard>, <uid>, and <source keyspace/shard> arguments are all required for the SourceShardAdd command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1316,7 +1316,7 @@ func commandShardReplicationAdd(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <tablet alias> arguments are required for the ShardReplicationAdd command.")
+		return fmt.Errorf("the <keyspace/shard> and <tablet alias> arguments are required for the ShardReplicationAdd command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1335,7 +1335,7 @@ func commandShardReplicationRemove(ctx context.Context, wr *wrangler.Wrangler, s
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <tablet alias> arguments are required for the ShardReplicationRemove command.")
+		return fmt.Errorf("the <keyspace/shard> and <tablet alias> arguments are required for the ShardReplicationRemove command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1354,7 +1354,7 @@ func commandShardReplicationFix(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <cell> and <keyspace/shard> arguments are required for the ShardReplicationRemove command.")
+		return fmt.Errorf("the <cell> and <keyspace/shard> arguments are required for the ShardReplicationRemove command")
 	}
 
 	cell := subFlags.Arg(0)
@@ -1375,7 +1375,7 @@ func commandWaitForFilteredReplication(ctx context.Context, wr *wrangler.Wrangle
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the WaitForFilteredReplication command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the WaitForFilteredReplication command")
 	}
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
 	if err != nil {
@@ -1456,7 +1456,7 @@ func commandRemoveShardCell(ctx context.Context, wr *wrangler.Wrangler, subFlags
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace/shard> and <cell> arguments are required for the RemoveShardCell command.")
+		return fmt.Errorf("the <keyspace/shard> and <cell> arguments are required for the RemoveShardCell command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1473,7 +1473,7 @@ func commandDeleteShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() == 0 {
-		return fmt.Errorf("The <keyspace/shard> argument must be used to identify at least one keyspace and shard when calling the DeleteShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument must be used to identify at least one keyspace and shard when calling the DeleteShard command")
 	}
 
 	keyspaceShards, err := shardParamsToKeyspaceShards(ctx, wr, subFlags.Args())
@@ -1504,7 +1504,7 @@ func commandCreateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the CreateKeyspace command.")
+		return fmt.Errorf("the <keyspace name> argument is required for the CreateKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1542,7 +1542,7 @@ func commandDeleteKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("Must specify the <keyspace> argument for DeleteKeyspace.")
+		return fmt.Errorf("must specify the <keyspace> argument for DeleteKeyspace")
 	}
 
 	return wr.DeleteKeyspace(ctx, subFlags.Arg(0), *recursive)
@@ -1555,7 +1555,7 @@ func commandRemoveKeyspaceCell(ctx context.Context, wr *wrangler.Wrangler, subFl
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace> and <cell> arguments are required for the RemoveKeyspaceCell command.")
+		return fmt.Errorf("the <keyspace> and <cell> arguments are required for the RemoveKeyspaceCell command")
 	}
 
 	return wr.RemoveKeyspaceCell(ctx, subFlags.Arg(0), subFlags.Arg(1), *force, *recursive)
@@ -1566,7 +1566,7 @@ func commandGetKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace> argument is required for the GetKeyspace command.")
+		return fmt.Errorf("the <keyspace> argument is required for the GetKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1592,7 +1592,7 @@ func commandSetKeyspaceShardingInfo(ctx context.Context, wr *wrangler.Wrangler, 
 		return err
 	}
 	if subFlags.NArg() > 3 || subFlags.NArg() < 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the SetKeyspaceShardingInfo command. The <column name> and <column type> arguments are both optional.")
+		return fmt.Errorf("the <keyspace name> argument is required for the SetKeyspaceShardingInfo command. The <column name> and <column type> arguments are both optional")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1612,7 +1612,7 @@ func commandSetKeyspaceShardingInfo(ctx context.Context, wr *wrangler.Wrangler, 
 	keyspaceIDTypeSet := (kit != topodatapb.KeyspaceIdType_UNSET)
 	columnNameSet := (columnName != "")
 	if (keyspaceIDTypeSet && !columnNameSet) || (!keyspaceIDTypeSet && columnNameSet) {
-		return fmt.Errorf("Both <column name> and <column type> must be set, or both must be unset.")
+		return fmt.Errorf("both <column name> and <column type> must be set, or both must be unset")
 	}
 
 	return wr.SetKeyspaceShardingInfo(ctx, keyspace, columnName, kit, *force)
@@ -1626,7 +1626,7 @@ func commandSetKeyspaceServedFrom(ctx context.Context, wr *wrangler.Wrangler, su
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <keyspace name> and <tablet type> arguments are required for the SetKeyspaceServedFrom command.")
+		return fmt.Errorf("the <keyspace name> and <tablet type> arguments are required for the SetKeyspaceServedFrom command")
 	}
 	keyspace := subFlags.Arg(0)
 	servedType, err := parseTabletType(subFlags.Arg(1), []topodatapb.TabletType{topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_RDONLY})
@@ -1647,7 +1647,7 @@ func commandRebuildKeyspaceGraph(ctx context.Context, wr *wrangler.Wrangler, sub
 		return err
 	}
 	if subFlags.NArg() == 0 {
-		return fmt.Errorf("The <keyspace> argument must be used to specify at least one keyspace when calling the RebuildKeyspaceGraph command.")
+		return fmt.Errorf("the <keyspace> argument must be used to specify at least one keyspace when calling the RebuildKeyspaceGraph command")
 	}
 
 	var cellArray []string
@@ -1673,7 +1673,7 @@ func commandValidateKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlag
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the ValidateKeyspace command.")
+		return fmt.Errorf("the <keyspace name> argument is required for the ValidateKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1689,7 +1689,7 @@ func commandMigrateServedTypes(ctx context.Context, wr *wrangler.Wrangler, subFl
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <source keyspace/shard> and <served tablet type> arguments are both required for the MigrateServedTypes command.")
+		return fmt.Errorf("the <source keyspace/shard> and <served tablet type> arguments are both required for the MigrateServedTypes command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1701,7 +1701,7 @@ func commandMigrateServedTypes(ctx context.Context, wr *wrangler.Wrangler, subFl
 		return err
 	}
 	if servedType == topodatapb.TabletType_MASTER && *skipReFreshState {
-		return fmt.Errorf("The skip-refresh-state flag can only be specified for non-master migrations.")
+		return fmt.Errorf("the skip-refresh-state flag can only be specified for non-master migrations")
 	}
 	var cells []string
 	if *cellsStr != "" {
@@ -1718,7 +1718,7 @@ func commandMigrateServedFrom(ctx context.Context, wr *wrangler.Wrangler, subFla
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <destination keyspace/shard> and <served tablet type> arguments are both required for the MigrateServedFrom command.")
+		return fmt.Errorf("the <destination keyspace/shard> and <served tablet type> arguments are both required for the MigrateServedFrom command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1741,7 +1741,7 @@ func commandFindAllShardsInKeyspace(ctx context.Context, wr *wrangler.Wrangler, 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace> argument is required for the FindAllShardsInKeyspace command.")
+		return fmt.Errorf("the <keyspace> argument is required for the FindAllShardsInKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1769,7 +1769,7 @@ func commandListAllTablets(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <cell name> argument is required for the ListAllTablets command.")
+		return fmt.Errorf("the <cell name> argument is required for the ListAllTablets command")
 	}
 
 	cell := subFlags.Arg(0)
@@ -1781,7 +1781,7 @@ func commandListTablets(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() == 0 {
-		return fmt.Errorf("The <tablet alias> argument is required for the ListTablets command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the ListTablets command")
 	}
 
 	paths := subFlags.Args()
@@ -1797,15 +1797,15 @@ func commandListTablets(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandGetSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	tables := subFlags.String("tables", "", "Specifies a comma-separated list of regular expressions for which tables should gather information")
-	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of regular expressions for tables to exclude")
+	tables := subFlags.String("tables", "", "Specifies a comma-separated list of tables for which we should gather information. Each is either an exact match, or a regular expression of the form /regexp/")
+	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the output")
 	tableNamesOnly := subFlags.Bool("table_names_only", false, "Only displays table names that match")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the GetSchema command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the GetSchema command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -1838,7 +1838,7 @@ func commandReloadSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the ReloadSchema command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the ReloadSchema command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -1848,13 +1848,13 @@ func commandReloadSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 }
 
 func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of regular expressions for tables to exclude")
+	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the validation")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the ValidateSchemaShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ValidateSchemaShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1869,13 +1869,13 @@ func commandValidateSchemaShard(ctx context.Context, wr *wrangler.Wrangler, subF
 }
 
 func commandValidateSchemaKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of regular expressions for tables to exclude")
+	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", false, "Includes views in the validation")
 	if err := subFlags.Parse(args); err != nil {
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the ValidateSchemaKeyspace command.")
+		return fmt.Errorf("the <keyspace name> argument is required for the ValidateSchemaKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1895,7 +1895,7 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace> argument is required for the commandApplySchema command.")
+		return fmt.Errorf("the <keyspace> argument is required for the commandApplySchema command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1916,8 +1916,8 @@ func commandApplySchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fl
 }
 
 func commandCopySchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
-	tables := subFlags.String("tables", "", "Specifies a comma-separated list of regular expressions for which tables  gather schema information for")
-	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of regular expressions for which tables to exclude")
+	tables := subFlags.String("tables", "", "Specifies a comma-separated list of tables to copy. Each is either an exact match, or a regular expression of the form /regexp/")
+	excludeTables := subFlags.String("exclude_tables", "", "Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	includeViews := subFlags.Bool("include-views", true, "Includes views in the output")
 	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 10*time.Second, "The amount of time to wait for slaves to receive the schema change via replication.")
 	if err := subFlags.Parse(args); err != nil {
@@ -1925,7 +1925,7 @@ func commandCopySchemaShard(ctx context.Context, wr *wrangler.Wrangler, subFlags
 	}
 
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <source keyspace/shard> and <destination keyspace/shard> arguments are both required for the CopySchemaShard command. Instead of the <source keyspace/shard> argument, you can also specify <tablet alias> which refers to a specific tablet of the shard in the source keyspace.")
+		return fmt.Errorf("the <source keyspace/shard> and <destination keyspace/shard> arguments are both required for the CopySchemaShard command. Instead of the <source keyspace/shard> argument, you can also specify <tablet alias> which refers to a specific tablet of the shard in the source keyspace")
 	}
 	var tableArray []string
 	if *tables != "" {
@@ -1956,7 +1956,7 @@ func commandValidateVersionShard(ctx context.Context, wr *wrangler.Wrangler, sub
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is requird for the ValidateVersionShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ValidateVersionShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -1971,7 +1971,7 @@ func commandValidateVersionKeyspace(ctx context.Context, wr *wrangler.Wrangler, 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the ValidateVersionKeyspace command.")
+		return fmt.Errorf("the <keyspace name> argument is required for the ValidateVersionKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -1983,7 +1983,7 @@ func commandGetPermissions(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <tablet alias> argument is required for the GetPermissions command.")
+		return fmt.Errorf("the <tablet alias> argument is required for the GetPermissions command")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(subFlags.Arg(0))
 	if err != nil {
@@ -2001,7 +2001,7 @@ func commandValidatePermissionsShard(ctx context.Context, wr *wrangler.Wrangler,
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace/shard> argument is required for the ValidatePermissionsShard command.")
+		return fmt.Errorf("the <keyspace/shard> argument is required for the ValidatePermissionsShard command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(0))
@@ -2016,7 +2016,7 @@ func commandValidatePermissionsKeyspace(ctx context.Context, wr *wrangler.Wrangl
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace name> argument is required for the ValidatePermissionsKeyspace command.")
+		return fmt.Errorf("the <keyspace name> argument is required for the ValidatePermissionsKeyspace command")
 	}
 
 	keyspace := subFlags.Arg(0)
@@ -2028,7 +2028,7 @@ func commandGetVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *fla
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace> argument is required for the GetVSchema command.")
+		return fmt.Errorf("the <keyspace> argument is required for the GetVSchema command")
 	}
 	keyspace := subFlags.Arg(0)
 	schema, err := wr.TopoServer().GetVSchema(ctx, keyspace)
@@ -2052,7 +2052,7 @@ func commandRebuildVSchemaGraph(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 0 {
-		return fmt.Errorf("RebuildVSchemaGraph doesn't take any arguments.")
+		return fmt.Errorf("RebuildVSchemaGraph doesn't take any arguments")
 	}
 
 	return topotools.RebuildVSchema(ctx, wr.Logger(), wr.TopoServer(), cells)
@@ -2069,10 +2069,10 @@ func commandApplyVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *f
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <keyspace> argument is required for the ApplyVSchema command.")
+		return fmt.Errorf("the <keyspace> argument is required for the ApplyVSchema command")
 	}
 	if (*vschema == "") == (*vschemaFile == "") {
-		return fmt.Errorf("Either the vschema or vschemaFile flag must be specified when calling the ApplyVSchema command.")
+		return fmt.Errorf("rither the vschema or vschemaFile flag must be specified when calling the ApplyVSchema command")
 	}
 	var schema []byte
 	if *vschemaFile != "" {
@@ -2113,7 +2113,7 @@ func commandGetSrvKeyspaceNames(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <cell> argument is required for the GetSrvKeyspaceNames command.")
+		return fmt.Errorf("the <cell> argument is required for the GetSrvKeyspaceNames command")
 	}
 
 	srvKeyspaceNames, err := wr.TopoServer().GetSrvKeyspaceNames(ctx, subFlags.Arg(0))
@@ -2131,7 +2131,7 @@ func commandGetSrvKeyspace(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <cell> and <keyspace> arguments are required for the GetSrvKeyspace command.")
+		return fmt.Errorf("the <cell> and <keyspace> arguments are required for the GetSrvKeyspace command")
 	}
 
 	srvKeyspace, err := wr.TopoServer().GetSrvKeyspace(ctx, subFlags.Arg(0), subFlags.Arg(1))
@@ -2146,7 +2146,7 @@ func commandGetSrvVSchema(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 		return err
 	}
 	if subFlags.NArg() != 1 {
-		return fmt.Errorf("The <cell> argument is required for the GetSrvVSchema command.")
+		return fmt.Errorf("the <cell> argument is required for the GetSrvVSchema command")
 	}
 
 	srvVSchema, err := wr.TopoServer().GetSrvVSchema(ctx, subFlags.Arg(0))
@@ -2161,7 +2161,7 @@ func commandGetShardReplication(ctx context.Context, wr *wrangler.Wrangler, subF
 		return err
 	}
 	if subFlags.NArg() != 2 {
-		return fmt.Errorf("The <cell> and <keyspace/shard> arguments are required for the GetShardReplication command.")
+		return fmt.Errorf("the <cell> and <keyspace/shard> arguments are required for the GetShardReplication command")
 	}
 
 	keyspace, shard, err := topoproto.ParseKeyspaceShard(subFlags.Arg(1))
@@ -2186,7 +2186,7 @@ func commandHelp(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.Flag
 	case 1:
 		RunCommand(ctx, wr, []string{subFlags.Arg(0), "--help"})
 	default:
-		return fmt.Errorf("When calling the Help command, either specify a single argument that identifies the name of the command to get help with or do not specify any additional arguments.")
+		return fmt.Errorf("when calling the Help command, either specify a single argument that identifies the name of the command to get help with or do not specify any additional arguments")
 	}
 
 	return nil
@@ -2269,7 +2269,7 @@ func RunCommand(ctx context.Context, wr *wrangler.Wrangler, args []string) error
 	if len(args) == 0 {
 		wr.Logger().Printf("No command specified. Please see the list below:\n\n")
 		PrintAllCommands(wr.Logger())
-		return fmt.Errorf("No command was specified.")
+		return fmt.Errorf("no command was specified")
 	}
 
 	action := args[0]

--- a/go/vt/worker/legacy_split_clone_cmd.go
+++ b/go/vt/worker/legacy_split_clone_cmd.go
@@ -52,7 +52,7 @@ const legacySplitCloneHTML2 = `
   <h1>Split Clone Action</h1>
     <form action="/Clones/LegacySplitClone" method="post">
       <LABEL for="excludeTables">Exclude Tables: </LABEL>
-        <INPUT type="text" id="excludeTables" name="excludeTables" value="moving.*"></BR>
+        <INPUT type="text" id="excludeTables" name="excludeTables" value="/ignored/"></BR>
       <LABEL for="strategy">Strategy: </LABEL>
         <INPUT type="text" id="strategy" name="strategy" value=""></BR>
       <LABEL for="sourceReaderCount">Source Reader Count: </LABEL>
@@ -84,7 +84,7 @@ var legacySplitCloneTemplate = mustParseTemplate("splitClone", legacySplitCloneH
 var legacySplitCloneTemplate2 = mustParseTemplate("splitClone2", legacySplitCloneHTML2)
 
 func commandLegacySplitClone(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
-	excludeTables := subFlags.String("exclude_tables", "", "comma separated list of tables to exclude")
+	excludeTables := subFlags.String("exclude_tables", "", "comma separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	strategy := subFlags.String("strategy", "", "which strategy to use for restore, use 'vtworker LegacySplitClone --strategy=-help k/s' for more info")
 	sourceReaderCount := subFlags.Int("source_reader_count", defaultSourceReaderCount, "number of concurrent streaming queries to use on the source")
 	destinationPackCount := subFlags.Int("destination_pack_count", defaultDestinationPackCount, "number of packets to pack in one destination insert")

--- a/go/vt/worker/split_clone_cmd.go
+++ b/go/vt/worker/split_clone_cmd.go
@@ -55,7 +55,7 @@ const splitCloneHTML2 = `
       <LABEL for="offline">Do Offline Copy: (exact copy at a specific GTID, required before shard migration, source and destination tablets will be put out of serving during copy)</LABEL>
         <INPUT type="checkbox" id="offline" name="offline" value="true"{{if .DefaultOnline}} checked{{end}}></BR>
       <LABEL for="excludeTables">Exclude Tables: </LABEL>
-        <INPUT type="text" id="excludeTables" name="excludeTables" value="moving.*"></BR>
+        <INPUT type="text" id="excludeTables" name="excludeTables" value="/ignored/"></BR>
       <LABEL for="strategy">Strategy: </LABEL>
         <INPUT type="text" id="strategy" name="strategy" value=""></BR>
       <LABEL for="chunkCount">Chunk Count: </LABEL>
@@ -99,7 +99,7 @@ var splitCloneTemplate2 = mustParseTemplate("splitClone2", splitCloneHTML2)
 func commandSplitClone(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
 	online := subFlags.Bool("online", defaultOnline, "do online copy (optional approximate copy, source and destination tablets will not be put out of serving, minimizes downtime during offline copy)")
 	offline := subFlags.Bool("offline", defaultOffline, "do offline copy (exact copy at a specific GTID, required before shard migration, source and destination tablets will be put out of serving during copy)")
-	excludeTables := subFlags.String("exclude_tables", "", "comma separated list of tables to exclude")
+	excludeTables := subFlags.String("exclude_tables", "", "comma separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/")
 	strategy := subFlags.String("strategy", "", "which strategy to use for restore, use 'vtworker SplitClone --strategy=-help k/s' for more info")
 	chunkCount := subFlags.Int("chunk_count", defaultChunkCount, "number of chunks per table")
 	minRowsPerChunk := subFlags.Int("min_rows_per_chunk", defaultMinRowsPerChunk, "minimum number of rows per chunk (may reduce --chunk_count)")

--- a/go/vt/worker/vertical_split_clone_cmd.go
+++ b/go/vt/worker/vertical_split_clone_cmd.go
@@ -50,7 +50,7 @@ const verticalSplitCloneHTML2 = `
   <h1>Vertical Split Clone Action</h1>
     <form action="/Clones/VerticalSplitClone" method="post">
       <LABEL for="tables">Tables: </LABEL>
-        <INPUT type="text" id="tables" name="tables" value="moving.*"></BR>
+        <INPUT type="text" id="tables" name="tables" value="/moving/"></BR>
       <LABEL for="online">Do Online Copy: (optional approximate copy, source and destination tablets will not be put out of serving, minimizes downtime during offline copy)</LABEL>
         <INPUT type="checkbox" id="online" name="online" value="true"{{if .DefaultOnline}} checked{{end}}></BR>
       <LABEL for="offline">Do Offline Copy: (exact copy at a specific GTID, required before shard migration, source and destination tablets will be put out of serving during copy)</LABEL>
@@ -97,7 +97,7 @@ var verticalSplitCloneTemplate2 = mustParseTemplate("verticalSplitClone2", verti
 func commandVerticalSplitClone(wi *Instance, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) (Worker, error) {
 	online := subFlags.Bool("online", defaultOnline, "do online copy (optional approximate copy, source and destination tablets will not be put out of serving, minimizes downtime during offline copy)")
 	offline := subFlags.Bool("offline", defaultOffline, "do offline copy (exact copy at a specific GTID, required before shard migration, source and destination tablets will be put out of serving during copy)")
-	tables := subFlags.String("tables", "", "comma separated list of tables to replicate (used for vertical split)")
+	tables := subFlags.String("tables", "", "comma separated list of tables to replicate (used for vertical split). Each is either an exact match, or a regular expression of the form /regexp/")
 	strategy := subFlags.String("strategy", "", "which strategy to use for restore, use 'vtworker VerticalSplitClone --strategy=-help k/s' for more info")
 	chunkCount := subFlags.Int("chunk_count", defaultChunkCount, "number of chunks per table")
 	minRowsPerChunk := subFlags.Int("min_rows_per_chunk", defaultMinRowsPerChunk, "minimum number of rows per chunk (may reduce --chunk_count)")

--- a/go/vt/worker/vertical_split_clone_test.go
+++ b/go/vt/worker/vertical_split_clone_test.go
@@ -167,7 +167,7 @@ func TestVerticalSplitClone(t *testing.T) {
 		// code is executed. But the intent here is not to throttle the test, hence
 		// the rate limit is set very high.
 		"-max_tps", "9999",
-		"-tables", "moving.*,view1",
+		"-tables", "/moving/,view1",
 		"-source_reader_count", "10",
 		// Each chunk pipeline will process 10 rows. To spread them out across 3
 		// write queries, set the max row count per query to 4. (10 = 4+4+2)

--- a/test/automation_vertical_split.py
+++ b/test/automation_vertical_split.py
@@ -45,7 +45,7 @@ class TestAutomationVerticalSplit(vertical_split.TestVerticalSplit):
     params = {'source_keyspace': 'source_keyspace',
               'dest_keyspace': 'destination_keyspace',
               'shard_list': '0',
-              'tables': 'moving.*,view1',
+              'tables': '/moving/,view1',
               'vtctld_endpoint': vtctld_endpoint,
               'vtworker_endpoint': vtworker_endpoint,
              }
@@ -61,13 +61,13 @@ class TestAutomationVerticalSplit(vertical_split.TestVerticalSplit):
 
     self._check_srv_keyspace('')
     self._check_blacklisted_tables(vertical_split.source_master,
-                                   ['moving.*', 'view1'])
+                                   ['/moving/', 'view1'])
     self._check_blacklisted_tables(vertical_split.source_replica,
-                                   ['moving.*', 'view1'])
+                                   ['/moving/', 'view1'])
     self._check_blacklisted_tables(vertical_split.source_rdonly1,
-                                   ['moving.*', 'view1'])
+                                   ['/moving/', 'view1'])
     self._check_blacklisted_tables(vertical_split.source_rdonly2,
-                                   ['moving.*', 'view1'])
+                                   ['/moving/', 'view1'])
 
     # check the binlog player is gone now
     vertical_split.destination_master.wait_for_binlog_player_count(0)

--- a/test/vertical_split.py
+++ b/test/vertical_split.py
@@ -330,7 +330,7 @@ index by_msg (msg)
 
     # check we can or cannot access the tables
     for table in ['moving1', 'moving2']:
-      if expected and 'moving.*' in expected:
+      if expected and '/moving/' in expected:
         # table is blacklisted, should get the error
         _, stderr = utils.run_vtctl(['VtTabletExecute', '-json',
                                      t.tablet_alias,
@@ -385,14 +385,14 @@ index by_msg (msg)
         'unexpected errors for VtgateApiErrorCounts inside %s' % str(v))
 
   def test_vertical_split(self):
-    utils.run_vtctl(['CopySchemaShard', '--tables', 'moving.*,view1',
+    utils.run_vtctl(['CopySchemaShard', '--tables', '/moving/,view1',
                      source_rdonly1.tablet_alias, 'destination_keyspace/0'],
                     auto_log=True)
 
     utils.run_vtworker(['--cell', 'test_nj',
                         '--command_display_interval', '10ms',
                         'VerticalSplitClone',
-                        '--tables', 'moving.*,view1',
+                        '--tables', '/moving/,view1',
                         '--chunk_count', '10',
                         '--min_rows_per_chunk', '1',
                         '--min_healthy_rdonly_tablets', '1',
@@ -436,7 +436,7 @@ index by_msg (msg)
 
     # get status for destination master tablet, make sure we have it all
     self.check_running_binlog_player(destination_master, 700, 300,
-                                     extra_text='moving.*')
+                                     extra_text='moving')
 
     # check query service is off on destination master, as filtered
     # replication is enabled. Even health check should not interfere.
@@ -499,8 +499,8 @@ index by_msg (msg)
                              'ServedFrom(replica): source_keyspace\n')
     self._check_blacklisted_tables(source_master, None)
     self._check_blacklisted_tables(source_replica, None)
-    self._check_blacklisted_tables(source_rdonly1, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly2, ['moving.*', 'view1'])
+    self._check_blacklisted_tables(source_rdonly1, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly2, ['/moving/', 'view1'])
     self._check_client_conn_redirection(
         'destination_keyspace',
         ['master', 'replica'], ['moving1', 'moving2'])
@@ -510,9 +510,9 @@ index by_msg (msg)
                     auto_log=True)
     self._check_srv_keyspace('ServedFrom(master): source_keyspace\n')
     self._check_blacklisted_tables(source_master, None)
-    self._check_blacklisted_tables(source_replica, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly1, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly2, ['moving.*', 'view1'])
+    self._check_blacklisted_tables(source_replica, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly1, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly2, ['/moving/', 'view1'])
     self._check_client_conn_redirection(
         'destination_keyspace',
         ['master'], ['moving1', 'moving2'])
@@ -524,15 +524,15 @@ index by_msg (msg)
                              'ServedFrom(replica): source_keyspace\n')
     self._check_blacklisted_tables(source_master, None)
     self._check_blacklisted_tables(source_replica, None)
-    self._check_blacklisted_tables(source_rdonly1, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly2, ['moving.*', 'view1'])
+    self._check_blacklisted_tables(source_rdonly1, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly2, ['/moving/', 'view1'])
     utils.run_vtctl(['MigrateServedFrom', 'destination_keyspace/0', 'replica'],
                     auto_log=True)
     self._check_srv_keyspace('ServedFrom(master): source_keyspace\n')
     self._check_blacklisted_tables(source_master, None)
-    self._check_blacklisted_tables(source_replica, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly1, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly2, ['moving.*', 'view1'])
+    self._check_blacklisted_tables(source_replica, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly1, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly2, ['/moving/', 'view1'])
     self._check_client_conn_redirection(
         'destination_keyspace',
         ['master'], ['moving1', 'moving2'])
@@ -541,10 +541,10 @@ index by_msg (msg)
     utils.run_vtctl(['MigrateServedFrom', 'destination_keyspace/0', 'master'],
                     auto_log=True)
     self._check_srv_keyspace('')
-    self._check_blacklisted_tables(source_master, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_replica, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly1, ['moving.*', 'view1'])
-    self._check_blacklisted_tables(source_rdonly2, ['moving.*', 'view1'])
+    self._check_blacklisted_tables(source_master, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_replica, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly1, ['/moving/', 'view1'])
+    self._check_blacklisted_tables(source_rdonly2, ['/moving/', 'view1'])
 
     # check the binlog player is gone now
     self.check_no_binlog_player(destination_master)
@@ -585,7 +585,7 @@ index by_msg (msg)
     self._assert_tablet_controls([topodata_pb2.MASTER, topodata_pb2.REPLICA])
 
     # re-add rdonly:
-    utils.run_vtctl(['SetShardTabletControl', '--tables=moving.*,view1',
+    utils.run_vtctl(['SetShardTabletControl', '--tables=/moving/,view1',
                      'source_keyspace/0', 'rdonly'], auto_log=True)
     self._assert_tablet_controls([topodata_pb2.MASTER, topodata_pb2.REPLICA,
                                   topodata_pb2.RDONLY])
@@ -607,7 +607,7 @@ index by_msg (msg)
     expected_dbtypes_set = set(expected_dbtypes)
     for tc in shard_json['tablet_controls']:
       self.assertIn(tc['tablet_type'], expected_dbtypes_set)
-      self.assertEqual(['moving.*', 'view1'], tc['blacklisted_tables'])
+      self.assertEqual(['/moving/', 'view1'], tc['blacklisted_tables'])
       expected_dbtypes_set.remove(tc['tablet_type'])
     self.assertEqual(0, len(expected_dbtypes_set),
                      'Not all expected db types were blacklisted')


### PR DESCRIPTION
Instead of always using regexps, now we support either a
case-insensitive table name, or a regexp of the form /regexp/