### PR TITLE
Populate Tablet.Type together with Target.TabletType in TabletStats.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -466,6 +466,7 @@ func (hcc *healthCheckConn) update(shr *querypb.StreamHealthResponse, serving bo
 	defer hcc.mu.Unlock()
 	hcc.lastResponseTimestamp = time.Now()
 	hcc.tabletStats.Target = shr.Target
+	hcc.tabletStats.Tablet.Type = shr.Target.TabletType
 	hcc.tabletStats.Serving = serving
 	hcc.tabletStats.TabletExternallyReparentedTimestamp = shr.TabletExternallyReparentedTimestamp
 	hcc.tabletStats.Stats = shr.RealtimeStats

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -60,6 +60,7 @@ func TestHealthCheck(t *testing.T) {
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
+	tablet.Type = topodatapb.TabletType_MASTER
 	want = &TabletStats{
 		Key:     "a,vt:1",
 		Tablet:  tablet,
@@ -102,6 +103,7 @@ func TestHealthCheck(t *testing.T) {
 	}
 	input <- shr
 	t.Logf(`input <- {{Keyspace: "k", Shard: "s", TabletType: REPLICA}, Serving: true, TabletExternallyReparentedTimestamp: 0, {SecondsBehindMaster: 1, CpuUsage: 0.5}}`)
+	tablet.Type = topodatapb.TabletType_REPLICA
 	want = &TabletStats{
 		Key:     "a,vt:1",
 		Tablet:  tablet,
@@ -234,6 +236,7 @@ func TestHealthCheckCloseWaitsForGoRoutines(t *testing.T) {
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
+	tablet.Type = topodatapb.TabletType_MASTER
 	want = &TabletStats{
 		Key:     "a,vt:1",
 		Tablet:  tablet,
@@ -329,6 +332,7 @@ func TestHealthCheckTimeout(t *testing.T) {
 		TabletExternallyReparentedTimestamp: 10,
 		RealtimeStats:                       &querypb.RealtimeStats{SecondsBehindMaster: 1, CpuUsage: 0.2},
 	}
+	tablet.Type = topodatapb.TabletType_MASTER
 	want = &TabletStats{
 		Key:     "a,vt:1",
 		Tablet:  tablet,
@@ -367,6 +371,7 @@ func TestHealthCheckTimeout(t *testing.T) {
 
 func TestTemplate(t *testing.T) {
 	tablet := topo.NewTablet(0, "cell", "a")
+	tablet.Type = topodatapb.TabletType_MASTER
 	ts := []*TabletStats{
 		{
 			Key:     "a",


### PR DESCRIPTION
Without this it's impossible to watch after changes in tablet type (e.g. monitor
transitions RDONLY->BACKUP->RDONLY), because Target is not populated until the
first successful connection and Tablet.Type is not up-to-date after the health
updates start to flow in.