### PR TITLE
vtgate: Report TRANSIENT_ERROR as info error to avoid alerting on it.

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -920,6 +920,11 @@ func handleExecuteError(err error, statsKey []string, query map[string]interface
 	case vtrpcpb.ErrorCode_PERMISSION_DENIED:
 		// User violated permissions (TableACL), no need to log.
 		infoErrors.Add("PermissionDenied", 1)
+	case vtrpcpb.ErrorCode_TRANSIENT_ERROR:
+		// Temporary error which should be retried by user. Do not log.
+		// As of 01/2017, only the vttablet transaction throttler and the vtgate
+		// master buffer (if buffer full) return this error.
+		infoErrors.Add("TransientError", 1)
 	default:
 		// Regular error, we will log if caused by vtgate.
 		normalErrors.Add(statsKey, 1)


### PR DESCRIPTION
By default, each error increments the variable "VtgateApiErrorCounts".

However, some errors are excluded as informational errors because they do not signal a problem within vtgate.

This commit changes the reporting of TRANSIENT_ERRORS from the "VtgateApiErrorCounts" variable to "VtgateInfoErrorCounts".

This is necessary because this error code is used by the vtgate buffer to signal an internal error condition e.g. that the buffer is full. In this particular case, the request cannot be buffered and instead the client should retry. Another known usage is the vttablet transaction throttler when it rejects a transaction as throttled.

BUG=26755052