### PR TITLE
Removing topo.Impl.ValidateShard method.

### DIFF
--- a/go/vt/etcdtopo/shard.go
+++ b/go/vt/etcdtopo/shard.go
@@ -52,12 +52,6 @@ func (s *Server) UpdateShard(ctx context.Context, keyspace, shard string, value 
 	return int64(resp.Node.ModifiedIndex), nil
 }
 
-// ValidateShard implements topo.Server.
-func (s *Server) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	_, _, err := s.GetShard(ctx, keyspace, shard)
-	return err
-}
-
 // GetShard implements topo.Server.
 func (s *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	resp, err := s.getGlobal().Get(shardFilePath(keyspace, shard), false /* sort */, false /* recursive */)

--- a/go/vt/topo/etcd2topo/shard.go
+++ b/go/vt/topo/etcd2topo/shard.go
@@ -43,11 +43,6 @@ func (s *Server) UpdateShard(ctx context.Context, keyspace, shard string, value 
 	return int64(version.(EtcdVersion)), nil
 }
 
-// ValidateShard implements topo.Server.
-func (s *Server) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	return nil
-}
-
 // GetShard implements topo.Server.
 func (s *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -350,20 +350,6 @@ func (tee *Tee) UpdateShard(ctx context.Context, keyspace, shard string, value *
 	return
 }
 
-// ValidateShard is part of the topo.Server interface
-func (tee *Tee) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	err := tee.primary.ValidateShard(ctx, keyspace, shard)
-	if err != nil {
-		return err
-	}
-
-	if err := tee.secondary.ValidateShard(ctx, keyspace, shard); err != nil {
-		// not critical enough to fail
-		log.Warningf("secondary.ValidateShard(%v,%v) failed: %v", keyspace, shard, err)
-	}
-	return nil
-}
-
 // GetShard is part of the topo.Server interface
 func (tee *Tee) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	s, v, err := tee.readFrom.GetShard(ctx, keyspace, shard)

--- a/go/vt/topo/memorytopo/shard.go
+++ b/go/vt/topo/memorytopo/shard.go
@@ -39,11 +39,6 @@ func (mt *MemoryTopo) UpdateShard(ctx context.Context, keyspace, shard string, v
 	return int64(version.(NodeVersion)), nil
 }
 
-// ValidateShard implements topo.Impl.ValidateShard
-func (mt *MemoryTopo) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	return nil
-}
-
 // GetShard implements topo.Impl.GetShard
 func (mt *MemoryTopo) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -133,9 +133,6 @@ type Impl interface {
 	// Do not use directly, but instead use topo.UpdateShardFields.
 	UpdateShard(ctx context.Context, keyspace, shard string, value *topodatapb.Shard, existingVersion int64) (newVersion int64, err error)
 
-	// ValidateShard performs routine checks on the shard.
-	ValidateShard(ctx context.Context, keyspace, shard string) error
-
 	// GetShard reads a shard and returns it, along with its version.
 	// Can return ErrNoNode
 	GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error)

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -289,10 +289,6 @@ func Validate(ctx context.Context, ts Server, tabletAlias *topodatapb.TabletAlia
 	}
 
 	// Validate the entry in the shard replication nodes
-	if err = ts.ValidateShard(ctx, tablet.Keyspace, tablet.Shard); err != nil {
-		return err
-	}
-
 	si, err := ts.GetShardReplication(ctx, tablet.Alias.Cell, tablet.Keyspace, tablet.Shard)
 	if err != nil {
 		return err

--- a/go/vt/topo/test/faketopo/faketopo.go
+++ b/go/vt/topo/test/faketopo/faketopo.go
@@ -92,11 +92,6 @@ func (ft FakeTopo) UpdateShard(ctx context.Context, keyspace, shard string, valu
 	return 0, errNotImplemented
 }
 
-// ValidateShard is part of the topo.Server interface.
-func (ft FakeTopo) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	return errNotImplemented
-}
-
 // GetShard is part of the topo.Server interface.
 func (ft FakeTopo) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	return nil, 0, errNotImplemented

--- a/go/vt/topo/test/shard.go
+++ b/go/vt/topo/test/shard.go
@@ -156,9 +156,4 @@ func checkShard(t *testing.T, ts topo.Impl) {
 	if _, err := ts.GetShardNames(ctx, "test_keyspace666"); err != topo.ErrNoNode {
 		t.Errorf("GetShardNames(666): %v", err)
 	}
-
-	// test ValidateShard
-	if err := ts.ValidateShard(ctx, "test_keyspace", "b0-c0"); err != nil {
-		t.Errorf("ValidateShard(test_keyspace, b0-c0) failed: %v", err)
-	}
 }

--- a/go/vt/topo/zk2topo/shard.go
+++ b/go/vt/topo/zk2topo/shard.go
@@ -45,11 +45,6 @@ func (zs *Server) UpdateShard(ctx context.Context, keyspace, shard string, value
 	return int64(version.(ZKVersion)), nil
 }
 
-// ValidateShard is part of the topo.Server interface.
-func (zs *Server) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	return nil
-}
-
 // GetShard is part of the topo.Server interface.
 func (zs *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)

--- a/go/vt/zktopo/shard.go
+++ b/go/vt/zktopo/shard.go
@@ -73,22 +73,6 @@ func (zkts *Server) UpdateShard(ctx context.Context, keyspace, shard string, val
 	return int64(stat.Version), nil
 }
 
-// ValidateShard is part of the topo.Server interface
-func (zkts *Server) ValidateShard(ctx context.Context, keyspace, shard string) error {
-	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)
-	zkPaths := []string{
-		path.Join(shardPath, "action"),
-		path.Join(shardPath, "actionlog"),
-	}
-	for _, zkPath := range zkPaths {
-		_, _, err := zkts.zconn.Get(zkPath)
-		if err != nil {
-			return convertError(err)
-		}
-	}
-	return nil
-}
-
 // GetShard is part of the topo.Server interface
 func (zkts *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
 	shardPath := path.Join(GlobalKeyspacesPath, keyspace, "shards", shard)


### PR DESCRIPTION
It is not implemented by any topo service except the old zookeeper that
is being deprecated. It also has no value.