### PR TITLE
Always close cursor before closing connection in Tablet.mquery().

### DIFF
--- a/test/tablet.py
+++ b/test/tablet.py
@@ -254,6 +254,7 @@ class Tablet(object):
     try:
       return cursor.fetchall()
     finally:
+      cursor.close()
       conn.close()
 
   def assert_table_count(self, dbname, table, n, where=''):


### PR DESCRIPTION
Otherwise destruction of a cursor attached to already closed (or maybe even
destroyed) connection can crash.