### PR TITLE
Always wait for mysqld shutdown when terminating mysqlctld.

### DIFF
--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -100,10 +100,10 @@ func main() {
 	defer servenv.Close()
 
 	// Take mysqld down with us on SIGTERM before entering lame duck.
-	servenv.OnTerm(func() {
+	servenv.OnTermSync(func() {
 		log.Infof("mysqlctl received SIGTERM, shutting down mysqld first")
 		ctx := context.Background()
-		mysqld.Shutdown(ctx, false)
+		mysqld.Shutdown(ctx, true)
 	})
 
 	// Start RPC server and wait for SIGTERM.


### PR DESCRIPTION
I'm sure in many places (and especially in tests) we always assume that when
mysqlctld is terminated mysqld is terminated as well. But due to mysqlctld not
waiting for actual mysqld shutdown mysqld could still remain running when
mysqlctld is already gone. This led to extra flakiness of the tests using live
mysqld with mysqlctld.

BUG=34071871