### PR TITLE
update docs to reflect that shard keyranges can be > 1 byte

### DIFF
--- a/doc/Sharding.md
+++ b/doc/Sharding.md
@@ -96,6 +96,7 @@ Start=[], End=[]: Full Key Range
 Start=[], End=[0x80]: Lower half of the Key Range.
 Start=[0x80], End=[]: Upper half of the Key Range.
 Start=[0x40], End=[0x80]: Second quarter of the Key Range.
+Start=[0xFF00], End=[0xFF80]: Second to last 1/512th of the Key Range.
 ```
 
 Two key ranges are consecutive if the end value of one range equals the
@@ -116,6 +117,14 @@ full partition:
 * 40-80
 * 80-c0
 * c0-
+
+Shards do not need to handle the same size portion of the key space. For example, the following five shards would also be a valid full partition, albeit with a highly uneven distribution of keys.
+
+* -80
+* 80-c0
+* c0-dc00
+* dc00-dc80
+* dc80-
 
 ## Resharding
 

--- a/docs/reference/vitess-api.html
+++ b/docs/reference/vitess-api.html
@@ -2032,16 +2032,44 @@
 </tr>
 </thead><tbody>
 <tr>
-<td style="text-align: left"><code>exclude_field_names</code> <br>bool</td>
-<td style="text-align: left">If set, the resulting Field array won’t have a Name, just a Type. This is an optimization for high-QPS queries where the client knows what it&#39;s getting.</td>
-</tr>
-<tr>
 <td style="text-align: left"><code>include_event_token</code> <br>bool</td>
-<td style="text-align: left">If set, we will try to include an EventToken with the responses.</td>
+<td style="text-align: left">This used to be exclude_field_names, which was replaced by IncludedFields enum below If set, we will try to include an EventToken with the responses.</td>
 </tr>
 <tr>
 <td style="text-align: left"><code>compare_event_token</code> <br><a href="#query.eventtoken">EventToken</a></td>
 <td style="text-align: left">EventToken is a structure that describes a point in time in a replication stream on one shard. The most recent known replication position can be retrieved from vttablet when executing a query. It is also sent with the replication streams from the binlog service.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>included_fields</code> <br><a href="#executeoptions.includedfields">IncludedFields</a></td>
+<td style="text-align: left">Controls what fields are returned in Field message responses from mysql, i.e. field name, table name, etc. This is an optimization for high-QPS queries where the client knows what it&#39;s getting</td>
+</tr>
+</tbody></table>
+
+<h4 id="enums">Enums</h4>
+
+<h5 id="executeoptions-includedfields">ExecuteOptions.IncludedFields</h5>
+
+<table><thead>
+<tr>
+<th style="text-align: left">Name</th>
+<th style="text-align: left">Value</th>
+<th style="text-align: left">Description</th>
+</tr>
+</thead><tbody>
+<tr>
+<td style="text-align: left"><code>TYPE_AND_NAME</code></td>
+<td style="text-align: left"><code>0</code></td>
+<td style="text-align: left"></td>
+</tr>
+<tr>
+<td style="text-align: left"><code>TYPE_ONLY</code></td>
+<td style="text-align: left"><code>1</code></td>
+<td style="text-align: left"></td>
+</tr>
+<tr>
+<td style="text-align: left"><code>ALL</code></td>
+<td style="text-align: left"><code>2</code></td>
+<td style="text-align: left"></td>
 </tr>
 </tbody></table>
 
@@ -2064,6 +2092,38 @@
 <tr>
 <td style="text-align: left"><code>type</code> <br><a href="#query.type">Type</a></td>
 <td style="text-align: left">vitess-defined type. Conversion function is in sqltypes package.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>table</code> <br>string</td>
+<td style="text-align: left">Remaining fields from mysql C API. These fields are only populated when ExecuteOptions.included_fields is set to IncludedFields.ALL.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>org_table</code> <br>string</td>
+<td style="text-align: left"></td>
+</tr>
+<tr>
+<td style="text-align: left"><code>database</code> <br>string</td>
+<td style="text-align: left"></td>
+</tr>
+<tr>
+<td style="text-align: left"><code>org_name</code> <br>string</td>
+<td style="text-align: left"></td>
+</tr>
+<tr>
+<td style="text-align: left"><code>column_length</code> <br>uint32</td>
+<td style="text-align: left">column_length is really a uint32. All 32 bits can be used.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>charset</code> <br>uint32</td>
+<td style="text-align: left">charset is actually a uint16. Only the lower 16 bits are used.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>decimals</code> <br>uint32</td>
+<td style="text-align: left">decimals is actualy a uint8. Only the lower 8 bits are used.</td>
+</tr>
+<tr>
+<td style="text-align: left"><code>flags</code> <br>uint32</td>
+<td style="text-align: left">flags is actually a uint16. Only the lower 16 bits are used.</td>
 </tr>
 </tbody></table>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -22,25 +22,25 @@
     <loc>http://vitess.io/user-guide/horizontal-sharding.html</loc>
   </url>
   <url>
-    <loc>http://vitess.io/search/</loc>
-  </url>
-  <url>
-    <loc>http://vitess.io/about/</loc>
-  </url>
-  <url>
     <loc>http://vitess.io/overview/</loc>
   </url>
   <url>
-    <loc>http://vitess.io/contributing/</loc>
-  </url>
-  <url>
-    <loc>http://vitess.io/getting-started/</loc>
+    <loc>http://vitess.io/about/</loc>
   </url>
   <url>
     <loc>http://vitess.io/terms/</loc>
   </url>
   <url>
     <loc>http://vitess.io/</loc>
+  </url>
+  <url>
+    <loc>http://vitess.io/search/</loc>
+  </url>
+  <url>
+    <loc>http://vitess.io/getting-started/</loc>
+  </url>
+  <url>
+    <loc>http://vitess.io/contributing/</loc>
   </url>
   <url>
     <loc>http://vitess.io/user-guide/introduction.html</loc>

--- a/docs/user-guide/sharding.html
+++ b/docs/user-guide/sharding.html
@@ -380,6 +380,7 @@ value equal to or higher than 0x80 are assigned to the other shard.</p>
 <span class="nv">Start</span><span class="o">=[]</span>, <span class="nv">End</span><span class="o">=[</span>0x80<span class="o">]</span>: Lower half of the Key Range.
 <span class="nv">Start</span><span class="o">=[</span>0x80<span class="o">]</span>, <span class="nv">End</span><span class="o">=[]</span>: Upper half of the Key Range.
 <span class="nv">Start</span><span class="o">=[</span>0x40<span class="o">]</span>, <span class="nv">End</span><span class="o">=[</span>0x80<span class="o">]</span>: Second quarter of the Key Range.
+<span class="nv">Start</span><span class="o">=[</span>0xFF00<span class="o">]</span>, <span class="nv">End</span><span class="o">=[</span>0xFF80<span class="o">]</span>: Second to last 1/512th of the Key Range.
 </code></pre></div>
 <p>Two key ranges are consecutive if the end value of one range equals the
 start value of the other range.</p>
@@ -392,14 +393,16 @@ by a hyphen. For instance, if a shard&#39;s key range is the array of bytes
 beginning with [ 0x80 ] and ending, noninclusively, with [ 0xc0], then
 the shard&#39;s name is <code>80-c0</code>.</p>
 
-<p>Using this naming convention, the following four shards would be a valid
-full partition:</p>
+<p>Using this naming convention, the following six shards would be a valid
+full (albeit highly uneven) partition:</p>
 
 <ul>
 <li>-40</li>
 <li>40-80</li>
 <li>80-c0</li>
-<li>c0-</li>
+<li>c000-d0c0</li>
+<li>d0c0-d000</li>
+<li>d000-</li>
 </ul>
 
 <h2 id="resharding">Resharding</h2>

--- a/docs/user-guide/sharding.html
+++ b/docs/user-guide/sharding.html
@@ -393,16 +393,24 @@ by a hyphen. For instance, if a shard&#39;s key range is the array of bytes
 beginning with [ 0x80 ] and ending, noninclusively, with [ 0xc0], then
 the shard&#39;s name is <code>80-c0</code>.</p>
 
-<p>Using this naming convention, the following six shards would be a valid
-full (albeit highly uneven) partition:</p>
+<p>Using this naming convention, the following four shards would be a valid
+full partition:</p>
 
 <ul>
 <li>-40</li>
 <li>40-80</li>
 <li>80-c0</li>
-<li>c000-d0c0</li>
-<li>d0c0-d000</li>
-<li>d000-</li>
+<li>c0-</li>
+</ul>
+
+<p>Shards do not need to handle the same size portion of the key space. For example, the following five shards would also be a valid full partition, albeit with a highly uneven distribution of keys.</p>
+
+<ul>
+<li>-80</li>
+<li>80-c0</li>
+<li>c0-dc00</li>
+<li>dc00-dc80</li>
+<li>dc80-</li>
 </ul>
 
 <h2 id="resharding">Resharding</h2>


### PR DESCRIPTION
As discussed in the slack channel, I mistakenly that the shard keys needed to map to a single byte and hence a limit of 256 shards.

This PR updates the examples in the docs to show that key ranges can span more than one byte.
