### PR TITLE
make bootstrap work on machines where python is python3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -235,7 +235,7 @@ else
   cd $VTTOP/third_party/py && \
     tar -xzf mock-1.0.1.tar.gz && \
     cd mock-1.0.1 && \
-    python ./setup.py install --prefix=$mock_dist && \
+    python2 ./setup.py install --prefix=$mock_dist && \
     touch $mock_dist/.build_finished && \
     cd .. && \
     rm -r mock-1.0.1
@@ -253,8 +253,8 @@ ln -sf $VTTOP/misc/git/commit-msg.bugnumber $VTTOP/.git/hooks/commit-msg
 echo "Installing selenium and chromedriver"
 selenium_dist=$VTROOT/dist/selenium
 mkdir -p $selenium_dist
-virtualenv $selenium_dist
-$selenium_dist/bin/pip install selenium
+virtualenv2 $selenium_dist
+$selenium_dist/bin/pip2 install selenium
 mkdir -p $VTROOT/dist/chromedriver
 curl -sL http://chromedriver.storage.googleapis.com/2.25/chromedriver_linux64.zip > chromedriver_linux64.zip
 unzip -o -q chromedriver_linux64.zip -d $VTROOT/dist/chromedriver

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -235,7 +235,7 @@ else
   cd $VTTOP/third_party/py && \
     tar -xzf mock-1.0.1.tar.gz && \
     cd mock-1.0.1 && \
-    python2 ./setup.py install --prefix=$mock_dist && \
+    $PYTHON ./setup.py install --prefix=$mock_dist && \
     touch $mock_dist/.build_finished && \
     cd .. && \
     rm -r mock-1.0.1
@@ -253,8 +253,8 @@ ln -sf $VTTOP/misc/git/commit-msg.bugnumber $VTTOP/.git/hooks/commit-msg
 echo "Installing selenium and chromedriver"
 selenium_dist=$VTROOT/dist/selenium
 mkdir -p $selenium_dist
-virtualenv2 $selenium_dist
-$selenium_dist/bin/pip2 install selenium
+$VIRTUALENV $selenium_dist
+$selenium_dist/bin/$PIP install selenium
 mkdir -p $VTROOT/dist/chromedriver
 curl -sL http://chromedriver.storage.googleapis.com/2.25/chromedriver_linux64.zip > chromedriver_linux64.zip
 unzip -o -q chromedriver_linux64.zip -d $VTROOT/dist/chromedriver

--- a/dev.env
+++ b/dev.env
@@ -35,6 +35,7 @@ export PYTHONPATH=$(prepend_path $PYTHONPATH $VTROOT/py-vtdb)
 export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test)
 export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test/cluster/sandbox)
 
+# Ensure we bootstrap and install_grpc use python2 on systems which default to python3
 command -v python2 >/dev/null 2>&1 && PYTHON=python2 || PYTHON=python
 export PYTHON
 command -v pip2 >/dev/null 2>&1 && PIP=pip2 || PIP=pip

--- a/dev.env
+++ b/dev.env
@@ -35,6 +35,13 @@ export PYTHONPATH=$(prepend_path $PYTHONPATH $VTROOT/py-vtdb)
 export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test)
 export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test/cluster/sandbox)
 
+command -v python2 >/dev/null 2>&1 && PYTHON=python2 || PYTHON=python
+export PYTHON
+command -v pip2 >/dev/null 2>&1 && PIP=pip2 || PIP=pip
+export PIP
+command -v virtualenv2 >/dev/null 2>&1 && VIRTUALENV=virtualenv2 || VIRTUALENV=virtualenv
+export VIRTUALENV
+
 selenium_dist=$VTROOT/dist/selenium
 export PYTHONPATH=$(prepend_path $PYTHONPATH $selenium_dist)
 

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -28,14 +28,14 @@ fi
 if [ -n "$grpc_dist" ]; then
   # Create a virtualenv, which also creates a virualenv-boxed pip.
   # Update both pip and virtualenv.
-  virtualenv $grpc_dist/usr/local
-  $grpc_dist/usr/local/bin/pip install --upgrade pip
-  $grpc_dist/usr/local/bin/pip install --upgrade --ignore-installed virtualenv
+  virtualenv2 -v $grpc_dist/usr/local
+  $grpc_dist/usr/local/bin/pip2 install --upgrade pip
+  $grpc_dist/usr/local/bin/pip2 install --upgrade --ignore-installed virtualenv
 else
-  pip install --upgrade pip
+  pip2 install --upgrade pip
   # System wide installations require an explicit upgrade of
   # certain gRPC Python dependencies e.g. "six" on Debian Jessie.
-  pip install --upgrade --ignore-installed six
+  pip2 install --upgrade --ignore-installed six
 fi
 
 # clone the repository, setup the submodules
@@ -47,7 +47,7 @@ git submodule update --init
 # OSX specific setting + dependencies
 if [ `uname -s` == "Darwin" ]; then
   export GRPC_PYTHON_BUILD_WITH_CYTHON=1
-  $grpc_dist/usr/local/bin/pip install Cython
+  $grpc_dist/usr/local/bin/pip2 install Cython
 
   # Work-around macOS Sierra blocker, see: https://github.com/youtube/vitess/issues/2115
   # TODO(mberlin): Remove this when the underlying issue is fixed and available
@@ -83,9 +83,9 @@ fi
 # Dependencies like protobuf python will be installed automatically.
 grpcio_ver=1.0.4
 if [ -n "$grpc_dist" ]; then
-  $grpc_dist/usr/local/bin/pip install --upgrade grpcio==$grpcio_ver
+  $grpc_dist/usr/local/bin/pip2 install --upgrade grpcio==$grpcio_ver
 else
-  pip install --upgrade grpcio==$grpcio_ver
+  pip2 install --upgrade grpcio==$grpcio_ver
 fi
 
 # Build PHP extension, only if requested.

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -28,14 +28,14 @@ fi
 if [ -n "$grpc_dist" ]; then
   # Create a virtualenv, which also creates a virualenv-boxed pip.
   # Update both pip and virtualenv.
-  virtualenv2 -v $grpc_dist/usr/local
-  $grpc_dist/usr/local/bin/pip2 install --upgrade pip
-  $grpc_dist/usr/local/bin/pip2 install --upgrade --ignore-installed virtualenv
+  $VIRTUALENV -v $grpc_dist/usr/local
+  $grpc_dist/usr/local/bin/$PIP install --upgrade pip
+  $grpc_dist/usr/local/bin/$PIP install --upgrade --ignore-installed virtualenv
 else
-  pip2 install --upgrade pip
+  $PIP install --upgrade pip
   # System wide installations require an explicit upgrade of
   # certain gRPC Python dependencies e.g. "six" on Debian Jessie.
-  pip2 install --upgrade --ignore-installed six
+  $PIP install --upgrade --ignore-installed six
 fi
 
 # clone the repository, setup the submodules
@@ -47,7 +47,7 @@ git submodule update --init
 # OSX specific setting + dependencies
 if [ `uname -s` == "Darwin" ]; then
   export GRPC_PYTHON_BUILD_WITH_CYTHON=1
-  $grpc_dist/usr/local/bin/pip2 install Cython
+  $grpc_dist/usr/local/bin/$PIP install Cython
 
   # Work-around macOS Sierra blocker, see: https://github.com/youtube/vitess/issues/2115
   # TODO(mberlin): Remove this when the underlying issue is fixed and available
@@ -83,9 +83,9 @@ fi
 # Dependencies like protobuf python will be installed automatically.
 grpcio_ver=1.0.4
 if [ -n "$grpc_dist" ]; then
-  $grpc_dist/usr/local/bin/pip2 install --upgrade grpcio==$grpcio_ver
+  $grpc_dist/usr/local/bin/$PIP install --upgrade grpcio==$grpcio_ver
 else
-  pip2 install --upgrade grpcio==$grpcio_ver
+  $PIP install --upgrade grpcio==$grpcio_ver
 fi
 
 # Build PHP extension, only if requested.


### PR DESCRIPTION
when i was getting started this really tripped me up a bunch.
i'm on arch linux, which might not be a big deal. but freebsd also has python3 as default.

we can debate this. i don't feel super strongly about it, just wanted to get it out there.