### PR TITLE
Add a couple mysqlctld config options

### DIFF
--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -47,6 +47,11 @@ type Mycnf struct {
 	// (used by vt software to check server is running)
 	SocketFile string
 
+	// GeneralLogPath is the path to store general logs at,
+	// if general-log is enabled.
+	// (unused by vt software for now)
+	GeneralLogPath string
+
 	// ErrorLogPath is the path to store error logs at.
 	// (unused by vt software for now)
 	ErrorLogPath string
@@ -91,9 +96,13 @@ type Mycnf struct {
 	path     string // the actual path that represents this mycnf
 }
 
-func (cnf *Mycnf) lookupAndCheck(key string) string {
+func (cnf *Mycnf) lookup(key string) string {
 	key = normKey([]byte(key))
-	val := cnf.mycnfMap[key]
+	return cnf.mycnfMap[key]
+}
+
+func (cnf *Mycnf) lookupAndCheck(key string) string {
+	val := cnf.lookup(key)
 	if val == "" {
 		panic(fmt.Errorf("Value for key '%v' not set", key))
 	}
@@ -158,11 +167,13 @@ func ReadMycnf(cnfFile string) (mycnf *Mycnf, err error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed: failed to convert port %v", err)
 	}
+
 	mycnf.MysqlPort = int32(port)
 	mycnf.DataDir = mycnf.lookupAndCheck("datadir")
 	mycnf.InnodbDataHomeDir = mycnf.lookupAndCheck("innodb_data_home_dir")
 	mycnf.InnodbLogGroupHomeDir = mycnf.lookupAndCheck("innodb_log_group_home_dir")
 	mycnf.SocketFile = mycnf.lookupAndCheck("socket")
+	mycnf.GeneralLogPath = mycnf.lookup("general_log_file")
 	mycnf.ErrorLogPath = mycnf.lookupAndCheck("log-error")
 	mycnf.SlowLogPath = mycnf.lookupAndCheck("slow-query-log-file")
 	mycnf.RelayLogPath = mycnf.lookupAndCheck("relay-log")

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -22,6 +22,7 @@ var (
 	flagInnodbDataHomeDir     *string
 	flagInnodbLogGroupHomeDir *string
 	flagSocketFile            *string
+	flagGeneralLogPath        *string
 	flagErrorLogPath          *string
 	flagSlowLogPath           *string
 	flagRelayLogPath          *string
@@ -47,6 +48,7 @@ func RegisterFlags() {
 	flagInnodbDataHomeDir = flag.String("mycnf_innodb_data_home_dir", "", "Innodb data home directory")
 	flagInnodbLogGroupHomeDir = flag.String("mycnf_innodb_log_group_home_dir", "", "Innodb log group home directory")
 	flagSocketFile = flag.String("mycnf_socket_file", "", "mysql socket file")
+	flagGeneralLogPath = flag.String("mycnf_general_log_path", "", "mysql general log path")
 	flagErrorLogPath = flag.String("mycnf_error_log_path", "", "mysql error log path")
 	flagSlowLogPath = flag.String("mycnf_slow_log_path", "", "mysql slow query log path")
 	flagRelayLogPath = flag.String("mycnf_relay_log_path", "", "mysql relay log path")
@@ -85,6 +87,7 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 			InnodbDataHomeDir:     *flagInnodbDataHomeDir,
 			InnodbLogGroupHomeDir: *flagInnodbLogGroupHomeDir,
 			SocketFile:            *flagSocketFile,
+			GeneralLogPath:        *flagGeneralLogPath,
 			ErrorLogPath:          *flagErrorLogPath,
 			SlowLogPath:           *flagSlowLogPath,
 			RelayLogPath:          *flagRelayLogPath,

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -55,6 +55,7 @@ func NewMycnf(tabletUID uint32, mysqlPort int32) *Mycnf {
 	cnf.InnodbDataHomeDir = path.Join(tabletDir, innodbDataSubdir)
 	cnf.InnodbLogGroupHomeDir = path.Join(tabletDir, innodbLogSubdir)
 	cnf.SocketFile = path.Join(tabletDir, "mysql.sock")
+	cnf.GeneralLogPath = path.Join(tabletDir, "general.log")
 	cnf.ErrorLogPath = path.Join(tabletDir, "error.log")
 	cnf.SlowLogPath = path.Join(tabletDir, "slow-query.log")
 	cnf.RelayLogPath = path.Join(tabletDir, relayLogDir,


### PR DESCRIPTION
Added a GeneralLogPath property which can be used in making a my.cnf. I did not add it to the templates because it's optional and not read unless `--general-log` is enabled. I could add it if we want.

I added this because the path should be relative to the TabletDir, like the other paths (error.log, etc), and it's hard to have access to that path pre-mysqlctld configuration. So I can't really hard code into my template or `EXTRA_MY_CNF`. This way I can include `general_log_file = {{.GeneralLogPath}}` in my my.cnf template, and `makeMycnf` will fill it out