### PR TITLE
docker/test/run: Avoid using non-universal --tmpdir flag on mktemp

### DIFF
--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -32,7 +32,7 @@ args="$args -v /tmp/mavencache:/home/vitess/.m2"
 
 # Mount in host VTDATAROOT if one exists, since it might be a RAM disk or SSD.
 if [[ -n "$VTDATAROOT" ]]; then
-  hostdir=`mktemp -d --tmpdir=$VTDATAROOT test-XXX`
+  hostdir=`mktemp -d --tmpdir=$VTDATAROOT test-XXX 2>/dev/null || mktemp -d $VTDATAROOT/test-XXX 2>/dev/null`
   testid=`basename $hostdir`
 
   chmod 777 $hostdir

--- a/docker/test/run.sh
+++ b/docker/test/run.sh
@@ -32,7 +32,7 @@ args="$args -v /tmp/mavencache:/home/vitess/.m2"
 
 # Mount in host VTDATAROOT if one exists, since it might be a RAM disk or SSD.
 if [[ -n "$VTDATAROOT" ]]; then
-  hostdir=`mktemp -d --tmpdir=$VTDATAROOT test-XXX 2>/dev/null || mktemp -d $VTDATAROOT/test-XXX 2>/dev/null`
+  hostdir=`mktemp -d $VTDATAROOT/test-XXX`
   testid=`basename $hostdir`
 
   chmod 777 $hostdir


### PR DESCRIPTION
On OSX 10.11, mktemp does not support a `--tmpdir` argument. This was causing `go run test.go` to fail.

This PR adds a fallback which is compatible with OSX's mktemp version.