### PR TITLE
vtgate/buffer: Lower default duration after which we stop buffering from 40s to 20s.

### DIFF
--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -120,7 +120,7 @@ func resetFlags() {
 	flag.Set("enable_vtgate_buffer", "false")
 	flag.Set("vtgate_buffer_window", "10s")
 	flag.Set("vtgate_buffer_keyspace_shards", "")
-	flag.Set("vtgate_buffer_max_failover_duration", "40s")
+	flag.Set("vtgate_buffer_max_failover_duration", "20s")
 	flag.Set("vtgate_buffer_min_time_between_failovers", "5m")
 }
 

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -12,7 +12,7 @@ var (
 
 	window                  = flag.Duration("vtgate_buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
 	size                    = flag.Int("vtgate_buffer_size", 10, "Maximum number of buffered requests in flight (across all ongoing failovers).")
-	maxFailoverDuration     = flag.Duration("vtgate_buffer_max_failover_duration", 40*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
+	maxFailoverDuration     = flag.Duration("vtgate_buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
 	minTimeBetweenFailovers = flag.Duration("vtgate_buffer_min_time_between_failovers", 5*time.Minute, "Minimum time between the end of a failover and the start of the next one. Faster consecutive failovers will not trigger buffering.")
 
 	drainConcurrency = flag.Int("vtgate_buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously.")


### PR DESCRIPTION
This setting (--vtgate_buffer_max_failover_duration) is meant as a protection in case we don't observe the end of the failover. Shorter values are better in case of a false positive to reduce the time queries are buffered (and therefore not served).

Note that the default buffer window is 10s i.e. in case of a 20s failover, only requests 10s "old" or younger will remain in the buffer and may be successfully drained/retried.

BUG=26755052