### PR TITLE
test: Remove RunHealthCheck calls after vtworker commands.

### DIFF
--- a/test/automation_horizontal_resharding.py
+++ b/test/automation_horizontal_resharding.py
@@ -91,7 +91,7 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
         self, worker.shard_master,
         serving=False, tablet_control_disabled=True)
 
-    # dest shard -80: query service must be disabled after MigrateServedTypes.
+    # dest shard -80: query service must be enabled after MigrateServedTypes.
     utils.check_tablet_query_service(
         self, worker.shard_0_rdonly1,
         serving=True, tablet_control_disabled=False)
@@ -102,7 +102,7 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
         self, worker.shard_0_master,
         serving=True, tablet_control_disabled=False)
 
-    # dest shard 80-: query service must be disabled after MigrateServedTypes.
+    # dest shard 80-: query service must be enabled after MigrateServedTypes.
     utils.check_tablet_query_service(
         self, worker.shard_1_rdonly1,
         serving=True, tablet_control_disabled=False)

--- a/test/automation_horizontal_resharding.py
+++ b/test/automation_horizontal_resharding.py
@@ -80,27 +80,6 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
 
     # Check that query service is disabled (source shard) or enabled (dest).
 
-    # The 'rdonly' tablet requires an explicit healthcheck first because
-    # the following sequence of events is happening in this test:
-    # - SplitDiff returns 'rdonly' as 'spare' tablet (NOT_SERVING)
-    # - MigrateServedTypes runs and does not refresh then 'spare' tablet
-    #   (still NOT_SERVING)
-    #   Shard_TabletControl.DisableQueryService=true will be set in the topology
-    # - explicit or periodic healthcheck runs:
-    #   a) tablet seen as caught up, change type from 'spare' to 'rdonly'
-    #      (change to SERVING)
-    #   b) post-action callback agent.refreshTablet() reads the topology
-    #      and finds out that DisableQueryService=true is set.
-    #      (change to NOT_SERVING)
-    #
-    # We must run an explicit healthcheck or we can see one of the two states:
-    # - NOT_SERVING, DisableQueryService=false, tablet type 'spare'
-    #   (immediately after SplitDiff returned)
-    # - SERVING, DisableQueryService=false, tablet type 'rdonly'
-    #   (during healthcheck before post-action callback is called)
-    utils.run_vtctl(['RunHealthCheck', worker.shard_rdonly1.tablet_alias],
-                    auto_log=True)
-
     # source shard: query service must be disabled after MigrateServedTypes.
     utils.check_tablet_query_service(
         self, worker.shard_rdonly1,
@@ -113,9 +92,6 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
         serving=False, tablet_control_disabled=True)
 
     # dest shard -80: query service must be disabled after MigrateServedTypes.
-    # Run explicit healthcheck because 'rdonly' tablet may still be 'spare'.
-    utils.run_vtctl(['RunHealthCheck', worker.shard_0_rdonly1.tablet_alias],
-                    auto_log=True)
     utils.check_tablet_query_service(
         self, worker.shard_0_rdonly1,
         serving=True, tablet_control_disabled=False)
@@ -127,9 +103,6 @@ class TestAutomationHorizontalResharding(worker.TestBaseSplitClone):
         serving=True, tablet_control_disabled=False)
 
     # dest shard 80-: query service must be disabled after MigrateServedTypes.
-    # Run explicit healthcheck because 'rdonly' tablet is still 'spare'.
-    utils.run_vtctl(['RunHealthCheck', worker.shard_1_rdonly1.tablet_alias],
-                    auto_log=True)
     utils.check_tablet_query_service(
         self, worker.shard_1_rdonly1,
         serving=True, tablet_control_disabled=False)

--- a/test/automation_vertical_split.py
+++ b/test/automation_vertical_split.py
@@ -54,11 +54,6 @@ class TestAutomationVerticalSplit(vertical_split.TestVerticalSplit):
     args.extend(['--param=' + k + '=' + v for k, v in params.items()])
     utils.run(environment.binary_args('automation_client') + args)
 
-    # One of the two source rdonly tablets went spare after the diff.
-    # Force a healthcheck on both to get them back to "rdonly".
-    for t in [vertical_split.source_rdonly1, vertical_split.source_rdonly2]:
-      utils.run_vtctl(['RunHealthCheck', t.tablet_alias])
-
     self._check_srv_keyspace('')
     self._check_blacklisted_tables(vertical_split.source_master,
                                    ['/moving/', 'view1'])


### PR DESCRIPTION
In the past, the calls were necessary for tablets where vtworker stopped replication and changed their type from e.g. RDONLY to WORKER (DRAINED) and then later to SPARE. Back then, we depended on the healthcheck to change the tablet's type back from SPARE to RDONLY. However, these days vtworker changes the tablet back to RDONLY and therefore the RunHealthCheck call is obsolete now.