### PR TITLE
FIX: Return the right RowsAffected value when CLIENT_FOUND_ROWS is enabled.

### DIFF
--- a/go/sqldb/conn_params.go
+++ b/go/sqldb/conn_params.go
@@ -29,6 +29,7 @@ type ConnParams struct {
 // FIXME(alainjobart) when this package is merge with go/mysqlconn,
 // use the same constant.
 const capabilityClientSSL = 1 << 11
+const clientFoundRows = 1 << 1
 
 // EnableSSL will set the right flag on the parameters.
 func (cp *ConnParams) EnableSSL() {
@@ -38,4 +39,18 @@ func (cp *ConnParams) EnableSSL() {
 // SslEnabled returns if SSL is enabled.
 func (cp *ConnParams) SslEnabled() bool {
 	return (cp.Flags & capabilityClientSSL) > 0
+}
+
+// EnableClientFoundRows will set the CLIENT_FOUND_ROWS flag on the parameters
+// so that MySQL returns the found (matched) rows when a DML is executed
+// rather than the affected rows
+func (cp *ConnParams) EnableClientFoundRows() {
+	cp.Flags |= clientFoundRows
+}
+
+// IsClientFoundRows returns if CLIENT_FOUND_ROWS MySQL flag is enabled,
+// which causes MySQL to returns the found (matched) rows when a DML is executed
+// rather than the affected rows
+func (cp *ConnParams) IsClientFoundRows() bool {
+	return (cp.Flags & clientFoundRows) > 0
 }

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -485,6 +485,7 @@ func (qre *QueryExecutor) execInsertPKRows(conn *TxConnection, pkRows [][]sqltyp
 }
 
 func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, error) {
+
 	pkRows, err := buildValueList(qre.plan.TableInfo, qre.plan.PKValues, qre.bindVars)
 	if err != nil {
 		return nil, err
@@ -511,8 +512,9 @@ func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, er
 	if err != nil {
 		return nil, err
 	}
+
 	// Follow MySQL convention. RowsAffected must be 2 if a row was updated.
-	if result.RowsAffected == 1 {
+	if result.RowsAffected == 1 && !conn.info.IsClientFoundRows() {
 		result.RowsAffected = 2
 	}
 	return result, err


### PR DESCRIPTION
This is related to, but does not solve https://github.com/youtube/vitess/issues/2530.

Currently it is already possible, through setting `-db-config-app-flags 2` on vttablet , to enable `CLIENT_FOUND_ROWS` for vitess connections. This modifies the RowsAffected return value for DML queries, as described here: https://dev.mysql.com/doc/refman/5.7/en/mysql-affected-rows.html

This mostly works already, except in the case of upserts. In that case we are modifying the RowsAffected result to fake an upsert despite really executing an update behind the scenes. In the case of CLIENT_FOUND_ROWS, we should not be modifying that value.

This fix adds a function for modifying ClientFoundRows, and does not modify RowsAffected when that is set on a connection. Added a test to validate. The test is very similar to the existing `TestQueryExecutorPlanUpsertPkAutoCommit` but with a different return value, and the EnableClientFoundRows() set.

@sougou 