### PR TITLE
Make backup test work with MySQL 5.7.

### DIFF
--- a/test/backup.py
+++ b/test/backup.py
@@ -43,7 +43,7 @@ def setUpModule():
     except MySQLdb.DatabaseError:
       password_col = 'authentication_string'
     utils.wait_procs([tablet_master.teardown_mysql()])
-    tablet_master.remove_tree()
+    tablet_master.remove_tree(ignore_options=True)
 
     # Create a new init_db.sql file that sets up passwords for all users.
     # Then we use a db-credentials-file with the passwords.

--- a/test/backup.py
+++ b/test/backup.py
@@ -30,6 +30,21 @@ def setUpModule():
   try:
     environment.topo_server().setup()
 
+    # Determine which column is used for user passwords in this MySQL version.
+    proc = tablet_master.init_mysql()
+    if use_mysqlctld:
+      tablet_master.wait_for_mysqlctl_socket()
+    else:
+      utils.wait_procs([proc])
+    try:
+      tablet_master.mquery('mysql', 'select password from mysql.user limit 0',
+                           user='root')
+      password_col = 'password'
+    except MySQLdb.DatabaseError:
+      password_col = 'authentication_string'
+    utils.wait_procs([tablet_master.teardown_mysql()])
+    tablet_master.remove_tree()
+
     # Create a new init_db.sql file that sets up passwords for all users.
     # Then we use a db-credentials-file with the passwords.
     new_init_db = environment.tmproot + '/init_db_with_passwords.sql'
@@ -39,20 +54,20 @@ def setUpModule():
       fd.write(init_db)
       fd.write('''
 # Set real passwords for all users.
-UPDATE mysql.user SET Password = PASSWORD('RootPass')
+UPDATE mysql.user SET %s = PASSWORD('RootPass')
   WHERE User = 'root' AND Host = 'localhost';
-UPDATE mysql.user SET Password = PASSWORD('VtDbaPass')
+UPDATE mysql.user SET %s = PASSWORD('VtDbaPass')
   WHERE User = 'vt_dba' AND Host = 'localhost';
-UPDATE mysql.user SET Password = PASSWORD('VtAppPass')
+UPDATE mysql.user SET %s = PASSWORD('VtAppPass')
   WHERE User = 'vt_app' AND Host = 'localhost';
-UPDATE mysql.user SET Password = PASSWORD('VtAllprivsPass')
+UPDATE mysql.user SET %s = PASSWORD('VtAllprivsPass')
   WHERE User = 'vt_allprivs' AND Host = 'localhost';
-UPDATE mysql.user SET Password = PASSWORD('VtReplPass')
-  WHERE User = 'vt_repl' AND Host = '%';
-UPDATE mysql.user SET Password = PASSWORD('VtFilteredPass')
+UPDATE mysql.user SET %s = PASSWORD('VtReplPass')
+  WHERE User = 'vt_repl' AND Host = '%%';
+UPDATE mysql.user SET %s = PASSWORD('VtFilteredPass')
   WHERE User = 'vt_filtered' AND Host = 'localhost';
 FLUSH PRIVILEGES;
-''')
+''' % tuple([password_col] * 6))
     credentials = {
         'vt_dba': ['VtDbaPass'],
         'vt_app': ['VtAppPass'],


### PR DESCRIPTION
MySQL 5.7 doesn't have "password" field in mysql.user table anymore, it uses
"authentication_string" to store the password hash. I'm fixing the test to
determine whether the "password" field exists in mysql.user and then to use
either "password" or "authentication_string" depending on what exists in the
used MySQL version.

On the way I'm also inlining the use_mysqlctld=True variable because it's
hardcoded and is never set to False, and removing the variable simplifies the
code.

BUG=34071871