### PR TITLE
Fix Impossible Query to account for Group By clauses

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -21,7 +21,7 @@
 {
   "PlanID": "PASS_SELECT",
   "TableName": "a",
-  "FieldQuery": "select * from a where 1 != 1",
+  "FieldQuery": "select * from a where 1 != 1 group by b",
   "FullQuery": "select * from a group by b limit :#maxLimit"
 }
 

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -1,3 +1,17 @@
+# Group by with aggregation
+"select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc"
+{
+  "Original": "select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc",
+    "FieldQuery": "select col1, count(col2) as col2_count from unsharded where 1 != 1 group by col1"
+  }
+}
 # Group by unsharded
 "select col1, col2 from unsharded group by col2"
 {
@@ -9,7 +23,7 @@
       "Sharded": false
     },
     "Query": "select col1, col2 from unsharded group by col2",
-    "FieldQuery": "select col1, col2 from unsharded where 1 != 1"
+    "FieldQuery": "select col1, col2 from unsharded where 1 != 1 group by col2"
   }
 }
 
@@ -24,7 +38,7 @@
       "Sharded": true
     },
     "Query": "select col1, col2 from user where id = 1 group by col2",
-    "FieldQuery": "select col1, col2 from user where 1 != 1",
+    "FieldQuery": "select col1, col2 from user where 1 != 1 group by col2",
     "Vindex": "user_index",
     "Values": 1
   }
@@ -41,7 +55,7 @@
       "Sharded": true
     },
     "Query": "select col1, id from user group by id",
-    "FieldQuery": "select col1, id from user where 1 != 1"
+    "FieldQuery": "select col1, id from user where 1 != 1 group by id"
   }
 }
 
@@ -56,7 +70,7 @@
       "Sharded": true
     },
     "Query": "select id from user group by id, col",
-    "FieldQuery": "select id from user where 1 != 1"
+    "FieldQuery": "select id from user where 1 != 1 group by id, col"
   }
 }
 

--- a/go/vt/sqlparser/impossible_query.go
+++ b/go/vt/sqlparser/impossible_query.go
@@ -1,0 +1,28 @@
+package sqlparser
+
+// FormatImpossibleQuery creates an impossible query in a TrackedBuffer.
+// An impossible query is a modified version of a query where all selects have where clauses that are
+// impossible for mysql to resolve. This is used in the vtgate and vttablet:
+//
+// - In the vtgate it's used for joins: if the first query returns no result, then vtgate uses the impossible
+// query just to fetch field info from vttablet
+// - In the vttablet, it's just an optimization: the field info is fetched once form MySQL, cached and reused
+// for subsequent queries
+func FormatImpossibleQuery(buf *TrackedBuffer, node SQLNode) {
+	switch node := node.(type) {
+	case *Select:
+		buf.Myprintf("select %v from %v where 1 != 1", node.SelectExprs, node.From)
+		if node.GroupBy != nil {
+			node.GroupBy.Format(buf)
+		}
+	case *JoinTableExpr:
+		if node.Join == LeftJoinStr || node.Join == RightJoinStr {
+			// ON clause is requried
+			buf.Myprintf("%v %s %v on 1 != 1", node.LeftExpr, node.Join, node.RightExpr)
+		} else {
+			buf.Myprintf("%v %s %v", node.LeftExpr, node.Join, node.RightExpr)
+		}
+	default:
+		node.Format(buf)
+	}
+}

--- a/go/vt/sqlparser/tracked_buffer.go
+++ b/go/vt/sqlparser/tracked_buffer.go
@@ -30,6 +30,13 @@ func NewTrackedBuffer(nodeFormatter func(buf *TrackedBuffer, node SQLNode)) *Tra
 	}
 }
 
+// Convenience function, initiates the writing of a single SQLNode tree by passing
+// through to Myprintf with a default format string
+func (buf *TrackedBuffer) WriteNode(node SQLNode) *TrackedBuffer {
+	buf.Myprintf("%v", node)
+	return buf
+}
+
 // Myprintf mimics fmt.Fprintf(buf, ...), but limited to Node(%v),
 // Node.Value(%s) and string(%s). It also allows a %a for a value argument, in
 // which case it adds tracking info for future substitutions.

--- a/go/vt/tabletserver/endtoend/queries_test.go
+++ b/go/vt/tabletserver/endtoend/queries_test.go
@@ -93,7 +93,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "3"},
 			},
 			Rewritten: []string{
-				"select eid, sum(id) from vitess_a where 1 != 1",
+				"select eid, sum(id) from vitess_a where 1 != 1 group by eid",
 				"select /* group by */ eid, sum(id) from vitess_a group by eid limit 10001",
 			},
 			RowsAffected: 1,


### PR DESCRIPTION
We had a query which uses an aggregation and group by, and our mysql uses sql_mode=only_full_group_by. The impossible query generated by vitess did not include the group by clause, and so the query violated the conditions of only_full_group_by:

> In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'Foo.sr.id'; this is incompatible with sql_mode=only_full_group_by

This PR does three things:

* Include the GroupBy in the select query, if the GroupBy is not nil
* Refactors the code path so that both the vttablet and vtgate use the same impossible query generation code.
* Update all tests to expect a group by in the generated field queries

In terms of refactoring, creating a new file in the sqlparser packaged seemed cleanest. I have not created new tests for this file, because it seems to be covered by the existing planbuilder and route tests. But if you'd like me to add new tests, I can do so.

Note: my CLA should be ready some time this week, waiting on legal department