### PR TITLE
Include on clauses in impossible queries, to avoid only_full_group_by in aggregations with joins

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -75,7 +75,7 @@
 {
   "PlanID": "PASS_SELECT",
   "TableName": "",
-  "FieldQuery": "select * from a right join b on 1 != 1 where 1 != 1",
+  "FieldQuery": "select * from a right join b on c = d where 1 != 1",
   "FullQuery": "select * from a right join b on c = d limit :#maxLimit"
 }
 

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -176,7 +176,7 @@
       "Sharded": true
     },
     "Query": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where user.id = 5",
-    "FieldQuery": "select user_extra.id from user join user_extra where 1 != 1",
+    "FieldQuery": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -193,7 +193,7 @@
       "Sharded": true
     },
     "Query": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where user_extra.user_id = 5",
-    "FieldQuery": "select user_extra.id from user join user_extra where 1 != 1",
+    "FieldQuery": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -210,7 +210,7 @@
       "Sharded": true
     },
     "Query": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where user.id = 5",
-    "FieldQuery": "select user_extra.id from user left join user_extra on 1 != 1 where 1 != 1",
+    "FieldQuery": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -227,7 +227,7 @@
       "Sharded": true
     },
     "Query": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where user_extra.user_id = 5",
-    "FieldQuery": "select user_extra.id from user left join user_extra on 1 != 1 where 1 != 1"
+    "FieldQuery": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where 1 != 1"
   }
 }
 
@@ -715,7 +715,7 @@
       "Sharded": true
     },
     "Query": "select user_extra.Id from user join user_extra on user.iD = user_extra.User_Id where user.Id = 5",
-    "FieldQuery": "select user_extra.Id from user join user_extra where 1 != 1",
+    "FieldQuery": "select user_extra.Id from user join user_extra on user.iD = user_extra.User_Id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -144,7 +144,7 @@
       "Sharded": false
     },
     "Query": "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a = m2.b",
-    "FieldQuery": "select m1.col from unsharded as m1 left join unsharded as m2 on 1 != 1 where 1 != 1"
+    "FieldQuery": "select m1.col from unsharded as m1 left join unsharded as m2 on m1.a = m2.b where 1 != 1"
   }
 }
 
@@ -307,7 +307,7 @@
       "Sharded": false
     },
     "Query": "select m1.col from unsharded as m2 left join unsharded as m1 on m1.a = m2.b",
-    "FieldQuery": "select m1.col from unsharded as m2 left join unsharded as m1 on 1 != 1 where 1 != 1"
+    "FieldQuery": "select m1.col from unsharded as m2 left join unsharded as m1 on m1.a = m2.b where 1 != 1"
   }
 }
 
@@ -322,7 +322,7 @@
       "Sharded": false
     },
     "Query": "select m1.col from unsharded as m3 left join (unsharded as m1 join unsharded as m2) on m1.a = m2.b",
-    "FieldQuery": "select m1.col from unsharded as m3 left join (unsharded as m1 join unsharded as m2) on 1 != 1 where 1 != 1"
+    "FieldQuery": "select m1.col from unsharded as m3 left join (unsharded as m1 join unsharded as m2) on m1.a = m2.b where 1 != 1"
   }
 }
 
@@ -484,7 +484,7 @@
       "Sharded": true
     },
     "Query": "select user.col from user join user_extra on user.id = user_extra.user_id",
-    "FieldQuery": "select user.col from user join user_extra where 1 != 1"
+    "FieldQuery": "select user.col from user join user_extra on user.id = user_extra.user_id where 1 != 1"
   }
 }
 
@@ -499,7 +499,7 @@
       "Sharded": true
     },
     "Query": "select user.col from user join user_extra on user.col between 1 and 2 and user.id = user_extra.user_id",
-    "FieldQuery": "select user.col from user join user_extra where 1 != 1"
+    "FieldQuery": "select user.col from user join user_extra on user.col between 1 and 2 and user.id = user_extra.user_id where 1 != 1"
   }
 }
 
@@ -514,7 +514,7 @@
       "Sharded": true
     },
     "Query": "select user.col from user join user_extra on user_extra.user_id = user.id",
-    "FieldQuery": "select user.col from user join user_extra where 1 != 1"
+    "FieldQuery": "select user.col from user join user_extra on user_extra.user_id = user.id where 1 != 1"
   }
 }
 
@@ -529,7 +529,7 @@
       "Sharded": true
     },
     "Query": "select user.col from user join user_extra on user.id = 5 and user.id = user_extra.user_id",
-    "FieldQuery": "select user.col from user join user_extra where 1 != 1",
+    "FieldQuery": "select user.col from user join user_extra on user.id = 5 and user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -737,7 +737,7 @@
       "Sharded": true
     },
     "Query": "select t.id from (select id from user where id = 5) as t join user_extra on t.id = user_extra.user_id",
-    "FieldQuery": "select t.id from (select id from user where 1 != 1) as t join user_extra where 1 != 1",
+    "FieldQuery": "select t.id from (select id from user where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -754,7 +754,7 @@
       "Sharded": true
     },
     "Query": "select t.id from (select user.id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id",
-    "FieldQuery": "select t.id from (select user.id from user where 1 != 1) as t join user_extra where 1 != 1",
+    "FieldQuery": "select t.id from (select user.id from user where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
     "Values": 5
   }
@@ -775,7 +775,7 @@
       "Sharded": true
     },
     "Query": "select t.id from user_extra join (select id from user where id = 5) as t on t.id = user_extra.user_id",
-    "FieldQuery": "select t.id from user_extra join (select id from user where 1 != 1) as t where 1 != 1"
+    "FieldQuery": "select t.id from user_extra join (select id from user where 1 != 1) as t on t.id = user_extra.user_id where 1 != 1"
   }
 }
 
@@ -897,7 +897,7 @@
       "Sharded": true
     },
     "Query": "select user.col from user join user_extra on user.ID = user_extra.User_Id",
-    "FieldQuery": "select user.col from user join user_extra where 1 != 1"
+    "FieldQuery": "select user.col from user join user_extra on user.ID = user_extra.User_Id where 1 != 1"
   }
 }
 

--- a/go/vt/sqlparser/impossible_query.go
+++ b/go/vt/sqlparser/impossible_query.go
@@ -15,12 +15,6 @@ func FormatImpossibleQuery(buf *TrackedBuffer, node SQLNode) {
 		if node.GroupBy != nil {
 			node.GroupBy.Format(buf)
 		}
-	case *JoinTableExpr:
-		node.Format(buf)
-		if node.On == nil && (node.Join == LeftJoinStr || node.Join == RightJoinStr) {
-			// ON clause is requried
-			buf.Myprintf(" on 1 != 1", node.LeftExpr, node.Join, node.RightExpr)
-		}
 	default:
 		node.Format(buf)
 	}

--- a/go/vt/sqlparser/impossible_query.go
+++ b/go/vt/sqlparser/impossible_query.go
@@ -16,11 +16,10 @@ func FormatImpossibleQuery(buf *TrackedBuffer, node SQLNode) {
 			node.GroupBy.Format(buf)
 		}
 	case *JoinTableExpr:
-		if node.Join == LeftJoinStr || node.Join == RightJoinStr {
+		node.Format(buf)
+		if node.On == nil && (node.Join == LeftJoinStr || node.Join == RightJoinStr) {
 			// ON clause is requried
-			buf.Myprintf("%v %s %v on 1 != 1", node.LeftExpr, node.Join, node.RightExpr)
-		} else {
-			buf.Myprintf("%v %s %v", node.LeftExpr, node.Join, node.RightExpr)
+			buf.Myprintf(" on 1 != 1", node.LeftExpr, node.Join, node.RightExpr)
 		}
 	default:
 		node.Format(buf)

--- a/go/vt/tabletserver/endtoend/queries_test.go
+++ b/go/vt/tabletserver/endtoend/queries_test.go
@@ -148,7 +148,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "2", "1", "2"},
 			},
 			Rewritten: []string{
-				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b where 1 != 1",
+				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* join */ a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
 			RowsAffected: 2,
@@ -161,7 +161,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "2", "1", "2"},
 			},
 			Rewritten: []string{
-				"select a.eid, a.id, b.eid, b.id from vitess_a as a straight_join vitess_b as b where 1 != 1",
+				"select a.eid, a.id, b.eid, b.id from vitess_a as a straight_join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* straight_join */ a.eid, a.id, b.eid, b.id from vitess_a as a straight_join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
 			RowsAffected: 2,
@@ -174,7 +174,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "2", "1", "2"},
 			},
 			Rewritten: []string{
-				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b where 1 != 1",
+				"select a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* cross join */ a.eid, a.id, b.eid, b.id from vitess_a as a join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
 			RowsAffected: 2,
@@ -200,7 +200,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "2", "1", "2"},
 			},
 			Rewritten: []string{
-				"select a.eid, a.id, b.eid, b.id from vitess_a as a left join vitess_b as b on 1 != 1 where 1 != 1",
+				"select a.eid, a.id, b.eid, b.id from vitess_a as a left join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* left join */ a.eid, a.id, b.eid, b.id from vitess_a as a left join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
 			RowsAffected: 2,
@@ -213,7 +213,7 @@ func TestNocacheCases(t *testing.T) {
 				{"1", "2", "1", "2"},
 			},
 			Rewritten: []string{
-				"select a.eid, a.id, b.eid, b.id from vitess_a as a right join vitess_b as b on 1 != 1 where 1 != 1",
+				"select a.eid, a.id, b.eid, b.id from vitess_a as a right join vitess_b as b on a.eid = b.eid and a.id = b.id where 1 != 1",
 				"select /* right join */ a.eid, a.id, b.eid, b.id from vitess_a as a right join vitess_b as b on a.eid = b.eid and a.id = b.id limit 10001",
 			},
 			RowsAffected: 2,


### PR DESCRIPTION
We have some queries which have aggregations as well as a join, and the existing impossible query was causing `only_full_group_by` errors in MySQL.  Here's an example query:

```
mysql> select incident.*, t.id, t.team, t.slack_room, count(ais_other.id) as suppressionCount from incidents as incident join teams as t join active_incident_suppressions as ais_filter left join active_incident_suppressions as ais_other on 1 != 1 where 1 != 1 group by incident.id;
ERROR 1055 (42000): Expression #16 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'Otto.t.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

The t.id needs to either be joined on, or added to the group by. In this case it makes sense to be joined on.

This PR adds the On clause when it exists, and falls back to `1 != 1` when it does not, for left and right joins. Updated all tests to account for new formatting.

I verified with EXPLAIN that the new queries still result in `Impossible WHERE` and so should be just as fast, but safer.

cc @sougou  