### PR TITLE
k8s end2end test updates

### DIFF
--- a/test/end2end/base_end2end_test.py
+++ b/test/end2end/base_end2end_test.py
@@ -58,7 +58,7 @@ class BaseEnd2EndTest(unittest.TestCase):
 
 
 def main():
-  import utils
+  import utils  # pylint: disable=g-import-not-at-top
   parser = optparse.OptionParser(usage='usage: %prog [options] [test_names]')
   parser.add_option('-e', '--environment_type', help='Environment type',
                     default=None)

--- a/test/end2end/base_environment.py
+++ b/test/end2end/base_environment.py
@@ -483,28 +483,26 @@ class BaseEnvironment(object):
     raise VitessEnvironmentError(
         'is_tablet_undrained unsupported in this environment')
 
-  def poll_for_varz(self, tablet_name, varz, condition_msg, timeout=60.0,
-                    condition_fn=None, converter=str):
+  def poll_for_varz(self, tablet_name, varz, timeout=60.0,
+                    condition_fn=None, converter=str, condition_msg=None):
     """Polls for varz to exist, or match specific conditions, within a timeout.
 
     Args:
       tablet_name: the name of the process that we're trying to poll vars from.
       varz: name of the vars to fetch from varz.
-      condition_msg: string describing the conditions that we're polling for,
-        used for error messaging.
       timeout: number of seconds that we should attempt to poll for.
       condition_fn: a function that takes the var as input, and returns a truthy
         value if it matches the success conditions.
       converter: function to convert varz value.
-
-    Raises:
-      TestError: if the varz conditions aren't met within the given timeout.
+      condition_msg: string describing the conditions that we're polling for,
+        used for error messaging.
 
     Returns:
       dict of requested varz.
 
     Raises:
-      VitessEnvironmentError: Raised if unsupported.
+      VitessEnvironmentError: Raised if unsupported or if the varz conditions
+        aren't met within the given timeout.
     """
     raise VitessEnvironmentError(
         'poll_for_varz unsupported in this environment')
@@ -514,4 +512,19 @@ class BaseEnvironment(object):
     master_tablet = self.get_current_master_name(keyspace, shard)
     self.vtctl_helper.execute_vtctl_command(
         ['ExecuteFetchAsDba', master_tablet, 'truncate %s' % tablename])
+
+  def get_tablet_query_total_count(self, tablet_name):
+    """Gets the total query count of a specified tablet.
+
+    Args:
+      tablet_name: Name of the tablet to get query count from (string).
+
+    Returns:
+      Query total count (int).
+
+    Raises:
+      VitessEnvironmentError: Raised if unsupported.
+    """
+    raise VitessEnvironmentError(
+        'get_tablet_query_total_count unsupported in this environment')
 

--- a/test/end2end/drain_test.py
+++ b/test/end2end/drain_test.py
@@ -145,15 +145,13 @@ class DrainTest(base_end2end_test.BaseEnd2EndTest):
                          starting_index=self.num_inserts * attempt)
         num_rows1 = self.get_row_count(tablet_to_drain)
         self.assertEquals(num_rows0, num_rows1)
-        query_count0 = self.env.poll_for_varz(
-            tablet_to_drain, ['Queries'], ' ')['Queries']['TotalCount']
+        query_count0 = self.env.get_tablet_query_total_count(tablet_to_drain)
         self.read_rows(
             keyspace, self.num_inserts, self.num_inserts * (attempt + 1),
             self.env.get_tablet_cell(tablet_to_drain))
         self.env.undrain_tablet(tablet_to_drain)
         self.wait_for_undrained_tablet(tablet_to_drain)
-        query_count1 = self.env.poll_for_varz(
-            tablet_to_drain, ['Queries'], ' ')['Queries']['TotalCount']
+        query_count1 = self.env.get_tablet_query_total_count(tablet_to_drain)
         logging.info('%s total query count before/after reads: %d/%d',
                      tablet_to_drain, query_count0, query_count1)
         self.assertEquals(query_count0, query_count1)

--- a/test/end2end/k8s_environment.py
+++ b/test/end2end/k8s_environment.py
@@ -217,33 +217,34 @@ class K8sEnvironment(base_environment.BaseEnvironment):
       self, keyspace, shard_name, failover_completion_timeout_s=60):
     return 0
 
-  def poll_for_varz(self, tablet_name, varz, condition_msg, timeout=60.0,
-                    condition_fn=None, converter=str):
+  def poll_for_varz(self, tablet_name, varz, timeout=60.0,
+                    condition_fn=None, converter=str, condition_msg=None):
     """Polls for varz to exist, or match specific conditions, within a timeout.
 
     Args:
       tablet_name: the name of the process that we're trying to poll vars from.
       varz: name of the vars to fetch from varz
-      condition_msg: string describing the conditions that we're polling for,
-        used for error messaging.
       timeout: number of seconds that we should attempt to poll for.
       condition_fn: a function that takes the var as input, and returns a truthy
         value if it matches the success conditions.
       converter: function to convert varz value
+      condition_msg: string describing the conditions that we're polling for,
+        used for error messaging.
 
     Raises:
       VitessEnvironmentError: Raised if the varz conditions aren't met within
-        the given timeout
+        the given timeout.
 
     Returns:
-      dict of requested varz
+      dict of requested varz.
     """
     start_time = time.time()
     while True:
       if (time.time() - start_time) >= timeout:
-        raise base_environment.VitessEnvironmentError(
-            'Timed out polling for varz; condition "%s" not met' % (
-                condition_msg))
+        timeout_error_msg = 'Timed out polling for varz.'
+        if condition_fn and condition_msg:
+          timeout_error_msg += ' Condition "%s" not met.' % condition_msg
+        raise base_environment.VitessEnvironmentError(timeout_error_msg)
       hostname = self.get_tablet_ip_port(tablet_name)
       tablet_pod = 'vttablet-%s' % self.get_tablet_uid(tablet_name)
       host_varz = subprocess.check_output([
@@ -303,3 +304,8 @@ class K8sEnvironment(base_environment.BaseEnvironment):
 
   def is_tablet_undrained(self, tablet_name):
     return not self.is_tablet_drained(tablet_name)
+
+  def get_tablet_query_total_count(self, tablet_name):
+    return self.poll_for_varz(
+        tablet_name, ['Queries'])['Queries']['TotalCount']
+


### PR DESCRIPTION
Minor test cleanup:
- Inlined some constants in backup_test that were only used once.
- Added get_tablet_query_total_count to environment since it's slightly different in k8s vs. internally.
- Reordered params for poll_for_varz to make it a shade cleaner.

Tests still work on a gke/k8s cluster.

@dumbunny 