### PR TITLE
Mysql protocol implementation.

### DIFF
--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -7,6 +7,7 @@ set -e
 cell='test'
 web_port=15001
 grpc_port=15991
+mysql_server_port=3306
 
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
@@ -17,6 +18,7 @@ $VTROOT/bin/vtgate \
   -log_dir $VTDATAROOT/tmp \
   -port $web_port \
   -grpc_port $grpc_port \
+  -mysql_server_port $mysql_server_port \
   -cell $cell \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \

--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -231,7 +231,7 @@ func (conn *Connection) ExecuteFetch(query string, maxrows int, wantfields bool)
 		return nil, &sqldb.SQLError{
 			Num:     0,
 			Message: fmt.Sprintf("Row count exceeded %d", maxrows),
-			Query:   string(query),
+			Query:   query,
 		}
 	}
 	if wantfields {

--- a/go/mysqlconn/client.go
+++ b/go/mysqlconn/client.go
@@ -1,0 +1,485 @@
+package mysqlconn
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqldb"
+)
+
+// connectResult is used by Connect.
+type connectResult struct {
+	c   *Conn
+	err error
+}
+
+// Connect creates a connection to a server.
+// It then handles the initial handshake.
+//
+// If context is canceled before the end of the process, this function
+// will return nil, ctx.Err().
+//
+// FIXME(alainjobart) once we have more of a server side, add test cases
+// to cover all failure scenarios.
+func Connect(ctx context.Context, params *sqldb.ConnParams) (*Conn, error) {
+	netProto := "tcp"
+	addr := ""
+	if params.UnixSocket != "" {
+		netProto = "unix"
+		addr = params.UnixSocket
+	} else {
+		addr = net.JoinHostPort(params.Host, fmt.Sprintf("%v", params.Port))
+	}
+
+	// Figure out the character set we want.
+	characterSet, err := parseCharacterSet(params.Charset)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start a background connection routine.  It first
+	// establishes a network connection, returns it on the channel,
+	// then starts the negotiation, and returns the result on the channel.
+	// It can send on the channel, before closing it:
+	// - a connectResult with an error and nothing else (when dial fails).
+	// - a connectResult with a *Conn and no error, then another one
+	//   with possibly an error.
+	status := make(chan connectResult)
+	go func() {
+		defer close(status)
+		var err error
+		var conn net.Conn
+
+		// Cap the Dial time with the context deadline, plus a
+		// few seconds. We want to reclaim resources quickly
+		// and not let this go routine stuck in Dial forever.
+		//
+		// We add a few seconds so we detect the context is
+		// Done() before timing out the Dial. That way we'll
+		// return the right error to the client (ctx.Err(), vs
+		// DialTimeout() error).
+		if deadline, ok := ctx.Deadline(); ok {
+			timeout := deadline.Sub(time.Now()) + 5*time.Second
+			conn, err = net.DialTimeout(netProto, addr, timeout)
+		} else {
+			conn, err = net.Dial(netProto, addr)
+		}
+		if err != nil {
+			status <- connectResult{
+				err: sqldb.NewSQLError(CRConnectionError, "", "net.Dial(%v,%v) failed: %v", netProto, addr, err),
+			}
+			return
+		}
+
+		// Send the connection back, so the other side can close it.
+		c := newConn(conn)
+		status <- connectResult{
+			c: c,
+		}
+
+		// During the handshake, and if the context is
+		// canceled, the connection will be closed. That will
+		// make any read or write just return with an error
+		// right away.
+		status <- connectResult{
+			err: c.clientHandshake(characterSet, params),
+		}
+	}()
+
+	// Wait on the context and the status, for the connection to happen.
+	var c *Conn
+	select {
+	case <-ctx.Done():
+		// The background routine may send us a few things,
+		// wait for them and terminate them properly in the
+		// background.
+		go func() {
+			dialCR := <-status // This one can take a while.
+			if dialCR.err != nil {
+				// Dial failed, nothing else to do.
+				return
+			}
+			// Dial worked, close the connection, wait for the end.
+			// We wait as not to leave a channel with an unread value.
+			dialCR.c.Close()
+			<-status
+		}()
+		return nil, ctx.Err()
+	case cr := <-status:
+		if cr.err != nil {
+			// Dial failed, no connection was ever established.
+			return nil, cr.err
+		}
+
+		// Dial worked, we have a connection. Keep going.
+		c = cr.c
+	}
+
+	// Wait for the end of the handshake.
+	select {
+	case <-ctx.Done():
+		// We are interrupted. Close the connection, wait for
+		// the handshake to finish in the background.
+		c.Close()
+		go func() {
+			// Since we closed the connection, this one should be fast.
+			// We wait as not to leave a channel with an unread value.
+			<-status
+		}()
+		return nil, ctx.Err()
+	case cr := <-status:
+		if cr.err != nil {
+			c.Close()
+			return nil, cr.err
+		}
+	}
+	return c, nil
+}
+
+// parseCharacterSet parses the provided character set.
+func parseCharacterSet(cs string) (uint8, error) {
+	// Check if it's empty, return utf8. This is a reasonable default.
+	if cs == "" {
+		return CharacterSetUtf8, nil
+	}
+
+	// Check if it's in our map.
+	characterSet, ok := CharacterSetMap[strings.ToLower(cs)]
+	if ok {
+		return characterSet, nil
+	}
+
+	// As a fallback, try to parse a number. So we support more values.
+	if i, err := strconv.ParseInt(cs, 10, 8); err == nil {
+		return uint8(i), nil
+	}
+
+	// No luck.
+	return 0, fmt.Errorf("failed to interpret character set '%v'. Try using an integer value if needed", cs)
+}
+
+// clientHandshake handles the client side of the handshake.
+// Note the connection can be closed while this is running.
+func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) error {
+	// Wait for the server initial handshake packet, and parse it.
+	data, err := c.readPacket()
+	if err != nil {
+		return sqldb.NewSQLError(CRConnHostError, "", "initial packet read failed: %v", err)
+	}
+	capabilities, cipher, err := c.parseInitialHandshakePacket(data)
+	if err != nil {
+		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "parsing initial handshake packet failed: %v", err)
+	}
+
+	// Sanity check.
+	if capabilities&CapabilityClientProtocol41 == 0 {
+		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "cannot connect to servers earlier than 4.1")
+	}
+
+	// If client asked for SSL, but server doesn't support it, stop right here.
+	if capabilities&CapabilityClientSSL == 0 && params.SslCert != "" && params.SslKey != "" {
+		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "server doesn't support SSL but client asked for it")
+	}
+
+	// Remember a subset of the capabilities, so we can use them later in the protocol.
+	c.Capabilities = capabilities & (CapabilityClientDeprecateEOF)
+
+	// Build and send our handshake response 41.
+	if err := c.writeHandshakeResponse41(capabilities, cipher, characterSet, params); err != nil {
+		return err
+	}
+
+	// Read the server response.
+	response, err := c.readPacket()
+	if err != nil {
+		return fmt.Errorf("initial server response failed: %v", err)
+	}
+	switch response[0] {
+	case OKPacket:
+		// OK packet, we are authenticated. We keep going.
+	case ErrPacket:
+		return parseErrorPacket(response)
+	default:
+		// FIXME(alainjobart) handle extra auth cases and so on.
+		return fmt.Errorf("initial server response is asking for more information, not implemented yet: %v", response)
+	}
+
+	// If the server didn't support DbName in its handshake, set
+	// it now. This is what the 'mysql' client does.
+	if capabilities&CapabilityClientConnectWithDB == 0 && params.DbName != "" {
+		// Write the packet.
+		if err := c.writeComInitDB(params.DbName); err != nil {
+			return fmt.Errorf("failed to write ComInitDB packet: %v", err)
+		}
+
+		// Wait for response, should be OK.
+		response, err := c.readPacket()
+		if err != nil {
+			return fmt.Errorf("initial server response failed: %v", err)
+		}
+		switch response[0] {
+		case OKPacket:
+			// OK packet, we are authenticated.
+			return nil
+		case ErrPacket:
+			return parseErrorPacket(response)
+		default:
+			// FIXME(alainjobart) handle extra auth cases and so on.
+			return fmt.Errorf("initial server response is asking for more information, not implemented yet: %v", response)
+		}
+	}
+
+	return nil
+}
+
+func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) {
+	pos := 0
+
+	// Protocol version.
+	pver, pos, ok := readByte(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no protocol version")
+	}
+	if pver != protocolVersion {
+		return 0, nil, fmt.Errorf("bad protocol version: %v", pver)
+	}
+
+	// Read the server version.
+	c.ServerVersion, pos, ok = readNullString(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no server version")
+	}
+
+	// Read the connection id.
+	c.ConnectionID, pos, ok = readUint32(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no conneciton id")
+	}
+
+	// Read the first part of the auth-plugin-data
+	authPluginData, pos, ok := readBytes(data, pos, 8)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no auth-plugin-data-part-1")
+	}
+
+	// One byte filler, 0. We don't really care about the value.
+	_, pos, ok = readByte(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no filler")
+	}
+
+	// Lower 2 bytes of the capability flags.
+	capLower, pos, ok := readUint16(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no capability flags (lower 2 bytes)")
+	}
+	var capabilities = uint32(capLower)
+
+	// The packet can end here.
+	if pos == len(data) {
+		return capabilities, authPluginData, nil
+	}
+
+	// Character set.
+	characterSet, pos, ok := readByte(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no character set")
+	}
+	c.CharacterSet = characterSet
+
+	// Status flags. Ignored.
+	_, pos, ok = readUint16(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no status flags")
+	}
+
+	// Upper 2 bytes of the capability flags.
+	capUpper, pos, ok := readUint16(data, pos)
+	if !ok {
+		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no capability flags (upper 2 bytes)")
+	}
+	capabilities += uint32(capUpper) << 16
+
+	// Length of auth-plugin-data, or 0.
+	// Only with CLIENT_PLUGIN_AUTH capability.
+	var authPluginDataLength byte
+	if capabilities&CapabilityClientPluginAuth != 0 {
+		authPluginDataLength, pos, ok = readByte(data, pos)
+		if !ok {
+			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no length of auth-plugin-data")
+		}
+	} else {
+		// One byte filler, 0. We don't really care about the value.
+		_, pos, ok = readByte(data, pos)
+		if !ok {
+			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no length of auth-plugin-data filler")
+		}
+	}
+
+	// 10 reserved 0 bytes.
+	pos += 10
+
+	if capabilities&CapabilityClientSecureConnection != 0 {
+		// The next part of the auth-plugin-data.
+		// The length is max(13, length of auth-plugin-data - 8).
+		l := int(authPluginDataLength) - 8
+		if l > 13 {
+			l = 13
+		}
+		var authPluginDataPart2 []byte
+		authPluginDataPart2, pos, ok = readBytes(data, pos, l)
+		if !ok {
+			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no auth-plugin-data-part-2")
+		}
+
+		// The last byte has to be 0, and is not part of the data.
+		if authPluginDataPart2[l-1] != 0 {
+			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: auth-plugin-data-part-2 is not 0 terminated")
+		}
+		authPluginData = append(authPluginData, authPluginDataPart2[0:l-1]...)
+	}
+
+	// Auth-plugin name.
+	if capabilities&CapabilityClientPluginAuth != 0 {
+		authPluginName, _, ok := readNullString(data, pos)
+		if !ok {
+			// Fallback for versions prior to 5.5.10 and
+			// 5.6.2 that don't have a null terminated string.
+			authPluginName = string(data[pos : len(data)-1])
+		}
+
+		if authPluginName != mysqlNativePassword {
+			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: only support %v auth plugin name, but got %v", mysqlNativePassword, authPluginName)
+		}
+	}
+
+	return capabilities, authPluginData, nil
+}
+
+func (c *Conn) writeHandshakeResponse41(capabilities uint32, cipher []byte, characterSet uint8, params *sqldb.ConnParams) error {
+	var flags uint32 = CapabilityClientLongPassword |
+		CapabilityClientLongFlag |
+		CapabilityClientProtocol41 |
+		CapabilityClientTransactions |
+		CapabilityClientSecureConnection |
+		CapabilityClientPluginAuth |
+		CapabilityClientPluginAuthLenencClientData
+
+	// FIXME(alainjobart) add SSL, multi statement, client found rows.
+
+	// Password encryption.
+	scrambledPassword := scramblePassword(cipher, []byte(params.Pass))
+
+	length :=
+		4 + // Client capability flags.
+			4 + // Max-packet size.
+			1 + // Character set.
+			23 + // Reserved.
+			lenNullString(params.Uname) +
+			// length of scrambled passsword is handled below.
+			len(scrambledPassword) +
+			21 + // "mysql_native_password" string.
+			1 // terminating zero.
+
+	// Add the DB name if the server supports it.
+	if params.DbName != "" && (capabilities&CapabilityClientConnectWithDB != 0) {
+		flags |= CapabilityClientConnectWithDB
+		length += lenNullString(params.DbName)
+	}
+
+	if capabilities&CapabilityClientPluginAuthLenencClientData != 0 {
+		length += lenEncIntSize(uint64(len(scrambledPassword)))
+	} else {
+		length++
+	}
+
+	data := make([]byte, length)
+	pos := 0
+
+	// Client capability flags.
+	pos = writeUint32(data, pos, flags)
+
+	// Max-packet size, always 0. See doc.go.
+	pos += 4
+
+	// Character set.
+	pos = writeByte(data, pos, characterSet)
+
+	// FIXME(alainjobart): With SSL can send this now.
+	// For now we don't support it.
+	if params.SslCert != "" && params.SslKey != "" {
+		return fmt.Errorf("SSL support is not implemented yet in this client")
+	}
+
+	// 23 reserved bytes, all 0.
+	pos += 23
+
+	// Username
+	pos = writeNullString(data, pos, params.Uname)
+
+	// Scrambled password.  The length is encoded as variable length if
+	// CapabilityClientPluginAuthLenencClientData is set.
+	if capabilities&CapabilityClientPluginAuthLenencClientData != 0 {
+		pos = writeLenEncInt(data, pos, uint64(len(scrambledPassword)))
+	} else {
+		data[pos] = byte(len(scrambledPassword))
+		pos++
+	}
+	pos += copy(data[pos:], scrambledPassword)
+
+	// DbName, only if server supports it.
+	if params.DbName != "" && (capabilities&CapabilityClientConnectWithDB != 0) {
+		pos = writeNullString(data, pos, params.DbName)
+		c.SchemaName = params.DbName
+	}
+
+	// Assume native client during response
+	pos = writeNullString(data, pos, mysqlNativePassword)
+
+	// Sanity-check the length.
+	if pos != len(data) {
+		return fmt.Errorf("writeHandshakeResponse41: only packed %v bytes, out of %v allocated", pos, len(data))
+	}
+
+	if err := c.writePacket(data); err != nil {
+		return fmt.Errorf("cannot send HandshakeResponse41: %v", err)
+	}
+	c.flush()
+
+	return nil
+}
+
+// Encrypt password using 4.1+ method
+func scramblePassword(scramble, password []byte) []byte {
+	if len(password) == 0 {
+		return nil
+	}
+
+	// stage1Hash = SHA1(password)
+	crypt := sha1.New()
+	crypt.Write(password)
+	stage1 := crypt.Sum(nil)
+
+	// scrambleHash = SHA1(scramble + SHA1(stage1Hash))
+	// inner Hash
+	crypt.Reset()
+	crypt.Write(stage1)
+	hash := crypt.Sum(nil)
+	// outer Hash
+	crypt.Reset()
+	crypt.Write(scramble)
+	crypt.Write(hash)
+	scramble = crypt.Sum(nil)
+
+	// token = scrambleHash XOR stage1Hash
+	for i := range scramble {
+		scramble[i] ^= stage1[i]
+	}
+	return scramble
+}

--- a/go/mysqlconn/client_test.go
+++ b/go/mysqlconn/client_test.go
@@ -1,0 +1,404 @@
+package mysqlconn
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vttest"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// assertSQLError makes sure we get the right error.
+func assertSQLError(t *testing.T, err error, code int, sqlState string, subtext string) {
+	if err == nil {
+		t.Fatalf("was expecting SQLError %v / %v / %v but got no error.", code, sqlState, subtext)
+	}
+	serr, ok := err.(*sqldb.SQLError)
+	if !ok {
+		t.Fatalf("was expecting SQLError %v / %v / %v but got: %v", code, sqlState, subtext, err)
+	}
+	if serr.Num != code {
+		t.Fatalf("was expecting SQLError %v / %v / %v but got code %v", code, sqlState, subtext, serr.Num)
+	}
+	if serr.State != sqlState {
+		t.Fatalf("was expecting SQLError %v / %v / %v but got state %v", code, sqlState, subtext, serr.State)
+	}
+	if subtext != "" && !strings.Contains(serr.Message, subtext) {
+		t.Fatalf("was expecting SQLError %v / %v / %v but got message %v", code, sqlState, subtext, serr.Message)
+
+	}
+}
+
+// TestConnectTimeout runs connection failure scenarios against a
+// server that's not listening or has trouble.  This test is not meant
+// to use a valid server. So we do not test bad handshakes here.
+func TestConnectTimeout(t *testing.T) {
+	// Create a socket, but it's not accepting. So all Dial
+	// attempts will timeout.
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("cannot listen: %v", err)
+	}
+	host := listener.Addr().(*net.TCPAddr).IP.String()
+	port := listener.Addr().(*net.TCPAddr).Port
+	params := &sqldb.ConnParams{
+		Host: host,
+		Port: port,
+	}
+	defer listener.Close()
+
+	// Test that canceling the context really interrupts the Connect.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_, err := Connect(ctx, params)
+		if err != context.Canceled {
+			t.Errorf("Was expecting context.Canceled but got: %v", err)
+		}
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Tests a connection timeout works.
+	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
+	_, err = Connect(ctx, params)
+	cancel()
+	if err != context.DeadlineExceeded {
+		t.Errorf("Was expecting context.DeadlineExceeded but got: %v", err)
+	}
+
+	// Now the server will listen, but close all connections on accept.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				// Listener was closed.
+				return
+			}
+			conn.Close()
+		}
+	}()
+	ctx = context.Background()
+	_, err = Connect(ctx, params)
+	assertSQLError(t, err, CRConnHostError, SSSignalException, "initial packet read failed")
+
+	// Tests a connection where Dial fails properly returns the
+	// right error. To simulate exactly the right failure, try to dial
+	// a Unix socket that's just a temp file.
+	fd, err := ioutil.TempFile("", "mysqlconn")
+	if err != nil {
+		t.Fatalf("cannot create TemFile: %v", err)
+	}
+	name := fd.Name()
+	fd.Close()
+	params.UnixSocket = name
+	ctx = context.Background()
+	_, err = Connect(ctx, params)
+	os.Remove(name)
+	assertSQLError(t, err, CRConnectionError, SSSignalException, "connection refused")
+}
+
+// TestWithRealDatabase runs a real MySQL database, and runs all kinds
+// of tests on it. To minimize overhead, we only run one database, and
+// run all the tests on it.
+func TestWithRealDatabase(t *testing.T) {
+	hdl, err := vttest.LaunchVitess(
+		vttest.MySQLOnly("vttest"),
+		vttest.Schema("create table a(id int, name varchar(128), primary key(id))"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer func() {
+		err = hdl.TearDown()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+	}()
+	params, err := hdl.MySQLConnParams()
+	if err != nil {
+		t.Error(err)
+	}
+
+	ctx := context.Background()
+	conn, err := Connect(ctx, &params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try a simple error case.
+	_, err = conn.ExecuteFetch("select * from aa", 1000, true)
+	if err == nil || !strings.Contains(err.Error(), "Table 'vttest.aa' doesn't exist") {
+		t.Fatalf("expected error but got: %v", err)
+	}
+
+	// Try a simple insert.
+	result, err := conn.ExecuteFetch("insert into a(id, name) values(10, 'nice name')", 1000, true)
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+	if result.RowsAffected != 1 || len(result.Rows) != 0 {
+		t.Errorf("unexpected result for insert: %v", result)
+	}
+
+	// And re-read what we inserted.
+	result, err = conn.ExecuteFetch("select * from a", 1000, true)
+	if err != nil {
+		t.Fatalf("insert failed: %v", err)
+	}
+	expectedResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name:         "id",
+				Type:         querypb.Type_INT32,
+				Table:        "a",
+				OrgTable:     "a",
+				Database:     "vttest",
+				OrgName:      "id",
+				ColumnLength: 11,
+				Charset:      63,    // binary
+				Flags:        16387, // NOT_NULL_FLAG, PRI_KEY_FLAG, PART_KEY_FLAG
+			},
+			{
+				Name:         "name",
+				Type:         querypb.Type_VARCHAR,
+				Table:        "a",
+				OrgTable:     "a",
+				Database:     "vttest",
+				OrgName:      "name",
+				ColumnLength: 384,
+				Charset:      33, // utf8
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("10")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
+			},
+		},
+	}
+	if !reflect.DeepEqual(result, expectedResult) {
+		t.Errorf("unexpected result for select, got:\n%v\nexpected:\n%v\n", result, expectedResult)
+	}
+
+	// Now be serious: insert a thousand rows.
+	timeInserts(t, &params, 1000)
+
+	// And use a streaming query to read them back.
+	// Do it twice to make sure state is reset properly.
+	readRowsUsingStream(t, &params, 1001)
+	readRowsUsingStream(t, &params, 1001)
+
+	if true {
+		// Return early, rest is more load tests.
+		return
+	}
+
+	// More serious, even more. Get 1001 rows, 10000 times.
+	timeSelects(t, &params, 10000, 1001)
+
+	// Use the new client, do parallel reads.
+	timeParallelReads(t, &params, 10, 10000)
+
+	// Use the old client, do the same parallel query.
+	timeOldParallelReads(t, params, 10, 10000)
+}
+
+func readRowsUsingStream(t *testing.T, params *sqldb.ConnParams, expectedCount int) {
+	t.Logf("============= readRowsUsingStream %v expected rows", expectedCount)
+
+	// Connect.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Start the streaming query.
+	start := time.Now()
+	if err := conn.ExecuteStreamFetch("select * from a"); err != nil {
+		t.Fatalf("ExecuteStreamFetch failed: %v", err)
+	}
+
+	// Check the fields.
+	expectedFields := []*querypb.Field{
+		{
+			Name:         "id",
+			Type:         querypb.Type_INT32,
+			Table:        "a",
+			OrgTable:     "a",
+			Database:     "vttest",
+			OrgName:      "id",
+			ColumnLength: 11,
+			Charset:      63,    // binary
+			Flags:        16387, // NOT_NULL_FLAG, PRI_KEY_FLAG, PART_KEY_FLAG
+		},
+		{
+			Name:         "name",
+			Type:         querypb.Type_VARCHAR,
+			Table:        "a",
+			OrgTable:     "a",
+			Database:     "vttest",
+			OrgName:      "name",
+			ColumnLength: 384,
+			Charset:      33, // utf8
+		},
+	}
+	fields, err := conn.Fields()
+	if err != nil {
+		t.Fatalf("Fields failed: %v", err)
+	}
+	if !reflect.DeepEqual(fields, expectedFields) {
+		t.Fatalf("fields are not right, got:\n%v\nexpected:\n%v", fields, expectedFields)
+	}
+
+	// Read the rows.
+	count := 0
+	for {
+		row, err := conn.FetchNext()
+		if err != nil {
+			t.Fatalf("FetchNext failed: %v", err)
+		}
+		if row == nil {
+			// We're done.
+			break
+		}
+		if len(row) != 2 {
+			t.Fatalf("Unexpected row found: %v", row)
+		}
+		count++
+	}
+	if count != expectedCount {
+		t.Errorf("Got unexpected count %v for query, was expecting %v", count, expectedCount)
+	}
+	conn.CloseResult()
+	t.Logf("     --> %v\n", time.Since(start))
+}
+
+func timeInserts(t *testing.T, params *sqldb.ConnParams, count int) {
+	t.Logf("============= timeInserts %v rows", count)
+
+	// Connect.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Time the insert.
+	start := time.Now()
+	for i := 0; i < count; i++ {
+		_, err := conn.ExecuteFetch(fmt.Sprintf("insert into a(id, name) values(%v, 'nice name %v')", 1000+i, i), 1000, true)
+		if err != nil {
+			t.Fatalf("ExecuteFetch(%v) failed: %v", i, err)
+		}
+	}
+	t.Logf("     --> %v\n", time.Since(start))
+}
+
+func timeSelects(t *testing.T, params *sqldb.ConnParams, count, expectedCount int) {
+	t.Logf("============= timeSelects running %v times expecting %v rows", count, expectedCount)
+
+	// Connect.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Time the insert.
+	start := time.Now()
+	for i := 0; i < count; i++ {
+		result, err := conn.ExecuteFetch("select * from a", expectedCount, true)
+		if err != nil {
+			t.Fatalf("ExecuteFetch(%v) failed: %v", i, err)
+		}
+		if len(result.Rows) != expectedCount {
+			t.Fatalf("ExecuteFetch(%v) returned a weird result: %v", i, result)
+		}
+	}
+	t.Logf("     --> %v\n", time.Since(start))
+}
+
+func timeParallelReads(t *testing.T, params *sqldb.ConnParams, parallelCount, queryCount int) {
+	t.Logf("============= timeParallelReads %v threads, each running %v queries", parallelCount, queryCount)
+
+	ctx := context.Background()
+	start := time.Now()
+	wg := sync.WaitGroup{}
+	for i := 0; i < parallelCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			conn, err := Connect(ctx, params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for j := 0; j < queryCount; j++ {
+				result, err := conn.ExecuteFetch("select * from a", 10000, true)
+				if err != nil {
+					t.Fatalf("ExecuteFetch(%v) failed: %v", i, err)
+				}
+				if len(result.Rows) != 1001 {
+					t.Fatalf("ExecuteFetch(%v) returned a weird result: %v", i, result)
+				}
+			}
+			conn.Close()
+		}()
+	}
+	wg.Wait()
+	t.Logf("     --> %v\n", time.Since(start))
+}
+
+func timeOldParallelReads(t *testing.T, params sqldb.ConnParams, parallelCount, queryCount int) {
+	t.Logf("============= timeOldParallelReads %v threads, each running %v queries", parallelCount, queryCount)
+
+	start := time.Now()
+	wg := sync.WaitGroup{}
+	for i := 0; i < parallelCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			conn, err := mysql.Connect(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for j := 0; j < queryCount; j++ {
+				result, err := conn.ExecuteFetch("select * from a", 10000, true)
+				if err != nil {
+					t.Fatalf("ExecuteFetch(%v) failed: %v", j, err)
+				}
+				if len(result.Rows) != 1001 {
+					t.Fatalf("ExecuteFetch(%v) returned a weird result: %v", j, result)
+				}
+			}
+
+			conn.Close()
+		}()
+	}
+	wg.Wait()
+	t.Logf("     --> %v\n", time.Since(start))
+}

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -1,0 +1,389 @@
+package mysqlconn
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+
+	"github.com/youtube/vitess/go/sqldb"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+const (
+	// connBufferSize is how much we buffer for reading and
+	// writing.
+	connBufferSize = 16 * 1024
+)
+
+// Conn is a connection between a client and a server, using the MySQL
+// binary protocol. It is built on top of an existing net.Conn, that
+// has already been established.
+//
+// Use Connect on the client side to create a connection.
+// Use NewListener to create a server side and listen for connections.
+type Conn struct {
+	// conn is the underlying network connection.
+	// Calling Close() on the Conn will close this connection.
+	// If there are any ongoing reads or writes, they may get interrupted.
+	conn net.Conn
+
+	// ConnectionID is set:
+	// - at Connect() time for clients, with the value returned by
+	// the server.
+	// - at accept time for the server.
+	// If Close() or Shutdown() was called, this is reset to 0.
+	ConnectionID uint32
+
+	// Capabilities is the current set of features this connection
+	// is using.  It is the features that are both supported by
+	// the client and the server, and currently in use.
+	// It is set after the initial handshake.
+	//
+	// It is only used for CapabilityClientDeprecateEOF.
+	Capabilities uint32
+
+	// CharacterSet is the character set used by the other side of the
+	// connection.
+	// It is set during the initial handshake.
+	// See the values in constants.go.
+	CharacterSet uint8
+
+	// SchemaName is the default database name to use. It is set
+	// during handshake, and by ComInitDb packets. Both client and
+	// servers maintain it.
+	SchemaName string
+
+	// ServerVersion is set during Connect with the server
+	// version.  It is not changed afterwards. It is unused for
+	// server-side connections.
+	ServerVersion string
+
+	// StatusFlags are the status flags we will base our returned flags on.
+	// This is a bit field, with values documented in constants.go.
+	// An interesting value here would be ServerStatusAutocommit.
+	// It is only used by the server. These flags can be changed
+	// by Handler methods.
+	StatusFlags uint16
+
+	// ClientData is a place where an application can store any
+	// connection-related data. Mostly used on the server side, to
+	// avoid maps indexed by ConnectionID for instance.
+	ClientData interface{}
+
+	// Packet encoding variables.
+	reader   *bufio.Reader
+	writer   *bufio.Writer
+	sequence uint8
+
+	// Internal variables for sqldb.Conn API for stream queries.
+	// This is set only if a streaming query is in progress.
+	fields []*querypb.Field
+}
+
+func newConn(conn net.Conn) *Conn {
+	return &Conn{
+		conn: conn,
+
+		reader:   bufio.NewReaderSize(conn, connBufferSize),
+		writer:   bufio.NewWriterSize(conn, connBufferSize),
+		sequence: 0,
+	}
+}
+
+func (c *Conn) readOnePacket() ([]byte, error) {
+	var header [4]byte
+
+	if _, err := io.ReadFull(c.reader, header[:]); err != nil {
+		return nil, fmt.Errorf("io.ReadFull(header size) failed: %v", err)
+	}
+
+	sequence := uint8(header[3])
+	if sequence != c.sequence {
+		return nil, fmt.Errorf("invalid sequence, expected %v got %v", c.sequence, sequence)
+	}
+
+	c.sequence++
+
+	length := int(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16)
+	if length == 0 {
+		// This can be caused by the packet after a packet of
+		// exactly size MaxPacketSize.
+		return nil, nil
+	}
+
+	data := make([]byte, length)
+	if _, err := io.ReadFull(c.reader, data); err != nil {
+		return nil, fmt.Errorf("io.ReadFull(packet body of length %v) failed: %v", length, err)
+	}
+	return data, nil
+}
+
+func (c *Conn) readPacket() ([]byte, error) {
+	// Optimize for a single packet case.
+	data, err := c.readOnePacket()
+	if err != nil {
+		return nil, err
+	}
+
+	// This is a single packet.
+	if len(data) < MaxPacketSize {
+		return data, nil
+	}
+
+	// There is more than one packet, read them all.
+	for {
+		next, err := c.readOnePacket()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(next) == 0 {
+			// Again, the packet after a packet of exactly size MaxPacketSize.
+			break
+		}
+
+		data = append(data, next...)
+		if len(next) < MaxPacketSize {
+			break
+		}
+	}
+
+	return data, nil
+}
+
+// writePacket writes a packet, possibly cutting it into multiple
+// chunks.  Note this is not very efficient, as the client probably
+// has to build the []byte and that makes a memory copy.
+//
+// TODO(alainjobart): to write packets more efficiently, the following API should be added:
+// startPacket(length int)
+//   - remembers we started writing a packet.
+//   - writes the first packet header.
+// writePacketChunk(data []byte) / writeByte(b byte)
+//   - writes the bytes, respecting packet boundaries.
+//   - if we need to go from one packet to the next, do it.
+// - checks we're not past the initial packet size.
+// finishPacket()
+//   - checks the packet is done.
+//   - write an empty packet if the write was a multiple of MaxPacketSize
+func (c *Conn) writePacket(data []byte) error {
+	index := 0
+	length := len(data)
+
+	for {
+		// Packet length is capped to MaxPacketSize.
+		packetLength := length
+		if packetLength > MaxPacketSize {
+			packetLength = MaxPacketSize
+		}
+
+		// Compute and write the header.
+		var header [4]byte
+		header[0] = byte(packetLength)
+		header[1] = byte(packetLength >> 8)
+		header[2] = byte(packetLength >> 16)
+		header[3] = c.sequence
+		if n, err := c.writer.Write(header[:]); err != nil {
+			return fmt.Errorf("Write(header) failed: %v", err)
+		} else if n != 4 {
+			return fmt.Errorf("Write(header) returned a short write: %v < 4", n)
+		}
+
+		// Write the body.
+		if n, err := c.writer.Write(data[index : index+packetLength]); err != nil {
+			return fmt.Errorf("Write(packet) failed: %v", err)
+		} else if n != packetLength {
+			return fmt.Errorf("Write(packet) returned a short write: %v < %v", n, packetLength)
+		}
+
+		// Update our state.
+		c.sequence++
+		length -= packetLength
+		if length == 0 {
+			if packetLength == MaxPacketSize {
+				// The packet we just sent had exactly
+				// MaxPacketSize size, we need to
+				// sent a zero-size packet too.
+				header[0] = 0
+				header[1] = 0
+				header[2] = 0
+				header[3] = c.sequence
+				if n, err := c.writer.Write(header[:]); err != nil {
+					return fmt.Errorf("Write(empty header) failed: %v", err)
+				} else if n != 4 {
+					return fmt.Errorf("Write(empty header) returned a short write: %v < 4", n)
+				}
+				c.sequence++
+			}
+			return nil
+		}
+		index += packetLength
+	}
+}
+
+func (c *Conn) flush() {
+	c.writer.Flush()
+}
+
+// Close closes the connection.
+func (c *Conn) Close() {
+	c.ConnectionID = 0
+	c.conn.Close()
+}
+
+//
+// Packet writing methods, for generic packets.
+//
+
+func (c *Conn) writeOKPacket(affectedRows, lastInsertID uint64, flags uint16, warnings uint16) error {
+	length := 1 + // OKPacket
+		lenEncIntSize(affectedRows) +
+		lenEncIntSize(lastInsertID) +
+		2 + // flags
+		2 // warnings
+	data := make([]byte, length)
+	pos := 0
+	pos = writeByte(data, pos, OKPacket)
+	pos = writeLenEncInt(data, pos, affectedRows)
+	pos = writeLenEncInt(data, pos, lastInsertID)
+	pos = writeUint16(data, pos, flags)
+	pos = writeUint16(data, pos, warnings)
+
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	c.flush()
+	return nil
+}
+
+// writeOKPacketWithEOFHeader writes an OK packet with an EOF header.
+// This is used at the end of a result set if
+// CapabilityClientDeprecateEOF is set.
+func (c *Conn) writeOKPacketWithEOFHeader(affectedRows, lastInsertID uint64, flags uint16, warnings uint16) error {
+	length := 1 + // EOFPacket
+		lenEncIntSize(affectedRows) +
+		lenEncIntSize(lastInsertID) +
+		2 + // flags
+		2 // warnings
+	data := make([]byte, length)
+	pos := 0
+	pos = writeByte(data, pos, EOFPacket)
+	pos = writeLenEncInt(data, pos, affectedRows)
+	pos = writeLenEncInt(data, pos, lastInsertID)
+	pos = writeUint16(data, pos, flags)
+	pos = writeUint16(data, pos, warnings)
+
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	c.flush()
+	return nil
+}
+
+func (c *Conn) writeErrorPacket(errorCode uint16, sqlState string, format string, args ...interface{}) error {
+	errorMessage := fmt.Sprintf(format, args...)
+	length := 1 + 2 + 1 + 5 + len(errorMessage)
+	data := make([]byte, length)
+	pos := 0
+	pos = writeByte(data, pos, ErrPacket)
+	pos = writeUint16(data, pos, errorCode)
+	pos = writeByte(data, pos, '#')
+	if sqlState == "" {
+		sqlState = SSSignalException
+	}
+	if len(sqlState) != 5 {
+		panic("sqlState has to be 5 characters long")
+	}
+	pos = writeEOFString(data, pos, sqlState)
+	pos = writeEOFString(data, pos, errorMessage)
+
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	c.flush()
+	return nil
+}
+
+func (c *Conn) writeErrorPacketFromError(err error) error {
+	if se, ok := err.(*sqldb.SQLError); ok {
+		return c.writeErrorPacket(uint16(se.Num), se.State, "%v", se.Message)
+	}
+
+	return c.writeErrorPacket(ERUnknownError, SSSignalException, "unknown error: %v", err)
+}
+
+func (c *Conn) writeEOFPacket(flags uint16, warnings uint16) error {
+	length := 5
+	data := make([]byte, length)
+	pos := 0
+	pos = writeByte(data, pos, EOFPacket)
+	pos = writeUint16(data, pos, warnings)
+	pos = writeUint16(data, pos, flags)
+
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	return nil
+}
+
+//
+// Packet parsing methods, for generic packets.
+//
+
+func parseOKPacket(data []byte) (uint64, uint64, uint16, uint16, error) {
+	// We already read the type.
+	pos := 1
+
+	// Affected rows.
+	affectedRows, pos, ok := readLenEncInt(data, pos)
+	if !ok {
+		return 0, 0, 0, 0, fmt.Errorf("invalid OK packet affectedRows: %v", data)
+	}
+
+	// Last Insert ID.
+	lastInsertID, pos, ok := readLenEncInt(data, pos)
+	if !ok {
+		return 0, 0, 0, 0, fmt.Errorf("invalid OK packet lastInsertID: %v", data)
+	}
+
+	// Status flags.
+	statusFlags, pos, ok := readUint16(data, pos)
+	if !ok {
+		return 0, 0, 0, 0, fmt.Errorf("invalid OK packet statusFlags: %v", data)
+	}
+
+	// Warnings.
+	warnings, pos, ok := readUint16(data, pos)
+	if !ok {
+		return 0, 0, 0, 0, fmt.Errorf("invalid OK packet warnings: %v", data)
+	}
+
+	return affectedRows, lastInsertID, statusFlags, warnings, nil
+}
+
+func parseErrorPacket(data []byte) error {
+	// We already read the type.
+	pos := 1
+
+	// Error code is 2 bytes.
+	code, pos, ok := readUint16(data, pos)
+	if !ok {
+		return fmt.Errorf("invalid error packet code: %v", data)
+	}
+
+	// '#' marker of the SQL state is 1 byte. Ignored.
+	pos++
+
+	// SQL state is 5 bytes
+	sqlState, pos, ok := readBytes(data, pos, 5)
+	if !ok {
+		return fmt.Errorf("invalid error packet sqlState: %v", data)
+	}
+
+	// Human readable error message is the rest.
+	msg := string(data[pos:])
+
+	return sqldb.NewSQLError(int(code), string(sqlState), "%v", msg)
+}

--- a/go/mysqlconn/conn_test.go
+++ b/go/mysqlconn/conn_test.go
@@ -1,0 +1,177 @@
+package mysqlconn
+
+import (
+	"bytes"
+	"net"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqldb"
+)
+
+func createSocketPair(t *testing.T) (net.Listener, *Conn, *Conn) {
+	// Create a listener.
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	addr := listener.Addr().String()
+
+	// Dial a client, Accept a server.
+	wg := sync.WaitGroup{}
+
+	var clientConn net.Conn
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		clientConn, err = net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatalf("Dial failed: %v", err)
+		}
+	}()
+
+	var serverConn net.Conn
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		serverConn, err = listener.Accept()
+		if err != nil {
+			t.Fatalf("Accept failed: %v", err)
+		}
+	}()
+
+	wg.Wait()
+
+	// Create a Conn on both sides.
+	cConn := newConn(clientConn)
+	sConn := newConn(serverConn)
+
+	return listener, sConn, cConn
+}
+
+// Write a packet on one side, read it on the other, check it's correct.
+func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
+	// Have to do it in the background if it cannot be buffered.
+	go func() {
+		defer func() {
+			if x := recover(); x != nil {
+				t.Fatalf("%v", x)
+			}
+		}()
+		if err := cConn.writePacket(data); err != nil {
+			t.Fatalf("writePacket failed: %v", err)
+		}
+		cConn.flush()
+	}()
+
+	received, err := sConn.readPacket()
+	if err != nil || !bytes.Equal(data, received) {
+		t.Fatalf("readPacket failed: %v %v", received, err)
+	}
+}
+
+func TestPackets(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Verify all packets go through correctly.
+	// Small one.
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+	verifyPacketComms(t, cConn, sConn, data)
+
+	// Under the limit, still one packet.
+	data = make([]byte, MaxPacketSize-1)
+	data[0] = 0xab
+	data[MaxPacketSize-2] = 0xef
+	verifyPacketComms(t, cConn, sConn, data)
+
+	// Exactly the limit, two packets.
+	data = make([]byte, MaxPacketSize)
+	data[0] = 0xab
+	data[MaxPacketSize-1] = 0xef
+	verifyPacketComms(t, cConn, sConn, data)
+
+	// Over the limit, two packets.
+	data = make([]byte, MaxPacketSize+1000)
+	data[0] = 0xab
+	data[MaxPacketSize+999] = 0xef
+	verifyPacketComms(t, cConn, sConn, data)
+}
+
+func TestBasicPackets(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Write OK packet, read it, compare.
+	if err := sConn.writeOKPacket(12, 34, 56, 78); err != nil {
+		t.Fatalf("writeOKPacket failed: %v", err)
+	}
+	data, err := cConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != OKPacket {
+		t.Fatalf("cConn.readPacket - OKPacket failed: %v %v", data, err)
+	}
+	affectedRows, lastInsertID, statusFlags, warnings, err := parseOKPacket(data)
+	if err != nil || affectedRows != 12 || lastInsertID != 34 || statusFlags != 56 || warnings != 78 {
+		t.Errorf("parseOKPacket returned unexpected data: %v %v %v %v %v", affectedRows, lastInsertID, statusFlags, warnings, err)
+	}
+
+	// Write OK packet with EOF header, read it, compare.
+	if err := sConn.writeOKPacketWithEOFHeader(12, 34, 56, 78); err != nil {
+		t.Fatalf("writeOKPacketWithEOFHeader failed: %v", err)
+	}
+	data, err = cConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != EOFPacket {
+		t.Fatalf("cConn.readPacket - OKPacket with EOF header failed: %v %v", data, err)
+	}
+	affectedRows, lastInsertID, statusFlags, warnings, err = parseOKPacket(data)
+	if err != nil || affectedRows != 12 || lastInsertID != 34 || statusFlags != 56 || warnings != 78 {
+		t.Errorf("parseOKPacket returned unexpected data: %v %v %v %v %v", affectedRows, lastInsertID, statusFlags, warnings, err)
+	}
+
+	// Write error packet, read it, compare.
+	if err := sConn.writeErrorPacket(ERAccessDeniedError, SSAccessDeniedError, "access denied: %v", "reason"); err != nil {
+		t.Fatalf("writeErrorPacket failed: %v", err)
+	}
+	data, err = cConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != ErrPacket {
+		t.Fatalf("cConn.readPacket - ErrorPacket failed: %v %v", data, err)
+	}
+	err = parseErrorPacket(data)
+	if !reflect.DeepEqual(err, sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "access denied: reason")) {
+		t.Errorf("parseErrorPacket returned unexpected data: %v", err)
+	}
+
+	// Write error packet from error, read it, compare.
+	if err := sConn.writeErrorPacketFromError(sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "access denied")); err != nil {
+		t.Fatalf("writeErrorPacketFromError failed: %v", err)
+	}
+	data, err = cConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != ErrPacket {
+		t.Fatalf("cConn.readPacket - ErrorPacket failed: %v %v", data, err)
+	}
+	err = parseErrorPacket(data)
+	if !reflect.DeepEqual(err, sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "access denied")) {
+		t.Errorf("parseErrorPacket returned unexpected data: %v", err)
+	}
+
+	// Write EOF packet, read it, compare first byte. Payload is always ignored.
+	if err := sConn.writeEOFPacket(0x8912, 0xabba); err != nil {
+		t.Fatalf("writeEOFPacket failed: %v", err)
+	}
+	sConn.flush()
+	data, err = cConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != EOFPacket {
+		t.Fatalf("cConn.readPacket - EOFPacket failed: %v %v", data, err)
+	}
+}

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -1,0 +1,252 @@
+package mysqlconn
+
+const (
+	// MaxPacketSize is the maximum payload length of a packet
+	// the server supports.
+	MaxPacketSize = (1 << 24) - 1
+
+	// protocolVersion is the current version of the protocol.
+	// Always 10.
+	protocolVersion = 10
+
+	// mysqlNativePassword is the auth form we use.
+	mysqlNativePassword = "mysql_native_password"
+)
+
+// Capability flags.
+// Originally found in include/mysql/mysql_com.h
+const (
+	// CapabilityClientLongPassword is CLIENT_LONG_PASSWORD.
+	// New more secure passwords. Assumed to be set since 4.1.1.
+	// We do not check this anywhere.
+	CapabilityClientLongPassword = 1
+
+	// CLIENT_FOUND_ROWS 1 << 1 See doc.go.
+
+	// CapabilityClientLongFlag is CLIENT_LONG_FLAG.
+	// Longer flags in Protocol::ColumnDefinition320.
+	// Set it everywhere, not used, as we use Protocol::ColumnDefinition41.
+	CapabilityClientLongFlag = 1 << 2
+
+	// CapabilityClientConnectWithDB is CLIENT_CONNECT_WITH_DB.
+	// One can specify db on connect.
+	CapabilityClientConnectWithDB = 1 << 3
+
+	// CLIENT_NO_SCHEMA 1 << 4
+	// Do not permit database.table.column. We do permit it.
+
+	// CLIENT_COMPRESS 1 << 5
+	// We do not support compression. CPU is usually our bottleneck.
+
+	// CLIENT_ODBC 1 << 6
+	// No special behavior since 3.22.
+
+	// CLIENT_LOCAL_FILES 1 << 7
+	// Client can use LOCAL INFILE request of LOAD DATA|XML.
+	// We do not set it.
+
+	// CLIENT_IGNORE_SPACE 1 << 8
+	// Parser can ignore spaces before '('.
+	// We ignore this.
+
+	// CapabilityClientProtocol41 is CLIENT_PROTOCOL_41.
+	// New 4.1 protocol. Enforced everywhere.
+	CapabilityClientProtocol41 = 1 << 9
+
+	// CLIENT_INTERACTIVE 1 << 10
+	// Not specified, ignored.
+
+	// CapabilityClientSSL is CLIENT_SSL.
+	// Switch to SSL after handshake.
+	// Not supported yet, but checked.
+	CapabilityClientSSL = 1 << 11
+
+	// CLIENT_IGNORE_SIGPIPE 1 << 12
+	// Do not issue SIGPIPE if network failures occur (libmysqlclient only).
+
+	// CapabilityClientTransactions is CLIENT_TRANSACTIONS.
+	// Can send status flags in EOF_Packet.
+	// This flag is optional in 3.23, but always set by the server since 4.0.
+	// We just do it all the time.
+	CapabilityClientTransactions = 1 << 13
+
+	// CLIENT_RESERVED 1 << 14
+
+	// CapabilityClientSecureConnection is CLIENT_SECURE_CONNECTION.
+	// New 4.1 authentication. Always set, expected, never checked.
+	CapabilityClientSecureConnection = 1 << 15
+
+	// CLIENT_MULTI_STATEMENTS 1 << 16
+	// Can handle multiple statements per COM_QUERY and COM_STMT_PREPARE.
+	// Not yet supported.
+
+	// CLIENT_MULTI_RESULTS 1 << 17
+	// Can send multiple resultsets for COM_QUERY.
+	// Not yet supported.
+
+	// CLIENT_PS_MULTI_RESULTS 1 << 18
+	// Can send multiple resultsets for COM_STMT_EXECUTE.
+	// Not yet supported.
+
+	// CapabilityClientPluginAuth is CLIENT_PLUGIN_AUTH.
+	// Client supports plugin authentication.
+	CapabilityClientPluginAuth = 1 << 19
+
+	// CLIENT_CONNECT_ATTRS 1 << 20
+	// Permits connection attributes in Protocol::HandshakeResponse41.
+	// Not yet supported.
+
+	// CapabilityClientPluginAuthLenencClientData is CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA
+	CapabilityClientPluginAuthLenencClientData = 1 << 21
+
+	// CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS 1 << 22
+	// Announces support for expired password extension.
+	// Not yet supported.
+
+	// CLIENT_SESSION_TRACK 1 << 23
+	// Can set SERVER_SESSION_STATE_CHANGED in the Status Flags
+	// and send session-state change data after a OK packet.
+	// Not yet supported.
+
+	// CapabilityClientDeprecateEOF is CLIENT_DEPRECATE_EOF
+	// Expects an OK (instead of EOF) after the resultset rows of a Text Resultset.
+	CapabilityClientDeprecateEOF = 1 << 24
+)
+
+// Packet types.
+// Originally found in include/mysql/mysql_com.h
+const (
+	// ComQuit is COM_QUIT.
+	ComQuit = 0x01
+
+	// ComInitDB is COM_INIT_DB.
+	ComInitDB = 0x02
+
+	// ComQuery is COM_QUERY.
+	ComQuery = 0x03
+
+	// ComPing is COM_PING.
+	ComPing = 0x0e
+
+	// OKPacket is the header of the OK packet.
+	OKPacket = 0x00
+
+	// EOFPacket is the header of the EOF packet.
+	EOFPacket = 0xfe
+
+	// ErrPacket is the header of the error packet.
+	ErrPacket = 0xff
+
+	// NullValue is the encoded value of NULL.
+	NullValue = 0xfb
+)
+
+// Error codes for client-side errors.
+// Originally found in include/mysql/errmsg.h
+const (
+	// CRConnectionError is CR_CONNECTION_ERROR
+	CRConnectionError = 2002
+
+	// CRConnHostError is CR_CONN_HOST_ERROR
+	CRConnHostError = 2003
+
+	// CR_SERVER_HANDSHAKE_ERR
+	CRServerHandshakeErr = 2012
+)
+
+// Error codes for server-side errors.
+// Originally found in include/mysql/mysqld_error.h
+const (
+	// ERAccessDeniedError is ER_ACCESS_DENIED_ERROR
+	ERAccessDeniedError = 1045
+
+	// ERUnknownComError is ER_UNKNOWN_COM_ERROR
+	ERUnknownComError = 1047
+
+	// ERUnknownError is ER_UNKNOWN_ERROR
+	ERUnknownError = 1105
+
+	// ERCantDoThisDuringAnTransaction is
+	// ER_CANT_DO_THIS_DURING_AN_TRANSACTION
+	ERCantDoThisDuringAnTransaction = 1179
+)
+
+// Sql states for errors.
+// Originally found in include/mysql/sql_state.h
+const (
+	// SSSignalException is ER_SIGNAL_EXCEPTION
+	SSSignalException = "HY000"
+
+	// SSAccessDeniedError is ER_ACCESS_DENIED_ERROR
+	SSAccessDeniedError = "28000"
+
+	// SSUnknownComError is ER_UNKNOWN_COM_ERROR
+	SSUnknownComError = "08S01"
+
+	// SSHandshakeError is ER_HANDSHAKE_ERROR
+	SSHandshakeError = "08S01"
+
+	// SSCantDoThisDuringAnTransaction is
+	// ER_CANT_DO_THIS_DURING_AN_TRANSACTION
+	SSCantDoThisDuringAnTransaction = "25000"
+)
+
+// Status flags. They are returned by the server in a few cases.
+// Originally found in include/mysql/mysql_com.h
+// See http://dev.mysql.com/doc/internals/en/status-flags.html
+const (
+	// ServerStatusAutocommit is SERVER_STATUS_AUTOCOMMIT.
+	ServerStatusAutocommit = 0x0002
+)
+
+// A few interesting character set values.
+// See http://dev.mysql.com/doc/internals/en/character-set.html#packet-Protocol::CharacterSet
+const (
+	// CharacterSetUtf8 is for UTF8. We use this by default.
+	CharacterSetUtf8 = 33
+)
+
+// CharacterSetMap maps the charset name (used in ConnParams) to the
+// integer value.  Interesting ones have their own constant above.
+var CharacterSetMap = map[string]uint8{
+	"big5":     1,
+	"dec8":     3,
+	"cp850":    4,
+	"hp8":      6,
+	"koi8r":    7,
+	"latin1":   8,
+	"latin2":   9,
+	"swe7":     10,
+	"ascii":    11,
+	"ujis":     12,
+	"sjis":     13,
+	"hebrew":   16,
+	"tis620":   18,
+	"euckr":    19,
+	"koi8u":    22,
+	"gb2312":   24,
+	"greek":    25,
+	"cp1250":   26,
+	"gbk":      28,
+	"latin5":   30,
+	"armscii8": 32,
+	"utf8":     CharacterSetUtf8,
+	"ucs2":     35,
+	"cp866":    36,
+	"keybcs2":  37,
+	"macce":    38,
+	"macroman": 39,
+	"cp852":    40,
+	"latin7":   41,
+	"utf8mb4":  45,
+	"cp1251":   51,
+	"utf16":    54,
+	"utf16le":  56,
+	"cp1256":   57,
+	"cp1257":   59,
+	"utf32":    60,
+	"binary":   63,
+	"geostd8":  92,
+	"cp932":    95,
+	"eucjpms":  97,
+}

--- a/go/mysqlconn/doc.go
+++ b/go/mysqlconn/doc.go
@@ -1,0 +1,91 @@
+// Package mysqlconn is a library to support MySQL binary protocol,
+// both client and server sides.
+package mysqlconn
+
+/*
+
+Implementation notes, collected during coding.
+
+The reference for the capabilities is at this location:
+http://dev.mysql.com/doc/internals/en/capability-flags.html
+
+--
+CLIENT_FOUND_ROWS
+
+The doc says:
+Send found rows instead of affected rows in EOF_Packet.
+Value
+0x00000002
+
+Not sure what needs to be done here. Ignored for now.
+
+--
+CLIENT_CONNECT_WITH_DB:
+
+It drives the ability to connect with a database name.
+The server needs to send this flag if it supports it.
+If the client supports it as well, and wants to connect with a database name,
+then the client can set the flag in its response, and then put the database name
+in the handshake response.
+
+If the server doesn't support it (meaning it is not set in the server
+capability flags), then the client may set the flag or not (as the
+server should ignore it anyway), and then should send a COM_INIT_DB
+message to set the database.
+
+--
+CLIENT_SSL:
+
+SSL is not supported yet, in neither client nor server. It is not a lot to add.
+
+--
+PLUGABLE AUTHENTICATION:
+
+We only support mysql_native_password for now, both client and server
+side. It wouldn't be a lot of work to add SHA256 for instance.
+
+--
+Maximum Packet Size:
+
+Set to zero by client and ignored by the server. Not sure what to do
+with this now.  It seems the mysql client is sending 16777216 to the
+server, which is what we use anyway. Not sure any client will send any
+lower value, and if they do, not sure what the first 3 bytes of a
+packet should be (still 0xff 0xff 0xff or the max packet size).
+
+--
+CLIENT_CONNECT_ATTRS
+
+The client can send up optional connection attributes with this flags.
+I don't see a use for them yet.
+
+--
+Multi result sets:
+
+Only used by stored procedures returning multiple result sets.
+Unclear if it is also used when the CLIENT_MULTI_STATEMENTS flag is used.
+See: http://dev.mysql.com/doc/internals/en/multi-resultset.html
+
+The flags returned is then used to mark if there are more result sets
+coming up.
+
+We do not support any of this yet. It would be nice to plumb that for
+ExecuteBatch later on though.
+
+--
+Character sets:
+
+See: http://dev.mysql.com/doc/internals/en/character-set.html#packet-Protocol::CharacterSet
+
+We maintain a map of character set names to integer value.
+
+--
+Server protection:
+
+We should add the following protections for the server:
+- Limit the number of concurrently opened client connections.
+- Add an idle timeout and close connections after that timeout is reached.
+  Should start during initial handshake, maybe have a shorter value during
+  handshake.
+
+*/

--- a/go/mysqlconn/encoding.go
+++ b/go/mysqlconn/encoding.go
@@ -1,0 +1,222 @@
+package mysqlconn
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// This file contains the data encoding and decoding functions.
+
+//
+// Encoding methods.
+//
+// The same assumptions are made for all the encoding functions:
+// - there is enough space to write the data in the buffer. If not, we
+// will panic with out of bounds.
+// - all functions start writing at 'pos' in the buffer, and return the next position.
+
+// lenEncIntSize returns the number of bytes required to encode a
+// variable-length integer.
+func lenEncIntSize(i uint64) int {
+	switch {
+	case i < 251:
+		return 1
+	case i < 1<<16:
+		return 3
+	case i < 1<<24:
+		return 4
+	default:
+		return 9
+	}
+}
+
+func writeLenEncInt(data []byte, pos int, i uint64) int {
+	switch {
+	case i < 251:
+		data[pos] = byte(i)
+		return pos + 1
+	case i < 1<<16:
+		data[pos] = 0xfc
+		data[pos+1] = byte(i)
+		data[pos+2] = byte(i >> 8)
+		return pos + 3
+	case i < 1<<24:
+		data[pos] = 0xfd
+		data[pos+1] = byte(i)
+		data[pos+2] = byte(i >> 8)
+		data[pos+3] = byte(i >> 16)
+		return pos + 4
+	default:
+		data[pos] = 0xfe
+		data[pos+1] = byte(i)
+		data[pos+2] = byte(i >> 8)
+		data[pos+3] = byte(i >> 16)
+		data[pos+4] = byte(i >> 24)
+		data[pos+5] = byte(i >> 32)
+		data[pos+6] = byte(i >> 40)
+		data[pos+7] = byte(i >> 48)
+		data[pos+8] = byte(i >> 56)
+		return pos + 9
+	}
+}
+
+func lenNullString(value string) int {
+	return len(value) + 1
+}
+
+func writeNullString(data []byte, pos int, value string) int {
+	pos += copy(data[pos:], []byte(value))
+	data[pos] = 0
+	return pos + 1
+}
+
+func writeEOFString(data []byte, pos int, value string) int {
+	pos += copy(data[pos:], []byte(value))
+	return pos
+}
+
+func writeByte(data []byte, pos int, value byte) int {
+	data[pos] = value
+	return pos + 1
+}
+
+func writeUint16(data []byte, pos int, value uint16) int {
+	data[pos] = byte(value)
+	data[pos+1] = byte(value >> 8)
+	return pos + 2
+}
+
+func writeUint32(data []byte, pos int, value uint32) int {
+	data[pos] = byte(value)
+	data[pos+1] = byte(value >> 8)
+	data[pos+2] = byte(value >> 16)
+	data[pos+3] = byte(value >> 24)
+	return pos + 4
+}
+
+func lenEncStringSize(value string) int {
+	l := len(value)
+	return lenEncIntSize(uint64(l)) + l
+}
+
+func writeLenEncString(data []byte, pos int, value string) int {
+	pos = writeLenEncInt(data, pos, uint64(len(value)))
+	return writeEOFString(data, pos, value)
+}
+
+//
+// Decoding methods.
+//
+// The same assumptions are made for all the decoding functions:
+// - they return the decode data, the new position to read from, and ak 'ok' flag.
+// - all functions start reading at 'pos' in the buffer, and return the next position.
+//
+
+func readByte(data []byte, pos int) (byte, int, bool) {
+	if pos >= len(data) {
+		return 0, 0, false
+	}
+	return data[pos], pos + 1, true
+}
+
+func readBytes(data []byte, pos int, size int) ([]byte, int, bool) {
+	if pos+size-1 >= len(data) {
+		return nil, 0, false
+	}
+	return data[pos : pos+size], pos + size, true
+}
+
+func readNullString(data []byte, pos int) (string, int, bool) {
+	end := bytes.IndexByte(data[pos:], 0)
+	if end == -1 {
+		return "", 0, false
+	}
+	return string(data[pos : pos+end]), pos + end + 1, true
+}
+
+func readUint16(data []byte, pos int) (uint16, int, bool) {
+	if pos+1 >= len(data) {
+		return 0, 0, false
+	}
+	return binary.LittleEndian.Uint16(data[pos : pos+2]), pos + 2, true
+}
+
+func readUint32(data []byte, pos int) (uint32, int, bool) {
+	if pos+3 >= len(data) {
+		return 0, 0, false
+	}
+	return binary.LittleEndian.Uint32(data[pos : pos+4]), pos + 4, true
+}
+
+func readLenEncInt(data []byte, pos int) (uint64, int, bool) {
+	if pos >= len(data) {
+		return 0, 0, false
+	}
+	switch data[pos] {
+	case 0xfc:
+		// Encoded in the next 2 bytes.
+		if pos+2 >= len(data) {
+			return 0, 0, false
+		}
+		return uint64(data[pos+1]) |
+			uint64(data[pos+2])<<8, pos + 3, true
+	case 0xfd:
+		// Encoded in the next 3 bytes.
+		if pos+3 >= len(data) {
+			return 0, 0, false
+		}
+		return uint64(data[pos+1]) |
+			uint64(data[pos+2])<<8 |
+			uint64(data[pos+3])<<16, pos + 4, true
+	case 0xfe:
+		// Encoded in the next 8 bytes.
+		if pos+8 >= len(data) {
+			return 0, 0, false
+		}
+		return uint64(data[pos+1]) |
+			uint64(data[pos+2])<<8 |
+			uint64(data[pos+3])<<16 |
+			uint64(data[pos+4])<<24 |
+			uint64(data[pos+5])<<32 |
+			uint64(data[pos+6])<<40 |
+			uint64(data[pos+7])<<48 |
+			uint64(data[pos+8])<<56, pos + 9, true
+	}
+	return uint64(data[pos]), pos + 1, true
+}
+
+func readLenEncString(data []byte, pos int) (string, int, bool) {
+	size, pos, ok := readLenEncInt(data, pos)
+	if !ok {
+		return "", 0, false
+	}
+	s := int(size)
+	if pos+s-1 >= len(data) {
+		return "", 0, false
+	}
+	return string(data[pos : pos+s]), pos + s, true
+}
+
+func skipLenEncString(data []byte, pos int) (int, bool) {
+	size, pos, ok := readLenEncInt(data, pos)
+	if !ok {
+		return 0, false
+	}
+	s := int(size)
+	if pos+s-1 >= len(data) {
+		return 0, false
+	}
+	return pos + s, true
+}
+
+func readLenEncStringAsBytes(data []byte, pos int) ([]byte, int, bool) {
+	size, pos, ok := readLenEncInt(data, pos)
+	if !ok {
+		return nil, 0, false
+	}
+	s := int(size)
+	if pos+s-1 >= len(data) {
+		return nil, 0, false
+	}
+	return data[pos : pos+s], pos + s, true
+}

--- a/go/mysqlconn/encoding_test.go
+++ b/go/mysqlconn/encoding_test.go
@@ -1,0 +1,293 @@
+package mysqlconn
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncLenInt(t *testing.T) {
+	tests := []struct {
+		value   uint64
+		encoded []byte
+	}{
+		{0x00, []byte{0x00}},
+		{0x0a, []byte{0x0a}},
+		{0xfa, []byte{0xfa}},
+		{0xfb, []byte{0xfc, 0xfb, 0x00}},
+		{0xfc, []byte{0xfc, 0xfc, 0x00}},
+		{0xfd, []byte{0xfc, 0xfd, 0x00}},
+		{0xfe, []byte{0xfc, 0xfe, 0x00}},
+		{0xff, []byte{0xfc, 0xff, 0x00}},
+		{0x0100, []byte{0xfc, 0x00, 0x01}},
+		{0x876a, []byte{0xfc, 0x6a, 0x87}},
+		{0xffff, []byte{0xfc, 0xff, 0xff}},
+		{0x010000, []byte{0xfd, 0x00, 0x00, 0x01}},
+		{0xabcdef, []byte{0xfd, 0xef, 0xcd, 0xab}},
+		{0xffffff, []byte{0xfd, 0xff, 0xff, 0xff}},
+		{0x01000000, []byte{0xfe, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00}},
+		{0xa0a1a2a3a4a5a6a7, []byte{0xfe, 0xa7, 0xa6, 0xa5, 0xa4, 0xa3, 0xa2, 0xa1, 0xa0}},
+	}
+	for _, test := range tests {
+		// Check lenEncIntSize first.
+		if got := lenEncIntSize(test.value); got != len(test.encoded) {
+			t.Errorf("lenEncIntSize returned %v but expected %v for %x", got, len(test.encoded), test.value)
+		}
+
+		// Check successful encoding.
+		data := make([]byte, len(test.encoded))
+		pos := writeLenEncInt(data, 0, test.value)
+		if pos != len(test.encoded) {
+			t.Errorf("unexpected pos %v after writeLenEncInt(%x), expected %v", pos, test.value, len(test.encoded))
+		}
+		if !bytes.Equal(data, test.encoded) {
+			t.Errorf("unexpected encoded value for %x, got %v expected %v", test.value, data, test.encoded)
+		}
+
+		// Check successful encoding with offset.
+		data = make([]byte, len(test.encoded)+1)
+		pos = writeLenEncInt(data, 1, test.value)
+		if pos != len(test.encoded)+1 {
+			t.Errorf("unexpected pos %v after writeLenEncInt(%x, 1), expected %v", pos, test.value, len(test.encoded)+1)
+		}
+		if !bytes.Equal(data[1:], test.encoded) {
+			t.Errorf("unexpected encoded value for %x, got %v expected %v", test.value, data, test.encoded)
+		}
+
+		// Check succesful decoding.
+		got, pos, ok := readLenEncInt(test.encoded, 0)
+		if !ok || got != test.value || pos != len(test.encoded) {
+			t.Errorf("readLenEncInt returned %x/%v/%v but expected %x/%v/%v", got, pos, ok, test.value, len(test.encoded), true)
+		}
+
+		// Check failed decoding.
+		got, pos, ok = readLenEncInt(test.encoded[:len(test.encoded)-1], 0)
+		if ok {
+			t.Errorf("readLenEncInt returned ok=true for shorter value %x", test.value)
+		}
+	}
+}
+
+func TestEncUint16(t *testing.T) {
+	data := make([]byte, 10)
+
+	val16 := uint16(0xabcd)
+
+	if got := writeUint16(data, 2, val16); got != 4 {
+		t.Errorf("writeUint16 returned %v but expected 4", got)
+	}
+
+	if data[2] != 0xcd || data[3] != 0xab {
+		t.Errorf("writeUint16 returned bad result: %v", data)
+	}
+
+	got16, pos, ok := readUint16(data, 2)
+	if !ok || got16 != val16 || pos != 4 {
+		t.Errorf("readUint16 returned %v/%v/%v but expected %v/%v/%v", got16, pos, ok, val16, 4, true)
+	}
+
+	got16, pos, ok = readUint16(data, 9)
+	if ok {
+		t.Errorf("readUint16 returned ok=true for shorter value")
+	}
+}
+
+func TestEncBytes(t *testing.T) {
+	data := make([]byte, 10)
+
+	if got := writeByte(data, 5, 0xab); got != 6 || data[5] != 0xab {
+		t.Errorf("writeByte returned bad result: %v %v", got, data[5])
+	}
+
+	got, pos, ok := readByte(data, 5)
+	if !ok || got != 0xab || pos != 6 {
+		t.Errorf("readByte returned %v/%v/%v but expected %v/%v/%v", got, pos, ok, 0xab, 6, true)
+	}
+
+	got, pos, ok = readByte(data, 10)
+	if ok {
+		t.Errorf("readByte returned ok=true for shorter value")
+	}
+
+	b, pos, ok := readBytes(data, 5, 2)
+	expected := []byte{0xab, 0x00}
+	if !ok || !bytes.Equal(b, expected) || pos != 7 {
+		t.Errorf("readBytes returned %v/%v/%v but expected %v/%v/%v", b, pos, ok, expected, 7, true)
+	}
+
+	b, pos, ok = readBytes(data, 9, 2)
+	if ok {
+		t.Errorf("readBytes returned ok=true for shorter value")
+	}
+}
+
+func TestEncUint32(t *testing.T) {
+	data := make([]byte, 10)
+
+	val32 := uint32(0xabcdef10)
+
+	if got := writeUint32(data, 2, val32); got != 6 {
+		t.Errorf("writeUint32 returned %v but expected 6", got)
+	}
+
+	if data[2] != 0x10 || data[3] != 0xef || data[4] != 0xcd || data[5] != 0xab {
+		t.Errorf("writeUint32 returned bad result: %v", data)
+	}
+
+	got32, pos, ok := readUint32(data, 2)
+	if !ok || got32 != val32 || pos != 6 {
+		t.Errorf("readUint32 returned %v/%v/%v but expected %v/%v/%v", got32, pos, ok, val32, 6, true)
+	}
+
+	got32, pos, ok = readUint32(data, 7)
+	if ok {
+		t.Errorf("readUint32 returned ok=true for shorter value")
+	}
+}
+
+func TestEncString(t *testing.T) {
+	tests := []struct {
+		value       string
+		lenEncoded  []byte
+		nullEncoded []byte
+	}{
+		{
+			"",
+			[]byte{0x00},
+			[]byte{0x00},
+		},
+		{
+			"a",
+			[]byte{0x01, 'a'},
+			[]byte{'a', 0x00},
+		},
+		{
+			"0123456789",
+			[]byte{0x0a, '0', '1', '2', '3', '4', '5', '6', '7', '8', '9'},
+			[]byte{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 0x00},
+		},
+	}
+	for _, test := range tests {
+		// len encoded tests.
+
+		// Check lenEncStringSize first.
+		if got := lenEncStringSize(test.value); got != len(test.lenEncoded) {
+			t.Errorf("lenEncStringSize returned %v but expected %v for %v", got, len(test.lenEncoded), test.value)
+		}
+
+		// Check lenNullString
+		if got := lenNullString(test.value); got != len(test.nullEncoded) {
+			t.Errorf("lenNullString returned %v but expected %v for %v", got, len(test.nullEncoded), test.value)
+		}
+
+		// Check successful encoding.
+		data := make([]byte, len(test.lenEncoded))
+		pos := writeLenEncString(data, 0, test.value)
+		if pos != len(test.lenEncoded) {
+			t.Errorf("unexpected pos %v after writeLenEncString(%v), expected %v", pos, test.value, len(test.lenEncoded))
+		}
+		if !bytes.Equal(data, test.lenEncoded) {
+			t.Errorf("unexpected lenEncoded value for %v, got %v expected %v", test.value, data, test.lenEncoded)
+		}
+
+		// Check successful encoding with offset.
+		data = make([]byte, len(test.lenEncoded)+1)
+		pos = writeLenEncString(data, 1, test.value)
+		if pos != len(test.lenEncoded)+1 {
+			t.Errorf("unexpected pos %v after writeLenEncString(%v, 1), expected %v", pos, test.value, len(test.lenEncoded)+1)
+		}
+		if !bytes.Equal(data[1:], test.lenEncoded) {
+			t.Errorf("unexpected lenEncoded value for %v, got %v expected %v", test.value, data[1:], test.lenEncoded)
+		}
+
+		// Check succesful decoding as string.
+		got, pos, ok := readLenEncString(test.lenEncoded, 0)
+		if !ok || got != test.value || pos != len(test.lenEncoded) {
+			t.Errorf("readLenEncString returned %v/%v/%v but expected %v/%v/%v", got, pos, ok, test.value, len(test.lenEncoded), true)
+		}
+
+		// Check failed decoding with shorter data.
+		got, pos, ok = readLenEncString(test.lenEncoded[:len(test.lenEncoded)-1], 0)
+		if ok {
+			t.Errorf("readLenEncString returned ok=true for shorter value %v", test.value)
+		}
+
+		// Check failed decoding with no data.
+		got, pos, ok = readLenEncString([]byte{}, 0)
+		if ok {
+			t.Errorf("readLenEncString returned ok=true for empty value %v", test.value)
+		}
+
+		// Check succesful skipping as string.
+		pos, ok = skipLenEncString(test.lenEncoded, 0)
+		if !ok || pos != len(test.lenEncoded) {
+			t.Errorf("skipLenEncString returned %v/%v but expected %v/%v", pos, ok, len(test.lenEncoded), true)
+		}
+
+		// Check failed skipping with shorter data.
+		pos, ok = skipLenEncString(test.lenEncoded[:len(test.lenEncoded)-1], 0)
+		if ok {
+			t.Errorf("skipLenEncString returned ok=true for shorter value %v", test.value)
+		}
+
+		// Check failed skipping with no data.
+		pos, ok = skipLenEncString([]byte{}, 0)
+		if ok {
+			t.Errorf("skipLenEncString returned ok=true for empty value %v", test.value)
+		}
+
+		// Check succesful decoding as bytes.
+		gotb, pos, ok := readLenEncStringAsBytes(test.lenEncoded, 0)
+		if !ok || string(gotb) != test.value || pos != len(test.lenEncoded) {
+			t.Errorf("readLenEncString returned %v/%v/%v but expected %v/%v/%v", gotb, pos, ok, test.value, len(test.lenEncoded), true)
+		}
+
+		// Check failed decoding as bytes with shorter data.
+		gotb, pos, ok = readLenEncStringAsBytes(test.lenEncoded[:len(test.lenEncoded)-1], 0)
+		if ok {
+			t.Errorf("readLenEncStringAsBytes returned ok=true for shorter value %v", test.value)
+		}
+
+		// Check failed decoding as bytes with no data.
+		gotb, pos, ok = readLenEncStringAsBytes([]byte{}, 0)
+		if ok {
+			t.Errorf("readLenEncStringAsBytes returned ok=true for empty value %v", test.value)
+		}
+
+		// null encoded tests.
+
+		// Check successful encoding.
+		data = make([]byte, len(test.nullEncoded))
+		pos = writeNullString(data, 0, test.value)
+		if pos != len(test.nullEncoded) {
+			t.Errorf("unexpected pos %v after writeNullString(%v), expected %v", pos, test.value, len(test.nullEncoded))
+		}
+		if !bytes.Equal(data, test.nullEncoded) {
+			t.Errorf("unexpected nullEncoded value for %v, got %v expected %v", test.value, data, test.nullEncoded)
+		}
+
+		// Check succesful decoding.
+		got, pos, ok = readNullString(test.nullEncoded, 0)
+		if !ok || got != test.value || pos != len(test.nullEncoded) {
+			t.Errorf("readNullString returned %v/%v/%v but expected %v/%v/%v", got, pos, ok, test.value, len(test.nullEncoded), true)
+		}
+
+		// Check failed decoding with shorter data.
+		got, pos, ok = readNullString(test.nullEncoded[:len(test.nullEncoded)-1], 0)
+		if ok {
+			t.Errorf("readNullString returned ok=true for shorter value %v", test.value)
+		}
+
+		// EOF encoded tests.
+		// We use the nullEncoded value, removing the 0 at the end.
+
+		// Check successful encoding.
+		data = make([]byte, len(test.nullEncoded)-1)
+		pos = writeEOFString(data, 0, test.value)
+		if pos != len(test.nullEncoded)-1 {
+			t.Errorf("unexpected pos %v after writeEOFString(%v), expected %v", pos, test.value, len(test.nullEncoded)-1)
+		}
+		if !bytes.Equal(data, test.nullEncoded[:len(test.nullEncoded)-1]) {
+			t.Errorf("unexpected nullEncoded value for %v, got %v expected %v", test.value, data, test.nullEncoded)
+		}
+	}
+}

--- a/go/mysqlconn/fakesqldb/server.go
+++ b/go/mysqlconn/fakesqldb/server.go
@@ -1,0 +1,217 @@
+// Package fakesqldb provides a MySQL server for tests.
+package fakesqldb
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/youtube/vitess/go/mysqlconn"
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+// DB is a fake database and all its methods are thread safe.  It
+// creates a mysqlconn.Listener and implements the mysqlconn.Hanlder
+// interface.
+type DB struct {
+	// Fields set at construction time.
+
+	// listener is our mysqlconn.Listener.
+	listener *mysqlconn.Listener
+
+	// Fields set at runtime.
+
+	// mu protects all the following fields.
+	mu sync.Mutex
+	// isConnFail trigger a panic in the connection handler.
+	isConnFail bool
+	// data maps tolower(query) to a result.
+	data map[string]*sqltypes.Result
+	// rejectedData maps tolower(query) to an error.
+	rejectedData map[string]error
+	// patternData is a list of regexp to results.
+	patternData []exprResult
+	// queryCalled keeps track of how many times a query was called.
+	queryCalled map[string]int
+}
+
+type exprResult struct {
+	expr   *regexp.Regexp
+	result *sqltypes.Result
+}
+
+// New creates a server, and starts listening.
+func New(t *testing.T) (*DB, *sqldb.ConnParams) {
+	// Create our DB.
+	db := &DB{
+		data:         make(map[string]*sqltypes.Result),
+		rejectedData: make(map[string]error),
+		queryCalled:  make(map[string]int),
+	}
+
+	// Start listening.
+	var err error
+	db.listener, err = mysqlconn.NewListener("tcp", ":0", db)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+
+	db.listener.PasswordMap["user1"] = "password1"
+	go func() {
+		db.listener.Accept()
+	}()
+
+	// Return the connection parameters.
+	host := db.listener.Addr().(*net.TCPAddr).IP.String()
+	port := db.listener.Addr().(*net.TCPAddr).Port
+
+	return db, &sqldb.ConnParams{
+		Host:    host,
+		Port:    port,
+		Uname:   "user1",
+		Pass:    "password1",
+		Charset: "utf8",
+	}
+}
+
+// Close closes the Listener.
+func (db *DB) Close() {
+	db.listener.Close()
+}
+
+//
+// mysqlconn.Handler interface
+//
+
+// NewConnection is part of the mysqlconn.Handler interface.
+func (db *DB) NewConnection(c *mysqlconn.Conn) {
+	if db.IsConnFail() {
+		panic(fmt.Errorf("simulating a connection failure"))
+	}
+}
+
+// ConnectionClosed is part of the mysqlconn.Handler interface.
+func (db *DB) ConnectionClosed(c *mysqlconn.Conn) {
+}
+
+// ComQuery is part of the mysqlconn.Handler interface.
+func (db *DB) ComQuery(c *mysqlconn.Conn, query string) (*sqltypes.Result, error) {
+	key := strings.ToLower(query)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.queryCalled[key]++
+
+	// Using special handling for 'SET NAMES utf8'.  The driver
+	// may send this at connection time, and we don't want it to
+	// interfere.
+	if key == "set names utf8" {
+		return &sqltypes.Result{}, nil
+	}
+
+	// check if we should reject it.
+	if err, ok := db.rejectedData[key]; ok {
+		return nil, err
+	}
+
+	// Check explicit queries from AddQuery().
+	result, ok := db.data[key]
+	if ok {
+		return result, nil
+	}
+
+	// Check query patterns from AddQueryPattern().
+	for _, pat := range db.patternData {
+		if pat.expr.MatchString(query) {
+			return pat.result, nil
+		}
+	}
+
+	// Nothing matched.
+	return nil, fmt.Errorf("query: %s is not supported", query)
+}
+
+//
+// Methods to add expected queries and results.
+//
+
+// AddQuery adds a query and its expected result.
+func (db *DB) AddQuery(query string, expectedResult *sqltypes.Result) {
+	result := &sqltypes.Result{}
+	*result = *expectedResult
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	key := strings.ToLower(query)
+	db.data[key] = result
+	db.queryCalled[key] = 0
+}
+
+// AddQueryPattern adds an expected result for a set of queries.
+// These patterns are checked if no exact matches from AddQuery() are found.
+// This function forces the addition of begin/end anchors (^$) and turns on
+// case-insensitive matching mode.
+func (db *DB) AddQueryPattern(queryPattern string, expectedResult *sqltypes.Result) {
+	expr := regexp.MustCompile("(?is)^" + queryPattern + "$")
+	result := *expectedResult
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.patternData = append(db.patternData, exprResult{expr, &result})
+}
+
+// DeleteQuery deletes query from the fake DB.
+func (db *DB) DeleteQuery(query string) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	key := strings.ToLower(query)
+	delete(db.data, key)
+	delete(db.queryCalled, key)
+}
+
+// AddRejectedQuery adds a query which will be rejected at execution time.
+func (db *DB) AddRejectedQuery(query string, err error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.rejectedData[strings.ToLower(query)] = err
+}
+
+// DeleteRejectedQuery deletes query from the fake DB.
+func (db *DB) DeleteRejectedQuery(query string) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	delete(db.rejectedData, strings.ToLower(query))
+}
+
+// GetQueryCalledNum returns how many times db executes a certain query.
+func (db *DB) GetQueryCalledNum(query string) int {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	num, ok := db.queryCalled[strings.ToLower(query)]
+	if !ok {
+		return 0
+	}
+	return num
+}
+
+// EnableConnFail makes connection to this fake DB fail.
+func (db *DB) EnableConnFail() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.isConnFail = true
+}
+
+// DisableConnFail makes connection to this fake DB success.
+func (db *DB) DisableConnFail() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.isConnFail = false
+}
+
+// IsConnFail tests whether there is a connection failure.
+func (db *DB) IsConnFail() bool {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.isConnFail
+}

--- a/go/mysqlconn/query.go
+++ b/go/mysqlconn/query.go
@@ -1,0 +1,509 @@
+package mysqlconn
+
+import (
+	"fmt"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// This file contains the methods related to queries.
+
+func (c *Conn) writeComQuery(query string) error {
+	data := make([]byte, len(query)+1)
+	data[0] = ComQuery
+	copy(data[1:], []byte(query))
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	c.flush()
+	return nil
+}
+
+func (c *Conn) writeComInitDB(db string) error {
+	data := make([]byte, len(db)+1)
+	data[0] = ComInitDB
+	copy(data[1:], []byte(db))
+	if err := c.writePacket(data); err != nil {
+		return err
+	}
+	c.flush()
+	return nil
+}
+
+func (c *Conn) readColumnDefinition(field *querypb.Field, index int) error {
+	colDef, err := c.readPacket()
+	if err != nil {
+		return err
+	}
+
+	// Catalog is ignored, always set to "def"
+	pos, ok := skipLenEncString(colDef, 0)
+	if !ok {
+		return fmt.Errorf("skipping col %v catalog failed", index)
+	}
+
+	// schema, table, orgTable, name and OrgName are strings.
+	field.Database, pos, ok = readLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v schema failed", index)
+	}
+	field.Table, pos, ok = readLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v table failed", index)
+	}
+	field.OrgTable, pos, ok = readLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v org_table failed", index)
+	}
+	field.Name, pos, ok = readLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v name failed", index)
+	}
+	field.OrgName, pos, ok = readLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v org_name failed", index)
+	}
+
+	// Skip length of fixed-length fields.
+	pos++
+
+	// characterSet is a uint16.
+	characterSet, pos, ok := readUint16(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v characterSet failed", index)
+	}
+	field.Charset = uint32(characterSet)
+
+	// columnLength is a uint32.
+	field.ColumnLength, pos, ok = readUint32(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v columnLength failed", index)
+	}
+
+	// type is one byte
+	t, pos, ok := readByte(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v type failed", index)
+	}
+
+	// flags is 2 bytes
+	flags, pos, ok := readUint16(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v flags failed", index)
+	}
+	field.Flags = uint32(flags)
+
+	// Convert MySQL type to Vitess type.
+	field.Type, err = sqltypes.MySQLToType(int64(t), int64(flags))
+	if err != nil {
+		return fmt.Errorf("MySQLToType(%v,%v) failed for column %v: %v", t, flags, index, err)
+	}
+
+	// Decimals is a byte.
+	decimals, pos, ok := readByte(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v decimals failed", index)
+	}
+	field.Decimals = uint32(decimals)
+
+	return nil
+}
+
+// readColumnDefinitionType is a faster version of
+// readColumnDefinition that only fills in the Type.
+func (c *Conn) readColumnDefinitionType(field *querypb.Field, index int) error {
+	colDef, err := c.readPacket()
+	if err != nil {
+		return err
+	}
+
+	// catalog, schema, table, orgTable, name and orgName are
+	// strings, all skipped.
+	pos, ok := skipLenEncString(colDef, 0)
+	if !ok {
+		return fmt.Errorf("skipping col %v catalog failed", index)
+	}
+	pos, ok = skipLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("skipping col %v schema failed", index)
+	}
+	pos, ok = skipLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("skipping col %v table failed", index)
+	}
+	pos, ok = skipLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("skipping col %v org_table failed", index)
+	}
+	pos, ok = skipLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("skipping col %v name failed", index)
+	}
+	pos, ok = skipLenEncString(colDef, pos)
+	if !ok {
+		return fmt.Errorf("skipping col %v org_name failed", index)
+	}
+
+	// Skip length of fixed-length fields.
+	pos++
+
+	// characterSet is a uint16.
+	_, pos, ok = readUint16(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v characterSet failed", index)
+	}
+
+	// columnLength is a uint32.
+	_, pos, ok = readUint32(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v columnLength failed", index)
+	}
+
+	// type is one byte
+	t, pos, ok := readByte(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v type failed", index)
+	}
+
+	// flags is 2 bytes
+	flags, pos, ok := readUint16(colDef, pos)
+	if !ok {
+		return fmt.Errorf("extracting col %v flags failed", index)
+	}
+
+	// Convert MySQL type to Vitess type.
+	field.Type, err = sqltypes.MySQLToType(int64(t), int64(flags))
+	if err != nil {
+		return fmt.Errorf("MySQLToType(%v,%v) failed for column %v: %v", t, flags, index, err)
+	}
+
+	// skip decimals
+
+	return nil
+}
+
+func (c *Conn) parseRow(data []byte, fields []*querypb.Field) ([]sqltypes.Value, error) {
+	colNumber := len(fields)
+	result := make([]sqltypes.Value, colNumber)
+	pos := 0
+	for i := 0; i < colNumber; i++ {
+		if data[pos] == 0xfb {
+			pos++
+			continue
+		}
+		var s []byte
+		var ok bool
+		s, pos, ok = readLenEncStringAsBytes(data, pos)
+		if !ok {
+			return nil, fmt.Errorf("decoding string failed")
+		}
+		result[i] = sqltypes.MakeTrusted(fields[i].Type, s)
+	}
+	return result, nil
+}
+
+// ExecuteFetch is the same as sqldb.Conn.ExecuteFetch.
+func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltypes.Result, error) {
+	// This is a new command, need to reset the sequence.
+	c.sequence = 0
+
+	// Send the query as a COM_QUERY packet.
+	if err := c.writeComQuery(query); err != nil {
+		return nil, err
+	}
+
+	// Get the result.
+	affectedRows, lastInsertID, colNumber, err := c.readComQueryResponse()
+	if err != nil {
+		return nil, err
+	}
+	if colNumber == 0 {
+		// OK packet, means no results. Just use the numbers.
+		return &sqltypes.Result{
+			RowsAffected: affectedRows,
+			InsertID:     lastInsertID,
+		}, nil
+	}
+
+	fields := make([]querypb.Field, colNumber)
+	result := &sqltypes.Result{
+		Fields: make([]*querypb.Field, colNumber),
+	}
+
+	// Read column headers. One packet per column.
+	// Build the fields.
+	for i := 0; i < colNumber; i++ {
+		result.Fields[i] = &fields[i]
+
+		if wantfields {
+			if err := c.readColumnDefinition(result.Fields[i], i); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := c.readColumnDefinitionType(result.Fields[i], i); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+		// EOF is only present here if it's not deprecated.
+		data, err := c.readPacket()
+		if err != nil {
+			return nil, err
+		}
+		switch data[0] {
+		case EOFPacket:
+			// This is what we expect.
+			// Warnings and status flags are ignored.
+			break
+		case ErrPacket:
+			// Error packet.
+			return nil, parseErrorPacket(data)
+		default:
+			return nil, fmt.Errorf("unexpected packet after fields: %v", data)
+		}
+	}
+
+	// read each row until EOF or OK packet.
+	for {
+		data, err := c.readPacket()
+		if err != nil {
+			return nil, err
+		}
+
+		switch data[0] {
+		case EOFPacket:
+			// This packet may be one of two kinds:
+			// - an EOF packet,
+			// - an OK packet with an EOF header if
+			// CapabilityClientDeprecateEOF is set.
+			// We do not parse it anyway, so it doesn't matter.
+
+			// Strip the partial Fields before returning.
+			if !wantfields {
+				result.Fields = nil
+			}
+			return result, nil
+		case ErrPacket:
+			// Error packet.
+			return nil, parseErrorPacket(data)
+		}
+
+		// Check we're not over the limit before we add more.
+		if len(result.Rows) == maxrows {
+			if err := c.drainResults(); err != nil {
+				return nil, err
+			}
+			return nil, &sqldb.SQLError{
+				Num:     0,
+				Message: fmt.Sprintf("Row count exceeded %d", maxrows),
+				Query:   query,
+			}
+		}
+
+		// Regular row.
+		row, err := c.parseRow(data, result.Fields)
+		if err != nil {
+			return nil, err
+		}
+		result.Rows = append(result.Rows, row)
+	}
+}
+
+// drainResults will read all packets for a result set and ignore them.
+func (c *Conn) drainResults() error {
+	for {
+		data, err := c.readPacket()
+		if err != nil {
+			return err
+		}
+
+		switch data[0] {
+		case EOFPacket:
+			// This packet may be one of two kinds:
+			// - an EOF packet,
+			// - an OK packet with an EOF header if
+			// CapabilityClientDeprecateEOF is set.
+			// We do not parse it anyway, so it doesn't matter.
+			return nil
+		case ErrPacket:
+			// Error packet.
+			return parseErrorPacket(data)
+		}
+	}
+}
+
+func (c *Conn) readComQueryResponse() (uint64, uint64, int, error) {
+	data, err := c.readPacket()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	if len(data) == 0 {
+		return 0, 0, 0, fmt.Errorf("invalid empty COM_QUERY response packet")
+	}
+
+	switch data[0] {
+	case OKPacket:
+		affectedRows, lastInsertID, _, _, err := parseOKPacket(data)
+		return affectedRows, lastInsertID, 0, err
+	case ErrPacket:
+		// Error
+		return 0, 0, 0, parseErrorPacket(data)
+	case 0xfb:
+		// Local infile
+		return 0, 0, 0, fmt.Errorf("not implemented")
+	}
+
+	n, pos, ok := readLenEncInt(data, 0)
+	if !ok {
+		return 0, 0, 0, fmt.Errorf("cannot get column number")
+	}
+	if pos != len(data) {
+		return 0, 0, 0, fmt.Errorf("extra data in COM_QUERY response")
+	}
+	return 0, 0, int(n), nil
+}
+
+func (c *Conn) parseComQuery(data []byte) string {
+	return string(data[1:])
+}
+
+func (c *Conn) parseComInitDB(data []byte) string {
+	return string(data[1:])
+}
+
+func (c *Conn) sendColumnCount(count uint64) error {
+	length := lenEncIntSize(count)
+	data := make([]byte, length)
+	writeLenEncInt(data, 0, count)
+	return c.writePacket(data)
+}
+
+func (c *Conn) writeColumnDefinition(field *querypb.Field) error {
+	length := 4 + // lenEncStringSize("def")
+		lenEncStringSize(field.Database) +
+		lenEncStringSize(field.Table) +
+		lenEncStringSize(field.OrgTable) +
+		lenEncStringSize(field.Name) +
+		lenEncStringSize(field.OrgName) +
+		1 + // length of fixed length fields
+		2 + // character set
+		4 + // column length
+		1 + // type
+		2 + // flags
+		1 + // decimals
+		2 // filler
+
+	// Only get the type back. The flags can be retrieved from the
+	// Field.
+	typ, _ := sqltypes.TypeToMySQL(field.Type)
+
+	data := make([]byte, length)
+	pos := 0
+
+	pos = writeLenEncString(data, pos, "def") // Always the same.
+	pos = writeLenEncString(data, pos, field.Database)
+	pos = writeLenEncString(data, pos, field.Table)
+	pos = writeLenEncString(data, pos, field.OrgTable)
+	pos = writeLenEncString(data, pos, field.Name)
+	pos = writeLenEncString(data, pos, field.OrgName)
+	pos = writeByte(data, pos, 0x0c)
+	pos = writeUint16(data, pos, uint16(field.Charset))
+	pos = writeUint32(data, pos, field.ColumnLength)
+	pos = writeByte(data, pos, byte(typ))
+	pos = writeUint16(data, pos, uint16(field.Flags))
+	pos = writeByte(data, pos, byte(field.Decimals))
+	pos += 2
+
+	if pos != len(data) {
+		return fmt.Errorf("internal error: packing of column definition used %v bytes instead of %v", pos, len(data))
+	}
+
+	return c.writePacket(data)
+}
+
+func (c *Conn) writeRow(row []sqltypes.Value) error {
+	length := 0
+	for _, val := range row {
+		if val.IsNull() {
+			length++
+		} else {
+			l := len(val.Raw())
+			length += lenEncIntSize(uint64(l)) + l
+		}
+	}
+
+	data := make([]byte, length)
+	pos := 0
+	for _, val := range row {
+		if val.IsNull() {
+			pos = writeByte(data, pos, NullValue)
+		} else {
+			l := len(val.Raw())
+			pos = writeLenEncInt(data, pos, uint64(l))
+			pos += copy(data[pos:], val.Raw())
+		}
+	}
+
+	if pos != length {
+		return fmt.Errorf("internal error packet row: got %v bytes but expected %v", pos, length)
+	}
+
+	return c.writePacket(data)
+}
+
+// writeResult writes a query Result to the wire.
+func (c *Conn) writeResult(result *sqltypes.Result) error {
+	if len(result.Fields) == 0 {
+		// This is just an INSERT result, send an OK packet.
+		return c.writeOKPacket(result.RowsAffected, result.InsertID, c.StatusFlags, 0)
+	}
+
+	// Now send a packet with just the number of fields.
+	if err := c.sendColumnCount(uint64(len(result.Fields))); err != nil {
+		return err
+	}
+
+	// Now send each Field.
+	for _, field := range result.Fields {
+		if err := c.writeColumnDefinition(field); err != nil {
+			return err
+		}
+	}
+
+	// Now send an EOF packet.
+	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+		// With CapabilityClientDeprecateEOF, we do not send this EOF.
+		if err := c.writeEOFPacket(c.StatusFlags, 0); err != nil {
+			return err
+		}
+	}
+
+	// Now send one packet per row.
+	for _, row := range result.Rows {
+		if err := c.writeRow(row); err != nil {
+			return err
+		}
+	}
+
+	// And send either an EOF, or an OK packet.
+	// FIXME(alainjobart) if multi result is set, can send more after this.
+	// See doc.go.
+	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+		if err := c.writeEOFPacket(c.StatusFlags, 0); err != nil {
+			return err
+		}
+		c.flush()
+	} else {
+		// This will flush too.
+		if err := c.writeOKPacketWithEOFHeader(0, 0, c.StatusFlags, 0); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/go/mysqlconn/query_test.go
+++ b/go/mysqlconn/query_test.go
@@ -1,0 +1,214 @@
+package mysqlconn
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestComInitDB(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Write ComInitDB packet, read it, compare.
+	if err := cConn.writeComInitDB("my_db"); err != nil {
+		t.Fatalf("writeComInitDB failed: %v", err)
+	}
+	data, err := sConn.readPacket()
+	if err != nil || len(data) == 0 || data[0] != ComInitDB {
+		t.Fatalf("sConn.readPacket - ComInitDB failed: %v %v", data, err)
+	}
+	db := sConn.parseComInitDB(data)
+	if db != "my_db" {
+		t.Errorf("parseComInitDB returned unexpected data: %v", db)
+	}
+}
+
+func TestQueries(t *testing.T) {
+	listener, sConn, cConn := createSocketPair(t)
+	defer func() {
+		listener.Close()
+		sConn.Close()
+		cConn.Close()
+	}()
+
+	// Smallest result
+	checkQuery(t, sConn, cConn, &sqltypes.Result{})
+
+	// Typical Insert result
+	checkQuery(t, sConn, cConn, &sqltypes.Result{
+		RowsAffected: 0x8010203040506070,
+		InsertID:     0x0102030405060708,
+	})
+
+	// Typicall Select with TYPE_AND_NAME.
+	// One value is also NULL.
+	checkQuery(t, sConn, cConn, &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "id",
+				Type: querypb.Type_INT32,
+			},
+			{
+				Name: "name",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("10")),
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT32, []byte("20")),
+				sqltypes.NULL,
+			},
+		},
+	})
+
+	// Typicall Select with TYPE_AND_NAME.
+	// First value first column is an empty string, so it's encoded as 0.
+	checkQuery(t, sConn, cConn, &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Name: "name",
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
+			},
+		},
+	})
+
+	// Typicall Select with TYPE_ONLY.
+	checkQuery(t, sConn, cConn, &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Type: querypb.Type_INT64,
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("10")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("20")),
+			},
+		},
+	})
+
+	// Typicall Select with ALL.
+	checkQuery(t, sConn, cConn, &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{
+				Type:         querypb.Type_INT64,
+				Name:         "cool column name",
+				Table:        "table name",
+				OrgTable:     "org table",
+				Database:     "fine db",
+				OrgName:      "crazy org",
+				ColumnLength: 0x80020304,
+				Charset:      0x1234,
+				Decimals:     36,
+				Flags:        16387, // NOT_NULL_FLAG, PRI_KEY_FLAG, PART_KEY_FLAG
+			},
+		},
+		Rows: [][]sqltypes.Value{
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("10")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("20")),
+			},
+			{
+				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("30")),
+			},
+		},
+	})
+}
+
+func checkQuery(t *testing.T, sConn, cConn *Conn, result *sqltypes.Result) {
+	// The protocol depends on the CapabilityClientDeprecateEOF flag.
+	// So we want to test both cases.
+
+	sConn.Capabilities = 0
+	cConn.Capabilities = 0
+	checkQueryInternal(t, sConn, cConn, result, true /* wantfields */, true /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, false /* wantfields */, true /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, true /* wantfields */, false /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, false /* wantfields */, false /* allRows */)
+
+	sConn.Capabilities = CapabilityClientDeprecateEOF
+	cConn.Capabilities = CapabilityClientDeprecateEOF
+	checkQueryInternal(t, sConn, cConn, result, true /* wantfields */, true /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, false /* wantfields */, true /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, true /* wantfields */, false /* allRows */)
+	checkQueryInternal(t, sConn, cConn, result, false /* wantfields */, false /* allRows */)
+}
+
+func checkQueryInternal(t *testing.T, sConn, cConn *Conn, result *sqltypes.Result, wantfields, allRows bool) {
+
+	query := "query test"
+
+	// Use a go routine to run ExecuteFetch.
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		maxrows := 10000
+		if !allRows {
+			// Asking for just one row max. The results that have more will fail.
+			maxrows = 1
+		}
+		got, err := cConn.ExecuteFetch(query, maxrows, wantfields)
+		if !allRows && len(result.Rows) > 1 {
+			if err == nil {
+				t.Errorf("ExecuteFetch should have failed but got: %v", got)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("executeFetch failed: %v", err)
+		}
+		expected := *result
+		if !wantfields {
+			expected.Fields = nil
+		}
+		if !reflect.DeepEqual(got, &expected) {
+			t.Fatalf("executeFetch(wantfields=%v) returned:\n%v\nBut was expecting:\n%v", wantfields, got, expected)
+		}
+	}()
+
+	// The other side gets the request, and sends the result.
+	comQuery, err := sConn.readPacket()
+	if err != nil {
+		t.Fatalf("server cannot read query: %v", err)
+	}
+	if comQuery[0] != ComQuery {
+		t.Fatalf("server got bad packet: %v", comQuery)
+	}
+	got := sConn.parseComQuery(comQuery)
+	if got != query {
+		t.Errorf("server got query '%v' but expected '%v'", got, query)
+	}
+	if err := sConn.writeResult(result); err != nil {
+		t.Errorf("Error writing result to client: %v", err)
+	}
+	sConn.sequence = 0
+
+	wg.Wait()
+}

--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -1,0 +1,414 @@
+package mysqlconn
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"net"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/tb"
+)
+
+const (
+	// DefaultServerVersion is the default server version we're sending to the client.
+	// Can be changed.
+	DefaultServerVersion = "5.5.10-Vitess"
+)
+
+// A Handler is an interface used by Listener to send queries.
+// The implementation of this interface may store data in the ClientData
+// field of the Connection for its own purposes.
+//
+// For a given Connection, all these methods are serialized. It means
+// only one of these methods will be called concurrently for a given
+// Connection. So access to the Connection ClientData does not need to
+// be protected by a mutex.
+//
+// However, each connection is using one go routine, so multiple
+// Connection objects can call these concurrently, for different Connections.
+type Handler interface {
+	// NewConnection is called when a connection is created.
+	// It is not established yet. The handler can decide to
+	// set StatusFlags that will be returned by the handshake methods.
+	// In particular, ServerStatusAutocommit might be set.
+	NewConnection(c *Conn)
+
+	// ConnectionClosed is called when a connection is closed.
+	ConnectionClosed(c *Conn)
+
+	// ComQuery is called when a connection receives a query.
+	ComQuery(c *Conn, query string) (*sqltypes.Result, error)
+}
+
+// Listener is the MySQL server protocol listener.
+type Listener struct {
+	// Construction parameters, set by NewListener.
+
+	// handler is the data handler.
+	handler Handler
+
+	// This is the main listener socket.
+	listener net.Listener
+
+	// The following parameters are read by multiple connection go
+	// routines.  They are not protected by a mutex, so they
+	// should be set after NewListener, and not changed while
+	// Accept is running.
+
+	// ServerVersion is the version we will advertise.
+	ServerVersion string
+
+	// PasswordMap maps users to passwords.
+	PasswordMap map[string]string
+
+	// The following parameters are changed by the Accept routine.
+
+	// Incrementing ID for connection id.
+	connectionID uint32
+}
+
+// NewListener creates a new Listener.
+func NewListener(protocol, address string, handler Handler) (*Listener, error) {
+	listener, err := net.Listen(protocol, address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Listener{
+		ServerVersion: DefaultServerVersion,
+		handler:       handler,
+		PasswordMap:   make(map[string]string),
+		listener:      listener,
+		connectionID:  1,
+	}, nil
+}
+
+// Addr returns the listener address.
+func (l *Listener) Addr() net.Addr {
+	return l.listener.Addr()
+}
+
+// Accept runs an accept loop until the listener is closed.
+func (l *Listener) Accept() {
+	for {
+		conn, err := l.listener.Accept()
+		if err != nil {
+			// Close() was probably called.
+			return
+		}
+
+		connectionID := l.connectionID
+		l.connectionID++
+
+		go l.handle(conn, connectionID)
+	}
+}
+
+// handle is called in a go routine for each client connection.
+// FIXME(alainjobart) handle per-connection logs in a way that makes sense.
+// FIXME(alainjobart) add an idle timeout for the connection.
+func (l *Listener) handle(conn net.Conn, connectionID uint32) {
+	c := newConn(conn)
+	c.ConnectionID = connectionID
+
+	// Catch panics, and close the connection in any case.
+	defer func() {
+		if x := recover(); x != nil {
+			log.Errorf("mysql_server caught panic:\n%v\n%s", x, tb.Stack(4))
+		}
+		conn.Close()
+	}()
+
+	// Tell the handler about the connection coming and going.
+	l.handler.NewConnection(c)
+	defer l.handler.ConnectionClosed(c)
+
+	// First build and send the server handshake packet.
+	cipher, err := c.writeHandshakeV10(l.ServerVersion)
+	if err != nil {
+		log.Errorf("Cannot send HandshakeV10 packet: %v", err)
+		return
+	}
+
+	// Wait for the client response.
+	response, err := c.readPacket()
+	if err != nil {
+		log.Errorf("Cannot read client handshake response: %v", err)
+		return
+	}
+	username, authResponse, err := l.parseClientHandshakePacket(c, response)
+	if err != nil {
+		log.Errorf("Cannot parse client handshake response: %v", err)
+		return
+	}
+
+	// Find the user in our map
+	password, ok := l.PasswordMap[username]
+	if !ok {
+		log.Errorf("Invalid user: %v", username)
+		c.writeErrorPacket(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", username)
+		return
+	}
+
+	// Validate the password.
+	computedAuthResponse := scramblePassword(cipher, []byte(password))
+	if bytes.Compare(authResponse, computedAuthResponse) != 0 {
+		log.Errorf("Invalid password for user %v", username)
+		c.writeErrorPacket(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", username)
+		return
+	}
+
+	// Send an OK packet.
+	if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
+		log.Errorf("Cannot write OK packet: %v", err)
+		return
+	}
+
+	for {
+		c.sequence = 0
+		data, err := c.readPacket()
+		if err != nil {
+			log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
+			return
+		}
+
+		switch data[0] {
+		case ComQuit:
+			log.Infof("Client %v disconnected.", c.ConnectionID)
+			return
+		case ComInitDB:
+			db := c.parseComInitDB(data)
+			c.SchemaName = db
+			if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
+				log.Errorf("Error writing ComInitDB result to client %v: %v", c.ConnectionID, err)
+				return
+			}
+		case ComQuery:
+			query := c.parseComQuery(data)
+			log.Infof("Received command from client %v: %v", c.ConnectionID, query)
+			result, err := l.handler.ComQuery(c, query)
+			if err != nil {
+				if werr := c.writeErrorPacketFromError(err); werr != nil {
+					// If we can't even write the error, we're done.
+					log.Errorf("Error writing query error to client %v: %v", c.ConnectionID, werr)
+					return
+				}
+				continue
+			}
+			if err := c.writeResult(result); err != nil {
+				log.Errorf("Error writing result to client %v: %v", c.ConnectionID, err)
+				return
+			}
+		case ComPing:
+			// No payload to that one, just return OKPacket.
+			if err := c.writeOKPacket(0, 0, c.StatusFlags, 0); err != nil {
+				log.Errorf("Error writing ComPing result to client %v: %v", c.ConnectionID, err)
+				return
+			}
+		default:
+			log.Errorf("Got unhandled packet from client %v, returning error: %v", c.ConnectionID, data)
+			if err := c.writeErrorPacket(ERUnknownComError, SSUnknownComError, "command handling not implemented yet: %v", data[0]); err != nil {
+				log.Errorf("Error writing error packet to client: %v", err)
+				return
+			}
+
+		}
+	}
+}
+
+// Close stops the listener, and closes all connections.
+func (l *Listener) Close() {
+	l.listener.Close()
+}
+
+// writeHandshakeV10 writes the Initial Handshake Packet, server side.
+// It returns the cipher data.
+func (c *Conn) writeHandshakeV10(serverVersion string) ([]byte, error) {
+	capabilities := CapabilityClientLongPassword |
+		CapabilityClientLongFlag |
+		CapabilityClientConnectWithDB |
+		CapabilityClientProtocol41 |
+		CapabilityClientTransactions |
+		CapabilityClientSecureConnection |
+		CapabilityClientPluginAuth |
+		CapabilityClientPluginAuthLenencClientData |
+		CapabilityClientDeprecateEOF
+
+	length :=
+		1 + // protocol version
+			lenNullString(serverVersion) +
+			4 + // connection ID
+			8 + // first part of cipher data
+			1 + // filler byte
+			2 + // capability flags (lower 2 bytes)
+			1 + // character set
+			2 + // status flag
+			2 + // capability flags (upper 2 bytes)
+			1 + // length of auth plugin data
+			10 + // reserved (0)
+			13 + // auth-plugin-data
+			lenNullString(mysqlNativePassword) // auth-plugin-name
+
+	data := make([]byte, length)
+	pos := 0
+
+	// Protocol version.
+	pos = writeByte(data, pos, protocolVersion)
+
+	// Copy server version.
+	pos = writeNullString(data, pos, serverVersion)
+
+	// Add connectionID in.
+	pos = writeUint32(data, pos, c.ConnectionID)
+
+	// Generate the cipher, put 8 bytes in.
+	cipher := make([]byte, 20)
+	if _, err := rand.Read(cipher); err != nil {
+		return nil, err
+	}
+	pos += copy(data[pos:], cipher[:8])
+
+	// One filler byte, always 0.
+	pos = writeByte(data, pos, 0)
+
+	// Lower part of the capability flags.
+	pos = writeUint16(data, pos, uint16(capabilities))
+
+	// Character set.
+	pos = writeByte(data, pos, CharacterSetUtf8)
+
+	// Status flag.
+	pos = writeUint16(data, pos, c.StatusFlags)
+
+	// Upper part of the capability flags.
+	pos = writeUint16(data, pos, uint16(capabilities>>16))
+
+	// Length of auth plugin data.
+	// Always 21 (8 + 13).
+	pos = writeByte(data, pos, 21)
+
+	// Reserved
+	pos += 10
+
+	// Second part of auth plugin data.
+	pos += copy(data[pos:], cipher[8:])
+	data[pos] = 0
+	pos++
+
+	// Copy authPluginName.
+	pos = writeNullString(data, pos, mysqlNativePassword)
+
+	// Sanity check.
+	if pos != len(data) {
+		return nil, fmt.Errorf("error building Handshake packet: got %v bytes expected %v", pos, len(data))
+	}
+
+	if err := c.writePacket(data); err != nil {
+		return nil, fmt.Errorf("cannot write HandshakeV10 packet: %v", err)
+	}
+	c.flush()
+
+	return cipher, nil
+}
+
+// parseClientHandshakePacket parses the handshake sent by the client.
+// Returns the username, auth-data, error.
+func (l *Listener) parseClientHandshakePacket(c *Conn, data []byte) (string, []byte, error) {
+	pos := 0
+
+	// Client flags, 4 bytes.
+	clientFlags, pos, ok := readUint32(data, pos)
+	if !ok {
+		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read client flags")
+	}
+	if clientFlags&CapabilityClientProtocol41 == 0 {
+		return "", nil, fmt.Errorf("parseClientHandshakePacket: only support protocol 4.1")
+	}
+
+	// Remember a subset of the capabilities, so we can use them later in the protocol.
+	c.Capabilities = clientFlags & (CapabilityClientDeprecateEOF)
+
+	// Max packet size. Don't do anything with this now.
+	// See doc.go for more information.
+	/*maxPacketSize*/ _, pos, ok = readUint32(data, pos)
+	if !ok {
+		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read maxPacketSize")
+	}
+
+	// Character set. Need to handle it.
+	characterSet, pos, ok := readByte(data, pos)
+	if !ok {
+		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read characterSet")
+	}
+	c.CharacterSet = characterSet
+
+	// 23x reserved zero bytes.
+	pos += 23
+
+	// username
+	username, pos, ok := readNullString(data, pos)
+	if !ok {
+		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read username")
+	}
+
+	// auth-response can have three forms.
+	var authResponse []byte
+	if clientFlags&CapabilityClientPluginAuthLenencClientData != 0 {
+		var l uint64
+		l, pos, ok = readLenEncInt(data, pos)
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read auth-response variable length")
+		}
+		authResponse, pos, ok = readBytes(data, pos, int(l))
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read auth-response")
+		}
+
+	} else if clientFlags&CapabilityClientSecureConnection != 0 {
+		var l byte
+		l, pos, ok = readByte(data, pos)
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read auth-response length")
+		}
+
+		authResponse, pos, ok = readBytes(data, pos, int(l))
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read auth-response")
+		}
+	} else {
+		a := ""
+		a, pos, ok = readNullString(data, pos)
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read auth-response")
+		}
+		authResponse = []byte(a)
+	}
+
+	// db name.
+	if clientFlags&CapabilityClientConnectWithDB != 0 {
+		dbname := ""
+		dbname, pos, ok = readNullString(data, pos)
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read dbname")
+		}
+		c.SchemaName = dbname
+	}
+
+	// auth plugin name
+	authPluginName := "mysql_native_password"
+	if clientFlags&CapabilityClientPluginAuth != 0 {
+		authPluginName, pos, ok = readNullString(data, pos)
+		if !ok {
+			return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read authPluginName")
+		}
+	}
+	if authPluginName != mysqlNativePassword {
+		return "", nil, fmt.Errorf("invalid authPluginName, got %v but only support %v", authPluginName, mysqlNativePassword)
+	}
+
+	// FIXME(alainjobart) Add CLIENT_CONNECT_ATTRS parsing if we need it.
+
+	return username, authResponse, nil
+}

--- a/go/mysqlconn/server_test.go
+++ b/go/mysqlconn/server_test.go
@@ -1,0 +1,248 @@
+package mysqlconn
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+	vtenv "github.com/youtube/vitess/go/vt/env"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+type testHandler struct {
+	t *testing.T
+}
+
+func (th *testHandler) NewConnection(c *Conn) {
+}
+
+func (th *testHandler) ConnectionClosed(c *Conn) {
+}
+
+func (th *testHandler) ComQuery(c *Conn, query string) (*sqltypes.Result, error) {
+	th.t.Logf("ComQuery(id=%v,schemaName=%v): %v", c.ConnectionID, c.SchemaName, query)
+
+	if query == "error" {
+		return nil, sqldb.NewSQLError(ERUnknownComError, SSUnknownComError, "forced query handling error for: %v", query)
+	}
+
+	if query == "panic" {
+		panic("test panic attack!")
+	}
+
+	if query == "select rows" {
+		return &sqltypes.Result{
+			Fields: []*querypb.Field{
+				{
+					Name: "id",
+					Type: querypb.Type_INT32,
+				},
+				{
+					Name: "name",
+					Type: querypb.Type_VARCHAR,
+				},
+			},
+			Rows: [][]sqltypes.Value{
+				{
+					sqltypes.MakeTrusted(querypb.Type_INT32, []byte("10")),
+					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
+				},
+				{
+					sqltypes.MakeTrusted(querypb.Type_INT32, []byte("20")),
+					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nicer name")),
+				},
+			},
+		}, nil
+	}
+
+	if query == "insert" {
+		return &sqltypes.Result{
+			RowsAffected: 123,
+			InsertID:     123456789,
+		}, nil
+	}
+
+	if query == "schema echo" {
+		return &sqltypes.Result{
+			Fields: []*querypb.Field{
+				{
+					Name: "schema_name",
+					Type: querypb.Type_VARCHAR,
+				},
+			},
+			Rows: [][]sqltypes.Value{
+				{
+					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(c.SchemaName)),
+				},
+			},
+		}, nil
+	}
+
+	return &sqltypes.Result{}, nil
+}
+
+func TestServer(t *testing.T) {
+	th := &testHandler{t: t}
+
+	l, err := NewListener("tcp", ":0", th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	l.PasswordMap["user1"] = "password1"
+
+	go func() {
+		l.Accept()
+	}()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Setup the right parameters.
+	params := &sqldb.ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	// Run an 'error' command.
+	output, ok := runMysql(t, params, "error")
+	if ok {
+		t.Fatalf("mysql should have failed: %v", output)
+	}
+	t.Logf("Output of 'error' command:\n%v", output)
+	if !strings.Contains(output, "ERROR 1047 (08S01)") ||
+		!strings.Contains(output, "forced query handling error for") {
+		t.Errorf("Unexpected output for 'error'")
+	}
+
+	// Run a 'panic' command, other side should panic, recover and
+	// close the connection.
+	output, ok = runMysql(t, params, "panic")
+	if ok {
+		t.Fatalf("mysql should have failed: %v", output)
+	}
+	t.Logf("Output of 'panic' command:\n%v", output)
+	if !strings.Contains(output, "ERROR 2013 (HY000)") ||
+		!strings.Contains(output, "Lost connection to MySQL server during query") {
+		t.Errorf("Unexpected output for 'panic'")
+	}
+
+	// Run a 'select rows' command with results.
+	output, ok = runMysql(t, params, "select rows")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	t.Logf("Output of 'select rows' command:\n%v", output)
+	if !strings.Contains(output, "nice name") ||
+		!strings.Contains(output, "nicer name") ||
+		!strings.Contains(output, "2 rows in set") {
+		t.Errorf("Unexpected output for 'select rows'")
+	}
+
+	// Run an 'insert' command, no rows, but rows affected.
+	output, ok = runMysql(t, params, "insert")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	t.Logf("Output of 'insert' command:\n%v", output)
+	if !strings.Contains(output, "Query OK, 123 rows affected") {
+		t.Errorf("Unexpected output for 'insert'")
+	}
+
+	// Run a 'schema echo' command, to make sure db name is right.
+	params.DbName = "XXXfancyXXX"
+	output, ok = runMysql(t, params, "schema echo")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	t.Logf("Output of 'schema echo' command:\n%v", output)
+	if !strings.Contains(output, params.DbName) {
+		t.Errorf("Unexpected output for 'schema echo'")
+	}
+
+	// Uncomment to leave setup up for a while, to run tests manually.
+	//	fmt.Printf("Listening to server on host '%v' port '%v'.\n", host, port)
+	//	time.Sleep(60 * time.Minute)
+}
+
+// runMysql forks a mysql command line process connecting to the provided server.
+func runMysql(t *testing.T, params *sqldb.ConnParams, command string) (string, bool) {
+	dir, err := vtenv.VtMysqlRoot()
+	if err != nil {
+		t.Fatalf("vtenv.VtMysqlRoot failed: %v", err)
+	}
+	name, err := binaryPath(dir, "mysql")
+	if err != nil {
+		t.Fatalf("binaryPath failed: %v", err)
+	}
+	// The args contain '-v' 3 times, to switch to very verbose output.
+	// In particular, it has the message:
+	// Query OK, 1 row affected (0.00 sec)
+	args := []string{
+		"-e", command,
+		"-v", "-v", "-v",
+	}
+	if params.UnixSocket != "" {
+		args = append(args, []string{
+			"-S", params.UnixSocket,
+		}...)
+	} else {
+		args = append(args, []string{
+			"-h", params.Host,
+			"-P", fmt.Sprintf("%v", params.Port),
+		}...)
+	}
+	if params.Uname != "" {
+		args = append(args, []string{
+			"-u", params.Uname,
+		}...)
+	}
+	if params.Pass != "" {
+		args = append(args, "-p"+params.Pass)
+	}
+	if params.DbName != "" {
+		args = append(args, []string{
+			"-D", params.DbName,
+		}...)
+	}
+	env := []string{
+		"LD_LIBRARY_PATH=" + path.Join(dir, "lib/mysql"),
+	}
+
+	cmd := exec.Command(name, args...)
+	cmd.Env = env
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+	if err != nil {
+		t.Logf("mysql: %v failed: %v\n%v", name, err, output)
+		return output, false
+	}
+	return output, true
+}
+
+// binaryPath does a limited path lookup for a command,
+// searching only within sbin and bin in the given root.
+//
+// FIXME(alainjobart) move this to vt/env, and use it from
+// go/vt/mysqlctl too.
+func binaryPath(root, binary string) (string, error) {
+	subdirs := []string{"sbin", "bin"}
+	for _, subdir := range subdirs {
+		binPath := path.Join(root, subdir, binary)
+		if _, err := os.Stat(binPath); err == nil {
+			return binPath, nil
+		}
+	}
+	return "", fmt.Errorf("%s not found in any of %s/{%s}",
+		binary, root, strings.Join(subdirs, ","))
+}

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -1,0 +1,176 @@
+package mysqlconn
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// This file contains the methods needed to implement the sqldb.Conn
+// interface.  These methods don't necessarely make sense, but it's
+// easier to implement them as is, and then later on refactor
+// everything, once the C version of mysql connection is gone.
+//
+// ExecuteFetch is in query.go.
+// Close() is in conn.go.
+
+// ExecuteStreamFetch is part of the sqldb.Conn interface.
+func (c *Conn) ExecuteStreamFetch(query string) error {
+	// Sanity check.
+	if c.fields != nil {
+		return fmt.Errorf("streaming query already in progress")
+	}
+
+	// This is a new command, need to reset the sequence.
+	c.sequence = 0
+
+	// Send the query as a COM_QUERY packet.
+	if err := c.writeComQuery(query); err != nil {
+		return err
+	}
+
+	// Get the result.
+	_, _, colNumber, err := c.readComQueryResponse()
+	if err != nil {
+		return err
+	}
+	if colNumber == 0 {
+		// OK packet, means no results. Save an empty Fields array.
+		c.fields = make([]*querypb.Field, 0)
+		return nil
+	}
+
+	// Read the fields, save them.
+	fields := make([]querypb.Field, colNumber)
+	fieldsPointers := make([]*querypb.Field, colNumber)
+
+	// Read column headers. One packet per column.
+	// Build the fields.
+	for i := 0; i < colNumber; i++ {
+		fieldsPointers[i] = &fields[i]
+		if err := c.readColumnDefinition(fieldsPointers[i], i); err != nil {
+			return err
+		}
+	}
+
+	// Read the EOF after the fields if necessary.
+	if c.Capabilities&CapabilityClientDeprecateEOF == 0 {
+		// EOF is only present here if it's not deprecated.
+		data, err := c.readPacket()
+		if err != nil {
+			return err
+		}
+		switch data[0] {
+		case EOFPacket:
+			// This is what we expect.
+			// Warnings and status flags are ignored.
+			break
+		case ErrPacket:
+			// Error packet.
+			return parseErrorPacket(data)
+		default:
+			return fmt.Errorf("unexpected packet after fields: %v", data)
+		}
+	}
+
+	c.fields = fieldsPointers
+	return nil
+}
+
+// Fields is part of the sqldb.Conn interface.
+func (c *Conn) Fields() ([]*querypb.Field, error) {
+	if c.fields == nil {
+		return nil, fmt.Errorf("no streaming query in progress")
+	}
+	return c.fields, nil
+}
+
+// FetchNext is part of the sqldb.Conn interface.
+func (c *Conn) FetchNext() ([]sqltypes.Value, error) {
+	if c.fields == nil {
+		// We are already done.
+		return nil, nil
+	}
+
+	data, err := c.readPacket()
+	if err != nil {
+		return nil, err
+	}
+
+	switch data[0] {
+	case OKPacket:
+		// The entire contents of the packet is ignored.
+		// This packet is only seen if CapabilityClientDeprecateEOF is set.
+		// But we can still understand it anyway.
+		c.fields = nil
+		return nil, nil
+	case EOFPacket:
+		// Warnings and status flags are ignored.
+		c.fields = nil
+		return nil, nil
+	case ErrPacket:
+		// Error packet.
+		return nil, parseErrorPacket(data)
+	}
+
+	// Regular row.
+	return c.parseRow(data, c.fields)
+}
+
+// CloseResult is part of the sqldb.Conn interface.
+// Just drain the remaining values.
+func (c *Conn) CloseResult() {
+	for c.fields != nil {
+		_, err := c.FetchNext()
+		if err != nil {
+			c.fields = nil
+			return
+		}
+	}
+}
+
+// IsClosed is part of the sqldb.Conn interface.
+func (c *Conn) IsClosed() bool {
+	return c.ConnectionID == 0
+}
+
+// Shutdown is part of the sqldb.Conn interface.
+func (c *Conn) Shutdown() {
+	c.ConnectionID = 0
+	c.conn.Close()
+}
+
+// ID is part of the sqldb.Conn interface.
+func (c *Conn) ID() int64 {
+	return int64(c.ConnectionID)
+}
+
+// ReadPacket is part of the sqldb.Conn interface.
+func (c *Conn) ReadPacket() ([]byte, error) {
+	return c.readPacket()
+}
+
+// SendCommand is part of the sqldb.Conn interface.
+// Note this implementation is not efficient (and the command type is
+// a byte, not a uint32), but this is not used often.  We'll refactor it.
+func (c *Conn) SendCommand(command uint32, data []byte) error {
+	// This is a new command, need to reset the sequence.
+	c.sequence = 0
+
+	fullData := make([]byte, len(data)+1)
+	fullData[0] = byte(command)
+	copy(fullData[1:], data)
+	return c.writePacket(fullData)
+}
+
+func init() {
+	sqldb.Register("sqlconn", func(params sqldb.ConnParams) (sqldb.Conn, error) {
+		ctx := context.Background()
+		return Connect(ctx, &params)
+	})
+}

--- a/go/sqldb/sql_error.go
+++ b/go/sqldb/sql_error.go
@@ -7,6 +7,8 @@ package sqldb
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"strconv"
 )
 
 const (
@@ -43,6 +45,7 @@ func (se *SQLError) Error() string {
 	// Add MySQL errno and SQLSTATE in a format that we can later parse.
 	// There's no avoiding string parsing because all errors
 	// are converted to strings anyway at RPC boundaries.
+	// See NewSQLErrorFromError.
 	fmt.Fprintf(buf, " (errno %v) (sqlstate %v)", se.Num, se.State)
 
 	if se.Query != "" {
@@ -59,4 +62,50 @@ func (se *SQLError) Number() int {
 // SQLState returns the SQLSTATE value.
 func (se *SQLError) SQLState() string {
 	return se.State
+}
+
+var errExtract = regexp.MustCompile(`.*\(errno ([0-9]*)\) \(sqlstate ([0-9a-zA-Z]{5})\).*`)
+
+// NewSQLErrorFromError returns a *SQLError from the provided error.
+// If it's not the right type, it still tries to get it from a regexp.
+func NewSQLErrorFromError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if serr, ok := err.(*SQLError); ok {
+		return serr
+	}
+
+	msg := err.Error()
+	match := errExtract.FindStringSubmatch(msg)
+	if len(match) < 2 {
+		// Not found, build a generic SQLError.
+		// TODO(alainjobart) maybe we can also check the canonical
+		// error code, and translate that into the right error.
+
+		// FIXME(alainjobart): 1105 is unknown error. Will
+		// merge with sqlconn later.
+		return &SQLError{
+			Num:     1105,
+			State:   SQLStateGeneral,
+			Message: msg,
+		}
+	}
+
+	num, err := strconv.Atoi(match[1])
+	if err != nil {
+		return &SQLError{
+			Num:     1105,
+			State:   SQLStateGeneral,
+			Message: msg,
+		}
+	}
+
+	serr := &SQLError{
+		Num:     num,
+		State:   match[2],
+		Message: msg,
+	}
+	return serr
 }

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -1,0 +1,173 @@
+package vtgate
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"strings"
+
+	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/mysqlconn"
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/servenv"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+)
+
+var (
+	mysqlServerPort = flag.Int("mysql_server_port", 0, "If set, also listen for MySQL binary protocol connections on this port.")
+)
+
+// vtgateHandler implements the Listener interface.
+// It stores the Session in the ClientData of a Connection, if a transaction
+// is in progress.
+type vtgateHandler struct {
+	vtg *VTGate
+}
+
+func newVtgateHandler(vtg *VTGate) *vtgateHandler {
+	return &vtgateHandler{
+		vtg: vtg,
+	}
+}
+
+func (vh *vtgateHandler) NewConnection(c *mysqlconn.Conn) {
+}
+
+func (vh *vtgateHandler) ConnectionClosed(c *mysqlconn.Conn) {
+	// Rollback if there is an ongoing transaction. Ignore error.
+	ctx := context.Background()
+	vh.rollback(ctx, c)
+}
+
+func (vh *vtgateHandler) begin(ctx context.Context, c *mysqlconn.Conn) (*sqltypes.Result, error) {
+	// Check we're not inside a transaction already.
+	if c.ClientData != nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERCantDoThisDuringAnTransaction, mysqlconn.SSCantDoThisDuringAnTransaction, "already in a transaction")
+	}
+
+	// Do the begin.
+	session, err := vh.vtg.Begin(ctx, false /* singledb */)
+	if err != nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Begin failed: %v", err)
+	}
+
+	// Save the session.
+	c.ClientData = session
+	return &sqltypes.Result{}, nil
+}
+
+func (vh *vtgateHandler) commit(ctx context.Context, c *mysqlconn.Conn) (*sqltypes.Result, error) {
+	// Check we're inside a transaction already.
+	if c.ClientData == nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "not in a transaction")
+	}
+	session, ok := c.ClientData.(*vtgatepb.Session)
+	if !ok || session == nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
+	}
+
+	// Commit using vtgate's transaction mode.
+	if err := vh.vtg.Commit(ctx, vh.vtg.transactionMode == TxTwoPC, session); err != nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Commit failed: %v", err)
+	}
+
+	// Clear the Session.
+	c.ClientData = nil
+	return &sqltypes.Result{}, nil
+}
+
+func (vh *vtgateHandler) rollback(ctx context.Context, c *mysqlconn.Conn) (*sqltypes.Result, error) {
+	// Check we're inside a transaction already.
+	if c.ClientData == nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "not in a transaction")
+	}
+	session, ok := c.ClientData.(*vtgatepb.Session)
+	if !ok || session == nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
+	}
+
+	// Rollback.
+	if err := vh.vtg.Rollback(ctx, session); err != nil {
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Rollback failed: %v", err)
+	}
+
+	// Clear the Session.
+	c.ClientData = nil
+	return &sqltypes.Result{}, nil
+}
+
+func (vh *vtgateHandler) ComQuery(c *mysqlconn.Conn, query string) (*sqltypes.Result, error) {
+	// FIXME(alainjobart): do something better for context.
+	// Include some kind of callerid reference, using the
+	// authenticated user.
+	// Add some kind of timeout too.
+	ctx := context.Background()
+
+	// FIXME(alainjobart) would be good to have the parser understand this.
+	switch {
+	case strings.EqualFold(query, "begin"):
+		return vh.begin(ctx, c)
+	case strings.EqualFold(query, "commit"):
+		return vh.commit(ctx, c)
+	case strings.EqualFold(query, "rollback"):
+		return vh.rollback(ctx, c)
+	default:
+		// Grab the current session, if any.
+		var session *vtgatepb.Session
+		if c.ClientData != nil {
+			session, _ = c.ClientData.(*vtgatepb.Session)
+		}
+
+		// And just go to v3.
+		result, err := vh.vtg.Execute(ctx, query, make(map[string]interface{}), c.SchemaName, topodatapb.TabletType_MASTER, session, false /* notInTransaction */, &querypb.ExecuteOptions{
+			IncludedFields: querypb.ExecuteOptions_ALL,
+		})
+		return result, sqldb.NewSQLErrorFromError(err)
+	}
+}
+
+func init() {
+	var listener *mysqlconn.Listener
+
+	servenv.OnRun(func() {
+		// Flag is not set, just return.
+		if *mysqlServerPort == 0 {
+			return
+		}
+
+		// If no VTGate was created, just return.
+		if rpcVTGate == nil {
+			return
+		}
+
+		// Create a Listener.
+		var err error
+		vh := newVtgateHandler(rpcVTGate)
+		listener, err = mysqlconn.NewListener("tcp", net.JoinHostPort("", fmt.Sprintf("%v", *mysqlServerPort)), vh)
+		if err != nil {
+			log.Fatalf("mysqlconn.NewListener failed: %v", err)
+		}
+
+		// Add fake users for now.
+		// FIXME(alainjobart): add a config file with users
+		// and passwords.
+		listener.PasswordMap["mysql_user"] = "mysql_password"
+
+		// And starts listening.
+		go func() {
+			listener.Accept()
+		}()
+	})
+
+	servenv.OnTerm(func() {
+		if listener != nil {
+			listener.Close()
+		}
+	})
+}

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -90,7 +90,7 @@ func TestMySQL(t *testing.T) {
 	}
 	conn, err := mysql.Connect(params)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	_, err = conn.ExecuteFetch("insert into a values(1, 'name')", 10, false)
 	if err != nil {


### PR DESCRIPTION
New go native MySQL protocol package.
    
It implements both client and server side of the MySQL binary protocol.
A few notes:

* SSL is not supported yet. It wouldn't be too hard to add, but our
  current client library code doesn't support it either.
* only the usual mysql native password authentication is supported.
  Again, would be easy to support more.
* vtgate now has the option to listen using the MySQL protocol.
  The local examples are configured to do so.
* The API is not great, but is close to sqldb.Conn. Will be refactored
  once go/mysql is retired.
