### PR TITLE
Make mysqlconn the default implementation.

### DIFF
--- a/go/mysql/mysql.go
+++ b/go/mysql/mysql.go
@@ -45,10 +45,6 @@ func init() {
 	// This needs to be called before threads begin to spawn.
 	C.vt_library_init()
 	sqldb.Register("libmysqlclient", Connect)
-
-	// Comment this out and uncomment call to sqldb.RegisterDefault in
-	// go/mysqlconn/sqldb_conn.go to make it the default.
-	sqldb.RegisterDefault(Connect)
 }
 
 func handleError(err *error) {
@@ -65,6 +61,11 @@ type Connection struct {
 
 // Connect uses the connection parameters to connect and returns the connection
 func Connect(params sqldb.ConnParams) (sqldb.Conn, error) {
+	// FIXME(alainjobart) adding a panic to make sure this library is
+	// unused. Before the defer on purpose, so it actually panics.
+	if true {
+		panic("Added to make sure this library is unused.")
+	}
 	var err error
 	defer handleError(&err)
 

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -78,6 +78,9 @@ type Conn struct {
 	// - at accept time for the server.
 	ConnectionID uint32
 
+	// Closed is set to true when Close() is called on the connection.
+	Closed bool
+
 	// Capabilities is the current set of features this connection
 	// is using.  It is the features that are both supported by
 	// the client and the server, and currently in use.
@@ -535,6 +538,7 @@ func (c *Conn) RemoteAddr() net.Addr {
 // Close closes the connection. It can be called from a different go
 // routine to interrupt the current connection.
 func (c *Conn) Close() {
+	c.Closed = true
 	c.conn.Close()
 }
 

--- a/go/mysqlconn/server_test.go
+++ b/go/mysqlconn/server_test.go
@@ -189,6 +189,9 @@ func TestClientFoundRows(t *testing.T) {
 		t.Errorf("FoundRows flag: %x, second bit must be 0", th.lastConn.Capabilities)
 	}
 	c.Close()
+	if !c.IsClosed() {
+		t.Errorf("IsClosed returned true on Close-d connection.")
+	}
 
 	// Test with flag.
 	params.Flags |= CapabilityClientFoundRows

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -168,12 +168,11 @@ func (c *Conn) CloseResult() {
 
 // IsClosed is part of the sqldb.Conn interface.
 func (c *Conn) IsClosed() bool {
-	return c.ConnectionID == 0
+	return c.Closed
 }
 
 // Shutdown is part of the sqldb.Conn interface.
 func (c *Conn) Shutdown() {
-	c.ConnectionID = 0
 	c.conn.Close()
 }
 

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -179,12 +179,8 @@ func init() {
 		ctx := context.Background()
 		return Connect(ctx, &params)
 	})
-
-	// Uncomment this and comment out the call to sqldb.RegisterDefault in
-	// go/mysql/mysql.go to make this the default.
-
-	//	sqldb.RegisterDefault(func(params sqldb.ConnParams) (sqldb.Conn, error) {
-	//		ctx := context.Background()
-	//		return Connect(ctx, &params)
-	//	})
+	sqldb.RegisterDefault(func(params sqldb.ConnParams) (sqldb.Conn, error) {
+		ctx := context.Background()
+		return Connect(ctx, &params)
+	})
 }

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -35,7 +35,15 @@ import (
 
 // ExecuteStreamFetch is part of the sqldb.Conn interface.
 // Returns a sqldb.SQLError.
-func (c *Conn) ExecuteStreamFetch(query string) error {
+func (c *Conn) ExecuteStreamFetch(query string) (err error) {
+	defer func() {
+		if err != nil {
+			if sqlerr, ok := err.(*sqldb.SQLError); ok {
+				sqlerr.Query = query
+			}
+		}
+	}()
+
 	// Sanity check.
 	if c.fields != nil {
 		return sqldb.NewSQLError(CRCommandsOutOfSync, SSUnknownSQLState, "streaming query already in progress")

--- a/go/mysqlconn/sqldb_conn.go
+++ b/go/mysqlconn/sqldb_conn.go
@@ -171,11 +171,6 @@ func (c *Conn) IsClosed() bool {
 	return c.Closed
 }
 
-// Shutdown is part of the sqldb.Conn interface.
-func (c *Conn) Shutdown() {
-	c.conn.Close()
-}
-
 // ID is part of the sqldb.Conn interface.
 func (c *Conn) ID() int64 {
 	return int64(c.ConnectionID)

--- a/go/vt/dbconfigs/dbconfigs.go
+++ b/go/vt/dbconfigs/dbconfigs.go
@@ -58,7 +58,7 @@ const redactedPassword = "****"
 
 // The flags will change the global singleton
 func registerConnFlags(connParams *sqldb.ConnParams, name string) {
-	flag.StringVar(&connParams.Engine, "db-config-"+name+"-engine", "libmysqlclient", "db "+name+" engine to use (empty for default, libmysqlclient or mysqlconn)")
+	flag.StringVar(&connParams.Engine, "db-config-"+name+"-engine", "mysqlconn", "db "+name+" engine to use (empty for default, libmysqlclient or mysqlconn)")
 	flag.StringVar(&connParams.Host, "db-config-"+name+"-host", "", "db "+name+" connection host")
 	flag.IntVar(&connParams.Port, "db-config-"+name+"-port", 0, "db "+name+" connection port")
 	flag.StringVar(&connParams.Uname, "db-config-"+name+"-uname", "", "db "+name+" connection uname")

--- a/go/vt/vttablet/endtoend/message_test.go
+++ b/go/vt/vttablet/endtoend/message_test.go
@@ -64,6 +64,7 @@ func TestMessage(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
+		close(ch)
 	}()
 	// Once the test is done, consume any left-over pending
 	// messages. Some could make it into the pipeline and get

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -92,7 +92,7 @@ func TestDBConnKill(t *testing.T) {
 	// Kill failed because we are not able to connect to the database
 	db.EnableConnFail()
 	err = dbConn.Kill("test kill")
-	want := "Lost connection"
+	want := "errno 2013"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Exec: %v, want %s", err, want)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -433,8 +433,6 @@ func TestTxPoolExecFailDueToConnFail_Errno2013(t *testing.T) {
 }
 
 func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
-	before := tabletenv.InternalErrors.Counts()["StrayTransactions"]
-
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQuery("begin", &sqltypes.Result{})
@@ -450,7 +448,7 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 
 	// Close kills stray transaction.
 	txPool.Close()
-	if got, want := tabletenv.InternalErrors.Counts()["StrayTransactions"]-before, int64(1); got != want {
+	if got, want := tabletenv.InternalErrors.Counts()["StrayTransactions"], int64(1); got != want {
 		t.Fatalf("internal error count for stray transactions not increased: got = %v, want = %v", got, want)
 	}
 	if got, want := txPool.conns.Capacity(), int64(0); got != want {

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -30,7 +30,7 @@ import (
 
 	// FIXME(alainjobart) remove this when it's the only option.
 	// Registers our implementation.
-	_ "github.com/youtube/vitess/go/mysql"
+	_ "github.com/youtube/vitess/go/mysqlconn"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"


### PR DESCRIPTION
go/mysqlconn is then unused. Will be removed soon.