### PR TITLE
Refactoring error returns.

### DIFF
--- a/go/mysqlconn/client.go
+++ b/go/mysqlconn/client.go
@@ -72,7 +72,7 @@ func Connect(ctx context.Context, params *sqldb.ConnParams) (*Conn, error) {
 		}
 		if err != nil {
 			status <- connectResult{
-				err: sqldb.NewSQLError(CRConnHostError, "", "net.Dial(%v,%v) failed: %v", netProto, addr, err),
+				err: sqldb.NewSQLError(CRConnectionError, SSUnknownSQLState, "net.Dial(%v,%v) failed: %v", netProto, addr, err),
 			}
 			return
 		}
@@ -143,6 +143,7 @@ func Connect(ctx context.Context, params *sqldb.ConnParams) (*Conn, error) {
 }
 
 // parseCharacterSet parses the provided character set.
+// Returns SQLError(CRCantReadCharset) if it can't.
 func parseCharacterSet(cs string) (uint8, error) {
 	// Check if it's empty, return utf8. This is a reasonable default.
 	if cs == "" {
@@ -161,30 +162,31 @@ func parseCharacterSet(cs string) (uint8, error) {
 	}
 
 	// No luck.
-	return 0, fmt.Errorf("failed to interpret character set '%v'. Try using an integer value if needed", cs)
+	return 0, sqldb.NewSQLError(CRCantReadCharset, SSUnknownSQLState, "failed to interpret character set '%v'. Try using an integer value if needed", cs)
 }
 
 // clientHandshake handles the client side of the handshake.
 // Note the connection can be closed while this is running.
+// Returns a sqldb.SQLError.
 func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) error {
 	// Wait for the server initial handshake packet, and parse it.
-	data, err := c.ReadPacket()
+	data, err := c.readPacket()
 	if err != nil {
-		return sqldb.NewSQLError(CRConnHostError, "", "initial packet read failed: %v", err)
+		return sqldb.NewSQLError(CRServerLost, "", "initial packet read failed: %v", err)
 	}
 	capabilities, cipher, err := c.parseInitialHandshakePacket(data)
 	if err != nil {
-		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "parsing initial handshake packet failed: %v", err)
+		return err
 	}
 
 	// Sanity check.
 	if capabilities&CapabilityClientProtocol41 == 0 {
-		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "cannot connect to servers earlier than 4.1")
+		return sqldb.NewSQLError(CRVersionError, SSUnknownSQLState, "cannot connect to servers earlier than 4.1")
 	}
 
 	// If client asked for SSL, but server doesn't support it, stop right here.
 	if capabilities&CapabilityClientSSL == 0 && params.SslCert != "" && params.SslKey != "" {
-		return sqldb.NewSQLError(CRServerHandshakeErr, SSHandshakeError, "server doesn't support SSL but client asked for it")
+		return sqldb.NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "server doesn't support SSL but client asked for it")
 	}
 
 	// Remember a subset of the capabilities, so we can use them later in the protocol.
@@ -196,9 +198,9 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 	}
 
 	// Read the server response.
-	response, err := c.ReadPacket()
+	response, err := c.readPacket()
 	if err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 	}
 	switch response[0] {
 	case OKPacket:
@@ -219,9 +221,9 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 		}
 
 		// Wait for response, should be OK.
-		response, err := c.ReadPacket()
+		response, err := c.readPacket()
 		if err != nil {
-			return err
+			return sqldb.NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
 		}
 		switch response[0] {
 		case OKPacket:
@@ -231,7 +233,7 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 			return parseErrorPacket(response)
 		default:
 			// FIXME(alainjobart) handle extra auth cases and so on.
-			return fmt.Errorf("initial server response is asking for more information, not implemented yet: %v", response)
+			return sqldb.NewSQLError(CRServerHandshakeErr, SSUnknownSQLState, "initial server response is asking for more information, not implemented yet: %v", response)
 		}
 	}
 
@@ -239,47 +241,47 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 }
 
 // parseInitialHandshakePacket parses the initial handshake from the server.
-// It returns a regular error, the caller will turn it into a SQLError.
+// It returns a sqldb.SQLError with the right code.
 func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) {
 	pos := 0
 
 	// Protocol version.
 	pver, pos, ok := readByte(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no protocol version")
+		return 0, nil, sqldb.NewSQLError(CRVersionError, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no protocol version")
 	}
 	if pver != protocolVersion {
-		return 0, nil, fmt.Errorf("bad protocol version: %v", pver)
+		return 0, nil, sqldb.NewSQLError(CRVersionError, SSUnknownSQLState, "bad protocol version: %v", pver)
 	}
 
 	// Read the server version.
 	c.ServerVersion, pos, ok = readNullString(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no server version")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no server version")
 	}
 
 	// Read the connection id.
 	c.ConnectionID, pos, ok = readUint32(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no conneciton id")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no conneciton id")
 	}
 
 	// Read the first part of the auth-plugin-data
 	authPluginData, pos, ok := readBytes(data, pos, 8)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no auth-plugin-data-part-1")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no auth-plugin-data-part-1")
 	}
 
 	// One byte filler, 0. We don't really care about the value.
 	_, pos, ok = readByte(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no filler")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no filler")
 	}
 
 	// Lower 2 bytes of the capability flags.
 	capLower, pos, ok := readUint16(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no capability flags (lower 2 bytes)")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no capability flags (lower 2 bytes)")
 	}
 	var capabilities = uint32(capLower)
 
@@ -291,20 +293,20 @@ func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) 
 	// Character set.
 	characterSet, pos, ok := readByte(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no character set")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no character set")
 	}
 	c.CharacterSet = characterSet
 
 	// Status flags. Ignored.
 	_, pos, ok = readUint16(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no status flags")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no status flags")
 	}
 
 	// Upper 2 bytes of the capability flags.
 	capUpper, pos, ok := readUint16(data, pos)
 	if !ok {
-		return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no capability flags (upper 2 bytes)")
+		return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no capability flags (upper 2 bytes)")
 	}
 	capabilities += uint32(capUpper) << 16
 
@@ -314,13 +316,13 @@ func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) 
 	if capabilities&CapabilityClientPluginAuth != 0 {
 		authPluginDataLength, pos, ok = readByte(data, pos)
 		if !ok {
-			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no length of auth-plugin-data")
+			return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no length of auth-plugin-data")
 		}
 	} else {
 		// One byte filler, 0. We don't really care about the value.
 		_, pos, ok = readByte(data, pos)
 		if !ok {
-			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no length of auth-plugin-data filler")
+			return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no length of auth-plugin-data filler")
 		}
 	}
 
@@ -337,12 +339,12 @@ func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) 
 		var authPluginDataPart2 []byte
 		authPluginDataPart2, pos, ok = readBytes(data, pos, l)
 		if !ok {
-			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: packet has no auth-plugin-data-part-2")
+			return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: packet has no auth-plugin-data-part-2")
 		}
 
 		// The last byte has to be 0, and is not part of the data.
 		if authPluginDataPart2[l-1] != 0 {
-			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: auth-plugin-data-part-2 is not 0 terminated")
+			return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: auth-plugin-data-part-2 is not 0 terminated")
 		}
 		authPluginData = append(authPluginData, authPluginDataPart2[0:l-1]...)
 	}
@@ -357,13 +359,15 @@ func (c *Conn) parseInitialHandshakePacket(data []byte) (uint32, []byte, error) 
 		}
 
 		if authPluginName != mysqlNativePassword {
-			return 0, nil, fmt.Errorf("parseInitialHandshakePacket: only support %v auth plugin name, but got %v", mysqlNativePassword, authPluginName)
+			return 0, nil, sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "parseInitialHandshakePacket: only support %v auth plugin name, but got %v", mysqlNativePassword, authPluginName)
 		}
 	}
 
 	return capabilities, authPluginData, nil
 }
 
+// writeHandshakeResponse41 writes the handshake response.
+// Returns a sqldb.SQLError.
 func (c *Conn) writeHandshakeResponse41(capabilities uint32, cipher []byte, characterSet uint8, params *sqldb.ConnParams) error {
 	// Build our flags.
 	var flags uint32 = CapabilityClientLongPassword |
@@ -420,7 +424,7 @@ func (c *Conn) writeHandshakeResponse41(capabilities uint32, cipher []byte, char
 	// FIXME(alainjobart): With SSL can send this now.
 	// For now we don't support it.
 	if params.SslCert != "" && params.SslKey != "" {
-		return fmt.Errorf("SSL support is not implemented yet in this client")
+		return sqldb.NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "SSL support is not implemented yet in this client")
 	}
 
 	// 23 reserved bytes, all 0.
@@ -450,14 +454,14 @@ func (c *Conn) writeHandshakeResponse41(capabilities uint32, cipher []byte, char
 
 	// Sanity-check the length.
 	if pos != len(data) {
-		return fmt.Errorf("writeHandshakeResponse41: only packed %v bytes, out of %v allocated", pos, len(data))
+		return sqldb.NewSQLError(CRMalformedPacket, SSUnknownSQLState, "writeHandshakeResponse41: only packed %v bytes, out of %v allocated", pos, len(data))
 	}
 
 	if err := c.writePacket(data); err != nil {
-		return fmt.Errorf("cannot send HandshakeResponse41: %v", err)
+		return sqldb.NewSQLError(CRServerLost, SSUnknownSQLState, "cannot send HandshakeResponse41: %v", err)
 	}
 	if err := c.flush(); err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerLost, SSUnknownSQLState, "cannot flush HandshakeResponse41: %v", err)
 	}
 	return nil
 }

--- a/go/mysqlconn/client_test.go
+++ b/go/mysqlconn/client_test.go
@@ -89,7 +89,7 @@ func TestConnectTimeout(t *testing.T) {
 	}()
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
-	assertSQLError(t, err, CRConnHostError, SSSignalException, "initial packet read failed")
+	assertSQLError(t, err, CRServerLost, SSUnknownSQLState, "initial packet read failed")
 
 	// Tests a connection where Dial fails properly returns the
 	// right error. To simulate exactly the right failure, try to dial
@@ -104,7 +104,7 @@ func TestConnectTimeout(t *testing.T) {
 	ctx = context.Background()
 	_, err = Connect(ctx, params)
 	os.Remove(name)
-	assertSQLError(t, err, CRConnHostError, SSSignalException, "connection refused")
+	assertSQLError(t, err, CRConnectionError, SSUnknownSQLState, "connection refused")
 }
 
 // testKillWithRealDatabase opens a connection, issues a command that
@@ -136,7 +136,7 @@ func testKillWithRealDatabase(t *testing.T, params *sqldb.ConnParams) {
 	}
 
 	err = <-errChan
-	assertSQLError(t, err, CRServerLost, SSSignalException, "EOF")
+	assertSQLError(t, err, CRServerLost, SSUnknownSQLState, "EOF")
 }
 
 // testDupEntryWithRealDatabase tests a duplicate key is properly raised.

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -99,12 +99,12 @@ func (c *Conn) readOnePacket() ([]byte, error) {
 	var header [4]byte
 
 	if _, err := io.ReadFull(c.reader, header[:]); err != nil {
-		return nil, sqldb.NewSQLError(CRServerLost, SSSignalException, "io.ReadFull(header size) failed: %v", err)
+		return nil, fmt.Errorf("io.ReadFull(header size) failed: %v", err)
 	}
 
 	sequence := uint8(header[3])
 	if sequence != c.sequence {
-		return nil, sqldb.NewSQLError(CRServerLost, SSSignalException, "invalid sequence, expected %v got %v", c.sequence, sequence)
+		return nil, fmt.Errorf("invalid sequence, expected %v got %v", c.sequence, sequence)
 	}
 
 	c.sequence++
@@ -118,14 +118,15 @@ func (c *Conn) readOnePacket() ([]byte, error) {
 
 	data := make([]byte, length)
 	if _, err := io.ReadFull(c.reader, data); err != nil {
-		return nil, sqldb.NewSQLError(CRServerLost, SSSignalException, "io.ReadFull(packet body of length %v) failed: %v", length, err)
+		return nil, fmt.Errorf("io.ReadFull(packet body of length %v) failed: %v", length, err)
 	}
 	return data, nil
 }
 
-// ReadPacket reads a packet from the underlying connection.
+// readPacket reads a packet from the underlying connection.
 // It re-assembles packets that span more than one message.
-func (c *Conn) ReadPacket() ([]byte, error) {
+// This method returns a generic error, not a sqldb.SQLError.
+func (c *Conn) readPacket() ([]byte, error) {
 	// Optimize for a single packet case.
 	data, err := c.readOnePacket()
 	if err != nil {
@@ -158,6 +159,16 @@ func (c *Conn) ReadPacket() ([]byte, error) {
 	return data, nil
 }
 
+// ReadPacket reads a packet from the underlying connection.
+// it is the public API version, that returns a sqldb.SQLError.
+func (c *Conn) ReadPacket() ([]byte, error) {
+	result, err := c.readPacket()
+	if err != nil {
+		return nil, sqldb.NewSQLError(CRServerLost, SSUnknownSQLState, "%v", err)
+	}
+	return result, err
+}
+
 // writePacket writes a packet, possibly cutting it into multiple
 // chunks.  Note this is not very efficient, as the client probably
 // has to build the []byte and that makes a memory copy.
@@ -173,6 +184,8 @@ func (c *Conn) ReadPacket() ([]byte, error) {
 // finishPacket()
 //   - checks the packet is done.
 //   - write an empty packet if the write was a multiple of MaxPacketSize
+//
+// This method returns a generic error, not a sqldb.SQLError.
 func (c *Conn) writePacket(data []byte) error {
 	index := 0
 	length := len(data)
@@ -191,16 +204,16 @@ func (c *Conn) writePacket(data []byte) error {
 		header[2] = byte(packetLength >> 16)
 		header[3] = c.sequence
 		if n, err := c.writer.Write(header[:]); err != nil {
-			return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(header) failed: %v", err)
+			return fmt.Errorf("Write(header) failed: %v", err)
 		} else if n != 4 {
-			return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(header) returned a short write: %v < 4", n)
+			return fmt.Errorf("Write(header) returned a short write: %v < 4", n)
 		}
 
 		// Write the body.
 		if n, err := c.writer.Write(data[index : index+packetLength]); err != nil {
-			return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(packet) failed: %v", err)
+			return fmt.Errorf("Write(packet) failed: %v", err)
 		} else if n != packetLength {
-			return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(packet) returned a short write: %v < %v", n, packetLength)
+			return fmt.Errorf("Write(packet) returned a short write: %v < %v", n, packetLength)
 		}
 
 		// Update our state.
@@ -216,9 +229,9 @@ func (c *Conn) writePacket(data []byte) error {
 				header[2] = 0
 				header[3] = c.sequence
 				if n, err := c.writer.Write(header[:]); err != nil {
-					return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(empty header) failed: %v", err)
+					return fmt.Errorf("Write(empty header) failed: %v", err)
 				} else if n != 4 {
-					return sqldb.NewSQLError(CRServerLost, SSSignalException, "Write(empty header) returned a short write: %v < 4", n)
+					return fmt.Errorf("Write(empty header) returned a short write: %v < 4", n)
 				}
 				c.sequence++
 			}
@@ -228,9 +241,11 @@ func (c *Conn) writePacket(data []byte) error {
 	}
 }
 
+// flush flushes the written data to the socket.
+// This method returns a generic error, not a sqldb.SQLError.
 func (c *Conn) flush() error {
 	if err := c.writer.Flush(); err != nil {
-		return sqldb.NewSQLError(CRServerLost, SSSignalException, "Flush() failed: %v", err)
+		return fmt.Errorf("Flush() failed: %v", err)
 	}
 	return nil
 }
@@ -245,6 +260,9 @@ func (c *Conn) Close() {
 // Packet writing methods, for generic packets.
 //
 
+// writeOKPacket writes an OK packet.
+// Server -> Client.
+// This method returns a generic error, not a sqldb.SQLError.
 func (c *Conn) writeOKPacket(affectedRows, lastInsertID uint64, flags uint16, warnings uint16) error {
 	length := 1 + // OKPacket
 		lenEncIntSize(affectedRows) +
@@ -271,6 +289,8 @@ func (c *Conn) writeOKPacket(affectedRows, lastInsertID uint64, flags uint16, wa
 // writeOKPacketWithEOFHeader writes an OK packet with an EOF header.
 // This is used at the end of a result set if
 // CapabilityClientDeprecateEOF is set.
+// Server -> Client.
+// This method returns a generic error, not a sqldb.SQLError.
 func (c *Conn) writeOKPacketWithEOFHeader(affectedRows, lastInsertID uint64, flags uint16, warnings uint16) error {
 	length := 1 + // EOFPacket
 		lenEncIntSize(affectedRows) +
@@ -294,6 +314,9 @@ func (c *Conn) writeOKPacketWithEOFHeader(affectedRows, lastInsertID uint64, fla
 	return nil
 }
 
+// writeErrorPacket writes an error packet.
+// Server -> Client.
+// This method returns a generic error, not a sqldb.SQLError.
 func (c *Conn) writeErrorPacket(errorCode uint16, sqlState string, format string, args ...interface{}) error {
 	errorMessage := fmt.Sprintf(format, args...)
 	length := 1 + 2 + 1 + 5 + len(errorMessage)
@@ -303,7 +326,7 @@ func (c *Conn) writeErrorPacket(errorCode uint16, sqlState string, format string
 	pos = writeUint16(data, pos, errorCode)
 	pos = writeByte(data, pos, '#')
 	if sqlState == "" {
-		sqlState = SSSignalException
+		sqlState = SSUnknownSQLState
 	}
 	if len(sqlState) != 5 {
 		panic("sqlState has to be 5 characters long")
@@ -325,7 +348,7 @@ func (c *Conn) writeErrorPacketFromError(err error) error {
 		return c.writeErrorPacket(uint16(se.Num), se.State, "%v", se.Message)
 	}
 
-	return c.writeErrorPacket(ERUnknownError, SSSignalException, "unknown error: %v", err)
+	return c.writeErrorPacket(ERUnknownError, SSUnknownSQLState, "unknown error: %v", err)
 }
 
 func (c *Conn) writeEOFPacket(flags uint16, warnings uint16) error {
@@ -377,6 +400,7 @@ func parseOKPacket(data []byte) (uint64, uint64, uint16, uint16, error) {
 	return affectedRows, lastInsertID, statusFlags, warnings, nil
 }
 
+// parseErrorPacket parses the error packet and returns a sqldb.SQLError.
 func parseErrorPacket(data []byte) error {
 	// We already read the type.
 	pos := 1
@@ -384,7 +408,7 @@ func parseErrorPacket(data []byte) error {
 	// Error code is 2 bytes.
 	code, pos, ok := readUint16(data, pos)
 	if !ok {
-		return fmt.Errorf("invalid error packet code: %v", data)
+		return sqldb.NewSQLError(CRUnknownError, SSUnknownSQLState, "invalid error packet code: %v", data)
 	}
 
 	// '#' marker of the SQL state is 1 byte. Ignored.
@@ -393,7 +417,7 @@ func parseErrorPacket(data []byte) error {
 	// SQL state is 5 bytes
 	sqlState, pos, ok := readBytes(data, pos, 5)
 	if !ok {
-		return fmt.Errorf("invalid error packet sqlState: %v", data)
+		return sqldb.NewSQLError(CRUnknownError, SSUnknownSQLState, "invalid error packet sqlState: %v", data)
 	}
 
 	// Human readable error message is the rest.

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -150,17 +150,45 @@ const (
 // Error codes for client-side errors.
 // Originally found in include/mysql/errmsg.h
 const (
+	// CRUnknownError is CR_UNKNOWN_ERROR
+	CRUnknownError = 2000
+
 	// CRConnectionError is CR_CONNECTION_ERROR
 	CRConnectionError = 2002
 
 	// CRConnHostError is CR_CONN_HOST_ERROR
 	CRConnHostError = 2003
 
+	// CRServerGone is CR_SERVER_GONE_ERROR.
+	// This is returned if the client tries to send a command but it fails.
+	CRServerGone = 2006
+
+	// CRVersionError is CR_VERSION_ERROR
+	// This is returned if the server versions don't match what we support.
+	CRVersionError = 2007
+
 	// CRServerHandshakeErr is CR_SERVER_HANDSHAKE_ERR
 	CRServerHandshakeErr = 2012
 
-	// CRServerLost is CR_SERVER_LOST
+	// CRServerLost is CR_SERVER_LOST.
+	// Used when:
+	// - the client cannot write an initial auth packet.
+	// - the client cannot read an initial auth packet.
+	// - the client cannot read a response from the server.
 	CRServerLost = 2013
+
+	// CRCommandsOutOfSync is CR_COMMANDS_OUT_OF_SYNC
+	// Sent when the streaming calls are not done in the right order.
+	CRCommandsOutOfSync = 2014
+
+	// CRCantReadCharset is CR_CANT_READ_CHARSET
+	CRCantReadCharset = 2019
+
+	// CRSSLConnectionError is CR_SSL_CONNECTION_ERROR
+	CRSSLConnectionError = 2026
+
+	// CRMalformedPacket is CR_MALFORMED_PACKET
+	CRMalformedPacket = 2027
 )
 
 // Error codes for server-side errors.
@@ -186,8 +214,11 @@ const (
 // Sql states for errors.
 // Originally found in include/mysql/sql_state.h
 const (
-	// SSSignalException is ER_SIGNAL_EXCEPTION
-	SSSignalException = "HY000"
+	// SSUnknownSqlstate is ER_SIGNAL_EXCEPTION in
+	// include/mysql/sql_state.h, but:
+	// const char *unknown_sqlstate= "HY000"
+	// in client.c. So using that one.
+	SSUnknownSQLState = "HY000"
 
 	// SSDupKey is ER_DUP_KEY
 	SSDupKey = "23000"

--- a/go/mysqlconn/replication.go
+++ b/go/mysqlconn/replication.go
@@ -1,9 +1,12 @@
 package mysqlconn
 
+import "github.com/youtube/vitess/go/sqldb"
+
 // This file contains the methods related to replication.
 
 // WriteComBinlogDump writes a ComBinlogDump command.
 // See http://dev.mysql.com/doc/internals/en/com-binlog-dump.html for syntax.
+// Returns a sqldb.SQLError.
 func (c *Conn) WriteComBinlogDump(serverID uint32, binlogFilename string, binlogPos uint32, flags uint16) error {
 	c.sequence = 0
 	length := 1 + // ComBinlogDump
@@ -18,10 +21,10 @@ func (c *Conn) WriteComBinlogDump(serverID uint32, binlogFilename string, binlog
 	pos = writeUint32(data, pos, serverID)
 	pos = writeEOFString(data, pos, binlogFilename)
 	if err := c.writePacket(data); err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	if err := c.flush(); err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	return nil
 }
@@ -49,10 +52,10 @@ func (c *Conn) WriteComBinlogDumpGTID(serverID uint32, binlogFilename string, bi
 	pos = writeUint32(data, pos, uint32(len(gtidSet)))
 	pos += copy(data[pos:], gtidSet)
 	if err := c.writePacket(data); err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	if err := c.flush(); err != nil {
-		return err
+		return sqldb.NewSQLError(CRServerGone, SSUnknownSQLState, "%v", err)
 	}
 	return nil
 }

--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -133,7 +133,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 	}
 
 	// Wait for the client response.
-	response, err := c.ReadPacket()
+	response, err := c.readPacket()
 	if err != nil {
 		log.Errorf("Cannot read client handshake response: %v", err)
 		return
@@ -168,7 +168,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 
 	for {
 		c.sequence = 0
-		data, err := c.ReadPacket()
+		data, err := c.readPacket()
 		if err != nil {
 			log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
 			return
@@ -334,7 +334,8 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, data []byte) (string, []b
 
 	// Max packet size. Don't do anything with this now.
 	// See doc.go for more information.
-	/*maxPacketSize*/ _, pos, ok = readUint32(data, pos)
+	/*maxPacketSize*/
+	_, pos, ok = readUint32(data, pos)
 	if !ok {
 		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read maxPacketSize")
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -54,7 +54,7 @@ func (vh *vtgateHandler) begin(ctx context.Context, c *mysqlconn.Conn) (*sqltype
 	// Do the begin.
 	session, err := vh.vtg.Begin(ctx, false /* singledb */)
 	if err != nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Begin failed: %v", err)
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "vtgate.Begin failed: %v", err)
 	}
 
 	// Save the session.
@@ -65,16 +65,16 @@ func (vh *vtgateHandler) begin(ctx context.Context, c *mysqlconn.Conn) (*sqltype
 func (vh *vtgateHandler) commit(ctx context.Context, c *mysqlconn.Conn) (*sqltypes.Result, error) {
 	// Check we're inside a transaction already.
 	if c.ClientData == nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "not in a transaction")
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "not in a transaction")
 	}
 	session, ok := c.ClientData.(*vtgatepb.Session)
 	if !ok || session == nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
 	}
 
 	// Commit using vtgate's transaction mode.
 	if err := vh.vtg.Commit(ctx, vh.vtg.transactionMode == TxTwoPC, session); err != nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Commit failed: %v", err)
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "vtgate.Commit failed: %v", err)
 	}
 
 	// Clear the Session.
@@ -85,16 +85,16 @@ func (vh *vtgateHandler) commit(ctx context.Context, c *mysqlconn.Conn) (*sqltyp
 func (vh *vtgateHandler) rollback(ctx context.Context, c *mysqlconn.Conn) (*sqltypes.Result, error) {
 	// Check we're inside a transaction already.
 	if c.ClientData == nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "not in a transaction")
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "not in a transaction")
 	}
 	session, ok := c.ClientData.(*vtgatepb.Session)
 	if !ok || session == nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "internal error: got a weird ClientData of type %T: %v %v", c.ClientData, session, ok)
 	}
 
 	// Rollback.
 	if err := vh.vtg.Rollback(ctx, session); err != nil {
-		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSSignalException, "vtgate.Rollback failed: %v", err)
+		return nil, sqldb.NewSQLError(mysqlconn.ERUnknownError, mysqlconn.SSUnknownSQLState, "vtgate.Rollback failed: %v", err)
 	}
 
 	// Clear the Session.


### PR DESCRIPTION
Instead of creating errors at lowest layer, have the cleint code create
them when convenient. That way the server code doesn't get client
errors, and we can be more granular.

Changed a bunch of errors to match what the real MySQL client returns.