### PR TITLE
Always verify pool connections when working on ApplySchema request.

### DIFF
--- a/go/vt/mysqlctl/schema.go
+++ b/go/vt/mysqlctl/schema.go
@@ -133,7 +133,7 @@ func ResolveTables(mysqld MysqlDaemon, dbName string, tables []string) ([]string
 
 // GetColumns returns the columns of table.
 func (mysqld *Mysqld) GetColumns(dbName, table string) ([]string, error) {
-	conn, err := mysqld.dbaPool.Get(context.TODO())
+	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +152,7 @@ func (mysqld *Mysqld) GetColumns(dbName, table string) ([]string, error) {
 
 // GetPrimaryKeyColumns returns the primary key columns of table.
 func (mysqld *Mysqld) GetPrimaryKeyColumns(dbName, table string) ([]string, error) {
-	conn, err := mysqld.dbaPool.Get(context.TODO())
+	conn, err := getPoolReconnect(context.TODO(), mysqld.dbaPool)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When we just get a connection from the pool it might be already closed due to
MySQL restart or some other reason. This results in bogus errors returned to
the user requesting to apply new schema. By using getPoolReconnect() instead we
make sure that the connection we get is actually live. Note that only
GetColumns() and GetPrimaryKeyColumns() need to be fixed, because all other
places here already use getPoolReconnect().