### PR TITLE
tabletserver: Do not strip internal error message if terse errors is on.

### DIFF
--- a/go/vt/tabletserver/tabletserver.go
+++ b/go/vt/tabletserver/tabletserver.go
@@ -1162,6 +1162,17 @@ func (tsv *TabletServer) handleError(
 	if !ok {
 		panic(fmt.Errorf("Got an error that is not a TabletError: %v", err))
 	}
+
+	// If TerseErrors is on, strip the error message returned by MySQL and only
+	// keep the error number and sql state.
+	// This avoids leaking PII which may be contained in the bind variables: Since
+	// vttablet has to rewrite and include the bind variables in the query for
+	// MySQL, the bind variables data would show up in the error message.
+	//
+	// If no bind variables are specified, we do not strip the error message and
+	// the full user query may be included. We do this on purpose for use cases
+	// where users manually write queries and need the error message to debug
+	// e.g. syntax errors on the rewritten query.
 	var myError error
 	if tsv.config.TerseErrors && terr.SQLError != 0 && len(bindVariables) != 0 {
 		myError = &TabletError{


### PR DESCRIPTION
The error is needed by vtgate to start buffering when it sees such errors.