### PR TITLE
Update vendored gcloud libs.

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,30 +1,36 @@
 {
 	"comment": "",
-	"ignore": "",
+	"ignore": "appengine",
 	"package": [
 		{
-			"checksumSHA1": "XL2x7qzj2KP9Hc3GiiyKLv13xwc=",
+			"checksumSHA1": "BvDUxKpaWSE45ClbXX81wPAgeKE=",
 			"path": "cloud.google.com/go/compute/metadata",
-			"revision": "9e4a5900c09f149c2eb33b8d0cf666918f802a8f",
-			"revisionTime": "2016-07-29T21:51:17Z"
+			"revision": "686f0e89858ea78eae54d4b2021e6bfc7d3a30ca",
+			"revisionTime": "2016-12-16T21:27:53Z"
 		},
 		{
-			"checksumSHA1": "hiJXjkFEGy+sDFf6O58Ocdy9Rnk=",
+			"checksumSHA1": "dMDfOzNr3Cwy0V3wX5x98plV/GI=",
 			"path": "cloud.google.com/go/internal",
-			"revision": "9e4a5900c09f149c2eb33b8d0cf666918f802a8f",
-			"revisionTime": "2016-07-29T21:51:17Z"
+			"revision": "686f0e89858ea78eae54d4b2021e6bfc7d3a30ca",
+			"revisionTime": "2016-12-16T21:27:53Z"
 		},
 		{
-			"checksumSHA1": "krcptGqizmsGLj2RVgqlZBkkg5E=",
+			"checksumSHA1": "8u8didRbH9DvXgOSdUykp4tY7jQ=",
+			"path": "cloud.google.com/go/internal/optional",
+			"revision": "686f0e89858ea78eae54d4b2021e6bfc7d3a30ca",
+			"revisionTime": "2016-12-16T21:27:53Z"
+		},
+		{
+			"checksumSHA1": "JS4U8DjF1X5MIk9awzbSMQGe3bU=",
 			"path": "cloud.google.com/go/internal/testutil",
-			"revision": "49467e5deee2b3e98455bb834e029afc067d04f5",
-			"revisionTime": "2016-07-27T22:56:28Z"
+			"revision": "686f0e89858ea78eae54d4b2021e6bfc7d3a30ca",
+			"revisionTime": "2016-12-16T21:27:53Z"
 		},
 		{
-			"checksumSHA1": "C+KmlQL5HW14a7Q8X0HLvlpFeyo=",
+			"checksumSHA1": "WzLxnTacUIi4jIGjqbr5gyGw+OU=",
 			"path": "cloud.google.com/go/storage",
-			"revision": "86c12b7c8187ffdfe4c155cc6bfca41ad0cabbc5",
-			"revisionTime": "2016-10-06T05:51:44Z"
+			"revision": "686f0e89858ea78eae54d4b2021e6bfc7d3a30ca",
+			"revisionTime": "2016-12-16T21:27:53Z"
 		},
 		{
 			"path": "context",
@@ -279,7 +285,7 @@
 			"versionExact": "v2.0.0"
 		},
 		{
-			"checksumSHA1": "39c+shSLmvturiMmkG4MjIFQQB4=",
+			"checksumSHA1": "xxkW7oNoSomRcG2MGQtbyx3AOTw=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
 			"revisionTime": "2015-11-05T21:09:06Z"
@@ -327,7 +333,7 @@
 			"revisionTime": "2016-08-24T20:12:15Z"
 		},
 		{
-			"checksumSHA1": "7kHC8QJD74DCyQRYTxVP5AC4m2k=",
+			"checksumSHA1": "AHmMS4CyPSEuspow7JuWOjDj2ag=",
 			"path": "github.com/golang/protobuf/proto",
 			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
 			"revisionTime": "2016-08-24T20:12:15Z"
@@ -403,6 +409,12 @@
 			"path": "github.com/golang/protobuf/ptypes/wrappers",
 			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
 			"revisionTime": "2016-08-24T20:12:15Z"
+		},
+		{
+			"checksumSHA1": "HXrKXzLuGf6COtRsKYak0uMwmbY=",
+			"path": "github.com/googleapis/gax-go",
+			"revision": "da06d194a00e19ce00d9011a13931c3f6f6887c7",
+			"revisionTime": "2016-11-07T00:24:06Z"
 		},
 		{
 			"checksumSHA1": "d22rgDYcZ/l1RPHtCokJRHAh0QI=",
@@ -655,13 +667,13 @@
 			"revisionTime": "2016-04-12T22:48:50Z"
 		},
 		{
-			"checksumSHA1": "huY7w6ZQ5tPHGGOMnsB1FtZjlas=",
+			"checksumSHA1": "twGHVtdBnQIUnxwHpzhXgEkgOmo=",
 			"path": "golang.org/x/oauth2",
 			"revision": "04e1573abc896e70388bd387a69753c378d46466",
 			"revisionTime": "2016-07-30T22:43:56Z"
 		},
 		{
-			"checksumSHA1": "/OYTSw23ksVC1uq1Q5VjZofXofg=",
+			"checksumSHA1": "n2dCc7iDeNrGBKu7dr7qKD8TRjE=",
 			"path": "golang.org/x/oauth2/google",
 			"revision": "04e1573abc896e70388bd387a69753c378d46466",
 			"revisionTime": "2016-07-30T22:43:56Z"
@@ -769,130 +781,64 @@
 			"revisionTime": "2016-07-10T05:19:30Z"
 		},
 		{
-			"checksumSHA1": "3silmB9Kzfgep2oFc1rl/mHvPOs=",
+			"checksumSHA1": "bl+UShqB7buI8y7rOglJUbAmKm0=",
 			"path": "google.golang.org/api/gensupport",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
-			"checksumSHA1": "5mT9h0chNgkmNxXANnhbH6TsNLs=",
+			"checksumSHA1": "dQSH9AiO9j6t+/xxdlpRZ87YCUM=",
 			"path": "google.golang.org/api/googleapi",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
 			"checksumSHA1": "el0n9UGu9RKsmf2sAojHtRR3lj8=",
 			"path": "google.golang.org/api/googleapi/internal/uritemplates",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
-			"checksumSHA1": "1FFytQmYWvC8pICwfK8HPg/LiSI=",
+			"checksumSHA1": "Mr2fXhMRzlQCgANFm91s536pG7E=",
+			"path": "google.golang.org/api/googleapi/transport",
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
+		},
+		{
+			"checksumSHA1": "LHTqH7LLOWzy5U5eqC3crC8z9kM=",
 			"path": "google.golang.org/api/internal",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
 			"checksumSHA1": "8CjquSYlOhBYnGMr55VQ4GXR7CU=",
 			"path": "google.golang.org/api/iterator",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
-			"checksumSHA1": "1IG+DnyJkYwznTQuhXfhPry55SE=",
+			"checksumSHA1": "Het06QW2fuvcyPPy/4pwZdeQkhs=",
+			"path": "google.golang.org/api/iterator/testing",
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
+		},
+		{
+			"checksumSHA1": "B3Odad1+hfJqyA8rcJXMbxMSj44=",
 			"path": "google.golang.org/api/option",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
-			"checksumSHA1": "q6pXPo7akhYZw2DoZJNfpwjb1q0=",
+			"checksumSHA1": "xygm9BwoCg7vc0PPgAPdxNKJ38c=",
 			"path": "google.golang.org/api/storage/v1",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
-			"checksumSHA1": "sKPpvRSA3Enmb00Da9wXRHejDUM=",
+			"checksumSHA1": "HrVNBye0wbGdp0xjhEmN/+Ai8qk=",
 			"path": "google.golang.org/api/transport",
-			"revision": "3cf64a039723963488f603d140d0aec154fdcd20",
-			"revisionTime": "2016-10-06T16:45:29Z"
-		},
-		{
-			"checksumSHA1": "hUqAsLCtjrc8oXa8AznNPvhC3QY=",
-			"path": "google.golang.org/appengine",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "ADOB9+y5edl026RW6m7760nUjzo=",
-			"path": "google.golang.org/appengine/internal",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "rccBu+HNVpDlx0z1EtcOWUM5OME=",
-			"path": "google.golang.org/appengine/internal/aetesting",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "x6Thdfyasqd68dWZWqzWWeIfAfI=",
-			"path": "google.golang.org/appengine/internal/app_identity",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "TsNO8P0xUlLNyh3Ic/tzSp/fDWM=",
-			"path": "google.golang.org/appengine/internal/base",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "5QsV5oLGSfKZqTCVXP6NRz5T4Tw=",
-			"path": "google.golang.org/appengine/internal/datastore",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "Gep2T9zmVYV8qZfK2gu3zrmG6QE=",
-			"path": "google.golang.org/appengine/internal/log",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "eLZVX1EHLclFtQnjDIszsdyWRHo=",
-			"path": "google.golang.org/appengine/internal/modules",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "a1XY7rz3BieOVqVI2Et6rKiwQCk=",
-			"path": "google.golang.org/appengine/internal/remote_api",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "VA88sOHmVuIslrbHaWx9yEvjGjM=",
-			"path": "google.golang.org/appengine/internal/socket",
-			"revision": "f21d98e7aefbf9ff4d5eeba05d7a925cc7ac20c3",
-			"revisionTime": "2016-07-12T04:53:28Z"
-		},
-		{
-			"checksumSHA1": "QtAbHtHmDzcf6vOV9eqlCpKgjiw=",
-			"path": "google.golang.org/appengine/internal/urlfetch",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
-		},
-		{
-			"checksumSHA1": "MharNMGnQusRPdmBYXDxz2cCHPU=",
-			"path": "google.golang.org/appengine/socket",
-			"revision": "f21d98e7aefbf9ff4d5eeba05d7a925cc7ac20c3",
-			"revisionTime": "2016-07-12T04:53:28Z"
-		},
-		{
-			"checksumSHA1": "akOV9pYnCbcPA8wJUutSQVibdyg=",
-			"path": "google.golang.org/appengine/urlfetch",
-			"revision": "b67c870a16a2d58b3afa024461dcc51805f52e9d",
-			"revisionTime": "2016-03-31T04:59:47Z"
+			"revision": "55146ba61254fdb1c26d65ff3c04bc1611ad73fb",
+			"revisionTime": "2016-12-12T20:09:13Z"
 		},
 		{
 			"checksumSHA1": "ik8LzDNaQAzTAlxB6Xg7c9HI/BU=",


### PR DESCRIPTION
Specifically, this should pick up the latest exponential backoff retry behavior in the GCS client.