### PR TITLE
Update zksrv.sh

### DIFF
--- a/go/zk/zkctl/zksrv.sh
+++ b/go/zk/zkctl/zksrv.sh
@@ -23,7 +23,7 @@ log() {
   return 0
 }
 
-for java in /usr/local/bin/java /usr/bin/java; do
+for java in /usr/local/bin/java /usr/bin/java $JAVA_HOME/bin/java; do
   if [ -x "$java" ]; then
     break
   fi


### PR DESCRIPTION
fix the error : no java binary found
If I installed the java without yum or apt-get, but by setting the environment variable JAVA_HOME and PATH,the script with rise error :no java binary found

So we should consider the java binary installed manuelly