### PR TITLE
Mysqlconn migration

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -32,6 +32,10 @@ const (
 func init() {
 	// This needs to be called before threads begin to spawn.
 	C.vt_library_init()
+	sqldb.Register("libmysqlclient", Connect)
+
+	// Comment this out and uncomment call to sqldb.RegisterDefault in
+	// go/mysqlconn/sqldb_conn.go to make it the default.
 	sqldb.RegisterDefault(Connect)
 }
 

--- a/go/mysqlconn/client.go
+++ b/go/mysqlconn/client.go
@@ -72,7 +72,7 @@ func Connect(ctx context.Context, params *sqldb.ConnParams) (*Conn, error) {
 		}
 		if err != nil {
 			status <- connectResult{
-				err: sqldb.NewSQLError(CRConnectionError, "", "net.Dial(%v,%v) failed: %v", netProto, addr, err),
+				err: sqldb.NewSQLError(CRConnHostError, "", "net.Dial(%v,%v) failed: %v", netProto, addr, err),
 			}
 			return
 		}

--- a/go/mysqlconn/client_test.go
+++ b/go/mysqlconn/client_test.go
@@ -104,7 +104,7 @@ func TestConnectTimeout(t *testing.T) {
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
 	os.Remove(name)
-	assertSQLError(t, err, CRConnectionError, SSSignalException, "connection refused")
+	assertSQLError(t, err, CRConnHostError, SSSignalException, "connection refused")
 }
 
 // testKillWithRealDatabase opens a connection, issues a command that

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -172,6 +172,9 @@ const (
 	// ERUnknownComError is ER_UNKNOWN_COM_ERROR
 	ERUnknownComError = 1047
 
+	// ERDupEntry is ER_DUP_ENTRY
+	ERDupEntry = 1062
+
 	// ERUnknownError is ER_UNKNOWN_ERROR
 	ERUnknownError = 1105
 
@@ -185,6 +188,9 @@ const (
 const (
 	// SSSignalException is ER_SIGNAL_EXCEPTION
 	SSSignalException = "HY000"
+
+	// SSDupKey is ER_DUP_KEY
+	SSDupKey = "23000"
 
 	// SSAccessDeniedError is ER_ACCESS_DENIED_ERROR
 	SSAccessDeniedError = "28000"

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -268,3 +268,12 @@ var CharacterSetMap = map[string]uint8{
 	"cp932":    95,
 	"eucjpms":  97,
 }
+
+// IsNum returns true if a MySQL type is a numeric value.
+// It is the same as IS_NUM defined in mysql.h.
+//
+// FIXME(alainjobart) This needs to use the constants in
+// replication/constants.go, so we are using numerical values here.
+func IsNum(typ uint8) bool {
+	return ((typ <= 9 /* MYSQL_TYPE_INT24 */ && typ != 7 /* MYSQL_TYPE_TIMESTAMP */) || typ == 13 /* MYSQL_TYPE_YEAR */ || typ == 246 /* MYSQL_TYPE_NEWDECIMAL */)
+}

--- a/go/mysqlconn/doc.go
+++ b/go/mysqlconn/doc.go
@@ -88,4 +88,20 @@ We should add the following protections for the server:
   Should start during initial handshake, maybe have a shorter value during
   handshake.
 
+--
+NUM_FLAG flag:
+
+It is added by the C client library if the field is numerical.
+
+  if (IS_NUM(client_field->type))
+    client_field->flags|= NUM_FLAG;
+
+This is somewhat useless. Also, that flag overlaps with GROUP_FLAG
+(which seems to be used by the server only for temporary tables in
+some cases, so it's not a big deal).
+
+But eventually, we probably want to remove it entirely, as it is not
+transmitted over the wire. For now, we keep it for backward
+compatibility with the C client.
+
 */

--- a/go/mysqlconn/query.go
+++ b/go/mysqlconn/query.go
@@ -297,6 +297,7 @@ func (c *Conn) ExecuteFetch(query string, maxrows int, wantfields bool) (*sqltyp
 			if !wantfields {
 				result.Fields = nil
 			}
+			result.RowsAffected = uint64(len(result.Rows))
 			return result, nil
 		case ErrPacket:
 			// Error packet.

--- a/go/mysqlconn/query.go
+++ b/go/mysqlconn/query.go
@@ -117,6 +117,16 @@ func (c *Conn) readColumnDefinition(field *querypb.Field, index int) error {
 	// a Field without that data, so we don't return the flags.
 	if field.ColumnLength != 0 || field.Charset != 0 {
 		field.Flags = uint32(flags)
+
+		// FIXME(alainjobart): This is something the MySQL
+		// client library does: If the type is numerical, it
+		// adds a NUM_FLAG to the flags.  We're doing it here
+		// only to be compatible with the C library. Once
+		// we're not using that library any more, we'll remove this.
+		// See doc.go.
+		if IsNum(t) {
+			field.Flags |= uint32(querypb.MySqlFlag_NUM_FLAG)
+		}
 	}
 
 	return nil

--- a/go/mysqlconn/query_test.go
+++ b/go/mysqlconn/query_test.go
@@ -77,6 +77,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
+		RowsAffected: 2,
 	})
 
 	// Typicall Select with TYPE_AND_NAME.
@@ -179,6 +180,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.NULL,
 			},
 		},
+		RowsAffected: 2,
 	})
 
 	// Typicall Select with TYPE_AND_NAME.
@@ -198,6 +200,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nice name")),
 			},
 		},
+		RowsAffected: 2,
 	})
 
 	// Typicall Select with TYPE_ONLY.
@@ -215,6 +218,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("20")),
 			},
 		},
+		RowsAffected: 2,
 	})
 
 	// Typicall Select with ALL.
@@ -230,7 +234,10 @@ func TestQueries(t *testing.T) {
 				ColumnLength: 0x80020304,
 				Charset:      0x1234,
 				Decimals:     36,
-				Flags:        16387, // NOT_NULL_FLAG, PRI_KEY_FLAG, PART_KEY_FLAG
+				Flags: uint32(querypb.MySqlFlag_NOT_NULL_FLAG |
+					querypb.MySqlFlag_PRI_KEY_FLAG |
+					querypb.MySqlFlag_PART_KEY_FLAG |
+					querypb.MySqlFlag_NUM_FLAG),
 			},
 		},
 		Rows: [][]sqltypes.Value{
@@ -244,6 +251,7 @@ func TestQueries(t *testing.T) {
 				sqltypes.MakeTrusted(querypb.Type_INT64, []byte("30")),
 			},
 		},
+		RowsAffected: 3,
 	})
 }
 
@@ -313,8 +321,8 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		if !reflect.DeepEqual(got, &expected) {
 			for i, f := range got.Fields {
 				if !reflect.DeepEqual(f, expected.Fields[i]) {
-					t.Errorf("Got      field(%v) = %v", i, f)
-					t.Errorf("Expected field(%v) = %v", i, expected.Fields[i])
+					t.Logf("Got      field(%v) = %v", i, f)
+					t.Logf("Expected field(%v) = %v", i, expected.Fields[i])
 				}
 			}
 			t.Fatalf("ExecuteFetch(wantfields=%v) returned:\n%v\nBut was expecting:\n%v", wantfields, got, expected)
@@ -444,7 +452,8 @@ func testQueriesWithRealDatabase(t *testing.T, params *sqldb.ConnParams) {
 				Charset:      CharacterSetBinary,
 				Flags: uint32(querypb.MySqlFlag_NOT_NULL_FLAG |
 					querypb.MySqlFlag_PRI_KEY_FLAG |
-					querypb.MySqlFlag_PART_KEY_FLAG),
+					querypb.MySqlFlag_PART_KEY_FLAG |
+					querypb.MySqlFlag_NUM_FLAG),
 			},
 			{
 				Name:         "name",
@@ -518,7 +527,8 @@ func readRowsUsingStream(t *testing.T, conn *Conn, expectedCount int) {
 			Charset:      CharacterSetBinary,
 			Flags: uint32(querypb.MySqlFlag_NOT_NULL_FLAG |
 				querypb.MySqlFlag_PRI_KEY_FLAG |
-				querypb.MySqlFlag_PART_KEY_FLAG),
+				querypb.MySqlFlag_PART_KEY_FLAG |
+				querypb.MySqlFlag_NUM_FLAG),
 		},
 		{
 			Name:         "name",

--- a/go/mysqlconn/schema.go
+++ b/go/mysqlconn/schema.go
@@ -28,7 +28,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "COLUMN_NAME",
 		ColumnLength: 192,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Type",
@@ -39,7 +39,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "COLUMN_TYPE",
 		ColumnLength: 589815,
 		Charset:      33,
-		Flags:        17,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG | querypb.MySqlFlag_BLOB_FLAG),
 	},
 	{
 		Name:         "Null",
@@ -50,7 +50,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "IS_NULLABLE",
 		ColumnLength: 9,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Key",
@@ -61,7 +61,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "COLUMN_KEY",
 		ColumnLength: 9,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Default",
@@ -72,7 +72,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "COLUMN_DEFAULT",
 		ColumnLength: 589815,
 		Charset:      33,
-		Flags:        16,
+		Flags:        uint32(querypb.MySqlFlag_BLOB_FLAG),
 	},
 	{
 		Name:         "Extra",
@@ -83,7 +83,7 @@ var DescribeTableFields = []*querypb.Field{
 		OrgName:      "EXTRA",
 		ColumnLength: 90,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 }
 
@@ -134,7 +134,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "TABLE_NAME",
 		ColumnLength: 192,
 		Charset:      CharacterSetUtf8,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Non_unique",
@@ -145,7 +145,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "NON_UNIQUE",
 		ColumnLength: 1,
 		Charset:      CharacterSetBinary,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "Key_name",
@@ -156,7 +156,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "INDEX_NAME",
 		ColumnLength: 192,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Seq_in_index",
@@ -167,7 +167,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "SEQ_IN_INDEX",
 		ColumnLength: 2,
 		Charset:      CharacterSetBinary,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "Column_name",
@@ -178,7 +178,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "COLUMN_NAME",
 		ColumnLength: 192,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Collation",
@@ -199,6 +199,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "CARDINALITY",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
+		Flags:        uint32(querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "Sub_part",
@@ -209,6 +210,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "SUB_PART",
 		ColumnLength: 3,
 		Charset:      CharacterSetBinary,
+		Flags:        uint32(querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "Packed",
@@ -240,7 +242,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "INDEX_TYPE",
 		ColumnLength: 48,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "Comment",
@@ -261,7 +263,7 @@ var ShowIndexFromTableFields = []*querypb.Field{
 		OrgName:      "INDEX_COMMENT",
 		ColumnLength: 3072,
 		Charset:      33,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 }
 
@@ -320,7 +322,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "TABLE_NAME",
 		ColumnLength: 192,
 		Charset:      CharacterSetUtf8,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "table_type",
@@ -331,14 +333,14 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "TABLE_TYPE",
 		ColumnLength: 192,
 		Charset:      CharacterSetUtf8,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "unix_timestamp(create_time)",
 		Type:         querypb.Type_INT64,
 		ColumnLength: 11,
 		Charset:      CharacterSetBinary,
-		Flags:        128,
+		Flags:        uint32(querypb.MySqlFlag_BINARY_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "table_comment",
@@ -349,7 +351,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "TABLE_COMMENT",
 		ColumnLength: 6144,
 		Charset:      CharacterSetUtf8,
-		Flags:        1,
+		Flags:        uint32(querypb.MySqlFlag_NOT_NULL_FLAG),
 	},
 	{
 		Name:         "table_rows",
@@ -360,7 +362,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "TABLE_ROWS",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
-		Flags:        32,
+		Flags:        uint32(querypb.MySqlFlag_UNSIGNED_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "data_length",
@@ -371,7 +373,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "DATA_LENGTH",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
-		Flags:        32,
+		Flags:        uint32(querypb.MySqlFlag_UNSIGNED_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "index_length",
@@ -382,7 +384,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "INDEX_LENGTH",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
-		Flags:        32,
+		Flags:        uint32(querypb.MySqlFlag_UNSIGNED_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "data_free",
@@ -393,7 +395,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "DATA_FREE",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
-		Flags:        32,
+		Flags:        uint32(querypb.MySqlFlag_UNSIGNED_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 	{
 		Name:         "max_data_length",
@@ -404,7 +406,7 @@ var BaseShowTablesFields = []*querypb.Field{
 		OrgName:      "MAX_DATA_LENGTH",
 		ColumnLength: 21,
 		Charset:      CharacterSetBinary,
-		Flags:        32,
+		Flags:        uint32(querypb.MySqlFlag_UNSIGNED_FLAG | querypb.MySqlFlag_NUM_FLAG),
 	},
 }
 

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -160,8 +160,16 @@ func (c *Conn) ID() int64 {
 }
 
 func init() {
-	sqldb.Register("sqlconn", func(params sqldb.ConnParams) (sqldb.Conn, error) {
+	sqldb.Register("mysqlconn", func(params sqldb.ConnParams) (sqldb.Conn, error) {
 		ctx := context.Background()
 		return Connect(ctx, &params)
 	})
+
+	// Uncomment this and comment out the call to sqldb.RegisterDefault in
+	// go/mysql/mysql.go to make this the default.
+
+	//	sqldb.RegisterDefault(func(params sqldb.ConnParams) (sqldb.Conn, error) {
+	//		ctx := context.Background()
+	//		return Connect(ctx, &params)
+	//	})
 }

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -40,6 +40,7 @@ const (
 
 // The flags will change the global singleton
 func registerConnFlags(connParams *sqldb.ConnParams, name string) {
+	flag.StringVar(&connParams.Engine, "db-config-"+name+"-engine", "libmysqlclient", "db "+name+" engine to use (empty for default, libmysqlclient or mysqlconn)")
 	flag.StringVar(&connParams.Host, "db-config-"+name+"-host", "", "db "+name+" connection host")
 	flag.IntVar(&connParams.Port, "db-config-"+name+"-port", 0, "db "+name+" connection port")
 	flag.StringVar(&connParams.Uname, "db-config-"+name+"-uname", "", "db "+name+" connection uname")

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -315,7 +314,7 @@ func (mysqld *Mysqld) wait(ctx context.Context, params sqldb.ConnParams) error {
 		_, statErr := os.Stat(mysqld.config.SocketFile)
 		if statErr == nil {
 			// Make sure the socket file isn't stale.
-			conn, connErr := mysql.Connect(params)
+			conn, connErr := sqldb.Connect(params)
 			if connErr == nil {
 				conn.Close()
 				return nil

--- a/go/vt/tabletserver/dbconn_test.go
+++ b/go/vt/tabletserver/dbconn_test.go
@@ -145,8 +145,9 @@ func TestDBConnStream(t *testing.T) {
 			return nil
 		}, 10, querypb.ExecuteOptions_ALL)
 	db.DisableConnFail()
-	want := "Connection is closed"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("Error: %v, must contain %s\n", err, want)
+	want1 := "Connection is closed"
+	want2 := "use of closed network connection"
+	if err == nil || (!strings.Contains(err.Error(), want1) && !strings.Contains(err.Error(), want2)) {
+		t.Errorf("Error: '%v', must contain '%s' or '%s'\n", err, want1, want2)
 	}
 }

--- a/go/vt/tabletserver/endtoend/misc_test.go
+++ b/go/vt/tabletserver/endtoend/misc_test.go
@@ -16,7 +16,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/tabletserver/endtoend/framework"
 
@@ -226,7 +226,7 @@ func TestUpsertNonPKHit(t *testing.T) {
 }
 
 func TestSchemaReload(t *testing.T) {
-	conn, err := mysql.Connect(connParams)
+	conn, err := sqldb.Connect(connParams)
 	if err != nil {
 		t.Error(err)
 		return
@@ -260,7 +260,7 @@ func TestSchemaReload(t *testing.T) {
 }
 
 func TestSidecarTables(t *testing.T) {
-	conn, err := mysql.Connect(connParams)
+	conn, err := sqldb.Connect(connParams)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/tabletserver/endtoend/transaction_test.go
+++ b/go/vt/tabletserver/endtoend/transaction_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/vt/tabletserver"
 	"github.com/youtube/vitess/go/vt/tabletserver/endtoend/framework"
 
@@ -750,7 +750,7 @@ func TestManualTwopcz(t *testing.T) {
 	t.Skip()
 	client := framework.NewClient()
 	defer client.Execute("delete from vitess_test where intval=4", nil)
-	conn, err := mysql.Connect(connParams)
+	conn, err := sqldb.Connect(connParams)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -11,8 +11,12 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
+
+	// FIXME(alainjobart) remove this when it's the only option.
+	// Registers our implementation.
+	_ "github.com/youtube/vitess/go/mysqlconn"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
@@ -88,7 +92,7 @@ func TestMySQL(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	conn, err := mysql.Connect(params)
+	conn, err := sqldb.Connect(params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -16,7 +16,7 @@ import (
 
 	// FIXME(alainjobart) remove this when it's the only option.
 	// Registers our implementation.
-	_ "github.com/youtube/vitess/go/mysqlconn"
+	_ "github.com/youtube/vitess/go/mysql"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"


### PR DESCRIPTION
With this PR, the new go/mysqlconn can be used everywhere instead of the old go/mysql, by just switching a command line flag per type.

Fixed a number of interface incompatibilities on the way.

With this code, enabling the new code by default makes all tests pass as well.