### PR TITLE
JDBC - Add ConnectionProperties and IncludedFields support

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingConn.java
@@ -2,6 +2,7 @@ package com.youtube.vitess.client;
 
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.CursorWithError;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.SrvKeyspace;
 import com.youtube.vitess.proto.Topodata.TabletType;
@@ -50,46 +51,50 @@ public class VTGateBlockingConn implements Closeable {
     this.conn = conn;
   }
 
-  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.execute(ctx, query, bindVars, tabletType).checkedGet();
+    return conn.execute(ctx, query, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeShards(Context ctx, String query, String keyspace, Iterable<String> shards,
-      Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
-    return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+      Map<String, ?> bindVars, TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+    return conn.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public Cursor executeKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType)
+    return conn.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public Cursor executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     return conn.executeEntityIds(ctx, query, keyspace, entityColumnName, entityKeyspaceIds,
-        bindVars, tabletType).checkedGet();
-  }
-
-  public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
-      @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType) throws SQLException {
-    return executeBatch(ctx, queryList, bindVarsList, tabletType, false);
+        bindVars, tabletType, includedFields).checkedGet();
   }
 
   public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
       @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
-    return conn.executeBatch(ctx, queryList, bindVarsList, tabletType, asTransaction).checkedGet();
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return executeBatch(ctx, queryList, bindVarsList, tabletType, false, includedFields);
+  }
+
+  public List<CursorWithError> executeBatch(Context ctx, ArrayList<String> queryList,
+      @Nullable ArrayList<Map<String, ?>> bindVarsList, TabletType tabletType,
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeBatch(ctx, queryList, bindVarsList, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   /**
@@ -99,8 +104,9 @@ public class VTGateBlockingConn implements Closeable {
    *        the batch queries.
    */
   public List<Cursor> executeBatchShards(Context ctx, Iterable<? extends BoundShardQuery> queries,
-      TabletType tabletType, boolean asTransaction) throws SQLException {
-    return conn.executeBatchShards(ctx, queries, tabletType, asTransaction).checkedGet();
+      TabletType tabletType, boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields)
+      throws SQLException {
+    return conn.executeBatchShards(ctx, queries, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   /**
@@ -111,30 +117,34 @@ public class VTGateBlockingConn implements Closeable {
    */
   public List<Cursor> executeBatchKeyspaceIds(Context ctx,
       Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
-    return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction).checkedGet();
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.executeBatchKeyspaceIds(ctx, queries, tabletType, asTransaction, includedFields).checkedGet();
   }
 
   public Cursor streamExecute(Context ctx, String query, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
-    return conn.streamExecute(ctx, query, bindVars, tabletType);
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    return conn.streamExecute(ctx, query, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
-    return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType);
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
+      throws SQLException {
+    return conn.streamExecuteShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType);
+    return conn.streamExecuteKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields);
   }
 
   public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType);
+    return conn.streamExecuteKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields);
   }
 
   public VTGateBlockingTx begin(Context ctx) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateBlockingTx.java
@@ -2,6 +2,7 @@ package com.youtube.vitess.client;
 
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.CursorWithError;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.TabletType;
 import com.youtube.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
@@ -28,9 +29,10 @@ public class VTGateBlockingTx {
     this.tx = tx;
   }
 
-  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType)
+  public Cursor execute(Context ctx, String query, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.execute(ctx, query, bindVars, tabletType).checkedGet();
+    return tx.execute(ctx, query, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeShards(
@@ -39,9 +41,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<String> shards,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeShards(ctx, query, keyspace, shards, bindVars, tabletType).checkedGet();
+    return tx.executeShards(ctx, query, keyspace, shards, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeKeyspaceIds(
@@ -50,9 +53,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<byte[]> keyspaceIds,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType)
+    return tx.executeKeyspaceIds(ctx, query, keyspace, keyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
@@ -62,9 +66,10 @@ public class VTGateBlockingTx {
       String keyspace,
       Iterable<? extends KeyRange> keyRanges,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType).checkedGet();
+    return tx.executeKeyRanges(ctx, query, keyspace, keyRanges, bindVars, tabletType, includedFields).checkedGet();
   }
 
   public Cursor executeEntityIds(
@@ -74,29 +79,33 @@ public class VTGateBlockingTx {
       String entityColumnName,
       Map<byte[], ?> entityKeyspaceIds,
       Map<String, ?> bindVars,
-      TabletType tabletType)
+      TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     return tx.executeEntityIds(
-            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType)
+            ctx, query, keyspace, entityColumnName, entityKeyspaceIds, bindVars, tabletType, includedFields)
         .checkedGet();
   }
 
   public List<CursorWithError> executeBatch(Context ctx, List<String> queryList,
-      @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType)
+      @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatch(ctx, queryList, bindVarsList, tabletType).checkedGet();
+    return tx.executeBatch(ctx, queryList, bindVarsList, tabletType, includedFields).checkedGet();
   }
 
   public List<Cursor> executeBatchShards(
-      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType)
+      Context ctx, Iterable<? extends BoundShardQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatchShards(ctx, queries, tabletType).checkedGet();
+    return tx.executeBatchShards(ctx, queries, tabletType, includedFields).checkedGet();
   }
 
   public List<Cursor> executeBatchKeyspaceIds(
-      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType)
+      Context ctx, Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
-    return tx.executeBatchKeyspaceIds(ctx, queries, tabletType).checkedGet();
+    return tx.executeBatchKeyspaceIds(ctx, queries, tabletType, includedFields).checkedGet();
   }
 
   public void commit(Context ctx) throws SQLException {

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateConn.java
@@ -96,13 +96,18 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> execute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
-    ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
+    TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+    ExecuteRequest.Builder requestBuilder = ExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
         new AsyncFunction<ExecuteResponse, Cursor>() {
           @Override
@@ -114,15 +119,22 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteShardsRequest.Builder requestBuilder =
-        ExecuteShardsRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
-            .setTabletType(checkNotNull(tabletType));
+        ExecuteShardsRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(checkNotNull(keyspace))
+            .addAllShards(checkNotNull(shards))
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteShardsResponse, Cursor>() {
@@ -136,17 +148,22 @@ public final class VTGateConn implements Closeable {
   }
 
   public SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
         .addAllKeyspaceIds(
             Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
@@ -161,14 +178,19 @@ public final class VTGateConn implements Closeable {
 
   public SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
       Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
-        .setTabletType(checkNotNull(tabletType));
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
@@ -183,16 +205,21 @@ public final class VTGateConn implements Closeable {
 
   public SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
-        .setEntityColumnName(checkNotNull(entityColumnName)).addAllEntityKeyspaceIds(Iterables
+        .setEntityColumnName(checkNotNull(entityColumnName))
+        .addAllEntityKeyspaceIds(Iterables
             .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<Cursor>(
         Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
@@ -206,13 +233,14 @@ public final class VTGateConn implements Closeable {
   }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
-        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType) throws SQLException {
-        return executeBatch(ctx, queryList, bindVarsList, tabletType, false);
+        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+        Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
+        return executeBatch(ctx, queryList, bindVarsList, tabletType, false, includedFields);
     }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
         @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
-        boolean asTransaction) throws SQLException {
+        boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
         List<Query.BoundQuery> queries = new ArrayList<>();
 
         if (null != bindVarsList && bindVarsList.size() != queryList.size()) {
@@ -226,12 +254,18 @@ public final class VTGateConn implements Closeable {
         }
 
         Vtgate.ExecuteBatchRequest.Builder requestBuilder =
-            Vtgate.ExecuteBatchRequest.newBuilder().addAllQueries(checkNotNull(queries))
-                .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType))
-                .setAsTransaction(asTransaction);
+            Vtgate.ExecuteBatchRequest.newBuilder()
+                .addAllQueries(checkNotNull(queries))
+                .setKeyspace(keyspace)
+                .setTabletType(checkNotNull(tabletType))
+                .setAsTransaction(asTransaction)
+                .setOptions(Query.ExecuteOptions.newBuilder()
+                    .setIncludedFields(includedFields));
+
         if (ctx.getCallerId() != null) {
             requestBuilder.setCallerId(ctx.getCallerId());
         }
+
         return new SQLFuture<>(Futures
             .transformAsync(client.executeBatch(ctx, requestBuilder.build()),
                 new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
@@ -251,14 +285,21 @@ public final class VTGateConn implements Closeable {
    *        the batch queries.
    */
   public SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
-      Iterable<? extends BoundShardQuery> queries, TabletType tabletType, boolean asTransaction)
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType, boolean asTransaction,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     ExecuteBatchShardsRequest.Builder requestBuilder =
-        ExecuteBatchShardsRequest.newBuilder().addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
+        ExecuteBatchShardsRequest.newBuilder()
+            .addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType))
+            .setAsTransaction(asTransaction)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<List<Cursor>>(
         Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
@@ -280,13 +321,19 @@ public final class VTGateConn implements Closeable {
    */
   public SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
       Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
-      boolean asTransaction) throws SQLException {
+      boolean asTransaction, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder =
-        ExecuteBatchKeyspaceIdsRequest.newBuilder().addAllQueries(checkNotNull(queries))
-            .setTabletType(checkNotNull(tabletType)).setAsTransaction(asTransaction);
+        ExecuteBatchKeyspaceIdsRequest.newBuilder()
+            .addAllQueries(checkNotNull(queries))
+            .setTabletType(checkNotNull(tabletType))
+            .setAsTransaction(asTransaction)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new SQLFuture<List<Cursor>>(
         Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {
@@ -301,54 +348,78 @@ public final class VTGateConn implements Closeable {
   }
 
   public Cursor streamExecute(Context ctx, String query, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     StreamExecuteRequest.Builder requestBuilder =
-        StreamExecuteRequest.newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-            .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType));
+        StreamExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(checkNotNull(tabletType))
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecute(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<String> shards, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     StreamExecuteShardsRequest.Builder requestBuilder = StreamExecuteShardsRequest.newBuilder()
         .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllShards(checkNotNull(shards))
-        .setTabletType(checkNotNull(tabletType));
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllShards(checkNotNull(shards))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteShards(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteKeyspaceIds(Context ctx, String query, String keyspace,
-      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<byte[]> keyspaceIds, @Nullable Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     StreamExecuteKeyspaceIdsRequest.Builder requestBuilder = StreamExecuteKeyspaceIdsRequest
-        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
         .setKeyspace(checkNotNull(keyspace))
         .addAllKeyspaceIds(
             Iterables.transform(checkNotNull(keyspaceIds), Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(checkNotNull(tabletType));
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteKeyspaceIds(ctx, requestBuilder.build()));
   }
 
   public Cursor streamExecuteKeyRanges(Context ctx, String query, String keyspace,
       Iterable<? extends KeyRange> keyRanges, @Nullable Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     StreamExecuteKeyRangesRequest.Builder requestBuilder = StreamExecuteKeyRangesRequest
-        .newBuilder().setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
-        .setKeyspace(checkNotNull(keyspace)).addAllKeyRanges(checkNotNull(keyRanges))
-        .setTabletType(checkNotNull(tabletType));
+        .newBuilder()
+        .setQuery(Proto.bindQuery(checkNotNull(query), bindVars))
+        .setKeyspace(checkNotNull(keyspace))
+        .addAllKeyRanges(checkNotNull(keyRanges))
+        .setTabletType(checkNotNull(tabletType))
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     return new StreamCursor(client.streamExecuteKeyRanges(ctx, requestBuilder.build()));
   }
 

--- a/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/VTGateTx.java
@@ -78,14 +78,21 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> execute(Context ctx, String query, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("execute");
     ExecuteRequest.Builder requestBuilder =
-        ExecuteRequest.newBuilder().setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
-            .setTabletType(tabletType).setSession(session);
+        ExecuteRequest.newBuilder()
+            .setQuery(Proto.bindQuery(query, bindVars))
+            .setKeyspace(keyspace)
+            .setTabletType(tabletType)
+            .setSession(session)
+            .setOptions(Query.ExecuteOptions.newBuilder()
+                .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.execute(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteResponse, Cursor>() {
@@ -101,14 +108,22 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeShards(Context ctx, String query, String keyspace,
-      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType) throws SQLException {
+      Iterable<String> shards, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeShards");
     ExecuteShardsRequest.Builder requestBuilder = ExecuteShardsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllShards(shards)
-        .setTabletType(tabletType).setSession(session);
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .addAllShards(shards)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteShardsResponse, Cursor>() {
@@ -125,16 +140,23 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeKeyspaceIds(Context ctx, String query,
-      String keyspace, Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType)
+      String keyspace, Iterable<byte[]> keyspaceIds, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     checkCallIsAllowed("executeKeyspaceIds");
     ExecuteKeyspaceIdsRequest.Builder requestBuilder = ExecuteKeyspaceIdsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
         .addAllKeyspaceIds(Iterables.transform(keyspaceIds, Proto.BYTE_ARRAY_TO_BYTE_STRING))
-        .setTabletType(tabletType).setSession(session);
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call = new SQLFuture<>(
         Futures.transformAsync(client.executeKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyspaceIdsResponse, Cursor>() {
@@ -151,15 +173,23 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<Cursor> executeKeyRanges(Context ctx, String query, String keyspace,
-      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType)
+      Iterable<? extends KeyRange> keyRanges, Map<String, ?> bindVars, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields)
       throws SQLException {
     checkCallIsAllowed("executeKeyRanges");
     ExecuteKeyRangesRequest.Builder requestBuilder = ExecuteKeyRangesRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace).addAllKeyRanges(keyRanges)
-        .setTabletType(tabletType).setSession(session);
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .addAllKeyRanges(keyRanges)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeKeyRanges(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteKeyRangesResponse, Cursor>() {
@@ -177,16 +207,23 @@ public class VTGateTx {
 
   public synchronized SQLFuture<Cursor> executeEntityIds(Context ctx, String query, String keyspace,
       String entityColumnName, Map<byte[], ?> entityKeyspaceIds, Map<String, ?> bindVars,
-      TabletType tabletType) throws SQLException {
+      TabletType tabletType, Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeEntityIds");
     ExecuteEntityIdsRequest.Builder requestBuilder = ExecuteEntityIdsRequest.newBuilder()
-        .setQuery(Proto.bindQuery(query, bindVars)).setKeyspace(keyspace)
-        .setEntityColumnName(entityColumnName).addAllEntityKeyspaceIds(Iterables
+        .setQuery(Proto.bindQuery(query, bindVars))
+        .setKeyspace(keyspace)
+        .setEntityColumnName(entityColumnName)
+        .addAllEntityKeyspaceIds(Iterables
             .transform(entityKeyspaceIds.entrySet(), Proto.MAP_ENTRY_TO_ENTITY_KEYSPACE_ID))
-        .setTabletType(tabletType).setSession(session);
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<Cursor> call =
         new SQLFuture<>(Futures.transformAsync(client.executeEntityIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteEntityIdsResponse, Cursor>() {
@@ -203,7 +240,8 @@ public class VTGateTx {
   }
 
     public SQLFuture<List<CursorWithError>> executeBatch(Context ctx, List<String> queryList,
-        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType)
+        @Nullable List<Map<String, ?>> bindVarsList, TabletType tabletType,
+        Query.ExecuteOptions.IncludedFields includedFields)
         throws SQLException {
         List<Query.BoundQuery> queries = new ArrayList<>();
 
@@ -218,11 +256,18 @@ public class VTGateTx {
         }
 
         Vtgate.ExecuteBatchRequest.Builder requestBuilder =
-            Vtgate.ExecuteBatchRequest.newBuilder().addAllQueries(checkNotNull(queries))
-                .setKeyspace(keyspace).setTabletType(checkNotNull(tabletType)).setSession(session);
+            Vtgate.ExecuteBatchRequest.newBuilder()
+                .addAllQueries(checkNotNull(queries))
+                .setKeyspace(keyspace)
+                .setTabletType(checkNotNull(tabletType))
+                .setSession(session)
+                .setOptions(Query.ExecuteOptions.newBuilder()
+                    .setIncludedFields(includedFields));
+
         if (ctx.getCallerId() != null) {
             requestBuilder.setCallerId(ctx.getCallerId());
         }
+
         return new SQLFuture<>(Futures
             .transformAsync(client.executeBatch(ctx, requestBuilder.build()),
                 new AsyncFunction<Vtgate.ExecuteBatchResponse, List<CursorWithError>>() {
@@ -237,13 +282,20 @@ public class VTGateTx {
     }
 
   public synchronized SQLFuture<List<Cursor>> executeBatchShards(Context ctx,
-      Iterable<? extends BoundShardQuery> queries, TabletType tabletType) throws SQLException {
+      Iterable<? extends BoundShardQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeBatchShards");
     ExecuteBatchShardsRequest.Builder requestBuilder = ExecuteBatchShardsRequest.newBuilder()
-        .addAllQueries(queries).setTabletType(tabletType).setSession(session);
+        .addAllQueries(queries)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<List<Cursor>> call = new SQLFuture<>(
         Futures.transformAsync(client.executeBatchShards(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchShardsResponse, List<Cursor>>() {
@@ -261,13 +313,21 @@ public class VTGateTx {
   }
 
   public synchronized SQLFuture<List<Cursor>> executeBatchKeyspaceIds(Context ctx,
-      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType) throws SQLException {
+      Iterable<? extends BoundKeyspaceIdQuery> queries, TabletType tabletType,
+      Query.ExecuteOptions.IncludedFields includedFields) throws SQLException {
     checkCallIsAllowed("executeBatchKeyspaceIds");
     ExecuteBatchKeyspaceIdsRequest.Builder requestBuilder = ExecuteBatchKeyspaceIdsRequest
-        .newBuilder().addAllQueries(queries).setTabletType(tabletType).setSession(session);
+        .newBuilder()
+        .addAllQueries(queries)
+        .setTabletType(tabletType)
+        .setSession(session)
+        .setOptions(Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(includedFields));
+
     if (ctx.getCallerId() != null) {
       requestBuilder.setCallerId(ctx.getCallerId());
     }
+
     SQLFuture<List<Cursor>> call = new SQLFuture<>(
         Futures.transformAsync(client.executeBatchKeyspaceIds(ctx, requestBuilder.build()),
             new AsyncFunction<ExecuteBatchKeyspaceIdsResponse, List<Cursor>>() {

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -94,6 +94,7 @@ public abstract class RpcClientTest {
   private static final TabletType TABLET_TYPE = TabletType.REPLICA;
   private static final String TABLET_TYPE_ECHO = TABLET_TYPE.toString();
   private static final Query.ExecuteOptions.IncludedFields ALL_FIELDS = Query.ExecuteOptions.IncludedFields.ALL;
+  private static final String OPTIONS_ALL_FIELDS_ECHO = "included_fields:" + ALL_FIELDS.toString() + " ";
 
   private static final Map<String, Object> BIND_VARS = new ImmutableMap.Builder<String, Object>()
       .put("int", 123).put("float", 2.5).put("bytes", new byte[] {1, 2, 3}).build();
@@ -146,6 +147,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(
         conn.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -155,6 +157,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(SHARDS_ECHO, echo.get("shards"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
         BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -164,6 +167,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEYSPACE_IDS_ECHO, echo.get("keyspaceIds"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
         TABLET_TYPE, ALL_FIELDS));
@@ -173,6 +177,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEY_RANGES_ECHO, echo.get("keyRanges"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
         ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -183,6 +188,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(ENTITY_KEYSPACE_IDS_ECHO, echo.get("entityIds"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.executeBatchShards(ctx,
         Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
@@ -194,6 +200,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals("true", echo.get("asTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
@@ -206,6 +213,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals("true", echo.get("asTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
   }
 
   @Test
@@ -218,6 +226,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.streamExecuteShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS,
         TABLET_TYPE, ALL_FIELDS));
@@ -227,6 +236,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(SHARDS_ECHO, echo.get("shards"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.streamExecuteKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
         BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -236,6 +246,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEYSPACE_IDS_ECHO, echo.get("keyspaceIds"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(conn.streamExecuteKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES,
         BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -245,6 +256,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(KEY_RANGES_ECHO, echo.get("keyRanges"));
     Assert.assertEquals(BIND_VARS_ECHO, echo.get("bindVars"));
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
   }
 
   @Test
@@ -261,6 +273,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("notInTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(
         tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -272,6 +285,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("notInTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(tx.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
         BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -283,6 +297,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("notInTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(tx.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
         TABLET_TYPE, ALL_FIELDS));
@@ -294,6 +309,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("notInTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(tx.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
         ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
@@ -306,6 +322,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("notInTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     tx.rollback(ctx);
     tx = conn.begin(ctx);
@@ -321,6 +338,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("asTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     echo = getEcho(tx.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
@@ -334,6 +352,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
     Assert.assertEquals(SESSION_ECHO, echo.get("session"));
     Assert.assertEquals("false", echo.get("asTransaction"));
+    Assert.assertEquals(OPTIONS_ALL_FIELDS_ECHO, echo.get("options"));
 
     tx.commit(ctx);
   }

--- a/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/RpcClientTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.Field;
 import com.youtube.vitess.proto.Topodata.KeyRange;
 import com.youtube.vitess.proto.Topodata.KeyspaceIdType;
@@ -14,6 +15,12 @@ import com.youtube.vitess.proto.Topodata.SrvKeyspace.KeyspacePartition;
 import com.youtube.vitess.proto.Topodata.TabletType;
 import com.youtube.vitess.proto.Vtgate.SplitQueryResponse;
 import com.youtube.vitess.proto.Vtrpc.CallerID;
+
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
@@ -28,10 +35,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 /**
  * RpcClientTest tests a given implementation of RpcClient against a mock vtgate server
@@ -90,6 +93,7 @@ public abstract class RpcClientTest {
 
   private static final TabletType TABLET_TYPE = TabletType.REPLICA;
   private static final String TABLET_TYPE_ECHO = TABLET_TYPE.toString();
+  private static final Query.ExecuteOptions.IncludedFields ALL_FIELDS = Query.ExecuteOptions.IncludedFields.ALL;
 
   private static final Map<String, Object> BIND_VARS = new ImmutableMap.Builder<String, Object>()
       .put("int", 123).put("float", 2.5).put("bytes", new byte[] {1, 2, 3}).build();
@@ -136,7 +140,7 @@ public abstract class RpcClientTest {
   public void testEchoExecute() throws Exception {
     Map<String, String> echo;
 
-    echo = getEcho(conn.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(conn.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -144,7 +148,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(
-        conn.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE));
+        conn.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -153,7 +157,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -162,7 +166,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -171,7 +175,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
-        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
+        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -182,7 +186,7 @@ public abstract class RpcClientTest {
 
     echo = getEcho(conn.executeBatchShards(ctx,
         Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE, true).get(0));
+        TABLET_TYPE, true, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -194,7 +198,7 @@ public abstract class RpcClientTest {
     echo = getEcho(conn.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
             Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE, true).get(0));
+        TABLET_TYPE, true, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -208,7 +212,7 @@ public abstract class RpcClientTest {
   public void testEchoStreamExecute() throws Exception {
     Map<String, String> echo;
 
-    echo = getEcho(conn.streamExecute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(conn.streamExecute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -216,7 +220,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -225,7 +229,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -234,7 +238,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals(TABLET_TYPE_ECHO, echo.get("tabletType"));
 
     echo = getEcho(conn.streamExecuteKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -249,7 +253,7 @@ public abstract class RpcClientTest {
 
     VTGateBlockingTx tx = conn.begin(ctx);
 
-    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE));
+    echo = getEcho(tx.execute(ctx, ECHO_PREFIX + QUERY, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -259,7 +263,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(
-        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE));
+        tx.executeShards(ctx, ECHO_PREFIX + QUERY, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -270,7 +274,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyspaceIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEYSPACE_IDS,
-        BIND_VARS, TABLET_TYPE));
+        BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -281,7 +285,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeKeyRanges(ctx, ECHO_PREFIX + QUERY, KEYSPACE, KEY_RANGES, BIND_VARS,
-        TABLET_TYPE));
+        TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -292,7 +296,7 @@ public abstract class RpcClientTest {
     Assert.assertEquals("false", echo.get("notInTransaction"));
 
     echo = getEcho(tx.executeEntityIds(ctx, ECHO_PREFIX + QUERY, KEYSPACE, "column1",
-        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE));
+        ENTITY_KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -308,7 +312,7 @@ public abstract class RpcClientTest {
 
     echo = getEcho(tx.executeBatchShards(ctx,
         Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE).get(0));
+        TABLET_TYPE, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -321,7 +325,7 @@ public abstract class RpcClientTest {
     echo = getEcho(tx.executeBatchKeyspaceIds(ctx,
         Arrays.asList(
             Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, ECHO_PREFIX + QUERY, BIND_VARS)),
-        TABLET_TYPE).get(0));
+        TABLET_TYPE, ALL_FIELDS).get(0));
     Assert.assertEquals(CALLER_ID_ECHO, echo.get("callerId"));
     Assert.assertEquals(ECHO_PREFIX + QUERY, echo.get("query"));
     Assert.assertEquals(KEYSPACE, echo.get("keyspace"));
@@ -480,32 +484,32 @@ public abstract class RpcClientTest {
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.execute(ctx, query, BIND_VARS, TABLET_TYPE);
+        conn.execute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
+        conn.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
+        conn.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
+        conn.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
         conn.executeEntityIds(ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS,
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
@@ -513,7 +517,7 @@ public abstract class RpcClientTest {
       void execute(String query) throws Exception {
         conn.executeBatchShards(ctx,
             Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE,
-            true);
+            true, ALL_FIELDS);
       }
     });
     checkExecuteErrors(new Executable() {
@@ -521,7 +525,7 @@ public abstract class RpcClientTest {
       void execute(String query) throws Exception {
         conn.executeBatchKeyspaceIds(ctx,
             Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-            TABLET_TYPE, true);
+            TABLET_TYPE, true, ALL_FIELDS);
       }
     });
   }
@@ -531,26 +535,26 @@ public abstract class RpcClientTest {
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecute(ctx, query, BIND_VARS, TABLET_TYPE).next();
+        conn.streamExecute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS).next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE).next();
+        conn.streamExecuteShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS).next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE)
+        conn.streamExecuteKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS)
             .next();
       }
     });
     checkStreamExecuteErrors(new Executable() {
       @Override
       void execute(String query) throws Exception {
-        conn.streamExecuteKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE)
+        conn.streamExecuteKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS)
             .next();
       }
     });
@@ -561,39 +565,39 @@ public abstract class RpcClientTest {
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE);
+        tx.execute(ctx, query, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE);
+        tx.executeShards(ctx, query, KEYSPACE, SHARDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE);
+        tx.executeKeyspaceIds(ctx, query, KEYSPACE, KEYSPACE_IDS, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
-        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE);
+        tx.executeKeyRanges(ctx, query, KEYSPACE, KEY_RANGES, BIND_VARS, TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeEntityIds(ctx, query, KEYSPACE, "column1", ENTITY_KEYSPACE_IDS, BIND_VARS,
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
       @Override
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeBatchShards(ctx,
-            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE);
+            Arrays.asList(Proto.bindShardQuery(KEYSPACE, SHARDS, query, BIND_VARS)), TABLET_TYPE, ALL_FIELDS);
       }
     });
     checkTransactionExecuteErrors(new TransactionExecutable() {
@@ -601,7 +605,7 @@ public abstract class RpcClientTest {
       void execute(VTGateBlockingTx tx, String query) throws Exception {
         tx.executeBatchKeyspaceIds(ctx,
             Arrays.asList(Proto.bindKeyspaceIdQuery(KEYSPACE, KEYSPACE_IDS, query, BIND_VARS)),
-            TABLET_TYPE);
+            TABLET_TYPE, ALL_FIELDS);
       }
     });
   }

--- a/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
@@ -3,15 +3,13 @@ package com.youtube.vitess.client;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
-
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.TabletType;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.joda.time.Duration;
 import org.junit.Assert;
-
-import vttest.Vttest.VTTestTopology;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -20,6 +18,8 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import vttest.Vttest.VTTestTopology;
 
 public class TestUtil {
   static final Logger logger = LogManager.getLogger(TestUtil.class.getName());
@@ -119,7 +119,7 @@ public class TestUtil {
         bindVars.put("name", "name_" + id);
         bindVars.put("age", id % 10);
         bindVars.put("percent", id / 100.0);
-        tx.execute(ctx, insertSql, bindVars, TabletType.MASTER);
+        tx.execute(ctx, insertSql, bindVars, TabletType.MASTER, Query.ExecuteOptions.IncludedFields.ALL);
       }
       tx.commit(ctx);
     }

--- a/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/com/youtube/vitess/example/VitessClientExample.java
@@ -11,6 +11,7 @@ import com.youtube.vitess.client.VTGateBlockingTx;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.Row;
 import com.youtube.vitess.client.grpc.GrpcClientFactory;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata.TabletType;
 
 import org.joda.time.Duration;
@@ -57,7 +58,8 @@ public class VitessClientExample {
             ctx,
             "INSERT INTO messages (page,time_created_ns,message) VALUES (:page,:time_created_ns,:message)",
             bindVars,
-            TabletType.MASTER);
+            TabletType.MASTER,
+            Query.ExecuteOptions.IncludedFields.ALL);
         tx.commit(ctx);
       }
 
@@ -68,7 +70,8 @@ public class VitessClientExample {
               ctx,
               "SELECT page, time_created_ns, message FROM messages",
               null /* bindVars */,
-              TabletType.MASTER)) {
+              TabletType.MASTER,
+              Query.ExecuteOptions.IncludedFields.ALL)) {
         Row row;
         while ((row = cursor.next()) != null) {
           UnsignedLong page = row.getULong("page");

--- a/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessConf.java
+++ b/java/hadoop/src/main/java/com/youtube/vitess/hadoop/VitessConf.java
@@ -1,11 +1,12 @@
 package com.youtube.vitess.hadoop;
 
 import com.youtube.vitess.client.RpcClientFactory;
+import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Query.SplitQueryRequest;
 
-import java.util.Collection;
-
 import org.apache.hadoop.conf.Configuration;
+
+import java.util.Collection;
 
 /**
  * Collection of configuration properties used for {@link VitessInputFormat}
@@ -20,6 +21,7 @@ public class VitessConf {
   public static final String SPLIT_COLUMNS = "vitess.client.split_columns";
   public static final String ALGORITHM = "vitess.client.algorithm";
   public static final String RPC_FACTORY_CLASS = "vitess.client.factory";
+  public static final String INCLUDED_FIELDS = "vitess.client.included.fields";
   public static final String HOSTS_DELIM = ",";
 
   private Configuration conf;
@@ -96,5 +98,13 @@ public class VitessConf {
 
   public void setRpcFactoryClass(Class<? extends RpcClientFactory> clz) {
     conf.set(RPC_FACTORY_CLASS, clz.getName());
+  }
+
+  public Query.ExecuteOptions.IncludedFields getIncludedFields() {
+    return conf.getEnum(INCLUDED_FIELDS, Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+  }
+
+  public void setIncludedFields(Query.ExecuteOptions.IncludedFields includedFields) {
+    conf.setEnum(INCLUDED_FIELDS, includedFields);
   }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -1,11 +1,9 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
-import com.flipkart.vitess.util.StringUtils;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata;
 
-import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
@@ -28,10 +26,7 @@ public class ConnectionProperties {
                 }
             }
         } catch (Exception ex) {
-            RuntimeException rtEx = new RuntimeException();
-            rtEx.initCause(ex);
-
-            throw rtEx;
+            throw new RuntimeException(ex);
         }
     }
 
@@ -65,7 +60,6 @@ public class ConnectionProperties {
         for (Field propertyField : PROPERTY_LIST) {
             try {
                 ConnectionProperty propToSet = (ConnectionProperty) propertyField.get(this);
-
                 propToSet.initializeFrom(propsCopy);
             } catch (IllegalAccessException iae) {
                 throw new SQLException("Unable to initialize driver properties due to " + iae.toString());
@@ -88,7 +82,6 @@ public class ConnectionProperties {
 
     protected DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
         initializeProperties(info);
-
         int numProperties = PROPERTY_LIST.size();
         int listSize = numProperties + slotsToReserve;
         DriverPropertyInfo[] driverProperties = new DriverPropertyInfo[listSize];
@@ -97,11 +90,9 @@ public class ConnectionProperties {
             java.lang.reflect.Field propertyField = PROPERTY_LIST.get(i - slotsToReserve);
             try {
                 ConnectionProperty propToExpose = (ConnectionProperty) propertyField.get(this);
-
                 if (info != null) {
                     propToExpose.initializeFrom(info);
                 }
-
                 driverProperties[i] = propToExpose.getAsDriverPropertyInfo();
             } catch (IllegalAccessException iae) {
                 throw new SQLException("Internal properties failure", iae);
@@ -193,21 +184,12 @@ public class ConnectionProperties {
             return name;
         }
 
-        public Object getDefaultValue() {
-            return defaultValue;
-        }
-
-        public Object getValueAsObject() {
-            return valueAsObject;
-        }
-
         DriverPropertyInfo getAsDriverPropertyInfo() {
             DriverPropertyInfo dpi = new DriverPropertyInfo(this.name, null);
             dpi.choices = getAllowableValues();
             dpi.value = (this.valueAsObject != null) ? this.valueAsObject.toString() : null;
             dpi.required = this.required;
             dpi.description = this.description;
-
             return dpi;
         }
     }
@@ -245,10 +227,6 @@ public class ConnectionProperties {
 
         private final String[] allowableValues;
 
-        private StringConnectionProperty(String name, String description, String defaultValue) {
-            this(name, description, defaultValue, null);
-        }
-
         private StringConnectionProperty(String name, String description, String defaultValue, String[] allowableValuesToSet) {
             super(name, description, defaultValue);
             allowableValues = allowableValuesToSet;
@@ -266,10 +244,6 @@ public class ConnectionProperties {
         @Override
         String[] getAllowableValues() {
             return allowableValues;
-        }
-
-        String getValueAsString() {
-            return (String) valueAsObject;
         }
 
         public void setValue(String value) {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -1,0 +1,319 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.StringUtils;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class ConnectionProperties {
+
+    private static final ArrayList<java.lang.reflect.Field> PROPERTY_LIST = new ArrayList<>();
+
+    static {
+        try {
+            // Generate property list for use in dynamically filling out values from Properties objects in
+            // #initializeProperties below
+            java.lang.reflect.Field[] declaredFields = ConnectionProperties.class.getDeclaredFields();
+            for (int i = 0; i < declaredFields.length; i++) {
+                if (ConnectionProperties.ConnectionProperty.class.isAssignableFrom(declaredFields[i].getType())) {
+                    PROPERTY_LIST.add(declaredFields[i]);
+                }
+            }
+        } catch (Exception ex) {
+            RuntimeException rtEx = new RuntimeException();
+            rtEx.initCause(ex);
+
+            throw rtEx;
+        }
+    }
+
+    // Vitess-specific configs
+    private EnumConnectionProperty<Constants.QueryExecuteType> executeType = new EnumConnectionProperty<>(
+        Constants.Property.EXECUTE_TYPE,
+        "Query execution type: simple or stream",
+        Constants.DEFAULT_EXECUTE_TYPE);
+    private BooleanConnectionProperty twopcEnabled = new BooleanConnectionProperty(
+        Constants.Property.TWOPC_ENABLED,
+        "Whether to enable two-phased commit, for atomic distributed commits. See http://vitess.io/user-guide/twopc.html",
+        false);
+    private EnumConnectionProperty<Query.ExecuteOptions.IncludedFields> includedFields = new EnumConnectionProperty<>(
+        Constants.Property.INCLUDED_FIELDS,
+        "What fields to return from MySQL to the Driver. Limiting the fields returned can improve performance, but ALL is required for maximum JDBC API support",
+        Constants.DEFAULT_INCLUDED_FIELDS);
+    private EnumConnectionProperty<Topodata.TabletType> tabletType = new EnumConnectionProperty<>(
+        Constants.Property.TABLET_TYPE,
+        "Tablet Type to which Vitess will connect(master, replica, rdonly)",
+        Constants.DEFAULT_TABLET_TYPE);
+
+    // Caching of some hot properties to avoid casting over and over
+    private Topodata.TabletType tabletTypeCache;
+    private Query.ExecuteOptions.IncludedFields includedFieldsCache;
+    private boolean includeAllFieldsCache = true;
+    private boolean twopcEnabledCache = false;
+    private boolean simpleExecuteTypeCache = true;
+
+    void initializeProperties(Properties props) throws SQLException {
+        Properties propsCopy = (Properties) props.clone();
+        for (Field propertyField : PROPERTY_LIST) {
+            try {
+                ConnectionProperty propToSet = (ConnectionProperty) propertyField.get(this);
+
+                propToSet.initializeFrom(propsCopy);
+            } catch (IllegalAccessException iae) {
+                throw new SQLException("Unable to initialize driver properties due to " + iae.toString());
+            }
+        }
+        postInitialization();
+    }
+
+    private void postInitialization() throws SQLException {
+        this.tabletTypeCache = this.tabletType.getValueAsEnum();
+        this.includedFieldsCache = this.includedFields.getValueAsEnum();
+        this.includeAllFieldsCache = this.includedFieldsCache == Query.ExecuteOptions.IncludedFields.ALL;
+        this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
+        this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
+    }
+
+    static DriverPropertyInfo[] exposeAsDriverPropertyInfo(Properties info, int slotsToReserve) throws SQLException {
+        return new ConnectionProperties().exposeAsDriverPropertyInfoInternal(info, slotsToReserve);
+    }
+
+    protected DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
+        initializeProperties(info);
+
+        int numProperties = PROPERTY_LIST.size();
+        int listSize = numProperties + slotsToReserve;
+        DriverPropertyInfo[] driverProperties = new DriverPropertyInfo[listSize];
+
+        for (int i = slotsToReserve; i < listSize; i++) {
+            java.lang.reflect.Field propertyField = PROPERTY_LIST.get(i - slotsToReserve);
+            try {
+                ConnectionProperty propToExpose = (ConnectionProperty) propertyField.get(this);
+
+                if (info != null) {
+                    propToExpose.initializeFrom(info);
+                }
+
+                driverProperties[i] = propToExpose.getAsDriverPropertyInfo();
+            } catch (IllegalAccessException iae) {
+                throw new SQLException("Internal properties failure", iae);
+            }
+        }
+        return driverProperties;
+    }
+
+    public Query.ExecuteOptions.IncludedFields getIncludedFields() {
+        return this.includedFieldsCache;
+    }
+
+    public boolean isIncludeAllFields() {
+        return this.includeAllFieldsCache;
+    }
+
+    public void setIncludedFields(Query.ExecuteOptions.IncludedFields includedFields) {
+        this.includedFields.setValue(includedFields);
+        this.includedFieldsCache = includedFields;
+        this.includeAllFieldsCache = includedFields == Query.ExecuteOptions.IncludedFields.ALL;
+    }
+
+    public boolean getTwopcEnabled() {
+        return twopcEnabledCache;
+    }
+
+    public void setTwopcEnabled(boolean twopcEnabled) {
+        this.twopcEnabled.setValue(twopcEnabled);
+        this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
+    }
+
+    public Constants.QueryExecuteType getExecuteType() {
+        return executeType.getValueAsEnum();
+    }
+
+    public boolean isSimpleExecute() {
+        return simpleExecuteTypeCache;
+    }
+
+    public void setExecuteType(Constants.QueryExecuteType executeType) {
+        this.executeType.setValue(executeType);
+        this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
+    }
+
+    public Topodata.TabletType getTabletType() {
+        return tabletTypeCache;
+    }
+
+    public void setTabletType(Topodata.TabletType tabletType) {
+        this.tabletType.setValue(tabletType);
+        this.tabletTypeCache = this.tabletType.getValueAsEnum();
+    }
+
+    abstract static class ConnectionProperty {
+
+        private final String name;
+        private final boolean required = false;
+        private final String description;
+        final Object defaultValue;
+        Object valueAsObject;
+
+        private ConnectionProperty(String name, String description, Object defaultValue) {
+            this.name = name;
+            this.description = description;
+            this.defaultValue = defaultValue;
+        }
+
+        void initializeFrom(Properties extractFrom) {
+            String extractedValue = extractFrom.getProperty(getPropertyName());
+            String[] allowable = getAllowableValues();
+            if (allowable != null && extractedValue != null) {
+                boolean found = false;
+                for (String value : allowable) {
+                    found |= value.equalsIgnoreCase(extractedValue);
+                }
+                if (!found) {
+                    throw new IllegalArgumentException("Property '" + name + "' Value '" + extractedValue + "' not in the list of allowable values: " + Arrays.toString(allowable));
+                }
+            }
+            extractFrom.remove(getPropertyName());
+            initializeFrom(extractedValue);
+        }
+
+        abstract void initializeFrom(String extractedValue);
+
+        abstract String[] getAllowableValues();
+
+        public String getPropertyName() {
+            return name;
+        }
+
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        public Object getValueAsObject() {
+            return valueAsObject;
+        }
+
+        DriverPropertyInfo getAsDriverPropertyInfo() {
+            DriverPropertyInfo dpi = new DriverPropertyInfo(this.name, null);
+            dpi.choices = getAllowableValues();
+            dpi.value = (this.valueAsObject != null) ? this.valueAsObject.toString() : null;
+            dpi.required = this.required;
+            dpi.description = this.description;
+
+            return dpi;
+        }
+    }
+
+    private static class BooleanConnectionProperty extends ConnectionProperty {
+
+        private BooleanConnectionProperty(String name, String description, Boolean defaultValue) {
+            super(name, description, defaultValue);
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(extractedValue.equalsIgnoreCase("TRUE") || extractedValue.equalsIgnoreCase("YES"));
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        public void setValue(boolean value) {
+            this.valueAsObject = value;
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            return new String[]{Boolean.toString(true), Boolean.toString(false), "yes", "no"};
+        }
+
+        boolean getValueAsBoolean() {
+            return (boolean) valueAsObject;
+        }
+    }
+
+    private static class StringConnectionProperty extends ConnectionProperty {
+
+        private final String[] allowableValues;
+
+        private StringConnectionProperty(String name, String description, String defaultValue) {
+            this(name, description, defaultValue, null);
+        }
+
+        private StringConnectionProperty(String name, String description, String defaultValue, String[] allowableValuesToSet) {
+            super(name, description, defaultValue);
+            allowableValues = allowableValuesToSet;
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(extractedValue);
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            return allowableValues;
+        }
+
+        String getValueAsString() {
+            return (String) valueAsObject;
+        }
+
+        public void setValue(String value) {
+            this.valueAsObject = value;
+        }
+    }
+
+    private static class EnumConnectionProperty<T extends Enum<T>> extends ConnectionProperty {
+
+        private final Class<T> clazz;
+
+        private EnumConnectionProperty(String name, String description, Enum<T> defaultValue) {
+            super(name, description, defaultValue);
+            this.clazz = defaultValue.getDeclaringClass();
+            if (!clazz.isEnum()) {
+                throw new IllegalArgumentException("EnumConnectionProperty types should be enums");
+            }
+        }
+
+        @Override
+        void initializeFrom(String extractedValue) {
+            if (extractedValue != null) {
+                setValue(Enum.valueOf(clazz, extractedValue.toUpperCase()));
+            } else {
+                this.valueAsObject = this.defaultValue;
+            }
+        }
+
+        public void setValue(T value) {
+            this.valueAsObject = value;
+        }
+
+        @Override
+        String[] getAllowableValues() {
+            T[] enumConstants = clazz.getEnumConstants();
+            String[] allowed = new String[enumConstants.length];
+            for (int i = 0; i < enumConstants.length; i++) {
+                allowed[i] = enumConstants[i].toString();
+            }
+            return allowed;
+        }
+
+        T getValueAsEnum() {
+            return (T) valueAsObject;
+        }
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -6,7 +6,6 @@ import com.flipkart.vitess.util.MysqlDefs;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
-import com.youtube.vitess.proto.Topodata;
 
 import java.sql.Array;
 import java.sql.Blob;
@@ -38,37 +37,37 @@ import java.util.logging.Logger;
 /**
  * Created by harshit.gangal on 23/01/16.
  */
-public class VitessConnection implements Connection {
+public class VitessConnection extends ConnectionProperties implements Connection {
 
     private static final int DEFAULT_RESULT_SET_TYPE = ResultSet.TYPE_FORWARD_ONLY;
     private static final int DEFAULT_RESULT_SET_CONCURRENCY = ResultSet.CONCUR_READ_ONLY;
+
     /* Get actual class name to be printed on */
     private static Logger logger = Logger.getLogger(VitessConnection.class.getName());
     private static DatabaseMetaData databaseMetaData = null;
+
     /**
      * A Map of currently open statements
      */
-    protected Set<Statement> openStatements = new HashSet<>();
+    private Set<Statement> openStatements = new HashSet<>();
     private VitessVTGateManager.VTGateConnections vTGateConnections;
     private VTGateTx vtGateTx;
     private boolean closed = true;
     private boolean autoCommit = true;
     private boolean readOnly = false;
     private DBProperties dbProperties;
-    private VitessJDBCUrl vitessJDBCUrl;
-
+    private final VitessJDBCUrl vitessJDBCUrl;
 
     /**
      * Constructor to Create Connection Object
      *
      * @param url  - Connection url
-     * @param info - property for the connection
+     * @param connectionProperties - property for the connection
      * @throws SQLException
      */
-    public VitessConnection(String url, Properties info) throws SQLException {
-
+    public VitessConnection(String url, Properties connectionProperties) throws SQLException {
         try {
-            this.vitessJDBCUrl = new VitessJDBCUrl(url, info);
+            this.vitessJDBCUrl = new VitessJDBCUrl(url, connectionProperties);
             this.vTGateConnections = new VitessVTGateManager.VTGateConnections(vitessJDBCUrl);
             this.closed = false;
             this.dbProperties = null;
@@ -76,6 +75,8 @@ public class VitessConnection implements Connection {
             throw new SQLException(
                 Constants.SQLExceptionMessages.CONN_INIT_ERROR + " - " + e.getMessage(), e);
         }
+
+        initializeProperties(vitessJDBCUrl.getProperties());
     }
 
     /**
@@ -153,7 +154,7 @@ public class VitessConnection implements Connection {
         try {
             if (isInTransaction()) {
                 Context context = createContext(Constants.CONNECTION_TIMEOUT);
-                this.vtGateTx.commit(context, this.vitessJDBCUrl.isTwopcEnabled()).checkedGet();
+                this.vtGateTx.commit(context, getTwopcEnabled()).checkedGet();
             }
         } finally {
             this.vtGateTx = null;
@@ -583,16 +584,8 @@ public class VitessConnection implements Connection {
         this.vtGateTx = vtGateTx;
     }
 
-    public Topodata.TabletType getTabletType() {
-        return this.vitessJDBCUrl.getTabletType();
-    }
-
     public String getUrl() {
         return this.vitessJDBCUrl.getUrl();
-    }
-
-    public Constants.QueryExecuteType getExecuteTypeParam() {
-        return this.vitessJDBCUrl.getExecuteType();
     }
 
     /**

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
@@ -2,7 +2,12 @@ package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
@@ -24,6 +29,7 @@ public class VitessDriver implements Driver {
         }
     }
 
+    @Override
     public Connection connect(String url, Properties info) throws SQLException {
         return acceptsURL(url) ? new VitessConnection(url, info) : null;
     }
@@ -39,6 +45,7 @@ public class VitessDriver implements Driver {
      * <p/>
      * TODO: Write a better regex
      */
+    @Override
     public boolean acceptsURL(String url) throws SQLException {
         return null != url && url.startsWith(Constants.URL_PREFIX);
     }
@@ -49,12 +56,13 @@ public class VitessDriver implements Driver {
      * @return DriverPropertyInfo Array Object
      * @throws SQLException
      */
+    @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
         if (null == info) {
             info = new Properties();
         }
 
-        DriverPropertyInfo[] dpi = new DriverPropertyInfo[7];
+        DriverPropertyInfo[] dpi = ConnectionProperties.exposeAsDriverPropertyInfo(info, 5);
         if (acceptsURL(url)) {
             VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(url, info);
 
@@ -73,26 +81,14 @@ public class VitessDriver implements Driver {
             dpi[2].required = true;
             dpi[2].description = Constants.VITESS_KEYSPACE;
 
-            dpi[3] = new DriverPropertyInfo(Constants.Property.TABLET_TYPE,
-                vitessJDBCUrl.getTabletType().toString());
+            dpi[3] = new DriverPropertyInfo(Constants.Property.DBNAME, vitessJDBCUrl.getCatalog());
             dpi[3].required = false;
-            dpi[3].description = Constants.VITESS_TABLET_TYPE;
+            dpi[3].description = Constants.VITESS_DB_NAME;
 
-            dpi[4] = new DriverPropertyInfo(Constants.Property.EXECUTE_TYPE,
-                vitessJDBCUrl.getExecuteType().toString());
-            dpi[4].required = false;
-            dpi[4].description = Constants.EXECUTE_TYPE_DESC;
-
-            dpi[5] = new DriverPropertyInfo(Constants.Property.DBNAME, vitessJDBCUrl.getCatalog());
-            dpi[5].required = true;
-            dpi[5].description = Constants.VITESS_DB_NAME;
-
-            dpi[6] =
+            dpi[4] =
                 new DriverPropertyInfo(Constants.Property.USERNAME, vitessJDBCUrl.getUsername());
-            dpi[6].required = false;
-            dpi[6].description = Constants.USERNAME_DESC;
-
-
+            dpi[4].required = false;
+            dpi[4].description = Constants.USERNAME_DESC;
         } else {
             throw new SQLException(Constants.SQLExceptionMessages.INVALID_CONN_URL + " : " + url);
         }
@@ -100,18 +96,22 @@ public class VitessDriver implements Driver {
         return dpi;
     }
 
+    @Override
     public int getMajorVersion() {
         return Constants.DRIVER_MAJOR_VERSION;
     }
 
+    @Override
     public int getMinorVersion() {
         return Constants.DRIVER_MINOR_VERSION;
     }
 
+    @Override
     public boolean jdbcCompliant() {
         return Constants.JDBC_COMPLIANT;
     }
 
+    @Override
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
         throw new SQLFeatureNotSupportedException(
             Constants.SQLExceptionMessages.SQL_FEATURE_NOT_SUPPORTED);

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessDriver.java
@@ -51,8 +51,15 @@ public class VitessDriver implements Driver {
     }
 
     /**
+     * Given a String URL and a Properties object, computes the expected and
+     * required parameters for the driver. Parameters can be set in either the URL
+     * or Properties.
+     *
      * @param url  - Connection Url
+     *             A vitess-compatible URL, per {@link VitessJDBCUrl}
+     *             i.e. jdbc:vitess://locahost:9000/vt_keyspace?TABLET_TYPE=master
      * @param info - Property for the connection
+     *             May contain additional properties to configure this driver with
      * @return DriverPropertyInfo Array Object
      * @throws SQLException
      */

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessJDBCUrl.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessJDBCUrl.java
@@ -14,7 +14,17 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Created by naveen.nahata on 17/02/16.
+ * VitessJDBCUrl is responsible for parsing a driver URL and Properties object,
+ * returning a new Properties object with configuration from the URL and passed in Properties
+ * merged.
+ *
+ * Parameters passed in through the Properties object take precedence over the parameters
+ * in the URL, where there are conflicts.
+ *
+ * The Passed in URL is expected to conform to the following basic format:
+ *
+ * jdbc:vitess://username:password@ip1:port1,ip2:port2/keyspace/catalog?property1=value1..
+ *
  */
 public class VitessJDBCUrl {
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessPreparedStatement.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessPreparedStatement.java
@@ -117,14 +117,13 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                     .getAutoCommit()) {
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    if (Constants.QueryExecuteType.SIMPLE == vitessConnection
-                        .getExecuteTypeParam()) {
+                    if (vitessConnection.isSimpleExecute()) {
                         cursor =
-                            vtGateConn.execute(context, this.sql, this.bindVariables, tabletType)
+                            vtGateConn.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                                 .checkedGet();
                     } else {
                         cursor = vtGateConn
-                            .streamExecute(context, this.sql, this.bindVariables, tabletType);
+                            .streamExecute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields());
                     }
                 } else {
                     VTGateTx vtGateTx = this.vitessConnection.getVtGateTx();
@@ -136,7 +135,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                     }
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType)
+                    cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
                 }
             }
@@ -174,7 +173,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
         try {
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateConn.execute(context, this.sql, this.bindVariables, tabletType)
+                cursor = vtGateConn.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                     .checkedGet();
             } else {
                 VTGateTx vtGateTx = this.vitessConnection.getVtGateTx();
@@ -186,7 +185,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                 }
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType)
+                cursor = vtGateTx.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                     .checkedGet();
             }
 
@@ -443,7 +442,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateConn.executeBatch(context, batchedQueries, batchedArgs, tabletType)
+                    vtGateConn.executeBatch(context, batchedQueries, batchedArgs, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
             } else {
                 vtGateTx = this.vitessConnection.getVtGateTx();
@@ -456,7 +455,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateTx.executeBatch(context, batchedQueries, batchedArgs, tabletType)
+                    vtGateTx.executeBatch(context, batchedQueries, batchedArgs, tabletType, vitessConnection.getIncludedFields())
                         .checkedGet();
             }
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
@@ -111,11 +111,10 @@ public class VitessStatement implements Statement {
                     .getAutoCommit()) {
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    if (Constants.QueryExecuteType.SIMPLE == vitessConnection
-                        .getExecuteTypeParam()) {
-                        cursor = vtGateConn.execute(context, sql, null, tabletType).checkedGet();
+                    if (vitessConnection.isSimpleExecute()) {
+                        cursor = vtGateConn.execute(context, sql, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
                     } else {
-                        cursor = vtGateConn.streamExecute(context, sql, null, tabletType);
+                        cursor = vtGateConn.streamExecute(context, sql, null, tabletType, vitessConnection.getIncludedFields());
                     }
                 } else {
                     VTGateTx vtGateTx = this.vitessConnection.getVtGateTx();
@@ -128,7 +127,7 @@ public class VitessStatement implements Statement {
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 /* Stream query is not suppose to run in a txn. */
-                    cursor = vtGateTx.execute(context, sql, null, tabletType).checkedGet();
+                    cursor = vtGateTx.execute(context, sql, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
                 }
             }
 
@@ -424,7 +423,7 @@ public class VitessStatement implements Statement {
         try {
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateConn.execute(context, sql, null, tabletType).checkedGet();
+                cursor = vtGateConn.execute(context, sql, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
             } else {
                 vtGateTx = this.vitessConnection.getVtGateTx();
                 if (null == vtGateTx) {
@@ -435,7 +434,7 @@ public class VitessStatement implements Statement {
                 }
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                cursor = vtGateTx.execute(context, sql, null, tabletType).checkedGet();
+                cursor = vtGateTx.execute(context, sql, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
             }
 
             if (null == cursor) {
@@ -572,7 +571,7 @@ public class VitessStatement implements Statement {
             if (this.vitessConnection.getAutoCommit()) {
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateConn.executeBatch(context, batchedArgs, null, tabletType).checkedGet();
+                    vtGateConn.executeBatch(context, batchedArgs, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
             } else {
                 vtGateTx = this.vitessConnection.getVtGateTx();
                 if (null == vtGateTx) {
@@ -584,7 +583,7 @@ public class VitessStatement implements Statement {
 
                 Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
                 cursorWithErrorList =
-                    vtGateTx.executeBatch(context, batchedArgs, null, tabletType).checkedGet();
+                    vtGateTx.executeBatch(context, batchedArgs, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
             }
 
             if (null == cursorWithErrorList) {
@@ -644,7 +643,7 @@ public class VitessStatement implements Statement {
         Context context = this.vitessConnection.createContext(this.queryTimeoutInMillis);
         return this.vitessConnection.getVtGateConn()
             .executeKeyspaceIds(context, sql, keyspace, keyspaceIds, null,
-                this.vitessConnection.getTabletType()).checkedGet();
+                this.vitessConnection.getTabletType(), vitessConnection.getIncludedFields()).checkedGet();
     }
 
     /**

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessVTGateManager.java
@@ -78,21 +78,6 @@ public class VitessVTGateManager {
      * @param hostname
      * @param port
      * @param username
-     * @return
-     */
-    private static VTGateConn getVtGateConn(String hostname, int port, String username) {
-        Context context = CommonUtils.createContext(username, Constants.CONNECTION_TIMEOUT);
-        InetSocketAddress inetSocketAddress = new InetSocketAddress(hostname, port);
-        RpcClient client = new GrpcClientFactory().create(context, inetSocketAddress);
-        return (new VTGateConn(client));
-    }
-
-    /**
-     * Create vtGateConn object with given identifier.
-     *
-     * @param hostname
-     * @param port
-     * @param username
      * @param keyspace
      * @return
      */
@@ -114,8 +99,6 @@ public class VitessVTGateManager {
      * @param identifier
      * @param hostname
      * @param port
-     * @param username
-     * @param keyspace
      */
     private static void updateVtGateConnHashMap(String identifier, String hostname, int port,
         String username, String keyspace) {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
@@ -1,5 +1,8 @@
 package com.flipkart.vitess.util;
 
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
 /**
  * Created by harshit.gangal on 25/01/16.
  */
@@ -15,7 +18,7 @@ public class Constants {
     public static final String VITESS_TABLET_TYPE =
         "Tablet Type to which Vitess will connect(master, replica, rdonly)";
     public static final String DEFAULT_PORT = "15991";
-    public static final String DEFAULT_TABLET_TYPE = "MASTER";
+    public static final Topodata.TabletType DEFAULT_TABLET_TYPE = Topodata.TabletType.MASTER;
     public static final long CONNECTION_TIMEOUT = 30000;
     public static final String LITERAL_V = "v";
     public static final String LITERAL_SINGLE_QUOTE = "'";
@@ -30,7 +33,7 @@ public class Constants {
     public static final Constants.QueryExecuteType DEFAULT_EXECUTE_TYPE = QueryExecuteType.SIMPLE;
     public static final String EXECUTE_TYPE_DESC = "Query execution type: simple or stream \n";
     public static final String USERNAME_DESC = "Username used for ACL validation \n";
-
+    public static final Query.ExecuteOptions.IncludedFields DEFAULT_INCLUDED_FIELDS = Query.ExecuteOptions.IncludedFields.ALL;
 
     private Constants() {
     }
@@ -99,6 +102,7 @@ public class Constants {
         public static final String USERNAME = "userName";
         public static final String EXECUTE_TYPE = "executeType";
         public static final String TWOPC_ENABLED = "twopcEnabled";
+        public static final String INCLUDED_FIELDS = "includedFields";
     }
 
 

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
@@ -1,0 +1,25 @@
+package com.flipkart.vitess.jdbc;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import java.sql.SQLException;
+import java.util.Properties;
+
+public class BaseTest {
+    String dbURL = "jdbc:vitess://locahost:9000/vt_shipment/shipment";
+
+    @BeforeClass
+    public static void setUp() {
+        // load Vitess driver
+        try {
+            Class.forName("com.flipkart.vitess.jdbc.VitessDriver");
+        } catch (ClassNotFoundException e) {
+            Assert.fail("Driver is not in the CLASSPATH -> " + e.getMessage());
+        }
+    }
+
+    protected VitessConnection getVitessConnection() throws SQLException {
+        return new VitessConnection(dbURL, new Properties());
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class BaseTest {
-    String dbURL = "jdbc:vitess://locahost:9000/vt_keyspace/testDatabase";
+    String dbURL = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace";
 
     @BeforeClass
     public static void setUp() {

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
@@ -7,11 +7,10 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 public class BaseTest {
-    String dbURL = "jdbc:vitess://locahost:9000/vt_shipment/shipment";
+    String dbURL = "jdbc:vitess://locahost:9000/vt_keyspace/testDatabase";
 
     @BeforeClass
     public static void setUp() {
-        // load Vitess driver
         try {
             Class.forName("com.flipkart.vitess.jdbc.VitessDriver");
         } catch (ClassNotFoundException e) {

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
@@ -1,0 +1,165 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.DriverPropertyInfo;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Properties;
+
+public class ConnectionPropertiesTest {
+
+    @Test
+    public void testReflection() throws Exception {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = Mockito.spy(Properties.class);
+        Mockito.doReturn(info).when(info).clone();
+        props.initializeProperties(info);
+
+        // Just testing that we are properly picking up all the fields defined in the properties
+        // For each field we call initializeFrom, which should call getProperty and remove
+        Mockito.verify(info, Mockito.times(4)).getProperty(Mockito.anyString());
+        Mockito.verify(info, Mockito.times(4)).remove(Mockito.anyString());
+    }
+
+    @Test
+    public void testDefaults() throws SQLException {
+
+        ConnectionProperties props = new ConnectionProperties();
+        props.initializeProperties(new Properties());
+
+        Assert.assertEquals("executeType", Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
+        Assert.assertEquals("twopcEnabled", false, props.getTwopcEnabled());
+        Assert.assertEquals("includedFields", Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
+        Assert.assertEquals("includedFieldsCache", true, props.isIncludeAllFields());
+        Assert.assertEquals("tabletType", Constants.DEFAULT_TABLET_TYPE, props.getTabletType());
+    }
+
+    @Test
+    public void testInitializeFromProperties() throws SQLException {
+
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+        info.setProperty("executeType", Constants.QueryExecuteType.STREAM.name());
+        info.setProperty("twopcEnabled", "yes");
+        info.setProperty("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY.name());
+        info.setProperty(Constants.Property.TABLET_TYPE, Topodata.TabletType.BACKUP.name());
+
+        props.initializeProperties(info);
+
+        Assert.assertEquals("executeType", Constants.QueryExecuteType.STREAM, props.getExecuteType());
+        Assert.assertEquals("twopcEnabled", true, props.getTwopcEnabled());
+        Assert.assertEquals("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY, props.getIncludedFields());
+        Assert.assertEquals("includedFieldsCache", false, props.isIncludeAllFields());
+        Assert.assertEquals("tabletType", Topodata.TabletType.BACKUP, props.getTabletType());
+    }
+
+    @Test
+    public void testDriverPropertiesOutput() throws SQLException {
+        Properties info = new Properties();
+        DriverPropertyInfo[] infos = ConnectionProperties.exposeAsDriverPropertyInfo(info, 0);
+        Assert.assertEquals(4, infos.length);
+
+        // Test the expected fields for just 1
+        Assert.assertEquals("executeType", infos[0].name);
+        Assert.assertEquals("Query execution type: simple or stream",
+            infos[0].description);
+        Assert.assertEquals(false, infos[0].required);
+        Constants.QueryExecuteType[] enumConstants = Constants.QueryExecuteType.values();
+        String[] allowed = new String[enumConstants.length];
+        for (int i = 0; i < enumConstants.length; i++) {
+            allowed[i] = enumConstants[i].toString();
+        }
+        Assert.assertArrayEquals(allowed, infos[0].choices);
+
+        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[1].name);
+        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[2].name);
+        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[3].name);
+    }
+
+    @Test
+    public void testValidBooleanValues() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        info.setProperty(Constants.Property.TWOPC_ENABLED, "true");
+        props.initializeProperties(info);
+        Assert.assertEquals(true, props.getTwopcEnabled());
+        info.setProperty(Constants.Property.TWOPC_ENABLED, "yes");
+        props.initializeProperties(info);
+        Assert.assertEquals(true, props.getTwopcEnabled());
+        info.setProperty(Constants.Property.TWOPC_ENABLED, "no");
+        props.initializeProperties(info);
+        Assert.assertEquals(false, props.getTwopcEnabled());
+
+        info.setProperty(Constants.Property.TWOPC_ENABLED, "false-ish");
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have thrown an exception on bad value false-ish");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals(
+                "Property '" + Constants.Property.TWOPC_ENABLED + "' Value 'false-ish' not in the list of allowable values: "
+                    + Arrays.toString(new String[] { Boolean.toString(true), Boolean.toString(false), "yes", "no"})
+                , e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void testValidEnumValues() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        info.setProperty("executeType", "foo");
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have thrown an exception on bad value foo");
+        } catch (IllegalArgumentException e) {
+            Assert.assertEquals(
+                "Property 'executeType' Value 'foo' not in the list of allowable values: "
+                    + Arrays.toString(Constants.QueryExecuteType.values())
+                , e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSettersUpdateCaches() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        props.initializeProperties(new Properties());
+
+        // included fields and all boolean cache
+        Assert.assertEquals(Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
+        Assert.assertEquals(true, props.isIncludeAllFields());
+
+        // execute type and simple boolean cahce
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE == Constants.QueryExecuteType.SIMPLE, props.isSimpleExecute());
+
+        // tablet type and twopc
+        Assert.assertEquals(Constants.DEFAULT_TABLET_TYPE, props.getTabletType());
+        Assert.assertEquals(false, props.getTwopcEnabled());
+
+        props.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        props.setExecuteType(Constants.QueryExecuteType.STREAM);
+        props.setTabletType(Topodata.TabletType.BACKUP);
+        props.setTwopcEnabled(true);
+
+        // included fields and all boolean cache
+        Assert.assertEquals(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME, props.getIncludedFields());
+        Assert.assertEquals(false, props.isIncludeAllFields());
+
+        // execute type and simple boolean cahce
+        Assert.assertEquals(Constants.QueryExecuteType.STREAM, props.getExecuteType());
+        Assert.assertEquals(Constants.DEFAULT_EXECUTE_TYPE != Constants.QueryExecuteType.SIMPLE, props.isSimpleExecute());
+
+        // tablet type and twopc
+        Assert.assertEquals(Topodata.TabletType.BACKUP, props.getTabletType());
+        Assert.assertEquals(true, props.getTwopcEnabled());
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -184,7 +184,7 @@ public class VitessConnectionTest extends BaseTest {
 
     @Test public void testGetCatalog() throws SQLException {
         VitessConnection vitessConnection = getVitessConnection();
-        Assert.assertEquals("testDatabase", vitessConnection.getCatalog());
+        Assert.assertEquals("keyspace", vitessConnection.getCatalog());
     }
 
     @Test public void testSetCatalog() throws SQLException {
@@ -194,7 +194,7 @@ public class VitessConnectionTest extends BaseTest {
     }
 
     @Test public void testPropertiesFromJdbcUrl() throws SQLException {
-        String url = "jdbc:vitess://locahost:9000/vt_keyspace/testDatabase?TABLET_TYPE=replica&includedFields=type_and_name";
+        String url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&includedFields=type_and_name";
         VitessConnection conn = new VitessConnection(url, new Properties());
 
         // Properties from the url should be passed into the connection properties, and override whatever defaults we've defined

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -5,9 +5,10 @@ import com.google.common.util.concurrent.Futures;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.SQLFuture;
 import com.youtube.vitess.client.VTGateTx;
+import com.youtube.vitess.proto.Query;
+import com.youtube.vitess.proto.Topodata;
 
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.powermock.api.mockito.PowerMockito;
@@ -15,29 +16,15 @@ import org.powermock.api.mockito.PowerMockito;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 /**
  * Created by harshit.gangal on 19/01/16.
  */
-public class VitessConnectionTest {
-
-    String dbURL = "jdbc:vitess://locahost:9000/vt_shipment/shipment";
-
-    @BeforeClass public static void setUp() {
-        // load Vitess driver
-        try {
-            Class.forName("com.flipkart.vitess.jdbc.VitessDriver");
-        } catch (ClassNotFoundException e) {
-            Assert.fail("Driver is not in the CLASSPATH -> " + e.getMessage());
-        }
-    }
-
-    private VitessConnection getVitessConnection() throws SQLException {
-        return new VitessConnection(dbURL, null);
-    }
+public class VitessConnectionTest extends BaseTest {
 
     @Test public void testVitessConnection() throws SQLException {
-        VitessConnection vitessConnection = new VitessConnection(dbURL, null);
+        VitessConnection vitessConnection = new VitessConnection(dbURL, new Properties());
         Assert.assertEquals(false, vitessConnection.isClosed());
         Assert.assertNull(vitessConnection.getDbProperties());
     }
@@ -206,4 +193,13 @@ public class VitessConnectionTest {
         Assert.assertEquals("order", vitessConnection.getCatalog());
     }
 
+    @Test public void testPropertiesFromJdbcUrl() throws SQLException {
+        String url = "jdbc:vitess://locahost:9000/vt_shipment/shipment?TABLET_TYPE=replica&includedFields=type_and_name";
+        VitessConnection conn = new VitessConnection(url, new Properties());
+
+        // Properties from the url should be passed into the connection properties, and override whatever defaults we've defined
+        Assert.assertEquals(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME, conn.getIncludedFields());
+        Assert.assertEquals(false, conn.isIncludeAllFields());
+        Assert.assertEquals(Topodata.TabletType.REPLICA, conn.getTabletType());
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -184,17 +184,17 @@ public class VitessConnectionTest extends BaseTest {
 
     @Test public void testGetCatalog() throws SQLException {
         VitessConnection vitessConnection = getVitessConnection();
-        Assert.assertEquals("shipment", vitessConnection.getCatalog());
+        Assert.assertEquals("testDatabase", vitessConnection.getCatalog());
     }
 
     @Test public void testSetCatalog() throws SQLException {
         VitessConnection vitessConnection = getVitessConnection();
-        vitessConnection.setCatalog("order");
-        Assert.assertEquals("order", vitessConnection.getCatalog());
+        vitessConnection.setCatalog("myDB");
+        Assert.assertEquals("myDB", vitessConnection.getCatalog());
     }
 
     @Test public void testPropertiesFromJdbcUrl() throws SQLException {
-        String url = "jdbc:vitess://locahost:9000/vt_shipment/shipment?TABLET_TYPE=replica&includedFields=type_and_name";
+        String url = "jdbc:vitess://locahost:9000/vt_keyspace/testDatabase?TABLET_TYPE=replica&includedFields=type_and_name";
         VitessConnection conn = new VitessConnection(url, new Properties());
 
         // Properties from the url should be passed into the connection properties, and override whatever defaults we've defined

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessJDBCUrlTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessJDBCUrlTest.java
@@ -1,10 +1,12 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessJDBCUrl;
+import com.flipkart.vitess.util.Constants;
 import com.youtube.vitess.proto.Topodata;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.SQLException;
 import java.util.Properties;
 
 /**
@@ -69,7 +71,7 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(1).getPort());
         Assert.assertEquals("hostname3", vitessJDBCUrl.getHostInfos().get(2).getHostname());
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(2).getPort());
-        Assert.assertEquals(Topodata.TabletType.MASTER, vitessJDBCUrl.getTabletType());
+        Assert.assertEquals(Topodata.TabletType.MASTER.name(), vitessJDBCUrl.getProperties().getProperty(Constants.Property.TABLET_TYPE).toUpperCase());
         Assert.assertEquals("user", vitessJDBCUrl.getUsername());
     }
 
@@ -97,7 +99,7 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(2).getPort());
         Assert.assertEquals("hostname3", vitessJDBCUrl1.getHostInfos().get(2).getHostname());
         Assert.assertEquals(15001, vitessJDBCUrl1.getHostInfos().get(2).getPort());
-        Assert.assertEquals(vitessJDBCUrl.getTabletType(), Topodata.TabletType.MASTER);
+        Assert.assertEquals(Topodata.TabletType.MASTER.name(), vitessJDBCUrl.getProperties().getProperty(Constants.Property.TABLET_TYPE).toUpperCase());
         Assert.assertEquals("user", vitessJDBCUrl.getUsername());
     }
 
@@ -145,21 +147,31 @@ public class VitessJDBCUrlTest {
         Assert.assertEquals(15991, vitessJDBCUrl.getHostInfos().get(1).getPort());
         Assert.assertEquals("keyspace", vitessJDBCUrl.getKeyspace());
         Assert.assertEquals("catalog", vitessJDBCUrl.getCatalog());
-        Assert.assertEquals("val1", info.getProperty("prop1"));
-        Assert.assertEquals("val2", info.getProperty("prop2"));
+        Assert.assertEquals("val1", vitessJDBCUrl.getProperties().getProperty("prop1"));
+        Assert.assertEquals("val2", vitessJDBCUrl.getProperties().getProperty("prop2"));
     }
 
-    @Test public void testTwoPCEnabledURL() throws Exception {
-        VitessJDBCUrl vitessJDBCUrl =
-            new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=true", null);
-        Assert.assertTrue(vitessJDBCUrl.isTwopcEnabled());
+    @Test public void testLeaveOriginalPropertiesAlone() throws Exception {
+        Properties info = new Properties();
+        VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(
+            "jdbc:vitess://user:pass@hostname1:15991,hostname2:15991/keyspace/catalog?prop1=val1&prop2=val2",
+            info);
 
-        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991?twopcEnabled=false", null);
-        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
-
-        vitessJDBCUrl = new VitessJDBCUrl("jdbc:vitess://host:15991", null);
-        Assert.assertFalse(vitessJDBCUrl.isTwopcEnabled());
-
+        Assert.assertEquals(null, info.getProperty("prop1"));
+        Assert.assertEquals("val1", vitessJDBCUrl.getProperties().getProperty("prop1"));
     }
 
+    @Test public void testPropertiesTakePrecendenceOverUrl() throws SQLException {
+        Properties info = new Properties();
+        info.setProperty("prop1", "val3");
+        info.setProperty("prop2", "val4");
+
+        VitessJDBCUrl vitessJDBCUrl = new VitessJDBCUrl(
+            "jdbc:vitess://user:pass@hostname1:15991,hostname2:15991/keyspace/catalog?prop1=val1&prop2=val2&prop3=val3",
+            info);
+
+        Assert.assertEquals("val3", vitessJDBCUrl.getProperties().getProperty("prop1"));
+        Assert.assertEquals("val4", vitessJDBCUrl.getProperties().getProperty("prop2"));
+        Assert.assertEquals("val3", vitessJDBCUrl.getProperties().getProperty("prop3"));
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessPreparedStatementTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessPreparedStatementTest.java
@@ -91,18 +91,19 @@ import java.util.TimeZone;
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
 
@@ -170,22 +171,22 @@ import java.util.TimeZone;
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .streamExecute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.STREAM);
 
         VitessPreparedStatement preparedStatement;
@@ -253,17 +254,17 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessPreparedStatement preparedStatement =
             new VitessPreparedStatement(mockConn, sqlUpdate);
@@ -330,27 +331,28 @@ import java.util.TimeZone;
         Cursor mockCursor = PowerMockito.mock(Cursor.class);
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         SQLFuture mockSqlFutureVtGateTx = PowerMockito.mock(SQLFuture.class);
-        List<Query.Field> mockFieldList = PowerMockito.mock(ArrayList.class);
+        List<Query.Field> mockFieldList = PowerMockito.spy(new ArrayList<Query.Field>());
 
         PowerMockito.when(mockConn.getKeyspace()).thenReturn("test_keyspace");
         PowerMockito.when(mockConn.getVtGateConn()).thenReturn(mockVtGateConn);
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
 
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getAutoCommit()).thenReturn(true);
         PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureCursor);
@@ -366,7 +368,8 @@ import java.util.TimeZone;
 
             int fieldSize = 5;
             PowerMockito.when(mockCursor.getFields()).thenReturn(mockFieldList);
-            PowerMockito.when(mockFieldList.size()).thenReturn(fieldSize);
+            PowerMockito.doReturn(fieldSize).when(mockFieldList).size();
+            PowerMockito.doReturn(false).when(mockFieldList).isEmpty();
             boolean hasResultSet = preparedStatement.execute();
             Assert.assertTrue(hasResultSet);
             Assert.assertNotNull(preparedStatement.getResultSet());
@@ -377,7 +380,7 @@ import java.util.TimeZone;
             Assert.assertNotNull(preparedStatement.getResultSet());
 
             int mockUpdateCount = 10;
-            PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+            PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
             PowerMockito.when(mockCursor.getRowsAffected()).thenReturn((long) mockUpdateCount);
             preparedStatement = new VitessPreparedStatement(mockConn, sqlUpdate);
             hasResultSet = preparedStatement.execute();
@@ -412,9 +415,9 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFuture);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFuture);
         PowerMockito.when(mockSqlFuture.checkedGet()).thenReturn(mockCursor);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessPreparedStatement preparedStatement =
             new VitessPreparedStatement(mockConn, sqlSelect);
@@ -572,17 +575,17 @@ import java.util.TimeZone;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
 
         try {
@@ -669,7 +672,7 @@ import java.util.TimeZone;
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         PowerMockito.when(mockVtGateConn
             .executeBatch(Matchers.any(Context.class), Matchers.anyList(), Matchers.anyList(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
 
         List<CursorWithError> mockCursorWithErrorList = new ArrayList<>();
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursorWithErrorList);

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessStatementTest.java
@@ -10,6 +10,7 @@ import com.youtube.vitess.client.cursor.CursorWithError;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata;
 import com.youtube.vitess.proto.Vtrpc;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,19 +74,20 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -143,19 +145,19 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .streamExecute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.STREAM);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -214,17 +216,17 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -286,28 +288,29 @@ import java.util.List;
         Cursor mockCursor = PowerMockito.mock(Cursor.class);
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         SQLFuture mockSqlFutureVtGateTx = PowerMockito.mock(SQLFuture.class);
-        List<Query.Field> mockFieldList = PowerMockito.mock(ArrayList.class);
+        List<Query.Field> mockFieldList = PowerMockito.spy(new ArrayList<Query.Field>());
 
         PowerMockito.when(mockConn.getKeyspace()).thenReturn("test_keyspace");
         PowerMockito.when(mockConn.getVtGateConn()).thenReturn(mockVtGateConn);
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(null);
         PowerMockito.when(mockVtGateConn.begin(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureVtGateTx);
 
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockConn.getAutoCommit()).thenReturn(true);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockVtGateTx.commit(Matchers.any(Context.class)))
             .thenReturn(mockSqlFutureCursor);
 
@@ -320,7 +323,9 @@ import java.util.List;
 
             int fieldSize = 5;
             PowerMockito.when(mockCursor.getFields()).thenReturn(mockFieldList);
-            PowerMockito.when(mockFieldList.size()).thenReturn(fieldSize);
+            PowerMockito.doReturn(fieldSize).when(mockFieldList).size();
+            PowerMockito.doReturn(false).when(mockFieldList).isEmpty();
+
             boolean hasResultSet = statement.execute(sqlSelect);
             Assert.assertTrue(hasResultSet);
             Assert.assertNotNull(statement.getResultSet());
@@ -330,7 +335,7 @@ import java.util.List;
             Assert.assertNotNull(statement.getResultSet());
 
             int mockUpdateCount = 10;
-            PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+            PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
             PowerMockito.when(mockCursor.getRowsAffected()).thenReturn((long) mockUpdateCount);
             hasResultSet = statement.execute(sqlUpdate);
             Assert.assertFalse(hasResultSet);
@@ -363,9 +368,9 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFuture);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFuture);
         PowerMockito.when(mockSqlFuture.checkedGet()).thenReturn(mockCursor);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
 
         VitessStatement statement = new VitessStatement(mockConn);
         try {
@@ -400,9 +405,10 @@ import java.util.List;
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.REPLICA);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
-        PowerMockito.when(mockConn.getExecuteTypeParam())
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
+        PowerMockito.when(mockConn.getExecuteType())
             .thenReturn(Constants.QueryExecuteType.SIMPLE);
+        PowerMockito.when(mockConn.isSimpleExecute()).thenReturn(true);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
 
         VitessStatement statement = new VitessStatement(mockConn);
@@ -525,17 +531,17 @@ import java.util.List;
         PowerMockito.when(mockConn.getVtGateTx()).thenReturn(mockVtGateTx);
         PowerMockito.when(mockVtGateTx
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .execute(Matchers.any(Context.class), Matchers.anyString(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockVtGateConn
             .executeKeyspaceIds(Matchers.any(Context.class), Matchers.anyString(),
                 Matchers.anyString(), Matchers.anyCollection(), Matchers.anyMap(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursor);
         PowerMockito.when(mockSqlFutureVtGateTx.checkedGet()).thenReturn(mockVtGateTx);
-        PowerMockito.when(mockCursor.getFields()).thenReturn(null);
+        PowerMockito.when(mockCursor.getFields()).thenReturn(Query.QueryResult.getDefaultInstance().getFieldsList());
         PowerMockito.when(mockConn.getTabletType()).thenReturn(Topodata.TabletType.MASTER);
 
         VitessStatement statement = new VitessStatement(mockConn);
@@ -630,7 +636,7 @@ import java.util.List;
         SQLFuture mockSqlFutureCursor = PowerMockito.mock(SQLFuture.class);
         PowerMockito.when(mockVtGateConn
             .executeBatch(Matchers.any(Context.class), Matchers.anyList(), Matchers.anyList(),
-                Matchers.any(Topodata.TabletType.class))).thenReturn(mockSqlFutureCursor);
+                Matchers.any(Topodata.TabletType.class), Matchers.any(Query.ExecuteOptions.IncludedFields.class))).thenReturn(mockSqlFutureCursor);
 
         List<CursorWithError> mockCursorWithErrorList = new ArrayList<>();
         PowerMockito.when(mockSqlFutureCursor.checkedGet()).thenReturn(mockCursorWithErrorList);


### PR DESCRIPTION
This is PR 1 of 3 as replacement for https://github.com/youtube/vitess/pull/2455

I will submit followup PRs to add support for mysql metadata in VitessResultSet, and character encoding support.

This PR adds the foundational addition of ConnectionProperties. The idea here is to provide a lasting home for more explicit configuration options of the driver. I moved all non-host-related configs into here (leaving host, keyspace, password, etc in the VitessJdbcUrl class).

The bulk of the line changes here are passing the IncludedFields option down through all the various functions and tests.

@ashudeep-sharma 