### PR TITLE
throttler/demo: Fix panic "BUG: invalid TabletType forwarded: UNKNOWN".

### DIFF
--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -267,6 +267,11 @@ func (c *client) stop() {
 // It gets called by the healthCheck instance every time a tablet broadcasts
 // a health update.
 func (c *client) StatsUpdate(ts *discovery.TabletStats) {
+	// Ignore unless REPLICA or RDONLY.
+	if ts.Target.TabletType != topodatapb.TabletType_REPLICA && ts.Target.TabletType != topodatapb.TabletType_RDONLY {
+		return
+	}
+
 	c.throttler.RecordReplicationLag(time.Now(), ts)
 }
 


### PR DESCRIPTION
Only REPLICA and RDONLY stats updates should be forwarded to the throttler module.