### PR TITLE
A few miscellaneous fixes.

### DIFF
--- a/doc/SchemaSwap.md
+++ b/doc/SchemaSwap.md
@@ -65,7 +65,7 @@ Create a table".
 1.  Got to the Workflows section of vtctld UI (it will be at
     http://localhost:8001/api/v1/proxy/namespaces/default/services/vtctld:web/app2/workflows
     if you followed the Getting Started Guide as is) and press the "+" button in
-    the bottom right corner. You will be presented with "Create a new Workflow"
+    the top right corner. You will be presented with "Create a new Workflow"
     dialog.
 1.  In the "Factory Name" list select "Schema Swap".
 1.  In the field "Keyspace" enter "test_keyspace" (without quotes).
@@ -73,6 +73,12 @@ Create a table".
     want to execute. As an example we want to execute statement "ALTER TABLE
     messages ADD views BIGINT(20) UNSIGNED NULL".
 1.  Click "Create" button at the bottom of the dialog.
+
+Another way to start the schema swap is to execute vtctlclient command:
+
+``` sh
+vitess/examples/local$ ./lvtctl.sh WorkflowCreate schema_swap -keyspace=test_keyspace -sql='SQL statement'
+```
 
 From this point on all you need to do is watch how the schema swap process is
 progressing. Try expanding the displayed nodes in vtctld UI and look at the logs

--- a/doc/VitessReplication.md
+++ b/doc/VitessReplication.md
@@ -194,6 +194,13 @@ strengthened slightly to preventing loss of any transactions that were ever
 **committed** on the original master, eliminating so-called
 [phantom reads](http://bugs.mysql.com/bug.php?id=62174).
 
+On the other hand these behaviors also give a requirement that each shard must
+have at least 2 tablets with type *replica* (with addition of the master that
+can be demoted to type *replica* this gives a minimum of 3 tablets with initial
+type *replica*). This will allow for the master to have a semi-sync acker when
+one of the *replica* tablets is down for any reason (for a version update,
+machine reboot, schema swap or anything else).
+
 With regard to replication lag, note that this does **not** guarantee there is
 always at least one *replica* type slave from which queries will always return
 up-to-date results. Semi-sync guarantees that at least one slave has the

--- a/docs/user-guide/schema-swap.html
+++ b/docs/user-guide/schema-swap.html
@@ -346,7 +346,7 @@ Create a table&quot;.</p>
 <li> Got to the Workflows section of vtctld UI (it will be at
 <a href="http://localhost:8001/api/v1/proxy/namespaces/default/services/vtctld:web/app2/workflows">http://localhost:8001/api/v1/proxy/namespaces/default/services/vtctld:web/app2/workflows</a>
 if you followed the Getting Started Guide as is) and press the &quot;+&quot; button in
-the bottom right corner. You will be presented with &quot;Create a new Workflow&quot;
+the top right corner. You will be presented with &quot;Create a new Workflow&quot;
 dialog.</li>
 <li> In the &quot;Factory Name&quot; list select &quot;Schema Swap&quot;.</li>
 <li> In the field &quot;Keyspace&quot; enter &quot;test_keyspace&quot; (without quotes).</li>
@@ -356,6 +356,9 @@ messages ADD views BIGINT(20) UNSIGNED NULL&quot;.</li>
 <li> Click &quot;Create&quot; button at the bottom of the dialog.</li>
 </ol>
 
+<p>Another way to start the schema swap is to execute vtctlclient command:</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">vitess/examples/local<span class="nv">$ </span>./lvtctl.sh WorkflowCreate schema_swap -keyspace<span class="o">=</span>test_keyspace -sql<span class="o">=</span><span class="s1">&#39;SQL statement&#39;</span>
+</code></pre></div>
 <p>From this point on all you need to do is watch how the schema swap process is
 progressing. Try expanding the displayed nodes in vtctld UI and look at the logs
 of all the actions that process is doing. Once the UI shows &quot;Schema swap is

--- a/docs/user-guide/vitess-replication.html
+++ b/docs/user-guide/vitess-replication.html
@@ -475,6 +475,13 @@ strengthened slightly to preventing loss of any transactions that were ever
 <strong>committed</strong> on the original master, eliminating so-called
 <a href="http://bugs.mysql.com/bug.php?id=62174">phantom reads</a>.</p>
 
+<p>On the other hand these behaviors also give a requirement that each shard must
+have at least 2 tablets with type <em>replica</em> (with addition of the master that
+can be demoted to type <em>replica</em> this gives a minimum of 3 tablets with initial
+type <em>replica</em>). This will allow for the master to have a semi-sync acker when
+one of the <em>replica</em> tablets is down for any reason (for a version update,
+machine reboot, schema swap or anything else).</p>
+
 <p>With regard to replication lag, note that this does <strong>not</strong> guarantee there is
 always at least one <em>replica</em> type slave from which queries will always return
 up-to-date results. Semi-sync guarantees that at least one slave has the

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -363,11 +363,10 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 	if topoproto.TabletAliasEqual(shardInfo.MasterAlias, masterElectTabletAlias) {
 		return fmt.Errorf("master-elect tablet %v is already the master", topoproto.TabletAliasString(masterElectTabletAlias))
 	}
-	var oldMasterTabletInfo *topo.TabletInfo
-	ok = false
-	if shardInfo.MasterAlias != nil {
-		oldMasterTabletInfo, ok = tabletMap[*shardInfo.MasterAlias]
+	if topoproto.TabletAliasIsZero(shardInfo.MasterAlias) {
+		return fmt.Errorf("the shard has no master, use EmergencyReparentShard")
 	}
+	oldMasterTabletInfo, ok := tabletMap[*shardInfo.MasterAlias]
 	if !ok {
 		return fmt.Errorf("old master tablet %v is not in the shard", topoproto.TabletAliasString(shardInfo.MasterAlias))
 	}

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -363,7 +363,11 @@ func (wr *Wrangler) plannedReparentShardLocked(ctx context.Context, ev *events.R
 	if topoproto.TabletAliasEqual(shardInfo.MasterAlias, masterElectTabletAlias) {
 		return fmt.Errorf("master-elect tablet %v is already the master", topoproto.TabletAliasString(masterElectTabletAlias))
 	}
-	oldMasterTabletInfo, ok := tabletMap[*shardInfo.MasterAlias]
+	var oldMasterTabletInfo *topo.TabletInfo
+	ok = false
+	if shardInfo.MasterAlias != nil {
+		oldMasterTabletInfo, ok = tabletMap[*shardInfo.MasterAlias]
+	}
 	if !ok {
 		return fmt.Errorf("old master tablet %v is not in the shard", topoproto.TabletAliasString(shardInfo.MasterAlias))
 	}

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -163,7 +163,7 @@ func TestPlannedReparentNoMaster(t *testing.T) {
 	if err == nil {
 		t.Fatalf("PlannedReparentShard succeeded: %v", err)
 	}
-	if !strings.Contains(err.Error(), "is not in the shard") {
+	if !strings.Contains(err.Error(), "the shard has no master") {
 		t.Fatalf("PlannedReparentShard failed with the wrong error: %v", err)
 	}
 }

--- a/go/vt/wrangler/testlib/planned_reparent_shard_test.go
+++ b/go/vt/wrangler/testlib/planned_reparent_shard_test.go
@@ -6,6 +6,7 @@ package testlib
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -144,4 +145,25 @@ func TestPlannedReparentShard(t *testing.T) {
 
 	checkSemiSyncEnabled(t, true, true, newMaster)
 	checkSemiSyncEnabled(t, false, true, goodSlave1, goodSlave2, oldMaster)
+}
+
+func TestPlannedReparentNoMaster(t *testing.T) {
+	db := fakesqldb.Register()
+	ts := zk2topo.NewFakeServer("cell1", "cell2")
+	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())
+	vp := NewVtctlPipe(t, ts)
+	defer vp.Close()
+
+	// Create a few replicas.
+	replica1 := NewFakeTablet(t, wr, "cell1", 0, topodatapb.TabletType_REPLICA, db)
+	NewFakeTablet(t, wr, "cell1", 1, topodatapb.TabletType_REPLICA, db)
+	NewFakeTablet(t, wr, "cell1", 2, topodatapb.TabletType_REPLICA, db)
+
+	err := vp.Run([]string{"PlannedReparentShard", "-wait_slave_timeout", "10s", "-keyspace_shard", replica1.Tablet.Keyspace + "/" + replica1.Tablet.Shard, "-new_master", topoproto.TabletAliasString(replica1.Tablet.Alias)})
+	if err == nil {
+		t.Fatalf("PlannedReparentShard succeeded: %v", err)
+	}
+	if !strings.Contains(err.Error(), "is not in the shard") {
+		t.Fatalf("PlannedReparentShard failed with the wrong error: %v", err)
+	}
 }


### PR DESCRIPTION
1. Fix PlannedReparentShard to not panic when the shard doesn't have the master
   (MasterAlias is nil).
2. Fix documentation for schema swap to reflect the new UI and to also show how
   to start the schema swap from command line.
3. Expand documentation about Vitess replication to make it clear that with
   semi-sync each shard needs to have at least 2 replica tablets to make the
   master available in case of an outage of one of the replica tablets.
   This wasn't obvious to people setting up their production configurations.

Fixes #2385.

BUG=32724983