### PR TITLE
java client side 2pc changes

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
@@ -124,7 +124,11 @@ public class VTGateBlockingConn implements Closeable {
   }
 
   public VTGateBlockingTx begin(Context ctx) throws SQLException {
-    return new VTGateBlockingTx(conn.begin(ctx).checkedGet());
+    return begin(ctx, false);
+  }
+
+  public VTGateBlockingTx begin(Context ctx, boolean singleDB) throws SQLException {
+    return new VTGateBlockingTx(conn.begin(ctx, singleDB).checkedGet());
   }
 
   public List<SplitQueryResponse.Part> splitQuery(

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
@@ -92,7 +92,11 @@ public class VTGateBlockingTx {
   }
 
   public void commit(Context ctx) throws SQLException {
-    tx.commit(ctx).checkedGet();
+    commit(ctx, false);
+  }
+
+  public void commit(Context ctx, boolean atomic) throws SQLException {
+    tx.commit(ctx, atomic).checkedGet();
   }
 
   public void rollback(Context ctx) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -311,7 +311,11 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<VTGateTx> begin(Context ctx) throws SQLException {
-    BeginRequest.Builder requestBuilder = BeginRequest.newBuilder();
+    return begin(ctx, false);
+  }
+
+  public SQLFuture<VTGateTx> begin(Context ctx, boolean singleDB) throws SQLException {
+    BeginRequest.Builder requestBuilder = BeginRequest.newBuilder().setSingleDb(singleDB);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -246,9 +246,14 @@ public class VTGateTx {
     return call;
   }
 
-  public synchronized SQLFuture<Void> commit(Context ctx) throws SQLException {
+    public synchronized SQLFuture<Void> commit(Context ctx) throws SQLException {
+        return commit(ctx, false);
+    }
+
+  public synchronized SQLFuture<Void> commit(Context ctx, boolean atomic) throws SQLException {
     checkCallIsAllowed("commit");
-    CommitRequest.Builder requestBuilder = CommitRequest.newBuilder().setSession(session);
+    CommitRequest.Builder requestBuilder = CommitRequest.newBuilder().setSession(session)
+                                                        .setAtomic(atomic);
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -8,8 +8,30 @@ import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
 import com.youtube.vitess.proto.Topodata;
 
-import java.sql.*;
-import java.util.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.ClientInfoStatus;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.logging.Logger;
 
@@ -131,7 +153,7 @@ public class VitessConnection implements Connection {
         try {
             if (isInTransaction()) {
                 Context context = createContext(Constants.CONNECTION_TIMEOUT);
-                this.vtGateTx.commit(context).checkedGet();
+                this.vtGateTx.commit(context, this.vitessJDBCUrl.isTwopcEnabled()).checkedGet();
             }
         } finally {
             this.vtGateTx = null;

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessJDBCUrl.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessJDBCUrl.java
@@ -26,6 +26,7 @@ public class VitessJDBCUrl {
     private final String keyspace;
     private String catalog;
     private final String executeType;
+    private final boolean twopcEnabled;
 
 
     /*
@@ -105,6 +106,8 @@ public class VitessJDBCUrl {
 
         this.executeType = info.getProperty(Constants.Property.EXECUTE_TYPE);
         this.url = url;
+        this.twopcEnabled =
+            "true".equalsIgnoreCase(info.getProperty(Constants.Property.TWOPC_ENABLED));
     }
 
     public String getUsername() {
@@ -247,4 +250,7 @@ public class VitessJDBCUrl {
         }
     }
 
+    public boolean isTwopcEnabled() {
+        return twopcEnabled;
+    }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
@@ -98,6 +98,7 @@ public class Constants {
         public static final String KEYSPACE = "KEYSPACE";
         public static final String USERNAME = "userName";
         public static final String EXECUTE_TYPE = "executeType";
+        public static final String TWOPC_ENABLED = "twopcEnabled";
     }
 
 

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessConnectionTest.java
@@ -123,7 +123,8 @@ public class VitessConnectionTest {
         VTGateTx mockVtGateTx = PowerMockito.mock(VTGateTx.class);
         vitessConnection.setVtGateTx(mockVtGateTx);
         SQLFuture<Void> v = new SQLFuture<>(Futures.<Void>immediateFuture(null));
-        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class))).thenReturn(v);
+        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class), Matchers.anyBoolean()))
+            .thenReturn(v);
         vitessConnection.commit();
         Assert.assertEquals(null, vitessConnection.getVtGateTx());
     }
@@ -133,7 +134,7 @@ public class VitessConnectionTest {
         vitessConnection.setAutoCommit(false);
         VTGateTx mockVtGateTx = PowerMockito.mock(VTGateTx.class);
         vitessConnection.setVtGateTx(mockVtGateTx);
-        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class)))
+        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class), Matchers.anyBoolean()))
             .thenThrow(new SQLException());
         try {
             vitessConnection.commit();
@@ -148,7 +149,8 @@ public class VitessConnectionTest {
         VTGateTx mockVtGateTx = PowerMockito.mock(VTGateTx.class);
         vitessConnection.setVtGateTx(mockVtGateTx);
         SQLFuture<Void> v = new SQLFuture<>(Futures.<Void>immediateFuture(null));
-        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class))).thenReturn(v);
+        PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class), Matchers.anyBoolean()))
+            .thenReturn(v);
         vitessConnection.commit();
         Assert.assertEquals(null, vitessConnection.getVtGateTx());
     }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessJDBCUrlTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/test/VitessJDBCUrlTest.java
@@ -148,4 +148,18 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals("val1", info.getProperty("prop1"));
         Assert.assertEquals("val2", info.getProperty("prop2"));
     }
+
+    @Test public void testTwoPCEnabledURL() throws Exception {
+        VitessJDBCUrl vitessJDBCUrl =
+            new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=true", null);
+        Assert.assertTrue(vitessJDBCUrl.isTwopcEnabled());
+
+        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=false", null);
+        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
+
+        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991", null);
+        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
+
+    }
+
 }


### PR DESCRIPTION
Changes
* Java Client has default functions which will internally call begin(ctx, singledb) and commit(ctx, atomic) with default value as false.
* JDBC will consider singledb as false.
* Only Property that it accepts id through connection url or property with property name as **twopcEnabled** with value set as true or false. 
* If the property is not set it will be considered as false.