### PR TITLE
Add backup test that runs without using mysqlctld.

### DIFF
--- a/test/backup.py
+++ b/test/backup.py
@@ -11,14 +11,11 @@ import environment
 import tablet
 import utils
 
-use_mysqlctld = True
+use_mysqlctld = False
 
-tablet_master = tablet.Tablet(use_mysqlctld=use_mysqlctld,
-                              vt_dba_passwd='VtDbaPass')
-tablet_replica1 = tablet.Tablet(use_mysqlctld=use_mysqlctld,
-                                vt_dba_passwd='VtDbaPass')
-tablet_replica2 = tablet.Tablet(use_mysqlctld=use_mysqlctld,
-                                vt_dba_passwd='VtDbaPass')
+tablet_master = None
+tablet_replica1 = None
+tablet_replica2 = None
 
 new_init_db = ''
 db_credentials_file = ''
@@ -26,6 +23,14 @@ db_credentials_file = ''
 
 def setUpModule():
   global new_init_db, db_credentials_file
+  global tablet_master, tablet_replica1, tablet_replica2
+
+  tablet_master = tablet.Tablet(use_mysqlctld=use_mysqlctld,
+                                vt_dba_passwd='VtDbaPass')
+  tablet_replica1 = tablet.Tablet(use_mysqlctld=use_mysqlctld,
+                                  vt_dba_passwd='VtDbaPass')
+  tablet_replica2 = tablet.Tablet(use_mysqlctld=use_mysqlctld,
+                                  vt_dba_passwd='VtDbaPass')
 
   try:
     environment.topo_server().setup()

--- a/test/backup_mysqlctld.py
+++ b/test/backup_mysqlctld.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""Re-runs backup.py with use_mysqlctld=True."""
+
+import backup
+import utils
+
+if __name__ == '__main__':
+  backup.use_mysqlctld = True
+  utils.main(backup)

--- a/test/config.json
+++ b/test/config.json
@@ -33,7 +33,7 @@
 			"Args": [],
 			"Command": [],
 			"Manual": false,
-			"Shard": 4,
+			"Shard": 3,
 			"RetryMax": 0,
 			"Tags": []
 		},

--- a/test/config.json
+++ b/test/config.json
@@ -28,6 +28,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"backup_mysqlctld": {
+			"File": "backup_mysqlctld.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 4,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"binlog": {
 			"File": "binlog.py",
 			"Args": [],


### PR DESCRIPTION
This changes backup.py to run using use_mysqlctld=False and adds another test
backup_mysqlctld.py that executes the same code from backup.py but with
use_mysqlctld=True. backup.py is slightly modified to be able to run in both
modes.