### PR TITLE
vtgate/buffer: Do not start buffering on errno 2006.

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -180,11 +180,6 @@ func causedByFailover(err error) bool {
 			if strings.Contains(err.Error(), "fatal: failover in progress (errno 1227) (sqlstate 42000)") {
 				return true
 			}
-		case vtrpcpb.ErrorCode_UNKNOWN_ERROR:
-			// Google internal flavor.
-			if strings.Contains(err.Error(), "fatal: MySQL server has gone away (errno 2006) (sqlstate HY000)") {
-				return true
-			}
 		}
 	}
 	return false


### PR DESCRIPTION
This error condition is too broad. It happens when MySQL kills the connection to vttablet and must not be related to a failover.

NOTE: This change is already LGTM'd internally and does not need to be approved again.