### PR TITLE
Do not stop the restore process after the "point of no return".

### DIFF
--- a/test/backup.py
+++ b/test/backup.py
@@ -327,6 +327,19 @@ class TestBackup(unittest.TestCase):
 
     self._restore_old_master_test(_restore_in_place)
 
+  def test_terminated_restore(self):
+    def _terminated_restore(t):
+      for e in utils.vtctld_connection.execute_vtctl_command(
+          ['RestoreFromBackup', t.tablet_alias]):
+        logging.info('%s', e.value)
+        if 'shutdown mysqld' in e.value:
+          break
+      logging.info('waiting for restore to finish')
+      t.wait_for_vttablet_type('replica')
+
+    utils.Vtctld().start()
+    self._restore_old_master_test(_terminated_restore)
+
   def test_backup_transform(self):
     """Use a transform, tests we backup and restore properly."""
     # Insert data on master, make sure slave gets it.

--- a/test/backup.py
+++ b/test/backup.py
@@ -335,7 +335,7 @@ class TestBackup(unittest.TestCase):
         if 'shutdown mysqld' in e.value:
           break
       logging.info('waiting for restore to finish')
-      t.wait_for_vttablet_type('replica')
+      utils.wait_for_tablet_type(t.tablet_alias, 'replica', timeout=30)
 
     utils.Vtctld().start()
     self._restore_old_master_test(_terminated_restore)

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -563,11 +563,11 @@ class Tablet(object):
 
     return self.proc
 
-  def _wait_for_vttablet_var(self, var_name, expected, timeout=60.0, port=None):
+  def wait_for_vttablet_state(self, expected, timeout=60.0, port=None):
     expr = re.compile('^' + expected + '$')
     while True:
       v = utils.get_vars(port or self.port)
-      last_seen_value = '?'
+      last_seen_state = '?'
       if v is None:
         if self.proc.poll() is not None:
           raise utils.TestError(
@@ -576,31 +576,23 @@ class Tablet(object):
             '  vttablet %s not answering at /debug/vars, waiting...',
             self.tablet_alias)
       else:
-        if var_name not in v:
+        if 'TabletStateName' not in v:
           logging.debug(
-              '  vttablet %s is not exporting %s, waiting...',
-              self.tablet_alias, var_name)
+              '  vttablet %s not exporting TabletStateName, waiting...',
+              self.tablet_alias)
         else:
-          s = v[var_name]
-          last_seen_value = s
+          s = v['TabletStateName']
+          last_seen_state = s
           if expr.match(s):
             break
           else:
             logging.debug(
-                '  vttablet %s has var %s set to %s != %s', self.tablet_alias,
-                var_name, s, expected)
+                '  vttablet %s in state %s != %s', self.tablet_alias, s,
+                expected)
       timeout = utils.wait_step(
-          'waiting for %s var %s to be set to %s (last seen value: %s)' %
-          (self.tablet_alias, var_name, expected, last_seen_value),
+          'waiting for %s state %s (last seen state: %s)' %
+          (self.tablet_alias, expected, last_seen_state),
           timeout, sleep_time=0.1)
-
-  def wait_for_vttablet_state(self, expected, timeout=60.0, port=None):
-    return self._wait_for_vttablet_var('TabletStateName', expected,
-                                       timeout=timeout, port=port)
-
-  def wait_for_vttablet_type(self, expected, timeout=60.0, port=None):
-    return self._wait_for_vttablet_var('TabletType', expected,
-                                       timeout=timeout, port=port)
 
   def wait_for_mysqlctl_socket(self, timeout=60.0):
     mysql_sock = os.path.join(self.tablet_dir, 'mysql.sock')


### PR DESCRIPTION
Once vttablet shuts down MySQL and starts deleting all files, it won't be able
to recover if the context is cancelled (e.g. because the RPC got cancelled).
That will render the tablet completely unusable. To avoid that let's just not
interrupt the restore process once it passed that point of no return.