### PR TITLE
2pc: alert on unresolved prepares.

### DIFF
--- a/go/vt/tabletserver/query_service_stats.go
+++ b/go/vt/tabletserver/query_service_stats.go
@@ -26,6 +26,8 @@ type QueryServiceStats struct {
 	ErrorStats *stats.Counters
 	// InternalErros shows number of errors from internal components.
 	InternalErrors *stats.Counters
+	// Unresolved tracks unresolved items. For now it's just Prepares.
+	Unresolved *stats.Counters
 	// UserTableQueryCount shows number of queries received for each CallerID/table combination.
 	UserTableQueryCount *stats.MultiCounters
 	// UserTableQueryTimesNs shows total latency for each CallerID/table combination.
@@ -50,6 +52,7 @@ func NewQueryServiceStats(statsPrefix string, enablePublishStats bool) *QuerySer
 	infoErrorsName := ""
 	errorStatsName := ""
 	internalErrorsName := ""
+	unresolvedName := ""
 	resultStatsName := ""
 	userTableQueryCountName := ""
 	userTableQueryTimesNsName := ""
@@ -64,6 +67,7 @@ func NewQueryServiceStats(statsPrefix string, enablePublishStats bool) *QuerySer
 		infoErrorsName = statsPrefix + "InfoErrors"
 		errorStatsName = statsPrefix + "Errors"
 		internalErrorsName = statsPrefix + "InternalErrors"
+		unresolvedName = statsPrefix + "Unresolved"
 		resultStatsName = statsPrefix + "Results"
 		userTableQueryCountName = statsPrefix + "UserTableQueryCount"
 		userTableQueryTimesNsName = statsPrefix + "UserTableQueryTimesNs"
@@ -80,6 +84,7 @@ func NewQueryServiceStats(statsPrefix string, enablePublishStats bool) *QuerySer
 		InfoErrors:     stats.NewCounters(infoErrorsName, "Retry", "DupKey"),
 		ErrorStats:     stats.NewCounters(errorStatsName, "Fail", "TxPoolFull", "NotInTx", "Deadlock", "Fatal"),
 		InternalErrors: stats.NewCounters(internalErrorsName, "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail"),
+		Unresolved:     stats.NewCounters(unresolvedName, "Prepares"),
 		UserTableQueryCount: stats.NewMultiCounters(
 			userTableQueryCountName, []string{"TableName", "CallerID", "Type"}),
 		UserTableQueryTimesNs: stats.NewMultiCounters(


### PR DESCRIPTION
If data loss causes a distributed transaction metadata to
be lost, prepared transactions can linger forever. Add an
alert for this condition.

This is the last of the code changes for 2PC. After this,
I'll update the design doc and make a user guide.