### PR TITLE
Fixed the panic-handling code in vttablet.

### DIFF
--- a/go/tb/error.go
+++ b/go/tb/error.go
@@ -64,7 +64,8 @@ func Errorf(msg string, args ...interface{}) error {
 	return stackError{fmt.Errorf(msg, args...), stack}
 }
 
-// Taken from runtime/debug.go
+// Stack is taken from runtime/debug.go
+// calldepth is the number of (bottommost) frames to skip.
 func Stack(calldepth int) []byte {
 	return stack(calldepth)
 }


### PR DESCRIPTION
Previously, if a VTTablet method returned a non TabletError error
an 'uncaught panic' error would be returned (erroneously). This PR
rewrites the error handling logic to fix that and be clearer.

Renamed handleError to handlePanicAndSendLogStat.
Renamed handleErrorNoPanic to handleError.
Moved the panic-handling code to handlePanicAndSendLogStat from handleError (using the new naming 
here)

This PR also fixes a bug in SplitQuery in which we returned a failure to create the split query algorithm as 
a non TabletError error.

@sougou PTAL.