### PR TITLE
JDBC - With IncludedFields.ALL, adds support for all non-encoding field metadata

### DIFF
--- a/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java
@@ -653,6 +653,8 @@ public class Row {
       case VARBINARY: // fall through
       case CHAR: // fall through
       case BINARY:
+      case GEOMETRY:
+      case JSON:
         return value.toByteArray();
       default:
         throw new SQLDataException("unknown field type: " + field.getType());

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -30,6 +30,16 @@ public class ConnectionProperties {
         }
     }
 
+    // Configs for handing tinyint(1)
+    private BooleanConnectionProperty tinyInt1isBit = new BooleanConnectionProperty(
+        "tinyInt1isBit",
+        "Should the driver treat the datatype TINYINT(1) as the BIT type (because the server silently converts BIT -> TINYINT(1) when creating tables)?",
+        true);
+    private BooleanConnectionProperty yearIsDateType = new BooleanConnectionProperty(
+        "yearIsDateType",
+        "Should the JDBC driver treat the MySQL type \"YEAR\" as a java.sql.Date, or as a SHORT?",
+        true);
+
     // Vitess-specific configs
     private EnumConnectionProperty<Constants.QueryExecuteType> executeType = new EnumConnectionProperty<>(
         Constants.Property.EXECUTE_TYPE,
@@ -99,6 +109,22 @@ public class ConnectionProperties {
             }
         }
         return driverProperties;
+    }
+
+    public boolean getTinyInt1isBit() {
+        return tinyInt1isBit.getValueAsBoolean();
+    }
+
+    public void setTinyInt1isBit(boolean tinyInt1isBit) {
+        this.tinyInt1isBit.setValue(tinyInt1isBit);
+    }
+
+    public boolean getYearIsDateType() {
+        return yearIsDateType.getValueAsBoolean();
+    }
+
+    public void setYearIsDateType(boolean yearIsDateType) {
+        this.yearIsDateType.setValue(yearIsDateType);
     }
 
     public Query.ExecuteOptions.IncludedFields getIncludedFields() {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
@@ -127,7 +127,7 @@ public class FieldWithMetadata {
 
     private void checkConnection() throws SQLException {
         if (connection == null) {
-            throw new SQLException(Constants.SQLExceptionMessages.SQL_FEATURE_NOT_SUPPORTED);
+            throw new SQLException(Constants.SQLExceptionMessages.CONN_UNAVAILABLE);
         }
     }
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
@@ -1,0 +1,368 @@
+package com.flipkart.vitess.jdbc;
+
+import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.MysqlDefs;
+import com.youtube.vitess.proto.Query;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+public class FieldWithMetadata {
+
+    private final VitessConnection connection;
+    private final Query.Field field;
+    private final Query.Type vitessType;
+    private final boolean isSingleBit;
+    private final int precisionAdjustFactor;
+
+    private int javaType;
+    private int colFlag;
+    private String encoding;
+    private String collationName;
+    private int collationIndex;
+    private int maxBytesPerChar;
+
+    public FieldWithMetadata(VitessConnection connection, Query.Field field) throws SQLException {
+        this.connection = connection;
+        this.field = field;
+        this.colFlag = field.getFlags();
+        this.vitessType = field.getType();
+        this.collationIndex = field.getCharset();
+
+        // Map MySqlTypes to java.sql Types
+        if (MysqlDefs.vitesstoMySqlType.containsKey(vitessType)) {
+            this.javaType = MysqlDefs.vitesstoMySqlType.get(vitessType);
+        } else if (field.getType().equals(Query.Type.TUPLE)) {
+            throw new SQLException(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE);
+        } else {
+            throw new SQLException(Constants.SQLExceptionMessages.UNKNOWN_COLUMN_TYPE);
+        }
+
+        // All of the below remapping and metadata fields require the extra
+        // fields included when includeFields=IncludedFields.ALL
+        if (connection != null && connection.isIncludeAllFields()) {
+            // Re-map TINYINT(1) as bit or pseudo-boolean
+            if (this.javaType == Types.TINYINT && this.field.getColumnLength() == 1 && connection.getTinyInt1isBit()) {
+                this.javaType = Types.BIT;
+            }
+
+            if (!isNativeNumericType() && !isNativeDateTimeType()) {
+                if (this.javaType == Types.BIT) {
+                    this.isSingleBit = field.getColumnLength() == 0 || field.getColumnLength() == 1;
+                } else {
+                    this.isSingleBit = false;
+                }
+            } else {
+                this.isSingleBit = false;
+            }
+
+            // Precision can be calculated from column length, but needs
+            // to be adjusted for the extra bytes used by the negative sign
+            // and decimal points, where appropriate.
+            if (isSigned()) {
+                switch (javaType) {
+                    case Types.FLOAT:
+                    case Types.REAL:
+                    case Types.DOUBLE:
+                    case Types.BIT:
+                        // float/real/double are the same regardless of sign/decimal
+                        // bit values can't actually be signed
+                        this.precisionAdjustFactor = 0;
+                        break;
+                    default:
+                        // other types we adjust for the negative symbol, and decimal
+                        // symbol if there are decimals
+                        this.precisionAdjustFactor = getDecimals() > 0 ? -2 : -1;
+                }
+            } else {
+                switch (javaType) {
+                    case Types.DECIMAL:
+                    case Types.NUMERIC:
+                        // adjust for the decimal
+                        this.precisionAdjustFactor = -1;
+                        break;
+                    default:
+                        // all other types need no adjustment
+                        this.precisionAdjustFactor = 0;
+                }
+            }
+        } else {
+            // Defaults to appease final variables when not including all fields
+            this.isSingleBit = false;
+            this.precisionAdjustFactor = 0;
+        }
+    }
+
+    private boolean isNativeNumericType() {
+        switch (this.javaType) {
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.FLOAT:
+            case Types.DOUBLE:
+            case Types.REAL:
+            case Types.DECIMAL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isNativeDateTimeType() {
+        switch (this.javaType) {
+            case Types.DATE:
+            case Types.TIME:
+            case Types.TIMESTAMP:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public VitessConnection getConnection() throws SQLException {
+        checkConnection();
+        return connection;
+    }
+
+    private void checkConnection() throws SQLException {
+        if (connection == null) {
+            throw new SQLException(Constants.SQLExceptionMessages.SQL_FEATURE_NOT_SUPPORTED);
+        }
+    }
+
+    public boolean isAutoIncrement() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.AUTO_INCREMENT_FLAG_VALUE) > 0);
+    }
+
+    public boolean isBinary() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.BINARY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isBlob() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.BLOB_FLAG_VALUE) > 0);
+    }
+
+    public boolean isMultipleKey() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.MULTIPLE_KEY_FLAG_VALUE) > 0);
+    }
+
+    boolean isNotNull() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return true;
+        }
+        return ((this.colFlag & Query.MySqlFlag.NOT_NULL_FLAG_VALUE) > 0);
+    }
+
+    public boolean isZeroFill() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.ZEROFILL_FLAG_VALUE) > 0);
+    }
+
+    public boolean isPrimaryKey() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.PRI_KEY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isUniqueKey() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return ((this.colFlag & Query.MySqlFlag.UNIQUE_KEY_FLAG_VALUE) > 0);
+    }
+
+    public boolean isUnsigned() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return true;
+        }
+        return ((this.colFlag & Query.MySqlFlag.UNSIGNED_FLAG_VALUE) > 0);
+    }
+
+    public boolean isSigned() throws SQLException {
+        checkConnection();
+        return !isUnsigned();
+    }
+
+    boolean isOpaqueBinary() throws SQLException {
+        checkConnection();
+        return false;
+    }
+
+    /**
+     * Is this field _definitely_ not writable?
+     *
+     * @return true if this field can not be written to in an INSERT/UPDATE
+     * statement.
+     */
+    boolean isReadOnly() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        String orgColumnName = getOrgName();
+        String orgTableName = getOrgTable();
+        return !(orgColumnName != null && orgColumnName.length() > 0 && orgTableName != null && orgTableName.length() > 0);
+    }
+
+    public String getName() {
+        return field.getName();
+    }
+
+    public String getTable() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getTable();
+    }
+
+    public String getOrgTable() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getOrgTable();
+    }
+
+    public String getDatabase() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getDatabase();
+    }
+
+    public String getOrgName() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return null;
+        }
+        return field.getOrgName();
+    }
+
+    public int getColumnLength() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return field.getColumnLength();
+    }
+
+    public int getDecimals() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return field.getDecimals();
+    }
+
+    public int getJavaType() {
+        return javaType;
+    }
+
+    public Query.Type getVitessType() {
+        return vitessType;
+    }
+
+    public int getVitessTypeValue() {
+        return field.getTypeValue();
+    }
+
+    /**
+     * Precision can be calculated from column length, but needs
+     * to be adjusted for the extra values that can be included for the various
+     * numeric types
+     */
+    public int getPrecisionAdjustFactor() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return 0;
+        }
+        return precisionAdjustFactor;
+    }
+
+    public boolean isSingleBit() throws SQLException {
+        checkConnection();
+        if (!connection.isIncludeAllFields()) {
+            return false;
+        }
+        return isSingleBit;
+    }
+
+    @Override
+    public String toString() {
+        try {
+            StringBuilder asString = new StringBuilder();
+            asString.append(getClass().getCanonicalName());
+            asString.append("[");
+            asString.append("catalog=");
+            asString.append(this.getDatabase());
+            asString.append(",tableName=");
+            asString.append(this.getTable());
+            asString.append(",originalTableName=");
+            asString.append(this.getOrgTable());
+            asString.append(",columnName=");
+            asString.append(this.getName());
+            asString.append(",originalColumnName=");
+            asString.append(this.getOrgName());
+            asString.append(",vitessType=");
+            asString.append(getVitessType());
+            asString.append("(");
+            asString.append(getJavaType());
+            asString.append(")");
+            asString.append(",flags=");
+            if (isAutoIncrement()) {
+                asString.append("AUTO_INCREMENT");
+            }
+            if (isPrimaryKey()) {
+                asString.append(" PRIMARY_KEY");
+            }
+            if (isUniqueKey()) {
+                asString.append(" UNIQUE_KEY");
+            }
+            if (isBinary()) {
+                asString.append(" BINARY");
+            }
+            if (isBlob()) {
+                asString.append(" BLOB");
+            }
+            if (isMultipleKey()) {
+                asString.append(" MULTI_KEY");
+            }
+            if (isUnsigned()) {
+                asString.append(" UNSIGNED");
+            }
+            if (isZeroFill()) {
+                asString.append(" ZEROFILL");
+            }
+            return asString.toString();
+        } catch (Throwable t) {
+            return super.toString();
+        }
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -1,7 +1,6 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
-import com.flipkart.vitess.util.MysqlDefs;
 import com.google.common.collect.ImmutableList;
 import com.youtube.vitess.proto.Query;
 
@@ -19,9 +18,9 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
 
     /* Get actual class name to be printed on */
     private static Logger logger = Logger.getLogger(VitessResultSetMetaData.class.getName());
-    private List<Query.Field> fields;
+    private List<FieldWithMetadata> fields;
 
-    public VitessResultSetMetaData(List<Query.Field> fields) {
+    public VitessResultSetMetaData(List<FieldWithMetadata> fields) throws SQLException {
         this.fields = ImmutableList.copyOf(fields);
     }
 
@@ -30,15 +29,33 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public boolean isAutoIncrement(int column) throws SQLException {
-        return false;
+        return getField(column).isAutoIncrement();
     }
 
     public boolean isCaseSensitive(int column) throws SQLException {
-        return true;
+        FieldWithMetadata field = getField(column);
+        switch (field.getJavaType()) {
+            case Types.BIT:
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.FLOAT:
+            case Types.REAL:
+            case Types.DOUBLE:
+            case Types.DATE:
+            case Types.DECIMAL:
+            case Types.NUMERIC:
+            case Types.TIME:
+            case Types.TIMESTAMP:
+                return false;
+            default:
+                return true;
+        }
     }
 
     public boolean isSearchable(int column) throws SQLException {
-        return false;
+        return true;
     }
 
     public boolean isCurrency(int column) throws SQLException {
@@ -46,11 +63,11 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public int isNullable(int column) throws SQLException {
-        return 0;
+        return getField(column).isNotNull() ? 0 : 2;
     }
 
     public boolean isSigned(int column) throws SQLException {
-        return false;
+        return getField(column).isSigned();
     }
 
     public int getColumnDisplaySize(int column) throws SQLException {
@@ -58,51 +75,65 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public String getColumnLabel(int column) throws SQLException {
-        Query.Field field = getField(column);
-        return field.getName();
+        return getField(column).getName();
     }
 
     public String getColumnName(int column) throws SQLException {
-        Query.Field field = getField(column);
-        return field.getName();
+        return getField(column).getName();
     }
 
     public String getSchemaName(int column) throws SQLException {
-        return null;
+        return getField(column).getDatabase();
     }
 
     public int getPrecision(int column) throws SQLException {
         return 0;
     }
 
+    private static boolean isDecimalType(int javaType, int vitessType) {
+        switch (javaType) {
+            case Types.BIT:
+            case Types.TINYINT:
+            case Types.INTEGER:
+            case Types.BIGINT:
+            case Types.FLOAT:
+            case Types.REAL:
+            case Types.DOUBLE:
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return true;
+            case Types.SMALLINT:
+                return vitessType != Query.Type.YEAR_VALUE;
+            default:
+                return false;
+        }
+    }
+
     public int getScale(int column) throws SQLException {
+        FieldWithMetadata field = getField(column);
+        if (isDecimalType(field.getJavaType(), field.getVitessTypeValue())) {
+            return getField(column).getDecimals();
+        }
         return 0;
     }
 
     public String getTableName(int column) throws SQLException {
-        return null;
+        return getField(column).getTable();
     }
 
     public String getCatalogName(int column) throws SQLException {
-        return null;
+        return getField(column).getDatabase();
     }
 
     public int getColumnType(int column) throws SQLException {
-        Query.Field field = getField(column);
-        if (MysqlDefs.vitesstoMySqlType.containsKey(field.getType())) {
-            return MysqlDefs.vitesstoMySqlType.get(field.getType());
-        } else if (field.getType().equals(Query.Type.TUPLE)) {
-            throw new SQLException(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE);
-        } else {
-            throw new SQLException(Constants.SQLExceptionMessages.UNKNOWN_COLUMN_TYPE);
-        }
+        return getField(column).getJavaType();
     }
 
     public String getColumnTypeName(int column) throws SQLException {
-        Query.Field field = getField(column);
+        FieldWithMetadata field = getField(column);
 
-        int vitessTypeValue = field.getTypeValue();
-        int jdbcType = MysqlDefs.vitesstoMySqlType.get(field.getType());
+        int vitessTypeValue = field.getVitessTypeValue();
+        int javaType = field.getJavaType();
 
         switch (vitessTypeValue) {
             case Query.Type.BIT_VALUE:
@@ -167,13 +198,13 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
                 return "VARCHAR";
 
             case Query.Type.VARBINARY_VALUE:
-                if (jdbcType == Types.VARBINARY) {
+                if (javaType == Types.VARBINARY) {
                     return "VARBINARY";
                 }
                 return "VARCHAR";
 
             case Query.Type.BINARY_VALUE:
-                if (jdbcType == Types.BINARY) {
+                if (javaType == Types.BINARY) {
                     return "BINARY";
                 }
                 return "CHAR";
@@ -199,7 +230,7 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public boolean isReadOnly(int column) throws SQLException {
-        return false;
+        return getField(column).isReadOnly();
     }
 
     public boolean isWritable(int column) throws SQLException {
@@ -207,11 +238,16 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public boolean isDefinitelyWritable(int column) throws SQLException {
-        return !isReadOnly(column);
+        return isWritable(column);
     }
 
     public String getColumnClassName(int column) throws SQLException {
-        return null;
+        FieldWithMetadata field = getField(column);
+        if (!field.getConnection().isIncludeAllFields()) {
+            return null;
+        }
+        return getClassNameForJavaType(field.getJavaType(), field.getVitessTypeValue(), field.isUnsigned(),
+            field.isBinary() || field.isBlob(), field.isOpaqueBinary(), field.getConnection().getYearIsDateType());
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {
@@ -222,12 +258,75 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
         return false;
     }
 
-    protected Query.Field getField(int columnIndex) throws SQLException {
+    private FieldWithMetadata getField(int columnIndex) throws SQLException {
         if (columnIndex >= 1 && columnIndex <= this.fields.size()) {
             return fields.get(columnIndex - 1);
         } else {
             throw new SQLException(
                 Constants.SQLExceptionMessages.INVALID_COLUMN_INDEX + ": " + columnIndex);
+        }
+    }
+
+    private String getClassNameForJavaType(int javaType, int vitessType, boolean isUnsigned, boolean isBinaryOrBlob, boolean isOpaqueBinary,
+                                          boolean treatYearAsDate) {
+        switch (javaType) {
+            case Types.BIT:
+            case Types.BOOLEAN:
+                return "java.lang.Boolean";
+            case Types.TINYINT:
+                if (isUnsigned) {
+                    return "java.lang.Integer";
+                }
+                return "java.lang.Integer";
+            case Types.SMALLINT:
+                if (vitessType == Query.Type.YEAR_VALUE) {
+                    return treatYearAsDate ? "java.sql.Date" : "java.lang.Short";
+                }
+                if (isUnsigned) {
+                    return "java.lang.Integer";
+                }
+                return "java.lang.Integer";
+            case Types.INTEGER:
+                if (!isUnsigned || vitessType == Query.Type.UINT24_VALUE) {
+                    return "java.lang.Integer";
+                }
+                return "java.lang.Long";
+            case Types.BIGINT:
+                if (!isUnsigned) {
+                    return "java.lang.Long";
+                }
+                return "java.math.BigInteger";
+            case Types.DECIMAL:
+            case Types.NUMERIC:
+                return "java.math.BigDecimal";
+            case Types.REAL:
+                return "java.lang.Float";
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return "java.lang.Double";
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                if (!isOpaqueBinary) {
+                    return "java.lang.String";
+                }
+                return "[B";
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                if (isBinaryOrBlob) {
+                    return "[B";
+                } else {
+                    return "java.lang.String";
+                }
+            case Types.DATE:
+                return treatYearAsDate ? "java.sql.Date" : "java.lang.Short";
+            case Types.TIME:
+                return "java.sql.Time";
+            case Types.TIMESTAMP:
+                return "java.sql.Timestamp";
+            default:
+                return "java.lang.Object";
         }
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -62,8 +62,16 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
         return false;
     }
 
+    /**
+     * Indicates the nullability of values in the designated column.
+     *
+     * @param column the first column is 1, the second is 2, ...
+     * @return the nullability status of the given column; one of <code>columnNoNulls</code>,
+     *          <code>columnNullable</code> or <code>columnNullableUnknown</code>
+     * @exception SQLException if a database access error occurs
+     */
     public int isNullable(int column) throws SQLException {
-        return getField(column).isNotNull() ? 0 : 2;
+        return getField(column).isNotNull() ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullableUnknown;
     }
 
     public boolean isSigned(int column) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -71,7 +71,11 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
      * @exception SQLException if a database access error occurs
      */
     public int isNullable(int column) throws SQLException {
-        return getField(column).isNotNull() ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullableUnknown;
+        FieldWithMetadata field = getField(column);
+        if (!field.getConnection().isIncludeAllFields()) {
+            return ResultSetMetaData.columnNullableUnknown;
+        }
+        return field.isNotNull() ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
     }
 
     public boolean isSigned(int column) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
@@ -13,7 +13,6 @@ import com.youtube.vitess.proto.Topodata;
 import com.youtube.vitess.proto.Vtrpc;
 
 import java.sql.BatchUpdateException;
-import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -322,7 +321,7 @@ public class VitessStatement implements Statement {
         return this.resultSetType;
     }
 
-    public Connection getConnection() throws SQLException {
+    public VitessConnection getConnection() throws SQLException {
         checkOpen();
         return vitessConnection;
     }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
 
 
     public static final class SQLExceptionMessages {
+        public static final String CONN_UNAVAILABLE = "Connection not available";
         public static final String CONN_CLOSED = "Connection is Closed";
         public static final String INIT_FAILED = "Failed to Initialize Vitess JDBC Driver";
         public static final String INVALID_CONN_URL = "Connection URL is invalid";

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
@@ -174,6 +174,8 @@ public final class MysqlDefs {
         vitesstoMySqlType.put(Query.Type.ENUM, Types.CHAR);
         vitesstoMySqlType.put(Query.Type.SET, Types.CHAR);
         vitesstoMySqlType.put(Query.Type.TUPLE, Types.OTHER);
+        vitesstoMySqlType.put(Query.Type.GEOMETRY, Types.BINARY);
+        vitesstoMySqlType.put(Query.Type.JSON, Types.BINARY);
     }
 
     static {

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/BaseTest.java
@@ -21,4 +21,8 @@ public class BaseTest {
     protected VitessConnection getVitessConnection() throws SQLException {
         return new VitessConnection(dbURL, new Properties());
     }
+
+    protected VitessStatement getVitessStatement() throws SQLException {
+        return new VitessStatement(getVitessConnection());
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
@@ -15,6 +15,8 @@ import java.util.Properties;
 
 public class ConnectionPropertiesTest {
 
+    private static final int NUM_PROPS = 6;
+
     @Test
     public void testReflection() throws Exception {
         ConnectionProperties props = new ConnectionProperties();
@@ -24,8 +26,8 @@ public class ConnectionPropertiesTest {
 
         // Just testing that we are properly picking up all the fields defined in the properties
         // For each field we call initializeFrom, which should call getProperty and remove
-        Mockito.verify(info, Mockito.times(4)).getProperty(Mockito.anyString());
-        Mockito.verify(info, Mockito.times(4)).remove(Mockito.anyString());
+        Mockito.verify(info, Mockito.times(NUM_PROPS)).getProperty(Mockito.anyString());
+        Mockito.verify(info, Mockito.times(NUM_PROPS)).remove(Mockito.anyString());
     }
 
     @Test
@@ -34,6 +36,8 @@ public class ConnectionPropertiesTest {
         ConnectionProperties props = new ConnectionProperties();
         props.initializeProperties(new Properties());
 
+        Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
+        Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
         Assert.assertEquals("executeType", Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
         Assert.assertEquals("twopcEnabled", false, props.getTwopcEnabled());
         Assert.assertEquals("includedFields", Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
@@ -46,6 +50,8 @@ public class ConnectionPropertiesTest {
 
         ConnectionProperties props = new ConnectionProperties();
         Properties info = new Properties();
+        info.setProperty("tinyInt1isBit", "yes");
+        info.setProperty("yearIsDateType", "yes");
         info.setProperty("executeType", Constants.QueryExecuteType.STREAM.name());
         info.setProperty("twopcEnabled", "yes");
         info.setProperty("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY.name());
@@ -53,6 +59,8 @@ public class ConnectionPropertiesTest {
 
         props.initializeProperties(info);
 
+        Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
+        Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
         Assert.assertEquals("executeType", Constants.QueryExecuteType.STREAM, props.getExecuteType());
         Assert.assertEquals("twopcEnabled", true, props.getTwopcEnabled());
         Assert.assertEquals("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY, props.getIncludedFields());
@@ -64,23 +72,27 @@ public class ConnectionPropertiesTest {
     public void testDriverPropertiesOutput() throws SQLException {
         Properties info = new Properties();
         DriverPropertyInfo[] infos = ConnectionProperties.exposeAsDriverPropertyInfo(info, 0);
-        Assert.assertEquals(4, infos.length);
+        Assert.assertEquals(NUM_PROPS, infos.length);
 
         // Test the expected fields for just 1
-        Assert.assertEquals("executeType", infos[0].name);
+        int indexForFullTest = 2;
+        Assert.assertEquals("executeType", infos[indexForFullTest].name);
         Assert.assertEquals("Query execution type: simple or stream",
-            infos[0].description);
-        Assert.assertEquals(false, infos[0].required);
+            infos[indexForFullTest].description);
+        Assert.assertEquals(false, infos[indexForFullTest].required);
         Constants.QueryExecuteType[] enumConstants = Constants.QueryExecuteType.values();
         String[] allowed = new String[enumConstants.length];
         for (int i = 0; i < enumConstants.length; i++) {
             allowed[i] = enumConstants[i].toString();
         }
-        Assert.assertArrayEquals(allowed, infos[0].choices);
+        Assert.assertArrayEquals(allowed, infos[indexForFullTest].choices);
 
-        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[1].name);
-        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[2].name);
-        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[3].name);
+        // Test that name exists for the others, as a sanity check
+        Assert.assertEquals("tinyInt1isBit", infos[0].name);
+        Assert.assertEquals("yearIsDateType", infos[1].name);
+        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[3].name);
+        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[4].name);
+        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[5].name);
     }
 
     @Test

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
@@ -1,0 +1,259 @@
+package com.flipkart.vitess.jdbc;
+
+import com.youtube.vitess.proto.Query;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.sql.SQLException;
+import java.sql.Types;
+
+@PrepareForTest(FieldWithMetadata.class)
+@RunWith(PowerMockRunner.class)
+public class FieldWithMetadataTest extends BaseTest {
+
+    @Test
+    public void testTinyIntAsBit() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.INT8)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+        conn.setTinyInt1isBit(true);
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+
+        raw = raw.toBuilder()
+            .setColumnLength(1)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+    }
+
+    @Test
+    public void testPrecisionAdjustFactor() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        assertPrecisionEquals(conn, Query.Type.FLOAT32, true, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.FLOAT64, true, 32, 0);
+        assertPrecisionEquals(conn, Query.Type.BIT, true, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, true, 0, -1);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, true, 3, -2);
+        assertPrecisionEquals(conn, Query.Type.INT32, true, /* this can't happen, but just checking */3, -2);
+        assertPrecisionEquals(conn, Query.Type.INT32, true, 0, -1);
+        assertPrecisionEquals(conn, Query.Type.FLOAT32, false, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.FLOAT64, false, 32, 0);
+        assertPrecisionEquals(conn, Query.Type.BIT, false, 0, 0);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, false, 0, -1);
+        assertPrecisionEquals(conn, Query.Type.DECIMAL, false, 3, -1);
+        assertPrecisionEquals(conn, Query.Type.UINT32, false, 0, 0);
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (Query.Type type : Query.Type.values()) {
+            if (type == Query.Type.UNRECOGNIZED) {
+                continue;
+            }
+
+            // All should be 0
+            assertPrecisionEquals(conn, type, true, 0, 0);
+            assertPrecisionEquals(conn, type, false, 0, 0);
+            assertPrecisionEquals(conn, type, true, 2, 0);
+            assertPrecisionEquals(conn, type, false, 2, 0);
+        }
+    }
+
+    private void assertPrecisionEquals(VitessConnection conn, Query.Type fieldType, boolean signed, int decimals, int expectedPrecisionAdjustFactor) throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(fieldType)
+            .setDecimals(decimals)
+            .setFlags(signed ? 0 : Query.MySqlFlag.UNSIGNED_FLAG_VALUE)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(expectedPrecisionAdjustFactor, fieldWithMetadata.getPrecisionAdjustFactor());
+    }
+
+    @Test
+    public void testFlags() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.VARBINARY)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(false, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(false, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(false, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */true, fieldWithMetadata.isSigned());
+        Assert.assertEquals(false, fieldWithMetadata.isZeroFill());
+
+        int value = 0;
+        for (Query.MySqlFlag flag : Query.MySqlFlag.values()) {
+            if (flag == Query.MySqlFlag.UNRECOGNIZED) {
+                continue;
+            }
+            value |= flag.getNumber();
+        }
+        raw = raw.toBuilder()
+            .setFlags(value)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isBinary());
+        Assert.assertEquals(true, fieldWithMetadata.isBlob());
+        Assert.assertEquals(true, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(true, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(true, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(true, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */false, fieldWithMetadata.isSigned());
+        Assert.assertEquals(true, fieldWithMetadata.isZeroFill());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isAutoIncrement());
+        Assert.assertEquals(false, fieldWithMetadata.isMultipleKey());
+        Assert.assertEquals(true, fieldWithMetadata.isNotNull());
+        Assert.assertEquals(false, fieldWithMetadata.isPrimaryKey());
+        Assert.assertEquals(false, fieldWithMetadata.isUniqueKey());
+        Assert.assertEquals(true, fieldWithMetadata.isUnsigned());
+        Assert.assertEquals(/* just inverses isUnsigned */false, fieldWithMetadata.isSigned());
+        Assert.assertEquals(false, fieldWithMetadata.isZeroFill());
+
+    }
+
+    @Test
+    public void testReadOnly() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setOrgTable("foo")
+            .build();
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgName("")
+            .setOrgTable("foo")
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgName("foo")
+            .setOrgTable("")
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        raw = raw.toBuilder()
+            .setOrgTable("")
+            .setOrgName("")
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isReadOnly());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isReadOnly());
+    }
+
+    @Test
+    public void testDefaultsWithoutAllFields() throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setName("foo")
+            .setOrgName("foo")
+            .setTable("foo")
+            .setOrgTable("foo")
+            .setDatabase("foo")
+            .setType(Query.Type.CHAR)
+            .setFlags(Query.MySqlFlag.AUTO_INCREMENT_FLAG_VALUE |
+                Query.MySqlFlag.PRI_KEY_FLAG_VALUE |
+                Query.MySqlFlag.UNIQUE_KEY_FLAG_VALUE |
+                Query.MySqlFlag.BINARY_FLAG_VALUE |
+                Query.MySqlFlag.BLOB_FLAG_VALUE |
+                Query.MySqlFlag.MULTIPLE_KEY_FLAG_VALUE |
+                Query.MySqlFlag.UNSIGNED_FLAG_VALUE |
+                Query.MySqlFlag.ZEROFILL_FLAG_VALUE
+            )
+            .build();
+        VitessConnection conn = getVitessConnection();
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        FieldWithMetadata field = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals("foo", field.getName());
+        Assert.assertEquals(null, field.getOrgName());
+        Assert.assertEquals(null, field.getTable());
+        Assert.assertEquals(null, field.getOrgTable());
+        Assert.assertEquals(null, field.getDatabase());
+        Assert.assertEquals(0, field.getDecimals());
+        Assert.assertEquals(0, field.getColumnLength());
+        Assert.assertEquals(0, field.getPrecisionAdjustFactor());
+        Assert.assertEquals(false, field.isSingleBit());
+        Assert.assertEquals(false, field.isAutoIncrement());
+        Assert.assertEquals(false, field.isBinary());
+        Assert.assertEquals(false, field.isBlob());
+        Assert.assertEquals(false, field.isMultipleKey());
+        Assert.assertEquals(true, field.isNotNull());
+        Assert.assertEquals(false, field.isZeroFill());
+        Assert.assertEquals(false, field.isPrimaryKey());
+        Assert.assertEquals(false, field.isUniqueKey());
+        Assert.assertEquals(true, field.isUnsigned());
+        Assert.assertEquals(false, field.isSigned());
+        Assert.assertEquals(false, field.isOpaqueBinary());
+        Assert.assertEquals(false, field.isReadOnly());
+    }
+
+    @Test
+    public void testToString() throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setName("foo")
+            .setOrgName("foo")
+            .setTable("foo")
+            .setOrgTable("foo")
+            .setDatabase("foo")
+            .setType(Query.Type.CHAR)
+            .setFlags(Query.MySqlFlag.AUTO_INCREMENT_FLAG_VALUE |
+                    Query.MySqlFlag.PRI_KEY_FLAG_VALUE |
+                    Query.MySqlFlag.UNIQUE_KEY_FLAG_VALUE |
+                    Query.MySqlFlag.BINARY_FLAG_VALUE |
+                    Query.MySqlFlag.BLOB_FLAG_VALUE |
+                    Query.MySqlFlag.MULTIPLE_KEY_FLAG_VALUE |
+                    Query.MySqlFlag.UNSIGNED_FLAG_VALUE |
+                    Query.MySqlFlag.ZEROFILL_FLAG_VALUE
+            )
+            .build();
+        FieldWithMetadata field = new FieldWithMetadata(getVitessConnection(), raw);
+        String result = "com.flipkart.vitess.jdbc.FieldWithMetadata[catalog=foo," +
+            "tableName=foo,originalTableName=foo," +
+            "columnName=foo,originalColumnName=foo," +
+            "vitessType=" + Query.Type.CHAR.toString() + "(1)," +
+            "flags=AUTO_INCREMENT PRIMARY_KEY UNIQUE_KEY BINARY " +
+            "BLOB MULTI_KEY UNSIGNED ZEROFILL";
+        Assert.assertEquals(result, field.toString());
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
@@ -6,6 +6,7 @@ import com.youtube.vitess.proto.Query;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -296,14 +297,14 @@ public class VitessResultSetMetadataTest extends BaseTest {
         VitessConnection conn = getVitessConnection();
         List<FieldWithMetadata> fieldList = getFieldList(conn);
         VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals("NOT_NULL flag means 0 value for isNullable", 0, md.isNullable(1));
+        Assert.assertEquals("NOT_NULL flag means columnNoNulls (0) value for isNullable", ResultSetMetaData.columnNoNulls, md.isNullable(1));
         for (int i = 1; i < fieldList.size(); i++) {
-            Assert.assertEquals("lack of NOT_NULL flag means 2 value for isNullable", 2, md.isNullable(i + 1));
+            Assert.assertEquals("lack of NOT_NULL flag means columnNullable (1) value for isNullable", ResultSetMetaData.columnNullable, md.isNullable(i + 1));
         }
 
         conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
         for (int i = 0; i < fieldList.size(); i++) {
-            Assert.assertEquals(fieldList.get(i).getName() + " - isNullable is 0 for all when lack of included fields", 0, md.isNullable(i + 1));
+            Assert.assertEquals(fieldList.get(i).getName() + " - isNullable is columnNullableUnknown (2) for all when lack of included fields", 2, md.isNullable(i + 1));
         }
     }
 
@@ -426,7 +427,7 @@ public class VitessResultSetMetadataTest extends BaseTest {
             Assert.assertEquals(shouldBeSensitive, vitessResultSetMetaData.isCaseSensitive(i));
             Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isSearchable(i));
             Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isCurrency(i));
-            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.isNullable(i));
+            Assert.assertEquals(field.getName(), ResultSetMetaData.columnNullableUnknown, vitessResultSetMetaData.isNullable(i));
             Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isSigned(i));
             Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getColumnDisplaySize(i));
             Assert.assertEquals(field.getName(), field.getName(), vitessResultSetMetaData.getColumnLabel(i));

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
@@ -1,78 +1,98 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessResultSetMetaData;
 import com.flipkart.vitess.util.Constants;
 import com.youtube.vitess.proto.Query;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Created by ashudeep.sharma on 08/02/16.
  */
-public class VitessResultSetMetadataTest {
+public class VitessResultSetMetadataTest extends BaseTest {
 
-    private List<Query.Field> fieldList;
+    private List<FieldWithMetadata> fieldList;
 
-    public void initializeFieldList() {
+    private List<Query.Field> generateFieldList() {
+        List<Query.Field> fieldList = new ArrayList<>();
 
-        fieldList = new ArrayList<>();
-        fieldList.add(Query.Field.newBuilder().setName("col1").setType(Query.Type.INT8).build());
-        fieldList.add(Query.Field.newBuilder().setName("col2").setType(Query.Type.UINT8).build());
-        fieldList.add(Query.Field.newBuilder().setName("col3").setType(Query.Type.INT16).build());
-        fieldList.add(Query.Field.newBuilder().setName("col4").setType(Query.Type.UINT16).build());
-        fieldList.add(Query.Field.newBuilder().setName("col5").setType(Query.Type.INT24).build());
-        fieldList.add(Query.Field.newBuilder().setName("col6").setType(Query.Type.UINT24).build());
-        fieldList.add(Query.Field.newBuilder().setName("col7").setType(Query.Type.INT32).build());
-        fieldList.add(Query.Field.newBuilder().setName("col8").setType(Query.Type.UINT32).build());
-        fieldList.add(Query.Field.newBuilder().setName("col9").setType(Query.Type.INT64).build());
-        fieldList.add(Query.Field.newBuilder().setName("col10").setType(Query.Type.UINT64).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col11").setType(Query.Type.FLOAT32).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col12").setType(Query.Type.FLOAT64).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col13").setType(Query.Type.TIMESTAMP).build());
-        fieldList.add(Query.Field.newBuilder().setName("col14").setType(Query.Type.DATE).build());
-        fieldList.add(Query.Field.newBuilder().setName("col15").setType(Query.Type.TIME).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col16").setType(Query.Type.DATETIME).build());
-        fieldList.add(Query.Field.newBuilder().setName("col17").setType(Query.Type.YEAR).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col18").setType(Query.Type.DECIMAL).build());
-        fieldList.add(Query.Field.newBuilder().setName("col19").setType(Query.Type.TEXT).build());
-        fieldList.add(Query.Field.newBuilder().setName("col20").setType(Query.Type.BLOB).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col21").setType(Query.Type.VARCHAR).build());
-        fieldList
-            .add(Query.Field.newBuilder().setName("col22").setType(Query.Type.VARBINARY).build());
-        fieldList.add(Query.Field.newBuilder().setName("col23").setType(Query.Type.CHAR).build());
-        fieldList.add(Query.Field.newBuilder().setName("col24").setType(Query.Type.BINARY).build());
-        fieldList.add(Query.Field.newBuilder().setName("col25").setType(Query.Type.BIT).build());
-        fieldList.add(Query.Field.newBuilder().setName("col26").setType(Query.Type.ENUM).build());
-        fieldList.add(Query.Field.newBuilder().setName("col27").setType(Query.Type.SET).build());
-        fieldList.add(Query.Field.newBuilder().setName("col28").setType(Query.Type.TUPLE).build());
+        fieldList.add(field("col1", "tbl", Query.Type.INT8, 4)
+            .setFlags(Query.MySqlFlag.NOT_NULL_FLAG_VALUE).setOrgName("foo").setOrgTable("foo").build());
+        fieldList.add(field("col2", "tbl", Query.Type.UINT8, 3).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col3", "tbl", Query.Type.INT16, 6).build());
+        fieldList.add(field("col4", "tbl", Query.Type.UINT16, 5).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col5", "tbl", Query.Type.INT24, 9).build());
+        fieldList.add(field("col6", "tbl", Query.Type.UINT24, 8).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col7", "tbl", Query.Type.INT32, 11).build());
+        fieldList.add(field("col8", "tbl", Query.Type.UINT32, 10).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col9", "tbl", Query.Type.INT64, 20).build());
+        fieldList.add(field("col10", "tbl", Query.Type.UINT64, 20).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col11", "tbl", Query.Type.FLOAT32, 12).setDecimals(31).build());
+        fieldList.add(field("col12", "tbl", Query.Type.FLOAT64, 22).setDecimals(31).build());
+        fieldList.add(field("col13", "tbl", Query.Type.TIMESTAMP, 10).build());
+        fieldList.add(field("col14", "tbl", Query.Type.DATE, 10).build());
+        fieldList.add(field("col15", "tbl", Query.Type.TIME, 10).build());
+        fieldList.add(field("col16", "tbl", Query.Type.DATETIME, 19).build());
+        fieldList.add(field("col17", "tbl", Query.Type.YEAR, 4).build());
+        fieldList.add(field("col18", "tbl", Query.Type.DECIMAL, 7).setDecimals(2).build());
+        fieldList.add(field("col19", "tbl", Query.Type.TEXT, 765).build());
+        fieldList.add(field("col20", "tbl", Query.Type.BLOB, 65535)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE | Query.MySqlFlag.BLOB_FLAG_VALUE)
+            .setDecimals(/* this is set to facilitate testing of getScale, since this is non-numeric */2).build());
+        fieldList.add(field("col21", "tbl", Query.Type.VARCHAR, 768).build());
+        fieldList.add(field("col22", "tbl", Query.Type.VARBINARY, 256).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col23", "tbl", Query.Type.CHAR, 48).build());
+        fieldList.add(field("col24", "tbl", Query.Type.BINARY, 4).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col25", "tbl", Query.Type.BIT, 8).build());
+        fieldList.add(field("col26", "tbl", Query.Type.ENUM, 3).build());
+        fieldList.add(field("col27", "tbl", Query.Type.SET, 9).build());
+        fieldList.add(field("col28", "tbl", Query.Type.TUPLE, 0).build());
+        fieldList.add(field("col29", "tbl", Query.Type.VARBINARY, 256).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col30", "tbl", Query.Type.BLOB, 65535)
+            .setFlags(Query.MySqlFlag.BLOB_FLAG_VALUE).build());
+        return fieldList;
     }
 
-    public List<Query.Field> getFieldList() {
+    private Query.Field.Builder field(String name, String table, Query.Type type, int length) {
+        return Query.Field.newBuilder()
+            .setName(name)
+            .setTable(table)
+            .setType(type)
+            .setColumnLength(length);
+    }
 
-        initializeFieldList();
+    private void initializeFieldList(VitessConnection connection) throws SQLException {
+        List<Query.Field> fields = generateFieldList();
+        this.fieldList = new ArrayList<>(fields.size());
+        for (Query.Field field : fields) {
+            this.fieldList.add(new FieldWithMetadata(connection, field));
+        }
+    }
+
+    public List<FieldWithMetadata> getFieldList() throws SQLException {
+        return getFieldList(getVitessConnection());
+    }
+
+    public List<FieldWithMetadata> getFieldList(VitessConnection conn) throws SQLException {
+        initializeFieldList(conn);
         return this.fieldList;
     }
 
     @Test public void testgetColumnCount() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
+        List<FieldWithMetadata> fieldList = getFieldList();
         VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(28, vitessResultSetMetadata.getColumnCount());
+        Assert.assertEquals(30, vitessResultSetMetadata.getColumnCount());
     }
 
     @Test public void testgetColumnName() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
+        List<FieldWithMetadata> fieldList = getFieldList();
         VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
         for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
             Assert.assertEquals("col" + i, vitessResultSetMetadata.getColumnName(i));
@@ -81,7 +101,120 @@ public class VitessResultSetMetadataTest {
 
     @Test public void testgetColumnTypeName() throws SQLException {
 
-        List<Query.Field> fieldList = getFieldList();
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("TINYINT", vitessResultSetMetadata.getColumnTypeName(1));
+        Assert.assertEquals("TINYINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(2));
+        Assert.assertEquals("SMALLINT", vitessResultSetMetadata.getColumnTypeName(3));
+        Assert.assertEquals("SMALLINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(4));
+        Assert.assertEquals("MEDIUMINT", vitessResultSetMetadata.getColumnTypeName(5));
+        Assert.assertEquals("MEDIUMINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(6));
+        Assert.assertEquals("INT", vitessResultSetMetadata.getColumnTypeName(7));
+        Assert.assertEquals("INT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(8));
+        Assert.assertEquals("BIGINT", vitessResultSetMetadata.getColumnTypeName(9));
+        Assert.assertEquals("BIGINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(10));
+        Assert.assertEquals("FLOAT", vitessResultSetMetadata.getColumnTypeName(11));
+        Assert.assertEquals("DOUBLE", vitessResultSetMetadata.getColumnTypeName(12));
+        Assert.assertEquals("TIMESTAMP", vitessResultSetMetadata.getColumnTypeName(13));
+        Assert.assertEquals("DATE", vitessResultSetMetadata.getColumnTypeName(14));
+        Assert.assertEquals("TIME", vitessResultSetMetadata.getColumnTypeName(15));
+        Assert.assertEquals("DATETIME", vitessResultSetMetadata.getColumnTypeName(16));
+        Assert.assertEquals("YEAR", vitessResultSetMetadata.getColumnTypeName(17));
+        Assert.assertEquals("DECIMAL", vitessResultSetMetadata.getColumnTypeName(18));
+        Assert.assertEquals("TEXT", vitessResultSetMetadata.getColumnTypeName(19));
+        Assert.assertEquals("BLOB", vitessResultSetMetadata.getColumnTypeName(20));
+        Assert.assertEquals("VARCHAR", vitessResultSetMetadata.getColumnTypeName(21));
+        Assert.assertEquals("VARBINARY", vitessResultSetMetadata.getColumnTypeName(22));
+        Assert.assertEquals("CHAR", vitessResultSetMetadata.getColumnTypeName(23));
+        Assert.assertEquals("BINARY", vitessResultSetMetadata.getColumnTypeName(24));
+        Assert.assertEquals("BIT", vitessResultSetMetadata.getColumnTypeName(25));
+        Assert.assertEquals("ENUM", vitessResultSetMetadata.getColumnTypeName(26));
+        Assert.assertEquals("SET", vitessResultSetMetadata.getColumnTypeName(27));
+        Assert.assertEquals("TUPLE", vitessResultSetMetadata.getColumnTypeName(28));
+        Assert.assertEquals("VARBINARY", vitessResultSetMetadata.getColumnTypeName(29));
+        Assert.assertEquals("BLOB", vitessResultSetMetadata.getColumnTypeName(30));
+    }
+
+    @Test public void testgetColumnType() throws SQLException {
+
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("TINYINT", Types.TINYINT, vitessResultSetMetadata.getColumnType(1));
+        Assert.assertEquals("TINYINT", Types.TINYINT, vitessResultSetMetadata.getColumnType(2));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(3));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(4));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(5));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(6));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(7));
+        Assert.assertEquals("INTEGER", Types.INTEGER, vitessResultSetMetadata.getColumnType(8));
+        Assert.assertEquals("BIGINT", Types.BIGINT, vitessResultSetMetadata.getColumnType(9));
+        Assert.assertEquals("BIGINT", Types.BIGINT, vitessResultSetMetadata.getColumnType(10));
+        Assert.assertEquals("FLOAT", Types.FLOAT, vitessResultSetMetadata.getColumnType(11));
+        Assert.assertEquals("DOUBLE", Types.DOUBLE, vitessResultSetMetadata.getColumnType(12));
+        Assert.assertEquals("TIMESTAMP", Types.TIMESTAMP, vitessResultSetMetadata.getColumnType(13));
+        Assert.assertEquals("DATE", Types.DATE, vitessResultSetMetadata.getColumnType(14));
+        Assert.assertEquals("TIME", Types.TIME, vitessResultSetMetadata.getColumnType(15));
+        Assert.assertEquals("TIMESTAMP", Types.TIMESTAMP, vitessResultSetMetadata.getColumnType(16));
+        Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(17));
+        Assert.assertEquals("DECIMAL", Types.DECIMAL, vitessResultSetMetadata.getColumnType(18));
+        Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(19));
+        Assert.assertEquals("BLOB", Types.BLOB, vitessResultSetMetadata.getColumnType(20));
+        Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(21));
+        Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(22));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(23));
+        Assert.assertEquals("BINARY", Types.BINARY, vitessResultSetMetadata.getColumnType(24));
+        Assert.assertEquals("BIT", Types.BIT, vitessResultSetMetadata.getColumnType(25));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(26));
+        Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(27));
+        Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(29));
+        Assert.assertEquals("BLOB", Types.BLOB, vitessResultSetMetadata.getColumnType(30));
+        try {
+            int type = vitessResultSetMetadata.getColumnType(28);
+        } catch (SQLException ex) {
+            Assert
+                .assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE, ex.getMessage());
+        }
+
+        try {
+            int type = vitessResultSetMetadata.getColumnType(0);
+        } catch (SQLException ex) {
+            Assert.assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_INDEX + ": " + 0,
+                ex.getMessage());
+        }
+    }
+
+    @Test public void testgetColumnLabel() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
+        for (int i = 1; i <= vitessResultSetMetaData.getColumnCount(); i++) {
+            Assert.assertEquals("col" + i, vitessResultSetMetaData.getColumnLabel(i));
+        }
+    }
+
+    @Test public void testgetTableName() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
+            Assert.assertEquals(vitessResultSetMetadata.getTableName(i), "tbl");
+        }
+    }
+
+    @Test public void isReadOnlyTest() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
+        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals(vitessResultSetMetadata.isReadOnly(1), false);
+        Assert.assertEquals(vitessResultSetMetadata.isWritable(1), true);
+        Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(1), true);
+
+        for (int i = 2; i <= vitessResultSetMetadata.getColumnCount(); i++) {
+            Assert.assertEquals(vitessResultSetMetadata.isReadOnly(i), true);
+            Assert.assertEquals(vitessResultSetMetadata.isWritable(i), false);
+            Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(i), false);
+        }
+    }
+
+    @Test public void getColumnTypeNameTest() throws SQLException {
+        List<FieldWithMetadata> fieldList = getFieldList();
         VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
         Assert.assertEquals("TINYINT", vitessResultSetMetadata.getColumnTypeName(1));
         Assert.assertEquals("TINYINT UNSIGNED", vitessResultSetMetadata.getColumnTypeName(2));
@@ -113,89 +246,203 @@ public class VitessResultSetMetadataTest {
         Assert.assertEquals("TUPLE", vitessResultSetMetadata.getColumnTypeName(28));
     }
 
-    @Test public void testgetColumnType() throws SQLException {
-
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(-6, vitessResultSetMetadata.getColumnType(1));
-        Assert.assertEquals(-6, vitessResultSetMetadata.getColumnType(2));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(3));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(4));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(5));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(6));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(7));
-        Assert.assertEquals(4, vitessResultSetMetadata.getColumnType(8));
-        Assert.assertEquals(-5, vitessResultSetMetadata.getColumnType(9));
-        Assert.assertEquals(-5, vitessResultSetMetadata.getColumnType(10));
-        Assert.assertEquals(6, vitessResultSetMetadata.getColumnType(11));
-        Assert.assertEquals(8, vitessResultSetMetadata.getColumnType(12));
-        Assert.assertEquals(93, vitessResultSetMetadata.getColumnType(13));
-        Assert.assertEquals(91, vitessResultSetMetadata.getColumnType(14));
-        Assert.assertEquals(92, vitessResultSetMetadata.getColumnType(15));
-        Assert.assertEquals(93, vitessResultSetMetadata.getColumnType(16));
-        Assert.assertEquals(5, vitessResultSetMetadata.getColumnType(17));
-        Assert.assertEquals(3, vitessResultSetMetadata.getColumnType(18));
-        Assert.assertEquals(12, vitessResultSetMetadata.getColumnType(19));
-        Assert.assertEquals(2004, vitessResultSetMetadata.getColumnType(20));
-        Assert.assertEquals(12, vitessResultSetMetadata.getColumnType(21));
-        Assert.assertEquals(-3, vitessResultSetMetadata.getColumnType(22));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(23));
-        Assert.assertEquals(-2, vitessResultSetMetadata.getColumnType(24));
-        Assert.assertEquals(-7, vitessResultSetMetadata.getColumnType(25));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(26));
-        Assert.assertEquals(1, vitessResultSetMetadata.getColumnType(27));
-        try {
-            int type = vitessResultSetMetadata.getColumnType(28);
-        } catch (SQLException ex) {
-            Assert
-                .assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_TYPE, ex.getMessage());
-        }
-
-        try {
-            int type = vitessResultSetMetadata.getColumnType(0);
-        } catch (SQLException ex) {
-            Assert.assertEquals(Constants.SQLExceptionMessages.INVALID_COLUMN_INDEX + ": " + 0,
-                ex.getMessage());
-        }
-    }
-
-    @Test public void testgetColumnLabel() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetaData.getColumnCount(); i++) {
-            Assert.assertEquals("col" + i, vitessResultSetMetaData.getColumnLabel(i));
-        }
-    }
-
-    @Test public void isReadOnlyTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
-            Assert.assertEquals(vitessResultSetMetadata.isReadOnly(i), false);
-            Assert.assertEquals(vitessResultSetMetadata.isWritable(i), true);
-            Assert.assertEquals(vitessResultSetMetadata.isDefinitelyWritable(i), true);
-        }
-    }
-
-    @Test public void getColumnClassNameTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
-        VitessResultSetMetaData vitessResultSetMetadata = new VitessResultSetMetaData(fieldList);
-        for (int i = 1; i <= vitessResultSetMetadata.getColumnCount(); i++) {
-            Assert.assertEquals(vitessResultSetMetadata.getColumnClassName(i), null);
-        }
-    }
-
     @Test public void getSchemaNameTest() throws SQLException {
-        List<Query.Field> fieldList = getFieldList();
+        List<FieldWithMetadata> fieldList = getFieldList();
         VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
-        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getTableName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getCatalogName(1), null);
-        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), null);
+        Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), "");
+        Assert.assertEquals(vitessResultSetMetaData.getCatalogName(1), "");
         Assert.assertEquals(vitessResultSetMetaData.getPrecision(1), 0);
         Assert.assertEquals(vitessResultSetMetaData.getScale(1), 0);
         Assert.assertEquals(vitessResultSetMetaData.getColumnDisplaySize(1), 0);
         Assert.assertEquals(vitessResultSetMetaData.isCurrency(1), false);
+    }
+
+    @Test public void testCaseSensitivity() throws SQLException {
+        VitessConnection connection = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(connection);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+
+        // numeric types and date types are not case sensitive
+        Assert.assertEquals("int8 case sensitivity", false, md.isCaseSensitive(1));
+        Assert.assertEquals("uint8 case sensitivity", false, md.isCaseSensitive(2));
+        Assert.assertEquals("int16 case sensitivity", false, md.isCaseSensitive(3));
+        Assert.assertEquals("uint16 case sensitivity", false, md.isCaseSensitive(4));
+        Assert.assertEquals("int24 case sensitivity", false, md.isCaseSensitive(5));
+        Assert.assertEquals("uint24 case sensitivity", false, md.isCaseSensitive(6));
+        Assert.assertEquals("int32 case sensitivity", false, md.isCaseSensitive(7));
+        Assert.assertEquals("uint32 case sensitivity", false, md.isCaseSensitive(8));
+        Assert.assertEquals("int64 case sensitivity", false, md.isCaseSensitive(9));
+        Assert.assertEquals("uint64 case sensitivity", false, md.isCaseSensitive(10));
+        Assert.assertEquals("float32 case sensitivity", false, md.isCaseSensitive(11));
+        Assert.assertEquals("float64 case sensitivity", false, md.isCaseSensitive(12));
+        Assert.assertEquals("timestamp case sensitivity", false, md.isCaseSensitive(13));
+        Assert.assertEquals("date case sensitivity", false, md.isCaseSensitive(14));
+        Assert.assertEquals("time case sensitivity", false, md.isCaseSensitive(15));
+        Assert.assertEquals("datetime case sensitivity", false, md.isCaseSensitive(16));
+        Assert.assertEquals("year case sensitivity", false, md.isCaseSensitive(17));
+        Assert.assertEquals("decimal case sensitivity", false, md.isCaseSensitive(18));
+        for (int i = 18; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - non-numeric case insensitive", i != 24, md.isCaseSensitive(i + 1));
+        }
+
+        connection.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        // with limited included fields, we can really only know about numeric types -- those should return false.  the rest should return true
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - non-numeric case insensitive due to lack of included fields", i >= 18 && i != 24, md.isCaseSensitive(i + 1));
+        }
+    }
+
+    @Test public void testIsNullable() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("NOT_NULL flag means 0 value for isNullable", 0, md.isNullable(1));
+        for (int i = 1; i < fieldList.size(); i++) {
+            Assert.assertEquals("lack of NOT_NULL flag means 2 value for isNullable", 2, md.isNullable(i + 1));
+        }
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - isNullable is 0 for all when lack of included fields", 0, md.isNullable(i + 1));
+        }
+    }
+
+    @Test public void testGetScale() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("int8 precision", 0, md.getScale(1));
+        Assert.assertEquals("uint8 precision", 0, md.getScale(2));
+        Assert.assertEquals("int16 precision", 0, md.getScale(3));
+        Assert.assertEquals("uint16 precision", 0, md.getScale(4));
+        Assert.assertEquals("int24 precision", 0, md.getScale(5));
+        Assert.assertEquals("uint24 precision", 0, md.getScale(6));
+        Assert.assertEquals("int32 precision", 0, md.getScale(7));
+        Assert.assertEquals("uint32 precision", 0, md.getScale(8));
+        Assert.assertEquals("int64 precision", 0, md.getScale(9));
+        Assert.assertEquals("uint64 precision", 0, md.getScale(10));
+        Assert.assertEquals("float32 precision", 31, md.getScale(11));
+        Assert.assertEquals("float64 precision", 31, md.getScale(12));
+        Assert.assertEquals("timestamp precision", 0, md.getScale(13));
+        Assert.assertEquals("date precision", 0, md.getScale(14));
+        Assert.assertEquals("time precision", 0, md.getScale(15));
+        Assert.assertEquals("datetime precision", 0, md.getScale(16));
+        Assert.assertEquals("year precision",  0, md.getScale(17));
+        Assert.assertEquals("decimal precision", 2, md.getScale(18));
+        Assert.assertEquals("text precision", 0, md.getScale(19));
+        Assert.assertEquals("blob precision", 0, md.getScale(20));
+        Assert.assertEquals("varchar precision", 0, md.getScale(21));
+        Assert.assertEquals("varbinary precision", 0, md.getScale(22));
+        Assert.assertEquals("char precision", 0, md.getScale(23));
+        Assert.assertEquals("binary precision", 0, md.getScale(24));
+        Assert.assertEquals("bit precision", 0, md.getScale(25));
+        Assert.assertEquals("enum precision", 0, md.getScale(26));
+        Assert.assertEquals("set precision", 0, md.getScale(27));
+        Assert.assertEquals("tuple precision", 0, md.getScale(28));
+        Assert.assertEquals("varbinary precision", 0, md.getScale(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getScale is 0 for all when lack of included fields", 0, md.getScale(i + 1));
+        }
+    }
+
+    @Test public void testGetColumnClassName() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(1));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(2));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(3));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(4));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(5));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(6));
+        Assert.assertEquals("java.lang.Integer", md.getColumnClassName(7));
+        Assert.assertEquals("java.lang.Long", md.getColumnClassName(8));
+        Assert.assertEquals("java.lang.Long", md.getColumnClassName(9));
+        Assert.assertEquals("java.math.BigInteger", md.getColumnClassName(10));
+        Assert.assertEquals("java.lang.Double", md.getColumnClassName(11));
+        Assert.assertEquals("java.lang.Double", md.getColumnClassName(12));
+        Assert.assertEquals("java.sql.Timestamp", md.getColumnClassName(13));
+        Assert.assertEquals("java.sql.Date", md.getColumnClassName(14));
+        Assert.assertEquals("java.sql.Time", md.getColumnClassName(15));
+        Assert.assertEquals("java.sql.Timestamp", md.getColumnClassName(16));
+        Assert.assertEquals("java.sql.Date", md.getColumnClassName(17));
+        Assert.assertEquals("java.math.BigDecimal", md.getColumnClassName(18));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(19));
+        Assert.assertEquals("java.lang.Object", md.getColumnClassName(20));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(21));
+        Assert.assertEquals("[B", md.getColumnClassName(22));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(23));
+        Assert.assertEquals("[B", md.getColumnClassName(24));
+        Assert.assertEquals("java.lang.Boolean", md.getColumnClassName(25));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(26));
+        Assert.assertEquals("java.lang.String", md.getColumnClassName(27));
+        Assert.assertEquals("java.lang.Object", md.getColumnClassName(28));
+        Assert.assertEquals("[B", md.getColumnClassName(29));
+
+        conn.setYearIsDateType(false);
+        md = new VitessResultSetMetaData(fieldList);
+        Assert.assertEquals("java.lang.Short", md.getColumnClassName(17));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - class name is null when no included fields", null, md.getColumnClassName(i + 1));
+        }
+    }
+
+    /**
+     * Some of the tests above verify that their particular part honors the IncludedFields.ALL value, but
+     * this further verifies that when someone has disabled ALL, the values returned by the driver are basically the same
+     * as what they used to be before we supported returning all fields.
+     */
+    @Test public void testDefaultValuesWithoutIncludedFields() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        List<FieldWithMetadata> fields = getFieldList(conn);
+        VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fields);
+        for (int i = 1; i < fields.size() + 1; i++) {
+            FieldWithMetadata field = fields.get(i - 1);
+            Assert.assertEquals(false, vitessResultSetMetaData.isAutoIncrement(i));
+            boolean shouldBeSensitive = true;
+            switch (field.getJavaType()) {
+                case Types.BIT:
+                case Types.TINYINT:
+                case Types.SMALLINT:
+                case Types.INTEGER:
+                case Types.BIGINT:
+                case Types.FLOAT:
+                case Types.REAL:
+                case Types.DOUBLE:
+                case Types.DATE:
+                case Types.DECIMAL:
+                case Types.NUMERIC:
+                case Types.TIME:
+                case Types.TIMESTAMP:
+                    shouldBeSensitive = false;
+                    break;
+            }
+            Assert.assertEquals(shouldBeSensitive, vitessResultSetMetaData.isCaseSensitive(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isSearchable(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isCurrency(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.isNullable(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isSigned(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getColumnDisplaySize(i));
+            Assert.assertEquals(field.getName(), field.getName(), vitessResultSetMetaData.getColumnLabel(i));
+            Assert.assertEquals(field.getName(), field.getName(), vitessResultSetMetaData.getColumnName(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getPrecision(i));
+            Assert.assertEquals(field.getName(), 0, vitessResultSetMetaData.getScale(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getTableName(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getCatalogName(i));
+            // These two do not depend on IncludedFields and are covered by tests above
+            //Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnType(i));
+            //Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnTypeName(i));
+            Assert.assertEquals(field.getName(), false, vitessResultSetMetaData.isReadOnly(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isWritable(i));
+            Assert.assertEquals(field.getName(), true, vitessResultSetMetaData.isDefinitelyWritable(i));
+            Assert.assertEquals(field.getName(), null, vitessResultSetMetaData.getColumnClassName(i));
+        }
     }
 }
 

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
@@ -1,10 +1,10 @@
 package com.flipkart.vitess.jdbc;
 
-import com.flipkart.vitess.jdbc.VitessResultSet;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.SimpleCursor;
 import com.youtube.vitess.proto.Query;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -18,7 +18,7 @@ import java.sql.Timestamp;
 /**
  * Created by harshit.gangal on 19/01/16.
  */
-public class VitessResultSetTest {
+public class VitessResultSetTest extends BaseTest {
 
     public Cursor getCursorWithRows() {
         /*
@@ -199,20 +199,20 @@ public class VitessResultSetTest {
             .addFields(Query.Field.newBuilder().setName("col1").build())
             .addFields(Query.Field.newBuilder().setName("col2").build()).build());
 
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         Assert.assertEquals(false, vitessResultSet.next());
     }
 
     @Test public void testNextWithNonZeroRows() throws Exception {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         Assert.assertEquals(true, vitessResultSet.next());
         Assert.assertEquals(false, vitessResultSet.next());
     }
 
     @Test public void testgetString() throws SQLException {
         Cursor cursor = getCursorWithRowsAsNull();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals("-50", vitessResultSet.getString(1));
         Assert.assertEquals("50", vitessResultSet.getString(2));
@@ -246,11 +246,11 @@ public class VitessResultSetTest {
     @Test public void testgetBoolean() throws SQLException {
         Cursor cursor = getCursorWithRows();
         Cursor cursorWithRowsAsNull = getCursorWithRowsAsNull();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(true, vitessResultSet.getBoolean(25));
         Assert.assertEquals(false, vitessResultSet.getBoolean(1));
-        vitessResultSet = new VitessResultSet(cursorWithRowsAsNull);
+        vitessResultSet = new VitessResultSet(cursorWithRowsAsNull, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(false, vitessResultSet.getBoolean(25));
         Assert.assertEquals(false, vitessResultSet.getBoolean(1));
@@ -258,7 +258,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetByte() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte(1));
         Assert.assertEquals(1, vitessResultSet.getByte(25));
@@ -266,42 +266,42 @@ public class VitessResultSetTest {
 
     @Test public void testgetShort() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-23000, vitessResultSet.getShort(3));
     }
 
     @Test public void testgetInt() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-100, vitessResultSet.getInt(7));
     }
 
     @Test public void testgetLong() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-1000, vitessResultSet.getInt(9));
     }
 
     @Test public void testgetFloat() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(24.52f, vitessResultSet.getFloat(11), 0.001);
     }
 
     @Test public void testgetDouble() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(100.43, vitessResultSet.getFloat(12), 0.001);
     }
 
     @Test public void testBigDecimal() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new BigDecimal(BigInteger.valueOf(123456789), 5),
             vitessResultSet.getBigDecimal(18));
@@ -309,28 +309,28 @@ public class VitessResultSetTest {
 
     @Test public void testgetBytes() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertArrayEquals("HELLO TDS TEAM".getBytes("UTF-8"), vitessResultSet.getBytes(19));
     }
 
     @Test public void testgetDate() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new java.sql.Date(116, 1, 6), vitessResultSet.getDate(14));
     }
 
     @Test public void testgetTime() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new Time(12, 34, 56), vitessResultSet.getTime(15));
     }
 
     @Test public void testgetTimestamp() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new Timestamp(116, 1, 6, 14, 15, 16, 0),
             vitessResultSet.getTimestamp(13));
@@ -338,7 +338,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetStringbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals("-50", vitessResultSet.getString("col1"));
         Assert.assertEquals("50", vitessResultSet.getString("col2"));
@@ -371,7 +371,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetBooleanbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(true, vitessResultSet.getBoolean("col25"));
         Assert.assertEquals(false, vitessResultSet.getBoolean("col1"));
@@ -379,7 +379,7 @@ public class VitessResultSetTest {
 
     @Test public void testgetBytebyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-50, vitessResultSet.getByte("col1"));
         Assert.assertEquals(1, vitessResultSet.getByte("col25"));
@@ -387,42 +387,42 @@ public class VitessResultSetTest {
 
     @Test public void testgetShortbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-23000, vitessResultSet.getShort("col3"));
     }
 
     @Test public void testgetIntbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-100, vitessResultSet.getInt("col7"));
     }
 
     @Test public void testgetLongbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(-1000, vitessResultSet.getInt("col9"));
     }
 
     @Test public void testgetFloatbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(24.52f, vitessResultSet.getFloat("col11"), 0.001);
     }
 
     @Test public void testgetDoublebyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(100.43, vitessResultSet.getFloat("col12"), 0.001);
     }
 
     @Test public void testBigDecimalbyColumnLabel() throws SQLException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new BigDecimal(BigInteger.valueOf(123456789), 5),
             vitessResultSet.getBigDecimal("col18"));
@@ -431,7 +431,7 @@ public class VitessResultSetTest {
     @Test public void testgetBytesbyColumnLabel()
         throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertArrayEquals("HELLO TDS TEAM".getBytes("UTF-8"),
             vitessResultSet.getBytes("col19"));
@@ -439,14 +439,14 @@ public class VitessResultSetTest {
 
     @Test public void testgetDatebyColumnLabel() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new java.sql.Date(116, 1, 6), vitessResultSet.getDate("col14"));
     }
 
     @Test public void testgetTimebyColumnLabel() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new Time(12, 34, 56), vitessResultSet.getTime("col15"));
     }
@@ -454,7 +454,7 @@ public class VitessResultSetTest {
     @Test public void testgetTimestampbyColumnLabel()
         throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         Assert.assertEquals(new Timestamp(116, 1, 6, 14, 15, 16, 0),
             vitessResultSet.getTimestamp("col13"));
@@ -462,11 +462,16 @@ public class VitessResultSetTest {
 
     @Test public void testgetAsciiStream() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         vitessResultSet.next();
         // Need to implement AssertEquivalant
         //Assert.assertEquals((InputStream)(new ByteArrayInputStream("HELLO TDS TEAM".getBytes())), vitessResultSet
         // .getAsciiStream(19));
     }
 
+    @Test public void testEnhancedFieldsFromCursor() throws Exception {
+        Cursor cursor = getCursorWithRows();
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
+        Assert.assertEquals(cursor.getFields().size(), vitessResultSet.getFields().size());
+    }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
@@ -199,13 +199,13 @@ public class VitessResultSetTest extends BaseTest {
             .addFields(Query.Field.newBuilder().setName("col1").build())
             .addFields(Query.Field.newBuilder().setName("col2").build()).build());
 
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
         Assert.assertEquals(false, vitessResultSet.next());
     }
 
     @Test public void testNextWithNonZeroRows() throws Exception {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
         Assert.assertEquals(true, vitessResultSet.next());
         Assert.assertEquals(false, vitessResultSet.next());
     }
@@ -462,7 +462,7 @@ public class VitessResultSetTest extends BaseTest {
 
     @Test public void testgetAsciiStream() throws SQLException, UnsupportedEncodingException {
         Cursor cursor = getCursorWithRows();
-        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor);
         vitessResultSet.next();
         // Need to implement AssertEquivalant
         //Assert.assertEquals((InputStream)(new ByteArrayInputStream("HELLO TDS TEAM".getBytes())), vitessResultSet


### PR DESCRIPTION
@ashudeep-sharma 

Part 2 of 3. This one adds support for all of the VitessResultSetMetadata getters. I've preserved the old default values when IncludedFields != ALL. I've added tests to ensure that all works as expected.  FieldWithMetadata is similar to `mysql-connector-j` Field.java, but wraps our Field proto. You'll notice that it adds support for remapping fields to their real java type based on flags passed from mysql -- more of that to come when we do the last part (char encodings)

FieldWithMetadata has 100% test coverage, and all new code in other classes have near that as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/2489)
<!-- Reviewable:end -->
