### PR TITLE
v3: improved symtab resolution

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -69,9 +69,9 @@
 }
 
 # update by primary keyspace id, stray where clause
-"update user set val = 1 where  id = id2 and id = 1"
+"update user set val = 1 where id = id2 and id = 1"
 {
-  "Original": "update user set val = 1 where  id = id2 and id = 1",
+  "Original": "update user set val = 1 where id = id2 and id = 1",
   "Instructions": {
     "Opcode": "UpdateEqual",
     "Keyspace": {
@@ -86,9 +86,9 @@
 }
 
 # update by primary keyspace id, stray where clause with conversion error
-"update user set val = 1 where  id = 1.1 and id = 1"
+"update user set val = 1 where id = 1.1 and id = 1"
 {
-  "Original": "update user set val = 1 where  id = 1.1 and id = 1",
+  "Original": "update user set val = 1 where id = 1.1 and id = 1",
   "Instructions": {
     "Opcode": "UpdateEqual",
     "Keyspace": {

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -685,6 +685,10 @@
   }
 }
 
+# unresolved symbol in inner subquery.
+"select id from user where id = :a and user.col in (select user_extra.col from user_extra where user_extra.user_id = :a and foo.id = 1)"
+"symbol foo.id not found"
+
 # outer and inner subquery route by same outermost column value
 "select id2 from user uu where id in (select id from user where id = uu.id and user.col in (select user_extra.col from user_extra where user_extra.user_id = uu.id))"
 {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -45,28 +45,39 @@
   }
 }
 
-# Group by references non-existent col
-"select id from user group by col"
-"symbol col not found"
-
-# HAVING references base name of a column
-"select user.col1 from user having col1 = 2"
+# Group by implicitly references table col
+"select id from user group by id, col"
 {
-  "Original": "select user.col1 from user having col1 = 2",
+  "Original": "select id from user group by id, col",
   "Instructions": {
     "Opcode": "SelectScatter",
     "Keyspace": {
       "Name": "user",
       "Sharded": true
     },
-    "Query": "select user.col1 from user having col1 = 2",
-    "FieldQuery": "select user.col1 from user where 1 != 1"
+    "Query": "select id from user group by id, col",
+    "FieldQuery": "select id from user where 1 != 1"
   }
 }
 
-# HAVING references base name of non-existent column
+# Group by references outer query
+"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 group by aa)"
+"symbol aa not found"
+
+# HAVING implicitly references table col
 "select user.col1 from user having col2 = 2"
-"symbol col2 not found"
+{
+  "Original": "select user.col1 from user having col2 = 2",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select user.col1 from user having col2 = 2",
+    "FieldQuery": "select user.col1 from user where 1 != 1"
+  }
+}
 
 # ambiguous symbol reference
 "select user.col1, user_extra.col1 from user join user_extra having col1 = 2"
@@ -152,22 +163,9 @@
   }
 }
 
-# Correlated subquery in having clause, subquery also has having clause, even more rare case.
-# We're testing to make sure that the inner 'id' finds the outer id of the select. The code path
-# is different for the having clause. So, we have a separate test case for it.
+# Correlated subquery in having clause, subquery also has having clause. Not allowed
 "select id, col from user having col in (select user_extra.col extra_col, user.id as user_id from user join user_extra on user.id = user_extra.user_id having user_id = id and extra_col = col)"
-{
-  "Original": "select id, col from user having col in (select user_extra.col extra_col, user.id as user_id from user join user_extra on user.id = user_extra.user_id having user_id = id and extra_col = col)",
-  "Instructions": {
-    "Opcode": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select id, col from user having col in (select user_extra.col as extra_col, user.id as user_id from user join user_extra on user.id = user_extra.user_id having user_id = id and extra_col = col)",
-    "FieldQuery": "select id, col from user where 1 != 1"
-  }
-}
+"symbol id not found"
 
 # Correlated subquery in having clause, subquery also has having clause, even more rare case.
 # We're looking for symbol not found error this time.
@@ -436,6 +434,10 @@
     }
   }
 }
+
+# Order by references outer query
+"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 order by aa)"
+"symbol aa not found"
 
 # Order by, verify outer symtab is searched according to its own context.
 "select u.id from user u having u.id in (select col2 from user where user.id = u.id order by u.col)"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -98,10 +98,6 @@
 "select user.id from user, user_extra group by id"
 "unsupported: complex join and group by"
 
-# Group by references outer query
-"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 group by aa)"
-"unsupported: subquery references outer query in group by"
-
 # Group by and scatter
 "select col from user group by col"
 "unsupported: scatter and group by"
@@ -109,10 +105,6 @@
 # subqueries not supported in group by
 "select id from user group by (select id from user_extra)"
 "unsupported: subqueries in group by expression"
-
-# Order by references outer query
-"select aa, id from user where id = 5 having id in (select u.id from user u join user_extra e on u.id = e.user_id where u.id = 5 order by aa)"
-"unsupported: subquery references outer query in order by"
 
 # Order by uses complex expression
 "select id from user order by id+1"
@@ -152,6 +144,14 @@
 
 # delete from with no where clause
 "delete from user"
+"unsupported: multi-shard where clause in DML"
+
+# update with non-comparison expr
+"update user set val = 1 where id between 1 and 2"
+"unsupported: multi-shard where clause in DML"
+
+# delete with non-comparison expr
+"delete from user where id between 1 and 2"
 "unsupported: multi-shard where clause in DML"
 
 # update with primary id through IN clause

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -17,9 +17,7 @@ import (
 // clauses like GROUP BY, etc.
 
 // pushGroupBy processes the group by clause. It resolves all symbols,
-// and ensures that there are no subqueries. It also verifies that the
-// references don't addres an outer query. We only support group by
-// for unsharded or single shard routes.
+// and ensures that there are no subqueries.
 func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 	if groupBy == nil {
 		return nil
@@ -31,15 +29,11 @@ func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
-			_, isLocal, err := bldr.Symtab().Find(node, true)
+			_, _, err := bldr.Symtab().Find(node, true)
 			if err != nil {
 				return false, err
 			}
-			if !isLocal {
-				return false, errors.New("unsupported: subquery references outer query in group by")
-			}
 		case *sqlparser.Subquery:
-			// TODO(sougou): better error.
 			return false, errors.New("unsupported: subqueries in group by expression")
 		}
 		return true, nil
@@ -70,9 +64,6 @@ func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 // are readjusted on push-down to match the numbers of the individual
 // queries.
 func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
-	s := bldr.Symtab().SetState(symtabOrderBy)
-	defer bldr.Symtab().SetState(s)
-
 	switch len(orderBy) {
 	case 0:
 		return nil
@@ -92,14 +83,10 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		var rb *route
 		switch node := order.Expr.(type) {
 		case *sqlparser.ColName:
-			var isLocal bool
 			var err error
-			rb, isLocal, err = bldr.Symtab().Find(node, true)
+			rb, _, err = bldr.Symtab().Find(node, true)
 			if err != nil {
 				return err
-			}
-			if !isLocal {
-				return errors.New("unsupported: subquery references outer query in order by")
 			}
 		case sqlparser.NumVal:
 			num, err := strconv.ParseInt(string(node), 0, 64)

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -561,23 +561,14 @@ func (rb *route) SupplyCol(ref colref) int {
 			return i
 		}
 	}
-	ts := ref.Meta.(*tabsym)
-	colname := ref.Name()
-	rb.Colsyms = append(rb.Colsyms, &colsym{
-		Alias: colname,
-		QualifiedName: &sqlparser.ColName{
-			Qualifier: ts.Alias,
-			Name:      colname,
-		},
-		Underlying: ref,
-	})
+	rb.Colsyms = append(rb.Colsyms, &colsym{Underlying: ref})
 	rb.Select.SelectExprs = append(
 		rb.Select.SelectExprs,
 		&sqlparser.NonStarExpr{
 			Expr: &sqlparser.ColName{
 				Metadata:  ref.Meta,
-				Qualifier: &sqlparser.TableName{Name: ts.ASTName},
-				Name:      colname,
+				Qualifier: &sqlparser.TableName{Name: ref.Meta.(*tabsym).ASTName},
+				Name:      ref.Name(),
 			},
 		},
 	)


### PR DESCRIPTION
Addresses: #1861.
The new resolution algorithm better mimics MySQL behavior: GROUP BY,
HAVING and ORDER BY search column aliases as well as table names.
It's not possible to exactly mimic MySQL's behavior without knowledge
of the full schema. However, such cases happen only if the SQL attempts
to hide table column names with column aliases, which is uncommon
and not recommended.
The most common application constructs where the post-process constructs
reference table columns should now work.