### PR TITLE
Ensure installed hooks are on the repo hook path

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -247,6 +247,7 @@ mkdir -p $VTTOP/.git/hooks
 ln -sf $VTTOP/misc/git/pre-commit $VTTOP/.git/hooks/pre-commit
 ln -sf $VTTOP/misc/git/prepare-commit-msg.bugnumber $VTTOP/.git/hooks/prepare-commit-msg
 ln -sf $VTTOP/misc/git/commit-msg.bugnumber $VTTOP/.git/hooks/commit-msg
+(cd $VTTOP && git config core.hooksPath $VTTOP/.git/hooks)
 
 # Download chromedriver
 echo "Installing selenium and chromedriver"


### PR DESCRIPTION
If anyone has globally configured hooks, their hookPath will take precedence over the hooks we install for vitess. By calling `git config core.hooksPath` we'll ensure that our hooks are the ones that get executed for the vitess repo. I first cd to $VTTOP to ensure if for some reason someone executes bootstrap.sh outside the git repo, we don't accidentally mess with someone's env.

cc @michael-berlin 