### PR TITLE
sample error code rename

### DIFF
--- a/go/cmd/vtgateclienttest/goclienttest/errors.go
+++ b/go/cmd/vtgateclienttest/goclienttest/errors.go
@@ -25,13 +25,13 @@ var (
 	partialErrorPrefix = "partialerror://"
 
 	executeErrors = map[string]vtrpcpb.ErrorCode{
-		"bad input":         vtrpcpb.ErrorCode_BAD_INPUT,
-		"deadline exceeded": vtrpcpb.ErrorCode_DEADLINE_EXCEEDED,
-		"integrity error":   vtrpcpb.ErrorCode_INTEGRITY_ERROR,
-		"transient error":   vtrpcpb.ErrorCode_TRANSIENT_ERROR,
-		"unauthenticated":   vtrpcpb.ErrorCode_UNAUTHENTICATED,
-		"aborted":           vtrpcpb.ErrorCode_NOT_IN_TX,
-		"unknown error":     vtrpcpb.ErrorCode_UNKNOWN_ERROR,
+		"bad input":         vterrors.InvalidArgument,
+		"deadline exceeded": vterrors.DeadlineExceeded,
+		"integrity error":   vterrors.AlreadyExists,
+		"transient error":   vterrors.Unavailable,
+		"unauthenticated":   vterrors.Unauthenticated,
+		"aborted":           vterrors.Aborted,
+		"unknown error":     vterrors.Unknown,
 	}
 )
 

--- a/go/cmd/vtgateclienttest/services/errors.go
+++ b/go/cmd/vtgateclienttest/services/errors.go
@@ -19,7 +19,6 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // errorClient implements vtgateservice.VTGateService
@@ -81,53 +80,53 @@ func trimmedRequestToError(received string) error {
 	switch received {
 	case "bad input":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_BAD_INPUT,
+			vterrors.InvalidArgument,
 			errors.New("vtgate test client forced error: bad input"),
 		)
 	case "deadline exceeded":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_DEADLINE_EXCEEDED,
+			vterrors.DeadlineExceeded,
 			errors.New("vtgate test client forced error: deadline exceeded"),
 		)
 	case "integrity error":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_INTEGRITY_ERROR,
+			vterrors.AlreadyExists,
 			errors.New("vtgate test client forced error: integrity error (errno 1062) (sqlstate 23000)"),
 		)
 	// request backlog and general throttling type errors
 	case "transient error":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+			vterrors.Unavailable,
 			errors.New("request_backlog: too many requests in flight: vtgate test client forced error: transient error"),
 		)
 	case "throttled error":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+			vterrors.Unavailable,
 			errors.New("request_backlog: exceeded XXX quota, rate limiting: vtgate test client forced error: transient error"),
 		)
 	case "unauthenticated":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_UNAUTHENTICATED,
+			vterrors.Unauthenticated,
 			errors.New("vtgate test client forced error: unauthenticated"),
 		)
 	case "aborted":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_NOT_IN_TX,
+			vterrors.Aborted,
 			errors.New("vtgate test client forced error: aborted"),
 		)
 	case "query not served":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			vterrors.FailedPrecondition,
 			errors.New("vtgate test client forced error: query not served"),
 		)
 	case "unknown error":
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_UNKNOWN_ERROR,
+			vterrors.Unknown,
 			errors.New("vtgate test client forced error: unknown error"),
 		)
 	default:
 		return vterrors.FromError(
-			vtrpcpb.ErrorCode_UNKNOWN_ERROR,
+			vterrors.Unknown,
 			fmt.Errorf("vtgate test client error request unrecognized: %v", received),
 		)
 	}

--- a/go/vt/dtids/dtids.go
+++ b/go/vt/dtids/dtids.go
@@ -15,7 +15,6 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // New generates a dtid based on Session_ShardSession.
@@ -27,7 +26,7 @@ func New(mmShard *vtgatepb.Session_ShardSession) string {
 func ShardSession(dtid string) (*vtgatepb.Session_ShardSession, error) {
 	splits := strings.Split(dtid, ":")
 	if len(splits) != 3 {
-		return nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid parts in dtid: %s", dtid))
+		return nil, vterrors.FromError(vterrors.InvalidArgument, fmt.Errorf("invalid parts in dtid: %s", dtid))
 	}
 	target := &querypb.Target{
 		Keyspace:   splits[0],
@@ -36,7 +35,7 @@ func ShardSession(dtid string) (*vtgatepb.Session_ShardSession, error) {
 	}
 	txid, err := strconv.ParseInt(splits[2], 10, 0)
 	if err != nil {
-		return nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
+		return nil, vterrors.FromError(vterrors.InvalidArgument, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
 	}
 	return &vtgatepb.Session_ShardSession{
 		Target:        target,
@@ -48,11 +47,11 @@ func ShardSession(dtid string) (*vtgatepb.Session_ShardSession, error) {
 func TransactionID(dtid string) (int64, error) {
 	splits := strings.Split(dtid, ":")
 	if len(splits) != 3 {
-		return 0, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid parts in dtid: %s", dtid))
+		return 0, vterrors.FromError(vterrors.InvalidArgument, fmt.Errorf("invalid parts in dtid: %s", dtid))
 	}
 	txid, err := strconv.ParseInt(splits[2], 10, 0)
 	if err != nil {
-		return 0, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
+		return 0, vterrors.FromError(vterrors.InvalidArgument, fmt.Errorf("invalid transaction id in dtid: %s", dtid))
 	}
 	return txid, nil
 }

--- a/go/vt/tabletserver/codex.go
+++ b/go/vt/tabletserver/codex.go
@@ -9,9 +9,9 @@ import (
 	"github.com/youtube/vitess/go/vt/schema"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // buildValueList builds the set of PK reference rows used to drive the next query.
@@ -42,7 +42,7 @@ func resolvePKValues(tableInfo *TableInfo, pkValues []interface{}, bindVars map[
 		if length == -1 {
 			length = len(list)
 		} else if len(list) != length {
-			return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "mismatched lengths for values %v", pkValues)
+			return tabletenv.NewTabletError(vterrors.InvalidArgument, "mismatched lengths for values %v", pkValues)
 		}
 		return nil
 	}
@@ -93,7 +93,7 @@ func resolvePKValues(tableInfo *TableInfo, pkValues []interface{}, bindVars map[
 func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]interface{}) ([]sqltypes.Value, error) {
 	val, _, err := sqlparser.FetchBindVar(key, bindVars)
 	if err != nil {
-		return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+		return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 	}
 
 	switch list := val.(type) {
@@ -102,7 +102,7 @@ func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]int
 		for i, v := range list {
 			sqlval, err := sqltypes.BuildConverted(col.Type, v)
 			if err != nil {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+				return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 			}
 			if err = validateValue(col, sqlval); err != nil {
 				return nil, err
@@ -112,7 +112,7 @@ func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]int
 		return resolved, nil
 	case *querypb.BindVariable:
 		if list.Type != querypb.Type_TUPLE {
-			return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "expecting list for bind var %s: %v", key, list)
+			return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "expecting list for bind var %s: %v", key, list)
 		}
 		resolved := make([]sqltypes.Value, len(list.Values))
 		for i, v := range list.Values {
@@ -120,7 +120,7 @@ func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]int
 			sqlval := sqltypes.MakeTrusted(v.Type, v.Value)
 			sqlval, err := sqltypes.BuildConverted(col.Type, sqlval)
 			if err != nil {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+				return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 			}
 			if err = validateValue(col, sqlval); err != nil {
 				return nil, err
@@ -129,7 +129,7 @@ func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]int
 		}
 		return resolved, nil
 	default:
-		return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "unknown type for bind variable %v", key)
+		return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "unknown type for bind variable %v", key)
 	}
 }
 
@@ -159,12 +159,12 @@ func resolveValue(col *schema.TableColumn, value interface{}, bindVars map[strin
 	if v, ok := value.(string); ok {
 		value, _, err = sqlparser.FetchBindVar(v, bindVars)
 		if err != nil {
-			return result, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+			return result, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 		}
 	}
 	result, err = sqltypes.BuildConverted(col.Type, value)
 	if err != nil {
-		return result, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+		return result, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 	}
 	if err = validateValue(col, result); err != nil {
 		return result, err
@@ -178,23 +178,23 @@ func resolveNumber(value interface{}, bindVars map[string]interface{}) (int64, e
 	if v, ok := value.(string); ok {
 		value, _, err = sqlparser.FetchBindVar(v, bindVars)
 		if err != nil {
-			return 0, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+			return 0, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 		}
 	}
 	v, err := sqltypes.BuildValue(value)
 	if err != nil {
-		return 0, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+		return 0, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 	}
 	ret, err := v.ParseInt64()
 	if err != nil {
-		return 0, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "%v", err)
+		return 0, tabletenv.NewTabletError(vterrors.InvalidArgument, "%v", err)
 	}
 	return ret, nil
 }
 
 func validateRow(tableInfo *TableInfo, columnNumbers []int, row []sqltypes.Value) error {
 	if len(row) != len(columnNumbers) {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "data inconsistency %d vs %d", len(row), len(columnNumbers))
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "data inconsistency %d vs %d", len(row), len(columnNumbers))
 	}
 	for j, value := range row {
 		if err := validateValue(&tableInfo.Columns[columnNumbers[j]], value); err != nil {
@@ -211,11 +211,11 @@ func validateValue(col *schema.TableColumn, value sqltypes.Value) error {
 	}
 	if sqltypes.IsIntegral(col.Type) {
 		if !value.IsIntegral() {
-			return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "type mismatch, expecting numeric type for %v for column: %v", value, col)
+			return tabletenv.NewTabletError(vterrors.InvalidArgument, "type mismatch, expecting numeric type for %v for column: %v", value, col)
 		}
 	} else if col.Type == sqltypes.VarBinary {
 		if !value.IsQuoted() {
-			return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "type mismatch, expecting string type for %v for column: %v", value, col)
+			return tabletenv.NewTabletError(vterrors.InvalidArgument, "type mismatch, expecting string type for %v for column: %v", value, col)
 		}
 	}
 	return nil

--- a/go/vt/tabletserver/codex_test.go
+++ b/go/vt/tabletserver/codex_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/schema"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func TestCodexBuildValuesList(t *testing.T) {
@@ -257,7 +257,7 @@ func TestCodexResolvePKValues(t *testing.T) {
 	pkValues = make([]interface{}, 0, 10)
 	pkValues = append(pkValues, sqltypes.MakeString([]byte("type_mismatch")))
 	_, _, err = resolvePKValues(&tableInfo, pkValues, nil)
-	testUtils.checkTabletError(t, err, vtrpcpb.ErrorCode_BAD_INPUT, "strconv.ParseInt")
+	testUtils.checkTabletError(t, err, vterrors.InvalidArgument, "strconv.ParseInt")
 	// pkValues with different length
 	bindVariables = make(map[string]interface{})
 	bindVariables[key] = 1
@@ -269,7 +269,7 @@ func TestCodexResolvePKValues(t *testing.T) {
 	pkValues = append(pkValues, []interface{}{":" + key})
 	pkValues = append(pkValues, []interface{}{":" + key2, ":" + key3})
 	_, _, err = resolvePKValues(&tableInfo, pkValues, bindVariables)
-	testUtils.checkTabletError(t, err, vtrpcpb.ErrorCode_BAD_INPUT, "mismatched lengths")
+	testUtils.checkTabletError(t, err, vterrors.InvalidArgument, "mismatched lengths")
 }
 
 func TestCodexResolveListArg(t *testing.T) {
@@ -284,7 +284,7 @@ func TestCodexResolveListArg(t *testing.T) {
 	bindVariables[key] = []interface{}{fmt.Errorf("error is not supported")}
 
 	_, err := resolveListArg(tableInfo.GetPKColumn(0), "::"+key, bindVariables)
-	testUtils.checkTabletError(t, err, vtrpcpb.ErrorCode_BAD_INPUT, "")
+	testUtils.checkTabletError(t, err, vterrors.InvalidArgument, "")
 
 	// This should successfully convert.
 	bindVariables[key] = []interface{}{"1"}
@@ -413,10 +413,10 @@ func TestCodexValidateRow(t *testing.T) {
 		[]string{"pk1", "pk2"})
 	// #columns and #rows do not match
 	err := validateRow(&tableInfo, []int{1}, []sqltypes.Value{})
-	testUtils.checkTabletError(t, err, vtrpcpb.ErrorCode_BAD_INPUT, "data inconsistency")
+	testUtils.checkTabletError(t, err, vterrors.InvalidArgument, "data inconsistency")
 	// column 0 is int type but row is in string type
 	err = validateRow(&tableInfo, []int{0}, []sqltypes.Value{sqltypes.MakeString([]byte("str"))})
-	testUtils.checkTabletError(t, err, vtrpcpb.ErrorCode_BAD_INPUT, "type mismatch")
+	testUtils.checkTabletError(t, err, vterrors.InvalidArgument, "type mismatch")
 }
 
 func TestCodexApplyFilterWithPKDefaults(t *testing.T) {

--- a/go/vt/tabletserver/connpool/dbconn.go
+++ b/go/vt/tabletserver/connpool/dbconn.go
@@ -16,8 +16,8 @@ import (
 	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"golang.org/x/net/context"
 )
 
@@ -64,17 +64,17 @@ func (dbc *DBConn) Exec(ctx context.Context, query string, maxrows int, wantfiel
 			return r, nil
 		case !tabletenv.IsConnErr(err):
 			// MySQL error that isn't due to a connection issue
-			return nil, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
+			return nil, tabletenv.NewTabletErrorSQL(vterrors.Unknown, err)
 		case attempt == 2:
 			// If the MySQL connection is bad, we assume that there is nothing wrong with
 			// the query itself, and retrying it might succeed. The MySQL connection might
 			// fix itself, or the query could succeed on a different VtTablet.
-			return nil, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, err)
+			return nil, tabletenv.NewTabletErrorSQL(vterrors.Internal, err)
 		}
 		err2 := dbc.reconnect()
 		if err2 != nil {
 			dbc.pool.checker.CheckMySQL()
-			return nil, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, err)
+			return nil, tabletenv.NewTabletErrorSQL(vterrors.Internal, err)
 		}
 	}
 	panic("unreachable")
@@ -185,7 +185,7 @@ func (dbc *DBConn) Kill(reason string) error {
 	if err != nil {
 		log.Warningf("Failed to get conn from dba pool: %v", err)
 		// TODO(aaijazi): Find the right error code for an internal error that we don't want to retry
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Failed to get conn from dba pool: %v", err)
+		return tabletenv.NewTabletError(vterrors.Internal, "Failed to get conn from dba pool: %v", err)
 	}
 	defer killConn.Recycle()
 	sql := fmt.Sprintf("kill %d", dbc.conn.ID())
@@ -193,7 +193,7 @@ func (dbc *DBConn) Kill(reason string) error {
 	if err != nil {
 		log.Errorf("Could not kill query %s: %v", dbc.Current(), err)
 		// TODO(aaijazi): Find the right error code for an internal error that we don't want to retry
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not kill query %s: %v", dbc.Current(), err)
+		return tabletenv.NewTabletError(vterrors.Internal, "Could not kill query %s: %v", dbc.Current(), err)
 	}
 	return nil
 }

--- a/go/vt/tabletserver/messager_engine.go
+++ b/go/vt/tabletserver/messager_engine.go
@@ -13,8 +13,7 @@ import (
 	"github.com/youtube/vitess/go/vt/schema"
 	"github.com/youtube/vitess/go/vt/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
-
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 // MessagerEngine is the engine for handling messages.
@@ -75,7 +74,7 @@ func (me *MessagerEngine) Subscribe(name string, rcv *messageReceiver) error {
 	defer me.mu.Unlock()
 	mm := me.managers[name]
 	if mm == nil {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "message table %s not found", name)
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "message table %s not found", name)
 	}
 	mm.Subscribe(rcv)
 	return nil

--- a/go/vt/tabletserver/query_executor_test.go
+++ b/go/vt/tabletserver/query_executor_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/youtube/vitess/go/vt/tableacl/simpleacl"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	tableaclpb "github.com/youtube/vitess/go/vt/proto/tableacl"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func TestQueryExecutorPlanDDL(t *testing.T) {
@@ -93,7 +93,7 @@ func TestQueryExecutorPlanPassDmlStrictMode(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: a tabletenv.TabletError", tabletError)
 	}
-	if tabletError.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	if tabletError.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %s, want: BAD_INPUT", tabletError.ErrorCode)
 	}
 }
@@ -132,7 +132,7 @@ func TestQueryExecutorPlanPassDmlStrictModeAutoCommit(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", tabletError)
 	}
-	if tabletError.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	if tabletError.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %s, want: BAD_INPUT", tabletError.ErrorCode)
 	}
 }
@@ -692,7 +692,7 @@ func TestQueryExecutorPlanPassSelectWithLockOutsideATransaction(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", err)
 	}
-	if got.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	if got.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %s, want: BAD_INPUT", got.ErrorCode)
 	}
 }
@@ -1037,7 +1037,7 @@ func TestQueryExecutorTableAclNoPermission(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", err)
 	}
-	if tabletError.ErrorCode != vtrpcpb.ErrorCode_PERMISSION_DENIED {
+	if tabletError.ErrorCode != vterrors.PermissionDenied {
 		t.Fatalf("got: %s, want: PERMISSION_DENIED", tabletError.ErrorCode)
 	}
 }
@@ -1091,7 +1091,7 @@ func TestQueryExecutorTableAclExemptACL(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", err)
 	}
-	if tabletError.ErrorCode != vtrpcpb.ErrorCode_PERMISSION_DENIED {
+	if tabletError.ErrorCode != vterrors.PermissionDenied {
 		t.Fatalf("got: %s, want: PERMISSION_DENIED", tabletError.ErrorCode)
 	}
 	if !strings.Contains(tabletError.Error(), "table acl error") {
@@ -1231,7 +1231,7 @@ func TestQueryExecutorBlacklistQRFail(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", err)
 	}
-	if got.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	if got.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %s, want: BAD_INPUT", got.ErrorCode)
 	}
 }
@@ -1291,7 +1291,7 @@ func TestQueryExecutorBlacklistQRRetry(t *testing.T) {
 	if !ok {
 		t.Fatalf("got: %v, want: *tabletenv.TabletError", err)
 	}
-	if got.ErrorCode != vtrpcpb.ErrorCode_QUERY_NOT_SERVED {
+	if got.ErrorCode != vterrors.FailedPrecondition {
 		t.Fatalf("got: %s, want: QUERY_NOT_SERVED", got.ErrorCode)
 	}
 }

--- a/go/vt/tabletserver/query_rules.go
+++ b/go/vt/tabletserver/query_rules.go
@@ -15,10 +15,10 @@ import (
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 //-----------------------------------------------
@@ -97,7 +97,7 @@ func (qrs *QueryRules) UnmarshalJSON(data []byte) (err error) {
 		// Ideally, we should have an error code that means "This isn't the query's
 		// fault, but don't retry either, as this will be a global problem".
 		// (true for all INTERNAL_ERRORS in query_rules)
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "%v", err)
+		return tabletenv.NewTabletError(vterrors.Internal, "%v", err)
 	}
 	for _, ruleInfo := range rulesInfo {
 		qr, err := BuildQueryRule(ruleInfo)
@@ -333,7 +333,7 @@ func (qr *QueryRule) AddBindVarCond(name string, onAbsent, onMismatch bool, op O
 			// Change the value to compiled regexp
 			re, err := regexp.Compile(makeExact(v))
 			if err != nil {
-				return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "processing %s: %v", v, err)
+				return tabletenv.NewTabletError(vterrors.Internal, "processing %s: %v", v, err)
 			}
 			converted = bvcre{re}
 		} else {
@@ -346,13 +346,13 @@ func (qr *QueryRule) AddBindVarCond(name string, onAbsent, onMismatch bool, op O
 		b := bvcKeyRange(*v)
 		converted = &b
 	default:
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "type %T not allowed as condition operand (%v)", value, value)
+		return tabletenv.NewTabletError(vterrors.Internal, "type %T not allowed as condition operand (%v)", value, value)
 	}
 	qr.bindVarConds = append(qr.bindVarConds, BindVarCond{name, onAbsent, onMismatch, op, converted})
 	return nil
 
 Error:
-	return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "invalid operator %s for type %T (%v)", op, value, value)
+	return tabletenv.NewTabletError(vterrors.Internal, "invalid operator %s for type %T (%v)", op, value, value)
 }
 
 // filterByPlan returns a new QueryRule if the query and planid match.
@@ -885,7 +885,7 @@ func MapStrOperator(strop string) (op Operator, err error) {
 	if op, ok := opmap[strop]; ok {
 		return op, nil
 	}
-	return QRNoOp, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "invalid Operator %s", strop)
+	return QRNoOp, tabletenv.NewTabletError(vterrors.Internal, "invalid Operator %s", strop)
 }
 
 // BuildQueryRule builds a query rule from a ruleInfo.
@@ -899,15 +899,15 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) 
 		case "Name", "Description", "RequestIP", "User", "Query", "Action":
 			sv, ok = v.(string)
 			if !ok {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for %s", k)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "want string for %s", k)
 			}
 		case "Plans", "BindVarConds", "TableNames":
 			lv, ok = v.([]interface{})
 			if !ok {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want list for %s", k)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "want list for %s", k)
 			}
 		default:
-			return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "unrecognized tag %s", k)
+			return nil, tabletenv.NewTabletError(vterrors.Internal, "unrecognized tag %s", k)
 		}
 		switch k {
 		case "Name":
@@ -917,27 +917,27 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) 
 		case "RequestIP":
 			err = qr.SetIPCond(sv)
 			if err != nil {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "could not set IP condition: %v", sv)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "could not set IP condition: %v", sv)
 			}
 		case "User":
 			err = qr.SetUserCond(sv)
 			if err != nil {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "could not set User condition: %v", sv)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "could not set User condition: %v", sv)
 			}
 		case "Query":
 			err = qr.SetQueryCond(sv)
 			if err != nil {
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "could not set Query condition: %v", sv)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "could not set Query condition: %v", sv)
 			}
 		case "Plans":
 			for _, p := range lv {
 				pv, ok := p.(string)
 				if !ok {
-					return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for Plans")
+					return nil, tabletenv.NewTabletError(vterrors.Internal, "want string for Plans")
 				}
 				pt, ok := planbuilder.PlanByName(pv)
 				if !ok {
-					return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "invalid plan name: %s", pv)
+					return nil, tabletenv.NewTabletError(vterrors.Internal, "invalid plan name: %s", pv)
 				}
 				qr.AddPlanCond(pt)
 			}
@@ -945,7 +945,7 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) 
 			for _, t := range lv {
 				tableName, ok := t.(string)
 				if !ok {
-					return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for TableNames")
+					return nil, tabletenv.NewTabletError(vterrors.Internal, "want string for TableNames")
 				}
 				qr.AddTableCond(tableName)
 			}
@@ -967,7 +967,7 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) 
 			case "FAIL_RETRY":
 				qr.act = QRFailRetry
 			default:
-				return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "invalid Action %s", sv)
+				return nil, tabletenv.NewTabletError(vterrors.Internal, "invalid Action %s", sv)
 			}
 		}
 	}
@@ -977,41 +977,41 @@ func BuildQueryRule(ruleInfo map[string]interface{}) (qr *QueryRule, err error) 
 func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch bool, op Operator, value interface{}, err error) {
 	bvcinfo, ok := bvc.(map[string]interface{})
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want json object for bind var conditions")
+		err = tabletenv.NewTabletError(vterrors.Internal, "want json object for bind var conditions")
 		return
 	}
 
 	var v interface{}
 	v, ok = bvcinfo["Name"]
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Name missing in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "Name missing in BindVarConds")
 		return
 	}
 	name, ok = v.(string)
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for Name in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "want string for Name in BindVarConds")
 		return
 	}
 
 	v, ok = bvcinfo["OnAbsent"]
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "OnAbsent missing in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "OnAbsent missing in BindVarConds")
 		return
 	}
 	onAbsent, ok = v.(bool)
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want bool for OnAbsent")
+		err = tabletenv.NewTabletError(vterrors.Internal, "want bool for OnAbsent")
 		return
 	}
 
 	v, ok = bvcinfo["Operator"]
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Operator missing in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "Operator missing in BindVarConds")
 		return
 	}
 	strop, ok := v.(string)
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for Operator")
+		err = tabletenv.NewTabletError(vterrors.Internal, "want string for Operator")
 		return
 	}
 	op, err = MapStrOperator(strop)
@@ -1023,7 +1023,7 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 	}
 	v, ok = bvcinfo["Value"]
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Value missing in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "Value missing in BindVarConds")
 		return
 	}
 	if op >= QREqual && op <= QRLessEqual {
@@ -1034,50 +1034,50 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 				// Maybe uint64
 				value, err = strconv.ParseUint(string(v), 10, 64)
 				if err != nil {
-					err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want int64/uint64: %s", string(v))
+					err = tabletenv.NewTabletError(vterrors.Internal, "want int64/uint64: %s", string(v))
 					return
 				}
 			}
 		case string:
 			value = v
 		default:
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string or number: %v", v)
+			err = tabletenv.NewTabletError(vterrors.Internal, "want string or number: %v", v)
 			return
 		}
 	} else if op == QRMatch || op == QRNoMatch {
 		strvalue, ok := v.(string)
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string: %v", v)
+			err = tabletenv.NewTabletError(vterrors.Internal, "want string: %v", v)
 			return
 		}
 		value = strvalue
 	} else if op == QRIn || op == QRNotIn {
 		kr, ok := v.(map[string]interface{})
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want keyrange for Value")
+			err = tabletenv.NewTabletError(vterrors.Internal, "want keyrange for Value")
 			return
 		}
 		keyrange := &topodatapb.KeyRange{}
 		strstart, ok := kr["Start"]
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Start missing in KeyRange")
+			err = tabletenv.NewTabletError(vterrors.Internal, "Start missing in KeyRange")
 			return
 		}
 		start, ok := strstart.(string)
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for Start")
+			err = tabletenv.NewTabletError(vterrors.Internal, "want string for Start")
 			return
 		}
 		keyrange.Start = []byte(start)
 
 		strend, ok := kr["End"]
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "End missing in KeyRange")
+			err = tabletenv.NewTabletError(vterrors.Internal, "End missing in KeyRange")
 			return
 		}
 		end, ok := strend.(string)
 		if !ok {
-			err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want string for End")
+			err = tabletenv.NewTabletError(vterrors.Internal, "want string for End")
 			return
 		}
 		keyrange.End = []byte(end)
@@ -1086,12 +1086,12 @@ func buildBindVarCondition(bvc interface{}) (name string, onAbsent, onMismatch b
 
 	v, ok = bvcinfo["OnMismatch"]
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "OnMismatch missing in BindVarConds")
+		err = tabletenv.NewTabletError(vterrors.Internal, "OnMismatch missing in BindVarConds")
 		return
 	}
 	onMismatch, ok = v.(bool)
 	if !ok {
-		err = tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "want bool for OnMismatch")
+		err = tabletenv.NewTabletError(vterrors.Internal, "want bool for OnMismatch")
 		return
 	}
 	return

--- a/go/vt/tabletserver/query_rules_test.go
+++ b/go/vt/tabletserver/query_rules_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func TestQueryRules(t *testing.T) {
@@ -796,7 +796,7 @@ func TestInvalidJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("invalid json, should get a tablet error")
 	}
-	if terr.ErrorCode != vtrpcpb.ErrorCode_INTERNAL_ERROR {
+	if terr.ErrorCode != vterrors.Internal {
 		t.Fatalf("got: %v wanted: INTERNAL_ERROR", terr.ErrorCode)
 	}
 }

--- a/go/vt/tabletserver/sandboxconn/sandboxconn.go
+++ b/go/vt/tabletserver/sandboxconn/sandboxconn.go
@@ -14,11 +14,11 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/queryservice"
 	"github.com/youtube/vitess/go/vt/tabletserver/querytypes"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // SandboxConn satisfies the QueryService interface
@@ -104,21 +104,21 @@ func (sbc *SandboxConn) getError() error {
 		sbc.MustFailRetry--
 		return &tabletconn.ServerError{
 			Err:        "retry: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	if sbc.MustFailFatal > 0 {
 		sbc.MustFailFatal--
 		return &tabletconn.ServerError{
 			Err:        "fatal: err",
-			ServerCode: vtrpcpb.ErrorCode_INTERNAL_ERROR,
+			ServerCode: vterrors.Internal,
 		}
 	}
 	if sbc.MustFailServer > 0 {
 		sbc.MustFailServer--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_BAD_INPUT,
+			ServerCode: vterrors.InvalidArgument,
 		}
 	}
 	if sbc.MustFailConn > 0 {
@@ -129,63 +129,63 @@ func (sbc *SandboxConn) getError() error {
 		sbc.MustFailTxPool--
 		return &tabletconn.ServerError{
 			Err:        "tx_pool_full: err",
-			ServerCode: vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED,
+			ServerCode: vterrors.ResourceExhausted,
 		}
 	}
 	if sbc.MustFailNotTx > 0 {
 		sbc.MustFailNotTx--
 		return &tabletconn.ServerError{
 			Err:        "not_in_tx: err",
-			ServerCode: vtrpcpb.ErrorCode_NOT_IN_TX,
+			ServerCode: vterrors.Aborted,
 		}
 	}
 	if sbc.MustFailCanceled > 0 {
 		sbc.MustFailCanceled--
 		return &tabletconn.ServerError{
 			Err:        "canceled: err",
-			ServerCode: vtrpcpb.ErrorCode_CANCELLED,
+			ServerCode: vterrors.Canceled,
 		}
 	}
 	if sbc.MustFailUnknownError > 0 {
 		sbc.MustFailUnknownError--
 		return &tabletconn.ServerError{
 			Err:        "unknown error: err",
-			ServerCode: vtrpcpb.ErrorCode_UNKNOWN_ERROR,
+			ServerCode: vterrors.Unknown,
 		}
 	}
 	if sbc.MustFailDeadlineExceeded > 0 {
 		sbc.MustFailDeadlineExceeded--
 		return &tabletconn.ServerError{
 			Err:        "deadline exceeded: err",
-			ServerCode: vtrpcpb.ErrorCode_DEADLINE_EXCEEDED,
+			ServerCode: vterrors.DeadlineExceeded,
 		}
 	}
 	if sbc.MustFailIntegrityError > 0 {
 		sbc.MustFailIntegrityError--
 		return &tabletconn.ServerError{
 			Err:        "integrity error: err",
-			ServerCode: vtrpcpb.ErrorCode_INTEGRITY_ERROR,
+			ServerCode: vterrors.AlreadyExists,
 		}
 	}
 	if sbc.MustFailPermissionDenied > 0 {
 		sbc.MustFailPermissionDenied--
 		return &tabletconn.ServerError{
 			Err:        "permission denied: err",
-			ServerCode: vtrpcpb.ErrorCode_PERMISSION_DENIED,
+			ServerCode: vterrors.PermissionDenied,
 		}
 	}
 	if sbc.MustFailTransientError > 0 {
 		sbc.MustFailTransientError--
 		return &tabletconn.ServerError{
 			Err:        "transient error: err",
-			ServerCode: vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+			ServerCode: vterrors.Unavailable,
 		}
 	}
 	if sbc.MustFailUnauthenticated > 0 {
 		sbc.MustFailUnauthenticated--
 		return &tabletconn.ServerError{
 			Err:        "unauthenticated: err",
-			ServerCode: vtrpcpb.ErrorCode_UNAUTHENTICATED,
+			ServerCode: vterrors.Unauthenticated,
 		}
 	}
 
@@ -281,7 +281,7 @@ func (sbc *SandboxConn) Prepare(ctx context.Context, target *querypb.Target, tra
 		sbc.MustFailPrepare--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -294,7 +294,7 @@ func (sbc *SandboxConn) CommitPrepared(ctx context.Context, target *querypb.Targ
 		sbc.MustFailCommitPrepared--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -307,7 +307,7 @@ func (sbc *SandboxConn) RollbackPrepared(ctx context.Context, target *querypb.Ta
 		sbc.MustFailRollbackPrepared--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -320,7 +320,7 @@ func (sbc *SandboxConn) CreateTransaction(ctx context.Context, target *querypb.T
 		sbc.MustFailCreateTransaction--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -334,7 +334,7 @@ func (sbc *SandboxConn) StartCommit(ctx context.Context, target *querypb.Target,
 		sbc.MustFailStartCommit--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -348,7 +348,7 @@ func (sbc *SandboxConn) SetRollback(ctx context.Context, target *querypb.Target,
 		sbc.MustFailSetRollback--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()
@@ -362,7 +362,7 @@ func (sbc *SandboxConn) ConcludeTransaction(ctx context.Context, target *querypb
 		sbc.MustFailConcludeTransaction--
 		return &tabletconn.ServerError{
 			Err:        "error: err",
-			ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+			ServerCode: vterrors.FailedPrecondition,
 		}
 	}
 	return sbc.getError()

--- a/go/vt/tabletserver/tabletconntest/tabletconntest.go
+++ b/go/vt/tabletserver/tabletconntest/tabletconntest.go
@@ -23,7 +23,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // testErrorHelper will check one instance of each error type,
@@ -31,22 +30,22 @@ import (
 func testErrorHelper(t *testing.T, f *FakeQueryService, name string, ef func(context.Context) error) {
 	errors := []*tabletenv.TabletError{
 		// A few generic errors
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "generic error"),
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_UNKNOWN_ERROR, "uncaught panic"),
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_UNAUTHENTICATED, "missing caller id"),
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_PERMISSION_DENIED, "table acl error: nil acl"),
+		tabletenv.NewTabletError(vterrors.InvalidArgument, "generic error"),
+		tabletenv.NewTabletError(vterrors.Unknown, "uncaught panic"),
+		tabletenv.NewTabletError(vterrors.Unauthenticated, "missing caller id"),
+		tabletenv.NewTabletError(vterrors.PermissionDenied, "table acl error: nil acl"),
 
 		// Client will retry on this specific error
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, "Query disallowed due to rule: %v", "cool rule"),
+		tabletenv.NewTabletError(vterrors.FailedPrecondition, "Query disallowed due to rule: %v", "cool rule"),
 
 		// Client may retry on another server on this specific error
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not verify strict mode"),
+		tabletenv.NewTabletError(vterrors.Internal, "Could not verify strict mode"),
 
 		// This is usually transaction pool full
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, "Transaction pool connection limit exceeded"),
+		tabletenv.NewTabletError(vterrors.ResourceExhausted, "Transaction pool connection limit exceeded"),
 
 		// Transaction expired or was unknown
-		tabletenv.NewTabletError(vtrpcpb.ErrorCode_NOT_IN_TX, "Transaction 12"),
+		tabletenv.NewTabletError(vterrors.Aborted, "Transaction 12"),
 	}
 	for _, e := range errors {
 		f.TabletError = e

--- a/go/vt/tabletserver/tabletenv/tablet_error_test.go
+++ b/go/vt/tabletserver/tabletenv/tablet_error_test.go
@@ -10,13 +10,12 @@ import (
 
 	"github.com/youtube/vitess/go/mysqlconn"
 	"github.com/youtube/vitess/go/sqldb"
-
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 func TestTabletErrorCode(t *testing.T) {
-	tErr := NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "error")
-	wantCode := vtrpcpb.ErrorCode_INTERNAL_ERROR
+	tErr := NewTabletError(vterrors.Internal, "error")
+	wantCode := vterrors.Internal
 	code := tErr.VtErrorCode()
 	if wantCode != code {
 		t.Errorf("VtErrorCode() => %v, want %v", code, wantCode)
@@ -25,26 +24,26 @@ func TestTabletErrorCode(t *testing.T) {
 
 func TestTabletErrorRetriableErrorTypeOverwrite(t *testing.T) {
 	sqlErr := sqldb.NewSQLError(mysqlconn.EROptionPreventsStatement, mysqlconn.SSUnknownSQLState, "read-only")
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqlErr)
-	if tabletErr.ErrorCode != vtrpcpb.ErrorCode_QUERY_NOT_SERVED {
+	tabletErr := NewTabletErrorSQL(vterrors.Internal, sqlErr)
+	if tabletErr.ErrorCode != vterrors.FailedPrecondition {
 		t.Fatalf("got: %v wanted: QUERY_NOT_SERVED", tabletErr.ErrorCode)
 	}
 
 	sqlErr = sqldb.NewSQLError(mysqlconn.ERDupEntry, mysqlconn.SSDupKey, "error")
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqlErr)
-	if tabletErr.ErrorCode != vtrpcpb.ErrorCode_INTEGRITY_ERROR {
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqlErr)
+	if tabletErr.ErrorCode != vterrors.AlreadyExists {
 		t.Fatalf("got: %v wanted: INTEGRITY_ERROR", tabletErr.ErrorCode)
 	}
 
 	sqlErr = sqldb.NewSQLError(mysqlconn.ERDataTooLong, mysqlconn.SSDataTooLong, "error")
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqlErr)
-	if tabletErr.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqlErr)
+	if tabletErr.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %v wanted: BAD_INPUT", tabletErr.ErrorCode)
 	}
 
 	sqlErr = sqldb.NewSQLError(mysqlconn.ERDataOutOfRange, mysqlconn.SSDataOutOfRange, "error")
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqlErr)
-	if tabletErr.ErrorCode != vtrpcpb.ErrorCode_BAD_INPUT {
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqlErr)
+	if tabletErr.ErrorCode != vterrors.InvalidArgument {
 		t.Fatalf("got: %v wanted: BAD_INPUT", tabletErr.ErrorCode)
 	}
 }
@@ -59,8 +58,8 @@ func TestTabletErrorMsgTooLong(t *testing.T) {
 	}
 	msg := string(buf)
 	sqlErr := sqldb.NewSQLError(mysqlconn.ERDupEntry, mysqlconn.SSDupKey, msg)
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqlErr)
-	if tabletErr.ErrorCode != vtrpcpb.ErrorCode_INTEGRITY_ERROR {
+	tabletErr := NewTabletErrorSQL(vterrors.Internal, sqlErr)
+	if tabletErr.ErrorCode != vterrors.AlreadyExists {
 		t.Fatalf("got %v wanted INTEGRITY_ERROR", tabletErr.ErrorCode)
 	}
 	if tabletErr.Message != string(buf[:maxErrLen]) {
@@ -69,15 +68,15 @@ func TestTabletErrorMsgTooLong(t *testing.T) {
 }
 
 func TestTabletErrorConnError(t *testing.T) {
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(1999, "HY000", "test"))
+	tabletErr := NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(1999, "HY000", "test"))
 	if IsConnErr(tabletErr) {
 		t.Fatalf("tablet error: %v is not a connection error", tabletErr)
 	}
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(2000, mysqlconn.SSUnknownSQLState, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(2000, mysqlconn.SSUnknownSQLState, "test"))
 	if !IsConnErr(tabletErr) {
 		t.Fatalf("tablet error: %v is a connection error", tabletErr)
 	}
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(mysqlconn.CRServerLost, mysqlconn.SSUnknownSQLState, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(mysqlconn.CRServerLost, mysqlconn.SSUnknownSQLState, "test"))
 	if IsConnErr(tabletErr) {
 		t.Fatalf("tablet error: %v is not a connection error", tabletErr)
 	}
@@ -106,26 +105,26 @@ func TestTabletErrorConnError(t *testing.T) {
 }
 
 func TestTabletErrorPrefix(t *testing.T) {
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr := NewTabletErrorSQL(vterrors.FailedPrecondition, sqldb.NewSQLError(2000, "HY000", "test"))
 	if tabletErr.Prefix() != "retry: " {
 		t.Fatalf("tablet error with error code: QUERY_NOT_SERVED should has prefix: 'retry: '")
 	}
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(2000, "HY000", "test"))
 	if tabletErr.Prefix() != "fatal: " {
 		t.Fatalf("tablet error with error code: INTERNAL_ERROR should has prefix: 'fatal: '")
 	}
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.ResourceExhausted, sqldb.NewSQLError(2000, "HY000", "test"))
 	if tabletErr.Prefix() != "tx_pool_full: " {
 		t.Fatalf("tablet error with error code: RESOURCE_EXHAUSTED should has prefix: 'tx_pool_full: '")
 	}
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_NOT_IN_TX, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Aborted, sqldb.NewSQLError(2000, "HY000", "test"))
 	if tabletErr.Prefix() != "not_in_tx: " {
 		t.Fatalf("tablet error with error code: NOT_IN_TX should has prefix: 'not_in_tx: '")
 	}
 }
 
 func TestTabletErrorRecordStats(t *testing.T) {
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_QUERY_NOT_SERVED, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr := NewTabletErrorSQL(vterrors.FailedPrecondition, sqldb.NewSQLError(2000, "HY000", "test"))
 	retryCounterBefore := InfoErrors.Counts()["Retry"]
 	tabletErr.RecordStats()
 	retryCounterAfter := InfoErrors.Counts()["Retry"]
@@ -133,7 +132,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("tablet error with error code QUERY_NOT_SERVED should increase Retry error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(2000, "HY000", "test"))
 	fatalCounterBefore := ErrorStats.Counts()["Fatal"]
 	tabletErr.RecordStats()
 	fatalCounterAfter := ErrorStats.Counts()["Fatal"]
@@ -141,7 +140,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("tablet error with error code INTERNAL_ERROR should increase Fatal error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.ResourceExhausted, sqldb.NewSQLError(2000, "HY000", "test"))
 	txPoolFullCounterBefore := ErrorStats.Counts()["TxPoolFull"]
 	tabletErr.RecordStats()
 	txPoolFullCounterAfter := ErrorStats.Counts()["TxPoolFull"]
@@ -149,7 +148,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("tablet error with error code RESOURCE_EXHAUSTED should increase TxPoolFull error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_NOT_IN_TX, sqldb.NewSQLError(2000, "HY000", "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Aborted, sqldb.NewSQLError(2000, "HY000", "test"))
 	notInTxCounterBefore := ErrorStats.Counts()["NotInTx"]
 	tabletErr.RecordStats()
 	notInTxCounterAfter := ErrorStats.Counts()["NotInTx"]
@@ -157,7 +156,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("tablet error with error code NOT_IN_TX should increase NotInTx error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, sqldb.NewSQLError(mysqlconn.ERDupEntry, mysqlconn.SSDupKey, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Unknown, sqldb.NewSQLError(mysqlconn.ERDupEntry, mysqlconn.SSDupKey, "test"))
 	dupKeyCounterBefore := InfoErrors.Counts()["DupKey"]
 	tabletErr.RecordStats()
 	dupKeyCounterAfter := InfoErrors.Counts()["DupKey"]
@@ -165,7 +164,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("sql error with SQL error mysqlconn.ERDupEntry should increase DupKey error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, sqldb.NewSQLError(mysqlconn.ERLockWaitTimeout, mysqlconn.SSUnknownSQLState, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Unknown, sqldb.NewSQLError(mysqlconn.ERLockWaitTimeout, mysqlconn.SSUnknownSQLState, "test"))
 	lockWaitTimeoutCounterBefore := ErrorStats.Counts()["Deadlock"]
 	tabletErr.RecordStats()
 	lockWaitTimeoutCounterAfter := ErrorStats.Counts()["Deadlock"]
@@ -173,7 +172,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("sql error with SQL error mysqlconn.ERLockWaitTimeout should increase Deadlock error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, sqldb.NewSQLError(mysqlconn.ERLockDeadlock, mysqlconn.SSLockDeadlock, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Unknown, sqldb.NewSQLError(mysqlconn.ERLockDeadlock, mysqlconn.SSLockDeadlock, "test"))
 	deadlockCounterBefore := ErrorStats.Counts()["Deadlock"]
 	tabletErr.RecordStats()
 	deadlockCounterAfter := ErrorStats.Counts()["Deadlock"]
@@ -181,7 +180,7 @@ func TestTabletErrorRecordStats(t *testing.T) {
 		t.Fatalf("sql error with SQL error mysqlconn.ERLockDeadlock should increase Deadlock error count by 1")
 	}
 
-	tabletErr = NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, sqldb.NewSQLError(mysqlconn.EROptionPreventsStatement, mysqlconn.SSUnknownSQLState, "test"))
+	tabletErr = NewTabletErrorSQL(vterrors.Unknown, sqldb.NewSQLError(mysqlconn.EROptionPreventsStatement, mysqlconn.SSUnknownSQLState, "test"))
 	failCounterBefore := ErrorStats.Counts()["Fail"]
 	tabletErr.RecordStats()
 	failCounterAfter := ErrorStats.Counts()["Fail"]
@@ -203,7 +202,7 @@ func TestTabletErrorLogUncaughtErr(t *testing.T) {
 }
 
 func TestTabletErrorTxPoolFull(t *testing.T) {
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, sqldb.NewSQLError(1000, "HY000", "test"))
+	tabletErr := NewTabletErrorSQL(vterrors.ResourceExhausted, sqldb.NewSQLError(1000, "HY000", "test"))
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -215,7 +214,7 @@ func TestTabletErrorTxPoolFull(t *testing.T) {
 }
 
 func TestTabletErrorFatal(t *testing.T) {
-	tabletErr := NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, sqldb.NewSQLError(1000, "HY000", "test"))
+	tabletErr := NewTabletErrorSQL(vterrors.Internal, sqldb.NewSQLError(1000, "HY000", "test"))
 	defer func() {
 		err := recover()
 		if err != nil {

--- a/go/vt/tabletserver/twopc.go
+++ b/go/vt/tabletserver/twopc.go
@@ -21,10 +21,10 @@ import (
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -137,7 +137,7 @@ func (tpc *TwoPC) Init(sidecarDBName string, dbaparams *sqldb.ConnParams) error 
 	}
 	for _, s := range statements {
 		if _, err := conn.ExecuteFetch(s, 0, false); err != nil {
-			return tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, err.Error())
+			return tabletenv.NewTabletError(vterrors.Internal, err.Error())
 		}
 	}
 	tpc.insertRedoTx = buildParsedQuery(
@@ -368,7 +368,7 @@ func (tpc *TwoPC) Transition(ctx context.Context, conn *TxConnection, dtid strin
 		return err
 	}
 	if qr.RowsAffected != 1 {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "could not transition to %v: %s", state, dtid)
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "could not transition to %v: %s", state, dtid)
 	}
 	return nil
 }

--- a/go/vt/tabletserver/tx_executor.go
+++ b/go/vt/tabletserver/tx_executor.go
@@ -13,8 +13,8 @@ import (
 	"github.com/youtube/vitess/go/trace"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 // TxExecutor is used for executing a transactional request.
@@ -32,7 +32,7 @@ type TxExecutor struct {
 // protocol, will perform all the cleanup.
 func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("PREPARE", time.Now())
 	txe.logStats.TransactionID = transactionID
@@ -51,7 +51,7 @@ func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 	err = txe.te.preparedPool.Put(conn, dtid)
 	if err != nil {
 		txe.te.txPool.localRollback(txe.ctx, conn)
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, "prepare failed for transaction %d: %v", transactionID, err)
+		return tabletenv.NewTabletError(vterrors.ResourceExhausted, "prepare failed for transaction %d: %v", transactionID, err)
 	}
 
 	localConn, err := txe.te.txPool.LocalBegin(txe.ctx)
@@ -78,12 +78,12 @@ func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 // marked as failed in the redo log.
 func (txe *TxExecutor) CommitPrepared(dtid string) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("COMMIT_PREPARED", time.Now())
 	conn, err := txe.te.preparedPool.FetchForCommit(dtid)
 	if err != nil {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "cannot commit dtid %s, state: %v", dtid, err)
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "cannot commit dtid %s, state: %v", dtid, err)
 	}
 	if conn == nil {
 		return nil
@@ -153,7 +153,7 @@ func (txe *TxExecutor) markFailed(ctx context.Context, dtid string) {
 // killer will be the one to eventually roll it back.
 func (txe *TxExecutor) RollbackPrepared(dtid string, originalID int64) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("ROLLBACK_PREPARED", time.Now())
 	conn, err := txe.te.txPool.LocalBegin(txe.ctx)
@@ -183,7 +183,7 @@ returnConn:
 // CreateTransaction creates the metadata for a 2PC transaction.
 func (txe *TxExecutor) CreateTransaction(dtid string, participants []*querypb.Target) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("CREATE_TRANSACTION", time.Now())
 	conn, err := txe.te.txPool.LocalBegin(txe.ctx)
@@ -203,7 +203,7 @@ func (txe *TxExecutor) CreateTransaction(dtid string, participants []*querypb.Ta
 // decision to commit the associated 2pc transaction.
 func (txe *TxExecutor) StartCommit(transactionID int64, dtid string) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("START_COMMIT", time.Now())
 	txe.logStats.TransactionID = transactionID
@@ -225,7 +225,7 @@ func (txe *TxExecutor) StartCommit(transactionID int64, dtid string) error {
 // If a transaction id is provided, that transaction is also rolled back.
 func (txe *TxExecutor) SetRollback(dtid string, transactionID int64) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("SET_ROLLBACK", time.Now())
 	txe.logStats.TransactionID = transactionID
@@ -257,7 +257,7 @@ func (txe *TxExecutor) SetRollback(dtid string, transactionID int64) error {
 // essentially resolving it.
 func (txe *TxExecutor) ConcludeTransaction(dtid string) error {
 	if !txe.te.twopcEnabled {
-		return tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("RESOLVE", time.Now())
 
@@ -277,7 +277,7 @@ func (txe *TxExecutor) ConcludeTransaction(dtid string) error {
 // ReadTransaction returns the metadata for the sepcified dtid.
 func (txe *TxExecutor) ReadTransaction(dtid string) (*querypb.TransactionMetadata, error) {
 	if !txe.te.twopcEnabled {
-		return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	return txe.te.twoPC.ReadTransaction(txe.ctx, dtid)
 }
@@ -285,15 +285,15 @@ func (txe *TxExecutor) ReadTransaction(dtid string) (*querypb.TransactionMetadat
 // ReadTwopcInflight returns info about all in-flight 2pc transactions.
 func (txe *TxExecutor) ReadTwopcInflight() (distributed []*DistributedTx, prepared, failed []*PreparedTx, err error) {
 	if !txe.te.twopcEnabled {
-		return nil, nil, nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_BAD_INPUT, "2pc is not enabled")
+		return nil, nil, nil, tabletenv.NewTabletError(vterrors.InvalidArgument, "2pc is not enabled")
 	}
 	prepared, failed, err = txe.te.twoPC.ReadAllRedo(txe.ctx)
 	if err != nil {
-		return nil, nil, nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not read redo: %v", err)
+		return nil, nil, nil, tabletenv.NewTabletError(vterrors.Internal, "Could not read redo: %v", err)
 	}
 	distributed, err = txe.te.twoPC.ReadAllTransactions(txe.ctx)
 	if err != nil {
-		return nil, nil, nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_INTERNAL_ERROR, "Could not read redo: %v", err)
+		return nil, nil, nil, tabletenv.NewTabletError(vterrors.Internal, "Could not read redo: %v", err)
 	}
 	return distributed, prepared, failed, nil
 }

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -23,6 +23,7 @@ import (
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
@@ -146,13 +147,13 @@ func (axp *TxPool) Begin(ctx context.Context) (int64, error) {
 			return 0, err
 		case pools.ErrTimeout:
 			axp.LogActive()
-			return 0, tabletenv.NewTabletError(vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, "Transaction pool connection limit exceeded")
+			return 0, tabletenv.NewTabletError(vterrors.ResourceExhausted, "Transaction pool connection limit exceeded")
 		}
-		return 0, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, err)
+		return 0, tabletenv.NewTabletErrorSQL(vterrors.Internal, err)
 	}
 	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
 		conn.Recycle()
-		return 0, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
+		return 0, tabletenv.NewTabletErrorSQL(vterrors.Unknown, err)
 	}
 	transactionID := axp.lastID.Add(1)
 	axp.activePool.Register(
@@ -191,7 +192,7 @@ func (axp *TxPool) Rollback(ctx context.Context, transactionID int64) error {
 func (axp *TxPool) Get(transactionID int64, reason string) (*TxConnection, error) {
 	v, err := axp.activePool.Get(transactionID, reason)
 	if err != nil {
-		return nil, tabletenv.NewTabletError(vtrpcpb.ErrorCode_NOT_IN_TX, "Transaction %d: %v", transactionID, err)
+		return nil, tabletenv.NewTabletError(vterrors.Aborted, "Transaction %d: %v", transactionID, err)
 	}
 	return v.(*TxConnection), nil
 }
@@ -214,7 +215,7 @@ func (axp *TxPool) LocalCommit(ctx context.Context, conn *TxConnection, messager
 	txStats.Add("Completed", time.Now().Sub(conn.StartTime))
 	if _, err := conn.Exec(ctx, "commit", 1, false); err != nil {
 		conn.Close()
-		return tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
+		return tabletenv.NewTabletErrorSQL(vterrors.Unknown, err)
 	}
 	messager.UpdateCaches(conn.NewMessages, conn.ChangedMessages)
 	return nil
@@ -233,7 +234,7 @@ func (axp *TxPool) localRollback(ctx context.Context, conn *TxConnection) error 
 	txStats.Add("Aborted", time.Now().Sub(conn.StartTime))
 	if _, err := conn.Exec(ctx, "rollback", 1, false); err != nil {
 		conn.Close()
-		return tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
+		return tabletenv.NewTabletErrorSQL(vterrors.Unknown, err)
 	}
 	return nil
 }
@@ -301,9 +302,9 @@ func (txc *TxConnection) Exec(ctx context.Context, query string, maxrows int, wa
 	if err != nil {
 		if tabletenv.IsConnErr(err) {
 			txc.pool.checker.CheckMySQL()
-			return nil, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_INTERNAL_ERROR, err)
+			return nil, tabletenv.NewTabletErrorSQL(vterrors.Internal, err)
 		}
-		return nil, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
+		return nil, tabletenv.NewTabletErrorSQL(vterrors.Unknown, err)
 	}
 	return r, nil
 }

--- a/go/vt/vterrors/aggregate.go
+++ b/go/vt/vterrors/aggregate.go
@@ -31,26 +31,26 @@ const (
 )
 
 var errorPriorities = map[vtrpcpb.ErrorCode]int{
-	vtrpcpb.ErrorCode_SUCCESS:            PrioritySuccess,
-	vtrpcpb.ErrorCode_CANCELLED:          PriorityCancelled,
-	vtrpcpb.ErrorCode_UNKNOWN_ERROR:      PriorityUnknownError,
-	vtrpcpb.ErrorCode_BAD_INPUT:          PriorityBadInput,
-	vtrpcpb.ErrorCode_DEADLINE_EXCEEDED:  PriorityDeadlineExceeded,
-	vtrpcpb.ErrorCode_INTEGRITY_ERROR:    PriorityIntegrityError,
-	vtrpcpb.ErrorCode_PERMISSION_DENIED:  PriorityPermissionDenied,
-	vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED: PriorityResourceExhausted,
-	vtrpcpb.ErrorCode_QUERY_NOT_SERVED:   PriorityQueryNotServed,
-	vtrpcpb.ErrorCode_NOT_IN_TX:          PriorityNotInTx,
-	vtrpcpb.ErrorCode_INTERNAL_ERROR:     PriorityInternalError,
-	vtrpcpb.ErrorCode_TRANSIENT_ERROR:    PriorityTransientError,
-	vtrpcpb.ErrorCode_UNAUTHENTICATED:    PriorityUnauthenticated,
+	OK:                 PrioritySuccess,
+	Canceled:           PriorityCancelled,
+	Unknown:            PriorityUnknownError,
+	InvalidArgument:    PriorityBadInput,
+	DeadlineExceeded:   PriorityDeadlineExceeded,
+	AlreadyExists:      PriorityIntegrityError,
+	PermissionDenied:   PriorityPermissionDenied,
+	ResourceExhausted:  PriorityResourceExhausted,
+	FailedPrecondition: PriorityQueryNotServed,
+	Aborted:            PriorityNotInTx,
+	Internal:           PriorityInternalError,
+	Unavailable:        PriorityTransientError,
+	Unauthenticated:    PriorityUnauthenticated,
 }
 
 // AggregateVtGateErrorCodes aggregates a list of errors into a single
 // error code.  It does so by finding the highest priority error code
 // in the list.
 func AggregateVtGateErrorCodes(errors []error) vtrpcpb.ErrorCode {
-	highCode := vtrpcpb.ErrorCode_SUCCESS
+	highCode := OK
 	for _, e := range errors {
 		code := RecoverVtErrorCode(e)
 		if errorPriorities[code] > errorPriorities[highCode] {

--- a/go/vt/vterrors/aggregate_test.go
+++ b/go/vt/vterrors/aggregate_test.go
@@ -27,36 +27,36 @@ func TestAggregateVtGateErrorCodes(t *testing.T) {
 		{
 			// aggregation of no errors is a success code
 			input:    nil,
-			expected: vtrpcpb.ErrorCode_SUCCESS,
+			expected: OK,
 		},
 		{
 			// single error code gets returned directly
-			input:    []error{errFromCode(vtrpcpb.ErrorCode_BAD_INPUT)},
-			expected: vtrpcpb.ErrorCode_BAD_INPUT,
+			input:    []error{errFromCode(InvalidArgument)},
+			expected: InvalidArgument,
 		},
 		{
 			// aggregate two codes to the highest priority
 			input: []error{
-				errFromCode(vtrpcpb.ErrorCode_SUCCESS),
-				errFromCode(vtrpcpb.ErrorCode_TRANSIENT_ERROR),
+				errFromCode(OK),
+				errFromCode(Unavailable),
 			},
-			expected: vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+			expected: Unavailable,
 		},
 		{
 			input: []error{
-				errFromCode(vtrpcpb.ErrorCode_SUCCESS),
-				errFromCode(vtrpcpb.ErrorCode_TRANSIENT_ERROR),
-				errFromCode(vtrpcpb.ErrorCode_BAD_INPUT),
+				errFromCode(OK),
+				errFromCode(Unavailable),
+				errFromCode(InvalidArgument),
 			},
-			expected: vtrpcpb.ErrorCode_BAD_INPUT,
+			expected: InvalidArgument,
 		},
 		{
 			// unknown errors map to the unknown code
 			input: []error{
-				errFromCode(vtrpcpb.ErrorCode_SUCCESS),
+				errFromCode(OK),
 				fmt.Errorf("unknown error"),
 			},
-			expected: vtrpcpb.ErrorCode_UNKNOWN_ERROR,
+			expected: Unknown,
 		},
 	}
 	for _, tc := range testcases {
@@ -79,12 +79,12 @@ func TestAggregateVtGateErrors(t *testing.T) {
 		},
 		{
 			input: []error{
-				errFromCode(vtrpcpb.ErrorCode_SUCCESS),
-				errFromCode(vtrpcpb.ErrorCode_TRANSIENT_ERROR),
-				errFromCode(vtrpcpb.ErrorCode_BAD_INPUT),
+				errFromCode(OK),
+				errFromCode(Unavailable),
+				errFromCode(InvalidArgument),
 			},
 			expected: FromError(
-				vtrpcpb.ErrorCode_BAD_INPUT,
+				InvalidArgument,
 				ConcatenateErrors([]error{errGeneric, errGeneric, errGeneric}),
 			),
 		},

--- a/go/vt/vterrors/grpc.go
+++ b/go/vt/vterrors/grpc.go
@@ -24,68 +24,84 @@ import (
 // See: https://github.com/grpc/grpc-go/issues/319
 const GRPCServerErrPrefix = "gRPCServerError:"
 
+const (
+	OK                 = vtrpcpb.ErrorCode_SUCCESS
+	Canceled           = vtrpcpb.ErrorCode_CANCELLED
+	Unknown            = vtrpcpb.ErrorCode_UNKNOWN_ERROR
+	InvalidArgument    = vtrpcpb.ErrorCode_BAD_INPUT
+	DeadlineExceeded   = vtrpcpb.ErrorCode_DEADLINE_EXCEEDED
+	AlreadyExists      = vtrpcpb.ErrorCode_INTEGRITY_ERROR
+	PermissionDenied   = vtrpcpb.ErrorCode_PERMISSION_DENIED
+	ResourceExhausted  = vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED
+	FailedPrecondition = vtrpcpb.ErrorCode_QUERY_NOT_SERVED
+	Aborted            = vtrpcpb.ErrorCode_NOT_IN_TX
+	Internal           = vtrpcpb.ErrorCode_INTERNAL_ERROR
+	Unavailable        = vtrpcpb.ErrorCode_TRANSIENT_ERROR
+	Unauthenticated    = vtrpcpb.ErrorCode_UNAUTHENTICATED
+)
+
 // GRPCCodeToErrorCode maps a gRPC codes.Code to a vtrpcpb.ErrorCode.
 func GRPCCodeToErrorCode(code codes.Code) vtrpcpb.ErrorCode {
 	switch code {
 	case codes.OK:
-		return vtrpcpb.ErrorCode_SUCCESS
+		return OK
 	case codes.Canceled:
-		return vtrpcpb.ErrorCode_CANCELLED
+		return Canceled
 	case codes.Unknown:
-		return vtrpcpb.ErrorCode_UNKNOWN_ERROR
+		return Unknown
 	case codes.InvalidArgument:
-		return vtrpcpb.ErrorCode_BAD_INPUT
+		return InvalidArgument
 	case codes.DeadlineExceeded:
-		return vtrpcpb.ErrorCode_DEADLINE_EXCEEDED
+		return DeadlineExceeded
 	case codes.AlreadyExists:
-		return vtrpcpb.ErrorCode_INTEGRITY_ERROR
+		return AlreadyExists
 	case codes.PermissionDenied:
-		return vtrpcpb.ErrorCode_PERMISSION_DENIED
+		return PermissionDenied
 	case codes.ResourceExhausted:
-		return vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED
+		return ResourceExhausted
 	case codes.FailedPrecondition:
-		return vtrpcpb.ErrorCode_QUERY_NOT_SERVED
+		return FailedPrecondition
 	case codes.Aborted:
-		return vtrpcpb.ErrorCode_NOT_IN_TX
+		return Aborted
 	case codes.Internal:
-		return vtrpcpb.ErrorCode_INTERNAL_ERROR
+		return Internal
 	case codes.Unavailable:
-		return vtrpcpb.ErrorCode_TRANSIENT_ERROR
+		return Unavailable
 	case codes.Unauthenticated:
-		return vtrpcpb.ErrorCode_UNAUTHENTICATED
+		return Unauthenticated
 	default:
-		return vtrpcpb.ErrorCode_UNKNOWN_ERROR
+		return Unknown
 	}
 }
 
 // ErrorCodeToGRPCCode maps a vtrpcpb.ErrorCode to a gRPC codes.Code.
 func ErrorCodeToGRPCCode(code vtrpcpb.ErrorCode) codes.Code {
 	switch code {
-	case vtrpcpb.ErrorCode_SUCCESS:
+	case OK:
 		return codes.OK
-	case vtrpcpb.ErrorCode_CANCELLED:
+	case Canceled:
 		return codes.Canceled
-	case vtrpcpb.ErrorCode_UNKNOWN_ERROR:
+	case Unknown:
 		return codes.Unknown
-	case vtrpcpb.ErrorCode_BAD_INPUT:
+	case InvalidArgument:
 		return codes.InvalidArgument
-	case vtrpcpb.ErrorCode_DEADLINE_EXCEEDED:
+	case DeadlineExceeded:
 		return codes.DeadlineExceeded
-	case vtrpcpb.ErrorCode_INTEGRITY_ERROR:
+	case AlreadyExists:
 		return codes.AlreadyExists
-	case vtrpcpb.ErrorCode_PERMISSION_DENIED:
+	case PermissionDenied:
 		return codes.PermissionDenied
-	case vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED:
+	case ResourceExhausted:
 		return codes.ResourceExhausted
-	case vtrpcpb.ErrorCode_QUERY_NOT_SERVED:
+	case FailedPrecondition:
 		return codes.FailedPrecondition
-	case vtrpcpb.ErrorCode_NOT_IN_TX:
+	case Aborted:
 		return codes.Aborted
-	case vtrpcpb.ErrorCode_INTERNAL_ERROR:
+	case Internal:
 		return codes.Internal
-	case vtrpcpb.ErrorCode_TRANSIENT_ERROR:
+	case Unavailable:
 		return codes.Unavailable
-	case vtrpcpb.ErrorCode_UNAUTHENTICATED:
+	case Unauthenticated:
 		return codes.Unauthenticated
 	default:
 		return codes.Unknown

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -29,7 +29,7 @@ func RecoverVtErrorCode(err error) vtrpcpb.ErrorCode {
 	if vtErr, ok := err.(VtError); ok {
 		return vtErr.VtErrorCode()
 	}
-	return vtrpcpb.ErrorCode_UNKNOWN_ERROR
+	return Unknown
 }
 
 // VitessError is the error type that we use internally for passing structured errors.
@@ -73,7 +73,7 @@ func (e *VitessError) AsString() string {
 // existing error.
 // Use this method also when you want to create a VitessError without a custom
 // message. For example:
-//	 err := vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR,
+//	 err := vterrors.FromError(vterrors.Internal,
 //     errors.New("no valid endpoint"))
 func FromError(code vtrpcpb.ErrorCode, err error) error {
 	return &VitessError{

--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -15,7 +15,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -26,9 +25,9 @@ const (
 )
 
 var (
-	failoverErr = vterrors.FromError(vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+	failoverErr = vterrors.FromError(vterrors.FailedPrecondition,
 		errors.New("vttablet: rpc error: code = 9 desc = gRPCServerError: retry: operation not allowed in state SHUTTING_DOWN"))
-	nonFailoverErr = vterrors.FromError(vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+	nonFailoverErr = vterrors.FromError(vterrors.FailedPrecondition,
 		errors.New("vttablet: rpc error: code = 9 desc = gRPCServerError: retry: TODO(mberlin): Insert here any realistic error not caused by a failover"))
 
 	statsKeyJoined = fmt.Sprintf("%s.%s", keyspace, shard)
@@ -517,7 +516,7 @@ func isCanceledError(err error) error {
 	if err == nil {
 		return fmt.Errorf("buffering should have stopped early and returned an error because the request was canceled from the outside")
 	}
-	if got, want := vterrors.RecoverVtErrorCode(err), vtrpcpb.ErrorCode_TRANSIENT_ERROR; got != want {
+	if got, want := vterrors.RecoverVtErrorCode(err), vterrors.Unavailable; got != want {
 		return fmt.Errorf("wrong error code for canceled buffered request. got = %v, want = %v", got, want)
 	}
 	if got, want := err.Error(), "context was canceled before failover finished: context canceled"; got != want {
@@ -531,7 +530,7 @@ func isEvictedError(err error) error {
 	if err == nil {
 		return errors.New("request should have been evicted because the buffer was full")
 	}
-	if got, want := vterrors.RecoverVtErrorCode(err), vtrpcpb.ErrorCode_TRANSIENT_ERROR; got != want {
+	if got, want := vterrors.RecoverVtErrorCode(err), vterrors.Unavailable; got != want {
 		return fmt.Errorf("wrong error code for evicted buffered request. got = %v, want = %v full error: %v", got, want, err)
 	}
 	if got, want := err.Error(), entryEvictedError.Error(); !strings.Contains(got, want) {
@@ -568,7 +567,7 @@ func TestEvictionNotPossible(t *testing.T) {
 	if bufferErr == nil || retryDone != nil {
 		t.Fatalf("buffer should have returned an error because it's full: err: %v retryDone: %v", bufferErr, retryDone)
 	}
-	if got, want := vterrors.RecoverVtErrorCode(bufferErr), vtrpcpb.ErrorCode_TRANSIENT_ERROR; got != want {
+	if got, want := vterrors.RecoverVtErrorCode(bufferErr), vterrors.Unavailable; got != want {
 		t.Fatalf("wrong error code for evicted buffered request. got = %v, want = %v", got, want)
 	}
 	if got, want := bufferErr.Error(), bufferFullError.Error(); !strings.Contains(got, want) {

--- a/go/vt/vtgate/gateway/discoverygateway_test.go
+++ b/go/vt/vtgate/gateway/discoverygateway_test.go
@@ -129,7 +129,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 	dg.tsc.ResetForTesting()
 	want := "target: ks.0.replica, no valid tablet"
 	err := f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_INTERNAL_ERROR)
+	verifyShardError(t, err, want, vterrors.Internal)
 
 	// tablet with error
 	hc.Reset()
@@ -137,7 +137,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 	hc.AddTestTablet("cell", "1.1.1.1", 1001, keyspace, shard, tabletType, false, 10, fmt.Errorf("no connection"))
 	want = "target: ks.0.replica, no valid tablet"
 	err = f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_INTERNAL_ERROR)
+	verifyShardError(t, err, want, vterrors.Internal)
 
 	// tablet without connection
 	hc.Reset()
@@ -145,7 +145,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 	ep1 := hc.AddTestTablet("cell", "1.1.1.1", 1001, keyspace, shard, tabletType, false, 10, nil).Tablet()
 	want = fmt.Sprintf(`target: ks.0.replica, no valid tablet`)
 	err = f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_INTERNAL_ERROR)
+	verifyShardError(t, err, want, vterrors.Internal)
 
 	// retry error
 	hc.Reset()
@@ -191,7 +191,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 	ep1 = sc1.Tablet()
 	want = fmt.Sprintf(`target: ks.0.replica, used tablet: (%+v), error: err`, ep1)
 	err = f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_BAD_INPUT)
+	verifyShardError(t, err, want, vterrors.InvalidArgument)
 
 	// conn error - no retry
 	hc.Reset()
@@ -201,7 +201,7 @@ func testDiscoveryGatewayGeneric(t *testing.T, streaming bool, f func(dg Gateway
 	ep1 = sc1.Tablet()
 	want = fmt.Sprintf(`target: ks.0.replica, used tablet: (%+v), error: conn`, ep1)
 	err = f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_UNKNOWN_ERROR)
+	verifyShardError(t, err, want, vterrors.Unknown)
 
 	// no failure
 	hc.Reset()
@@ -251,7 +251,7 @@ func testDiscoveryGatewayTransact(t *testing.T, streaming bool, f func(dg Gatewa
 	ep1 = sc1.Tablet()
 	want := fmt.Sprintf(`target: ks.0.replica, used tablet: (%+v), error: conn`, ep1)
 	err = f(dg, target)
-	verifyShardError(t, err, want, vtrpcpb.ErrorCode_UNKNOWN_ERROR)
+	verifyShardError(t, err, want, vterrors.Unknown)
 }
 
 func verifyShardError(t *testing.T, err error, wantErr string, wantCode vtrpcpb.ErrorCode) {

--- a/go/vt/vtgate/gateway/l2vtgategateway.go
+++ b/go/vt/vtgate/gateway/l2vtgategateway.go
@@ -22,10 +22,10 @@ import (
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
+	"github.com/youtube/vitess/go/vt/vterrors"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 const (
@@ -238,7 +238,7 @@ func (lg *l2VTGateGateway) canRetry(ctx context.Context, err error, inTransactio
 	}
 	if serverError, ok := err.(*tabletconn.ServerError); ok {
 		switch serverError.ServerCode {
-		case vtrpcpb.ErrorCode_INTERNAL_ERROR:
+		case vterrors.Internal:
 			// Do not retry on fatal error for streaming query.
 			// For streaming query, vttablet sends:
 			// - QUERY_NOT_SERVED, if streaming is not started yet;
@@ -248,7 +248,7 @@ func (lg *l2VTGateGateway) canRetry(ctx context.Context, err error, inTransactio
 				return false
 			}
 			fallthrough
-		case vtrpcpb.ErrorCode_QUERY_NOT_SERVED:
+		case vterrors.FailedPrecondition:
 			// Retry on QUERY_NOT_SERVED and
 			// INTERNAL_ERROR if not in a transaction.
 			return !inTransaction

--- a/go/vt/vtgate/l2vtgate/l2vtgate.go
+++ b/go/vt/vtgate/l2vtgate/l2vtgate.go
@@ -23,7 +23,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -98,7 +97,7 @@ func (l *L2VTGate) endAction(startTime time.Time, statsKey []string, err *error)
 		// keys or bad queries, as those errors are caused by
 		// client queries and are not VTGate's fault.
 		ec := vterrors.RecoverVtErrorCode(*err)
-		if ec != vtrpcpb.ErrorCode_INTEGRITY_ERROR && ec != vtrpcpb.ErrorCode_BAD_INPUT {
+		if ec != vterrors.AlreadyExists && ec != vterrors.InvalidArgument {
 			l.tabletCallErrorCount.Add(statsKey, 1)
 		}
 	}

--- a/go/vt/vtgate/masterbuffer/masterbuffer.go
+++ b/go/vt/vtgate/masterbuffer/masterbuffer.go
@@ -26,7 +26,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -48,7 +47,7 @@ var timeSleep = time.Sleep
 
 // errBufferFull is the error returned a buffer request is rejected because the buffer is full.
 var errBufferFull = vterrors.FromError(
-	vtrpcpb.ErrorCode_TRANSIENT_ERROR,
+	vterrors.Unavailable,
 	errors.New("master request buffer full, rejecting request"),
 )
 

--- a/go/vt/vtgate/resolver.go
+++ b/go/vt/vtgate/resolver.go
@@ -23,7 +23,6 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -58,7 +57,7 @@ func isRetryableError(err error) bool {
 	case *ScatterConnError:
 		return e.Retryable
 	case *gateway.ShardError:
-		return e.ErrorCode == vtrpcpb.ErrorCode_QUERY_NOT_SERVED
+		return e.ErrorCode == vterrors.FailedPrecondition
 	default:
 		return false
 	}
@@ -71,7 +70,7 @@ func isRetryableError(err error) bool {
 func (res *Resolver) ExecuteKeyspaceIds(ctx context.Context, sql string, bindVariables map[string]interface{}, keyspace string, keyspaceIds [][]byte, tabletType topodatapb.TabletType, session *vtgatepb.Session, notInTransaction bool, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
 	if sqlannotation.IsDML(sql) && len(keyspaceIds) > 1 {
 		return nil, vterrors.FromError(
-			vtrpcpb.ErrorCode_BAD_INPUT,
+			vterrors.InvalidArgument,
 			fmt.Errorf("DML should not span multiple keyspace_ids"),
 		)
 	}

--- a/go/vt/vtgate/resolver_test.go
+++ b/go/vt/vtgate/resolver_test.go
@@ -17,13 +17,13 @@ import (
 	"github.com/youtube/vitess/go/vt/discovery"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletconn"
 	"github.com/youtube/vitess/go/vt/topo"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vtgate/gateway"
 	"golang.org/x/net/context"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // This file uses the sandbox_test framework.
@@ -560,13 +560,13 @@ func TestIsRetryableError(t *testing.T) {
 		{fmt.Errorf("generic error"), false},
 		{&ScatterConnError{Retryable: true}, true},
 		{&ScatterConnError{Retryable: false}, false},
-		{&gateway.ShardError{ErrorCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED}, true},
-		{&gateway.ShardError{ErrorCode: vtrpcpb.ErrorCode_INTERNAL_ERROR}, false},
+		{&gateway.ShardError{ErrorCode: vterrors.FailedPrecondition}, true},
+		{&gateway.ShardError{ErrorCode: vterrors.Internal}, false},
 		// tabletconn.ServerError will not come directly here,
 		// they'll be wrapped in ScatterConnError or ShardConnError.
 		// So they can't be retried as is.
-		{&tabletconn.ServerError{ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED}, false},
-		{&tabletconn.ServerError{ServerCode: vtrpcpb.ErrorCode_PERMISSION_DENIED}, false},
+		{&tabletconn.ServerError{ServerCode: vterrors.FailedPrecondition}, false},
+		{&tabletconn.ServerError{ServerCode: vterrors.PermissionDenied}, false},
 	}
 
 	for _, tt := range connErrorTests {

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -12,7 +12,6 @@ import (
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // SafeSession is a mutex-protected version of the Session.
@@ -63,7 +62,7 @@ func (session *SafeSession) Append(shardSession *vtgatepb.Session_ShardSession) 
 	session.ShardSessions = append(session.ShardSessions, shardSession)
 	if session.SingleDb && len(session.ShardSessions) > 1 {
 		session.mustRollback = true
-		return vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, fmt.Errorf("multi-db transaction attempted: %v", session.ShardSessions))
+		return vterrors.FromError(vterrors.InvalidArgument, fmt.Errorf("multi-db transaction attempted: %v", session.ShardSessions))
 	}
 	return nil
 }

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -152,7 +152,7 @@ func testScatterConnGeneric(t *testing.T, name string, f func(sc *ScatterConn, s
 	_, err = f(sc, []string{"0", "1"})
 	// Verify server errors are consolidated.
 	want = fmt.Sprintf("target: %v.0.replica, used tablet: (alias:<cell:\"aa\" > hostname:\"0\" port_map:<key:\"vt\" value:1 > keyspace:\"%v\" shard:\"0\" type:REPLICA ), error: err\ntarget: %v.1.replica, used tablet: (alias:<cell:\"aa\" > hostname:\"1\" port_map:<key:\"vt\" value:1 > keyspace:\"%v\" shard:\"1\" type:REPLICA ), error: err", name, name, name, name)
-	verifyScatterConnError(t, err, want, vtrpcpb.ErrorCode_BAD_INPUT)
+	verifyScatterConnError(t, err, want, vterrors.InvalidArgument)
 	// Ensure that we tried only once.
 	if execCount := sbc0.ExecCount.Get(); execCount != 1 {
 		t.Errorf("want 1, got %v", execCount)
@@ -173,7 +173,7 @@ func testScatterConnGeneric(t *testing.T, name string, f func(sc *ScatterConn, s
 	// Verify server errors are consolidated.
 	want = fmt.Sprintf("target: %v.0.replica, used tablet: (alias:<cell:\"aa\" > hostname:\"0\" port_map:<key:\"vt\" value:1 > keyspace:\"%v\" shard:\"0\" type:REPLICA ), error: err\ntarget: %v.1.replica, used tablet: (alias:<cell:\"aa\" > hostname:\"1\" port_map:<key:\"vt\" value:1 > keyspace:\"%v\" shard:\"1\" type:REPLICA ), tx_pool_full: err", name, name, name, name)
 	// We should only surface the higher priority error code
-	verifyScatterConnError(t, err, want, vtrpcpb.ErrorCode_BAD_INPUT)
+	verifyScatterConnError(t, err, want, vterrors.InvalidArgument)
 	// Ensure that we tried only once.
 	if execCount := sbc0.ExecCount.Get(); execCount != 1 {
 		t.Errorf("want 1, got %v", execCount)
@@ -282,7 +282,7 @@ func TestScatterConnError(t *testing.T) {
 	err := &ScatterConnError{
 		Retryable: false,
 		Errs: []error{
-			&gateway.ShardError{ErrorCode: vtrpcpb.ErrorCode_PERMISSION_DENIED, Err: &tabletconn.ServerError{Err: "tabletconn error"}},
+			&gateway.ShardError{ErrorCode: vterrors.PermissionDenied, Err: &tabletconn.ServerError{Err: "tabletconn error"}},
 			fmt.Errorf("generic error"),
 			tabletconn.ConnClosed,
 		},

--- a/go/vt/vtgate/topo_utils.go
+++ b/go/vt/vtgate/topo_utils.go
@@ -18,7 +18,6 @@ import (
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func mapKeyspaceIdsToShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, keyspace string, tabletType topodatapb.TabletType, keyspaceIds [][]byte) (string, []string, error) {
@@ -47,7 +46,7 @@ func getAnyShard(ctx context.Context, topoServ topo.SrvTopoServer, cell, keyspac
 		return "", "", err
 	}
 	if len(allShards) == 0 {
-		return "", "", vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT,
+		return "", "", vterrors.FromError(vterrors.InvalidArgument,
 			fmt.Errorf("No shards found for this tabletType"),
 		)
 	}
@@ -58,7 +57,7 @@ func getKeyspaceShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, k
 	srvKeyspace, err := topoServ.GetSrvKeyspace(ctx, cell, keyspace)
 	if err != nil {
 		return "", nil, nil, vterrors.NewVitessError(
-			vtrpcpb.ErrorCode_INTERNAL_ERROR, err,
+			vterrors.Internal, err,
 			"keyspace %v fetch error: %v", keyspace, err,
 		)
 	}
@@ -70,7 +69,7 @@ func getKeyspaceShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, k
 			srvKeyspace, err = topoServ.GetSrvKeyspace(ctx, cell, keyspace)
 			if err != nil {
 				return "", nil, nil, vterrors.NewVitessError(
-					vtrpcpb.ErrorCode_INTERNAL_ERROR, err,
+					vterrors.Internal, err,
 					"keyspace %v fetch error: %v", keyspace, err,
 				)
 			}
@@ -80,7 +79,7 @@ func getKeyspaceShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, k
 	partition := topoproto.SrvKeyspaceGetPartition(srvKeyspace, tabletType)
 	if partition == nil {
 		return "", nil, nil, vterrors.NewVitessError(
-			vtrpcpb.ErrorCode_INTERNAL_ERROR, err,
+			vterrors.Internal, err,
 			"No partition found for tabletType %v in keyspace %v", topoproto.TabletTypeLString(tabletType), keyspace,
 		)
 	}
@@ -89,7 +88,7 @@ func getKeyspaceShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, k
 
 func getShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []byte) (string, error) {
 	if len(allShards) == 0 {
-		return "", vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT,
+		return "", vterrors.FromError(vterrors.InvalidArgument,
 			fmt.Errorf("No shards found for this tabletType"),
 		)
 	}
@@ -99,7 +98,7 @@ func getShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []
 			return shardReference.Name, nil
 		}
 	}
-	return "", vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT,
+	return "", vterrors.FromError(vterrors.InvalidArgument,
 		fmt.Errorf("KeyspaceId %v didn't match any shards %+v", hex.EncodeToString(keyspaceID), allShards),
 	)
 }
@@ -179,7 +178,7 @@ func mapExactShards(ctx context.Context, topoServ topo.SrvTopoServer, cell, keys
 		}
 		shardnum++
 	}
-	return keyspace, nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT,
+	return keyspace, nil, vterrors.FromError(vterrors.InvalidArgument,
 		fmt.Errorf("keyrange %v does not exactly match shards", key.KeyRangeString(kr)),
 	)
 }

--- a/go/vt/vtgate/tx_conn.go
+++ b/go/vt/vtgate/tx_conn.go
@@ -20,7 +20,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 // TxConn is used for executing transactional requests.
@@ -37,10 +36,10 @@ func NewTxConn(gw gateway.Gateway) *TxConn {
 // is used to ensure atomicity.
 func (txc *TxConn) Commit(ctx context.Context, twopc bool, session *SafeSession) error {
 	if session == nil {
-		return vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, errors.New("cannot commit: empty session"))
+		return vterrors.FromError(vterrors.InvalidArgument, errors.New("cannot commit: empty session"))
 	}
 	if !session.InTransaction() {
-		return vterrors.FromError(vtrpcpb.ErrorCode_NOT_IN_TX, errors.New("cannot commit: not in transaction"))
+		return vterrors.FromError(vterrors.Aborted, errors.New("cannot commit: not in transaction"))
 	}
 	if twopc {
 		return txc.commit2PC(ctx, session)
@@ -155,7 +154,7 @@ func (txc *TxConn) Resolve(ctx context.Context, dtid string) error {
 		}
 	default:
 		// Should never happen.
-		return vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR, fmt.Errorf("invalid state: %v", transaction.State))
+		return vterrors.FromError(vterrors.Internal, fmt.Errorf("invalid state: %v", transaction.State))
 	}
 	return nil
 }

--- a/go/vt/vtgate/tx_conn_test.go
+++ b/go/vt/vtgate/tx_conn_test.go
@@ -18,15 +18,14 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func TestTxConnCommitRollbackIncorrectSession(t *testing.T) {
 	sc, _, _ := newTestTxConnEnv("TestTxConn")
 	// nil session
 	err := sc.txConn.Commit(context.Background(), false, nil)
-	if got := vterrors.RecoverVtErrorCode(err); got != vtrpcpb.ErrorCode_BAD_INPUT {
-		t.Errorf("Commit: %v, want %v", got, vtrpcpb.ErrorCode_BAD_INPUT)
+	if got := vterrors.RecoverVtErrorCode(err); got != vterrors.InvalidArgument {
+		t.Errorf("Commit: %v, want %v", got, vterrors.InvalidArgument)
 	}
 
 	err = sc.txConn.Rollback(context.Background(), nil)
@@ -37,8 +36,8 @@ func TestTxConnCommitRollbackIncorrectSession(t *testing.T) {
 	// not in transaction
 	session := NewSafeSession(&vtgatepb.Session{})
 	err = sc.txConn.Commit(context.Background(), false, session)
-	if got := vterrors.RecoverVtErrorCode(err); got != vtrpcpb.ErrorCode_NOT_IN_TX {
-		t.Errorf("Commit: %v, want %v", got, vtrpcpb.ErrorCode_NOT_IN_TX)
+	if got := vterrors.RecoverVtErrorCode(err); got != vterrors.Aborted {
+		t.Errorf("Commit: %v, want %v", got, vterrors.Aborted)
 	}
 }
 
@@ -592,7 +591,7 @@ func TestTxConnMultiGoSessions(t *testing.T) {
 		},
 	}}
 	err := txc.runSessions(input, func(s *vtgatepb.Session_ShardSession) error {
-		return vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR, fmt.Errorf("err %s", s.Target.Keyspace))
+		return vterrors.FromError(vterrors.Internal, fmt.Errorf("err %s", s.Target.Keyspace))
 	})
 	want := "err 0"
 	if err == nil || err.Error() != want {
@@ -609,14 +608,14 @@ func TestTxConnMultiGoSessions(t *testing.T) {
 		},
 	}}
 	err = txc.runSessions(input, func(s *vtgatepb.Session_ShardSession) error {
-		return vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR, fmt.Errorf("err %s", s.Target.Keyspace))
+		return vterrors.FromError(vterrors.Internal, fmt.Errorf("err %s", s.Target.Keyspace))
 	})
 	want = "err 0\nerr 1"
 	if err == nil || err.Error() != want {
 		t.Errorf("runSessions(2): %v, want %s", err, want)
 	}
 	errCode := err.(*ScatterConnError).VtErrorCode()
-	wantCode := vtrpcpb.ErrorCode_INTERNAL_ERROR
+	wantCode := vterrors.Internal
 	if errCode != wantCode {
 		t.Errorf("Error code: %v, want %v", errCode, wantCode)
 	}
@@ -635,7 +634,7 @@ func TestTxConnMultiGoTargets(t *testing.T) {
 		Keyspace: "0",
 	}}
 	err := txc.runTargets(input, func(t *querypb.Target) error {
-		return vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR, fmt.Errorf("err %s", t.Keyspace))
+		return vterrors.FromError(vterrors.Internal, fmt.Errorf("err %s", t.Keyspace))
 	})
 	want := "err 0"
 	if err == nil || err.Error() != want {
@@ -648,14 +647,14 @@ func TestTxConnMultiGoTargets(t *testing.T) {
 		Keyspace: "1",
 	}}
 	err = txc.runTargets(input, func(t *querypb.Target) error {
-		return vterrors.FromError(vtrpcpb.ErrorCode_INTERNAL_ERROR, fmt.Errorf("err %s", t.Keyspace))
+		return vterrors.FromError(vterrors.Internal, fmt.Errorf("err %s", t.Keyspace))
 	})
 	want = "err 0\nerr 1"
 	if err == nil || err.Error() != want {
 		t.Errorf("runTargets(2): %v, want %s", err, want)
 	}
 	errCode := err.(*ScatterConnError).VtErrorCode()
-	wantCode := vtrpcpb.ErrorCode_INTERNAL_ERROR
+	wantCode := vterrors.Internal
 	if errCode != wantCode {
 		t.Errorf("Error code: %v, want %v", errCode, wantCode)
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -38,7 +38,6 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -631,7 +630,7 @@ func (vtg *VTGate) StreamExecuteShards(ctx context.Context, sql string, bindVari
 // Begin begins a transaction. It has to be concluded by a Commit or Rollback.
 func (vtg *VTGate) Begin(ctx context.Context, singledb bool) (*vtgatepb.Session, error) {
 	if !singledb && vtg.transactionMode == TxSingle {
-		return nil, vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, errors.New("multi-db transaction disallowed"))
+		return nil, vterrors.FromError(vterrors.InvalidArgument, errors.New("multi-db transaction disallowed"))
 	}
 	return &vtgatepb.Session{
 		InTransaction: true,
@@ -644,7 +643,7 @@ func (vtg *VTGate) Commit(ctx context.Context, twopc bool, session *vtgatepb.Ses
 	if twopc && vtg.transactionMode != TxTwoPC {
 		// Rollback the transaction to prevent future deadlocks.
 		vtg.txConn.Rollback(ctx, NewSafeSession(session))
-		return vterrors.FromError(vtrpcpb.ErrorCode_BAD_INPUT, errors.New("2pc transaction disallowed"))
+		return vterrors.FromError(vterrors.InvalidArgument, errors.New("2pc transaction disallowed"))
 	}
 	return formatError(vtg.txConn.Commit(ctx, twopc, NewSafeSession(session)))
 }
@@ -955,16 +954,16 @@ func handleExecuteError(err error, statsKey []string, query map[string]interface
 	// First we log in the right category.
 	ec := vterrors.RecoverVtErrorCode(err)
 	switch ec {
-	case vtrpcpb.ErrorCode_INTEGRITY_ERROR:
+	case vterrors.AlreadyExists:
 		// Duplicate key error, no need to log.
 		infoErrors.Add("DupKey", 1)
-	case vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED, vtrpcpb.ErrorCode_BAD_INPUT:
+	case vterrors.ResourceExhausted, vterrors.InvalidArgument:
 		// Tx pool full error, or bad input, no need to log.
 		normalErrors.Add(statsKey, 1)
-	case vtrpcpb.ErrorCode_PERMISSION_DENIED:
+	case vterrors.PermissionDenied:
 		// User violated permissions (TableACL), no need to log.
 		infoErrors.Add("PermissionDenied", 1)
-	case vtrpcpb.ErrorCode_TRANSIENT_ERROR:
+	case vterrors.Unavailable:
 		// Temporary error which should be retried by user. Do not log.
 		// As of 01/2017, only the vttablet transaction throttler and the vtgate
 		// master buffer (if buffer full) return this error.

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -1193,7 +1193,7 @@ func TestVTGateSplitQueryUnsharded(t *testing.T) {
 func TestIsErrorCausedByVTGate(t *testing.T) {
 	unknownError := fmt.Errorf("unknown error")
 	serverError := &tabletconn.ServerError{
-		ServerCode: vtrpcpb.ErrorCode_QUERY_NOT_SERVED,
+		ServerCode: vterrors.FailedPrecondition,
 		Err:        "vttablet: retry: error message",
 	}
 	shardConnUnknownErr := &gateway.ShardError{Err: unknownError}
@@ -1988,84 +1988,84 @@ func TestErrorPropagation(t *testing.T) {
 		sbc.MustFailCanceled = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailCanceled = 0
-	}, vtrpcpb.ErrorCode_CANCELLED)
+	}, vterrors.Canceled)
 
 	// ErrorCode_UNKNOWN_ERROR
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailUnknownError = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailUnknownError = 0
-	}, vtrpcpb.ErrorCode_UNKNOWN_ERROR)
+	}, vterrors.Unknown)
 
 	// ErrorCode_BAD_INPUT
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailServer = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailServer = 0
-	}, vtrpcpb.ErrorCode_BAD_INPUT)
+	}, vterrors.InvalidArgument)
 
 	// ErrorCode_DEADLINE_EXCEEDED
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailDeadlineExceeded = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailDeadlineExceeded = 0
-	}, vtrpcpb.ErrorCode_DEADLINE_EXCEEDED)
+	}, vterrors.DeadlineExceeded)
 
 	// ErrorCode_INTEGRITY_ERROR
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailIntegrityError = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailIntegrityError = 0
-	}, vtrpcpb.ErrorCode_INTEGRITY_ERROR)
+	}, vterrors.AlreadyExists)
 
 	// ErrorCode_PERMISSION_DENIED
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailPermissionDenied = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailPermissionDenied = 0
-	}, vtrpcpb.ErrorCode_PERMISSION_DENIED)
+	}, vterrors.PermissionDenied)
 
 	// ErrorCode_RESOURCE_EXHAUSTED
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailTxPool = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailTxPool = 0
-	}, vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED)
+	}, vterrors.ResourceExhausted)
 
 	// ErrorCode_QUERY_NOT_SERVED
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailRetry = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailRetry = 0
-	}, vtrpcpb.ErrorCode_QUERY_NOT_SERVED)
+	}, vterrors.FailedPrecondition)
 
 	// ErrorCode_NOT_IN_TX
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailNotTx = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailNotTx = 0
-	}, vtrpcpb.ErrorCode_NOT_IN_TX)
+	}, vterrors.Aborted)
 
 	// ErrorCode_INTERNAL_ERROR
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailFatal = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailFatal = 0
-	}, vtrpcpb.ErrorCode_INTERNAL_ERROR)
+	}, vterrors.Internal)
 
 	// ErrorCode_TRANSIENT_ERROR
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailTransientError = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailTransientError = 0
-	}, vtrpcpb.ErrorCode_TRANSIENT_ERROR)
+	}, vterrors.Unavailable)
 
 	// ErrorCode_UNAUTHENTICATED
 	testErrorPropagation(t, sbcs, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailUnauthenticated = 20
 	}, func(sbc *sandboxconn.SandboxConn) {
 		sbc.MustFailUnauthenticated = 0
-	}, vtrpcpb.ErrorCode_UNAUTHENTICATED)
+	}, vterrors.Unauthenticated)
 }
 
 // This test makes sure that if we start a transaction and hit a critical
@@ -2077,7 +2077,7 @@ func TestErrorIssuesRollback(t *testing.T) {
 
 	// Start a transaction, send one statement.
 	// Simulate an error that should trigger a rollback:
-	// vtrpcpb.ErrorCode_NOT_IN_TX case.
+	// vterrors.Aborted case.
 	session, err := rpcVTGate.Begin(context.Background(), false)
 	if err != nil {
 		t.Fatalf("cannot start a transaction: %v", err)
@@ -2116,7 +2116,7 @@ func TestErrorIssuesRollback(t *testing.T) {
 
 	// Start a transaction, send one statement.
 	// Simulate an error that should trigger a rollback:
-	// vtrpcpb.ErrorCode_RESOURCE_EXHAUSTED case.
+	// vterrors.ResourceExhausted case.
 	session, err = rpcVTGate.Begin(context.Background(), false)
 	if err != nil {
 		t.Fatalf("cannot start a transaction: %v", err)
@@ -2155,7 +2155,7 @@ func TestErrorIssuesRollback(t *testing.T) {
 
 	// Start a transaction, send one statement.
 	// Simulate an error that should *not* trigger a rollback:
-	// vtrpcpb.ErrorCode_INTEGRITY_ERROR case.
+	// vterrors.AlreadyExists case.
 	session, err = rpcVTGate.Begin(context.Background(), false)
 	if err != nil {
 		t.Fatalf("cannot start a transaction: %v", err)

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -42,7 +42,7 @@ type fakeVTGateService struct {
 }
 
 const expectedErrMatch string = "test vtgate error"
-const expectedCode vtrpcpb.ErrorCode = vtrpcpb.ErrorCode_BAD_INPUT
+const expectedCode vtrpcpb.ErrorCode = vterrors.InvalidArgument
 
 var errTestVtGateError = vterrors.FromError(expectedCode, errors.New(expectedErrMatch))
 

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -18,7 +18,6 @@ import (
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 
 	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	vtworkerdatapb "github.com/youtube/vitess/go/vt/proto/vtworkerdata"
 	vtworkerservicepb "github.com/youtube/vitess/go/vt/proto/vtworkerservice"
 )
@@ -43,7 +42,7 @@ func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworker
 	}
 	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
 	if err != nil {
-		return nil, vterrors.NewVitessError(vtrpcpb.ErrorCode_DEADLINE_EXCEEDED, err, "grpc.Dial() err: %v", err)
+		return nil, vterrors.NewVitessError(vterrors.DeadlineExceeded, err, "grpc.Dial() err: %v", err)
 	}
 	c := vtworkerservicepb.NewVtworkerClient(cc)
 


### PR DESCRIPTION
Surprisingly, this actually builds, and even the tests pass.
The code base references only vterrors.CanonicalError. The
only reference to vtrpcpb.ErrorCode_* is in vterrors where
the synonyms are defined.

For fun, I went with the orginal gRPC names, but this may look
better with the names from vtrpcpb. At least, one may not
accidentally think that these enums are the same values as
those in gRPC.

Looking at this again, I'm not that negative about those
weird proto names. My highly disturbed state has degraded
into a mild dislike. But there may still be value in the
fact that vterrors dictates the vitess error codes.