### PR TITLE
Cluster test updates.

### DIFF
--- a/py/vttest/sharding_utils.py
+++ b/py/vttest/sharding_utils.py
@@ -3,6 +3,27 @@
 """Sharding utils."""
 
 
+def get_shard_index(shard_name):
+  """Returns tuple of shard index, num_shards based on a shard name."""
+  if shard_name in ['0', '-']:
+    return 0, 1
+
+  shard_begin, shard_end = shard_name.split('-')
+  num_bytes_used = max(len(shard_begin), len(shard_end)) / 2
+  if shard_begin:
+    shard_begin = int(shard_begin, 16)
+  else:
+    shard_begin = 0
+  if shard_end:
+    shard_end = int(shard_end, 16)
+  else:
+    shard_end = 1 << num_bytes_used * 8
+  shard_width = shard_end - shard_begin
+  num_shards = (1 << num_bytes_used * 8) / (shard_width)
+  shard_num = shard_begin / shard_width
+  return shard_num, num_shards
+
+
 def get_shard_name(shard, num_shards):
   """Returns an appropriate shard name, as a string.
 

--- a/test/cluster/k8s_environment.py
+++ b/test/cluster/k8s_environment.py
@@ -211,6 +211,8 @@ class K8sEnvironment(base_environment.BaseEnvironment):
       except ValueError:
         pass
       time.sleep(5)
+
+    self.vtctl_helper.execute_vtctl_command(['RefreshState', tablet_name])
     return 0
 
   def wait_for_good_failover_status(

--- a/test/cluster/reparent_test.py
+++ b/test/cluster/reparent_test.py
@@ -147,7 +147,7 @@ class ReparentTest(base_cluster_test.BaseClusterTest):
 
     logging.info('Restarting %s/%s, current master: %s',
                  keyspace, shard_name, original_master_name)
-    ret_val = self.env.restart_mysql_task(original_master_name, 'mysql')
+    ret_val = self.env.restart_mysql_task(original_master_name, 'mysql', True)
 
     self.assertEquals(ret_val, 0,
                       msg='restart failed (returned %d)' % ret_val)


### PR DESCRIPTION
@dumbunny 

- Added get_shard_index function (used internally), which you already reviewed and commented on the other day.
- Some reparent test updates (ensure alloc is restarted instead of just mysql, call RefreshState on tablet after implicit restart).