### PR TITLE
Implementing the Consul topology client.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,6 +72,24 @@ else
 fi
 ln -snf $etcd_dist/etcd-${etcd_version}-linux-amd64/etcd $VTROOT/bin/etcd
 
+# Download and install consul, link consul binary into our root.
+consul_version=0.7.2
+consul_dist=$VTROOT/dist/consul
+consul_version_file=$consul_dist/version
+if [[ -f $consul_version_file && "$(cat $consul_version_file)" == "$consul_version" ]]; then
+  echo "skipping consul install. remove $consul_version_file to force re-install."
+else
+  rm -rf $consul_dist
+  mkdir -p $consul_dist
+  download_url=https://releases.hashicorp.com/consul
+  (cd $consul_dist && \
+    wget ${download_url}/${consul_version}/consul_${consul_version}_linux_amd64.zip && \
+    unzip consul_${consul_version}_linux_amd64.zip)
+  [ $? -eq 0 ] || fail "consul download failed"
+  echo "$consul_version" > $consul_version_file
+fi
+ln -snf $consul_dist/consul $VTROOT/bin/consul
+
 # install gRPC C++ base, so we can install the python adapters.
 # this also installs protobufs
 grpc_dist=$VTROOT/dist/grpc

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -55,11 +55,20 @@ RUN mkdir -p /vt/dist && \
     mv apache-maven-3.3.9 maven
 
 # Install etcd v3.0.15 binaries
-RUN mkdir -p /vt/dist /vt/bin && \
+RUN mkdir -p /vt/dist && \
     cd /vt/dist && \
     curl -sL --connect-timeout 10 --retry 3 \
          https://github.com/coreos/etcd/releases/download/v3.0.15/etcd-v3.0.15-linux-amd64.tar.gz | tar -xz && \
     mv etcd-v3.0.15-linux-amd64 etcd
+
+# Install consul 0.7.2 binaries
+RUN mkdir -p /vt/dist/consul && \
+    cd /vt/dist/consul && \
+    curl -sL --connect-timeout 10 --retry 3 \
+         -o consul_0.7.2_linux_amd64.zip \
+         https://releases.hashicorp.com/consul/0.7.2/consul_0.7.2_linux_amd64.zip && \
+    unzip consul_0.7.2_linux_amd64.zip && \
+    rm -f consul_0.7.2_linux_amd64.zip
 
 # Set up Vitess environment (equivalent to '. dev.env')
 ENV VTTOP /vt/src/github.com/youtube/vitess
@@ -71,7 +80,7 @@ ENV VTPORTSTART 15000
 ENV PYTHONPATH $VTROOT/dist/py-mock-1.0.1/lib/python2.7/site-packages:$VTROOT/py-vtdb:$VTROOT/dist/selenium/lib/python2.7/site-packages
 ENV GOBIN $VTROOT/bin
 ENV GOPATH $VTROOT
-ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$VTROOT/dist/etcd:$VTROOT/dist/chromedriver:$PATH
+ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$VTROOT/dist/etcd:$VTROOT/dist/consul:$VTROOT/dist/chromedriver:$PATH
 ENV VT_MYSQL_ROOT /usr
 ENV PKG_CONFIG_PATH $VTROOT/lib
 ENV GO15VENDOREXPERIMENT 1

--- a/go/cmd/l2vtgate/plugin_consultopo.go
+++ b/go/cmd/l2vtgate/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package main
+
+// This plugin imports consultopo to register the consul implementation of TopoServer.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/go/cmd/topo2topo/plugin_consultopo.go
+++ b/go/cmd/topo2topo/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package main
+
+// This plugin imports consultopo to register the consul implementation of TopoServer.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/go/cmd/vtctld/plugin_consultopo.go
+++ b/go/cmd/vtctld/plugin_consultopo.go
@@ -1,18 +1,18 @@
 package main
 
-// Imports and register the 'zk2' topo.Server and its Explorer.
+// Imports and register the 'consul' topo.Server and its Explorer.
 
 import (
 	"github.com/youtube/vitess/go/vt/servenv"
-	"github.com/youtube/vitess/go/vt/topo/zk2topo"
+	"github.com/youtube/vitess/go/vt/topo/consultopo"
 	"github.com/youtube/vitess/go/vt/vtctld"
 )
 
 func init() {
 	// Wait until flags are parsed, so we can check which topo server is in use.
 	servenv.OnRun(func() {
-		if s, ok := ts.Impl.(*zk2topo.Server); ok {
-			vtctld.HandleExplorer("zk2", vtctld.NewBackendExplorer(s))
+		if s, ok := ts.Impl.(*consultopo.Server); ok {
+			vtctld.HandleExplorer("consul", vtctld.NewBackendExplorer(s))
 		}
 	})
 }

--- a/go/cmd/vtctld/plugin_etcd2topo.go
+++ b/go/cmd/vtctld/plugin_etcd2topo.go
@@ -4,7 +4,7 @@
 
 package main
 
-// This plugin imports etcdtopo to register the etcd implementation of TopoServer.
+// Imports and register the 'etcd2' topo.Server and its Explorer.
 
 import (
 	"github.com/youtube/vitess/go/vt/servenv"

--- a/go/cmd/vtctld/plugin_etcdtopo.go
+++ b/go/cmd/vtctld/plugin_etcdtopo.go
@@ -4,7 +4,7 @@
 
 package main
 
-// This plugin imports etcdtopo to register the etcd implementation of TopoServer.
+// Imports and register the 'etcd' topo.Server and its Explorer.
 
 import (
 	"github.com/youtube/vitess/go/vt/etcdtopo"

--- a/go/cmd/vtctld/plugin_zktopo.go
+++ b/go/cmd/vtctld/plugin_zktopo.go
@@ -4,7 +4,7 @@
 
 package main
 
-// Imports and register the Zookeeper TopologyServer and its Explorer.
+// Imports and register the 'zookeeper' topo.Server and its Explorer.
 
 import (
 	"github.com/youtube/vitess/go/vt/servenv"

--- a/go/cmd/vtgate/plugin_consultopo.go
+++ b/go/cmd/vtgate/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package main
+
+// This plugin imports consultopo to register the consul implementation of TopoServer.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/go/cmd/vttablet/plugin_consultopo.go
+++ b/go/cmd/vttablet/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package main
+
+// This plugin imports consultopo to register the consul implementation of TopoServer.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/go/cmd/vtworker/plugin_consultopo.go
+++ b/go/cmd/vtworker/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package main
+
+// This plugin imports consultopo to register the consul implementation of TopoServer.
+
+import (
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/go/testfiles/ports.go
+++ b/go/testfiles/ports.go
@@ -38,6 +38,10 @@ var (
 	// GoVtEtcdtopoPort is used by the go/vt/etcdtopo package.
 	// Takes two ports.
 	GoVtEtcdtopoPort = GoVtZktopoPort + 3
+
+	// GoVtTopoConsultopoPort is used by the go/vt/topo/consultopo package.
+	// Takes five ports.
+	GoVtTopoConsultopoPort = GoVtEtcdtopoPort + 2
 )
 
 //

--- a/go/vt/topo/consultopo/cell.go
+++ b/go/vt/topo/consultopo/cell.go
@@ -59,7 +59,7 @@ func newCellClient(serverAddr, root string) (*cellClient, error) {
 func (c *cellClient) close() {
 }
 
-// cell returns a client for the given cell-local consul cluster.
+// clientForCell returns a client for the given cell-local consul cluster.
 // It caches clients for previously requested cells.
 func (s *Server) clientForCell(ctx context.Context, cell string) (*cellClient, error) {
 	// Global cell is the easy case.

--- a/go/vt/topo/consultopo/cell.go
+++ b/go/vt/topo/consultopo/cell.go
@@ -1,0 +1,126 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+	"sync"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hashicorp/consul/api"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// cellClient wraps a Client for keeping track of cell-local clusters.
+type cellClient struct {
+	// client is the consul api client.
+	client *api.Client
+	kv     *api.KV
+
+	// root is the root path for this client.
+	root string
+
+	// mu protects the following fields.
+	mu sync.Mutex
+	// locks is a map of *lockInstance structures.
+	// The key is the filepath of the Lock file.
+	locks map[string]*lockInstance
+}
+
+// lockInstance keeps track of one lock held by this client.
+type lockInstance struct {
+	// lock has the api.Lock structure.
+	lock *api.Lock
+
+	// done is closed when the lock is release by this process.
+	done chan struct{}
+}
+
+// newCellClient returns a new cellClient for the given address and root.
+func newCellClient(serverAddr, root string) (*cellClient, error) {
+	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cellClient{
+		client: client,
+		kv:     client.KV(),
+		root:   root,
+		locks:  make(map[string]*lockInstance),
+	}, nil
+}
+
+func (c *cellClient) close() {
+}
+
+// cell returns a client for the given cell-local consul cluster.
+// It caches clients for previously requested cells.
+func (s *Server) clientForCell(ctx context.Context, cell string) (*cellClient, error) {
+	// Global cell is the easy case.
+	if cell == topo.GlobalCell {
+		return s.global, nil
+	}
+
+	// Return a cached client if present.
+	s.mu.Lock()
+	client, ok := s.cells[cell]
+	s.mu.Unlock()
+	if ok {
+		return client, nil
+	}
+
+	// Fetch cell cluster addresses from the global cluster.
+	// These can proceed concurrently (we've released the lock).
+	serverAddr, root, err := s.getCellAddrs(ctx, cell)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the cache.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if another goroutine beat us to creating a client for
+	// this cell.
+	if client, ok = s.cells[cell]; ok {
+		return client, nil
+	}
+
+	// Create the client.
+	c, err := newCellClient(serverAddr, root)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %v: %v", serverAddr, err)
+	}
+	s.cells[cell] = c
+	return c, nil
+}
+
+// getCellAddrs returns the list of consul servers to try for the given
+// cell-local cluster, and the root directory. These lists are stored
+// in the global consul cluster.
+func (s *Server) getCellAddrs(ctx context.Context, cell string) (string, string, error) {
+	nodePath := path.Join(s.global.root, cellsPath, cell, topo.CellInfoFile)
+	pair, _, err := s.global.kv.Get(nodePath, nil)
+	if err != nil {
+		return "", "", err
+	}
+	if pair == nil {
+		return "", "", topo.ErrNoNode
+	}
+
+	ci := &topodatapb.CellInfo{}
+	if err := proto.Unmarshal(pair.Value, ci); err != nil {
+		return "", "", fmt.Errorf("cannot unmarshal cell node %v: %v", nodePath, err)
+	}
+	if ci.ServerAddress == "" {
+		return "", "", fmt.Errorf("CellInfo.ServerAddress node %v is empty, expected list of addresses", nodePath)
+	}
+
+	return ci.ServerAddress, ci.Root, nil
+}

--- a/go/vt/topo/consultopo/config.go
+++ b/go/vt/topo/consultopo/config.go
@@ -1,0 +1,11 @@
+package consultopo
+
+const (
+	// Path components
+	cellsPath     = "cells"
+	keyspacesPath = "keyspaces"
+	shardsPath    = "shards"
+	tabletsPath   = "tablets"
+	locksFilename = "Lock"
+	electionsPath = "elections"
+)

--- a/go/vt/topo/consultopo/directory.go
+++ b/go/vt/topo/consultopo/directory.go
@@ -1,0 +1,51 @@
+package consultopo
+
+import (
+	"path"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// ListDir is part of the topo.Backend interface.
+func (s *Server) ListDir(ctx context.Context, cell, dirPath string) ([]string, error) {
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return nil, err
+	}
+	nodePath := path.Join(c.root, dirPath) + "/"
+
+	keys, _, err := c.kv.Keys(nodePath, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		// No key starts with this prefix, means the directory
+		// doesn't exist.
+		return nil, topo.ErrNoNode
+	}
+
+	prefixLen := len(nodePath)
+	var result []string
+	for _, p := range keys {
+		// Remove the prefix, base path.
+		if !strings.HasPrefix(p, nodePath) {
+			return nil, ErrBadResponse
+		}
+		p = p[prefixLen:]
+
+		// Keep only the part until the first '/'.
+		if i := strings.Index(p, "/"); i >= 0 {
+			p = p[:i]
+		}
+
+		// Remove duplicates, add to list.
+		if len(result) == 0 || result[len(result)-1] != p {
+			result = append(result, p)
+		}
+	}
+
+	return result, nil
+}

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -1,0 +1,112 @@
+package consultopo
+
+import (
+	"path"
+
+	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// NewMasterParticipation is part of the topo.Server interface
+func (s *Server) NewMasterParticipation(name, id string) (topo.MasterParticipation, error) {
+	// Create the lock here.
+	electionPath := path.Join(s.global.root, electionsPath, name)
+	l, err := s.global.client.LockOpts(&api.LockOptions{
+		Key:   electionPath,
+		Value: []byte(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &consulMasterParticipation{
+		s:    s,
+		lock: l,
+		name: name,
+		id:   id,
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}, nil
+}
+
+// consulMasterParticipation implements topo.MasterParticipation.
+//
+// We use a key with name <global>/elections/<name> for the lock,
+// that contains the id.
+type consulMasterParticipation struct {
+	// s is our parent consul topo Server
+	s *Server
+
+	// lock is the *api.Lock structure we're going to use.
+	lock *api.Lock
+
+	// name is the name of this MasterParticipation
+	name string
+
+	// id is the process's current id.
+	id string
+
+	// stop is a channel closed when Stop is called.
+	stop chan struct{}
+
+	// done is a channel closed when we're done processing the Stop
+	done chan struct{}
+}
+
+// WaitForMastership is part of the topo.MasterParticipation interface.
+func (mp *consulMasterParticipation) WaitForMastership() (context.Context, error) {
+	// Try to lock until mp.stop is closed.
+	lost, err := mp.lock.Lock(mp.stop)
+	if err != nil {
+		// We can't lock. See if it was because we got canceled.
+		select {
+		case <-mp.stop:
+			close(mp.done)
+		default:
+		}
+		return nil, err
+	}
+
+	// We have the lock, keep mastership until we loose it.
+	lockCtx, lockCancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-lost:
+			// We lost the lock, nothing to do but lockCancel().
+			lockCancel()
+		case <-mp.stop:
+			// Stop was called. We stop the context first,
+			// so the running process is not thinking it
+			// is the master any more, then we unlock.
+			lockCancel()
+			if err := mp.lock.Unlock(); err != nil {
+				log.Errorf("master election(%v) Unlock failed: %v", mp.name, err)
+			}
+			close(mp.done)
+		}
+	}()
+
+	return lockCtx, nil
+}
+
+// Stop is part of the topo.MasterParticipation interface
+func (mp *consulMasterParticipation) Stop() {
+	close(mp.stop)
+	<-mp.done
+}
+
+// GetCurrentMasterID is part of the topo.MasterParticipation interface
+func (mp *consulMasterParticipation) GetCurrentMasterID(ctx context.Context) (string, error) {
+	electionPath := path.Join(mp.s.global.root, electionsPath, mp.name)
+	pair, _, err := mp.s.global.kv.Get(electionPath, nil)
+	if err != nil {
+		return "", err
+	}
+	if pair == nil {
+		return "", nil
+	}
+	return string(pair.Value), nil
+}

--- a/go/vt/topo/consultopo/error.go
+++ b/go/vt/topo/consultopo/error.go
@@ -1,0 +1,32 @@
+package consultopo
+
+import (
+	"errors"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// Errors specific to this package.
+var (
+	// ErrBadResponse is returned from this package if the
+	// response from the consul server does not contain the data
+	// that the API promises. The consul client unmarshals JSON
+	// from the server into a Response struct that uses pointers,
+	// so we need to check for nil pointers, or else a misbehaving
+	// consul could cause us to panic.
+	ErrBadResponse = errors.New("consul request returned success, but response is missing required data")
+)
+
+// convertError converts a context error into a topo error. All errors
+// are either application-level errors, or context errors.
+func convertError(err error) error {
+	switch err {
+	case context.Canceled:
+		return topo.ErrInterrupted
+	case context.DeadlineExceeded:
+		return topo.ErrTimeout
+	}
+	return err
+}

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -1,0 +1,146 @@
+package consultopo
+
+import (
+	"path"
+
+	"golang.org/x/net/context"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// Create is part of the topo.Backend interface.
+func (s *Server) Create(ctx context.Context, cell, filePath string, contents []byte) (topo.Version, error) {
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return nil, err
+	}
+	nodePath := path.Join(c.root, filePath)
+
+	// We need to do a Put with version=0 and get the version
+	// back.  KV.CAS does not return that information. However, a
+	// CAS in a transaction will return the node's data, so we use that.
+	ops := api.KVTxnOps{
+		&api.KVTxnOp{
+			Verb:  api.KVCAS,
+			Key:   nodePath,
+			Value: contents,
+			Index: 0,
+		},
+	}
+	ok, resp, _, err := c.kv.Txn(ops, nil)
+	if err != nil {
+		// Communication error.
+		return nil, err
+	}
+	if !ok {
+		// Transaction was rolled back, means the node exists.
+		return nil, topo.ErrNodeExists
+	}
+	return ConsulVersion(resp.Results[0].ModifyIndex), nil
+}
+
+// Update is part of the topo.Backend interface.
+func (s *Server) Update(ctx context.Context, cell, filePath string, contents []byte, version topo.Version) (topo.Version, error) {
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return nil, err
+	}
+	nodePath := path.Join(c.root, filePath)
+
+	// Again, we need to get the final version back.
+	// So we have to use a transactions, as Put doesn't return the version.
+	ops := api.KVTxnOps{
+		&api.KVTxnOp{
+			Verb:  api.KVSet,
+			Key:   nodePath,
+			Value: contents,
+		},
+	}
+	if version != nil {
+		ops[0].Verb = api.KVCAS
+		ops[0].Index = uint64(version.(ConsulVersion))
+	}
+	ok, resp, _, err := c.kv.Txn(ops, nil)
+	if err != nil {
+		// Communication error.
+		return nil, err
+	}
+	if !ok {
+		// Transaction was rolled back, means the node has a
+		// bad version.
+		return nil, topo.ErrBadVersion
+	}
+	return ConsulVersion(resp.Results[0].ModifyIndex), nil
+}
+
+// Get is part of the topo.Backend interface.
+func (s *Server) Get(ctx context.Context, cell, filePath string) ([]byte, topo.Version, error) {
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return nil, nil, err
+	}
+	nodePath := path.Join(c.root, filePath)
+
+	pair, _, err := c.kv.Get(nodePath, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if pair == nil {
+		return nil, nil, topo.ErrNoNode
+	}
+
+	return pair.Value, ConsulVersion(pair.ModifyIndex), nil
+}
+
+// Delete is part of the topo.Backend interface.
+func (s *Server) Delete(ctx context.Context, cell, filePath string, version topo.Version) error {
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return err
+	}
+	nodePath := path.Join(c.root, filePath)
+
+	// We need to differentiate if the node existed or not.
+	// So we cannot use a regular Delete, which doesn't tell us.
+	// Let's do a 'Get' and then a 'Delete' in a transaction:
+	// - If the node doesn't exists, the Get will fail and abort.
+	// - If the node exists, the Get will work, and the Delete will
+	// then execute (and may or may not work for other reasons).
+	ops := api.KVTxnOps{
+		&api.KVTxnOp{
+			Verb: api.KVGet,
+			Key:  nodePath,
+		},
+		&api.KVTxnOp{
+			Verb: api.KVDelete,
+			Key:  nodePath,
+		},
+	}
+	if version != nil {
+		// if we have a version, the delete we use specifies it.
+		ops[1].Verb = api.KVDeleteCAS
+		ops[1].Index = uint64(version.(ConsulVersion))
+	}
+	ok, resp, _, err := c.kv.Txn(ops, nil)
+	if err != nil {
+		// Communication error.
+		return err
+	}
+	if !ok {
+		// Transaction was rolled back, means the Get failed,
+		// or the Delete had the wrong version. See which one it was.
+		switch resp.Errors[0].OpIndex {
+		case 0:
+			// Get failed (operation 0), the node didn't exist.
+			return topo.ErrNoNode
+		case 1:
+			// DeleteCAS failed (operation 1), means bad version.
+			return topo.ErrBadVersion
+		default:
+			// very unexpected.
+			return ErrBadResponse
+		}
+	}
+	return nil
+}

--- a/go/vt/topo/consultopo/file.go
+++ b/go/vt/topo/consultopo/file.go
@@ -49,7 +49,7 @@ func (s *Server) Update(ctx context.Context, cell, filePath string, contents []b
 	nodePath := path.Join(c.root, filePath)
 
 	// Again, we need to get the final version back.
-	// So we have to use a transactions, as Put doesn't return the version.
+	// So we have to use a transaction, as Put doesn't return the version.
 	ops := api.KVTxnOps{
 		&api.KVTxnOp{
 			Verb:  api.KVSet,
@@ -102,7 +102,8 @@ func (s *Server) Delete(ctx context.Context, cell, filePath string, version topo
 	nodePath := path.Join(c.root, filePath)
 
 	// We need to differentiate if the node existed or not.
-	// So we cannot use a regular Delete, which doesn't tell us.
+	// So we cannot use a regular Delete, which returns success
+	// whether or not the node originally existed.
 	// Let's do a 'Get' and then a 'Delete' in a transaction:
 	// - If the node doesn't exists, the Get will fail and abort.
 	// - If the node exists, the Get will work, and the Delete will

--- a/go/vt/topo/consultopo/keyspace.go
+++ b/go/vt/topo/consultopo/keyspace.go
@@ -1,0 +1,79 @@
+// Copyright 2014, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// CreateKeyspace implements topo.Server.
+func (s *Server) CreateKeyspace(ctx context.Context, keyspace string, value *topodatapb.Keyspace) error {
+	data, err := proto.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	keyspacePath := path.Join(keyspacesPath, keyspace, topo.KeyspaceFile)
+	_, err = s.Create(ctx, topo.GlobalCell, keyspacePath, data)
+	return err
+}
+
+// UpdateKeyspace implements topo.Server.
+func (s *Server) UpdateKeyspace(ctx context.Context, keyspace string, value *topodatapb.Keyspace, existingVersion int64) (int64, error) {
+	data, err := proto.Marshal(value)
+	if err != nil {
+		return -1, err
+	}
+
+	keyspacePath := path.Join(keyspacesPath, keyspace, topo.KeyspaceFile)
+	version, err := s.Update(ctx, topo.GlobalCell, keyspacePath, data, VersionFromInt(existingVersion))
+	if err != nil {
+		return -1, err
+	}
+	return int64(version.(ConsulVersion)), nil
+}
+
+// GetKeyspace implements topo.Server.
+func (s *Server) GetKeyspace(ctx context.Context, keyspace string) (*topodatapb.Keyspace, int64, error) {
+	keyspacePath := path.Join(keyspacesPath, keyspace, topo.KeyspaceFile)
+	data, version, err := s.Get(ctx, topo.GlobalCell, keyspacePath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	k := &topodatapb.Keyspace{}
+	if err = proto.Unmarshal(data, k); err != nil {
+		return nil, 0, fmt.Errorf("bad keyspace data %v", err)
+	}
+
+	return k, int64(version.(ConsulVersion)), nil
+}
+
+// GetKeyspaces implements topo.Server.
+func (s *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
+	children, err := s.ListDir(ctx, topo.GlobalCell, keyspacesPath)
+	switch err {
+	case nil:
+		return children, nil
+	case topo.ErrNoNode:
+		return nil, nil
+	default:
+		return nil, err
+	}
+}
+
+// DeleteKeyspace implements topo.Server.
+func (s *Server) DeleteKeyspace(ctx context.Context, keyspace string) error {
+	keyspacePath := path.Join(keyspacesPath, keyspace, topo.KeyspaceFile)
+	return s.Delete(ctx, topo.GlobalCell, keyspacePath, nil)
+}

--- a/go/vt/topo/consultopo/lock.go
+++ b/go/vt/topo/consultopo/lock.go
@@ -1,0 +1,126 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	log "github.com/golang/glog"
+	"github.com/hashicorp/consul/api"
+	"github.com/youtube/vitess/go/vt/topo"
+	"golang.org/x/net/context"
+)
+
+func (s *Server) lock(ctx context.Context, c *cellClient, lockPath, contents string) (string, error) {
+	// Build the lock structure.
+	l, err := s.global.client.LockOpts(&api.LockOptions{
+		Key:   lockPath,
+		Value: []byte(contents),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	// Wait until we are the only ones in this client trying to
+	// lock that path.
+	c.mu.Lock()
+	li, ok := c.locks[lockPath]
+	for ok {
+		// Unlock, wait for something to change.
+		c.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return "", convertError(ctx.Err())
+		case <-li.done:
+		}
+
+		// The original locker is gone, try to get it again
+		c.mu.Lock()
+		li, ok = c.locks[lockPath]
+	}
+	li = &lockInstance{
+		lock: l,
+		done: make(chan struct{}),
+	}
+	c.locks[lockPath] = li
+	c.mu.Unlock()
+
+	// We are the only ones trying to lock now.
+	// FIXME(alainjobart) We don't look at the 'lost' channel
+	// returned here. We need to fix this in our code base, to add
+	// APIs to make sure a lock is still held.
+	_, err = l.Lock(ctx.Done())
+	if err != nil {
+		// Failed to lock, give up our slot in locks map.
+		// Close the channel to unblock anyone else.
+		c.mu.Lock()
+		delete(c.locks, lockPath)
+		c.mu.Unlock()
+		close(li.done)
+
+		return "", err
+	}
+
+	// We got the lock, we're good.
+	return lockPath, nil
+}
+
+// unlock releases a lock acquired by lock() on the given directory.
+// The string returned by lock() should be passed as the actionPath.
+func (s *Server) unlock(ctx context.Context, c *cellClient, lockPath, actionPath string) error {
+	// Sanity check.
+	if lockPath != actionPath {
+		return fmt.Errorf("unlock: actionPath doesn't match directory being unlocked: %q != %q", lockPath, actionPath)
+	}
+
+	c.mu.Lock()
+	li, ok := c.locks[lockPath]
+	c.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("unlock: lock %v not held", lockPath)
+	}
+
+	// Try to unlock our lock. We will clean up our entry anyway.
+	unlockErr := li.lock.Unlock()
+
+	c.mu.Lock()
+	delete(c.locks, lockPath)
+	c.mu.Unlock()
+	close(li.done)
+
+	return unlockErr
+}
+
+// LockKeyspaceForAction implements topo.Server.
+func (s *Server) LockKeyspaceForAction(ctx context.Context, keyspace, contents string) (string, error) {
+	// Check the keyspace exists first.
+	keyspacePath := path.Join(keyspacesPath, keyspace, topo.KeyspaceFile)
+	_, _, err := s.Get(ctx, topo.GlobalCell, keyspacePath)
+	if err != nil {
+		return "", err
+	}
+
+	return s.lock(ctx, s.global, path.Join(s.global.root, keyspacesPath, keyspace, locksFilename), contents)
+}
+
+// UnlockKeyspaceForAction implements topo.Server.
+func (s *Server) UnlockKeyspaceForAction(ctx context.Context, keyspace, actionPath, results string) error {
+	log.Infof("results of %v: %v", actionPath, results)
+	return s.unlock(ctx, s.global, path.Join(s.global.root, keyspacesPath, keyspace, locksFilename), actionPath)
+}
+
+// LockShardForAction implements topo.Server.
+func (s *Server) LockShardForAction(ctx context.Context, keyspace, shard, contents string) (string, error) {
+	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)
+	_, _, err := s.Get(ctx, topo.GlobalCell, shardPath)
+	if err != nil {
+		return "", err
+	}
+
+	return s.lock(ctx, s.global, path.Join(s.global.root, keyspacesPath, keyspace, shardsPath, shard, locksFilename), contents)
+}
+
+// UnlockShardForAction implements topo.Server.
+func (s *Server) UnlockShardForAction(ctx context.Context, keyspace, shard, actionPath, results string) error {
+	log.Infof("results of %v: %v", actionPath, results)
+	return s.unlock(ctx, s.global, path.Join(s.global.root, keyspacesPath, keyspace, shardsPath, shard, locksFilename), actionPath)
+}

--- a/go/vt/topo/consultopo/replication_graph.go
+++ b/go/vt/topo/consultopo/replication_graph.go
@@ -1,0 +1,91 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// UpdateShardReplicationFields implements topo.Server.
+func (s *Server) UpdateShardReplicationFields(ctx context.Context, cell, keyspace, shard string, update func(*topodatapb.ShardReplication) error) error {
+	p := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardReplicationFile)
+
+	for {
+		data, version, err := s.Get(ctx, cell, p)
+		sr := &topodatapb.ShardReplication{}
+		switch err {
+		case topo.ErrNoNode:
+			// Empty node, version is nil
+		case nil:
+			// Use any data we got.
+			if err = proto.Unmarshal(data, sr); err != nil {
+				return fmt.Errorf("bad ShardReplication data %v", err)
+			}
+		default:
+			return err
+		}
+
+		err = update(sr)
+		switch err {
+		case topo.ErrNoUpdateNeeded:
+			return nil
+		case nil:
+			// keep going
+		default:
+			return err
+		}
+
+		// marshall and save
+		data, err = proto.Marshal(sr)
+		if err != nil {
+			return err
+		}
+		if version == nil {
+			// We have to create, and we catch ErrNodeExists.
+			_, err = s.Create(ctx, cell, p, data)
+			if err != topo.ErrNodeExists {
+				return err
+			}
+		} else {
+			// We have to update, and we catch ErrBadVersion.
+			_, err = s.Update(ctx, cell, p, data, version)
+			if err != topo.ErrBadVersion {
+				return err
+			}
+		}
+	}
+}
+
+// GetShardReplication implements topo.Server.
+func (s *Server) GetShardReplication(ctx context.Context, cell, keyspace, shard string) (*topo.ShardReplicationInfo, error) {
+	p := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardReplicationFile)
+	data, _, err := s.Get(ctx, cell, p)
+	if err != nil {
+		return nil, err
+	}
+
+	sr := &topodatapb.ShardReplication{}
+	if err = proto.Unmarshal(data, sr); err != nil {
+		return nil, fmt.Errorf("bad ShardReplication data %v", err)
+	}
+
+	return topo.NewShardReplicationInfo(sr, cell, keyspace, shard), nil
+}
+
+// DeleteShardReplication implements topo.Server.
+func (s *Server) DeleteShardReplication(ctx context.Context, cell, keyspace, shard string) error {
+	p := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardReplicationFile)
+	return s.Delete(ctx, cell, p, nil)
+}
+
+// DeleteKeyspaceReplication implements topo.Server.
+func (s *Server) DeleteKeyspaceReplication(ctx context.Context, cell, keyspace string) error {
+	p := path.Join(keyspacesPath, keyspace)
+	return s.Delete(ctx, cell, p, nil)
+}

--- a/go/vt/topo/consultopo/server.go
+++ b/go/vt/topo/consultopo/server.go
@@ -1,0 +1,92 @@
+/*
+Package consultopo implements topo.Server with consul as the backend.
+*/
+package consultopo
+
+import (
+	"path"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// Server is the implementation of topo.Server for consul.
+type Server struct {
+	// global is a client configured to talk to a list of consul instances
+	// representing the global consul cluster.
+	global *cellClient
+
+	// mu protects the cells variable.
+	mu sync.Mutex
+	// cells contains clients configured to talk to a list of
+	// consul instances representing local consul clusters. These
+	// should be accessed with the Server.clientForCell() method, which
+	// will read the list of addresses for that cell from the
+	// global cluster and create clients as needed.
+	cells map[string]*cellClient
+}
+
+// Close implements topo.Server.Close.
+// It will nil out the global and cells fields, so any attempt to
+// re-use this server will panic.
+func (s *Server) Close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.cells {
+		c.close()
+	}
+	s.cells = nil
+
+	s.global.close()
+	s.global = nil
+}
+
+// GetKnownCells implements topo.Server.GetKnownCells.
+func (s *Server) GetKnownCells(ctx context.Context) ([]string, error) {
+	nodePath := path.Join(s.global.root, cellsPath) + "/"
+
+	keys, _, err := s.global.kv.Keys(nodePath, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(keys) == 0 {
+		// No key starts with this prefix, means the directory
+		// doesn't exist.
+		return nil, topo.ErrNoNode
+	}
+
+	prefixLen := len(nodePath)
+	suffix := "/" + topo.CellInfoFile
+	suffixLen := len(suffix)
+
+	var result []string
+	for _, p := range keys {
+		if strings.HasPrefix(p, nodePath) && strings.HasSuffix(p, suffix) {
+			p = p[prefixLen : len(p)-suffixLen]
+			result = append(result, p)
+		}
+	}
+
+	return result, nil
+}
+
+// NewServer returns a new consultopo.Server.
+func NewServer(serverAddr, root string) (*Server, error) {
+	global, err := newCellClient(serverAddr, root)
+	if err != nil {
+		return nil, err
+	}
+	return &Server{
+		global: global,
+		cells:  make(map[string]*cellClient),
+	}, nil
+}
+
+func init() {
+	topo.RegisterFactory("consul", func(serverAddr, root string) (topo.Impl, error) {
+		return NewServer(serverAddr, root)
+	})
+}

--- a/go/vt/topo/consultopo/server_test.go
+++ b/go/vt/topo/consultopo/server_test.go
@@ -1,0 +1,138 @@
+package consultopo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hashicorp/consul/api"
+	"github.com/youtube/vitess/go/testfiles"
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/topo/test"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// startConsul starts an consul subprocess, and waits for it to be ready.
+// Returns the exec.Cmd forked, the config file to remove after the test,
+// and the server address to RPC-connect to.
+func startConsul(t *testing.T) (*exec.Cmd, string, string) {
+	// Create a temporary config file, as ports cannot all be set via
+	// command line.
+	configFile, err := ioutil.TempFile("", "consul")
+	if err != nil {
+		t.Fatalf("cannot create tempfile: %v", err)
+	}
+	configName := configFile.Name()
+
+	// Create the JSON config, save it.
+	port := testfiles.GoVtTopoConsultopoPort
+	config := map[string]interface{}{
+		"ports": map[string]int{
+			"dns":      port,
+			"http":     port + 1,
+			"rpc":      port + 2,
+			"serf_lan": port + 3,
+			"serf_wan": port + 4,
+		},
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatalf("cannot json-encode config: %v", err)
+	}
+	if _, err := configFile.Write(data); err != nil {
+		t.Fatalf("cannot write config: %v", err)
+	}
+	configFile.Close()
+
+	cmd := exec.Command("consul",
+		"agent",
+		"-dev",
+		"-config-file", configName)
+	err = cmd.Start()
+	if err != nil {
+		t.Fatalf("failed to start consul: %v", err)
+	}
+
+	// Create a client to connect to the created consul.
+	serverAddr := fmt.Sprintf("localhost:%v", port+1)
+	cfg := api.DefaultConfig()
+	cfg.Address = serverAddr
+	c, err := api.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("api.NewClient(%v) failed: %v", serverAddr, err)
+	}
+
+	// Wait until we can list "/", or timeout.
+	start := time.Now()
+	kv := c.KV()
+	for {
+		if _, _, err := kv.List("/", nil); err == nil {
+			break
+		}
+		if time.Now().Sub(start) > 10*time.Second {
+			t.Fatalf("Failed to start consul daemon in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return cmd, configName, serverAddr
+}
+
+func TestConsulTopo(t *testing.T) {
+	// One test is going to wait that full period, so make it shorter.
+	*watchPollDuration = 100 * time.Millisecond
+
+	// Start a single consul in the background.
+	cmd, configName, serverAddr := startConsul(t)
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+		os.Remove(configName)
+	}()
+
+	// This function will create a toplevel directory for a new test.
+	testIndex := 0
+	newServer := func() *Server {
+		// Each test will use its own sub-directories.
+		testRoot := fmt.Sprintf("test-%v", testIndex)
+		testIndex++
+
+		// Create the server on the new root.
+		s, err := NewServer(serverAddr, path.Join(testRoot, "global"))
+		if err != nil {
+			t.Fatalf("NewServer() failed: %v", err)
+		}
+
+		// Create the CellInfo.
+		cell := "test"
+		ci := &topodatapb.CellInfo{
+			ServerAddress: serverAddr,
+			Root:          path.Join(testRoot, cell),
+		}
+		data, err := proto.Marshal(ci)
+		if err != nil {
+			t.Fatalf("cannot proto.Marshal CellInfo: %v", err)
+		}
+		nodePath := path.Join(s.global.root, cellsPath, cell, topo.CellInfoFile)
+		if _, err := s.global.kv.Put(&api.KVPair{
+			Key:   nodePath,
+			Value: data,
+		}, nil); err != nil {
+			t.Fatalf("s.global.kv.Put(%v) failed: %v", nodePath, err)
+		}
+
+		return s
+	}
+
+	// Run the TopoServerTestSuite tests.
+	test.TopoServerTestSuite(t, func() topo.Impl {
+		return newServer()
+	})
+}

--- a/go/vt/topo/consultopo/serving_graph.go
+++ b/go/vt/topo/consultopo/serving_graph.go
@@ -1,0 +1,83 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
+)
+
+// GetSrvKeyspaceNames implements topo.Server.
+func (s *Server) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]string, error) {
+	children, err := s.ListDir(ctx, cell, keyspacesPath)
+	switch err {
+	case nil:
+		return children, nil
+	case topo.ErrNoNode:
+		return nil, nil
+	default:
+		return nil, err
+	}
+}
+
+// UpdateSrvKeyspace implements topo.Server.
+func (s *Server) UpdateSrvKeyspace(ctx context.Context, cell, keyspace string, srvKeyspace *topodatapb.SrvKeyspace) error {
+	nodePath := path.Join(keyspacesPath, keyspace, topo.SrvKeyspaceFile)
+	data, err := proto.Marshal(srvKeyspace)
+	if err != nil {
+		return err
+	}
+	_, err = s.Update(ctx, cell, nodePath, data, nil)
+	return err
+}
+
+// DeleteSrvKeyspace implements topo.Server.
+func (s *Server) DeleteSrvKeyspace(ctx context.Context, cell, keyspace string) error {
+	nodePath := path.Join(keyspacesPath, keyspace, topo.SrvKeyspaceFile)
+	return s.Delete(ctx, cell, nodePath, nil)
+}
+
+// GetSrvKeyspace implements topo.Server.
+func (s *Server) GetSrvKeyspace(ctx context.Context, cell, keyspace string) (*topodatapb.SrvKeyspace, error) {
+	nodePath := path.Join(keyspacesPath, keyspace, topo.SrvKeyspaceFile)
+	data, _, err := s.Get(ctx, cell, nodePath)
+	if err != nil {
+		return nil, err
+	}
+	srvKeyspace := &topodatapb.SrvKeyspace{}
+	if err := proto.Unmarshal(data, srvKeyspace); err != nil {
+		return nil, fmt.Errorf("SrvKeyspace unmarshal failed: %v %v", data, err)
+	}
+	return srvKeyspace, nil
+}
+
+// UpdateSrvVSchema implements topo.Server.
+func (s *Server) UpdateSrvVSchema(ctx context.Context, cell string, srvVSchema *vschemapb.SrvVSchema) error {
+	nodePath := topo.SrvVSchemaFile
+	data, err := proto.Marshal(srvVSchema)
+	if err != nil {
+		return err
+	}
+	_, err = s.Update(ctx, cell, nodePath, data, nil)
+	return err
+}
+
+// GetSrvVSchema implements topo.Server.
+func (s *Server) GetSrvVSchema(ctx context.Context, cell string) (*vschemapb.SrvVSchema, error) {
+	nodePath := topo.SrvVSchemaFile
+	data, _, err := s.Get(ctx, cell, nodePath)
+	if err != nil {
+		return nil, err
+	}
+	srvVSchema := &vschemapb.SrvVSchema{}
+	if err := proto.Unmarshal(data, srvVSchema); err != nil {
+		return nil, fmt.Errorf("SrvVSchema unmarshal failed: %v %v", data, err)
+	}
+	return srvVSchema, nil
+}

--- a/go/vt/topo/consultopo/shard.go
+++ b/go/vt/topo/consultopo/shard.go
@@ -1,0 +1,79 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// CreateShard implements topo.Server.
+func (s *Server) CreateShard(ctx context.Context, keyspace, shard string, value *topodatapb.Shard) error {
+	data, err := proto.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)
+	_, err = s.Create(ctx, topo.GlobalCell, shardPath, data)
+	return err
+}
+
+// UpdateShard implements topo.Server.
+func (s *Server) UpdateShard(ctx context.Context, keyspace, shard string, value *topodatapb.Shard, existingVersion int64) (int64, error) {
+	data, err := proto.Marshal(value)
+	if err != nil {
+		return -1, err
+	}
+
+	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)
+	version, err := s.Update(ctx, topo.GlobalCell, shardPath, data, VersionFromInt(existingVersion))
+	if err != nil {
+		return -1, err
+	}
+	return int64(version.(ConsulVersion)), nil
+}
+
+// GetShard implements topo.Server.
+func (s *Server) GetShard(ctx context.Context, keyspace, shard string) (*topodatapb.Shard, int64, error) {
+	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)
+	data, version, err := s.Get(ctx, topo.GlobalCell, shardPath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	sh := &topodatapb.Shard{}
+	if err = proto.Unmarshal(data, sh); err != nil {
+		return nil, 0, fmt.Errorf("bad shard data: %v", err)
+	}
+
+	return sh, int64(version.(ConsulVersion)), nil
+}
+
+// GetShardNames implements topo.Server.
+func (s *Server) GetShardNames(ctx context.Context, keyspace string) ([]string, error) {
+	shardsPath := path.Join(keyspacesPath, keyspace, shardsPath)
+	children, err := s.ListDir(ctx, topo.GlobalCell, shardsPath)
+	if err == topo.ErrNoNode {
+		// The directory doesn't exist, let's see if the keyspace
+		// is here or not.
+		_, _, kerr := s.GetKeyspace(ctx, keyspace)
+		if kerr == nil {
+			// Keyspace is here, means no shards.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return children, err
+}
+
+// DeleteShard implements topo.Server.
+func (s *Server) DeleteShard(ctx context.Context, keyspace, shard string) error {
+	shardPath := path.Join(keyspacesPath, keyspace, shardsPath, shard, topo.ShardFile)
+	return s.Delete(ctx, topo.GlobalCell, shardPath, nil)
+}

--- a/go/vt/topo/consultopo/tablet.go
+++ b/go/vt/topo/consultopo/tablet.go
@@ -1,0 +1,93 @@
+package consultopo
+
+import (
+	"path"
+	"sort"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/topo/topoproto"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// tabletPathForAlias converts a tablet alias to the node path.
+func tabletPathForAlias(alias *topodatapb.TabletAlias) string {
+	return path.Join(tabletsPath, topoproto.TabletAliasString(alias), topo.TabletFile)
+}
+
+// CreateTablet implements topo.Server.
+func (s *Server) CreateTablet(ctx context.Context, tablet *topodatapb.Tablet) error {
+	data, err := proto.Marshal(tablet)
+	if err != nil {
+		return err
+	}
+
+	nodePath := tabletPathForAlias(tablet.Alias)
+	_, err = s.Create(ctx, tablet.Alias.Cell, nodePath, data)
+	return err
+}
+
+// UpdateTablet implements topo.Server.
+func (s *Server) UpdateTablet(ctx context.Context, tablet *topodatapb.Tablet, existingVersion int64) (int64, error) {
+	data, err := proto.Marshal(tablet)
+	if err != nil {
+		return 0, err
+	}
+
+	nodePath := tabletPathForAlias(tablet.Alias)
+	version, err := s.Update(ctx, tablet.Alias.Cell, nodePath, data, VersionFromInt(existingVersion))
+	if err != nil {
+		return 0, err
+	}
+	return int64(version.(ConsulVersion)), nil
+}
+
+// DeleteTablet implements topo.Server.
+func (s *Server) DeleteTablet(ctx context.Context, alias *topodatapb.TabletAlias) error {
+	nodePath := tabletPathForAlias(alias)
+	return s.Delete(ctx, alias.Cell, nodePath, nil)
+}
+
+// GetTablet implements topo.Server.
+func (s *Server) GetTablet(ctx context.Context, alias *topodatapb.TabletAlias) (*topodatapb.Tablet, int64, error) {
+	nodePath := tabletPathForAlias(alias)
+	data, version, err := s.Get(ctx, alias.Cell, nodePath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	tablet := &topodatapb.Tablet{}
+	if err := proto.Unmarshal(data, tablet); err != nil {
+		return nil, 0, err
+	}
+	return tablet, int64(version.(ConsulVersion)), nil
+}
+
+// GetTabletsByCell implements topo.Server.
+func (s *Server) GetTabletsByCell(ctx context.Context, cell string) ([]*topodatapb.TabletAlias, error) {
+	// Check if the cell exists first.
+	if _, err := s.clientForCell(ctx, cell); err != nil {
+		return nil, err
+	}
+
+	children, err := s.ListDir(ctx, cell, tabletsPath)
+	if err != nil {
+		if err == topo.ErrNoNode {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	sort.Strings(children)
+	result := make([]*topodatapb.TabletAlias, len(children))
+	for i, child := range children {
+		result[i], err = topoproto.ParseTabletAlias(child)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
+}

--- a/go/vt/topo/consultopo/version.go
+++ b/go/vt/topo/consultopo/version.go
@@ -1,0 +1,27 @@
+package consultopo
+
+import (
+	"fmt"
+
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// ConsulVersion is consul's idea of a version.
+// It implements topo.Version.
+// We use the native consul version type, uint64.
+type ConsulVersion uint64
+
+// String is part of the topo.Version interface.
+func (v ConsulVersion) String() string {
+	return fmt.Sprintf("%v", uint64(v))
+}
+
+// VersionFromInt is used by old-style functions to create a proper
+// Version: if version is -1, returns nil. Otherwise returns the
+// ConsulVersion object.
+func VersionFromInt(version int64) topo.Version {
+	if version == -1 {
+		return nil
+	}
+	return ConsulVersion(version)
+}

--- a/go/vt/topo/consultopo/vschema.go
+++ b/go/vt/topo/consultopo/vschema.go
@@ -1,0 +1,49 @@
+package consultopo
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/topo"
+
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
+)
+
+/*
+This file contains the vschema management code for consultopo.Server
+*/
+
+// SaveVSchema saves the JSON vschema into the topo.
+func (s *Server) SaveVSchema(ctx context.Context, keyspace string, vschema *vschemapb.Keyspace) error {
+	p := path.Join(keyspacesPath, keyspace, topo.VSchemaFile)
+	data, err := proto.Marshal(vschema)
+	if err != nil {
+		return err
+	}
+
+	if len(data) == 0 {
+		// No vschema, remove it. So we can remove the keyspace.
+		err = s.Delete(ctx, topo.GlobalCell, p, nil)
+	} else {
+		_, err = s.Update(ctx, topo.GlobalCell, p, data, nil)
+	}
+	return err
+}
+
+// GetVSchema fetches the vschema from the topo.
+func (s *Server) GetVSchema(ctx context.Context, keyspace string) (*vschemapb.Keyspace, error) {
+	p := path.Join(keyspacesPath, keyspace, topo.VSchemaFile)
+	data, _, err := s.Get(ctx, topo.GlobalCell, p)
+	if err != nil {
+		return nil, err
+	}
+	var vs vschemapb.Keyspace
+	err = proto.Unmarshal(data, &vs)
+	if err != nil {
+		return nil, fmt.Errorf("bad vschema data (%v): %q", err, data)
+	}
+	return &vs, nil
+}

--- a/go/vt/topo/consultopo/watch.go
+++ b/go/vt/topo/consultopo/watch.go
@@ -1,0 +1,99 @@
+package consultopo
+
+import (
+	"flag"
+	"fmt"
+	"path"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+var (
+	watchPollDuration = flag.Duration("topo_consul_watch_poll_duration", 30*time.Second, "time of the long poll for watch queries. Interrupting a watch may wait for up to that time.")
+)
+
+// Watch is part of the topo.Backend interface.
+func (s *Server) Watch(ctx context.Context, cell, filePath string) (*topo.WatchData, <-chan *topo.WatchData, topo.CancelFunc) {
+	// Initial get.
+	c, err := s.clientForCell(ctx, cell)
+	if err != nil {
+		return &topo.WatchData{Err: fmt.Errorf("Watch cannot get cell: %v", err)}, nil, nil
+	}
+	nodePath := path.Join(c.root, filePath)
+
+	pair, _, err := c.kv.Get(nodePath, nil)
+	if err != nil {
+		return &topo.WatchData{Err: err}, nil, nil
+	}
+	if pair == nil {
+		// Node doesn't exist.
+		return &topo.WatchData{Err: topo.ErrNoNode}, nil, nil
+	}
+
+	// Initial value to return.
+	wd := &topo.WatchData{
+		Contents: pair.Value,
+		Version:  ConsulVersion(pair.ModifyIndex),
+	}
+
+	// Create a context, will be used to cancel the watch.
+	watchCtx, watchCancel := context.WithCancel(context.Background())
+
+	// Create the notifications channel, send updates to it.
+	notifications := make(chan *topo.WatchData, 10)
+	go func() {
+		defer close(notifications)
+
+		for {
+			// Wait/poll until we get a new version.
+			// Get with a WaitIndex and WaitTime will return
+			// the current version at the end of WaitTime
+			// if it didn't change. So we just check for that
+			// and swallow the notifications when version matches.
+			waitIndex := pair.ModifyIndex
+			pair, _, err = c.kv.Get(nodePath, &api.QueryOptions{
+				WaitIndex: waitIndex,
+				WaitTime:  *watchPollDuration,
+			})
+			if err != nil {
+				// Serious error.
+				notifications <- &topo.WatchData{
+					Err: err,
+				}
+				return
+			}
+
+			// If the node disappeared, pair is nil.
+			if pair == nil {
+				notifications <- &topo.WatchData{
+					Err: topo.ErrNoNode,
+				}
+				return
+			}
+
+			// If we got a new value, send it.
+			if pair.ModifyIndex != waitIndex {
+				notifications <- &topo.WatchData{
+					Contents: pair.Value,
+					Version:  ConsulVersion(pair.ModifyIndex),
+				}
+			}
+
+			// See if the watch was canceled.
+			select {
+			case <-watchCtx.Done():
+				notifications <- &topo.WatchData{
+					Err: convertError(watchCtx.Err()),
+				}
+				return
+			default:
+			}
+		}
+	}()
+
+	return wd, notifications, topo.CancelFunc(watchCancel)
+}

--- a/go/vt/topo/etcd2topo/file.go
+++ b/go/vt/topo/etcd2topo/file.go
@@ -42,7 +42,7 @@ func (s *Server) Update(ctx context.Context, cell, filePath string, contents []b
 
 	if version != nil {
 		// We have to do a transaction. This means: if the
-		// current file revision if what we expect, save it.
+		// current file revision is what we expect, save it.
 		txnresp, err := c.cli.Txn(ctx).
 			If(clientv3.Compare(clientv3.ModRevision(nodePath), "=", int64(version.(EtcdVersion)))).
 			Then(clientv3.OpPut(nodePath, string(contents))).

--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"path"
 	"strconv"
-	"time"
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
@@ -27,34 +26,33 @@ var (
 // It is linked to the Lease.
 // Errors returned are converted to topo errors.
 func (s *Server) newUniqueEphemeralKV(ctx context.Context, leaseID clientv3.LeaseID, nodePath string, contents string) (string, int64, error) {
-	for {
-		newKey := fmt.Sprintf("%v/%v", nodePath, time.Now().UnixNano())
+	// Use the lease ID as the file name, so it's guaranteed unique.
+	newKey := fmt.Sprintf("%v/%v", nodePath, leaseID)
 
-		// Only create a new file if it doesn't exist already
-		// (version = 0), to avoid two processes using the
-		// same file name.
-		txnresp, err := s.global.cli.Txn(ctx).
-			If(clientv3.Compare(clientv3.Version(newKey), "=", 0)).
-			Then(clientv3.OpPut(newKey, contents, clientv3.WithLease(leaseID))).
-			Commit()
-		if err != nil {
-			if err == context.Canceled || err == context.DeadlineExceeded {
-				// Our context was canceled as we were sending
-				// a creation request. We don't know if it
-				// succeeded or not. In any case, let's try to
-				// delete the node, so we don't leave an orphan
-				// node behind for *leaseTTL time.
-				s.global.cli.Delete(context.Background(), newKey)
-			}
-			return "", 0, convertError(err)
+	// Only create a new file if it doesn't exist already
+	// (version = 0), to avoid two processes using the
+	// same file name. Since we use the lease ID, this should never happen.
+	txnresp, err := s.global.cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.Version(newKey), "=", 0)).
+		Then(clientv3.OpPut(newKey, contents, clientv3.WithLease(leaseID))).
+		Commit()
+	if err != nil {
+		if err == context.Canceled || err == context.DeadlineExceeded {
+			// Our context was canceled as we were sending
+			// a creation request. We don't know if it
+			// succeeded or not. In any case, let's try to
+			// delete the node, so we don't leave an orphan
+			// node behind for *leaseTTL time.
+			s.global.cli.Delete(context.Background(), newKey)
 		}
-		if !txnresp.Succeeded {
-			// The key already exists, try again.
-			continue
-		}
-		// The key was created.
-		return newKey, txnresp.Header.Revision, nil
+		return "", 0, convertError(err)
 	}
+	if !txnresp.Succeeded {
+		// The key already exists, that should not happen.
+		return "", 0, ErrBadResponse
+	}
+	// The key was created.
+	return newKey, txnresp.Header.Revision, nil
 }
 
 // waitOnLastRev waits on all revisions of the files in the provided

--- a/go/vt/topo/etcd2topo/server_test.go
+++ b/go/vt/topo/etcd2topo/server_test.go
@@ -73,7 +73,7 @@ func startEtcd(t *testing.T) (*exec.Cmd, string, string) {
 	return cmd, dataDir, clientAddr
 }
 
-func TestEtcdTopo(t *testing.T) {
+func TestEtcd2Topo(t *testing.T) {
 	// Start a single etcd in the background.
 	cmd, dataDir, clientAddr := startEtcd(t)
 	defer func() {

--- a/go/vt/vtctl/plugin_consultopo.go
+++ b/go/vt/vtctl/plugin_consultopo.go
@@ -1,0 +1,7 @@
+package vtctl
+
+import (
+	// Imports consultopo to register the consul implementation of
+	// TopoServer.
+	_ "github.com/youtube/vitess/go/vt/topo/consultopo"
+)

--- a/test/config.json
+++ b/test/config.json
@@ -335,6 +335,17 @@
 				"site_test"
 			]
 		},
+		"tabletmanager_consul": {
+			"File": "tabletmanager.py",
+			"Args": ["--topo-server-flavor=consul"],
+			"Command": [],
+			"Manual": false,
+			"Shard": 1,
+			"RetryMax": 0,
+			"Tags": [
+				"site_test"
+			]
+		},
 		"unit": {
 			"File": "",
 			"Args": [],

--- a/test/environment.py
+++ b/test/environment.py
@@ -15,6 +15,7 @@ import topo_flavor.zookeeper
 import topo_flavor.zk2
 import topo_flavor.etcd
 import topo_flavor.etcd2
+import topo_flavor.consul
 
 # This imports topo_server into this module, so clients can write
 # environment.topo_server().

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -495,6 +495,24 @@
 			"revisionTime": "2016-11-28T00:20:07Z"
 		},
 		{
+			"checksumSHA1": "FXiaccMs+1NvIHh8W44lQJeGqms=",
+			"path": "github.com/hashicorp/consul/api",
+			"revision": "dc2a54a77b3b053e77298d4ce587bdf0bd0bcd1c",
+			"revisionTime": "2016-12-21T13:20:54Z"
+		},
+		{
+			"checksumSHA1": "Uzyon2091lmwacNsl1hCytjhHtg=",
+			"path": "github.com/hashicorp/go-cleanhttp",
+			"revision": "ad28ea4487f05916463e2423a55166280e8254b5",
+			"revisionTime": "2016-04-07T17:41:26Z"
+		},
+		{
+			"checksumSHA1": "E3Xcanc9ouQwL+CZGOUyA/+giLg=",
+			"path": "github.com/hashicorp/serf/coordinate",
+			"revision": "d3a67ab21bc8a4643fa53a3633f2d951dd50c6ca",
+			"revisionTime": "2016-12-07T01:17:43Z"
+		},
+		{
 			"checksumSHA1": "fe0NspvyJjx6DhmTjIpO0zmR+kg=",
 			"path": "github.com/influxdb/influxdb/client",
 			"revision": "afde71eb1740fd763ab9450e1f700ba0e53c36d0",

--- a/vitess.io/resources/roadmap.md
+++ b/vitess.io/resources/roadmap.md
@@ -83,6 +83,8 @@ following core features:
   `zk2` and `etcd2` implementations will remain, so please migrate after upgrade
   to Vitess 2.1.
   
+* Added support for [Consul](http://consul.io) topology service client.
+
 * Initial version of the Master Buffering feature. It allows for buffering
   master traffic while a failover is in progress, and trade downtime with
   extra latency.


### PR DESCRIPTION
This change adds full support for a Consul-based topology service.
See https://www.consul.io/ for more information.

- Adding consul server to bootstrap.sh for download.
- Adding client library to vendor.json.
- In unit tests, we start a dev Consul instance.
- Adding consul support in end-to-end tests.
  Also running the test in travis.
- Updating topo doc.