### PR TITLE
Minor Optimization for Delete Vindex Queries

### DIFF
--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -421,7 +421,7 @@ func (route *Route) execDeleteEqual(vcursor VCursor, queryConstruct *queryinfo.Q
 	if len(ksid) == 0 {
 		return &sqltypes.Result{}, nil
 	}
-	if route.Subquery != "" {
+	if route.Subquery != "" && len(route.Table.Owned) != 0 {
 		err = route.deleteVindexEntries(vcursor, queryConstruct, ks, shard, ksid)
 		if err != nil {
 			return nil, fmt.Errorf("execDeleteEqual: %v", err)
@@ -684,7 +684,7 @@ func (route *Route) deleteVindexEntries(vcursor VCursor, queryConstruct *queryin
 				return err
 			}
 		default:
-			panic("unexpceted")
+			panic("unexpected")
 		}
 	}
 	return nil

--- a/go/vt/vtgate/router_dml_test.go
+++ b/go/vt/vtgate/router_dml_test.go
@@ -211,6 +211,24 @@ func TestDeleteEqual(t *testing.T) {
 	if sbc.Queries != nil {
 		t.Errorf("sbc.Queries: %+v, want nil\n", sbc.Queries)
 	}
+
+	sbc.Queries = nil
+	sbclookup.Queries = nil
+	sbclookup.SetResults([]*sqltypes.Result{{}})
+	_, err = routerExec(router, "delete from user_extra where user_id = 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries = []querytypes.BoundQuery{{
+		Sql:           "delete from user_extra where user_id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{},
+	}}
+	if !reflect.DeepEqual(sbc.Queries, wantQueries) {
+		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc.Queries, wantQueries)
+	}
+	if sbclookup.Queries != nil {
+		t.Errorf("sbc.Queries: %+v, want nil\n", sbc.Queries)
+	}
 }
 
 func TestDeleteComments(t *testing.T) {


### PR DESCRIPTION
This Pull Request contains a minor optimisation of not running an select queries on Vindexes if the Corresponding table doesn't have any owned ColVindexes.