### PR TITLE
2pc: avoid txid and dtid collisions

### DIFF
--- a/go/vt/dtids/dtids.go
+++ b/go/vt/dtids/dtids.go
@@ -1,0 +1,58 @@
+// Copyright 2016, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package dtids contains dtid convenience functions.
+package dtids
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/youtube/vitess/go/vt/vterrors"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+// New generates a dtid based on Session_ShardSession.
+func New(mmShard *vtgatepb.Session_ShardSession) string {
+	return fmt.Sprintf("%s:%s:%d", mmShard.Target.Keyspace, mmShard.Target.Shard, mmShard.TransactionId)
+}
+
+// ShardSession builds a Session_ShardSession from a dtid.
+func ShardSession(dtid string) (*vtgatepb.Session_ShardSession, error) {
+	splits := strings.Split(dtid, ":")
+	if len(splits) != 3 {
+		return nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid parts in dtid: %s", dtid))
+	}
+	target := &querypb.Target{
+		Keyspace:   splits[0],
+		Shard:      splits[1],
+		TabletType: topodatapb.TabletType_MASTER,
+	}
+	txid, err := strconv.ParseInt(splits[2], 10, 0)
+	if err != nil {
+		return nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
+	}
+	return &vtgatepb.Session_ShardSession{
+		Target:        target,
+		TransactionId: txid,
+	}, nil
+}
+
+// TransactionID extracts the original transaction ID from the dtid.
+func TransactionID(dtid string) (int64, error) {
+	splits := strings.Split(dtid, ":")
+	if len(splits) != 3 {
+		return 0, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid parts in dtid: %s", dtid))
+	}
+	txid, err := strconv.ParseInt(splits[2], 10, 0)
+	if err != nil {
+		return 0, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
+	}
+	return txid, nil
+}

--- a/go/vt/dtids/dtids_test.go
+++ b/go/vt/dtids/dtids_test.go
@@ -1,0 +1,63 @@
+package dtids
+
+import (
+	"reflect"
+	"testing"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+)
+
+func TestDTID(t *testing.T) {
+	in := &vtgatepb.Session_ShardSession{
+		Target: &querypb.Target{
+			Keyspace:   "aa",
+			Shard:      "0",
+			TabletType: topodatapb.TabletType_MASTER,
+		},
+		TransactionId: 1,
+	}
+	dtid := New(in)
+	want := "aa:0:1"
+	if dtid != want {
+		t.Errorf("generateDTID: %s, want %s", dtid, want)
+	}
+	out, err := ShardSession(dtid)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("ShardSession: %+v, want %+v", out, in)
+	}
+	_, err = ShardSession("badParts")
+	want = "invalid parts in dtid: badParts"
+	if err == nil || err.Error() != want {
+		t.Errorf("ShardSession(\"badParts\"): %v, want %s", err, want)
+	}
+	_, err = ShardSession("a:b:badid")
+	want = "invalid transaction id in dtid: a:b:badid"
+	if err == nil || err.Error() != want {
+		t.Errorf("ShardSession(\"a:b:badid\"): %v, want %s", err, want)
+	}
+}
+
+func TestTransactionID(t *testing.T) {
+	out, err := TransactionID("aa:0:1")
+	if err != nil {
+		t.Error(err)
+	}
+	if out != 1 {
+		t.Errorf("TransactionID(aa:0:1): %d, want 1", out)
+	}
+	_, err = TransactionID("badParts")
+	want := "invalid parts in dtid: badParts"
+	if err == nil || err.Error() != want {
+		t.Errorf("TransactionID(\"badParts\"): %v, want %s", err, want)
+	}
+	_, err = TransactionID("a:b:badid")
+	want = "invalid transaction id in dtid: a:b:badid"
+	if err == nil || err.Error() != want {
+		t.Errorf("TransactionID(\"a:b:badid\"): %v, want %s", err, want)
+	}
+}

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -111,6 +111,16 @@ func (axp *TxPool) Close() {
 	axp.pool.Close()
 }
 
+// AdjustLastID adjusts the last transaction id to be at least
+// as large as the input value. This will ensure that there are
+// no dtid collisions with future transactions.
+func (axp *TxPool) AdjustLastID(id int64) {
+	if current := axp.lastID.Get(); current < id {
+		log.Infof("Adjusting transaction id to: %d", id)
+		axp.lastID.Set(id)
+	}
+}
+
 // RollbackNonBusy rolls back all transactions that are not in use.
 // Transactions can be in use for situations like executing statements
 // or in prepared state.


### PR DESCRIPTION
This change makes sure that new transaction ids generated by
vttablet don't cause collisions with existing dtids.