### PR TITLE
JDBC - Introduce ConnectionProperties, support new MySQL field metadata, decode strings with proper charset

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
@@ -2,6 +2,7 @@ package com.youtube.vitess.client;
 
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.CursorWithError;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.SrvKeyspace;
 import com.youtube.vitess.proto.Topodata.TabletType;
@@ -50,46 +51,50 @@ public class VTGateBlockingConn implements Closeable {
     this.conn = conn;
   }
 
-  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.execute(ctx, query, bindVars, tabletType).checkedGet();
+    return conn.execute(ctx, query, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeShards(Context ctx, String query, String keyspace, Iterable<String> shards,
-      Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
-    return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+      Map<String, ?> bindVars, TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+    return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public Cursor executeKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
+    return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public Cursor executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     return conn.executeEntityIds(ctx, query, keyspace, entityColumnName, entityKeyspaceIds,
-        bindVars, tabletType).checkedGet();
-  }
-
-  public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
-      @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType) throws SQLException {
-    return executeBatch(ctx, queryList, bindVarsList, tabletType, false);
+        bindVars, tabletType, includedFields).checkedGet();
   }
 
   public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
       @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
-    return conn.executeBatch(ctx, queryList, bindVarsList, tabletType, asTransaction).checkedGet();
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return executeBatch(ctx, queryList, bindVarsList, tabletType, false, includedFields);
+  }
+
+  public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
+      @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType,
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeBatch(ctx, queryList, bindVarsList, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   /**
@@ -99,8 +104,9 @@ public class VTGateBlockingConn implements Closeable {
    *        the batch queries.
    */
   public List<Cursor> executeBatchShards(Context ctx, Iterable<? extends BoundShardQuery> queries,
-      TabletType tabletType, boolean asTransaction) throws SQLException {
-    return conn.executeBatchShards(ctx, queries, tabletType, asTransaction).checkedGet();
+      TabletType tabletType, boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields)
+      throws SQLException {
+    return conn.executeBatchShards(ctx, queries, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   /**
@@ -111,30 +117,34 @@ public class VTGateBlockingConn implements Closeable {
    */
   public List<Cursor> executeBatchKeyspaceIds(Context ctx,
       Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
-    return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction).checkedGet();
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   public Cursor streamExecute(Context ctx, String query, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
-    return conn.streamExecute(ctx, query, bindVars, tabletType);
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.streamExecute(ctx, query, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
-    return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType);
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
+      throws SQLException {
+    return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType);
+    return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType);
+    return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields);
   }
 
   public VTGateBlockingTx begin(Context ctx) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
@@ -2,6 +2,7 @@ package com.youtube.vitess.client;
 
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.CursorWithError;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.TabletType;
 import com.youtube.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
@@ -28,9 +29,10 @@ public class VTGateBlockingTx {
     this.tx = tx;
   }
 
-  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.execute(ctx, query, bindVars, tabletType).checkedGet();
+    return tx.execute(ctx, query, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeShards(
@@ -39,9 +41,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<String> shards,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+    return tx.executeShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeKeyspaceIds(
@@ -50,9 +53,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<byte[]> keyspaceIds,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+    return tx.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
@@ -62,9 +66,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<? extends KeyRange> keyRanges,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType).checkedGet();
+    return tx.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeEntityIds(
@@ -74,29 +79,33 @@ public class VTGateBlockingTx {
       String entityColumnName,
       Map<byte[], ?> entityKeyspaceIds,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     return tx.executeEntityIds(
-            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType)
+            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public List<CursorWithError> executeBatch(Context ctx, List<String> queryList,
-      @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType)
+      @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatch(ctx, queryList, bindVarsList, tabletType).checkedGet();
+    return tx.executeBatch(ctx, queryList, bindVarsList, tabletType, includedFields).checkedGet();
   }
 
   public List<Cursor> executeBatchShards(
-      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType)
+      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatchShards(ctx, queries, tabletType).checkedGet();
+    return tx.executeBatchShards(ctx, queries, tabletType, includedFields).checkedGet();
   }
 
   public List<Cursor> executeBatchKeyspaceIds(
-      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType)
+      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatchKeyspaceIds(ctx, queries, tabletType).checkedGet();
+    return tx.executeBatchKeyspaceIds(ctx, queries, tabletType, includedFields).checkedGet();
   }
 
   public void commit(Context ctx) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -96,13 +96,18 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> execute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
-    ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
+    TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    ExecuteRequest.Builder requestBuilder = ExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
         new AsyncFunction<ExecuteResponse, Cursor>() {
           @Override
@@ -114,15 +119,22 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType, 
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteShardsRequest.Builder requestBuilder =
-        ExecuteShardsRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
-            .setTabletType(checkNotNull(tabletType));
+        ExecuteShardsRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(checkNotNull(keyspace))
+            .addAllShards(checkNotNull(shards))
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteShardsResponse, Cursor>() {
@@ -136,17 +148,22 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType, 
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
         .addAllKeyspaceIds(
             Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
@@ -161,14 +178,19 @@ public final class VTGateConn implements Closeable {
 
   public SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
       Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
-        .setTabletType(checkNotNull(tabletType));
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
@@ -183,16 +205,21 @@ public final class VTGateConn implements Closeable {
 
   public SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
-        .setEntityColumnName(checkNotNull(entityColumnName)).addAllEntityKeyspaceIds(Iterables
+        .setEntityColumnName(checkNotNull(entityColumnName))
+        .addAllEntityKeyspaceIds(Iterables
             .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
@@ -206,13 +233,14 @@ public final class VTGateConn implements Closeable {
   }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
-        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType) throws SQLException {
-        return executeBatch(ctx, queryList, bindVarsList, tabletType, false);
+        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+        Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+        return executeBatch(ctx, queryList, bindVarsList, tabletType, false, includedFields);
     }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
         @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
-        boolean asTransaction) throws SQLException {
+        boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
         List<Query.BoundQuery> queries = new ArrayList<>();
 
         if (null != bindVarsList && bindVarsList.size() != queryList.size()) {
@@ -226,12 +254,18 @@ public final class VTGateConn implements Closeable {
         }
 
         Vtgate.ExecuteBatchRequest.Builder requestBuilder =
-            Vtgate.ExecuteBatchRequest.newBuilder().addAllQueries(checkNotNull(queries))
-                .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType))
-                .setAsTransaction(asTransaction);
+            Vtgate.ExecuteBatchRequest.newBuilder()
+                .addAllQueries(checkNotNull(queries))
+                .setKeyspace(keyspace)
+                .setTabletType(checkNotNull(tabletType))
+                .setAsTransaction(asTransaction)
+                .setOptions(Query.ExecuteOptions.newBuilder()
+                    .setIncludedFields(includedFields));
+
         if (ctx.getCallerId() != null) {
             requestBuilder.setCallerId(ctx.getCallerId());
         }
+
         return new SQLFuture<>(Futures
             .transformAsync(client.executeBatch(ctx, requestBuilder.build()),
                 new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
@@ -251,14 +285,21 @@ public final class VTGateConn implements Closeable {
    *        the batch queries.
    */
   public SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
-      Iterable<? extends BoundShardQuery> queries, TabletType tabletType, boolean asTransaction)
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType, boolean asTransaction,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteBatchShardsRequest.Builder requestBuilder =
-        ExecuteBatchShardsRequest.newBuilder().addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
+        ExecuteBatchShardsRequest.newBuilder()
+            .addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType))
+            .setAsTransaction(asTransaction)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<List<Cursor>>(
         Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
@@ -280,13 +321,19 @@ public final class VTGateConn implements Closeable {
    */
   public SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
       Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteBatchKeyspaceIdsRequest.newBuilder().addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
+        ExecuteBatchKeyspaceIdsRequest.newBuilder()
+            .addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType))
+            .setAsTransaction(asTransaction)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<List<Cursor>>(
         Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {
@@ -301,54 +348,78 @@ public final class VTGateConn implements Closeable {
   }
 
   public Cursor streamExecute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     StreamExecuteRequest.Builder requestBuilder =
-        StreamExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
+        StreamExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecute(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     StreamExecuteShardsRequest.Builder requestBuilder = StreamExecuteShardsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
-        .setTabletType(checkNotNull(tabletType));
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllShards(checkNotNull(shards))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteShards(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     StreamExecuteKeyspaceIdsRequest.Builder requestBuilder = StreamExecuteKeyspaceIdsRequest
-        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
         .addAllKeyspaceIds(
             Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteKeyspaceIds(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
       Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     StreamExecuteKeyRangesRequest.Builder requestBuilder = StreamExecuteKeyRangesRequest
-        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
-        .setTabletType(checkNotNull(tabletType));
+        .newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteKeyRanges(ctx, requestBuilder.build()));
   }
 

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -78,14 +78,21 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> execute(Context ctx, String query, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("execute");
     ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
-            .setTabletType(tabletType).setSession(session);
+        ExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(query, bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(tabletType)
+            .setSession(session)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteResponse, Cursor>() {
@@ -101,14 +108,22 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeShards");
     ExecuteShardsRequest.Builder requestBuilder = ExecuteShardsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllShards(shards)
-        .setTabletType(tabletType).setSession(session);
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .addAllShards(shards)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteShardsResponse, Cursor>() {
@@ -125,16 +140,23 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query,
-      String keyspace, Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      String keyspace, Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     checkCallIsAllowed("executeKeyspaceIds");
     ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
         .addAllKeyspaceIds(Iterables.transform(keyspaceIds, Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(tabletType).setSession(session);
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call = new SQLFuture<>(
         Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
@@ -151,15 +173,23 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     checkCallIsAllowed("executeKeyRanges");
     ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllKeyRanges(keyRanges)
-        .setTabletType(tabletType).setSession(session);
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .addAllKeyRanges(keyRanges)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
@@ -177,16 +207,23 @@ public class VTGateTx {
 
   public synchronized SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeEntityIds");
     ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
-        .setEntityColumnName(entityColumnName).addAllEntityKeyspaceIds(Iterables
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .setEntityColumnName(entityColumnName)
+        .addAllEntityKeyspaceIds(Iterables
             .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-        .setTabletType(tabletType).setSession(session);
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
@@ -203,7 +240,8 @@ public class VTGateTx {
   }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
-        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType)
+        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+        Query.ExecuteOptions.IncludedFields includedFields)
         throws SQLException {
         List<Query.BoundQuery> queries = new ArrayList<>();
 
@@ -218,11 +256,18 @@ public class VTGateTx {
         }
 
         Vtgate.ExecuteBatchRequest.Builder requestBuilder =
-            Vtgate.ExecuteBatchRequest.newBuilder().addAllQueries(checkNotNull(queries))
-                .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType)).setSession(session);
+            Vtgate.ExecuteBatchRequest.newBuilder()
+                .addAllQueries(checkNotNull(queries))
+                .setKeyspace(keyspace)
+                .setTabletType(checkNotNull(tabletType))
+                .setSession(session)
+                .setOptions(Query.ExecuteOptions.newBuilder()
+                    .setIncludedFields(includedFields));
+
         if (ctx.getCallerId() != null) {
             requestBuilder.setCallerId(ctx.getCallerId());
         }
+
         return new SQLFuture<>(Futures
             .transformAsync(client.executeBatch(ctx, requestBuilder.build()),
                 new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
@@ -237,13 +282,20 @@ public class VTGateTx {
     }
 
   public synchronized SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
-      Iterable<? extends BoundShardQuery> queries, TabletType tabletType) throws SQLException {
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeBatchShards");
     ExecuteBatchShardsRequest.Builder requestBuilder = ExecuteBatchShardsRequest.newBuilder()
-        .addAllQueries(queries).setTabletType(tabletType).setSession(session);
+        .addAllQueries(queries)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<List<Cursor>> call = new SQLFuture<>(
         Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
@@ -261,13 +313,21 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
-      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType) throws SQLException {
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeBatchKeyspaceIds");
     ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder = ExecuteBatchKeyspaceIdsRequest
-        .newBuilder().addAllQueries(queries).setTabletType(tabletType).setSession(session);
+        .newBuilder()
+        .addAllQueries(queries)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<List<Cursor>> call = new SQLFuture<>(
         Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {

--- a/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
@@ -1,7 +1,5 @@
 package com.youtube.vitess.client.cursor;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
@@ -9,6 +7,8 @@ import com.youtube.vitess.mysql.DateTime;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Query.Type;
+
+import javax.annotation.concurrent.NotThreadSafe;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.SQLDataException;
@@ -19,7 +19,8 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-import javax.annotation.concurrent.NotThreadSafe;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * Type-converting wrapper around raw {@link com.youtube.vitess.proto.Query.Row} proto.
@@ -653,6 +654,8 @@ public class Row {
       case VARBINARY: // fall through
       case CHAR: // fall through
       case BINARY:
+      case GEOMETRY:
+      case JSON:
         return value.toByteArray();
       default:
         throw new SQLDataException("unknown field type: " + field.getType());

--- a/java/client/src/main/java/com/youtube/vitess/client/cursor/SimpleCursor.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/cursor/SimpleCursor.java
@@ -4,11 +4,10 @@ import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Query.QueryResult;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
-
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * A {@link Cursor} that serves records from a single {@link QueryResult} object.

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.KeyspaceIdType;
@@ -14,6 +15,12 @@ import com.youtube.vitess.proto.Topodata.SrvKeyspace.KeyspacePartition;
 import com.youtube.vitess.proto.Topodata.TabletType;
 import com.youtube.vitess.proto.Vtgate.SplitQueryResponse;
 import com.youtube.vitess.proto.Vtrpc.CallerID;
+
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
@@ -28,10 +35,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * RpcClientTest tests a given implementation of RpcClient against a mock vtgate server
@@ -90,6 +93,7 @@ public abstract class RpcClientTest {
 
   private static final TabletType TABLET_TYPE = TabletType.REPLICA;
   private static final String TABLET_TYPE_ECHO = TABLET_TYPE.toString();
+  private static final Query.ExecuteOptions.IncludedFields ALL_FIELDS = Query.ExecuteOptions.IncludedFields.ALL;
 
   private static final Map<String, Object> BIND_VARS = new ImmutableMap.Builder<String, Object>()
       .put("int", 123).put("float", 2.5).put("bytes", new byte[] {1, 2, 3}).build();
@@ -136,7 +140,7 @@ public abstract class RpcClientTest {
   public void testEchoExecute() throws Exception {
     Map<String, String> echo;
 
-    echo = getEcho(conn.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(conn.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -144,7 +148,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(
-        conn.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE));
+        conn.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -153,7 +157,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -162,7 +166,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -171,7 +175,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
-        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
+        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -182,7 +186,7 @@ public abstract class RpcClientTest {
 
     echo = getEcho(conn.executeBatchShards(ctx,
         Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE, true).get(0));
+        TABLET_TYPE, true, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -194,7 +198,7 @@ public abstract class RpcClientTest {
     echo = getEcho(conn.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
             Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE, true).get(0));
+        TABLET_TYPE, true, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -208,7 +212,7 @@ public abstract class RpcClientTest {
   public void testEchoStreamExecute() throws Exception {
     Map<String, String> echo;
 
-    echo = getEcho(conn.streamExecute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(conn.streamExecute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -216,7 +220,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -225,7 +229,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -234,7 +238,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -249,7 +253,7 @@ public abstract class RpcClientTest {
 
     VTGateBlockingTx tx = conn.begin(ctx);
 
-    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -259,7 +263,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(
-        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE));
+        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -270,7 +274,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -281,7 +285,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -292,7 +296,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
-        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
+        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -308,7 +312,7 @@ public abstract class RpcClientTest {
 
     echo = getEcho(tx.executeBatchShards(ctx,
         Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE).get(0));
+        TABLET_TYPE, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -321,7 +325,7 @@ public abstract class RpcClientTest {
     echo = getEcho(tx.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
             Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE).get(0));
+        TABLET_TYPE, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -480,32 +484,32 @@ public abstract class RpcClientTest {
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.execute(ctx, query, BIND_VARS, TABLET_TYPE);
+        conn.execute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
+        conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
+        conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
+        conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
         conn.executeEntityIds(ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS,
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
@@ -513,7 +517,7 @@ public abstract class RpcClientTest {
       void execute(String query) throws Exception {
         conn.executeBatchShards(ctx,
             Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE,
-            true);
+            true, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
@@ -521,7 +525,7 @@ public abstract class RpcClientTest {
       void execute(String query) throws Exception {
         conn.executeBatchKeyspaceIds(ctx,
             Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-            TABLET_TYPE, true);
+            TABLET_TYPE, true, ALL_FIELDS);
       }
     });
   }
@@ -531,26 +535,26 @@ public abstract class RpcClientTest {
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecute(ctx, query, BIND_VARS, TABLET_TYPE).next();
+        conn.streamExecute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS).next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE).next();
+        conn.streamExecuteShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS).next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
+        conn.streamExecuteKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS)
             .next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE)
+        conn.streamExecuteKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS)
             .next();
       }
     });
@@ -561,39 +565,39 @@ public abstract class RpcClientTest {
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE);
+        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
+        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
+        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
+        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeEntityIds(ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS,
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeBatchShards(ctx,
-            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE);
+            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
@@ -601,7 +605,7 @@ public abstract class RpcClientTest {
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeBatchKeyspaceIds(ctx,
             Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
   }

--- a/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
@@ -3,15 +3,13 @@ package com.youtube.vitess.client;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.TabletType;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.joda.time.Duration;
 import org.junit.Assert;
-
-import vttest.Vttest.VTTestTopology;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -20,6 +18,8 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import vttest.Vttest.VTTestTopology;
 
 public class TestUtil {
   static final Logger logger = LogManager.getLogger(TestUtil.class.getName());
@@ -119,7 +119,7 @@ public class TestUtil {
         bindVars.put("name", "name_" + id);
         bindVars.put("age", id % 10);
         bindVars.put("percent", id / 100.0);
-        tx.execute(ctx, insertSql, bindVars, TabletType.MASTER);
+        tx.execute(ctx, insertSql, bindVars, TabletType.MASTER, Query.ExecuteOptions.IncludedFields.ALL);
       }
       tx.commit(ctx);
     }

--- a/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
@@ -11,6 +11,7 @@ import com.youtube.vitess.client.VTGateBlockingTx;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
 import com.youtube.vitess.client.grpc.GrpcClientFactory;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.TabletType;
 
 import org.joda.time.Duration;
@@ -57,7 +58,8 @@ public class VitessClientExample {
             ctx,
             "INSERT INTO messages (page,time_created_ns,message) VALUES (:page,:time_created_ns,:message)",
             bindVars,
-            TabletType.MASTER);
+            TabletType.MASTER,
+            Query.ExecuteOptions.IncludedFields.ALL);
         tx.commit(ctx);
       }
 
@@ -68,7 +70,8 @@ public class VitessClientExample {
               ctx,
               "SELECT page, time_created_ns, message FROM messages",
               null /* bindVars */,
-              TabletType.MASTER)) {
+              TabletType.MASTER,
+              Query.ExecuteOptions.IncludedFields.ALL)) {
         Row row;
         while ((row = cursor.next()) != null) {
           UnsignedLong page = row.getULong("page");

--- a/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessConf.java
+++ b/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessConf.java
@@ -1,11 +1,12 @@
 package com.youtube.vitess.hadoop;
 
 import com.youtube.vitess.client.RpcClientFactory;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.SplitQueryRequest;
 
-import java.util.Collection;
-
 import org.apache.hadoop.conf.Configuration;
+
+import java.util.Collection;
 
 /**
  * Collection of configuration properties used for {@link VitessInputFormat}
@@ -20,6 +21,7 @@ public class VitessConf {
   public static final String SPLIT_COLUMNS = "vitess.client.split_columns";
   public static final String ALGORITHM = "vitess.client.algorithm";
   public static final String RPC_FACTORY_CLASS = "vitess.client.factory";
+  public static final String INCLUDED_FIELDS = "vitess.client.included.fields";
   public static final String HOSTS_DELIM = ",";
 
   private Configuration conf;
@@ -96,5 +98,13 @@ public class VitessConf {
 
   public void setRpcFactoryClass(Class<? extends RpcClientFactory> clz) {
     conf.set(RPC_FACTORY_CLASS, clz.getName());
+  }
+
+  public Query.ExecuteOptions.IncludedFields getIncludedFields() {
+    return conf.getEnum(INCLUDED_FIELDS, Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+  }
+
+  public void setIncludedFields(Query.ExecuteOptions.IncludedFields includedFields) {
+    conf.setEnum(INCLUDED_FIELDS, includedFields);
   }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -1,0 +1,451 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.StringUtils;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class ConnectionProperties {
+
+    private static final ArrayList<java.lang.reflect.Field> PROPERTY_LIST = new ArrayList<>();
+
+    static {
+        try {
+            // Generate property list for use in dynamically filling out values from Properties objects in
+            // #initializeProperties below
+            java.lang.reflect.Field[] declaredFields = ConnectionProperties.class.getDeclaredFields();
+            for (int i = 0; i < declaredFields.length; i++) {
+                if (ConnectionProperties.ConnectionProperty.class.isAssignableFrom(declaredFields[i].getType())) {
+                    PROPERTY_LIST.add(declaredFields[i]);
+                }
+            }
+        } catch (Exception ex) {
+            RuntimeException rtEx = new RuntimeException();
+            rtEx.initCause(ex);
+
+            throw rtEx;
+        }
+    }
+
+    // Configs for handling deserialization of blobs
+    private BooleanConnectionProperty blobsAreStrings = new BooleanConnectionProperty(
+        "blobsAreStrings",
+        "Should the driver always treat BLOBs as Strings - specifically to work around dubious metadata returned by the server for GROUP BY clauses?",
+        false);
+    private BooleanConnectionProperty functionsNeverReturnBlobs = new BooleanConnectionProperty(
+        "functionsNeverReturnBlobs",
+        "Should the driver always treat data from functions returning BLOBs as Strings - specifically to work around dubious metadata returned by the server for GROUP BY clauses?",
+        false);
+
+    // Configs for handing tinyint(1)
+    private BooleanConnectionProperty tinyInt1isBit = new BooleanConnectionProperty(
+        "tinyInt1isBit",
+        "Should the driver treat the datatype TINYINT(1) as the BIT type (because the server silently converts BIT -> TINYINT(1) when creating tables)?",
+        true);
+    private BooleanConnectionProperty transformedBitIsBoolean = new BooleanConnectionProperty(
+        "transformedBitIsBoolean",
+        "If the driver converts TINYINT(1) to a different type, should it use BOOLEAN instead of BIT for future compatibility with MySQL-5.0, as MySQL-5.0 has a BIT type?",
+        false);
+
+    private BooleanConnectionProperty yearIsDateType = new BooleanConnectionProperty(
+        "yearIsDateType",
+        "Should the JDBC driver treat the MySQL type \"YEAR\" as a java.sql.Date, or as a SHORT?",
+        true);
+
+    // Configs for handling irregular blobs, those with characters outside the typical 4-byte encodings
+    private BooleanConnectionProperty useBlobToStoreUTF8OutsideBMP = new BooleanConnectionProperty(
+        "useBlobToStoreUTF8OutsideBMP",
+        "Tells the driver to treat [MEDIUM/LONG]BLOB columns as [LONG]VARCHAR columns holding text encoded in UTF-8 that has characters outside the BMP (4-byte encodings), which MySQL server can't handle natively.",
+        false);
+    private StringConnectionProperty utf8OutsideBmpIncludedColumnNamePattern = new StringConnectionProperty(
+        "utf8OutsideBmpIncludedColumnNamePattern",
+        "Used to specify exclusion rules to \"utf8OutsideBmpExcludedColumnNamePattern\". The regex must follow the patterns used for the java.util.regex package.",
+        null);
+    private StringConnectionProperty utf8OutsideBmpExcludedColumnNamePattern = new StringConnectionProperty(
+        "utf8OutsideBmpExcludedColumnNamePattern",
+        "When \"useBlobToStoreUTF8OutsideBMP\" is set to \"true\", column names matching the given regex will still be treated as BLOBs unless they match the regex specified for \"utf8OutsideBmpIncludedColumnNamePattern\". The regex must follow the patterns used for the java.util.regex package.",
+        null);
+
+    // Default encodings, for when one cannot be determined from field metadata
+    private StringConnectionProperty characterEncoding = new StringConnectionProperty(
+        "characterEncoding",
+        "If a character encoding cannot be detected, which fallback should be used when dealing with strings? (defaults is to 'autodetect')",
+        null);
+
+    // Vitess-specific configs
+    private EnumConnectionProperty<Constants.QueryExecuteType> executeType = new EnumConnectionProperty<>(
+        Constants.Property.EXECUTE_TYPE,
+        "Query execution type: simple or stream",
+        Constants.DEFAULT_EXECUTE_TYPE);
+    private BooleanConnectionProperty twopcEnabled = new BooleanConnectionProperty(
+        Constants.Property.TWOPC_ENABLED,
+        "Whether to enable two-phased commit, for atomic distributed commits. See http://vitess.io/user-guide/twopc.html",
+        false);
+    private EnumConnectionProperty<Query.ExecuteOptions.IncludedFields> includedFields = new EnumConnectionProperty<>(
+        Constants.Property.INCLUDED_FIELDS,
+        "What fields to return from MySQL to the Driver. Limiting the fields returned can improve performance, but ALL is required for maximum JDBC API support",
+        Constants.DEFAULT_INCLUDED_FIELDS);
+    private EnumConnectionProperty<Topodata.TabletType> tabletType = new EnumConnectionProperty<>(
+        Constants.Property.TABLET_TYPE,
+        "Tablet Type to which Vitess will connect(master, replica, rdonly)",
+        Constants.DEFAULT_TABLET_TYPE);
+
+    // Caching of some hot properties to avoid casting over and over
+    private Topodata.TabletType tabletTypeCache;
+    private Query.ExecuteOptions.IncludedFields includedFieldsCache;
+    private boolean includeAllFieldsCache = true;
+    private boolean twopcEnabledCache = false;
+    private boolean simpleExecuteTypeCache = true;
+    private String characterEncodingAsString = null;
+
+    void initializeProperties(Properties props) throws SQLException {
+        Properties propsCopy = (Properties) props.clone();
+        for (Field propertyField : PROPERTY_LIST) {
+            try {
+                ConnectionProperty propToSet = (ConnectionProperty) propertyField.get(this);
+
+                propToSet.initializeFrom(propsCopy);
+            } catch (IllegalAccessException iae) {
+                throw new SQLException("Unable to initialize driver properties due to " + iae.toString());
+            }
+        }
+        postInitialization();
+    }
+
+    private void postInitialization() throws SQLException {
+        this.tabletTypeCache = this.tabletType.getValueAsEnum();
+        this.includedFieldsCache = this.includedFields.getValueAsEnum();
+        this.includeAllFieldsCache = this.includedFieldsCache == Query.ExecuteOptions.IncludedFields.ALL;
+        this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
+        this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
+        this.characterEncodingAsString = this.characterEncoding.getValueAsString();
+
+        String testEncoding = ((String) this.characterEncoding.getValueAsObject());
+
+        if (testEncoding != null) {
+            // Attempt to use the encoding, and bail out if it can't be used
+            try {
+                String testString = "abc";
+                StringUtils.getBytes(testString, testEncoding);
+            } catch (UnsupportedEncodingException UE) {
+                throw new SQLException("Unsupported character encoding: " + testEncoding);
+            }
+        }
+    }
+
+    static DriverPropertyInfo[] exposeAsDriverPropertyInfo(Properties info, int slotsToReserve) throws SQLException {
+        return new ConnectionProperties().exposeAsDriverPropertyInfoInternal(info, slotsToReserve);
+    }
+
+    protected DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
+        initializeProperties(info);
+
+        int numProperties = PROPERTY_LIST.size();
+        int listSize = numProperties + slotsToReserve;
+        DriverPropertyInfo[] driverProperties = new DriverPropertyInfo[listSize];
+
+        for (int i = slotsToReserve; i < listSize; i++) {
+            java.lang.reflect.Field propertyField = PROPERTY_LIST.get(i - slotsToReserve);
+            try {
+                ConnectionProperty propToExpose = (ConnectionProperty) propertyField.get(this);
+
+                if (info != null) {
+                    propToExpose.initializeFrom(info);
+                }
+
+                driverProperties[i] = propToExpose.getAsDriverPropertyInfo();
+            } catch (IllegalAccessException iae) {
+                throw new SQLException("Internal properties failure", iae);
+            }
+        }
+        return driverProperties;
+    }
+
+    public boolean getBlobsAreStrings() {
+        return blobsAreStrings.getValueAsBoolean();
+    }
+
+    public void setBlobsAreStrings(boolean blobsAreStrings) {
+        this.blobsAreStrings.setValue(blobsAreStrings);
+    }
+
+    public boolean getUseBlobToStoreUTF8OutsideBMP() {
+        return useBlobToStoreUTF8OutsideBMP.getValueAsBoolean();
+    }
+
+    public void setUseBlobToStoreUTF8OutsideBMP(boolean useBlobToStoreUTF8OutsideBMP) {
+        this.useBlobToStoreUTF8OutsideBMP.setValue(useBlobToStoreUTF8OutsideBMP);
+    }
+
+    public boolean getTinyInt1isBit() {
+        return tinyInt1isBit.getValueAsBoolean();
+    }
+
+    public void setTinyInt1isBit(boolean tinyInt1isBit) {
+        this.tinyInt1isBit.setValue(tinyInt1isBit);
+    }
+
+    public boolean getTransformedBitIsBoolean() {
+        return transformedBitIsBoolean.getValueAsBoolean();
+    }
+
+    public void setTransformedBitIsBoolean(boolean transformedBitIsBoolean) {
+        this.transformedBitIsBoolean.setValue(transformedBitIsBoolean);
+    }
+
+    public boolean getFunctionsNeverReturnBlobs() {
+        return functionsNeverReturnBlobs.getValueAsBoolean();
+    }
+
+    public void setFunctionsNeverReturnBlobs(boolean functionsNeverReturnBlobs) {
+        this.functionsNeverReturnBlobs.setValue(functionsNeverReturnBlobs);
+    }
+
+    public String getUtf8OutsideBmpIncludedColumnNamePattern() {
+        return utf8OutsideBmpIncludedColumnNamePattern.getValueAsString();
+    }
+
+    public void setUtf8OutsideBmpIncludedColumnNamePattern(String pattern) {
+        this.utf8OutsideBmpIncludedColumnNamePattern.setValue(pattern);
+    }
+
+    public String getUtf8OutsideBmpExcludedColumnNamePattern() {
+        return utf8OutsideBmpExcludedColumnNamePattern.getValueAsString();
+    }
+
+    public void setUtf8OutsideBmpExcludedColumnNamePattern(String pattern) {
+        this.utf8OutsideBmpExcludedColumnNamePattern.setValue(pattern);
+    }
+
+    public boolean getYearIsDateType() {
+        return yearIsDateType.getValueAsBoolean();
+    }
+
+    public void setYearIsDateType(boolean yearIsDateType) {
+        this.yearIsDateType.setValue(yearIsDateType);
+    }
+
+    public String getEncoding() {
+        return characterEncodingAsString;
+    }
+
+    public void setEncoding(String encoding) {
+        this.characterEncoding.setValue(encoding);
+        this.characterEncodingAsString = this.characterEncoding.getValueAsString();
+    }
+
+    public Query.ExecuteOptions.IncludedFields getIncludedFields() {
+        return this.includedFieldsCache;
+    }
+
+    public boolean isIncludeAllFields() {
+        return this.includeAllFieldsCache;
+    }
+
+    public void setIncludedFields(Query.ExecuteOptions.IncludedFields includedFields) {
+        this.includedFields.setValue(includedFields);
+        this.includedFieldsCache = includedFields;
+        this.includeAllFieldsCache = includedFields == Query.ExecuteOptions.IncludedFields.ALL;
+    }
+
+    public boolean getTwopcEnabled() {
+        return twopcEnabledCache;
+    }
+
+    public void setTwopcEnabled(boolean twopcEnabled) {
+        this.twopcEnabled.setValue(twopcEnabled);
+        this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
+    }
+
+    public Constants.QueryExecuteType getExecuteType() {
+        return executeType.getValueAsEnum();
+    }
+
+    public boolean isSimpleExecute() {
+        return simpleExecuteTypeCache;
+    }
+
+    public void setExecuteType(Constants.QueryExecuteType executeType) {
+        this.executeType.setValue(executeType);
+        this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
+    }
+
+    public Topodata.TabletType getTabletType() {
+        return tabletTypeCache;
+    }
+
+    public void setTabletType(Topodata.TabletType tabletType) {
+        this.tabletType.setValue(tabletType);
+        this.tabletTypeCache = this.tabletType.getValueAsEnum();
+    }
+
+    abstract static class ConnectionProperty {
+
+        private final String name;
+        private final boolean required = false;
+        private final String description;
+        final Object defaultValue;
+        Object valueAsObject;
+
+        private ConnectionProperty(String name, String description, Object defaultValue) {
+            this.name = name;
+            this.description = description;
+            this.defaultValue = defaultValue;
+        }
+
+        void initializeFrom(Properties extractFrom) {
+            String extractedValue = extractFrom.getProperty(getPropertyName());
+            String[] allowable = getAllowableValues();
+            if (allowable != null && extractedValue != null) {
+                boolean found = false;
+                for (String value : allowable) {
+                    found |= value.equalsIgnoreCase(extractedValue);
+                }
+                if (!found) {
+                    throw new IllegalArgumentException("Property '" + name + "' Value '" + extractedValue + "' not in the list of allowable values: " + Arrays.toString(allowable));
+                }
+            }
+            extractFrom.remove(getPropertyName());
+            initializeFrom(extractedValue);
+        }
+
+        abstract void initializeFrom(String extractedValue);
+
+        abstract String[] getAllowableValues();
+
+        public String getPropertyName() {
+            return name;
+        }
+
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        public Object getValueAsObject() {
+            return valueAsObject;
+        }
+
+        DriverPropertyInfo getAsDriverPropertyInfo() {
+            DriverPropertyInfo dpi = new DriverPropertyInfo(this.name, null);
+            dpi.choices = getAllowableValues();
+            dpi.value = (this.valueAsObject != null) ? this.valueAsObject.toString() : null;
+            dpi.required = this.required;
+            dpi.description = this.description;
+
+            return dpi;
+        }
+    }
+
+    private static class BooleanConnectionProperty extends ConnectionProperty {
+
+        private BooleanConnectionProperty(String name, String description, Boolean defaultValue) {
+            super(name, description, defaultValue);
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(extractedValue.equalsIgnoreCase("TRUE") || extractedValue.equalsIgnoreCase("YES"));
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        public void setValue(boolean value) {
+            this.valueAsObject = value;
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            return new String[]{Boolean.toString(true), Boolean.toString(false), "yes", "no"};
+        }
+
+        boolean getValueAsBoolean() {
+            return (boolean) valueAsObject;
+        }
+    }
+
+    private static class StringConnectionProperty extends ConnectionProperty {
+
+        private final String[] allowableValues;
+
+        private StringConnectionProperty(String name, String description, String defaultValue) {
+            this(name, description, defaultValue, null);
+        }
+
+        private StringConnectionProperty(String name, String description, String defaultValue, String[] allowableValuesToSet) {
+            super(name, description, defaultValue);
+            allowableValues = allowableValuesToSet;
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(extractedValue);
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            return allowableValues;
+        }
+
+        String getValueAsString() {
+            return (String) valueAsObject;
+        }
+
+        public void setValue(String value) {
+            this.valueAsObject = value;
+        }
+    }
+
+    private static class EnumConnectionProperty<T extends Enum<T>> extends ConnectionProperty {
+
+        private final Class<T> clazz;
+
+        private EnumConnectionProperty(String name, String description, Enum<T> defaultValue) {
+            super(name, description, defaultValue);
+            this.clazz = defaultValue.getDeclaringClass();
+            if (!clazz.isEnum()) {
+                throw new IllegalArgumentException("EnumConnectionProperty types should be enums");
+            }
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(Enum.valueOf(clazz, extractedValue.toUpperCase()));
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        public void setValue(T value) {
+            this.valueAsObject = value;
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            T[] enumConstants = clazz.getEnumConstants();
+            String[] allowed = new String[enumConstants.length];
+            for (int i = 0; i < enumConstants.length; i++) {
+                allowed[i] = enumConstants[i].toString();
+            }
+            return allowed;
+        }
+
+        T getValueAsEnum() {
+            return (T) valueAsObject;
+        }
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
@@ -1,0 +1,512 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.StringUtils;
+import com.flipkart.vitess.util.charset.CharsetMapping;
+import com.youtube.vitess.proto.Query;
+
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.regex.PatternSyntaxException;
+
+public class FieldWithMetadata {
+
+    private final VitessConnection connection;
+    private final Query.Field field;
+    private final Query.Type vitessType;
+    private final boolean isImplicitTempTable;
+    private final boolean isSingleBit;
+    private final int precisionAdjustFactor;
+
+    private int javaType;
+    private int colFlag;
+    private String encoding;
+    private String collationName;
+    private int collationIndex;
+    private int maxBytesPerChar;
+
+    public FieldWithMetadata(VitessConnection connection, Query.Field field) throws SQLException {
+        this.connection = connection;
+        this.field = field;
+        this.colFlag = field.getFlags();
+        this.vitessType = field.getType();
+        this.collationIndex = field.getCharset();
+
+        // Map MySqlTypes to java.sql Types
+        if (MysqlDefs.vitessToJavaType.containsKey(vitessType)) {
+            this.javaType = MysqlDefs.vitessToJavaType.get(vitessType);
+        } else if (field.getType().equals(Query.Type.TUPLE)) {
+            throw new SQLException(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE);
+        } else {
+            throw new SQLException(Constants.SQLExceptionMessages.UNKNOWN_COLUMN_TYPE);
+        }
+
+        // All of the below remapping and metadata fields require the extra
+        // fields included when includeFields=IncludedFields.ALL
+        if (connection.isIncludeAllFields()) {
+            this.isImplicitTempTable = field.getTable().length() > 5 && field.getTable().startsWith("#sql_");
+
+            // Re-map  BLOB to 'real' blob type
+            if (this.javaType == Types.BLOB) {
+                boolean isFromFunction = field.getOrgTable().isEmpty();
+                if (connection.getBlobsAreStrings() || (connection.getFunctionsNeverReturnBlobs() && isFromFunction)) {
+                    this.javaType = Types.VARCHAR;
+                } else if (collationIndex == CharsetMapping.MYSQL_COLLATION_INDEX_binary) {
+                    if (connection.getUseBlobToStoreUTF8OutsideBMP() && shouldSetupForUtf8StringInBlob()) {
+                        if (this.getColumnLength() == MysqlDefs.LENGTH_TINYBLOB || this.getColumnLength() == MysqlDefs.LENGTH_BLOB) {
+                            this.javaType = Types.VARCHAR;
+                        } else {
+                            this.javaType = Types.LONGVARCHAR;
+                        }
+
+                        this.collationIndex = CharsetMapping.MYSQL_COLLATION_INDEX_utf8;
+                    } else {
+                        if (this.getColumnLength() == MysqlDefs.LENGTH_TINYBLOB) {
+                            this.javaType = Types.VARBINARY;
+                        } else if (this.getColumnLength() == MysqlDefs.LENGTH_BLOB || this.getColumnLength() == MysqlDefs.LENGTH_MEDIUMBLOB
+                            || this.getColumnLength() == MysqlDefs.LENGTH_LONGBLOB) {
+                            this.javaType = Types.LONGVARBINARY;
+                        }
+                    }
+                } else {
+                    // *TEXT masquerading as blob
+                    this.javaType = Types.LONGVARCHAR;
+                }
+            }
+
+            // Re-map TINYINT(1) as bit or pseudo-boolean
+            if (this.javaType == Types.TINYINT && this.field.getColumnLength() == 1 && connection.getTinyInt1isBit()) {
+                if (connection.getTransformedBitIsBoolean()) {
+                    this.javaType = Types.BOOLEAN;
+                } else {
+                    this.javaType = Types.BIT;
+                }
+            }
+
+            if (!isNativeNumericType() && !isNativeDateTimeType()) {
+                this.encoding = connection.getEncodingForIndex(this.collationIndex);
+
+                // ucs2, utf16, and utf32 cannot be used as a client character set, but if it was received from server under some circumstances we can parse them as
+                // utf16
+                if ("UnicodeBig".equals(this.encoding)) {
+                    this.encoding = "UTF-16";
+                }
+
+                // MySQL encodes JSON data with utf8mb4.
+                if (vitessType == Query.Type.JSON) {
+                    this.encoding = "UTF-8";
+                }
+
+                if (this.javaType == Types.BIT) {
+                    this.isSingleBit = field.getColumnLength() == 0 || field.getColumnLength() == 1;
+
+                    if (!isSingleBit) {
+                        this.colFlag |= Query.MySqlFlag.BINARY_FLAG_VALUE; // Pretend this is a full binary(128) and blob(16) so that this field is de-serializable.
+                        this.colFlag |= Query.MySqlFlag.BLOB_FLAG_VALUE;
+                    }
+                } else {
+                    this.isSingleBit = false;
+                }
+
+                // Re-map improperly typed binary types as non-binary counterparts if BINARY flag not set
+                boolean isBinary = isBinary();
+                if (javaType == Types.LONGVARBINARY && !isBinary) {
+                    this.javaType = Types.LONGVARCHAR;
+                } else if (javaType == Types.VARBINARY && !isBinary) {
+                    this.javaType = Types.VARCHAR;
+                }
+            } else {
+                // Default encoding for number-types and date-types
+                this.encoding = "US-ASCII";
+                this.isSingleBit = false;
+            }
+
+            // Precision can be calculated from column length, but needs
+            // to be adjusted for the extra values that can be included for the various
+            // numeric types
+            if (isSigned()) {
+                switch (javaType) {
+                    case Types.FLOAT:
+                    case Types.REAL:
+                    case Types.DOUBLE:
+                    case Types.BIT:
+                        // float/real/double are the same regardless of sign/decimal
+                        // bit values can't actually be signed
+                        this.precisionAdjustFactor = 0;
+                        break;
+                    default:
+                        // other types we adjust for the negative symbol, and decimal
+                        // symbol if there are decimals
+                        this.precisionAdjustFactor = getDecimals() > 0 ? -2 : -1;
+                }
+            } else {
+                switch (javaType) {
+                    case Types.DECIMAL:
+                    case Types.NUMERIC:
+                        // adjust for the decimal
+                        this.precisionAdjustFactor = -1;
+                        break;
+                    default:
+                        // all other types need no adjustment
+                        this.precisionAdjustFactor = 0;
+                }
+            }
+        } else {
+            // Defaults to appease final variables when not including all fields
+            this.isImplicitTempTable = false;
+            this.isSingleBit = false;
+            this.precisionAdjustFactor = 0;
+        }
+    }
+
+    private boolean isNativeNumericType() {
+        switch (this.javaType) {
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.FLOAT:
+            case Types.DOUBLE:
+            case Types.REAL:
+            case Types.DECIMAL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isNativeDateTimeType() {
+        switch (this.javaType) {
+            case Types.DATE:
+            case Types.TIME:
+            case Types.TIMESTAMP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean shouldSetupForUtf8StringInBlob() throws SQLException {
+        String includePattern = connection.getUtf8OutsideBmpIncludedColumnNamePattern();
+        String excludePattern = connection.getUtf8OutsideBmpExcludedColumnNamePattern();
+
+        // When UseBlobToStoreUTF8OutsideBMP is set, we by default set blobs to UTF-8. So we first
+        // look for fields to exclude from that remapping (blacklist)
+        if (excludePattern != null && !StringUtils.isNullOrEmptyWithoutWS(excludePattern)) {
+            try {
+                if (getOrgName().matches(excludePattern)) {
+                    // If we want to include more specific patters that were inadvertently covered by the exclude pattern,
+                    // we set the includePattern (whitelist)
+                    if (includePattern != null && !StringUtils.isNullOrEmptyWithoutWS(includePattern)) {
+                        try {
+                            if (getOrgName().matches(includePattern)) {
+                                return true;
+                            }
+                        } catch (PatternSyntaxException pse) {
+                            throw new SQLException("Illegal regex specified for \"utf8OutsideBmpIncludedColumnNamePattern\"", pse);
+                        }
+                    }
+
+                    return false;
+                }
+            } catch (PatternSyntaxException pse) {
+                throw new SQLException("Illegal regex specified for \"utf8OutsideBmpExcludedColumnNamePattern\"", pse);
+            }
+        }
+
+        return true;
+    }
+
+    public boolean isAutoIncrement() throws SQLException {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.AUTO_INCREMENT_FLAG_VALUE) > 0);
+    }
+
+    public boolean isBinary() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.BINARY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isBlob() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.BLOB_FLAG_VALUE) > 0);
+    }
+
+    public boolean isMultipleKey() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.MULTIPLE_KEY_FLAG_VALUE) > 0);
+    }
+
+    boolean isNotNull() {
+        if (!connection.isIncludeAllFields()) {
+            return true;
+        }
+        return ((this.colFlag & Query.MySqlFlag.NOT_NULL_FLAG_VALUE) > 0);
+    }
+
+    public boolean isZeroFill() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.ZEROFILL_FLAG_VALUE) > 0);
+    }
+
+    public boolean isPrimaryKey() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.PRI_KEY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isUniqueKey() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.UNIQUE_KEY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isUnsigned() {
+        if (!connection.isIncludeAllFields()) {
+            return true;
+        }
+        return ((this.colFlag & Query.MySqlFlag.UNSIGNED_FLAG_VALUE) > 0);
+    }
+
+    public boolean isSigned() {
+        return !isUnsigned();
+    }
+
+    boolean isOpaqueBinary() throws SQLException {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+
+        // Detect CHAR(n) CHARACTER SET BINARY which is a synonym for fixed-length binary types
+        if (this.collationIndex == CharsetMapping.MYSQL_COLLATION_INDEX_binary && isBinary()
+            && (this.javaType == Types.CHAR || this.javaType == Types.VARCHAR)) {
+            // Okay, queries resolved by temp tables also have this 'signature', check for that
+            return !isImplicitTemporaryTable();
+        }
+
+        // this is basically always false unless a valid charset is not found and someone explicitly sets a fallback
+        // using ConnectionProperties, as binary defaults to ISO8859-1 per mysql-connector-j implementation
+        return "binary".equalsIgnoreCase(getEncoding());
+
+    }
+
+    /**
+     * Is this field _definitely_ not writable?
+     *
+     * @return true if this field can not be written to in an INSERT/UPDATE
+     * statement.
+     */
+    boolean isReadOnly() throws SQLException {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+
+        String orgColumnName = getOrgName();
+        String orgTableName = getOrgTable();
+
+        return !(orgColumnName != null && orgColumnName.length() > 0 && orgTableName != null && orgTableName.length() > 0);
+    }
+
+    public String getCollation() throws SQLException {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+
+        if (this.collationName == null) {
+            int collationIndex = getCollationIndex();
+            try {
+                this.collationName = CharsetMapping.COLLATION_INDEX_TO_COLLATION_NAME[collationIndex];
+            } catch (ArrayIndexOutOfBoundsException ex) {
+                throw new SQLException("CollationIndex '" + collationIndex + "' out of bounds for collationName lookup, should be within 0 and " +  CharsetMapping.COLLATION_INDEX_TO_COLLATION_NAME.length, ex);
+            }
+        }
+        return this.collationName;
+    }
+
+
+    public synchronized int getMaxBytesPerCharacter() throws SQLException {
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+
+        if (this.maxBytesPerChar == 0) {
+            this.maxBytesPerChar = this.connection.getMaxBytesPerChar(getCollationIndex(), getEncoding());
+        }
+        return this.maxBytesPerChar;
+    }
+
+    public String getName() {
+        return field.getName();
+    }
+
+    public String getTable() {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getTable();
+    }
+
+    public String getOrgTable() {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getOrgTable();
+    }
+
+    public String getDatabase() {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getDatabase();
+    }
+
+    public String getOrgName() {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getOrgName();
+    }
+
+    public int getColumnLength() {
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return field.getColumnLength();
+    }
+
+    public int getDecimals() {
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return field.getDecimals();
+    }
+
+    public int getJavaType() {
+        return javaType;
+    }
+
+    public Query.Type getVitessType() {
+        return vitessType;
+    }
+
+    public int getVitessTypeValue() {
+        return field.getTypeValue();
+    }
+
+    public boolean isImplicitTemporaryTable() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return isImplicitTempTable;
+    }
+
+    public String getEncoding() {
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return encoding;
+    }
+
+    /**
+     * Precision can be calculated from column length, but needs
+     * to be adjusted for the extra values that can be included for the various
+     * numeric types
+     */
+    public int getPrecisionAdjustFactor() {
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return precisionAdjustFactor;
+    }
+
+    public boolean isSingleBit() {
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return isSingleBit;
+    }
+
+    private int getCollationIndex() {
+        return collationIndex;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            StringBuilder asString = new StringBuilder();
+            asString.append(super.toString());
+            asString.append("[");
+            asString.append("catalog=");
+            asString.append(this.getDatabase());
+            asString.append(",tableName=");
+            asString.append(this.getTable());
+            asString.append(",originalTableName=");
+            asString.append(this.getOrgTable());
+            asString.append(",columnName=");
+            asString.append(this.getName());
+            asString.append(",originalColumnName=");
+            asString.append(this.getOrgName());
+            asString.append(",vitessType=");
+            asString.append(getVitessType());
+            asString.append("(");
+            asString.append(getJavaType());
+            asString.append(")");
+            asString.append(",flags=");
+
+            if (isAutoIncrement()) {
+                asString.append(" AUTO_INCREMENT");
+            }
+
+            if (isPrimaryKey()) {
+                asString.append(" PRIMARY_KEY");
+            }
+
+            if (isUniqueKey()) {
+                asString.append(" UNIQUE_KEY");
+            }
+
+            if (isBinary()) {
+                asString.append(" BINARY");
+            }
+
+            if (isBlob()) {
+                asString.append(" BLOB");
+            }
+
+            if (isMultipleKey()) {
+                asString.append(" MULTI_KEY");
+            }
+
+            if (isUnsigned()) {
+                asString.append(" UNSIGNED");
+            }
+
+            if (isZeroFill()) {
+                asString.append(" ZEROFILL");
+            }
+
+            asString.append(", charsetIndex=");
+            asString.append(this.collationIndex);
+            asString.append(", charsetName=");
+            asString.append(this.encoding);
+            asString.append("]");
+
+            return asString.toString();
+        } catch (Throwable t) {
+            return super.toString();
+        }
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -3,10 +3,10 @@ package com.flipkart.vitess.jdbc;
 import com.flipkart.vitess.util.CommonUtils;
 import com.flipkart.vitess.util.Constants;
 import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
-import com.youtube.vitess.proto.Topodata;
 
 import java.sql.Array;
 import java.sql.Blob;
@@ -38,37 +38,37 @@ import java.util.logging.Logger;
 /**
  * Created by harshit.gangal on 23/01/16.
  */
-public class VitessConnection implements Connection {
+public class VitessConnection extends ConnectionProperties implements Connection {
 
     private static final int DEFAULT_RESULT_SET_TYPE = ResultSet.TYPE_FORWARD_ONLY;
     private static final int DEFAULT_RESULT_SET_CONCURRENCY = ResultSet.CONCUR_READ_ONLY;
+
     /* Get actual class name to be printed on */
     private static Logger logger = Logger.getLogger(VitessConnection.class.getName());
     private static DatabaseMetaData databaseMetaData = null;
+
     /**
      * A Map of currently open statements
      */
-    protected Set<Statement> openStatements = new HashSet<>();
+    private Set<Statement> openStatements = new HashSet<>();
     private VitessVTGateManager.VTGateConnections vTGateConnections;
     private VTGateTx vtGateTx;
     private boolean closed = true;
     private boolean autoCommit = true;
     private boolean readOnly = false;
     private DBProperties dbProperties;
-    private VitessJDBCUrl vitessJDBCUrl;
-
+    private final VitessJDBCUrl vitessJDBCUrl;
 
     /**
      * Constructor to Create Connection Object
      *
      * @param url  - Connection url
-     * @param info - property for the connection
+     * @param connectionProperties - property for the connection
      * @throws SQLException
      */
-    public VitessConnection(String url, Properties info) throws SQLException {
-
+    public VitessConnection(String url, Properties connectionProperties) throws SQLException {
         try {
-            this.vitessJDBCUrl = new VitessJDBCUrl(url, info);
+            this.vitessJDBCUrl = new VitessJDBCUrl(url, connectionProperties);
             this.vTGateConnections = new VitessVTGateManager.VTGateConnections(vitessJDBCUrl);
             this.closed = false;
             this.dbProperties = null;
@@ -76,6 +76,8 @@ public class VitessConnection implements Connection {
             throw new SQLException(
                 Constants.SQLExceptionMessages.CONN_INIT_ERROR + " - " + e.getMessage(), e);
         }
+
+        initializeProperties(vitessJDBCUrl.getProperties());
     }
 
     /**
@@ -153,7 +155,7 @@ public class VitessConnection implements Connection {
         try {
             if (isInTransaction()) {
                 Context context = createContext(Constants.CONNECTION_TIMEOUT);
-                this.vtGateTx.commit(context, this.vitessJDBCUrl.isTwopcEnabled()).checkedGet();
+                this.vtGateTx.commit(context, getTwopcEnabled()).checkedGet();
             }
         } finally {
             this.vtGateTx = null;
@@ -583,16 +585,8 @@ public class VitessConnection implements Connection {
         this.vtGateTx = vtGateTx;
     }
 
-    public Topodata.TabletType getTabletType() {
-        return this.vitessJDBCUrl.getTabletType();
-    }
-
     public String getUrl() {
         return this.vitessJDBCUrl.getUrl();
-    }
-
-    public Constants.QueryExecuteType getExecuteTypeParam() {
-        return this.vitessJDBCUrl.getExecuteType();
     }
 
     /**
@@ -848,5 +842,33 @@ public class VitessConnection implements Connection {
 
     public String getUsername() {
         return this.vitessJDBCUrl.getUsername();
+    }
+
+    public String getEncodingForIndex(int charsetIndex) throws SQLException {
+        String javaEncoding = null;
+
+        if (charsetIndex != MysqlDefs.NO_CHARSET_INFO) {
+            javaEncoding = CharsetMapping.getJavaEncodingForCollationIndex(charsetIndex, getEncoding());
+        }
+
+        // If nothing, get default based on configuration, may still be null
+        if (javaEncoding == null) {
+            javaEncoding = getEncoding();
+        }
+
+        return javaEncoding;
+    }
+
+    public int getMaxBytesPerChar(Integer charsetIndex, String javaCharsetName) {
+        // if we can get it by charsetIndex just doing it
+        String charset = CharsetMapping.getMysqlCharsetNameForCollationIndex(charsetIndex);
+
+        // if we didn't find charset name by index
+        if (charset == null) {
+            charset = CharsetMapping.getMysqlCharsetForJavaEncoding(javaCharsetName);
+        }
+
+        // checking against static maps
+        return CharsetMapping.getMblen(charset);
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
@@ -2,7 +2,12 @@ package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -24,6 +29,7 @@ public class VitessDriver implements Driver {
         }
     }
 
+    @Override
     public Connection connect(String url, Properties info) throws SQLException {
         return acceptsURL(url) ? new VitessConnection(url, info) : null;
     }
@@ -39,6 +45,7 @@ public class VitessDriver implements Driver {
      * <p/>
      * TODO: Write a better regex
      */
+    @Override
     public boolean acceptsURL(String url) throws SQLException {
         return null != url && url.startsWith(Constants.URL_PREFIX);
     }
@@ -49,12 +56,13 @@ public class VitessDriver implements Driver {
      * @return DriverPropertyInfo Array Object
      * @throws SQLException
      */
+    @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
         if (null == info) {
             info = new Properties();
         }
 
-        DriverPropertyInfo[] dpi = new DriverPropertyInfo[7];
+        DriverPropertyInfo[] dpi = ConnectionProperties.exposeAsDriverPropertyInfo(info, 5);
         if (acceptsURL(url)) {
             VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(url, info);
 
@@ -73,26 +81,14 @@ public class VitessDriver implements Driver {
             dpi[2].required = true;
             dpi[2].description = Constants.VITESS_KEYSPACE;
 
-            dpi[3] = new DriverPropertyInfo(Constants.Property.TABLET_TYPE,
-                vitessJDBCUrl.getTabletType().toString());
+            dpi[3] = new DriverPropertyInfo(Constants.Property.DBNAME, vitessJDBCUrl.getCatalog());
             dpi[3].required = false;
-            dpi[3].description = Constants.VITESS_TABLET_TYPE;
+            dpi[3].description = Constants.VITESS_DB_NAME;
 
-            dpi[4] = new DriverPropertyInfo(Constants.Property.EXECUTE_TYPE,
-                vitessJDBCUrl.getExecuteType().toString());
-            dpi[4].required = false;
-            dpi[4].description = Constants.EXECUTE_TYPE_DESC;
-
-            dpi[5] = new DriverPropertyInfo(Constants.Property.DBNAME, vitessJDBCUrl.getCatalog());
-            dpi[5].required = true;
-            dpi[5].description = Constants.VITESS_DB_NAME;
-
-            dpi[6] =
+            dpi[4] =
                 new DriverPropertyInfo(Constants.Property.USERNAME, vitessJDBCUrl.getUsername());
-            dpi[6].required = false;
-            dpi[6].description = Constants.USERNAME_DESC;
-
-
+            dpi[4].required = false;
+            dpi[4].description = Constants.USERNAME_DESC;
         } else {
             throw new SQLException(Constants.SQLExceptionMessages.INVALID_CONN_URL + " : " + url);
         }
@@ -100,18 +96,22 @@ public class VitessDriver implements Driver {
         return dpi;
     }
 
+    @Override
     public int getMajorVersion() {
         return Constants.DRIVER_MAJOR_VERSION;
     }
 
+    @Override
     public int getMinorVersion() {
         return Constants.DRIVER_MINOR_VERSION;
     }
 
+    @Override
     public boolean jdbcCompliant() {
         return Constants.JDBC_COMPLIANT;
     }
 
+    @Override
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException(
             Constants.SQLExceptionMessages.SQL_FEATURE_NOT_SUPPORTED);

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
@@ -3,7 +3,12 @@ package com.flipkart.vitess.jdbc;
 import com.flipkart.vitess.util.Constants;
 import com.youtube.vitess.proto.Query;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
 
 /**
@@ -418,7 +423,7 @@ public class VitessMariaDBDatabaseMetadata extends VitessDatabaseMetaData
                 {"TIMESTAMP", "93", "27", "'", "'", "[(M)]", "1", "0", "3", "0", "0", "0",
                     "TIMESTAMP", "0", "0", "0", "0", "10"}};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(connection, columnNames, columnTypes, data);
     }
 
     public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique,

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMySQLDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMySQLDatabaseMetadata.java
@@ -3,10 +3,25 @@ package com.flipkart.vitess.jdbc;
 import com.flipkart.vitess.util.Constants;
 import com.flipkart.vitess.util.MysqlDefs;
 import com.youtube.vitess.proto.Query;
+
 import org.apache.commons.lang.StringUtils;
 
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.RowIdLifetime;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.StringTokenizer;
+import java.util.TreeMap;
 import java.util.logging.Logger;
 
 /**
@@ -454,13 +469,13 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(connection, columnNames, columnTypes, data);
     }
 
     public ResultSet getSchemas() throws SQLException {
         String[] columnNames = {"TABLE_SCHEM", "TABLE_CATALOG"};
         Query.Type[] columnType = {Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getCatalogs() throws SQLException {
@@ -487,7 +502,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         vitessStatement.close();
         String[] columnName = new String[] {"TABLE_CAT"};
         Query.Type[] columntype = new Query.Type[] {Query.Type.CHAR};
-        return new VitessResultSet(columnName, columntype, data);
+        return new VitessResultSet(connection, columnName, columntype, data);
     }
 
     public ResultSet getTableTypes() throws SQLException {
@@ -496,7 +511,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         String[][] data =
             new String[][] {{"LOCAL TEMPORARY"}, {"SYSTEM TABLES"}, {"SYSTEM VIEW"}, {"TABLE"},
                 {"VIEW"}};
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(connection, columnNames, columnType, data);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getColumns(String catalog,
@@ -700,7 +715,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.INT32, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.CHAR, Query.Type.INT16, Query.Type.CHAR, Query.Type.CHAR};
 
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(connection, columnNames, columnType, data);
     }
 
     public ResultSet getColumnPrivileges(String catalog, String schema, String table,
@@ -791,7 +806,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             }
             vitessStatement.close();
         }
-        return new VitessResultSet(columnName, columnType, data);
+        return new VitessResultSet(connection, columnName, columnType, data);
     }
 
     public ResultSet getVersionColumns(String catalog, String schema, String table)
@@ -846,7 +861,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             new Query.Type[] {Query.Type.INT16, Query.Type.CHAR, Query.Type.INT32, Query.Type.CHAR,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT16, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(connection, columnNames, columnType, data);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getPrimaryKeys(
@@ -902,7 +917,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             new Query.Type[] {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.INT16, Query.Type.CHAR};
 
-        return new VitessResultSet(columnNames, columnType, sortedData);
+        return new VitessResultSet(connection, columnNames, columnType, sortedData);
     }
 
     public ResultSet getImportedKeys(String catalog, String schema, String table)
@@ -1019,7 +1034,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 {"TIMESTAMP", "93", "0", "'", "'", "[(M)]", "1", "false", "3", "false", "false",
                     "false", "TIMESTAMP", "0", "0", "0", "0", "10"}};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(connection, columnNames, columnTypes, data);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getIndexInfo(
@@ -1088,7 +1103,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT32, Query.Type.INT32,
                 Query.Type.CHAR};
 
-        return new VitessResultSet(columnName, columnType, data);
+        return new VitessResultSet(connection, columnName, columnType, data);
     }
 
     public boolean ownUpdatesAreVisible(int type) throws SQLException {
@@ -1131,7 +1146,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             {Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.INT32, Query.Type.VARCHAR, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern)
@@ -1142,7 +1157,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern)
@@ -1150,7 +1165,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         String[] columnNames = {"TABLE_CAT", "TYPE_SCHEM", "TABLE_NAME", "SUPERTABLE_NAME"};
         Query.Type[] columnType =
             {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern,
@@ -1167,7 +1182,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.INT32, Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT32,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT32, Query.Type.CHAR,
                 Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public int getSQLStateType() throws SQLException {
@@ -1186,14 +1201,14 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
         String[] columnNames = {"TABLE_CAT", "TABLE_CATALOG"};
         Query.Type[] columnType = {Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getClientInfoProperties() throws SQLException {
         String[] columnNames = {"NAME", "MAX_LEN", "DEFAULT_VALUE", "DESCRIPTION"};
         Query.Type[] columnType =
             {Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR, Query.Type.VARCHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
@@ -1218,7 +1233,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             {Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT32, Query.Type.INT32,
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(connection, columnNames, columnType, new String[][] {});
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessPreparedStatement.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessPreparedStatement.java
@@ -117,14 +117,13 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                     .getAutoCommit()) {
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    if (Constants.QueryExecuteType.SIMPLE == vitessConnection
-                        .getExecuteTypeParam()) {
+                    if (vitessConnection.isSimpleExecute()) {
                         cursor =
-                            vtGateConn.execute(context, this.sql, this.bindVariables, tabletType)
+                            vtGateConn.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                                 .checkedGet();
                     } else {
                         cursor = vtGateConn
-                            .streamExecute(context, this.sql, this.bindVariables, tabletType);
+                            .streamExecute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields());
                     }
                 } else {
                     VTGateTx vtGateTx = this.vitessConnection.getVtGateTx();
@@ -136,7 +135,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                     }
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType)
+                    cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
                 }
             }
@@ -145,7 +144,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                 throw new SQLException(Constants.SQLExceptionMessages.METHOD_CALL_FAILED);
             }
 
-            this.vitessResultSet = new VitessResultSet(cursor, this);
+            this.vitessResultSet = new VitessResultSet(vitessConnection, cursor, this);
         } catch (SQLRecoverableException ex) {
             this.vitessConnection.setVtGateTx(null);
             throw ex;
@@ -174,7 +173,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
         try {
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateConn.execute(context, this.sql, this.bindVariables, tabletType)
+                cursor = vtGateConn.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                     .checkedGet();
             } else {
                 VTGateTx vtGateTx = this.vitessConnection.getVtGateTx();
@@ -186,7 +185,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                 }
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType)
+                cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                     .checkedGet();
             }
 
@@ -232,7 +231,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
         if (showSql) {
             cursor = this.executeShow(this.sql);
             if (!(null == cursor || null == cursor.getFields() || cursor.getFields().isEmpty())) {
-                this.vitessResultSet = new VitessResultSet(cursor, this);
+                this.vitessResultSet = new VitessResultSet(vitessConnection, cursor, this);
                 return true;
             }
             throw new SQLException(Constants.SQLExceptionMessages.METHOD_CALL_FAILED);
@@ -443,7 +442,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateConn.executeBatch(context, batchedQueries, batchedArgs, tabletType)
+                    vtGateConn.executeBatch(context, batchedQueries, batchedArgs, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
             } else {
                 vtGateTx = this.vitessConnection.getVtGateTx();
@@ -456,7 +455,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateTx.executeBatch(context, batchedQueries, batchedArgs, tabletType)
+                    vtGateTx.executeBatch(context, batchedQueries, batchedArgs, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
             }
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -1,6 +1,8 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.StringUtils;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
@@ -9,9 +11,26 @@ import com.youtube.vitess.proto.Query;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URL;
-import java.sql.*;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.Ref;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -26,9 +45,10 @@ public class VitessResultSet implements ResultSet {
 
     /* Get actual class name to be printed on */
     private static Logger logger = Logger.getLogger(VitessResultSet.class.getName());
+    private final VitessConnection connection;
 
     private Cursor cursor;
-    private List<Query.Field> fields;
+    private List<FieldWithMetadata> fields;
     private VitessStatement vitessStatement;
     private boolean closed = false;
     private Row row;
@@ -40,11 +60,12 @@ public class VitessResultSet implements ResultSet {
      */
     private int lastIndexRead = -1;
 
-    public VitessResultSet(Cursor cursor) throws SQLException {
-        this(cursor, null);
+    public VitessResultSet(VitessConnection connection, Cursor cursor) throws SQLException {
+        this(connection, cursor, null);
     }
 
-    public VitessResultSet(Cursor cursor, VitessStatement vitessStatement) throws SQLException {
+    public VitessResultSet(VitessConnection connection, Cursor cursor, VitessStatement vitessStatement) throws SQLException {
+        this.connection = connection;
         if (null == cursor) {
             throw new SQLException(Constants.SQLExceptionMessages.CURSOR_NULL);
         }
@@ -52,7 +73,7 @@ public class VitessResultSet implements ResultSet {
         this.cursor = cursor;
         this.vitessStatement = vitessStatement;
         try {
-            this.fields = this.cursor.getFields();
+            this.fields = enhancedFieldsFromCursor();
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
@@ -63,8 +84,9 @@ public class VitessResultSet implements ResultSet {
         }
     }
 
-    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes, String[][] data)
+    public VitessResultSet(VitessConnection connection, String[] columnNames, Query.Type[] columnTypes, String[][] data)
         throws SQLException {
+        this.connection = connection;
 
         if (columnNames.length != columnTypes.length) {
             throw new SQLException(Constants.SQLExceptionMessages.INVALID_RESULT_SET);
@@ -93,15 +115,16 @@ public class VitessResultSet implements ResultSet {
         this.cursor = new SimpleCursor(queryResultBuilder.build());
         this.vitessStatement = null;
         try {
-            this.fields = this.cursor.getFields();
+            this.fields = enhancedFieldsFromCursor();
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
         this.currentRow = 0;
     }
 
-    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes,
+    public VitessResultSet(VitessConnection connection, String[] columnNames, Query.Type[] columnTypes,
         ArrayList<ArrayList<String>> data) throws SQLException {
+        this.connection = connection;
 
         if (columnNames.length != columnTypes.length) {
             throw new SQLException(Constants.SQLExceptionMessages.INVALID_RESULT_SET);
@@ -132,11 +155,26 @@ public class VitessResultSet implements ResultSet {
         this.cursor = new SimpleCursor(queryResultBuilder.build());
         this.vitessStatement = null;
         try {
-            fields = cursor.getFields();
+            this.fields = enhancedFieldsFromCursor();
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
         this.currentRow = 0;
+    }
+
+    private List<FieldWithMetadata> enhancedFieldsFromCursor() throws SQLException {
+        if (cursor == null|| cursor.getFields() == null) {
+            throw new SQLException(Constants.SQLExceptionMessages.CURSOR_NULL);
+        }
+
+        List<Query.Field> rawFields = cursor.getFields();
+        List<FieldWithMetadata> fields = new ArrayList<>(rawFields.size());
+
+        for (Query.Field field : rawFields) {
+            fields.add(new FieldWithMetadata(connection, field));
+        }
+
+        return fields;
     }
 
     public boolean next() throws SQLException {
@@ -190,7 +228,11 @@ public class VitessResultSet implements ResultSet {
         object = this.row.getObject(columnIndex);
 
         if (object instanceof byte[]) {
-            columnValue = new String((byte[]) object);
+            if (connection.isIncludeAllFields()) {
+                columnValue = convertBytesToString((byte[]) object, columnIndex);
+            } else {
+                columnValue = new String((byte[]) object);
+            }
         } else {
             columnValue = String.valueOf(object);
         }
@@ -209,9 +251,9 @@ public class VitessResultSet implements ResultSet {
         }
 
         // Mysql 5.0 and higher have a BIT Data Type, need to check for this as well.
-        Query.Field field = this.fields.get(columnIndex - 1);
+        FieldWithMetadata field = this.fields.get(columnIndex - 1);
 
-        if (field.getType() == Query.Type.BIT) {
+        if (field.getVitessTypeValue() == Query.Type.BIT_VALUE) {
             return byteArrayToBoolean(columnIndex);
         }
 
@@ -508,8 +550,9 @@ public class VitessResultSet implements ResultSet {
         //no-op, All exceptions thrown, none kept as warning
     }
 
+
     public ResultSetMetaData getMetaData() throws SQLException {
-        return new VitessResultSetMetaData(cursor.getFields());
+        return new VitessResultSetMetaData(connection, fields);
     }
 
     public Object getObject(int columnIndex) throws SQLException {
@@ -519,7 +562,60 @@ public class VitessResultSet implements ResultSet {
             return null;
         }
 
-        return this.row.getObject(columnIndex);
+        Object retVal = this.row.getObject(columnIndex);
+
+        if (connection.isIncludeAllFields() && retVal instanceof byte[]) {
+            retVal = convertBytesIfPossible((byte[]) retVal, columnIndex);
+        }
+
+        return retVal;
+    }
+
+    private Object convertBytesIfPossible(byte[] bytes, int columnIndex) throws SQLException {
+        FieldWithMetadata field = this.fields.get(columnIndex - 1);
+        String encoding = field.getEncoding();
+
+        switch (field.getJavaType()) {
+            case Types.BIT:
+                if (!field.isSingleBit()) {
+                    return bytes;
+                }
+
+                return byteArrayToBoolean(bytes);
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                if (!field.isOpaqueBinary()) {
+                    return convertBytesToString(bytes, encoding);
+                }
+
+                return bytes;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return bytes;
+            default:
+                return convertBytesToString(bytes, encoding);
+        }
+    }
+
+    private String convertBytesToString(byte[] bytes, int columnIndex) throws SQLException {
+        FieldWithMetadata field = this.fields.get(columnIndex - 1);
+        String encoding = field.getEncoding();
+
+        return convertBytesToString(bytes, encoding);
+    }
+
+    private String convertBytesToString(byte[] bytes, String encoding) throws SQLException {
+        if (encoding == null) {
+            return StringUtils.toString(bytes);
+        } else {
+            try {
+                return StringUtils.toString(bytes, 0, bytes.length, encoding);
+            } catch (UnsupportedEncodingException e) {
+                throw new SQLException("Unsupported character encoding: " + encoding, e);
+            }
+        }
     }
 
     public Object getObject(String columnLabel) throws SQLException {
@@ -1381,9 +1477,16 @@ public class VitessResultSet implements ResultSet {
             Constants.SQLExceptionMessages.SQL_FEATURE_NOT_SUPPORTED);
     }
 
-    private boolean byteArrayToBoolean(int columnIndex) throws SQLException {
-        Object value = this.row.getObject(columnIndex);
+    @VisibleForTesting
+    List<FieldWithMetadata> getFields() {
+        return fields;
+    }
 
+    private boolean byteArrayToBoolean(int columnIndex) throws SQLException {
+        return byteArrayToBoolean(this.row.getObject(columnIndex));
+    }
+
+    private boolean byteArrayToBoolean(Object value) throws SQLException {
         if (value == null) {
             return false;
         }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessVTGateManager.java
@@ -78,21 +78,6 @@ public class VitessVTGateManager {
      * @param hostname
      * @param port
      * @param username
-     * @return
-     */
-    private static VTGateConn getVtGateConn(String hostname, int port, String username) {
-        Context context = CommonUtils.createContext(username, Constants.CONNECTION_TIMEOUT);
-        InetSocketAddress inetSocketAddress = new InetSocketAddress(hostname, port);
-        RpcClient client = new GrpcClientFactory().create(context, inetSocketAddress);
-        return (new VTGateConn(client));
-    }
-
-    /**
-     * Create vtGateConn object with given identifier.
-     *
-     * @param hostname
-     * @param port
-     * @param username
      * @param keyspace
      * @return
      */
@@ -114,8 +99,6 @@ public class VitessVTGateManager {
      * @param identifier
      * @param hostname
      * @param port
-     * @param username
-     * @param keyspace
      */
     private static void updateVtGateConnHashMap(String identifier, String hostname, int port,
         String username, String keyspace) {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/CommonUtils.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/CommonUtils.java
@@ -2,6 +2,7 @@ package com.flipkart.vitess.util;
 
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.proto.Vtrpc;
+
 import org.joda.time.Duration;
 
 /**

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
@@ -1,5 +1,8 @@
 package com.flipkart.vitess.util;
 
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
 /**
  * Created by harshit.gangal on 25/01/16.
  */
@@ -15,7 +18,7 @@ public class Constants {
     public static final String VITESS_TABLET_TYPE =
         "Tablet Type to which Vitess will connect(master, replica, rdonly)";
     public static final String DEFAULT_PORT = "15991";
-    public static final String DEFAULT_TABLET_TYPE = "MASTER";
+    public static final Topodata.TabletType DEFAULT_TABLET_TYPE = Topodata.TabletType.MASTER;
     public static final long CONNECTION_TIMEOUT = 30000;
     public static final String LITERAL_V = "v";
     public static final String LITERAL_SINGLE_QUOTE = "'";
@@ -30,7 +33,7 @@ public class Constants {
     public static final Constants.QueryExecuteType DEFAULT_EXECUTE_TYPE = QueryExecuteType.SIMPLE;
     public static final String EXECUTE_TYPE_DESC = "Query execution type: simple or stream \n";
     public static final String USERNAME_DESC = "Username used for ACL validation \n";
-
+    public static final Query.ExecuteOptions.IncludedFields DEFAULT_INCLUDED_FIELDS = Query.ExecuteOptions.IncludedFields.ALL;
 
     private Constants() {
     }
@@ -100,6 +103,7 @@ public class Constants {
         public static final String USERNAME = "userName";
         public static final String EXECUTE_TYPE = "executeType";
         public static final String TWOPC_ENABLED = "twopcEnabled";
+        public static final String INCLUDED_FIELDS = "includedFields";
     }
 
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
@@ -72,10 +72,10 @@ public final class MysqlDefs {
     static final int FIELD_TYPE_YEAR = 13;
     static final int FIELD_TYPE_JSON = 245;
     static final int INIT_DB = 2;
-    static final long LENGTH_BLOB = 65535;
-    static final long LENGTH_LONGBLOB = 4294967295L;
-    static final long LENGTH_MEDIUMBLOB = 16777215;
-    static final long LENGTH_TINYBLOB = 255;
+    public static final int LENGTH_BLOB = 65535;
+    public static final int LENGTH_LONGBLOB = Integer.MAX_VALUE;
+    public static final int LENGTH_MEDIUMBLOB = 16777215;
+    public static final int LENGTH_TINYBLOB = 255;
     // Limitations
     static final int MAX_ROWS = 50000000; // From the MySQL FAQ
     static final byte OPEN_CURSOR_FLAG = 1;
@@ -103,7 +103,7 @@ public final class MysqlDefs {
     static final int STATISTICS = 9;
 
     static final int TIME = 15;
-    public static Map<Query.Type, Integer> vitesstoMySqlType = new HashMap<Query.Type, Integer>();
+    public static Map<Query.Type, Integer> vitessToJavaType = new HashMap<Query.Type, Integer>();
     public static Map<String, Integer> mysqlConnectionTransactionMapping =
         new HashMap<String, Integer>();
     private static Map<String, Integer> mysqlToJdbcTypesMap = new HashMap<String, Integer>();
@@ -145,35 +145,37 @@ public final class MysqlDefs {
     }
 
     static {
-        vitesstoMySqlType.put(Query.Type.NULL_TYPE, Types.NULL);
-        vitesstoMySqlType.put(Query.Type.INT8, Types.TINYINT);
-        vitesstoMySqlType.put(Query.Type.UINT8, Types.TINYINT);
-        vitesstoMySqlType.put(Query.Type.INT16, Types.SMALLINT);
-        vitesstoMySqlType.put(Query.Type.UINT16, Types.SMALLINT);
-        vitesstoMySqlType.put(Query.Type.INT24, Types.INTEGER);
-        vitesstoMySqlType.put(Query.Type.UINT24, Types.INTEGER);
-        vitesstoMySqlType.put(Query.Type.INT32, Types.INTEGER);
-        vitesstoMySqlType.put(Query.Type.UINT32, Types.INTEGER);
-        vitesstoMySqlType.put(Query.Type.INT64, Types.BIGINT);
-        vitesstoMySqlType.put(Query.Type.UINT64, Types.BIGINT);
-        vitesstoMySqlType.put(Query.Type.FLOAT32, Types.FLOAT);
-        vitesstoMySqlType.put(Query.Type.FLOAT64, Types.DOUBLE);
-        vitesstoMySqlType.put(Query.Type.TIMESTAMP, Types.TIMESTAMP);
-        vitesstoMySqlType.put(Query.Type.DATE, Types.DATE);
-        vitesstoMySqlType.put(Query.Type.TIME, Types.TIME);
-        vitesstoMySqlType.put(Query.Type.DATETIME, Types.TIMESTAMP);
-        vitesstoMySqlType.put(Query.Type.YEAR, Types.SMALLINT);
-        vitesstoMySqlType.put(Query.Type.DECIMAL, Types.DECIMAL);
-        vitesstoMySqlType.put(Query.Type.TEXT, Types.VARCHAR);
-        vitesstoMySqlType.put(Query.Type.BLOB, Types.BLOB);
-        vitesstoMySqlType.put(Query.Type.VARCHAR, Types.VARCHAR);
-        vitesstoMySqlType.put(Query.Type.VARBINARY, Types.VARBINARY);
-        vitesstoMySqlType.put(Query.Type.CHAR, Types.CHAR);
-        vitesstoMySqlType.put(Query.Type.BINARY, Types.BINARY);
-        vitesstoMySqlType.put(Query.Type.BIT, Types.BIT);
-        vitesstoMySqlType.put(Query.Type.ENUM, Types.CHAR);
-        vitesstoMySqlType.put(Query.Type.SET, Types.CHAR);
-        vitesstoMySqlType.put(Query.Type.TUPLE, Types.OTHER);
+        vitessToJavaType.put(Query.Type.NULL_TYPE, Types.NULL);
+        vitessToJavaType.put(Query.Type.INT8, Types.TINYINT);
+        vitessToJavaType.put(Query.Type.UINT8, Types.TINYINT);
+        vitessToJavaType.put(Query.Type.INT16, Types.SMALLINT);
+        vitessToJavaType.put(Query.Type.UINT16, Types.SMALLINT);
+        vitessToJavaType.put(Query.Type.INT24, Types.INTEGER);
+        vitessToJavaType.put(Query.Type.UINT24, Types.INTEGER);
+        vitessToJavaType.put(Query.Type.INT32, Types.INTEGER);
+        vitessToJavaType.put(Query.Type.UINT32, Types.INTEGER);
+        vitessToJavaType.put(Query.Type.INT64, Types.BIGINT);
+        vitessToJavaType.put(Query.Type.UINT64, Types.BIGINT);
+        vitessToJavaType.put(Query.Type.FLOAT32, Types.FLOAT);
+        vitessToJavaType.put(Query.Type.FLOAT64, Types.DOUBLE);
+        vitessToJavaType.put(Query.Type.TIMESTAMP, Types.TIMESTAMP);
+        vitessToJavaType.put(Query.Type.DATE, Types.DATE);
+        vitessToJavaType.put(Query.Type.TIME, Types.TIME);
+        vitessToJavaType.put(Query.Type.DATETIME, Types.TIMESTAMP);
+        vitessToJavaType.put(Query.Type.YEAR, Types.SMALLINT);
+        vitessToJavaType.put(Query.Type.DECIMAL, Types.DECIMAL);
+        vitessToJavaType.put(Query.Type.TEXT, Types.VARCHAR);
+        vitessToJavaType.put(Query.Type.BLOB, Types.BLOB);
+        vitessToJavaType.put(Query.Type.VARCHAR, Types.VARCHAR);
+        vitessToJavaType.put(Query.Type.VARBINARY, Types.VARBINARY);
+        vitessToJavaType.put(Query.Type.CHAR, Types.CHAR);
+        vitessToJavaType.put(Query.Type.BINARY, Types.BINARY);
+        vitessToJavaType.put(Query.Type.BIT, Types.BIT);
+        vitessToJavaType.put(Query.Type.ENUM, Types.CHAR);
+        vitessToJavaType.put(Query.Type.SET, Types.CHAR);
+        vitessToJavaType.put(Query.Type.TUPLE, Types.OTHER);
+        vitessToJavaType.put(Query.Type.GEOMETRY, Types.BINARY);
+        vitessToJavaType.put(Query.Type.JSON, Types.BINARY);
     }
 
     static {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
@@ -1,13 +1,21 @@
 package com.flipkart.vitess.util;
 
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by naveen.nahata on 05/02/16.
  */
 public class StringUtils {
+
+    private static final String platformEncoding = System.getProperty("file.encoding");
+    private static final ConcurrentHashMap<String, Charset> charsetsByAlias = new ConcurrentHashMap<String, Charset>();
 
     private StringUtils() {
     }
@@ -373,5 +381,79 @@ public class StringUtils {
         }
 
         return statementStartPos;
+    }
+
+    public static String toString(byte[] value, int offset, int length, String encoding) throws UnsupportedEncodingException {
+        Charset cs = findCharset(encoding);
+
+        return cs.decode(ByteBuffer.wrap(value, offset, length)).toString();
+    }
+
+    public static String toString(byte[] value, String encoding) throws UnsupportedEncodingException {
+        return findCharset(encoding)
+            .decode(ByteBuffer.wrap(value))
+            .toString();
+    }
+
+    public static String toString(byte[] value, int offset, int length) {
+        try {
+            return findCharset(platformEncoding)
+                .decode(ByteBuffer.wrap(value, offset, length))
+                .toString();
+        } catch (UnsupportedEncodingException e) {
+            // can't happen, emulating new String(byte[])
+        }
+
+        return null;
+    }
+
+    public static String toString(byte[] value) {
+        try {
+            return findCharset(platformEncoding)
+                .decode(ByteBuffer.wrap(value))
+                .toString();
+        } catch (UnsupportedEncodingException e) {
+            // can't happen, emulating new String(byte[])
+        }
+
+        return null;
+    }
+
+    public static byte[] getBytes(String value, String encoding) throws UnsupportedEncodingException {
+        return getBytes(value, 0, value.length(), encoding);
+    }
+
+    public static byte[] getBytes(String value, int offset, int length, String encoding) throws UnsupportedEncodingException {
+        Charset cs = findCharset(encoding);
+
+        ByteBuffer buf = cs.encode(CharBuffer.wrap(value.toCharArray(), offset, length));
+
+        // can't simply .array() this to get the bytes especially with variable-length charsets the buffer is sometimes larger than the actual encoded data
+        int encodedLen = buf.limit();
+        byte[] asBytes = new byte[encodedLen];
+        buf.get(asBytes, 0, encodedLen);
+
+        return asBytes;
+    }
+
+    private static Charset findCharset(String alias) throws UnsupportedEncodingException {
+        try {
+            Charset cs = charsetsByAlias.get(alias);
+
+            if (cs == null) {
+                cs = Charset.forName(alias);
+                Charset oldCs = charsetsByAlias.putIfAbsent(alias, cs);
+                if (oldCs != null) {
+                    // if the previous value was recently set by another thread we return it instead of value we found here
+                    cs = oldCs;
+                }
+            }
+
+            return cs;
+
+            // We re-throw these runtimes for compatibility with java.io
+        } catch (IllegalArgumentException iae) {
+            throw new UnsupportedEncodingException(alias);
+        }
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/CharsetMapping.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/CharsetMapping.java
@@ -1,0 +1,536 @@
+package com.flipkart.vitess.util.charset;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+public class CharsetMapping {
+    private static final int MAP_SIZE = 255; // Size of static maps
+    public static final String[] COLLATION_INDEX_TO_COLLATION_NAME;
+    private static final MysqlCharset[] COLLATION_INDEX_TO_CHARSET;
+
+    static final Map<String, MysqlCharset> CHARSET_NAME_TO_CHARSET;
+    private static final Map<String, List<MysqlCharset>> JAVA_ENCODING_UC_TO_MYSQL_CHARSET;
+
+    private static final String MYSQL_CHARSET_NAME_armscii8 = "armscii8";
+    private static final String MYSQL_CHARSET_NAME_ascii = "ascii";
+    private static final String MYSQL_CHARSET_NAME_big5 = "big5";
+    private static final String MYSQL_CHARSET_NAME_binary = "binary";
+    private static final String MYSQL_CHARSET_NAME_cp1250 = "cp1250";
+    private static final String MYSQL_CHARSET_NAME_cp1251 = "cp1251";
+    private static final String MYSQL_CHARSET_NAME_cp1256 = "cp1256";
+    private static final String MYSQL_CHARSET_NAME_cp1257 = "cp1257";
+    private static final String MYSQL_CHARSET_NAME_cp850 = "cp850";
+    private static final String MYSQL_CHARSET_NAME_cp852 = "cp852";
+    private static final String MYSQL_CHARSET_NAME_cp866 = "cp866";
+    private static final String MYSQL_CHARSET_NAME_cp932 = "cp932";
+    private static final String MYSQL_CHARSET_NAME_dec8 = "dec8";
+    private static final String MYSQL_CHARSET_NAME_eucjpms = "eucjpms";
+    private static final String MYSQL_CHARSET_NAME_euckr = "euckr";
+    private static final String MYSQL_CHARSET_NAME_gb18030 = "gb18030";
+    private static final String MYSQL_CHARSET_NAME_gb2312 = "gb2312";
+    private static final String MYSQL_CHARSET_NAME_gbk = "gbk";
+    private static final String MYSQL_CHARSET_NAME_geostd8 = "geostd8";
+    private static final String MYSQL_CHARSET_NAME_greek = "greek";
+    private static final String MYSQL_CHARSET_NAME_hebrew = "hebrew";
+    private static final String MYSQL_CHARSET_NAME_hp8 = "hp8";
+    private static final String MYSQL_CHARSET_NAME_keybcs2 = "keybcs2";
+    private static final String MYSQL_CHARSET_NAME_koi8r = "koi8r";
+    private static final String MYSQL_CHARSET_NAME_koi8u = "koi8u";
+    private static final String MYSQL_CHARSET_NAME_latin1 = "latin1";
+    private static final String MYSQL_CHARSET_NAME_latin2 = "latin2";
+    private static final String MYSQL_CHARSET_NAME_latin5 = "latin5";
+    private static final String MYSQL_CHARSET_NAME_latin7 = "latin7";
+    private static final String MYSQL_CHARSET_NAME_macce = "macce";
+    private static final String MYSQL_CHARSET_NAME_macroman = "macroman";
+    private static final String MYSQL_CHARSET_NAME_sjis = "sjis";
+    private static final String MYSQL_CHARSET_NAME_swe7 = "swe7";
+    private static final String MYSQL_CHARSET_NAME_tis620 = "tis620";
+    private static final String MYSQL_CHARSET_NAME_ucs2 = "ucs2";
+    private static final String MYSQL_CHARSET_NAME_ujis = "ujis";
+    private static final String MYSQL_CHARSET_NAME_utf16 = "utf16";
+    private static final String MYSQL_CHARSET_NAME_utf16le = "utf16le";
+    private static final String MYSQL_CHARSET_NAME_utf32 = "utf32";
+    private static final String MYSQL_CHARSET_NAME_utf8 = "utf8";
+    private static final String MYSQL_CHARSET_NAME_utf8mb4 = "utf8mb4";
+
+    private static final String MYSQL_4_0_CHARSET_NAME_cp1251cias = "cp1251cias";
+    private static final String MYSQL_4_0_CHARSET_NAME_cp1251csas = "cp1251csas";
+    private static final String MYSQL_4_0_CHARSET_NAME_croat = "croat";        // 4.1 =>	27	latin2		latin2_croatian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_czech = "czech";        // 4.1 =>	2	latin2		latin2_czech_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_danish = "danish";        // 4.1 =>	15	latin1		latin1_danish_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_dos = "dos";            // 4.1 =>	4	cp850		cp850_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_estonia = "estonia";        // 4.1 =>	20	latin7		latin7_estonian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_euc_kr = "euc_kr";        // 4.1 =>	19	euckr		euckr_korean_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_german1 = "german1";        // 4.1 =>	5	latin1		latin1_german1_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_hungarian = "hungarian";    // 4.1 =>	21	latin2		latin2_hungarian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_koi8_ru = "koi8_ru";        // 4.1 =>	7	koi8r		koi8r_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_koi8_ukr = "koi8_ukr";        // 4.1 =>	22	koi8u		koi8u_ukrainian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_latin1_de = "latin1_de";    // 4.1 =>	31	latin1		latin1_german2_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_latvian = "latvian";
+    private static final String MYSQL_4_0_CHARSET_NAME_latvian1 = "latvian1";
+    private static final String MYSQL_4_0_CHARSET_NAME_usa7 = "usa7";            // 4.1 =>	11	ascii		ascii_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_win1250 = "win1250";        // 4.1 =>	26	cp1250		cp1250_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_win1251 = "win1251";        // 4.1 =>	17	(removed)
+    private static final String MYSQL_4_0_CHARSET_NAME_win1251ukr = "win1251ukr";    // 4.1 =>	23	cp1251		cp1251_ukrainian_ci
+
+    private static final String NOT_USED = MYSQL_CHARSET_NAME_latin1; // punting for not-used character sets
+
+    public static final int MYSQL_COLLATION_INDEX_utf8 = 33;
+    public static final int MYSQL_COLLATION_INDEX_binary = 63;
+
+    static {
+        // complete list of mysql character sets and their corresponding java encoding names
+        MysqlCharset[] charset = new MysqlCharset[]{new MysqlCharset(MYSQL_4_0_CHARSET_NAME_usa7, 1, 0, new String[]{"US-ASCII"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_ascii, 1, 0, new String[]{"US-ASCII", "ASCII"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_big5, 2, 0, new String[]{"Big5"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_gbk, 2, 0, new String[]{"GBK"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_sjis, 2, 0, new String[]{"SHIFT_JIS", "Cp943", "WINDOWS-31J"}),    // SJIS is alias for SHIFT_JIS, Cp943 is rather a cp932 but we map it to sjis for years
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp932, 2, 1, new String[]{"WINDOWS-31J"}),        // MS932 is alias for WINDOWS-31J
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_gb2312, 2, 0, new String[]{"GB2312"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_ujis, 3, 0, new String[]{"EUC_JP"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_eucjpms, 3, 0, new String[]{"EUC_JP_Solaris"}, 5, 0, 3),    // "EUC_JP_Solaris = 	>5.0.3 eucjpms,"
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_gb18030, 4, 0, new String[]{"GB18030"}, 5, 7, 4),
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_euc_kr, 2, 0, new String[]{"EUC_KR"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_euckr, 2, 0, new String[]{"EUC-KR"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin1, 1, 1, new String[]{"Cp1252", "ISO8859_1"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_swe7, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_hp8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_dec8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_armscii8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_geostd8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin2, 1, 0, new String[]{"ISO8859_2"}),        // latin2 is an alias
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_czech, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_hungarian, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_croat, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_greek, 1, 0, new String[]{"ISO8859_7", "greek"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin7, 1, 0, new String[]{"ISO-8859-13"}),    // was ISO8859_7, that's incorrect; also + "LATIN7 =		latin7," is wrong java encoding name
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_hebrew, 1, 0, new String[]{"ISO8859_8"}),        // hebrew is an alias
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin5, 1, 0, new String[]{"ISO8859_9"}),        // LATIN5 is an alias
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latvian, 1, 0, new String[]{"ISO8859_13"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latvian1, 1, 0, new String[]{"ISO8859_13"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_estonia, 1, 1, new String[]{"ISO8859_13"}, 4, 0), //,	"ISO8859_13");	// punting for "estonia";
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp850, 1, 0, new String[]{"Cp850", "Cp437"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_dos, 1, 0, new String[]{"Cp850", "Cp437"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp852, 1, 0, new String[]{"Cp852"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_keybcs2, 1, 0, new String[]{"Cp852"}),    // new, Kamenicky encoding usually known as Cp895 but there is no official cp895 specification; close to Cp852, see http://ftp.muni.cz/pub/localization/charsets/cs-encodings-faq
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp866, 1, 0, new String[]{"Cp866"}),
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_koi8_ru, 1, 0, new String[]{"KOI8_R"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_koi8r, 1, 1, new String[]{"KOI8_R"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_koi8u, 1, 0, new String[]{"KOI8_R"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_koi8_ukr, 1, 0, new String[]{"KOI8_R"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_tis620, 1, 0, new String[]{"TIS620"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1250, 1, 0, new String[]{"Cp1250"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1250, 1, 0, new String[]{"Cp1250"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1251, 1, 1, new String[]{"Cp1251"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1251, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_cp1251cias, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_cp1251csas, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1251ukr, 1, 0, new String[]{"Cp1251"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1256, 1, 0, new String[]{"Cp1256"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1257, 1, 0, new String[]{"Cp1257"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_macroman, 1, 0, new String[]{"MacRoman"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_macce, 1, 0, new String[]{"MacCentralEurope"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf8, 3, 1, new String[]{"UTF-8"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf8mb4, 4, 0, new String[]{"UTF-8"}),            // "UTF-8 =				*> 5.5.2 utf8mb4,"
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_ucs2, 2, 0, new String[]{"UnicodeBig"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_binary, 1, 1, new String[]{"ISO8859_1"}),    // US-ASCII ?
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latin1_de, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_german1, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_danish, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf16, 4, 0, new String[]{"UTF-16"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf16le, 4, 0, new String[]{"UTF-16LE"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf32, 4, 0, new String[]{"UTF-32"})
+        };
+
+        HashMap<String, MysqlCharset> charsetNameToMysqlCharsetMap = new HashMap<String, MysqlCharset>();
+        HashMap<String, List<MysqlCharset>> javaUcToMysqlCharsetMap = new HashMap<String, List<MysqlCharset>>();
+
+        for (int i = 0; i < charset.length; i++) {
+            String charsetName = charset[i].charsetName;
+
+            charsetNameToMysqlCharsetMap.put(charsetName, charset[i]);
+
+            for (String encUC : charset[i].javaEncodingsUc) {
+
+                // fill javaUcToMysqlCharsetMap
+                List<MysqlCharset> charsets = javaUcToMysqlCharsetMap.get(encUC);
+                if (charsets == null) {
+                    charsets = new ArrayList<MysqlCharset>();
+                    javaUcToMysqlCharsetMap.put(encUC, charsets);
+                }
+                charsets.add(charset[i]);
+            }
+        }
+
+        CHARSET_NAME_TO_CHARSET = Collections.unmodifiableMap(charsetNameToMysqlCharsetMap);
+        JAVA_ENCODING_UC_TO_MYSQL_CHARSET = Collections.unmodifiableMap(javaUcToMysqlCharsetMap);
+
+        // complete list of mysql collations and their corresponding character sets each element of collation[1]..collation[MAP_SIZE-1] must not be null
+        Collation[] collation = new Collation[MAP_SIZE];
+        collation[1] = new Collation(1, "big5_chinese_ci", 1, MYSQL_CHARSET_NAME_big5);
+        collation[84] = new Collation(84, "big5_bin", 0, MYSQL_CHARSET_NAME_big5);
+
+        collation[2] = new Collation(2, "latin2_czech_cs", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[9] = new Collation(9, "latin2_general_ci", 1, MYSQL_CHARSET_NAME_latin2);
+        collation[21] = new Collation(21, "latin2_hungarian_ci", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[27] = new Collation(27, "latin2_croatian_ci", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[77] = new Collation(77, "latin2_bin", 0, MYSQL_CHARSET_NAME_latin2);
+
+        collation[4] = new Collation(4, "cp850_general_ci", 1, MYSQL_CHARSET_NAME_cp850);
+        collation[80] = new Collation(80, "cp850_bin", 0, MYSQL_CHARSET_NAME_cp850);
+
+        collation[5] = new Collation(5, "latin1_german1_ci", 1, MYSQL_CHARSET_NAME_latin1);
+        collation[8] = new Collation(8, "latin1_swedish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[15] = new Collation(15, "latin1_danish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[31] = new Collation(31, "latin1_german2_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[47] = new Collation(47, "latin1_bin", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[48] = new Collation(48, "latin1_general_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[49] = new Collation(49, "latin1_general_cs", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[76] = new Collation(76, "not_implemented", 0, NOT_USED);
+        collation[94] = new Collation(94, "latin1_spanish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[100] = new Collation(100, "not_implemented", 0, NOT_USED);
+        collation[125] = new Collation(125, "not_implemented", 0, NOT_USED);
+        collation[126] = new Collation(126, "not_implemented", 0, NOT_USED);
+        collation[127] = new Collation(127, "not_implemented", 0, NOT_USED);
+        collation[152] = new Collation(152, "not_implemented", 0, NOT_USED);
+        collation[153] = new Collation(153, "not_implemented", 0, NOT_USED);
+        collation[154] = new Collation(154, "not_implemented", 0, NOT_USED);
+        collation[155] = new Collation(155, "not_implemented", 0, NOT_USED);
+        collation[156] = new Collation(156, "not_implemented", 0, NOT_USED);
+        collation[157] = new Collation(157, "not_implemented", 0, NOT_USED);
+        collation[158] = new Collation(158, "not_implemented", 0, NOT_USED);
+        collation[184] = new Collation(184, "not_implemented", 0, NOT_USED);
+        collation[185] = new Collation(185, "not_implemented", 0, NOT_USED);
+        collation[186] = new Collation(186, "not_implemented", 0, NOT_USED);
+        collation[187] = new Collation(187, "not_implemented", 0, NOT_USED);
+        collation[188] = new Collation(188, "not_implemented", 0, NOT_USED);
+        collation[189] = new Collation(189, "not_implemented", 0, NOT_USED);
+        collation[190] = new Collation(190, "not_implemented", 0, NOT_USED);
+        collation[191] = new Collation(191, "not_implemented", 0, NOT_USED);
+        collation[216] = new Collation(216, "not_implemented", 0, NOT_USED);
+        collation[217] = new Collation(217, "not_implemented", 0, NOT_USED);
+        collation[218] = new Collation(218, "not_implemented", 0, NOT_USED);
+        collation[219] = new Collation(219, "not_implemented", 0, NOT_USED);
+        collation[220] = new Collation(220, "not_implemented", 0, NOT_USED);
+        collation[221] = new Collation(221, "not_implemented", 0, NOT_USED);
+        collation[222] = new Collation(222, "not_implemented", 0, NOT_USED);
+        collation[248] = new Collation(248, "gb18030_chinese_ci", 1, MYSQL_CHARSET_NAME_gb18030);
+        collation[249] = new Collation(249, "gb18030_bin", 0, MYSQL_CHARSET_NAME_gb18030);
+        collation[250] = new Collation(250, "gb18030_unicode_520_ci", 0, MYSQL_CHARSET_NAME_gb18030);
+        collation[251] = new Collation(251, "not_implemented", 0, NOT_USED);
+        collation[252] = new Collation(252, "not_implemented", 0, NOT_USED);
+        collation[253] = new Collation(253, "not_implemented", 0, NOT_USED);
+        collation[254] = new Collation(254, "not_implemented", 0, NOT_USED);
+        collation[10] = new Collation(10, "swe7_swedish_ci", 0, MYSQL_CHARSET_NAME_swe7);
+        collation[82] = new Collation(82, "swe7_bin", 0, MYSQL_CHARSET_NAME_swe7);
+        collation[6] = new Collation(6, "hp8_english_ci", 0, MYSQL_CHARSET_NAME_hp8);
+        collation[72] = new Collation(72, "hp8_bin", 0, MYSQL_CHARSET_NAME_hp8);
+        collation[3] = new Collation(3, "dec8_swedish_ci", 0, MYSQL_CHARSET_NAME_dec8);
+        collation[69] = new Collation(69, "dec8_bin", 0, MYSQL_CHARSET_NAME_dec8);
+        collation[32] = new Collation(32, "armscii8_general_ci", 0, MYSQL_CHARSET_NAME_armscii8);
+        collation[64] = new Collation(64, "armscii8_bin", 0, MYSQL_CHARSET_NAME_armscii8);
+        collation[92] = new Collation(92, "geostd8_general_ci", 0, MYSQL_CHARSET_NAME_geostd8);
+        collation[93] = new Collation(93, "geostd8_bin", 0, MYSQL_CHARSET_NAME_geostd8);
+
+        collation[7] = new Collation(7, "koi8r_general_ci", 0, MYSQL_CHARSET_NAME_koi8r);
+        collation[74] = new Collation(74, "koi8r_bin", 0, MYSQL_CHARSET_NAME_koi8r);
+
+        collation[11] = new Collation(11, "ascii_general_ci", 0, MYSQL_CHARSET_NAME_ascii);
+        collation[65] = new Collation(65, "ascii_bin", 0, MYSQL_CHARSET_NAME_ascii);
+
+        collation[12] = new Collation(12, "ujis_japanese_ci", 0, MYSQL_CHARSET_NAME_ujis);
+        collation[91] = new Collation(91, "ujis_bin", 0, MYSQL_CHARSET_NAME_ujis);
+
+        collation[13] = new Collation(13, "sjis_japanese_ci", 0, MYSQL_CHARSET_NAME_sjis);
+        collation[14] = new Collation(14, "cp1251_bulgarian_ci", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[16] = new Collation(16, "hebrew_general_ci", 0, MYSQL_CHARSET_NAME_hebrew);
+        collation[17] = new Collation(17, "latin1_german1_ci", 0, MYSQL_4_0_CHARSET_NAME_win1251);    // removed since 4.1
+        collation[18] = new Collation(18, "tis620_thai_ci", 0, MYSQL_CHARSET_NAME_tis620);
+        collation[19] = new Collation(19, "euckr_korean_ci", 0, MYSQL_CHARSET_NAME_euckr);
+        collation[20] = new Collation(20, "latin7_estonian_cs", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[22] = new Collation(22, "koi8u_general_ci", 0, MYSQL_CHARSET_NAME_koi8u);
+        collation[23] = new Collation(23, "cp1251_ukrainian_ci", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[24] = new Collation(24, "gb2312_chinese_ci", 0, MYSQL_CHARSET_NAME_gb2312);
+        collation[25] = new Collation(25, "greek_general_ci", 0, MYSQL_CHARSET_NAME_greek);
+        collation[26] = new Collation(26, "cp1250_general_ci", 1, MYSQL_CHARSET_NAME_cp1250);
+        collation[28] = new Collation(28, "gbk_chinese_ci", 1, MYSQL_CHARSET_NAME_gbk);
+        collation[29] = new Collation(29, "cp1257_lithuanian_ci", 0, MYSQL_CHARSET_NAME_cp1257);
+        collation[30] = new Collation(30, "latin5_turkish_ci", 1, MYSQL_CHARSET_NAME_latin5);
+        collation[33] = new Collation(33, "utf8_general_ci", 1, MYSQL_CHARSET_NAME_utf8);
+        collation[34] = new Collation(34, "cp1250_czech_cs", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[35] = new Collation(35, "ucs2_general_ci", 1, MYSQL_CHARSET_NAME_ucs2);
+        collation[36] = new Collation(36, "cp866_general_ci", 1, MYSQL_CHARSET_NAME_cp866);
+        collation[37] = new Collation(37, "keybcs2_general_ci", 1, MYSQL_CHARSET_NAME_keybcs2);
+        collation[38] = new Collation(38, "macce_general_ci", 1, MYSQL_CHARSET_NAME_macce);
+        collation[39] = new Collation(39, "macroman_general_ci", 1, MYSQL_CHARSET_NAME_macroman);
+        collation[40] = new Collation(40, "cp852_general_ci", 1, MYSQL_CHARSET_NAME_cp852);
+        collation[41] = new Collation(41, "latin7_general_ci", 1, MYSQL_CHARSET_NAME_latin7);
+        collation[42] = new Collation(42, "latin7_general_cs", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[43] = new Collation(43, "macce_bin", 0, MYSQL_CHARSET_NAME_macce);
+        collation[44] = new Collation(44, "cp1250_croatian_ci", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[45] = new Collation(45, "utf8mb4_general_ci", 1, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[46] = new Collation(46, "utf8mb4_bin", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[50] = new Collation(50, "cp1251_bin", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[51] = new Collation(51, "cp1251_general_ci", 1, MYSQL_CHARSET_NAME_cp1251);
+        collation[52] = new Collation(52, "cp1251_general_cs", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[53] = new Collation(53, "macroman_bin", 0, MYSQL_CHARSET_NAME_macroman);
+        collation[54] = new Collation(54, "utf16_general_ci", 1, MYSQL_CHARSET_NAME_utf16);
+        collation[55] = new Collation(55, "utf16_bin", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[56] = new Collation(56, "utf16le_general_ci", 1, MYSQL_CHARSET_NAME_utf16le);
+        collation[57] = new Collation(57, "cp1256_general_ci", 1, MYSQL_CHARSET_NAME_cp1256);
+        collation[58] = new Collation(58, "cp1257_bin", 0, MYSQL_CHARSET_NAME_cp1257);
+        collation[59] = new Collation(59, "cp1257_general_ci", 1, MYSQL_CHARSET_NAME_cp1257);
+        collation[60] = new Collation(60, "utf32_general_ci", 1, MYSQL_CHARSET_NAME_utf32);
+        collation[61] = new Collation(61, "utf32_bin", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[62] = new Collation(62, "utf16le_bin", 0, MYSQL_CHARSET_NAME_utf16le);
+        collation[63] = new Collation(63, "binary", 1, MYSQL_CHARSET_NAME_binary);
+        collation[66] = new Collation(66, "cp1250_bin", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[67] = new Collation(67, "cp1256_bin", 0, MYSQL_CHARSET_NAME_cp1256);
+        collation[68] = new Collation(68, "cp866_bin", 0, MYSQL_CHARSET_NAME_cp866);
+        collation[70] = new Collation(70, "greek_bin", 0, MYSQL_CHARSET_NAME_greek);
+        collation[71] = new Collation(71, "hebrew_bin", 0, MYSQL_CHARSET_NAME_hebrew);
+        collation[73] = new Collation(73, "keybcs2_bin", 0, MYSQL_CHARSET_NAME_keybcs2);
+        collation[75] = new Collation(75, "koi8u_bin", 0, MYSQL_CHARSET_NAME_koi8u);
+        collation[78] = new Collation(78, "latin5_bin", 0, MYSQL_CHARSET_NAME_latin5);
+        collation[79] = new Collation(79, "latin7_bin", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[81] = new Collation(81, "cp852_bin", 0, MYSQL_CHARSET_NAME_cp852);
+        collation[83] = new Collation(83, "utf8_bin", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[85] = new Collation(85, "euckr_bin", 0, MYSQL_CHARSET_NAME_euckr);
+        collation[86] = new Collation(86, "gb2312_bin", 0, MYSQL_CHARSET_NAME_gb2312);
+        collation[87] = new Collation(87, "gbk_bin", 0, MYSQL_CHARSET_NAME_gbk);
+        collation[88] = new Collation(88, "sjis_bin", 0, MYSQL_CHARSET_NAME_sjis);
+        collation[89] = new Collation(89, "tis620_bin", 0, MYSQL_CHARSET_NAME_tis620);
+        collation[90] = new Collation(90, "ucs2_bin", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[95] = new Collation(95, "cp932_japanese_ci", 1, MYSQL_CHARSET_NAME_cp932);
+        collation[96] = new Collation(96, "cp932_bin", 0, MYSQL_CHARSET_NAME_cp932);
+        collation[97] = new Collation(97, "eucjpms_japanese_ci", 1, MYSQL_CHARSET_NAME_eucjpms);
+        collation[98] = new Collation(98, "eucjpms_bin", 0, MYSQL_CHARSET_NAME_eucjpms);
+        collation[99] = new Collation(99, "cp1250_polish_ci", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[101] = new Collation(101, "utf16_unicode_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[102] = new Collation(102, "utf16_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[103] = new Collation(103, "utf16_latvian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[104] = new Collation(104, "utf16_romanian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[105] = new Collation(105, "utf16_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[106] = new Collation(106, "utf16_polish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[107] = new Collation(107, "utf16_estonian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[108] = new Collation(108, "utf16_spanish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[109] = new Collation(109, "utf16_swedish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[110] = new Collation(110, "utf16_turkish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[111] = new Collation(111, "utf16_czech_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[112] = new Collation(112, "utf16_danish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[113] = new Collation(113, "utf16_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[114] = new Collation(114, "utf16_slovak_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[115] = new Collation(115, "utf16_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[116] = new Collation(116, "utf16_roman_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[117] = new Collation(117, "utf16_persian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[118] = new Collation(118, "utf16_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[119] = new Collation(119, "utf16_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[120] = new Collation(120, "utf16_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[121] = new Collation(121, "utf16_german2_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[122] = new Collation(122, "utf16_croatian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[123] = new Collation(123, "utf16_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[124] = new Collation(124, "utf16_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[128] = new Collation(128, "ucs2_unicode_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[129] = new Collation(129, "ucs2_icelandic_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[130] = new Collation(130, "ucs2_latvian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[131] = new Collation(131, "ucs2_romanian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[132] = new Collation(132, "ucs2_slovenian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[133] = new Collation(133, "ucs2_polish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[134] = new Collation(134, "ucs2_estonian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[135] = new Collation(135, "ucs2_spanish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[136] = new Collation(136, "ucs2_swedish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[137] = new Collation(137, "ucs2_turkish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[138] = new Collation(138, "ucs2_czech_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[139] = new Collation(139, "ucs2_danish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[140] = new Collation(140, "ucs2_lithuanian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[141] = new Collation(141, "ucs2_slovak_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[142] = new Collation(142, "ucs2_spanish2_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[143] = new Collation(143, "ucs2_roman_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[144] = new Collation(144, "ucs2_persian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[145] = new Collation(145, "ucs2_esperanto_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[146] = new Collation(146, "ucs2_hungarian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[147] = new Collation(147, "ucs2_sinhala_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[148] = new Collation(148, "ucs2_german2_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[149] = new Collation(149, "ucs2_croatian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[150] = new Collation(150, "ucs2_unicode_520_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[151] = new Collation(151, "ucs2_vietnamese_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[159] = new Collation(159, "ucs2_general_mysql500_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[160] = new Collation(160, "utf32_unicode_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[161] = new Collation(161, "utf32_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[162] = new Collation(162, "utf32_latvian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[163] = new Collation(163, "utf32_romanian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[164] = new Collation(164, "utf32_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[165] = new Collation(165, "utf32_polish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[166] = new Collation(166, "utf32_estonian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[167] = new Collation(167, "utf32_spanish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[168] = new Collation(168, "utf32_swedish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[169] = new Collation(169, "utf32_turkish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[170] = new Collation(170, "utf32_czech_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[171] = new Collation(171, "utf32_danish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[172] = new Collation(172, "utf32_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[173] = new Collation(173, "utf32_slovak_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[174] = new Collation(174, "utf32_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[175] = new Collation(175, "utf32_roman_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[176] = new Collation(176, "utf32_persian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[177] = new Collation(177, "utf32_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[178] = new Collation(178, "utf32_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[179] = new Collation(179, "utf32_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[180] = new Collation(180, "utf32_german2_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[181] = new Collation(181, "utf32_croatian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[182] = new Collation(182, "utf32_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[183] = new Collation(183, "utf32_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[192] = new Collation(192, "utf8_unicode_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[193] = new Collation(193, "utf8_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[194] = new Collation(194, "utf8_latvian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[195] = new Collation(195, "utf8_romanian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[196] = new Collation(196, "utf8_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[197] = new Collation(197, "utf8_polish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[198] = new Collation(198, "utf8_estonian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[199] = new Collation(199, "utf8_spanish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[200] = new Collation(200, "utf8_swedish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[201] = new Collation(201, "utf8_turkish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[202] = new Collation(202, "utf8_czech_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[203] = new Collation(203, "utf8_danish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[204] = new Collation(204, "utf8_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[205] = new Collation(205, "utf8_slovak_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[206] = new Collation(206, "utf8_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[207] = new Collation(207, "utf8_roman_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[208] = new Collation(208, "utf8_persian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[209] = new Collation(209, "utf8_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[210] = new Collation(210, "utf8_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[211] = new Collation(211, "utf8_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[212] = new Collation(212, "utf8_german2_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[213] = new Collation(213, "utf8_croatian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[214] = new Collation(214, "utf8_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[215] = new Collation(215, "utf8_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[223] = new Collation(223, "utf8_general_mysql500_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[224] = new Collation(224, "utf8mb4_unicode_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[225] = new Collation(225, "utf8mb4_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[226] = new Collation(226, "utf8mb4_latvian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[227] = new Collation(227, "utf8mb4_romanian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[228] = new Collation(228, "utf8mb4_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[229] = new Collation(229, "utf8mb4_polish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[230] = new Collation(230, "utf8mb4_estonian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[231] = new Collation(231, "utf8mb4_spanish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[232] = new Collation(232, "utf8mb4_swedish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[233] = new Collation(233, "utf8mb4_turkish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[234] = new Collation(234, "utf8mb4_czech_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[235] = new Collation(235, "utf8mb4_danish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[236] = new Collation(236, "utf8mb4_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[237] = new Collation(237, "utf8mb4_slovak_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[238] = new Collation(238, "utf8mb4_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[239] = new Collation(239, "utf8mb4_roman_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[240] = new Collation(240, "utf8mb4_persian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[241] = new Collation(241, "utf8mb4_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[242] = new Collation(242, "utf8mb4_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[243] = new Collation(243, "utf8mb4_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[244] = new Collation(244, "utf8mb4_german2_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[245] = new Collation(245, "utf8mb4_croatian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[246] = new Collation(246, "utf8mb4_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[247] = new Collation(247, "utf8mb4_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+
+        COLLATION_INDEX_TO_COLLATION_NAME = new String[MAP_SIZE];
+        COLLATION_INDEX_TO_CHARSET = new MysqlCharset[MAP_SIZE];
+
+        // Add all collations to lookup maps for easy indexing
+        for (int i = 1; i < MAP_SIZE; i++) {
+            COLLATION_INDEX_TO_COLLATION_NAME[i] = collation[i].collationName;
+            COLLATION_INDEX_TO_CHARSET[i] = collation[i].mysqlCharset;
+        }
+
+        // Sanity check
+        for (int i = 1; i < MAP_SIZE; i++) {
+            if (COLLATION_INDEX_TO_COLLATION_NAME[i] == null) {
+                throw new RuntimeException("Assertion failure: No mapping from charset index " + i + " to a mysql collation");
+            }
+            if (COLLATION_INDEX_TO_COLLATION_NAME[i] == null) {
+                throw new RuntimeException("Assertion failure: No mapping from charset index " + i + " to a Java character set");
+            }
+        }
+    }
+
+    /**
+     * MySQL charset could map to several Java encodings.
+     * So here we choose the one according to next rules:
+     * <li>if there is no static mapping for this charset then return javaEncoding value as is because this
+     * could be a custom charset for example
+     * <li>if static mapping exists and javaEncoding equals to one of Java encoding canonical names or aliases available
+     * for this mapping then javaEncoding value as is; this is required when result should match to connection encoding, for example if connection encoding is
+     * Cp943 we must avoid getting SHIFT_JIS for sjis mysql charset
+     * <li>if static mapping exists and javaEncoding doesn't match any Java encoding canonical
+     * names or aliases available for this mapping then return default Java encoding (the first in mapping list)
+     *
+     * @param collationIndex
+     * @param javaEncoding
+     */
+    public static String getJavaEncodingForCollationIndex(Integer collationIndex, String javaEncoding) {
+        String res = javaEncoding;
+        if (collationIndex != null && collationIndex > 0 && collationIndex < MAP_SIZE) {
+            MysqlCharset cs = COLLATION_INDEX_TO_CHARSET[collationIndex];
+            if (cs != null) {
+                res = cs.getMatchingJavaEncoding(javaEncoding);
+            }
+        }
+        return res;
+    }
+
+    public static String getMysqlCharsetNameForCollationIndex(Integer collationIndex) {
+        if (collationIndex != null && collationIndex > 0 && collationIndex < MAP_SIZE) {
+            return COLLATION_INDEX_TO_CHARSET[collationIndex].charsetName;
+        }
+        return null;
+    }
+
+    public static String getMysqlCharsetForJavaEncoding(String javaEncoding) {
+        if (javaEncoding != null) {
+            List<MysqlCharset> mysqlCharsets = CharsetMapping.JAVA_ENCODING_UC_TO_MYSQL_CHARSET.get(javaEncoding.toUpperCase(Locale.ENGLISH));
+
+            if (mysqlCharsets != null && !mysqlCharsets.isEmpty()) {
+                return mysqlCharsets.get(0).charsetName;
+            }
+        }
+
+        return null;
+    }
+
+    public static int getMblen(String charsetName) {
+        if (charsetName != null) {
+            MysqlCharset cs = CHARSET_NAME_TO_CHARSET.get(charsetName);
+            if (cs != null) {
+                return cs.mblen;
+            }
+        }
+        return 0;
+    }
+}
+

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/Collation.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/Collation.java
@@ -1,0 +1,33 @@
+package com.flipkart.vitess.util.charset;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+class Collation {
+    public final int index;
+    public final String collationName;
+    public final int priority;
+    public final MysqlCharset mysqlCharset;
+
+    public Collation(int index, String collationName, int priority, String charsetName) {
+        this.index = index;
+        this.collationName = collationName;
+        this.priority = priority;
+        this.mysqlCharset = CharsetMapping.CHARSET_NAME_TO_CHARSET.get(charsetName);
+    }
+
+    @Override
+    public String toString() {
+        return "[" +
+            "index=" +
+            this.index +
+            ",collationName=" +
+            this.collationName +
+            ",charsetName=" +
+            this.mysqlCharset.charsetName +
+            ",javaCharsetName=" +
+            this.mysqlCharset.getMatchingJavaEncoding(null) +
+            "]";
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/MysqlCharset.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/MysqlCharset.java
@@ -1,0 +1,118 @@
+package com.flipkart.vitess.util.charset;
+
+import java.nio.charset.Charset;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+class MysqlCharset {
+    public final String charsetName;
+    public final int mblen;
+    public final int priority;
+    public final Set<String> javaEncodingsUc = new HashSet<>();
+    private String defaultEncoding = null;
+
+    public int major = 4;
+    public int minor = 1;
+    public int subminor = 0;
+
+    /**
+     * Constructs MysqlCharset object
+     *
+     * @param charsetName   MySQL charset name
+     * @param mblen         Max number of bytes per character
+     * @param priority      MysqlCharset with highest lever of this param will be used for Java encoding --> Mysql charsets conversion.
+     * @param javaEncodings List of Java encodings corresponding to this MySQL charset; the first name in list is the default for mysql --> java data conversion
+     */
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings) {
+        this.charsetName = charsetName;
+        this.mblen = mblen;
+        this.priority = priority;
+
+        for (int i = 0; i < javaEncodings.length; i++) {
+            String encoding = javaEncodings[i];
+            try {
+                Charset cs = Charset.forName(encoding);
+                addEncodingMapping(cs.name());
+
+                Set<String> als = cs.aliases();
+                Iterator<String> ali = als.iterator();
+                while (ali.hasNext()) {
+                    addEncodingMapping(ali.next());
+                }
+            } catch (Exception e) {
+                // if there is no support of this charset in JVM it's still possible to use our converter for 1-byte charsets
+                if (mblen == 1) {
+                    addEncodingMapping(encoding);
+                }
+            }
+        }
+
+        if (this.javaEncodingsUc.size() == 0) {
+            if (mblen > 1) {
+                addEncodingMapping("UTF-8");
+            } else {
+                addEncodingMapping("Cp1252");
+            }
+        }
+    }
+
+    private void addEncodingMapping(String encoding) {
+        String encodingUc = encoding.toUpperCase(Locale.ENGLISH);
+
+        if (this.defaultEncoding == null) {
+            this.defaultEncoding = encodingUc;
+        }
+
+        if (!this.javaEncodingsUc.contains(encodingUc)) {
+            this.javaEncodingsUc.add(encodingUc);
+        }
+    }
+
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings, int major, int minor) {
+        this(charsetName, mblen, priority, javaEncodings);
+        this.major = major;
+        this.minor = minor;
+    }
+
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings, int major, int minor, int subminor) {
+        this(charsetName, mblen, priority, javaEncodings);
+        this.major = major;
+        this.minor = minor;
+        this.subminor = subminor;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder asString = new StringBuilder();
+        asString.append("[");
+        asString.append("charsetName=");
+        asString.append(this.charsetName);
+        asString.append(",mblen=");
+        asString.append(this.mblen);
+        // asString.append(",javaEncoding=");
+        // asString.append(this.javaEncodings.toString());
+        asString.append("]");
+        return asString.toString();
+    }
+
+    /**
+     * If javaEncoding parameter value is one of available java encodings for this charset
+     * then returns javaEncoding value as is. Otherwise returns first available java encoding name.
+     *
+     * @param javaEncoding
+     * @throws SQLException
+     */
+    String getMatchingJavaEncoding(String javaEncoding) {
+        if (javaEncoding != null && this.javaEncodingsUc.contains(javaEncoding.toUpperCase(Locale.ENGLISH))) {
+            return javaEncoding;
+        }
+        return this.defaultEncoding;
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
@@ -1,0 +1,25 @@
+package com.flipkart.vitess.jdbc;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class BaseTest {
+    String dbURL = "jdbc:vitess://locahost:9000/vt_shipment/shipment";
+
+    @BeforeClass
+    public static void setUp() {
+        // load Vitess driver
+        try {
+            Class.forName("com.flipkart.vitess.jdbc.VitessDriver");
+        } catch (ClassNotFoundException e) {
+            Assert.fail("Driver is not in the CLASSPATH -> " + e.getMessage());
+        }
+    }
+
+    protected VitessConnection getVitessConnection() throws SQLException {
+        return new VitessConnection(dbURL, new Properties());
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
@@ -1,0 +1,214 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class ConnectionPropertiesTest {
+
+    @Test
+    public void testReflection() throws Exception {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = Mockito.spy(Properties.class);
+        Mockito.doReturn(info).when(info).clone();
+        props.initializeProperties(info);
+
+        // Just testing that we are properly picking up all the fields defined in the properties
+        // For each field we call initializeFrom, which should call getProperty and remove
+        Mockito.verify(info, Mockito.times(13)).getProperty(Mockito.anyString());
+        Mockito.verify(info, Mockito.times(13)).remove(Mockito.anyString());
+    }
+
+    @Test
+    public void testDefaults() throws SQLException {
+
+        ConnectionProperties props = new ConnectionProperties();
+        props.initializeProperties(new Properties());
+
+        Assert.assertEquals("blobsAreStrings", false, props.getBlobsAreStrings());
+        Assert.assertEquals("functionsNeverReturnBlobs", false, props.getFunctionsNeverReturnBlobs());
+        Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
+        Assert.assertEquals("transformedBitIsBoolean", false, props.getTransformedBitIsBoolean());
+        Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", false, props.getUseBlobToStoreUTF8OutsideBMP());
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", null, props.getUtf8OutsideBmpIncludedColumnNamePattern());
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", null, props.getUtf8OutsideBmpExcludedColumnNamePattern());
+        Assert.assertEquals("characterEncoding", null, props.getEncoding());
+        Assert.assertEquals("executeType", Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
+        Assert.assertEquals("twopcEnabled", false, props.getTwopcEnabled());
+        Assert.assertEquals("includedFields", Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
+        Assert.assertEquals("includedFieldsCache", true, props.isIncludeAllFields());
+        Assert.assertEquals("tabletType", Constants.DEFAULT_TABLET_TYPE, props.getTabletType());
+    }
+
+    @Test
+    public void testInitializeFromProperties() throws SQLException {
+
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+        info.setProperty("blobsAreStrings", "yes");
+        info.setProperty("functionsNeverReturnBlobs", "yes");
+        info.setProperty("tinyInt1isBit", "yes");
+        info.setProperty("transformedBitIsBoolean", "yes");
+        info.setProperty("yearIsDateType", "yes");
+        info.setProperty("useBlobToStoreUTF8OutsideBMP", "yes");
+        info.setProperty("utf8OutsideBmpIncludedColumnNamePattern", "(foo|bar)?baz");
+        info.setProperty("utf8OutsideBmpExcludedColumnNamePattern", "(foo|bar)?baz");
+        info.setProperty("characterEncoding", "utf-8");
+        info.setProperty("clobCharacterEncoding", "utf-8");
+        info.setProperty("executeType", Constants.QueryExecuteType.STREAM.name());
+        info.setProperty("twopcEnabled", "yes");
+        info.setProperty("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY.name());
+        info.setProperty(Constants.Property.TABLET_TYPE, Topodata.TabletType.BACKUP.name());
+
+        props.initializeProperties(info);
+
+        Assert.assertEquals("blobsAreStrings", true, props.getBlobsAreStrings());
+        Assert.assertEquals("functionsNeverReturnBlobs", true, props.getFunctionsNeverReturnBlobs());
+        Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
+        Assert.assertEquals("transformedBitIsBoolean", true, props.getTransformedBitIsBoolean());
+        Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", true, props.getUseBlobToStoreUTF8OutsideBMP());
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", "(foo|bar)?baz", props.getUtf8OutsideBmpIncludedColumnNamePattern());
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", "(foo|bar)?baz", props.getUtf8OutsideBmpExcludedColumnNamePattern());
+        Assert.assertEquals("characterEncoding", "utf-8", props.getEncoding());
+        Assert.assertEquals("executeType", Constants.QueryExecuteType.STREAM, props.getExecuteType());
+        Assert.assertEquals("twopcEnabled", true, props.getTwopcEnabled());
+        Assert.assertEquals("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY, props.getIncludedFields());
+        Assert.assertEquals("includedFieldsCache", false, props.isIncludeAllFields());
+        Assert.assertEquals("tabletType", Topodata.TabletType.BACKUP, props.getTabletType());
+    }
+
+    @Test(expected = SQLException.class)
+    public void testEncodingValidation() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        String fakeEncoding = "utf-12345";
+        info.setProperty("characterEncoding", fakeEncoding);
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have failed to parse encoding " + fakeEncoding);
+        } catch (SQLException e) {
+            Assert.assertEquals("Unsupported character encoding: " + fakeEncoding, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test
+    public void testDriverPropertiesOutput() throws SQLException {
+        Properties info = new Properties();
+        DriverPropertyInfo[] infos = ConnectionProperties.exposeAsDriverPropertyInfo(info, 0);
+        Assert.assertEquals(13, infos.length);
+
+        // Test the expected fields for just 1
+        Assert.assertEquals("blobsAreStrings", infos[0].name);
+        Assert.assertEquals("Should the driver always treat BLOBs as Strings - specifically to work around dubious metadata returned by the server for GROUP BY clauses?",
+            infos[0].description);
+        Assert.assertEquals(false, infos[0].required);
+        Assert.assertArrayEquals(new String[]{Boolean.toString(true), Boolean.toString(false), "yes", "no"}, infos[0].choices);
+
+        // Otherwise just test that they exist in there
+        Assert.assertEquals("functionsNeverReturnBlobs", infos[1].name);
+        Assert.assertEquals("tinyInt1isBit", infos[2].name);
+        Assert.assertEquals("transformedBitIsBoolean", infos[3].name);
+        Assert.assertEquals("yearIsDateType", infos[4].name);
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", infos[5].name);
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", infos[6].name);
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", infos[7].name);
+        Assert.assertEquals("characterEncoding", infos[8].name);
+        Assert.assertEquals(Constants.Property.EXECUTE_TYPE, infos[9].name);
+        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[10].name);
+        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[11].name);
+        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[12].name);
+    }
+
+    @Test
+    public void testValidBooleanValues() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        info.setProperty("blobsAreStrings", "true");
+        info.setProperty("functionsNeverReturnBlobs", "yes");
+        info.setProperty("tinyInt1isBit", "no");
+
+        props.initializeProperties(info);
+
+        Assert.assertEquals(true, props.getBlobsAreStrings());
+        Assert.assertEquals(true, props.getFunctionsNeverReturnBlobs());
+        Assert.assertEquals(false, props.getTinyInt1isBit());
+
+        info.setProperty("blobsAreStrings", "false-ish");
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have thrown an exception on bad value false-ish");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals(
+                "Property 'blobsAreStrings' Value 'false-ish' not in the list of allowable values: "
+                    + Arrays.toString(new String[] { Boolean.toString(true), Boolean.toString(false), "yes", "no"})
+                , e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testValidEnumValues() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        info.setProperty("executeType", "foo");
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have thrown an exception on bad value foo");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals(
+                "Property 'executeType' Value 'foo' not in the list of allowable values: "
+                    + Arrays.toString(Constants.QueryExecuteType.values())
+                , e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSettersUpdateCaches() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        props.initializeProperties(new Properties());
+
+        // included fields and all boolean cache
+        Assert.assertEquals(Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
+        Assert.assertEquals(true, props.isIncludeAllFields());
+
+        // execute type and simple boolean cahce
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE == Constants.QueryExecuteType.SIMPLE, props.isSimpleExecute());
+
+        // tablet type and twopc
+        Assert.assertEquals(Constants.DEFAULT_TABLET_TYPE, props.getTabletType());
+        Assert.assertEquals(false, props.getTwopcEnabled());
+
+        props.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        props.setExecuteType(Constants.QueryExecuteType.STREAM);
+        props.setTabletType(Topodata.TabletType.BACKUP);
+        props.setTwopcEnabled(true);
+
+        // included fields and all boolean cache
+        Assert.assertEquals(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME, props.getIncludedFields());
+        Assert.assertEquals(false, props.isIncludeAllFields());
+
+        // execute type and simple boolean cahce
+        Assert.assertEquals(Constants.QueryExecuteType.STREAM, props.getExecuteType());
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE != Constants.QueryExecuteType.SIMPLE, props.isSimpleExecute());
+
+        // tablet type and twopc
+        Assert.assertEquals(Topodata.TabletType.BACKUP, props.getTabletType());
+        Assert.assertEquals(true, props.getTwopcEnabled());
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
@@ -1,0 +1,581 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
+import com.youtube.vitess.proto.Query;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+@PrepareForTest(FieldWithMetadata.class)
+@RunWith(PowerMockRunner.class)
+public class FieldWithMetadataTest extends BaseTest {
+
+    @Test
+    public void testImplicitTempTable() throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("#sql_my_temptable")
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .setType(Query.Type.VARCHAR)
+            .setName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(getVitessConnection(), raw);
+
+        Assert.assertEquals(true, fieldWithMetadata.isImplicitTemporaryTable());
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        VitessConnection conn = getVitessConnection();
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        raw = Query.Field.newBuilder()
+            .setType(Query.Type.VARCHAR)
+            .setName("foo")
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+
+        Assert.assertEquals(false, fieldWithMetadata.isImplicitTemporaryTable());
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+    }
+
+    @Test
+    public void testBlobRemapping() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        conn.setBlobsAreStrings(true);
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("#sql_my_temptable")
+            .setCharset(/* latin1, doesn't matter just dont want utf8 for now */ 5)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .setType(Query.Type.BLOB)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setBlobsAreStrings(false);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setFunctionsNeverReturnBlobs(true);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setFunctionsNeverReturnBlobs(false);
+        conn.setUseBlobToStoreUTF8OutsideBMP(true);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+
+        raw = raw.toBuilder()
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setColumnLength(MysqlDefs.LENGTH_BLOB)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUtf8OutsideBmpExcludedColumnNamePattern("^fo.*$");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARBINARY, fieldWithMetadata.getJavaType());
+        Assert.assertNotEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUtf8OutsideBmpIncludedColumnNamePattern("^foo$");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        raw = raw.toBuilder()
+            .setColumnLength(MysqlDefs.LENGTH_LONGBLOB)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUseBlobToStoreUTF8OutsideBMP(false);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARBINARY, fieldWithMetadata.getJavaType());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BLOB, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(null, fieldWithMetadata.getCollation());
+    }
+
+    @Test
+    public void testTinyIntAsBitOrBool() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        conn.setBlobsAreStrings(true);
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.INT8)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+
+        conn.setTinyInt1isBit(true);
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+
+        raw = raw.toBuilder()
+            .setColumnLength(1)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+
+        conn.setTransformedBitIsBoolean(true);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BOOLEAN, fieldWithMetadata.getJavaType());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+    }
+
+    @Test
+    public void testNonNumericNotDateTimeRemapping() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.VARBINARY)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(/* utf-16 UnicodeBig */35)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(/* remapped by TEXT special case */Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("UTF-16", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARBINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setType(Query.Type.JSON)
+            .setColumnLength(MysqlDefs.LENGTH_LONGBLOB)
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("UTF-8", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setType(Query.Type.BIT)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("ISO-8859-1", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(true, fieldWithMetadata.isBlob());
+        Assert.assertEquals(true, fieldWithMetadata.isBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setColumnLength(1)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("ISO-8859-1", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(true, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+    }
+
+    @Test
+    public void testNumericAndDateTimeEncoding() throws SQLException{
+        VitessConnection conn = getVitessConnection();
+
+        Query.Type[] types = new Query.Type[]{
+            Query.Type.INT8,
+            Query.Type.UINT8,
+            Query.Type.INT16,
+            Query.Type.UINT16,
+            Query.Type.INT24,
+            Query.Type.UINT24,
+            Query.Type.INT32,
+            Query.Type.UINT32,
+            Query.Type.INT64,
+            Query.Type.UINT64,
+            Query.Type.DECIMAL,
+            Query.Type.UINT24,
+            Query.Type.INT32,
+            Query.Type.UINT32,
+            Query.Type.FLOAT32,
+            Query.Type.FLOAT64,
+            Query.Type.DATE,
+            Query.Type.DATETIME,
+            Query.Type.TIME,
+            Query.Type.TIMESTAMP,
+            Query.Type.YEAR
+        };
+
+
+        for (Query.Type type : types) {
+            Query.Field raw = Query.Field.newBuilder()
+                .setTable("foo")
+                .setColumnLength(3)
+                .setType(type)
+                .setName("foo")
+                .setOrgName("foo")
+                .setCharset(/* utf-16 UnicodeBig */35)
+                .build();
+
+            FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+            Assert.assertEquals(type.name(),"US-ASCII", fieldWithMetadata.getEncoding());
+            Assert.assertEquals(type.name(),false, fieldWithMetadata.isSingleBit());
+        }
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        for (Query.Type type : types) {
+            Query.Field raw = Query.Field.newBuilder()
+                .setTable("foo")
+                .setColumnLength(3)
+                .setType(type)
+                .setName("foo")
+                .setOrgName("foo")
+                .setCharset(/* utf-16 UnicodeBig */35)
+                .build();
+
+            FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+            Assert.assertEquals(type.name(),null, fieldWithMetadata.getEncoding());
+            Assert.assertEquals(type.name(),false, fieldWithMetadata.isSingleBit());
+        }
+    }
+
+    @Test
+    public void testPrecisionAdjustFactor() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        assertPrecisionEquals(conn, Query.Type.FLOAT32, true, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.FLOAT64, true, 32, 0);
+        assertPrecisionEquals(conn, Query.Type.BIT, true, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, true, 0, -1);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, true, 3, -2);
+        assertPrecisionEquals(conn, Query.Type.INT32, true, /* this can't happen, but just checking */3, -2);
+        assertPrecisionEquals(conn, Query.Type.INT32, true, 0, -1);
+
+        assertPrecisionEquals(conn, Query.Type.FLOAT32, false, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.FLOAT64, false, 32, 0);
+        assertPrecisionEquals(conn, Query.Type.BIT, false, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, false, 0, -1);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, false, 3, -1);
+        assertPrecisionEquals(conn, Query.Type.UINT32, false, 0, 0);
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (Query.Type type : Query.Type.values()) {
+            if (type == Query.Type.UNRECOGNIZED) {
+                continue;
+            }
+
+            // All should be 0
+            assertPrecisionEquals(conn, type, true, 0, 0);
+            assertPrecisionEquals(conn, type, false, 0, 0);
+            assertPrecisionEquals(conn, type, true, 2, 0);
+            assertPrecisionEquals(conn, type, false, 2, 0);
+        }
+    }
+
+    private void assertPrecisionEquals(VitessConnection conn, Query.Type fieldType, boolean signed, int decimals, int expectedPrecisionAdjustFactor) throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(fieldType)
+            .setDecimals(decimals)
+            .setFlags(signed ? 0 : Query.MySqlFlag.UNSIGNED_FLAG_VALUE)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(expectedPrecisionAdjustFactor, fieldWithMetadata.getPrecisionAdjustFactor());
+    }
+
+    @Test
+    public void testFlags() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.VARBINARY)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(false, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(false, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(false, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */true, fieldWithMetadata.isSigned());
+        Assert.assertEquals(false, fieldWithMetadata.isZeroFill());
+
+        int value = 0;
+        for (Query.MySqlFlag flag : Query.MySqlFlag.values()) {
+            if (flag == Query.MySqlFlag.UNRECOGNIZED) {
+                continue;
+            }
+            value |= flag.getNumber();
+        }
+
+        raw = raw.toBuilder()
+            .setFlags(value)
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isBinary());
+        Assert.assertEquals(true, fieldWithMetadata.isBlob());
+        Assert.assertEquals(true, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(true, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(true, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(true, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */false, fieldWithMetadata.isSigned());
+        Assert.assertEquals(true, fieldWithMetadata.isZeroFill());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(false, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(true, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(false, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */false, fieldWithMetadata.isSigned());
+        Assert.assertEquals(false, fieldWithMetadata.isZeroFill());
+
+    }
+
+    @Test
+    public void testOpaqueBinary() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isOpaqueBinary());
+
+        raw = raw.toBuilder()
+            .setTable("#sql_foo_bar")
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        raw = raw.toBuilder()
+            .setCharset(/* short circuits collation -> encoding lookup, resulting in null */-1)
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        conn.setEncoding("binary");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isOpaqueBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+    }
+
+    @Test
+    public void testReadOnly() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setOrgTable("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgName("")
+            .setOrgTable("foo")
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgName("foo")
+            .setOrgTable("")
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgTable("")
+            .setOrgName("")
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isReadOnly());
+    }
+
+    @Test
+    public void testCollations() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(33)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        String first = fieldWithMetadata.getCollation();
+        String second = fieldWithMetadata.getCollation();
+
+        Assert.assertEquals("utf8_general_ci", first);
+        Assert.assertEquals("cached response is same as first", first, second);
+
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+
+        try {
+            raw = raw.toBuilder()
+                // value chosen because it's obviously out of bounds for the underlying array
+                .setCharset(Integer.MAX_VALUE)
+                .build();
+
+            fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+            fieldWithMetadata.getCollation();
+            Assert.fail("Should have received an array index out of bounds because " +
+                "charset/collationIndex of Int.MAX is well above size of charset array");
+        } catch (SQLException e) {
+            if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                Assert.assertEquals("CollationIndex '" + Integer.MAX_VALUE + "' out of bounds for " +
+                    "collationName lookup, should be within 0 and " +
+                    CharsetMapping.COLLATION_INDEX_TO_COLLATION_NAME.length,
+                    e.getMessage());
+            } else {
+                // just rethrow so we fail that way
+                throw e;
+            }
+        }
+
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+        //Mockito.verify(fieldWithMetadata, Mockito.times(1)).getCollationIndex();
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        Assert.assertEquals("null response when not including all fields", null, fieldWithMetadata.getCollation());
+
+        // We should not call this at all, because we're short circuiting due to included fields
+        //Mockito.verify(fieldWithMetadata, Mockito.never()).getCollationIndex();
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(0)).invoke("getCollationIndex");
+    }
+
+    @Test
+    public void testMaxBytesPerChar() throws Exception {
+        // should this go in Connection? What should I test here?
+        VitessConnection conn = PowerMockito.spy(getVitessConnection());
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(33)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+
+        int first = fieldWithMetadata.getMaxBytesPerCharacter();
+        int second = fieldWithMetadata.getMaxBytesPerCharacter();
+
+        Assert.assertEquals("cached response is same as first", first, second);
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        Assert.assertEquals("0 return value when not including all fields", 0, fieldWithMetadata.getMaxBytesPerCharacter());
+
+        // We called getMaxBytesPerCharacter 3 times above, but should only have made 1 call to conn.getMaxBytesPerChar:
+        // first - call conn
+        // second - returne cached
+        // third - short circuit because not including all fields
+        // Will test the actual implementation/return value in VitessConnection
+        PowerMockito.verifyPrivate(conn, VerificationModeFactory.times(1)).invoke("getMaxBytesPerChar", 33, "UTF-8");
+
+        // Should not be called at all, because it's new for just this test
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(0)).invoke("getCollationIndex");
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -1,13 +1,16 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.google.common.util.concurrent.Futures;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.SQLFuture;
 import com.youtube.vitess.client.VTGateTx;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
@@ -15,29 +18,15 @@ import org.powermock.api.mockito.PowerMockito;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 /**
  * Created by harshit.gangal on 19/01/16.
  */
-public class VitessConnectionTest {
-
-    String dbURL = "jdbc:vitess://locahost:9000/vt_shipment/shipment";
-
-    @BeforeClass public static void setUp() {
-        // load Vitess driver
-        try {
-            Class.forName("com.flipkart.vitess.jdbc.VitessDriver");
-        } catch (ClassNotFoundException e) {
-            Assert.fail("Driver is not in the CLASSPATH -> " + e.getMessage());
-        }
-    }
-
-    private VitessConnection getVitessConnection() throws SQLException {
-        return new VitessConnection(dbURL, null);
-    }
+public class VitessConnectionTest extends BaseTest {
 
     @Test public void testVitessConnection() throws SQLException {
-        VitessConnection vitessConnection = new VitessConnection(dbURL, null);
+        VitessConnection vitessConnection = new VitessConnection(dbURL, new Properties());
         Assert.assertEquals(false, vitessConnection.isClosed());
         Assert.assertNull(vitessConnection.getDbProperties());
     }
@@ -206,4 +195,56 @@ public class VitessConnectionTest {
         Assert.assertEquals("order", vitessConnection.getCatalog());
     }
 
+    @Test public void testPropertiesFromJdbcUrl() throws SQLException {
+        String url = "jdbc:vitess://locahost:9000/vt_shipment/shipment?TABLET_TYPE=replica&includedFields=type_and_name&blobsAreStrings=yes";
+        VitessConnection conn = new VitessConnection(url, new Properties());
+
+        // Properties from the url should be passed into the connection properties, and override whatever defaults we've defined
+        Assert.assertEquals(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME, conn.getIncludedFields());
+        Assert.assertEquals(false, conn.isIncludeAllFields());
+        Assert.assertEquals(Topodata.TabletType.REPLICA, conn.getTabletType());
+        Assert.assertEquals(true, conn.getBlobsAreStrings());
+    }
+
+    @Test public void testGetEncodingForIndex() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        // No default encoding configured, and passing NO_CHARSET_INFO basically says "mysql doesn't know"
+        // which means don't try looking it up
+        Assert.assertEquals(null, conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
+        // Similarly, a null index or one landing out of bounds for the charset index should return null
+        Assert.assertEquals(null, conn.getEncodingForIndex(Integer.MAX_VALUE));
+        Assert.assertEquals(null, conn.getEncodingForIndex(-123));
+
+        // charsetIndex 25 is MYSQL_CHARSET_NAME_greek, which is a charset with multiple names, ISO8859_7 and greek
+        // Without an encoding configured in the connection, we should return the first (default) encoding for a charset,
+        // in this case ISO8859_7
+        Assert.assertEquals("ISO-8859-7", conn.getEncodingForIndex(25));
+        conn.setEncoding("greek");
+        // With an encoding configured, we should return that because it matches one of the names for the charset
+        Assert.assertEquals("greek", conn.getEncodingForIndex(25));
+
+        conn.setEncoding(null);
+        Assert.assertEquals("UTF-8", conn.getEncodingForIndex(33));
+        Assert.assertEquals("ISO-8859-1", conn.getEncodingForIndex(63));
+
+        conn.setEncoding("NOT_REAL");
+        // Same tests as the first one, but testing that when there is a default configured, it falls back to that regardless
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(Integer.MAX_VALUE));
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(-123));
+    }
+
+    @Test public void testGetMaxBytesPerChar() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        // Default state when no good info is passed in
+        Assert.assertEquals(0, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, null));
+        // use passed collation index
+        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, null));
+        // use first, if both are passed and valid
+        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, "UnicodeBig"));
+        // use passed default charset
+        Assert.assertEquals(2, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, "UnicodeBig"));
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessDatabaseMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessDatabaseMetadataTest.java
@@ -1,11 +1,11 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.*;
 import com.flipkart.vitess.util.Constants;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.SimpleCursor;
 import com.youtube.vitess.proto.Query;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,19 +13,25 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Properties;
 
 /**
  * Created by ashudeep.sharma on 08/03/16.
  */
-@RunWith(PowerMockRunner.class) @PrepareForTest(VitessMySQLDatabaseMetadata.class) public class VitessDatabaseMetadataTest {
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(VitessMySQLDatabaseMetadata.class)
+public class VitessDatabaseMetadataTest extends BaseTest{
 
     private ResultSet resultSet;
 
     @Test public void getPseudoColumnsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getPseudoColumns(null, null, null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -44,7 +50,7 @@ import java.util.Properties;
     }
 
     @Test public void getClientInfoPropertiesTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getClientInfoProperties();
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -55,7 +61,7 @@ import java.util.Properties;
     }
 
     @Test public void getSchemasTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getSchemas(null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -64,7 +70,7 @@ import java.util.Properties;
     }
 
     @Test public void getAttributesTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getAttributes(null, null, null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -93,7 +99,7 @@ import java.util.Properties;
 
     @Test public void getSuperTablesTest() throws SQLException {
 
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getSuperTables(null, null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -104,7 +110,7 @@ import java.util.Properties;
     }
 
     @Test public void getSuperTypesTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getSuperTypes(null, null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -117,7 +123,7 @@ import java.util.Properties;
     }
 
     @Test public void getUDTsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getUDTs(null, null, null, null);
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -131,7 +137,7 @@ import java.util.Properties;
     }
 
     @Test public void getTypeInfoTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getTypeInfo();
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -159,7 +165,7 @@ import java.util.Properties;
 
     @Test public void getTableTypesTest() throws SQLException {
 
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getTableTypes();
 
         ArrayList<String> data = new ArrayList<String>();
@@ -178,7 +184,7 @@ import java.util.Properties;
     }
 
     @Test public void getSchemasTest2() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         this.resultSet = vitessDatabaseMetaData.getSchemas();
 
         ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
@@ -187,61 +193,61 @@ import java.util.Properties;
     }
 
     @Test public void allProceduresAreCallableTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.allProceduresAreCallable());
     }
 
     @Test public void allTablesAreSelectableTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.allTablesAreSelectable());
     }
 
     @Test public void nullsAreSortedHighTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.nullsAreSortedHigh());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.nullsAreSortedHigh());
     }
 
     @Test public void nullsAreSortedLowTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.nullsAreSortedLow());
         Assert.assertEquals(true, vitessMariaDBDatabaseMetadata.nullsAreSortedLow());
     }
 
     @Test public void nullsAreSortedAtStartTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySQLDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySQLDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessMySQLDatabaseMetaData.nullsAreSortedAtStart());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.nullsAreSortedAtStart());
     }
 
     @Test public void nullsAreSortedAtEndTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySQLDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySQLDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessMySQLDatabaseMetaData.nullsAreSortedAtEnd());
         Assert.assertEquals(true, vitessMariaDBDatabaseMetadata.nullsAreSortedAtEnd());
     }
 
     @Test public void getDatabaseProductNameTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("MySQL", vitessDatabaseMetaData.getDatabaseProductName());
     }
 
     @Test public void getDriverVersionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         StringBuilder driverVersionBuilder = new StringBuilder();
         driverVersionBuilder.append(Constants.DRIVER_MAJOR_VERSION);
         driverVersionBuilder.append(".");
@@ -251,383 +257,383 @@ import java.util.Properties;
     }
 
     @Test public void getDriverMajorVersionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(Constants.DRIVER_MAJOR_VERSION,
             vitessDatabaseMetaData.getDriverMajorVersion());
     }
 
     @Test public void getDriverMinorVersionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(Constants.DRIVER_MINOR_VERSION,
             vitessDatabaseMetaData.getDriverMinorVersion());
     }
 
     @Test public void getSearchStringEscapeTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("\\", vitessDatabaseMetaData.getSearchStringEscape());
     }
 
     @Test public void getExtraNameCharactersTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("#@", vitessDatabaseMetaData.getExtraNameCharacters());
     }
 
     @Test public void supportsAlterTableWithAddColumnTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsAlterTableWithAddColumn());
     }
 
     @Test public void supportsAlterTableWithDropColumnTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsAlterTableWithDropColumn());
     }
 
     @Test public void supportsColumnAliasingTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsColumnAliasing());
     }
 
     @Test public void nullPlusNonNullIsNullTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.nullPlusNonNullIsNull());
     }
 
     @Test public void supportsExpressionsInOrderByTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsExpressionsInOrderBy());
     }
 
     @Test public void supportsOrderByUnrelatedTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOrderByUnrelated());
     }
 
     @Test public void supportsGroupByTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsGroupBy());
     }
 
     @Test public void supportsGroupByUnrelatedTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsGroupByUnrelated());
     }
 
     @Test public void supportsGroupByBeyondSelectTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsGroupByBeyondSelect());
     }
 
     @Test public void supportsLikeEscapeClauseTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsLikeEscapeClause());
     }
 
     @Test public void supportsMultipleResultSetsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsMultipleResultSets());
     }
 
     @Test public void supportsMultipleTransactionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsMultipleTransactions());
     }
 
     @Test public void supportsNonNullableColumnsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsNonNullableColumns());
     }
 
     @Test public void supportsMinimumSQLGrammarTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsMinimumSQLGrammar());
     }
 
     @Test public void supportsCoreSQLGrammarTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsCoreSQLGrammar());
     }
 
     @Test public void supportsExtendedSQLGrammarTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsExtendedSQLGrammar());
     }
 
     @Test public void supportsOuterJoinsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOuterJoins());
     }
 
     @Test public void supportsFullOuterJoinsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsFullOuterJoins());
     }
 
     @Test public void supportsLimitedOuterJoinsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsLimitedOuterJoins());
     }
 
     @Test public void getSchemaTermTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("", vitessDatabaseMetaData.getSchemaTerm());
     }
 
     @Test public void getProcedureTermTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("procedure", vitessDatabaseMetaData.getProcedureTerm());
     }
 
     @Test public void getCatalogTermTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("database", vitessDatabaseMetaData.getCatalogTerm());
     }
 
     @Test public void isCatalogAtStartTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessDatabaseMetaData.isCatalogAtStart());
     }
 
     @Test public void getCatalogSeparatorTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(".", vitessDatabaseMetaData.getCatalogSeparator());
     }
 
     @Test public void supportsSchemasInDataManipulationTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSchemasInDataManipulation());
     }
 
     @Test public void supportsSchemasInProcedureCallsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSchemasInProcedureCalls());
     }
 
     @Test public void supportsSchemasInTableDefinitionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSchemasInTableDefinitions());
     }
 
     @Test public void supportsSchemasInIndexDefinitionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSchemasInIndexDefinitions());
     }
 
     @Test public void supportsSelectForUpdateTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSelectForUpdate());
     }
 
     @Test public void supportsStoredProceduresTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsStoredProcedures());
     }
 
     @Test public void supportsSubqueriesInComparisonsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSubqueriesInComparisons());
     }
 
     @Test public void supportsSubqueriesInExistsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSubqueriesInExists());
     }
 
     @Test public void supportsSubqueriesInInsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSubqueriesInIns());
     }
 
     @Test public void supportsSubqueriesInQuantifiedsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsSubqueriesInQuantifieds());
     }
 
     @Test public void supportsCorrelatedSubqueriesTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsCorrelatedSubqueries());
     }
 
     @Test public void supportsUnionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsUnion());
     }
 
     @Test public void supportsUnionAllTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsUnionAll());
     }
 
     @Test public void supportsOpenCursorsAcrossRollbackTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOpenCursorsAcrossRollback());
     }
 
     @Test public void supportsOpenStatementsAcrossCommitTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOpenStatementsAcrossCommit());
     }
 
     @Test public void supportsOpenStatementsAcrossRollbackTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOpenStatementsAcrossRollback());
     }
 
     @Test public void supportsOpenCursorsAcrossCommitTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.supportsOpenCursorsAcrossCommit());
     }
 
     @Test public void getMaxBinaryLiteralLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(16777208, vitessDatabaseMetaData.getMaxBinaryLiteralLength());
     }
 
     @Test public void getMaxCharLiteralLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(16777208, vitessDatabaseMetaData.getMaxCharLiteralLength());
     }
 
     @Test public void getMaxColumnNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(64, vitessDatabaseMetaData.getMaxColumnNameLength());
     }
 
     @Test public void getMaxColumnsInGroupByTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(64, vitessDatabaseMetaData.getMaxColumnsInGroupBy());
     }
 
     @Test public void getMaxColumnsInIndexTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(16, vitessDatabaseMetaData.getMaxColumnsInIndex());
     }
 
     @Test public void getMaxColumnsInOrderByTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(64, vitessDatabaseMetaData.getMaxColumnsInOrderBy());
     }
 
     @Test public void getMaxColumnsInSelectTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(256, vitessDatabaseMetaData.getMaxColumnsInSelect());
     }
 
     @Test public void getMaxIndexLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(256, vitessDatabaseMetaData.getMaxIndexLength());
     }
 
     @Test public void doesMaxRowSizeIncludeBlobsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.doesMaxRowSizeIncludeBlobs());
     }
 
     @Test public void getMaxTableNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(64, vitessDatabaseMetaData.getMaxTableNameLength());
     }
 
     @Test public void getMaxTablesInSelectTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(256, vitessDatabaseMetaData.getMaxTablesInSelect());
     }
 
     @Test public void getMaxUserNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(16, vitessDatabaseMetaData.getMaxUserNameLength());
     }
 
     @Test public void supportsDataDefinitionAndDataManipulationTransactionsTest()
         throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false,
             vitessDatabaseMetaData.supportsDataDefinitionAndDataManipulationTransactions());
     }
 
     @Test public void dataDefinitionCausesTransactionCommitTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.dataDefinitionCausesTransactionCommit());
     }
 
     @Test public void dataDefinitionIgnoredInTransactionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.dataDefinitionIgnoredInTransactions());
     }
 
     @Test public void getIdentifierQuoteStringTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals("`", vitessDatabaseMetaData.getIdentifierQuoteString());
     }
 
     @Test public void getProceduresTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(null, vitessDatabaseMetaData.getProcedures(null, null, null));
     }
 
     @Test public void supportsResultSetTypeTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true,
             vitessDatabaseMetaData.supportsResultSetType(ResultSet.TYPE_FORWARD_ONLY));
@@ -652,7 +658,7 @@ import java.util.Properties;
     }
 
     @Test public void supportsResultSetConcurrencyTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         Assert.assertEquals(true, vitessDatabaseMetaData
             .supportsResultSetConcurrency(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY));
         Assert.assertEquals(false, vitessDatabaseMetaData
@@ -680,19 +686,19 @@ import java.util.Properties;
     }
 
     @Test public void getJDBCMajorVersionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(1, vitessDatabaseMetaData.getJDBCMajorVersion());
     }
 
     @Test public void getJDBCMinorVersionTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(0, vitessDatabaseMetaData.getJDBCMinorVersion());
     }
 
     @Test public void getNumericFunctionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(
             "ABS,ACOS,ASIN,ATAN,ATAN2,BIT_COUNT,CEILING,COS,COT,DEGREES,EXP,FLOOR,LOG,LOG10,MAX,MIN,MOD,PI,POW,POWER,"
@@ -701,7 +707,7 @@ import java.util.Properties;
     }
 
     @Test public void getStringFunctionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(
             "ASCII,BIN,BIT_LENGTH,CHAR,CHARACTER_LENGTH,CHAR_LENGTH,CONCAT,CONCAT_WS,CONV,ELT,EXPORT_SET,FIELD,"
@@ -715,9 +721,9 @@ import java.util.Properties;
     }
 
     @Test public void getSystemFunctionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySQLDatabaseMetadata = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySQLDatabaseMetadata = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatbaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(
             "DATABASE,USER,SYSTEM_USER,SESSION_USER,LAST_INSERT_ID,VERSION,PASSWORD,ENCRYPT",
@@ -727,7 +733,7 @@ import java.util.Properties;
     }
 
     @Test public void getTimeDateFunctionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(
             "DAYOFWEEK,WEEKDAY,DAYOFMONTH,DAYOFYEAR,MONTH,DAYNAME,MONTHNAME,QUARTER,WEEK,YEAR,HOUR,MINUTE,SECOND,"
@@ -739,7 +745,7 @@ import java.util.Properties;
     }
 
     @Test public void autoCommitFailureClosesAllResultSetsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.autoCommitFailureClosesAllResultSets());
     }
@@ -760,9 +766,9 @@ import java.util.Properties;
     }
 
     @Test public void getDriverNameTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySQLDatabaseMetadata = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySQLDatabaseMetadata = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert
             .assertEquals("Vitess MySQL JDBC Driver", vitessMySQLDatabaseMetadata.getDriverName());
@@ -771,7 +777,7 @@ import java.util.Properties;
     }
 
     @Test public void usesLocalFilesTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.usesLocalFiles());
         Assert.assertEquals(false, vitessDatabaseMetaData.usesLocalFilePerTable());
@@ -779,18 +785,18 @@ import java.util.Properties;
     }
 
     @Test public void storeIdentifiersTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessDatabaseMetaData.storesUpperCaseIdentifiers());
     }
 
     @Test public void supportsTransactionsTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         Assert.assertEquals(true, vitessDatabaseMetaData.supportsTransactions());
     }
 
     @Test public void supportsTransactionIsolationLevelTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         Assert.assertEquals(false,
             vitessDatabaseMetaData.supportsTransactionIsolationLevel(Connection.TRANSACTION_NONE));
         Assert.assertEquals(true, vitessDatabaseMetaData
@@ -804,50 +810,50 @@ import java.util.Properties;
     }
 
     @Test public void getMaxProcedureNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         Assert.assertEquals(256, vitessDatabaseMetaData.getMaxProcedureNameLength());
     }
 
     @Test public void getMaxCatalogNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(32, vitessMySqlDatabaseMetaData.getMaxCatalogNameLength());
         Assert.assertEquals(0, vitessMariaDBDatabaseMetadata.getMaxCatalogNameLength());
     }
 
     @Test public void getMaxRowSizeTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(2147483639, vitessMySqlDatabaseMetaData.getMaxRowSize());
         Assert.assertEquals(0, vitessMariaDBDatabaseMetadata.getMaxRowSize());
     }
 
     @Test public void getMaxStatementLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(65531, vitessMySqlDatabaseMetaData.getMaxStatementLength());
         Assert.assertEquals(0, vitessMariaDBDatabaseMetadata.getMaxStatementLength());
     }
 
     @Test public void getMaxStatementsTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(0, vitessMySqlDatabaseMetaData.getMaxStatements());
         Assert.assertEquals(0, vitessMariaDBDatabaseMetadata.getMaxStatements());
     }
 
     @Test public void supportsDataManipulationTransactionsOnlyTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false,
             vitessMySqlDatabaseMetaData.supportsDataManipulationTransactionsOnly());
@@ -856,45 +862,45 @@ import java.util.Properties;
     }
 
     @Test public void getMaxSchemaNameLengthTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(0, vitessMySqlDatabaseMetaData.getMaxSchemaNameLength());
         Assert.assertEquals(32, vitessMariaDBDatabaseMetadata.getMaxSchemaNameLength());
     }
 
     @Test public void supportsSavepointsTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessMySqlDatabaseMetaData.supportsSavepoints());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.supportsSavepoints());
     }
 
     @Test public void supportsMultipleOpenResultsTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessMySqlDatabaseMetaData.supportsMultipleOpenResults());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.supportsMultipleOpenResults());
     }
 
     @Test public void locatorsUpdateCopyTest() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(true, vitessMySqlDatabaseMetaData.locatorsUpdateCopy());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.locatorsUpdateCopy());
     }
 
     @Test public void supportsStatementPooling() throws SQLException {
-        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessMySqlDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         VitessDatabaseMetaData vitessMariaDBDatabaseMetadata =
-            new VitessMariaDBDatabaseMetadata(null);
+            new VitessMariaDBDatabaseMetadata(getVitessConnection());
 
         Assert.assertEquals(false, vitessMySqlDatabaseMetaData.supportsStatementPooling());
         Assert.assertEquals(false, vitessMariaDBDatabaseMetadata.supportsStatementPooling());
@@ -913,12 +919,11 @@ import java.util.Properties;
                 Query.Row.newBuilder().addLengths("dummyDB".length())
                     .setValues(ByteString.copyFromUtf8("dummyDB"))).build());
 
-        VitessStatement vitessStatement = PowerMockito.mock(VitessStatement.class);
+        VitessStatement vitessStatement = PowerMockito.spy(new VitessStatement(getVitessConnection()));
         PowerMockito.whenNew(VitessStatement.class).withAnyArguments().thenReturn(vitessStatement);
-        PowerMockito.when(vitessStatement.executeQuery(sql))
-            .thenReturn(new VitessResultSet(mockedCursor));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), mockedCursor)).when(vitessStatement).executeQuery(sql);
 
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         ResultSet resultSet = vitessDatabaseMetaData.getCatalogs();
         ArrayList<String> resultSetList = new ArrayList<String>();
         while (resultSet.next()) {
@@ -972,14 +977,13 @@ import java.util.Properties;
                 .setValues(ByteString.copyFromUtf8("TestDB2SampleLocalTemporaryLOCAL TEMPORARY")))
             .build());
 
-        VitessStatement vitessStatement = PowerMockito.mock(VitessStatement.class);
+        VitessStatement vitessStatement = PowerMockito.spy(new VitessStatement(getVitessConnection()));
         PowerMockito.whenNew(VitessStatement.class).withAnyArguments().thenReturn(vitessStatement);
-        PowerMockito.when(vitessStatement.executeQuery(sql))
-            .thenReturn(new VitessResultSet(mockedCursor));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), mockedCursor)).when(vitessStatement).executeQuery(sql);
 
-        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(null);
+        VitessDatabaseMetaData vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(getVitessConnection());
         ResultSet actualResultSet = vitessDatabaseMetaData.getTables("vt", null, null, null);
-        ResultSet expectedResultSet = new VitessResultSet(mockedCursor);
+        ResultSet expectedResultSet = new VitessResultSet(getVitessConnection(), mockedCursor);
 
         assertResultSetEquals(actualResultSet, expectedResultSet);
     }
@@ -1081,19 +1085,15 @@ import java.util.Properties;
                     "TestDB1sampleTable1trackingid12VARCHAR25565535101CommentNULL002552YESNONO")))
             .build());
 
-        VitessStatement vitessStatement = PowerMockito.mock(VitessStatement.class);
+        VitessStatement vitessStatement = PowerMockito.spy(new VitessStatement(getVitessConnection()));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), actualCursor)).when(vitessStatement).executeQuery(sql);
         PowerMockito.whenNew(VitessStatement.class).withAnyArguments().thenReturn(vitessStatement);
-        PowerMockito.when(vitessStatement.executeQuery(sql))
-            .thenReturn(new VitessResultSet(actualCursor));
 
-        VitessDatabaseMetaData vitessDatabaseMetaData =
-            PowerMockito.mock(VitessMySQLDatabaseMetadata.class);
-        PowerMockito.doCallRealMethod().when(vitessDatabaseMetaData)
-            .getColumns("TestDB1", null, null, null);
-        PowerMockito.when(vitessDatabaseMetaData.getTables("TestDB1", null, "%", new String[0]))
-            .thenReturn(new VitessResultSet(mockedTablecursor));
+        VitessDatabaseMetaData vitessDatabaseMetaData = PowerMockito.spy(new VitessMySQLDatabaseMetadata(getVitessConnection()));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), mockedTablecursor)).when(vitessDatabaseMetaData).getTables("TestDB1", null, "%", new String[0]);
+
         ResultSet actualResultSet = vitessDatabaseMetaData.getColumns("TestDB1", null, null, null);
-        ResultSet expectedResultSet = new VitessResultSet(expectedCursor);
+        ResultSet expectedResultSet = new VitessResultSet(getVitessConnection(), expectedCursor);
 
         assertResultSetEquals(actualResultSet, expectedResultSet);
     }
@@ -1135,17 +1135,17 @@ import java.util.Properties;
                 .addLengths("1".length()).addLengths("PRIMARY".length())
                 .setValues(ByteString.copyFromUtf8("vtshipmentshipmentid1PRIMARY"))).build());
 
-        VitessStatement vitessStatement = PowerMockito.mock(VitessStatement.class);
+        VitessStatement vitessStatement = PowerMockito.spy(new VitessStatement(getVitessConnection()));
         VitessDatabaseMetaData vitessDatabaseMetaData =
-            PowerMockito.mock(VitessMySQLDatabaseMetadata.class);
-        PowerMockito.mock(VitessMySQLDatabaseMetadata.class);
+            PowerMockito.spy(new VitessMySQLDatabaseMetadata(getVitessConnection()));
+
         PowerMockito.doCallRealMethod().when(vitessDatabaseMetaData)
             .getPrimaryKeys("vt", null, "shipment");
         PowerMockito.whenNew(VitessStatement.class).withAnyArguments().thenReturn(vitessStatement);
-        PowerMockito.when(vitessStatement.executeQuery(sql))
-            .thenReturn(new VitessResultSet(mockedCursor));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), mockedCursor)).when(vitessStatement).executeQuery(sql);
+
         ResultSet expectedResultSet = vitessDatabaseMetaData.getPrimaryKeys("vt", null, "shipment");
-        ResultSet actualResultSet = new VitessResultSet(expectedcursor);
+        ResultSet actualResultSet = new VitessResultSet(getVitessConnection(), expectedcursor);
 
         assertResultSetEquals(actualResultSet, expectedResultSet);
     }
@@ -1199,18 +1199,17 @@ import java.util.Properties;
                 .addLengths("434880".length()).addLengths("0".length()).addLengths(-1)
                 .setValues(ByteString.copyFromUtf8("vtshipmentfalsePRIMARY31shipmentidA4348800")))
             .build());
-        VitessStatement vitessStatement = PowerMockito.mock(VitessStatement.class);
+        VitessStatement vitessStatement = PowerMockito.spy(new VitessStatement(getVitessConnection()));
         VitessDatabaseMetaData vitessDatabaseMetaData =
-            PowerMockito.mock(VitessMySQLDatabaseMetadata.class);
-        PowerMockito.mock(VitessMySQLDatabaseMetadata.class);
+            PowerMockito.spy(new VitessMySQLDatabaseMetadata(getVitessConnection()));
+
         PowerMockito.doCallRealMethod().when(vitessDatabaseMetaData)
             .getIndexInfo("vt", null, "shipment", true, false);
         PowerMockito.whenNew(VitessStatement.class).withAnyArguments().thenReturn(vitessStatement);
-        PowerMockito.when(vitessStatement.executeQuery(sql))
-            .thenReturn(new VitessResultSet(mockedCursor));
+        PowerMockito.doReturn(new VitessResultSet(getVitessConnection(), mockedCursor)).when(vitessStatement).executeQuery(sql);
         ResultSet actualResultSet =
             vitessDatabaseMetaData.getIndexInfo("vt", null, "shipment", true, false);
-        ResultSet expectedResultSet = new VitessResultSet(expectedcursor);
+        ResultSet expectedResultSet = new VitessResultSet(getVitessConnection(), expectedcursor);
 
         assertResultSetEquals(actualResultSet, expectedResultSet);
     }
@@ -1283,12 +1282,12 @@ import java.util.Properties;
     @Test public void getUserNameTest() {
         try {
             VitessConnection vitessConnection =
-                new VitessConnection("jdbc:vitess://username@ip1:port1/keyspace", null);
+                new VitessConnection("jdbc:vitess://username@ip1:port1/keyspace", new Properties());
             VitessDatabaseMetaData vitessDatabaseMetaData =
                 new VitessMySQLDatabaseMetadata(vitessConnection);
             Assert.assertEquals("username", vitessDatabaseMetaData.getUserName());
 
-            vitessConnection = new VitessConnection("jdbc:vitess://ip1:port1/keyspace", null);
+            vitessConnection = new VitessConnection("jdbc:vitess://ip1:port1/keyspace", new Properties());
             vitessDatabaseMetaData = new VitessMySQLDatabaseMetadata(vitessConnection);
             Assert.assertEquals(null, vitessDatabaseMetaData.getUserName());
 

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessJDBCUrlTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessJDBCUrlTest.java
@@ -1,10 +1,12 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessJDBCUrl;
+import com.flipkart.vitess.util.Constants;
 import com.youtube.vitess.proto.Topodata;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 /**
@@ -69,7 +71,7 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(1).getPort());
         Assert.assertEquals("hostname3", vitessJDBCUrl.getHostInfos().get(2).getHostname());
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(2).getPort());
-        Assert.assertEquals(Topodata.TabletType.MASTER, vitessJDBCUrl.getTabletType());
+        Assert.assertEquals(Topodata.TabletType.MASTER.name(), vitessJDBCUrl.getProperties().getProperty(Constants.Property.TABLET_TYPE).toUpperCase());
         Assert.assertEquals("user", vitessJDBCUrl.getUsername());
     }
 
@@ -97,7 +99,7 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(2).getPort());
         Assert.assertEquals("hostname3", vitessJDBCUrl1.getHostInfos().get(2).getHostname());
         Assert.assertEquals(15001, vitessJDBCUrl1.getHostInfos().get(2).getPort());
-        Assert.assertEquals(vitessJDBCUrl.getTabletType(), Topodata.TabletType.MASTER);
+        Assert.assertEquals(Topodata.TabletType.MASTER.name(), vitessJDBCUrl.getProperties().getProperty(Constants.Property.TABLET_TYPE).toUpperCase());
         Assert.assertEquals("user", vitessJDBCUrl.getUsername());
     }
 
@@ -145,21 +147,31 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(1).getPort());
         Assert.assertEquals("keyspace", vitessJDBCUrl.getKeyspace());
         Assert.assertEquals("catalog", vitessJDBCUrl.getCatalog());
-        Assert.assertEquals("val1", info.getProperty("prop1"));
-        Assert.assertEquals("val2", info.getProperty("prop2"));
+        Assert.assertEquals("val1", vitessJDBCUrl.getProperties().getProperty("prop1"));
+        Assert.assertEquals("val2", vitessJDBCUrl.getProperties().getProperty("prop2"));
     }
 
-    @Test public void testTwoPCEnabledURL() throws Exception {
-        VitessJDBCUrl vitessJDBCUrl =
-            new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=true", null);
-        Assert.assertTrue(vitessJDBCUrl.isTwopcEnabled());
+    @Test public void testLeaveOriginalPropertiesAlone() throws Exception {
+        Properties info = new Properties();
+        VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(
+            "jdbc:vitess://user:pass@hostname1:15991,hostname2:15991/keyspace/catalog?prop1=val1&prop2=val2",
+            info);
 
-        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=false", null);
-        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
-
-        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991", null);
-        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
-
+        Assert.assertEquals(null, info.getProperty("prop1"));
+        Assert.assertEquals("val1", vitessJDBCUrl.getProperties().getProperty("prop1"));
     }
 
+    @Test public void testPropertiesTakePrecendenceOverUrl() throws SQLException {
+        Properties info = new Properties();
+        info.setProperty("prop1", "val3");
+        info.setProperty("prop2", "val4");
+
+        VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(
+            "jdbc:vitess://user:pass@hostname1:15991,hostname2:15991/keyspace/catalog?prop1=val1&prop2=val2&prop3=val3",
+            info);
+
+        Assert.assertEquals("val3", vitessJDBCUrl.getProperties().getProperty("prop1"));
+        Assert.assertEquals("val4", vitessJDBCUrl.getProperties().getProperty("prop2"));
+        Assert.assertEquals("val3", vitessJDBCUrl.getProperties().getProperty("prop3"));
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessPreparedStatementTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessPreparedStatementTest.java
@@ -1,7 +1,5 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessConnection;
-import com.flipkart.vitess.jdbc.VitessPreparedStatement;
 import com.flipkart.vitess.util.Constants;
 import com.google.common.collect.ImmutableMap;
 import com.youtube.vitess.client.Context;
@@ -94,18 +92,19 @@ import java.util.TimeZone;
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
 
@@ -173,22 +172,22 @@ import java.util.TimeZone;
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .streamExecute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.STREAM);
 
         VitessPreparedStatement preparedStatement;
@@ -256,17 +255,17 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessPreparedStatement preparedStatement =
             new VitessPreparedStatement(mockConn, sqlUpdate);
@@ -333,27 +332,28 @@ import java.util.TimeZone;
         Cursor mockCursor = PowerMockito.mock(Cursor.class);
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         SQLFuture mockSqlFutureVtGateTx = PowerMockito.mock(SQLFuture.class);
-        List<Query.Field> mockFieldList = PowerMockito.mock(ArrayList.class);
+        List<Query.Field> mockFieldList = PowerMockito.spy(new ArrayList<Query.Field>());
 
         PowerMockito.when(mockConn.getKeyspace()).thenReturn("test_keyspace");
         PowerMockito.when(mockConn.getVtGateConn()).thenReturn(mockVtGateConn);
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
 
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getAutoCommit()).thenReturn(true);
         PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureCursor);
@@ -369,7 +369,8 @@ import java.util.TimeZone;
 
             int fieldSize = 5;
             PowerMockito.when(mockCursor.getFields()).thenReturn(mockFieldList);
-            PowerMockito.when(mockFieldList.size()).thenReturn(fieldSize);
+            PowerMockito.doReturn(fieldSize).when(mockFieldList).size();
+            PowerMockito.doReturn(false).when(mockFieldList).isEmpty();
             boolean hasResultSet = preparedStatement.execute();
             Assert.assertTrue(hasResultSet);
             Assert.assertNotNull(preparedStatement.getResultSet());
@@ -380,7 +381,7 @@ import java.util.TimeZone;
             Assert.assertNotNull(preparedStatement.getResultSet());
 
             int mockUpdateCount = 10;
-            PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+            PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
             PowerMockito.when(mockCursor.getRowsAffected()).thenReturn((long) mockUpdateCount);
             preparedStatement = new VitessPreparedStatement(mockConn, sqlUpdate);
             hasResultSet = preparedStatement.execute();
@@ -415,9 +416,9 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFuture);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFuture);
         PowerMockito.when(mockSqlFuture.checkedGet()).thenReturn(mockCursor);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessPreparedStatement preparedStatement =
             new VitessPreparedStatement(mockConn, sqlSelect);
@@ -439,7 +440,7 @@ import java.util.TimeZone;
             Assert.assertEquals(-1, preparedStatement.getUpdateCount());
 
         } catch (SQLException e) {
-            Assert.fail("Test failed " + e.getMessage());
+            throw e;
         }
     }
 
@@ -575,17 +576,17 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
 
         try {
@@ -672,7 +673,7 @@ import java.util.TimeZone;
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         PowerMockito.when(mockVtGateConn
             .executeBatch(Matchers.any(Context.class), Matchers.anyList(), Matchers.anyList(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
 
         List<CursorWithError> mockCursorWithErrorList = new ArrayList<>();
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursorWithErrorList);

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
@@ -1,79 +1,101 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessResultSetMetaData;
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.proto.Query;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by ashudeep.sharma on 08/02/16.
  */
-public class VitessResultSetMetadataTest {
+public class VitessResultSetMetadataTest extends BaseTest {
 
-    private List<Query.Field> fieldList;
+    private List<FieldWithMetadata> fieldList;
 
-    public void initializeFieldList() {
+    private List<Query.Field> generateFieldList() {
+        List<Query.Field> fieldList = new ArrayList<>();
 
-        fieldList = new ArrayList<>();
-        fieldList.add(Query.Field.newBuilder().setName("col1").setType(Query.Type.INT8).build());
-        fieldList.add(Query.Field.newBuilder().setName("col2").setType(Query.Type.UINT8).build());
-        fieldList.add(Query.Field.newBuilder().setName("col3").setType(Query.Type.INT16).build());
-        fieldList.add(Query.Field.newBuilder().setName("col4").setType(Query.Type.UINT16).build());
-        fieldList.add(Query.Field.newBuilder().setName("col5").setType(Query.Type.INT24).build());
-        fieldList.add(Query.Field.newBuilder().setName("col6").setType(Query.Type.UINT24).build());
-        fieldList.add(Query.Field.newBuilder().setName("col7").setType(Query.Type.INT32).build());
-        fieldList.add(Query.Field.newBuilder().setName("col8").setType(Query.Type.UINT32).build());
-        fieldList.add(Query.Field.newBuilder().setName("col9").setType(Query.Type.INT64).build());
-        fieldList.add(Query.Field.newBuilder().setName("col10").setType(Query.Type.UINT64).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col11").setType(Query.Type.FLOAT32).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col12").setType(Query.Type.FLOAT64).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col13").setType(Query.Type.TIMESTAMP).build());
-        fieldList.add(Query.Field.newBuilder().setName("col14").setType(Query.Type.DATE).build());
-        fieldList.add(Query.Field.newBuilder().setName("col15").setType(Query.Type.TIME).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col16").setType(Query.Type.DATETIME).build());
-        fieldList.add(Query.Field.newBuilder().setName("col17").setType(Query.Type.YEAR).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col18").setType(Query.Type.DECIMAL).build());
-        fieldList.add(Query.Field.newBuilder().setName("col19").setType(Query.Type.TEXT).build());
-        fieldList.add(Query.Field.newBuilder().setName("col20").setType(Query.Type.BLOB).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col21").setType(Query.Type.VARCHAR).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col22").setType(Query.Type.VARBINARY).build());
-        fieldList.add(Query.Field.newBuilder().setName("col23").setType(Query.Type.CHAR).build());
-        fieldList.add(Query.Field.newBuilder().setName("col24").setType(Query.Type.BINARY).build());
-        fieldList.add(Query.Field.newBuilder().setName("col25").setType(Query.Type.BIT).build());
-        fieldList.add(Query.Field.newBuilder().setName("col26").setType(Query.Type.ENUM).build());
-        fieldList.add(Query.Field.newBuilder().setName("col27").setType(Query.Type.SET).build());
-        fieldList.add(Query.Field.newBuilder().setName("col28").setType(Query.Type.TUPLE).build());
+        fieldList.add(field("col1", "tbl", Query.Type.INT8, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.NOT_NULL_FLAG_VALUE).setOrgName("foo").setOrgTable("foo").build());
+        fieldList.add(field("col2", "tbl", Query.Type.UINT8, 3, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col3", "tbl", Query.Type.INT16, 6, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col4", "tbl", Query.Type.UINT16, 5, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col5", "tbl", Query.Type.INT24, 9, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col6", "tbl", Query.Type.UINT24, 8, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col7", "tbl", Query.Type.INT32, 11, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col8", "tbl", Query.Type.UINT32, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col9", "tbl", Query.Type.INT64, 20, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col10", "tbl", Query.Type.UINT64, 20, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col11", "tbl", Query.Type.FLOAT32, 12, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(31).build());
+        fieldList.add(field("col12", "tbl", Query.Type.FLOAT64, 22, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(31).build());
+        fieldList.add(field("col13", "tbl", Query.Type.TIMESTAMP, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col14", "tbl", Query.Type.DATE, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col15", "tbl", Query.Type.TIME, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col16", "tbl", Query.Type.DATETIME, 19, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col17", "tbl", Query.Type.YEAR, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col18", "tbl", Query.Type.DECIMAL, 7, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(2).build());
+        fieldList.add(field("col19", "tbl", Query.Type.TEXT, 765, /* utf8_bin -- not case insensitive */ 83).build());
+        fieldList.add(field("col20", "tbl", Query.Type.BLOB, 65535, CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE | Query.MySqlFlag.BLOB_FLAG_VALUE)
+            .setDecimals(/* this is set to facilitate testing of getScale, since this is non-numeric */2).build());
+        fieldList.add(field("col21", "tbl", Query.Type.VARCHAR, 768, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col22", "tbl", Query.Type.VARBINARY, 256, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col23", "tbl", Query.Type.CHAR, 48, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col24", "tbl", Query.Type.BINARY, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col25", "tbl", Query.Type.BIT, 8, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col26", "tbl", Query.Type.ENUM, 3, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col27", "tbl", Query.Type.SET, 9, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col28", "tbl", Query.Type.TUPLE, 0, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col29", "tbl", Query.Type.VARBINARY, 256, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col30", "tbl", Query.Type.BLOB, 65535, CharsetMapping.MYSQL_COLLATION_INDEX_utf8)
+            .setFlags(Query.MySqlFlag.BLOB_FLAG_VALUE).build());
+        return fieldList;
     }
 
-    public List<Query.Field> getFieldList() {
+    private Query.Field.Builder field(String name, String table, Query.Type type, int length, int charset) {
+        return Query.Field.newBuilder()
+            .setName(name)
+            .setTable(table)
+            .setType(type)
+            .setColumnLength(length)
+            .setCharset(charset);
+    }
 
-        initializeFieldList();
+    private void initializeFieldList(VitessConnection connection) throws SQLException {
+        List<Query.Field> fields = generateFieldList();
+        this.fieldList = new ArrayList<>(fields.size());
+        for (Query.Field field : fields) {
+            this.fieldList.add(new FieldWithMetadata(connection, field));
+        }
+    }
+
+    public List<FieldWithMetadata> getFieldList() throws SQLException {
+        return getFieldList(getVitessConnection());
+    }
+
+    public List<FieldWithMetadata> getFieldList(VitessConnection conn) throws SQLException {
+        initializeFieldList(conn);
         return this.fieldList;
     }
 
     @Test public void testgetColumnCount() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(28, vitessResultSetMetadata.getColumnCount());
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        Assert.assertEquals(30, vitessResultSetMetadata.getColumnCount());
     }
 
     @Test public void testgetColumnName() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
         for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
             Assert.assertEquals("col" + i, vitessResultSetMetadata.getColumnName(i));
         }
@@ -81,8 +103,122 @@ public class VitessResultSetMetadataTest {
 
     @Test public void testgetColumnTypeName() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        Assert.assertEquals("TINYINT", vitessResultSetMetadata.getColumnTypeName(1));
+        Assert.assertEquals("TINYINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(2));
+        Assert.assertEquals("SMALLINT", vitessResultSetMetadata.getColumnTypeName(3));
+        Assert.assertEquals("SMALLINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(4));
+        Assert.assertEquals("MEDIUMINT", vitessResultSetMetadata.getColumnTypeName(5));
+        Assert.assertEquals("MEDIUMINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(6));
+        Assert.assertEquals("INT", vitessResultSetMetadata.getColumnTypeName(7));
+        Assert.assertEquals("INT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(8));
+        Assert.assertEquals("BIGINT", vitessResultSetMetadata.getColumnTypeName(9));
+        Assert.assertEquals("BIGINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(10));
+        Assert.assertEquals("FLOAT", vitessResultSetMetadata.getColumnTypeName(11));
+        Assert.assertEquals("DOUBLE", vitessResultSetMetadata.getColumnTypeName(12));
+        Assert.assertEquals("TIMESTAMP", vitessResultSetMetadata.getColumnTypeName(13));
+        Assert.assertEquals("DATE", vitessResultSetMetadata.getColumnTypeName(14));
+        Assert.assertEquals("TIME", vitessResultSetMetadata.getColumnTypeName(15));
+        Assert.assertEquals("DATETIME", vitessResultSetMetadata.getColumnTypeName(16));
+        Assert.assertEquals("YEAR", vitessResultSetMetadata.getColumnTypeName(17));
+        Assert.assertEquals("DECIMAL", vitessResultSetMetadata.getColumnTypeName(18));
+        Assert.assertEquals("TEXT", vitessResultSetMetadata.getColumnTypeName(19));
+        Assert.assertEquals("BLOB", vitessResultSetMetadata.getColumnTypeName(20));
+        Assert.assertEquals("VARCHAR", vitessResultSetMetadata.getColumnTypeName(21));
+        Assert.assertEquals("VARBINARY", vitessResultSetMetadata.getColumnTypeName(22));
+        Assert.assertEquals("CHAR", vitessResultSetMetadata.getColumnTypeName(23));
+        Assert.assertEquals("BINARY", vitessResultSetMetadata.getColumnTypeName(24));
+        Assert.assertEquals("BIT", vitessResultSetMetadata.getColumnTypeName(25));
+        Assert.assertEquals("ENUM", vitessResultSetMetadata.getColumnTypeName(26));
+        Assert.assertEquals("SET", vitessResultSetMetadata.getColumnTypeName(27));
+        Assert.assertEquals("TUPLE", vitessResultSetMetadata.getColumnTypeName(28));
+        Assert.assertEquals("VARBINARY", vitessResultSetMetadata.getColumnTypeName(29));
+        Assert.assertEquals("BLOB", vitessResultSetMetadata.getColumnTypeName(30));
+    }
+
+    @Test public void testgetColumnType() throws SQLException {
+
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        Assert.assertEquals("TINYINT", Types.TINYINT, vitessResultSetMetadata.getColumnType(1));
+        Assert.assertEquals("TINYINT", Types.TINYINT, vitessResultSetMetadata.getColumnType(2));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(3));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(4));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(5));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(6));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(7));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(8));
+        Assert.assertEquals("BIGINT", Types.BIGINT, vitessResultSetMetadata.getColumnType(9));
+        Assert.assertEquals("BIGINT", Types.BIGINT, vitessResultSetMetadata.getColumnType(10));
+        Assert.assertEquals("FLOAT", Types.FLOAT, vitessResultSetMetadata.getColumnType(11));
+        Assert.assertEquals("DOUBLE", Types.DOUBLE, vitessResultSetMetadata.getColumnType(12));
+        Assert.assertEquals("TIMESTAMP", Types.TIMESTAMP, vitessResultSetMetadata.getColumnType(13));
+        Assert.assertEquals("DATE", Types.DATE, vitessResultSetMetadata.getColumnType(14));
+        Assert.assertEquals("TIME", Types.TIME, vitessResultSetMetadata.getColumnType(15));
+        Assert.assertEquals("TIMESTAMP", Types.TIMESTAMP, vitessResultSetMetadata.getColumnType(16));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(17));
+        Assert.assertEquals("DECIMAL", Types.DECIMAL, vitessResultSetMetadata.getColumnType(18));
+        Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(19));
+        Assert.assertEquals("LONGVARBINARY", Types.LONGVARBINARY, vitessResultSetMetadata.getColumnType(20));
+        Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(21));
+        Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(22));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(23));
+        Assert.assertEquals("BINARY", Types.BINARY, vitessResultSetMetadata.getColumnType(24));
+        Assert.assertEquals("BIT", Types.BIT, vitessResultSetMetadata.getColumnType(25));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(26));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(27));
+        Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(29));
+        Assert.assertEquals("LONGVARCHAR", Types.LONGVARCHAR, vitessResultSetMetadata.getColumnType(30));
+        try {
+            int type = vitessResultSetMetadata.getColumnType(28);
+        } catch (SQLException ex) {
+            Assert
+                .assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE, ex.getMessage());
+        }
+
+        try {
+            int type = vitessResultSetMetadata.getColumnType(0);
+        } catch (SQLException ex) {
+            Assert.assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_INDEX + ": " + 0,
+                ex.getMessage());
+        }
+    }
+
+    @Test public void testgetColumnLabel() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        for (int i = 1; i <= vitessResultSetMetaData.getColumnCount(); i++) {
+            Assert.assertEquals("col" + i, vitessResultSetMetaData.getColumnLabel(i));
+        }
+    }
+
+    @Test public void testgetTableName() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
+            Assert.assertEquals(vitessResultSetMetadata.getTableName(i), "tbl");
+        }
+    }
+
+    @Test public void isReadOnlyTest() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+
+        Assert.assertEquals(vitessResultSetMetadata.isReadOnly(1), false);
+        Assert.assertEquals(vitessResultSetMetadata.isWritable(1), true);
+        Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(1), true);
+
+        for (int i = 2; i <= vitessResultSetMetadata.getColumnCount(); i++) {
+            Assert.assertEquals(vitessResultSetMetadata.isReadOnly(i), true);
+            Assert.assertEquals(vitessResultSetMetadata.isWritable(i), false);
+            Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(i), false);
+        }
+    }
+
+    @Test public void getColumnTypeNameTest() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(getVitessConnection(), fieldList);
         Assert.assertEquals("TINYINT", vitessResultSetMetadata.getColumnTypeName(1));
         Assert.assertEquals("TINYINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(2));
         Assert.assertEquals("SMALLINT", vitessResultSetMetadata.getColumnTypeName(3));
@@ -113,89 +249,302 @@ public class VitessResultSetMetadataTest {
         Assert.assertEquals("TUPLE", vitessResultSetMetadata.getColumnTypeName(28));
     }
 
-    @Test public void testgetColumnType() throws SQLException {
-
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(-6, vitessResultSetMetadata.getColumnType(1));
-        Assert.assertEquals(-6, vitessResultSetMetadata.getColumnType(2));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(3));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(4));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(5));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(6));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(7));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(8));
-        Assert.assertEquals(-5, vitessResultSetMetadata.getColumnType(9));
-        Assert.assertEquals(-5, vitessResultSetMetadata.getColumnType(10));
-        Assert.assertEquals(6, vitessResultSetMetadata.getColumnType(11));
-        Assert.assertEquals(8, vitessResultSetMetadata.getColumnType(12));
-        Assert.assertEquals(93, vitessResultSetMetadata.getColumnType(13));
-        Assert.assertEquals(91, vitessResultSetMetadata.getColumnType(14));
-        Assert.assertEquals(92, vitessResultSetMetadata.getColumnType(15));
-        Assert.assertEquals(93, vitessResultSetMetadata.getColumnType(16));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(17));
-        Assert.assertEquals(3, vitessResultSetMetadata.getColumnType(18));
-        Assert.assertEquals(12, vitessResultSetMetadata.getColumnType(19));
-        Assert.assertEquals(2004, vitessResultSetMetadata.getColumnType(20));
-        Assert.assertEquals(12, vitessResultSetMetadata.getColumnType(21));
-        Assert.assertEquals(-3, vitessResultSetMetadata.getColumnType(22));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(23));
-        Assert.assertEquals(-2, vitessResultSetMetadata.getColumnType(24));
-        Assert.assertEquals(-7, vitessResultSetMetadata.getColumnType(25));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(26));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(27));
-        try {
-            int type = vitessResultSetMetadata.getColumnType(28);
-        } catch (SQLException ex) {
-            Assert
-                .assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE, ex.getMessage());
-        }
-
-        try {
-            int type = vitessResultSetMetadata.getColumnType(0);
-        } catch (SQLException ex) {
-            Assert.assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_INDEX + ": " + 0,
-                ex.getMessage());
-        }
-    }
-
-    @Test public void testgetColumnLabel() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetaData.getColumnCount(); i++) {
-            Assert.assertEquals("col" + i, vitessResultSetMetaData.getColumnLabel(i));
-        }
-    }
-
-    @Test public void isReadOnlyTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
-            Assert.assertEquals(vitessResultSetMetadata.isReadOnly(i), false);
-            Assert.assertEquals(vitessResultSetMetadata.isWritable(i), true);
-            Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(i), true);
-        }
-    }
-
-    @Test public void getColumnClassNameTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
-            Assert.assertEquals(vitessResultSetMetadata.getColumnClassName(i), null);
-        }
-    }
-
     @Test public void getSchemaNameTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getTableName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getCatalogName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getPrecision(1), 0);
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(getVitessConnection(), fieldList);
+        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), "");
+        Assert.assertEquals(vitessResultSetMetaData.getCatalogName(1), "");
+        Assert.assertEquals(vitessResultSetMetaData.getPrecision(1), 3);
         Assert.assertEquals(vitessResultSetMetaData.getScale(1), 0);
-        Assert.assertEquals(vitessResultSetMetaData.getColumnDisplaySize(1), 0);
+        Assert.assertEquals(vitessResultSetMetaData.getColumnDisplaySize(1), 4);
         Assert.assertEquals(vitessResultSetMetaData.isCurrency(1), false);
+    }
+
+    @Test public void testCaseSensitivity() throws SQLException {
+        VitessConnection connection = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(connection);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(connection, fieldList);
+
+        // numeric types and date types are not case sensitive
+        Assert.assertEquals("int8 case sensitivity", false, md.isCaseSensitive(1));
+        Assert.assertEquals("uint8 case sensitivity", false, md.isCaseSensitive(2));
+        Assert.assertEquals("int16 case sensitivity", false, md.isCaseSensitive(3));
+        Assert.assertEquals("uint16 case sensitivity", false, md.isCaseSensitive(4));
+        Assert.assertEquals("int24 case sensitivity", false, md.isCaseSensitive(5));
+        Assert.assertEquals("uint24 case sensitivity", false, md.isCaseSensitive(6));
+        Assert.assertEquals("int32 case sensitivity", false, md.isCaseSensitive(7));
+        Assert.assertEquals("uint32 case sensitivity", false, md.isCaseSensitive(8));
+        Assert.assertEquals("int64 case sensitivity", false, md.isCaseSensitive(9));
+        Assert.assertEquals("uint64 case sensitivity", false, md.isCaseSensitive(10));
+        Assert.assertEquals("float32 case sensitivity", false, md.isCaseSensitive(11));
+        Assert.assertEquals("float64 case sensitivity", false, md.isCaseSensitive(12));
+        Assert.assertEquals("timestamp case sensitivity", false, md.isCaseSensitive(13));
+        Assert.assertEquals("date case sensitivity", false, md.isCaseSensitive(14));
+        Assert.assertEquals("time case sensitivity", false, md.isCaseSensitive(15));
+        Assert.assertEquals("datetime case sensitivity", false, md.isCaseSensitive(16));
+        Assert.assertEquals("year case sensitivity", false, md.isCaseSensitive(17));
+        Assert.assertEquals("decimal case sensitivity", false, md.isCaseSensitive(18));
+
+        // These are handled on a case-by-case basis
+        Assert.assertEquals("text cases sensitivity", /* due to binary */true, md.isCaseSensitive(19));
+        Assert.assertEquals("blob case sensitivity", /* due to binary */true, md.isCaseSensitive(20));
+        Assert.assertEquals("varchar case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(21));
+        Assert.assertEquals("varbinary case sensitivity", /* due to binary */true, md.isCaseSensitive(22));
+        Assert.assertEquals("char case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(23));
+        Assert.assertEquals("binary case sensitivity", /* due to binary */true, md.isCaseSensitive(24));
+        Assert.assertEquals("bit case sensitivity", /* due to numeric type */false, md.isCaseSensitive(25));
+        Assert.assertEquals("enum case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(26));
+        Assert.assertEquals("set case sensitivity", /* due to utf-8_ci, SET == CHAR */ false, md.isCaseSensitive(27));
+        Assert.assertEquals("tuple case sensitivity", /* due to default case */ true, md.isCaseSensitive(28));
+        Assert.assertEquals("varbinary case sensitivity", /* due to binary */ true, md.isCaseSensitive(29));
+        Assert.assertEquals("text cases sensitivity", /* due to utf8_bin (not case insensitive) encoding */false, md.isCaseSensitive(30));
+
+        connection.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        // with limited included fields, we can really only know about numeric types -- those should return false.  the rest should return true
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - non-numeric case insensitive due to lack of included fields", i >= 18 && i != 24, md.isCaseSensitive(i + 1));
+        }
+    }
+
+    @Test public void testIsNullable() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(conn, fieldList);
+
+        Assert.assertEquals("NOT_NULL flag means 0 value for isNullable", 0, md.isNullable(1));
+
+        for (int i = 1; i < fieldList.size(); i++) {
+            Assert.assertEquals("lack of NOT_NULL flag means 2 value for isNullable", 2, md.isNullable(i + 1));
+        }
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - isNullable is 0 for all when lack of included fields", 0, md.isNullable(i + 1));
+        }
+    }
+
+    @Test public void testDisplaySize() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(conn, fieldList);
+
+        Assert.assertEquals("int8 display size", 4, md.getColumnDisplaySize(1));
+        Assert.assertEquals("uint8 display size", 3, md.getColumnDisplaySize(2));
+        Assert.assertEquals("int16 display size", 6, md.getColumnDisplaySize(3));
+        Assert.assertEquals("uint16 display size", 5, md.getColumnDisplaySize(4));
+        Assert.assertEquals("int24 display size", 9, md.getColumnDisplaySize(5));
+        Assert.assertEquals("uint24 display size", 8, md.getColumnDisplaySize(6));
+        Assert.assertEquals("int32 display size", 11, md.getColumnDisplaySize(7));
+        Assert.assertEquals("uint32 display size", 10, md.getColumnDisplaySize(8));
+        Assert.assertEquals("int64 display size", 20, md.getColumnDisplaySize(9));
+        // unsigned long gets an extra digit of precision over signed, so display sizes are the same
+        Assert.assertEquals("uint64 display size", 20, md.getColumnDisplaySize(10));
+        Assert.assertEquals("float32 display size", 12, md.getColumnDisplaySize(11));
+        Assert.assertEquals("float64 display size", 22, md.getColumnDisplaySize(12));
+        Assert.assertEquals("timestamp display size", 10, md.getColumnDisplaySize(13));
+        Assert.assertEquals("date display size", 10, md.getColumnDisplaySize(14));
+        Assert.assertEquals("time display size", 10, md.getColumnDisplaySize(15));
+        Assert.assertEquals("datetime display size", 19, md.getColumnDisplaySize(16));
+        Assert.assertEquals("year display size", 4, md.getColumnDisplaySize(17));
+        Assert.assertEquals("decimal display size", 7, md.getColumnDisplaySize(18));
+        Assert.assertEquals("text display size", 255, md.getColumnDisplaySize(19));
+        Assert.assertEquals("blob display size", 65535, md.getColumnDisplaySize(20));
+        Assert.assertEquals("varchar display size", 256, md.getColumnDisplaySize(21));
+        Assert.assertEquals("varbinary display size", 256, md.getColumnDisplaySize(22));
+        Assert.assertEquals("char display size", 16, md.getColumnDisplaySize(23));
+        Assert.assertEquals("binary display size", 4, md.getColumnDisplaySize(24));
+        Assert.assertEquals("bit display size", 8, md.getColumnDisplaySize(25));
+        Assert.assertEquals("enum display size", 1, md.getColumnDisplaySize(26));
+        Assert.assertEquals("set display size", 3, md.getColumnDisplaySize(27));
+        Assert.assertEquals("tuple display size", 0, md.getColumnDisplaySize(28));
+        Assert.assertEquals("varbinary display size", 256, md.getColumnDisplaySize(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getColumnDisplaySize is 0 for all when lack of included fields", 0, md.getColumnDisplaySize(i + 1));
+        }
+    }
+
+    @Test public void testGetPrecision() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(conn, fieldList);
+
+        Assert.assertEquals("int8 precision", 3, md.getPrecision(1));
+        Assert.assertEquals("uint8 precision", 3, md.getPrecision(2));
+        Assert.assertEquals("int16 precision", 5, md.getPrecision(3));
+        Assert.assertEquals("uint16 precision", 5, md.getPrecision(4));
+        Assert.assertEquals("int24 precision", 8, md.getPrecision(5));
+        Assert.assertEquals("uint24 precision", 8, md.getPrecision(6));
+        Assert.assertEquals("int32 precision", 10, md.getPrecision(7));
+        Assert.assertEquals("uint32 precision", 10, md.getPrecision(8));
+        Assert.assertEquals("int64 precision", 19, md.getPrecision(9));
+        Assert.assertEquals("uint64 precision", 20, md.getPrecision(10));
+        Assert.assertEquals("float32 precision", 12, md.getPrecision(11));
+        Assert.assertEquals("float64 precision", 22, md.getPrecision(12));
+        Assert.assertEquals("timestamp precision", 10, md.getPrecision(13));
+        Assert.assertEquals("date precision", 10, md.getPrecision(14));
+        Assert.assertEquals("time precision", 10, md.getPrecision(15));
+        Assert.assertEquals("datetime precision", 19, md.getPrecision(16));
+        Assert.assertEquals("year precision", 4, md.getPrecision(17));
+        Assert.assertEquals("decimal precision", 5, md.getPrecision(18)); // 7 - decimal - sign
+        Assert.assertEquals("text precision", 255, md.getPrecision(19));
+        Assert.assertEquals("blob precision", 65535, md.getPrecision(20));
+        Assert.assertEquals("varchar precision", 256, md.getPrecision(21));
+        Assert.assertEquals("varbinary precision", 256, md.getPrecision(22));
+        Assert.assertEquals("char precision", 16, md.getPrecision(23));
+        Assert.assertEquals("binary precision", 4, md.getPrecision(24));
+        Assert.assertEquals("bit precision", 8, md.getPrecision(25));
+        Assert.assertEquals("enum precision", 1, md.getPrecision(26));
+        Assert.assertEquals("set precision", 3, md.getPrecision(27));
+        Assert.assertEquals("tuple precision", 0, md.getPrecision(28));
+        Assert.assertEquals("varbinary precision", 256, md.getPrecision(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getPrecision is 0 for all when lack of included fields", 0, md.getPrecision(i + 1));
+        }
+    }
+
+    @Test public void testGetScale() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(conn, fieldList);
+
+        Assert.assertEquals("int8 precision", 0, md.getScale(1));
+        Assert.assertEquals("uint8 precision", 0, md.getScale(2));
+        Assert.assertEquals("int16 precision", 0, md.getScale(3));
+        Assert.assertEquals("uint16 precision", 0, md.getScale(4));
+        Assert.assertEquals("int24 precision", 0, md.getScale(5));
+        Assert.assertEquals("uint24 precision", 0, md.getScale(6));
+        Assert.assertEquals("int32 precision", 0, md.getScale(7));
+        Assert.assertEquals("uint32 precision", 0, md.getScale(8));
+        Assert.assertEquals("int64 precision", 0, md.getScale(9));
+        Assert.assertEquals("uint64 precision", 0, md.getScale(10));
+        Assert.assertEquals("float32 precision", 31, md.getScale(11));
+        Assert.assertEquals("float64 precision", 31, md.getScale(12));
+        Assert.assertEquals("timestamp precision", 0, md.getScale(13));
+        Assert.assertEquals("date precision", 0, md.getScale(14));
+        Assert.assertEquals("time precision", 0, md.getScale(15));
+        Assert.assertEquals("datetime precision", 0, md.getScale(16));
+        Assert.assertEquals("year precision",  0, md.getScale(17));
+        Assert.assertEquals("decimal precision", 2, md.getScale(18));
+        Assert.assertEquals("text precision", 0, md.getScale(19));
+        Assert.assertEquals("blob precision", 0, md.getScale(20));
+        Assert.assertEquals("varchar precision", 0, md.getScale(21));
+        Assert.assertEquals("varbinary precision", 0, md.getScale(22));
+        Assert.assertEquals("char precision", 0, md.getScale(23));
+        Assert.assertEquals("binary precision", 0, md.getScale(24));
+        Assert.assertEquals("bit precision", 0, md.getScale(25));
+        Assert.assertEquals("enum precision", 0, md.getScale(26));
+        Assert.assertEquals("set precision", 0, md.getScale(27));
+        Assert.assertEquals("tuple precision", 0, md.getScale(28));
+        Assert.assertEquals("varbinary precision", 0, md.getScale(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getScale is 0 for all when lack of included fields", 0, md.getScale(i + 1));
+        }
+    }
+
+    @Test public void testGetColumnClassName() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(conn, fieldList);
+
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(1));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(2));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(3));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(4));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(5));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(6));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(7));
+        Assert.assertEquals("java.lang.Long", md.getColumnClassName(8));
+        Assert.assertEquals("java.lang.Long", md.getColumnClassName(9));
+        Assert.assertEquals("java.math.BigInteger", md.getColumnClassName(10));
+        Assert.assertEquals("java.lang.Double", md.getColumnClassName(11));
+        Assert.assertEquals("java.lang.Double", md.getColumnClassName(12));
+        Assert.assertEquals("java.sql.Timestamp", md.getColumnClassName(13));
+        Assert.assertEquals("java.sql.Date", md.getColumnClassName(14));
+        Assert.assertEquals("java.sql.Time", md.getColumnClassName(15));
+        Assert.assertEquals("java.sql.Timestamp", md.getColumnClassName(16));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(17));
+        Assert.assertEquals("java.math.BigDecimal", md.getColumnClassName(18));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(19));
+        Assert.assertEquals("[B", md.getColumnClassName(20));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(21));
+        Assert.assertEquals("[B", md.getColumnClassName(22));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(23));
+        Assert.assertEquals("[B", md.getColumnClassName(24));
+        Assert.assertEquals("java.lang.Boolean", md.getColumnClassName(25));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(26));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(27));
+        Assert.assertEquals("java.lang.Object", md.getColumnClassName(28));
+        Assert.assertEquals("[B", md.getColumnClassName(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - class name is null when no included fields", null, md.getColumnClassName(i + 1));
+        }
+    }
+
+    /**
+     * Some of the tests above verify that their particular part honors the IncludedFields.ALL value, but
+     * this further verifies that when someone has disabled ALL, the values returned by the driver are basically the same
+     * as what they used to be before we supported returning all fields.
+     */
+    @Test public void testDefaultValuesWithoutIncludedFields() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        List<FieldWithMetadata> fields = getFieldList(conn);
+        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(conn, fields);
+
+        for (int i = 1; i < fields.size() + 1; i++) {
+            FieldWithMetadata field = fields.get(i - 1);
+            Assert.assertEquals(false, vitessResultSetMetaData.isAutoIncrement(i));
+
+            boolean shouldBeSensitive = true;
+            switch (field.getJavaType()) {
+                case Types.BIT:
+                case Types.TINYINT:
+                case Types.SMALLINT:
+                case Types.INTEGER:
+                case Types.BIGINT:
+                case Types.FLOAT:
+                case Types.REAL:
+                case Types.DOUBLE:
+                case Types.DATE:
+                case Types.DECIMAL:
+                case Types.NUMERIC:
+                case Types.TIME:
+                case Types.TIMESTAMP:
+                    shouldBeSensitive = false;
+                    break;
+            }
+
+            Assert.assertEquals(shouldBeSensitive, vitessResultSetMetaData.isCaseSensitive(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isSearchable(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isCurrency(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.isNullable(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isSigned(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getColumnDisplaySize(i));
+            Assert.assertEquals(field.getName(), field.getName(), vitessResultSetMetaData.getColumnLabel(i));
+            Assert.assertEquals(field.getName(), field.getName(), vitessResultSetMetaData.getColumnName(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getPrecision(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getScale(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getTableName(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getCatalogName(i));
+            // These two do not depend on IncludedFields and are covered by tests above
+            //Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnType(i));
+            //Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnTypeName(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isReadOnly(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isWritable(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isDefinitelyWritable(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnClassName(i));
+        }
     }
 }
 

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
@@ -1,12 +1,21 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessResultSet;
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.StringUtils;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.SimpleCursor;
 import com.youtube.vitess.proto.Query;
+
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -18,7 +27,9 @@ import java.sql.Timestamp;
 /**
  * Created by harshit.gangal on 19/01/16.
  */
-public class VitessResultSetTest {
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(VitessResultSet.class)
+public class VitessResultSetTest extends BaseTest {
 
     public Cursor getCursorWithRows() {
         /*
@@ -199,20 +210,20 @@ public class VitessResultSetTest {
             .addFields(Query.Field.newBuilder().setName("col1").build())
             .addFields(Query.Field.newBuilder().setName("col2").build()).build());
 
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         Assert.assertEquals(false, vitessResultSet.next());
     }
 
     @Test public void testNextWithNonZeroRows() throws Exception {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         Assert.assertEquals(true, vitessResultSet.next());
         Assert.assertEquals(false, vitessResultSet.next());
     }
 
     @Test public void testgetString() throws SQLException {
         Cursor cursor = getCursorWithRowsAsNull();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals("-50", vitessResultSet.getString(1));
         Assert.assertEquals("50", vitessResultSet.getString(2));
@@ -246,11 +257,11 @@ public class VitessResultSetTest {
     @Test public void testgetBoolean() throws SQLException {
         Cursor cursor = getCursorWithRows();
         Cursor cursorWithRowsAsNull = getCursorWithRowsAsNull();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(true, vitessResultSet.getBoolean(25));
         Assert.assertEquals(false, vitessResultSet.getBoolean(1));
-        vitessResultSet = new VitessResultSet(cursorWithRowsAsNull);
+        vitessResultSet = new VitessResultSet(getVitessConnection(), cursorWithRowsAsNull);
         vitessResultSet.next();
         Assert.assertEquals(false, vitessResultSet.getBoolean(25));
         Assert.assertEquals(false, vitessResultSet.getBoolean(1));
@@ -258,7 +269,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetByte() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte(1));
         Assert.assertEquals(1, vitessResultSet.getByte(25));
@@ -266,42 +277,42 @@ public class VitessResultSetTest {
 
     @Test public void testgetShort() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-23000, vitessResultSet.getShort(3));
     }
 
     @Test public void testgetInt() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-100, vitessResultSet.getInt(7));
     }
 
     @Test public void testgetLong() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-1000, vitessResultSet.getInt(9));
     }
 
     @Test public void testgetFloat() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(24.52f, vitessResultSet.getFloat(11), 0.001);
     }
 
     @Test public void testgetDouble() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(100.43, vitessResultSet.getFloat(12), 0.001);
     }
 
     @Test public void testBigDecimal() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new BigDecimal(BigInteger.valueOf(123456789), 5),
             vitessResultSet.getBigDecimal(18));
@@ -309,28 +320,28 @@ public class VitessResultSetTest {
 
     @Test public void testgetBytes() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertArrayEquals("HELLO TDS TEAM".getBytes("UTF-8"), vitessResultSet.getBytes(19));
     }
 
     @Test public void testgetDate() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new java.sql.Date(116, 1, 6), vitessResultSet.getDate(14));
     }
 
     @Test public void testgetTime() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new Time(12, 34, 56), vitessResultSet.getTime(15));
     }
 
     @Test public void testgetTimestamp() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new Timestamp(116, 1, 6, 14, 15, 16, 0),
             vitessResultSet.getTimestamp(13));
@@ -338,7 +349,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetStringbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals("-50", vitessResultSet.getString("col1"));
         Assert.assertEquals("50", vitessResultSet.getString("col2"));
@@ -371,7 +382,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetBooleanbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(true, vitessResultSet.getBoolean("col25"));
         Assert.assertEquals(false, vitessResultSet.getBoolean("col1"));
@@ -379,7 +390,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetBytebyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte("col1"));
         Assert.assertEquals(1, vitessResultSet.getByte("col25"));
@@ -387,42 +398,42 @@ public class VitessResultSetTest {
 
     @Test public void testgetShortbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-23000, vitessResultSet.getShort("col3"));
     }
 
     @Test public void testgetIntbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-100, vitessResultSet.getInt("col7"));
     }
 
     @Test public void testgetLongbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(-1000, vitessResultSet.getInt("col9"));
     }
 
     @Test public void testgetFloatbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(24.52f, vitessResultSet.getFloat("col11"), 0.001);
     }
 
     @Test public void testgetDoublebyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(100.43, vitessResultSet.getFloat("col12"), 0.001);
     }
 
     @Test public void testBigDecimalbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new BigDecimal(BigInteger.valueOf(123456789), 5),
             vitessResultSet.getBigDecimal("col18"));
@@ -431,7 +442,7 @@ public class VitessResultSetTest {
     @Test public void testgetBytesbyColumnLabel()
         throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertArrayEquals("HELLO TDS TEAM".getBytes("UTF-8"),
             vitessResultSet.getBytes("col19"));
@@ -439,14 +450,14 @@ public class VitessResultSetTest {
 
     @Test public void testgetDatebyColumnLabel() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new java.sql.Date(116, 1, 6), vitessResultSet.getDate("col14"));
     }
 
     @Test public void testgetTimebyColumnLabel() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new Time(12, 34, 56), vitessResultSet.getTime("col15"));
     }
@@ -454,7 +465,7 @@ public class VitessResultSetTest {
     @Test public void testgetTimestampbyColumnLabel()
         throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         Assert.assertEquals(new Timestamp(116, 1, 6, 14, 15, 16, 0),
             vitessResultSet.getTimestamp("col13"));
@@ -462,11 +473,232 @@ public class VitessResultSetTest {
 
     @Test public void testgetAsciiStream() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
         vitessResultSet.next();
         // Need to implement AssertEquivalant
         //Assert.assertEquals((InputStream)(new ByteArrayInputStream("HELLO TDS TEAM".getBytes())), vitessResultSet
         // .getAsciiStream(19));
     }
 
+    @Test public void testEnhancedFieldsFromCursor() throws Exception {
+        Cursor cursor = getCursorWithRows();
+        VitessResultSet vitessResultSet = new VitessResultSet(getVitessConnection(), cursor);
+        Assert.assertEquals(cursor.getFields().size(), vitessResultSet.getFields().size());
+    }
+
+    @Test public void testGetStringUsesEncoding() throws Exception {
+        VitessConnection conn = getVitessConnection();
+        VitessResultSet resultOne = PowerMockito.spy(new VitessResultSet(conn, getCursorWithRows()));
+        resultOne.next();
+        // test all ways to get to convertBytesToString
+
+        // Verify that we're going through convertBytesToString for column types that return bytes (string-like),
+        // but not for those that return a real object
+        resultOne.getString("col21"); // is a string, should go through convert bytes
+        resultOne.getString("col13"); // is a datetime, should not
+        PowerMockito.verifyPrivate(resultOne, VerificationModeFactory.times(1)).invoke("convertBytesToString", Matchers.any(byte[].class), Matchers.anyInt());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        VitessResultSet resultTwo = PowerMockito.spy(new VitessResultSet(conn, getCursorWithRows()));
+        resultTwo.next();
+
+        // neither of these should go through convertBytesToString, because we didn't include all fields
+        resultTwo.getString("col21");
+        resultTwo.getString("col13");
+        PowerMockito.verifyPrivate(resultTwo, VerificationModeFactory.times(0)).invoke("convertBytesToString", Matchers.any(byte[].class), Matchers.anyInt());
+    }
+
+    @Test public void testGetObjectForBitValues() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        ByteString.Output value = ByteString.newOutput();
+        value.write(new byte[] {1});
+        value.write(new byte[] {0});
+        value.write(new byte[] {1,2,3,4});
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            .addFields(Query.Field.newBuilder().setName("col1").setColumnLength(1).setType(Query.Type.BIT))
+            .addFields(Query.Field.newBuilder().setName("col2").setColumnLength(1).setType(Query.Type.BIT))
+            .addFields(Query.Field.newBuilder().setName("col3").setColumnLength(4).setType(Query.Type.BIT))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(1)
+                .addLengths(1)
+                .addLengths(4)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        Assert.assertEquals(true, vitessResultSet.getObject(1));
+        Assert.assertEquals(false, vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(new byte[] {1,2,3,4}, (byte[]) vitessResultSet.getObject(3));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(3)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        Assert.assertArrayEquals(new byte[] { 1 }, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(new byte[] { 0 }, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(new byte[] {1,2,3,4}, (byte[]) vitessResultSet.getObject(3));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+    }
+
+    @Test public void testGetObjectForVarBinLikeValues() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        ByteString.Output value = ByteString.newOutput();
+
+        byte[] binary = new byte[] {1,2,3,4};
+        byte[] varbinary = new byte[] {1,2,3,4,5,6,7,8,9,10,11,12,13};
+        byte[] blob = new byte[MysqlDefs.LENGTH_BLOB];
+        for (int i = 0; i < blob.length; i++) {
+            blob[i] = 1;
+        }
+        byte[] fakeGeometry = new byte[] {2,3,4};
+
+        value.write(binary);
+        value.write(varbinary);
+        value.write(blob);
+        value.write(fakeGeometry);
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            .addFields(Query.Field.newBuilder().setName("col1")
+                .setColumnLength(4)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.BINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(13)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.VARBINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addFields(Query.Field.newBuilder().setName("col3") // should go to LONGVARBINARY due to below settings
+                .setColumnLength(MysqlDefs.LENGTH_BLOB)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+                .setType(Query.Type.BLOB))
+            .addFields(Query.Field.newBuilder().setName("col4")
+                .setType(Query.Type.GEOMETRY)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.BINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(4)
+                .addLengths(13)
+                .addLengths(MysqlDefs.LENGTH_BLOB)
+                .addLengths(3)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        // All of these types should pass straight through, returning the direct bytes
+        Assert.assertArrayEquals(binary, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varbinary, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(blob, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(fakeGeometry, (byte[]) vitessResultSet.getObject(4));
+
+        // We should still call the function 4 times
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(4)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        // Same as above since this doesn't really do much but pass right through for the varbinary type
+        Assert.assertArrayEquals(binary, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varbinary, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(blob, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(fakeGeometry, (byte[]) vitessResultSet.getObject(4));
+
+        // Never call because not including all
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+    }
+
+    @Test public void testGetObjectForStringLikeValues() throws Exception {
+        ByteString.Output value = ByteString.newOutput();
+
+        String trimmedCharStr = "wasting space";
+        String varcharStr = "i have a variable length!";
+        String masqueradingBlobStr = "look at me, im a blob";
+        String textStr = "an enthralling string of TEXT in some foreign language";
+
+        int paddedCharColLength = 20;
+        byte[] trimmedChar = StringUtils.getBytes(trimmedCharStr, "UTF-16");
+        byte[] varchar = StringUtils.getBytes(varcharStr, "UTF-8");
+        byte[] masqueradingBlob = StringUtils.getBytes(masqueradingBlobStr, "US-ASCII");
+        byte[] text = StringUtils.getBytes(textStr, "ISO8859_8");
+        byte[] opaqueBinary = new byte[] { 1,2,3,4,5,6,7,8,9};
+
+        value.write(trimmedChar);
+        value.write(varchar);
+        value.write(opaqueBinary);
+        value.write(masqueradingBlob);
+        value.write(text);
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            // This tests CHAR
+            .addFields(Query.Field.newBuilder().setName("col1")
+                .setColumnLength(paddedCharColLength)
+                .setCharset(/* utf-16 collation index from CharsetMapping */ 54)
+                .setType(Query.Type.CHAR))
+            // This tests VARCHAR
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(varchar.length)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_utf8)
+                .setType(Query.Type.VARCHAR))
+            // This tests VARCHAR that is an opaque binary
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(opaqueBinary.length)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+                .setType(Query.Type.VARCHAR))
+            // This tests LONGVARCHAR
+            .addFields(Query.Field.newBuilder().setName("col3")
+                .setColumnLength(masqueradingBlob.length)
+                .setCharset(/* us-ascii collation index from CharsetMapping */11)
+                .setType(Query.Type.BLOB))
+            // This tests TEXT, which falls through the default case of the switch
+            .addFields(Query.Field.newBuilder().setName("col4")
+                .setColumnLength(text.length)
+                .setCharset(/* corresponds to greek, from CharsetMapping */25)
+                .setType(Query.Type.TEXT))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(trimmedChar.length)
+                .addLengths(varchar.length)
+                .addLengths(opaqueBinary.length)
+                .addLengths(masqueradingBlob.length)
+                .addLengths(text.length)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessConnection conn = getVitessConnection();
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        Assert.assertEquals(trimmedCharStr, vitessResultSet.getObject(1));
+        Assert.assertEquals(varcharStr, vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(opaqueBinary, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertEquals(masqueradingBlobStr, vitessResultSet.getObject(4));
+        Assert.assertEquals(textStr, vitessResultSet.getObject(5));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(5)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(conn, new SimpleCursor(result)));
+        vitessResultSet.next();
+
+        Assert.assertArrayEquals(trimmedChar, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varchar, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(opaqueBinary, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(masqueradingBlob, (byte[]) vitessResultSet.getObject(4));
+        Assert.assertArrayEquals(text, (byte[]) vitessResultSet.getObject(5));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.anyInt());
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessStatementTest.java
@@ -1,7 +1,5 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessConnection;
-import com.flipkart.vitess.jdbc.VitessStatement;
 import com.flipkart.vitess.util.Constants;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.SQLFuture;
@@ -12,6 +10,7 @@ import com.youtube.vitess.client.cursor.CursorWithError;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata;
 import com.youtube.vitess.proto.Vtrpc;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,19 +74,20 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -145,19 +145,19 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .streamExecute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.STREAM);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -216,17 +216,17 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -288,28 +288,29 @@ import java.util.List;
         Cursor mockCursor = PowerMockito.mock(Cursor.class);
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         SQLFuture mockSqlFutureVtGateTx = PowerMockito.mock(SQLFuture.class);
-        List<Query.Field> mockFieldList = PowerMockito.mock(ArrayList.class);
+        List<Query.Field> mockFieldList = PowerMockito.spy(new ArrayList<Query.Field>());
 
         PowerMockito.when(mockConn.getKeyspace()).thenReturn("test_keyspace");
         PowerMockito.when(mockConn.getVtGateConn()).thenReturn(mockVtGateConn);
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
 
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getAutoCommit()).thenReturn(true);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureCursor);
 
@@ -322,7 +323,9 @@ import java.util.List;
 
             int fieldSize = 5;
             PowerMockito.when(mockCursor.getFields()).thenReturn(mockFieldList);
-            PowerMockito.when(mockFieldList.size()).thenReturn(fieldSize);
+            PowerMockito.doReturn(fieldSize).when(mockFieldList).size();
+            PowerMockito.doReturn(false).when(mockFieldList).isEmpty();
+
             boolean hasResultSet = statement.execute(sqlSelect);
             Assert.assertTrue(hasResultSet);
             Assert.assertNotNull(statement.getResultSet());
@@ -332,7 +335,7 @@ import java.util.List;
             Assert.assertNotNull(statement.getResultSet());
 
             int mockUpdateCount = 10;
-            PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+            PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
             PowerMockito.when(mockCursor.getRowsAffected()).thenReturn((long) mockUpdateCount);
             hasResultSet = statement.execute(sqlUpdate);
             Assert.assertFalse(hasResultSet);
@@ -365,9 +368,9 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFuture);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFuture);
         PowerMockito.when(mockSqlFuture.checkedGet()).thenReturn(mockCursor);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -388,7 +391,7 @@ import java.util.List;
             Assert.assertEquals(-1, statement.getUpdateCount());
 
         } catch (SQLException e) {
-            Assert.fail("Test failed " + e.getMessage());
+            throw e;
         }
     }
 
@@ -402,9 +405,10 @@ import java.util.List;
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.REPLICA);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
 
         VitessStatement statement = new VitessStatement(mockConn);
@@ -418,7 +422,7 @@ import java.util.List;
                 Assert.assertEquals("Statement is closed", ex.getMessage());
             }
         } catch (SQLException e) {
-            Assert.fail("Test failed " + e.getMessage());
+            throw e;
         }
     }
 
@@ -527,17 +531,17 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
 
         VitessStatement statement = new VitessStatement(mockConn);
@@ -632,7 +636,7 @@ import java.util.List;
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         PowerMockito.when(mockVtGateConn
             .executeBatch(Matchers.any(Context.class), Matchers.anyList(), Matchers.anyList(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
 
         List<CursorWithError> mockCursorWithErrorList = new ArrayList<>();
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursorWithErrorList);


### PR DESCRIPTION
JDBC-side support for the newly introduced IncludedFields execute option. When set to
IncludedFields.ALL, enables the decoding of bytes to string using the charset passed from
MySQL. Also adds support for other metadata such as table name, precision, scale, etc.

* The new decoding code piggybacks on the existing parsing that the java client Row class does -- we still call through to `this.row.getObject()`, and only handle decoding of results that are `byte[]` in the JDBC.

* Implementation details were pulled from or modeled after the mysql-connector-j JDBC implementation and simplified to work within the constructs of the vitess-returned responses. For instance, the FieldWithMetadata constructor will look slightly similar to the Field.java in mysql-connector-j. This code is heavily tested in FieldWithMetadataTest.java.

In order to facilitate the various ways one might interpret these charsets, adds more
robust configuration parsing through a ConnectionProperties class. VitessJDBCUrl is used
to parse the URL and pass configurations into the Properties, for access from ConnectionProperties

* A few functional changes happened with this move, which are reflected in the new tests. Primarily, the property parsing no longer influences the passed in Properties object from `Driver.connect()`. Instead we make a copy, and use that for our `VitessConnection`.

Ample testing added to all new features, including testing to ensure that when IncludedFields is
not set to ALL, the return values remain similar to what they used to be.

The new classes in the `com.flipkart.vitess.util.charset` package are pulled from the mysql-connector-j current version, the only changes I made were not functional -- just removing of code that we don't need for this implementation.

There is further work we could do in the future with this foundation in place:

- Support dynamic/custom charsets by querying the server for `SHOW COLLATION` like the standard mysql jdbc does
- Move more of the parsing code from the `Row` class into the JDBC implementation, to get closer parity with mysql on how encoding/decoding of things like timestamps, numbers, etc are made.