### PR TITLE
vtgate/buffer: Reduce --vtgate_buffer_min_time_between_failovers defa…

### DIFF
--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -13,7 +13,7 @@ var (
 	window                  = flag.Duration("vtgate_buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
 	size                    = flag.Int("vtgate_buffer_size", 10, "Maximum number of buffered requests in flight (across all ongoing failovers).")
 	maxFailoverDuration     = flag.Duration("vtgate_buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
-	minTimeBetweenFailovers = flag.Duration("vtgate_buffer_min_time_between_failovers", 5*time.Minute, "Minimum time between the end of a failover and the start of the next one. Faster consecutive failovers will not trigger buffering.")
+	minTimeBetweenFailovers = flag.Duration("vtgate_buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one. Faster consecutive failovers will not trigger buffering.")
 
 	drainConcurrency = flag.Int("vtgate_buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously.")
 


### PR DESCRIPTION
…ult value from 5 to 1 minutes.

After internal discussions, it's not unlikely that a second failover for the same shard could happen after a minute.

BUG=26755052