### PR TITLE
v3: support for ',' joins

### DIFF
--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -73,6 +73,66 @@
   }
 }
 
+# ',' join
+"select music.col from user, music"
+{
+  "Original": "select music.col from user, music",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select 1 from user",
+      "FieldQuery": "select 1 from user where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select music.col from music",
+      "FieldQuery": "select music.col from music where 1 != 1"
+    },
+    "Cols": [
+      1
+    ]
+  }
+}
+
+# ',' join unsharded
+"select u1.a, u2.a from unsharded u1, unsharded u2"
+{
+  "Original": "select u1.a, u2.a from unsharded u1, unsharded u2",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2",
+    "FieldQuery": "select u1.a, u2.a from unsharded as u1, unsharded as u2 where 1 != 1"
+  }
+}
+
+# ',' 3-way join unsharded
+"select u1.a, u2.a from unsharded u1, unsharded u2, unsharded u3"
+{
+  "Original": "select u1.a, u2.a from unsharded u1, unsharded u2, unsharded u3",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2, unsharded as u3",
+    "FieldQuery": "select u1.a, u2.a from unsharded as u1, unsharded as u2, unsharded as u3 where 1 != 1"
+  }
+}
+
 # Left join, single chunk
 "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a=m2.b"
 {
@@ -840,6 +900,14 @@
     "FieldQuery": "select user.col from user join user_extra where 1 != 1"
   }
 }
+
+# verify ',' vs JOIN precedence
+"select u1.a from unsharded u1, unsharded u2 join unsharded u3 on u1.a = u2.a"
+"symbol u1.a not found"
+
+# first expression fails for ',' join (code coverage: ensure error is returned)
+"select user.foo.col from user.foo, user"
+"table foo not found"
 
 # table names should be case-sensitive
 "select unsharded.id from unsharded where Unsharded.val = 1"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -14,10 +14,6 @@
 "explain select * from user"
 "unsupported construct"
 
-# ',' operator for joins
-"select * from user, user_extra"
-"unsupported: ',' join operator"
-
 # union operations in subqueries (FROM)
 "select * from (select * from user union select * from user_extra) as t"
 "unsupported: union operator in subqueries"
@@ -96,6 +92,10 @@
 
 # group by and joins
 "select user.id from user join user_extra group by id"
+"unsupported: complex join and group by"
+
+# group by and ',' joins
+"select user.id from user, user_extra group by id"
 "unsupported: complex join and group by"
 
 # Group by references outer query

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -19,7 +19,15 @@ import (
 // with all the routes identified.
 func processTableExprs(tableExprs sqlparser.TableExprs, vschema VSchema) (builder, error) {
 	if len(tableExprs) != 1 {
-		return nil, errors.New("unsupported: ',' join operator")
+		lplan, err := processTableExpr(tableExprs[0], vschema)
+		if err != nil {
+			return nil, err
+		}
+		rplan, err := processTableExprs(tableExprs[1:], vschema)
+		if err != nil {
+			return nil, err
+		}
+		return lplan.Join(rplan, nil)
 	}
 	return processTableExpr(tableExprs[0], vschema)
 }


### PR DESCRIPTION
Addresses #2373.
',' operators will now be allowed for joins. They will be treated
as JOIN operators without an ON clause. This will work for unsharded
joins as well as cross-shard joins. For now, we will not look for
join conditions in the WHERE clause to identify single-shard queries.