### PR TITLE
Adds decoding of strings and string-like blobs based on the charset returned by MySQL

### DIFF
--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -112,15 +112,19 @@ public class ConnectionProperties {
             }
         }
         postInitialization();
+        checkConfiguredEncodingSupport();
     }
 
-    private void postInitialization() throws SQLException {
+    private void postInitialization() {
         this.tabletTypeCache = this.tabletType.getValueAsEnum();
         this.includedFieldsCache = this.includedFields.getValueAsEnum();
         this.includeAllFieldsCache = this.includedFieldsCache == Query.ExecuteOptions.IncludedFields.ALL;
         this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
         this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
         this.characterEncodingAsString = this.characterEncoding.getValueAsString();
+    }
+
+    private void checkConfiguredEncodingSupport() throws SQLException {
         if (characterEncodingAsString != null) {
             // Attempt to use the encoding, and bail out if it can't be used
             try {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -124,9 +124,12 @@ public class ConnectionProperties {
         this.characterEncodingAsString = this.characterEncoding.getValueAsString();
     }
 
+    /**
+     * Attempt to use the encoding, and bail out if it can't be used
+     * @throws SQLException if exception occurs while attempting to use the encoding
+     */
     private void checkConfiguredEncodingSupport() throws SQLException {
         if (characterEncodingAsString != null) {
-            // Attempt to use the encoding, and bail out if it can't be used
             try {
                 String testString = "abc";
                 StringUtils.getBytes(testString, characterEncodingAsString);
@@ -140,7 +143,7 @@ public class ConnectionProperties {
         return new ConnectionProperties().exposeAsDriverPropertyInfoInternal(info, slotsToReserve);
     }
 
-    protected DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
+    private DriverPropertyInfo[] exposeAsDriverPropertyInfoInternal(Properties info, int slotsToReserve) throws SQLException {
         initializeProperties(info);
         int numProperties = PROPERTY_LIST.size();
         int listSize = numProperties + slotsToReserve;

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/ConnectionProperties.java
@@ -1,9 +1,11 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.StringUtils;
 import com.youtube.vitess.proto.Query;
 import com.youtube.vitess.proto.Topodata;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
@@ -30,6 +32,16 @@ public class ConnectionProperties {
         }
     }
 
+    // Configs for handling deserialization of blobs
+    private BooleanConnectionProperty blobsAreStrings = new BooleanConnectionProperty(
+        "blobsAreStrings",
+        "Should the driver always treat BLOBs as Strings - specifically to work around dubious metadata returned by the server for GROUP BY clauses?",
+        false);
+    private BooleanConnectionProperty functionsNeverReturnBlobs = new BooleanConnectionProperty(
+        "functionsNeverReturnBlobs",
+        "Should the driver always treat data from functions returning BLOBs as Strings - specifically to work around dubious metadata returned by the server for GROUP BY clauses?",
+        false);
+
     // Configs for handing tinyint(1)
     private BooleanConnectionProperty tinyInt1isBit = new BooleanConnectionProperty(
         "tinyInt1isBit",
@@ -39,6 +51,29 @@ public class ConnectionProperties {
         "yearIsDateType",
         "Should the JDBC driver treat the MySQL type \"YEAR\" as a java.sql.Date, or as a SHORT?",
         true);
+
+    // Configs for handling irregular blobs, those with characters outside the typical 4-byte encodings
+    private BooleanConnectionProperty useBlobToStoreUTF8OutsideBMP = new BooleanConnectionProperty(
+        "useBlobToStoreUTF8OutsideBMP",
+        "Tells the driver to treat [MEDIUM/LONG]BLOB columns as [LONG]VARCHAR columns holding text encoded in UTF-8 that has characters outside the BMP (4-byte encodings), which MySQL server can't handle natively.",
+        false);
+    private StringConnectionProperty utf8OutsideBmpIncludedColumnNamePattern = new StringConnectionProperty(
+        "utf8OutsideBmpIncludedColumnNamePattern",
+        "Used to specify exclusion rules to \"utf8OutsideBmpExcludedColumnNamePattern\". The regex must follow the patterns used for the java.util.regex package.",
+        null,
+        null);
+    private StringConnectionProperty utf8OutsideBmpExcludedColumnNamePattern = new StringConnectionProperty(
+        "utf8OutsideBmpExcludedColumnNamePattern",
+        "When \"useBlobToStoreUTF8OutsideBMP\" is set to \"true\", column names matching the given regex will still be treated as BLOBs unless they match the regex specified for \"utf8OutsideBmpIncludedColumnNamePattern\". The regex must follow the patterns used for the java.util.regex package.",
+        null,
+        null);
+
+    // Default encodings, for when one cannot be determined from field metadata
+    private StringConnectionProperty characterEncoding = new StringConnectionProperty(
+        "characterEncoding",
+        "If a character encoding cannot be detected, which fallback should be used when dealing with strings? (defaults is to 'autodetect')",
+        null,
+        null);
 
     // Vitess-specific configs
     private EnumConnectionProperty<Constants.QueryExecuteType> executeType = new EnumConnectionProperty<>(
@@ -64,6 +99,7 @@ public class ConnectionProperties {
     private boolean includeAllFieldsCache = true;
     private boolean twopcEnabledCache = false;
     private boolean simpleExecuteTypeCache = true;
+    private String characterEncodingAsString = null;
 
     void initializeProperties(Properties props) throws SQLException {
         Properties propsCopy = (Properties) props.clone();
@@ -84,6 +120,16 @@ public class ConnectionProperties {
         this.includeAllFieldsCache = this.includedFieldsCache == Query.ExecuteOptions.IncludedFields.ALL;
         this.twopcEnabledCache = this.twopcEnabled.getValueAsBoolean();
         this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
+        this.characterEncodingAsString = this.characterEncoding.getValueAsString();
+        if (characterEncodingAsString != null) {
+            // Attempt to use the encoding, and bail out if it can't be used
+            try {
+                String testString = "abc";
+                StringUtils.getBytes(testString, characterEncodingAsString);
+            } catch (UnsupportedEncodingException UE) {
+                throw new SQLException("Unsupported character encoding: " + characterEncodingAsString);
+            }
+        }
     }
 
     static DriverPropertyInfo[] exposeAsDriverPropertyInfo(Properties info, int slotsToReserve) throws SQLException {
@@ -111,6 +157,22 @@ public class ConnectionProperties {
         return driverProperties;
     }
 
+    public boolean getBlobsAreStrings() {
+        return blobsAreStrings.getValueAsBoolean();
+    }
+
+    public void setBlobsAreStrings(boolean blobsAreStrings) {
+        this.blobsAreStrings.setValue(blobsAreStrings);
+    }
+
+    public boolean getUseBlobToStoreUTF8OutsideBMP() {
+        return useBlobToStoreUTF8OutsideBMP.getValueAsBoolean();
+    }
+
+    public void setUseBlobToStoreUTF8OutsideBMP(boolean useBlobToStoreUTF8OutsideBMP) {
+        this.useBlobToStoreUTF8OutsideBMP.setValue(useBlobToStoreUTF8OutsideBMP);
+    }
+
     public boolean getTinyInt1isBit() {
         return tinyInt1isBit.getValueAsBoolean();
     }
@@ -119,12 +181,45 @@ public class ConnectionProperties {
         this.tinyInt1isBit.setValue(tinyInt1isBit);
     }
 
+    public boolean getFunctionsNeverReturnBlobs() {
+        return functionsNeverReturnBlobs.getValueAsBoolean();
+    }
+
+    public void setFunctionsNeverReturnBlobs(boolean functionsNeverReturnBlobs) {
+        this.functionsNeverReturnBlobs.setValue(functionsNeverReturnBlobs);
+    }
+
+    public String getUtf8OutsideBmpIncludedColumnNamePattern() {
+        return utf8OutsideBmpIncludedColumnNamePattern.getValueAsString();
+    }
+
+    public void setUtf8OutsideBmpIncludedColumnNamePattern(String pattern) {
+        this.utf8OutsideBmpIncludedColumnNamePattern.setValue(pattern);
+    }
+
+    public String getUtf8OutsideBmpExcludedColumnNamePattern() {
+        return utf8OutsideBmpExcludedColumnNamePattern.getValueAsString();
+    }
+
+    public void setUtf8OutsideBmpExcludedColumnNamePattern(String pattern) {
+        this.utf8OutsideBmpExcludedColumnNamePattern.setValue(pattern);
+    }
+
     public boolean getYearIsDateType() {
         return yearIsDateType.getValueAsBoolean();
     }
 
     public void setYearIsDateType(boolean yearIsDateType) {
         this.yearIsDateType.setValue(yearIsDateType);
+    }
+
+    public String getEncoding() {
+        return characterEncodingAsString;
+    }
+
+    public void setEncoding(String encoding) {
+        this.characterEncoding.setValue(encoding);
+        this.characterEncodingAsString = this.characterEncoding.getValueAsString();
     }
 
     public Query.ExecuteOptions.IncludedFields getIncludedFields() {
@@ -265,6 +360,10 @@ public class ConnectionProperties {
             } else {
                 this.valueAsObject = this.defaultValue;
             }
+        }
+
+        public String getValueAsString() {
+            return (String) valueAsObject;
         }
 
         @Override

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/FieldWithMetadata.java
@@ -422,7 +422,7 @@ public class FieldWithMetadata {
         return javaType;
     }
 
-    public Query.Type getVitessType() {
+    private Query.Type getVitessType() {
         return vitessType;
     }
 
@@ -430,7 +430,7 @@ public class FieldWithMetadata {
         return field.getTypeValue();
     }
 
-    public boolean isImplicitTemporaryTable() {
+    boolean isImplicitTemporaryTable() {
         if (!connection.isIncludeAllFields()) {
             return false;
         }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -844,7 +844,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         return this.vitessJDBCUrl.getUsername();
     }
 
-    public String getEncodingForIndex(int charsetIndex) throws SQLException {
+    public String getEncodingForIndex(int charsetIndex) {
         String javaEncoding = null;
         if (charsetIndex != MysqlDefs.NO_CHARSET_INFO) {
             javaEncoding = CharsetMapping.getJavaEncodingForCollationIndex(charsetIndex, getEncoding());

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -3,6 +3,7 @@ package com.flipkart.vitess.jdbc;
 import com.flipkart.vitess.util.CommonUtils;
 import com.flipkart.vitess.util.Constants;
 import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
@@ -841,5 +842,28 @@ public class VitessConnection extends ConnectionProperties implements Connection
 
     public String getUsername() {
         return this.vitessJDBCUrl.getUsername();
+    }
+
+    public String getEncodingForIndex(int charsetIndex) throws SQLException {
+        String javaEncoding = null;
+        if (charsetIndex != MysqlDefs.NO_CHARSET_INFO) {
+            javaEncoding = CharsetMapping.getJavaEncodingForCollationIndex(charsetIndex, getEncoding());
+        }
+        // If nothing, get default based on configuration, may still be null
+        if (javaEncoding == null) {
+            javaEncoding = getEncoding();
+        }
+        return javaEncoding;
+    }
+
+    public int getMaxBytesPerChar(Integer charsetIndex, String javaCharsetName) {
+        // if we can get it by charsetIndex just doing it
+        String charset = CharsetMapping.getMysqlCharsetNameForCollationIndex(charsetIndex);
+        // if we didn't find charset name by its full name
+        if (charset == null) {
+            charset = CharsetMapping.getMysqlCharsetForJavaEncoding(javaCharsetName);
+        }
+        // checking against static maps
+        return CharsetMapping.getMblen(charset);
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -757,8 +757,6 @@ public class VitessResultSet implements ResultSet {
             throw new SQLException(Constants.SQLExceptionMessages.CLOSED_RESULT_SET);
     }
 
-    //Unsupported Methods
-
     private void preAccessor(int columnIndex) throws SQLException {
         checkOpen();
 
@@ -774,6 +772,8 @@ public class VitessResultSet implements ResultSet {
     private boolean isNull(int columnIndex) throws SQLException {
         return null == this.row.getObject(columnIndex);
     }
+
+    //Unsupported Methods
 
     public InputStream getAsciiStream(int columnIndex) throws SQLException {
         throw new SQLFeatureNotSupportedException(
@@ -1469,7 +1469,7 @@ public class VitessResultSet implements ResultSet {
         return byteArrayToBoolean(this.row.getObject(columnIndex));
     }
 
-    private boolean byteArrayToBoolean(Object value) throws SQLException {
+    private boolean byteArrayToBoolean(Object value) {
         if (value == null) {
             return false;
         }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -1,6 +1,7 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.StringUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
@@ -10,6 +11,7 @@ import com.youtube.vitess.proto.Query;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.sql.Array;
@@ -28,6 +30,7 @@ import java.sql.SQLXML;
 import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -217,13 +220,16 @@ public class VitessResultSet implements ResultSet {
         }
 
         object = this.row.getObject(columnIndex);
-
         if (object instanceof byte[]) {
-            columnValue = new String((byte[]) object);
+            FieldWithMetadata field = this.fields.get(columnIndex - 1);
+            if (field.hasConnection() && field.getConnection().isIncludeAllFields()) {
+                columnValue = convertBytesToString((byte[]) object, field.getEncoding());
+            } else {
+                columnValue = new String((byte[]) object);
+            }
         } else {
             columnValue = String.valueOf(object);
         }
-
         return columnValue;
     }
 
@@ -549,7 +555,50 @@ public class VitessResultSet implements ResultSet {
             return null;
         }
 
-        return this.row.getObject(columnIndex);
+        Object retVal = this.row.getObject(columnIndex);
+
+        FieldWithMetadata field = this.fields.get(columnIndex - 1);
+        if (field.hasConnection() && field.getConnection().isIncludeAllFields() && retVal instanceof byte[]) {
+            retVal = convertBytesIfPossible((byte[]) retVal, field);
+        }
+
+        return retVal;
+    }
+
+    private Object convertBytesIfPossible(byte[] bytes, FieldWithMetadata field) throws SQLException {
+        String encoding = field.getEncoding();
+        switch (field.getJavaType()) {
+            case Types.BIT:
+                if (!field.isSingleBit()) {
+                    return bytes;
+                }
+                return byteArrayToBoolean(bytes);
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                if (!field.isOpaqueBinary()) {
+                    return convertBytesToString(bytes, encoding);
+                }
+                return bytes;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return bytes;
+            default:
+                return convertBytesToString(bytes, encoding);
+        }
+    }
+
+    private String convertBytesToString(byte[] bytes, String encoding) throws SQLException {
+        if (encoding == null) {
+            return StringUtils.toString(bytes);
+        } else {
+            try {
+                return StringUtils.toString(bytes, 0, bytes.length, encoding);
+            } catch (UnsupportedEncodingException e) {
+                throw new SQLException("Unsupported character encoding: " + encoding, e);
+            }
+        }
     }
 
     public Object getObject(String columnLabel) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -103,7 +103,8 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
         if (!field.getConnection().isIncludeAllFields()) {
             return 0;
         }
-        return field.getColumnLength() / field.getMaxBytesPerCharacter();
+        // If we can't find a charset, we'll return 0. In that case assume 1 byte per char
+        return field.getColumnLength() / Math.max(field.getMaxBytesPerCharacter(), 1);
     }
 
     public String getColumnLabel(int column) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -49,6 +49,22 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
             case Types.TIME:
             case Types.TIMESTAMP:
                 return false;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+                if (field.isBinary() || !field.getConnection().isIncludeAllFields()) {
+                    return true;
+                }
+                try {
+                    String collationName = field.getCollation();
+                    return collationName != null && !collationName.endsWith("_ci");
+                } catch (SQLException e) {
+                    if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                        return false;
+                    } else {
+                        throw e;
+                    }
+                }
             default:
                 return true;
         }
@@ -83,7 +99,11 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public int getColumnDisplaySize(int column) throws SQLException {
-        return 0;
+        FieldWithMetadata field = getField(column);
+        if (!field.getConnection().isIncludeAllFields()) {
+            return 0;
+        }
+        return field.getColumnLength() / field.getMaxBytesPerCharacter();
     }
 
     public String getColumnLabel(int column) throws SQLException {
@@ -99,7 +119,20 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
     }
 
     public int getPrecision(int column) throws SQLException {
-        return 0;
+        FieldWithMetadata field = getField(column);
+        if (!field.getConnection().isIncludeAllFields()) {
+            return 0;
+        }
+        if (isDecimalType(field.getJavaType(), field.getVitessTypeValue())) {
+            return field.getColumnLength() + field.getPrecisionAdjustFactor();
+        }
+        switch (field.getJavaType()) {
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+                return field.getColumnLength();
+            default:
+                return field.getColumnLength() / field.getMaxBytesPerCharacter();
+        }
     }
 
     private static boolean isDecimalType(int javaType, int vitessType) {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
@@ -72,10 +72,15 @@ public final class MysqlDefs {
     static final int FIELD_TYPE_YEAR = 13;
     static final int FIELD_TYPE_JSON = 245;
     static final int INIT_DB = 2;
+
+    // Unlike mysql-vanilla, vtgate returns ints for Field.getLength(). To ensure no type conversion issues,
+    // we diverge from mysql-connector-j here, who instead have these fields as longs, and have a function clampedGetLength
+    // to convert field lengths to ints after comparison.
     public static final int LENGTH_BLOB = 65535;
     public static final int LENGTH_LONGBLOB = Integer.MAX_VALUE;
     public static final int LENGTH_MEDIUMBLOB = 16777215;
     public static final int LENGTH_TINYBLOB = 255;
+
     // Limitations
     static final int MAX_ROWS = 50000000; // From the MySQL FAQ
     static final byte OPEN_CURSOR_FLAG = 1;

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/MysqlDefs.java
@@ -72,10 +72,10 @@ public final class MysqlDefs {
     static final int FIELD_TYPE_YEAR = 13;
     static final int FIELD_TYPE_JSON = 245;
     static final int INIT_DB = 2;
-    static final long LENGTH_BLOB = 65535;
-    static final long LENGTH_LONGBLOB = 4294967295L;
-    static final long LENGTH_MEDIUMBLOB = 16777215;
-    static final long LENGTH_TINYBLOB = 255;
+    public static final int LENGTH_BLOB = 65535;
+    public static final int LENGTH_LONGBLOB = Integer.MAX_VALUE;
+    public static final int LENGTH_MEDIUMBLOB = 16777215;
+    public static final int LENGTH_TINYBLOB = 255;
     // Limitations
     static final int MAX_ROWS = 50000000; // From the MySQL FAQ
     static final byte OPEN_CURSOR_FLAG = 1;

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
@@ -359,7 +359,6 @@ public class StringUtils {
      */
     public static int findStartOfStatement(String sql) {
         int statementStartPos = 0;
-
         if (StringUtils.startsWithIgnoreCaseAndWs(sql, "/*")) {
             statementStartPos = sql.indexOf("*/");
 
@@ -379,13 +378,11 @@ public class StringUtils {
                 }
             }
         }
-
         return statementStartPos;
     }
 
     public static String toString(byte[] value, int offset, int length, String encoding) throws UnsupportedEncodingException {
         Charset cs = findCharset(encoding);
-
         return cs.decode(ByteBuffer.wrap(value, offset, length)).toString();
     }
 
@@ -403,7 +400,6 @@ public class StringUtils {
         } catch (UnsupportedEncodingException e) {
             // can't happen, emulating new String(byte[])
         }
-
         return null;
     }
 
@@ -415,7 +411,6 @@ public class StringUtils {
         } catch (UnsupportedEncodingException e) {
             // can't happen, emulating new String(byte[])
         }
-
         return null;
     }
 
@@ -425,21 +420,17 @@ public class StringUtils {
 
     public static byte[] getBytes(String value, int offset, int length, String encoding) throws UnsupportedEncodingException {
         Charset cs = findCharset(encoding);
-
         ByteBuffer buf = cs.encode(CharBuffer.wrap(value.toCharArray(), offset, length));
-
         // can't simply .array() this to get the bytes especially with variable-length charsets the buffer is sometimes larger than the actual encoded data
         int encodedLen = buf.limit();
         byte[] asBytes = new byte[encodedLen];
         buf.get(asBytes, 0, encodedLen);
-
         return asBytes;
     }
 
     private static Charset findCharset(String alias) throws UnsupportedEncodingException {
         try {
             Charset cs = charsetsByAlias.get(alias);
-
             if (cs == null) {
                 cs = Charset.forName(alias);
                 Charset oldCs = charsetsByAlias.putIfAbsent(alias, cs);
@@ -448,9 +439,7 @@ public class StringUtils {
                     cs = oldCs;
                 }
             }
-
             return cs;
-
             // We re-throw these runtimes for compatibility with java.io
         } catch (IllegalArgumentException iae) {
             throw new UnsupportedEncodingException(alias);

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
@@ -1,13 +1,21 @@
 package com.flipkart.vitess.util;
 
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by naveen.nahata on 05/02/16.
  */
 public class StringUtils {
+
+    private static final String platformEncoding = System.getProperty("file.encoding");
+    private static final ConcurrentHashMap<String, Charset> charsetsByAlias = new ConcurrentHashMap<String, Charset>();
 
     private StringUtils() {
     }
@@ -373,5 +381,79 @@ public class StringUtils {
         }
 
         return statementStartPos;
+    }
+
+    public static String toString(byte[] value, int offset, int length, String encoding) throws UnsupportedEncodingException {
+        Charset cs = findCharset(encoding);
+
+        return cs.decode(ByteBuffer.wrap(value, offset, length)).toString();
+    }
+
+    public static String toString(byte[] value, String encoding) throws UnsupportedEncodingException {
+        return findCharset(encoding)
+            .decode(ByteBuffer.wrap(value))
+            .toString();
+    }
+
+    public static String toString(byte[] value, int offset, int length) {
+        try {
+            return findCharset(platformEncoding)
+                .decode(ByteBuffer.wrap(value, offset, length))
+                .toString();
+        } catch (UnsupportedEncodingException e) {
+            // can't happen, emulating new String(byte[])
+        }
+
+        return null;
+    }
+
+    public static String toString(byte[] value) {
+        try {
+            return findCharset(platformEncoding)
+                .decode(ByteBuffer.wrap(value))
+                .toString();
+        } catch (UnsupportedEncodingException e) {
+            // can't happen, emulating new String(byte[])
+        }
+
+        return null;
+    }
+
+    public static byte[] getBytes(String value, String encoding) throws UnsupportedEncodingException {
+        return getBytes(value, 0, value.length(), encoding);
+    }
+
+    public static byte[] getBytes(String value, int offset, int length, String encoding) throws UnsupportedEncodingException {
+        Charset cs = findCharset(encoding);
+
+        ByteBuffer buf = cs.encode(CharBuffer.wrap(value.toCharArray(), offset, length));
+
+        // can't simply .array() this to get the bytes especially with variable-length charsets the buffer is sometimes larger than the actual encoded data
+        int encodedLen = buf.limit();
+        byte[] asBytes = new byte[encodedLen];
+        buf.get(asBytes, 0, encodedLen);
+
+        return asBytes;
+    }
+
+    private static Charset findCharset(String alias) throws UnsupportedEncodingException {
+        try {
+            Charset cs = charsetsByAlias.get(alias);
+
+            if (cs == null) {
+                cs = Charset.forName(alias);
+                Charset oldCs = charsetsByAlias.putIfAbsent(alias, cs);
+                if (oldCs != null) {
+                    // if the previous value was recently set by another thread we return it instead of value we found here
+                    cs = oldCs;
+                }
+            }
+
+            return cs;
+
+            // We re-throw these runtimes for compatibility with java.io
+        } catch (IllegalArgumentException iae) {
+            throw new UnsupportedEncodingException(alias);
+        }
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/CharsetMapping.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/CharsetMapping.java
@@ -1,0 +1,536 @@
+package com.flipkart.vitess.util.charset;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+public class CharsetMapping {
+    private static final int MAP_SIZE = 255; // Size of static maps
+    public static final String[] COLLATION_INDEX_TO_COLLATION_NAME;
+    private static final MysqlCharset[] COLLATION_INDEX_TO_CHARSET;
+
+    static final Map<String, MysqlCharset> CHARSET_NAME_TO_CHARSET;
+    private static final Map<String, List<MysqlCharset>> JAVA_ENCODING_UC_TO_MYSQL_CHARSET;
+
+    private static final String MYSQL_CHARSET_NAME_armscii8 = "armscii8";
+    private static final String MYSQL_CHARSET_NAME_ascii = "ascii";
+    private static final String MYSQL_CHARSET_NAME_big5 = "big5";
+    private static final String MYSQL_CHARSET_NAME_binary = "binary";
+    private static final String MYSQL_CHARSET_NAME_cp1250 = "cp1250";
+    private static final String MYSQL_CHARSET_NAME_cp1251 = "cp1251";
+    private static final String MYSQL_CHARSET_NAME_cp1256 = "cp1256";
+    private static final String MYSQL_CHARSET_NAME_cp1257 = "cp1257";
+    private static final String MYSQL_CHARSET_NAME_cp850 = "cp850";
+    private static final String MYSQL_CHARSET_NAME_cp852 = "cp852";
+    private static final String MYSQL_CHARSET_NAME_cp866 = "cp866";
+    private static final String MYSQL_CHARSET_NAME_cp932 = "cp932";
+    private static final String MYSQL_CHARSET_NAME_dec8 = "dec8";
+    private static final String MYSQL_CHARSET_NAME_eucjpms = "eucjpms";
+    private static final String MYSQL_CHARSET_NAME_euckr = "euckr";
+    private static final String MYSQL_CHARSET_NAME_gb18030 = "gb18030";
+    private static final String MYSQL_CHARSET_NAME_gb2312 = "gb2312";
+    private static final String MYSQL_CHARSET_NAME_gbk = "gbk";
+    private static final String MYSQL_CHARSET_NAME_geostd8 = "geostd8";
+    private static final String MYSQL_CHARSET_NAME_greek = "greek";
+    private static final String MYSQL_CHARSET_NAME_hebrew = "hebrew";
+    private static final String MYSQL_CHARSET_NAME_hp8 = "hp8";
+    private static final String MYSQL_CHARSET_NAME_keybcs2 = "keybcs2";
+    private static final String MYSQL_CHARSET_NAME_koi8r = "koi8r";
+    private static final String MYSQL_CHARSET_NAME_koi8u = "koi8u";
+    private static final String MYSQL_CHARSET_NAME_latin1 = "latin1";
+    private static final String MYSQL_CHARSET_NAME_latin2 = "latin2";
+    private static final String MYSQL_CHARSET_NAME_latin5 = "latin5";
+    private static final String MYSQL_CHARSET_NAME_latin7 = "latin7";
+    private static final String MYSQL_CHARSET_NAME_macce = "macce";
+    private static final String MYSQL_CHARSET_NAME_macroman = "macroman";
+    private static final String MYSQL_CHARSET_NAME_sjis = "sjis";
+    private static final String MYSQL_CHARSET_NAME_swe7 = "swe7";
+    private static final String MYSQL_CHARSET_NAME_tis620 = "tis620";
+    private static final String MYSQL_CHARSET_NAME_ucs2 = "ucs2";
+    private static final String MYSQL_CHARSET_NAME_ujis = "ujis";
+    private static final String MYSQL_CHARSET_NAME_utf16 = "utf16";
+    private static final String MYSQL_CHARSET_NAME_utf16le = "utf16le";
+    private static final String MYSQL_CHARSET_NAME_utf32 = "utf32";
+    private static final String MYSQL_CHARSET_NAME_utf8 = "utf8";
+    private static final String MYSQL_CHARSET_NAME_utf8mb4 = "utf8mb4";
+
+    private static final String MYSQL_4_0_CHARSET_NAME_cp1251cias = "cp1251cias";
+    private static final String MYSQL_4_0_CHARSET_NAME_cp1251csas = "cp1251csas";
+    private static final String MYSQL_4_0_CHARSET_NAME_croat = "croat";        // 4.1 =>	27	latin2		latin2_croatian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_czech = "czech";        // 4.1 =>	2	latin2		latin2_czech_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_danish = "danish";        // 4.1 =>	15	latin1		latin1_danish_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_dos = "dos";            // 4.1 =>	4	cp850		cp850_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_estonia = "estonia";        // 4.1 =>	20	latin7		latin7_estonian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_euc_kr = "euc_kr";        // 4.1 =>	19	euckr		euckr_korean_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_german1 = "german1";        // 4.1 =>	5	latin1		latin1_german1_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_hungarian = "hungarian";    // 4.1 =>	21	latin2		latin2_hungarian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_koi8_ru = "koi8_ru";        // 4.1 =>	7	koi8r		koi8r_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_koi8_ukr = "koi8_ukr";        // 4.1 =>	22	koi8u		koi8u_ukrainian_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_latin1_de = "latin1_de";    // 4.1 =>	31	latin1		latin1_german2_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_latvian = "latvian";
+    private static final String MYSQL_4_0_CHARSET_NAME_latvian1 = "latvian1";
+    private static final String MYSQL_4_0_CHARSET_NAME_usa7 = "usa7";            // 4.1 =>	11	ascii		ascii_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_win1250 = "win1250";        // 4.1 =>	26	cp1250		cp1250_general_ci
+    private static final String MYSQL_4_0_CHARSET_NAME_win1251 = "win1251";        // 4.1 =>	17	(removed)
+    private static final String MYSQL_4_0_CHARSET_NAME_win1251ukr = "win1251ukr";    // 4.1 =>	23	cp1251		cp1251_ukrainian_ci
+
+    private static final String NOT_USED = MYSQL_CHARSET_NAME_latin1; // punting for not-used character sets
+
+    public static final int MYSQL_COLLATION_INDEX_utf8 = 33;
+    public static final int MYSQL_COLLATION_INDEX_binary = 63;
+
+    static {
+        // complete list of mysql character sets and their corresponding java encoding names
+        MysqlCharset[] charset = new MysqlCharset[]{new MysqlCharset(MYSQL_4_0_CHARSET_NAME_usa7, 1, 0, new String[]{"US-ASCII"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_ascii, 1, 0, new String[]{"US-ASCII", "ASCII"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_big5, 2, 0, new String[]{"Big5"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_gbk, 2, 0, new String[]{"GBK"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_sjis, 2, 0, new String[]{"SHIFT_JIS", "Cp943", "WINDOWS-31J"}),    // SJIS is alias for SHIFT_JIS, Cp943 is rather a cp932 but we map it to sjis for years
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp932, 2, 1, new String[]{"WINDOWS-31J"}),        // MS932 is alias for WINDOWS-31J
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_gb2312, 2, 0, new String[]{"GB2312"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_ujis, 3, 0, new String[]{"EUC_JP"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_eucjpms, 3, 0, new String[]{"EUC_JP_Solaris"}, 5, 0, 3),    // "EUC_JP_Solaris = 	>5.0.3 eucjpms,"
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_gb18030, 4, 0, new String[]{"GB18030"}, 5, 7, 4),
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_euc_kr, 2, 0, new String[]{"EUC_KR"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_euckr, 2, 0, new String[]{"EUC-KR"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin1, 1, 1, new String[]{"Cp1252", "ISO8859_1"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_swe7, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_hp8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_dec8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_armscii8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+            new MysqlCharset(MYSQL_CHARSET_NAME_geostd8, 1, 0, new String[]{"Cp1252"}),            // new mapping, Cp1252 ?
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin2, 1, 0, new String[]{"ISO8859_2"}),        // latin2 is an alias
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_czech, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_hungarian, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_croat, 1, 0, new String[]{"ISO8859_2"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_greek, 1, 0, new String[]{"ISO8859_7", "greek"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin7, 1, 0, new String[]{"ISO-8859-13"}),    // was ISO8859_7, that's incorrect; also + "LATIN7 =		latin7," is wrong java encoding name
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_hebrew, 1, 0, new String[]{"ISO8859_8"}),        // hebrew is an alias
+            new MysqlCharset(MYSQL_CHARSET_NAME_latin5, 1, 0, new String[]{"ISO8859_9"}),        // LATIN5 is an alias
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latvian, 1, 0, new String[]{"ISO8859_13"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latvian1, 1, 0, new String[]{"ISO8859_13"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_estonia, 1, 1, new String[]{"ISO8859_13"}, 4, 0), //,	"ISO8859_13");	// punting for "estonia";
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp850, 1, 0, new String[]{"Cp850", "Cp437"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_dos, 1, 0, new String[]{"Cp850", "Cp437"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp852, 1, 0, new String[]{"Cp852"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_keybcs2, 1, 0, new String[]{"Cp852"}),    // new, Kamenicky encoding usually known as Cp895 but there is no official cp895 specification; close to Cp852, see http://ftp.muni.cz/pub/localization/charsets/cs-encodings-faq
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp866, 1, 0, new String[]{"Cp866"}),
+
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_koi8_ru, 1, 0, new String[]{"KOI8_R"}, 4, 0),
+            new MysqlCharset(MYSQL_CHARSET_NAME_koi8r, 1, 1, new String[]{"KOI8_R"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_koi8u, 1, 0, new String[]{"KOI8_R"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_koi8_ukr, 1, 0, new String[]{"KOI8_R"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_tis620, 1, 0, new String[]{"TIS620"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1250, 1, 0, new String[]{"Cp1250"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1250, 1, 0, new String[]{"Cp1250"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1251, 1, 1, new String[]{"Cp1251"}),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1251, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_cp1251cias, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_cp1251csas, 1, 0, new String[]{"Cp1251"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_win1251ukr, 1, 0, new String[]{"Cp1251"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1256, 1, 0, new String[]{"Cp1256"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_cp1257, 1, 0, new String[]{"Cp1257"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_macroman, 1, 0, new String[]{"MacRoman"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_macce, 1, 0, new String[]{"MacCentralEurope"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf8, 3, 1, new String[]{"UTF-8"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf8mb4, 4, 0, new String[]{"UTF-8"}),            // "UTF-8 =				*> 5.5.2 utf8mb4,"
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_ucs2, 2, 0, new String[]{"UnicodeBig"}),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_binary, 1, 1, new String[]{"ISO8859_1"}),    // US-ASCII ?
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_latin1_de, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_german1, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+            new MysqlCharset(MYSQL_4_0_CHARSET_NAME_danish, 1, 0, new String[]{"ISO8859_1"}, 4, 0),
+
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf16, 4, 0, new String[]{"UTF-16"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf16le, 4, 0, new String[]{"UTF-16LE"}),
+            new MysqlCharset(MYSQL_CHARSET_NAME_utf32, 4, 0, new String[]{"UTF-32"})
+        };
+
+        HashMap<String, MysqlCharset> charsetNameToMysqlCharsetMap = new HashMap<String, MysqlCharset>();
+        HashMap<String, List<MysqlCharset>> javaUcToMysqlCharsetMap = new HashMap<String, List<MysqlCharset>>();
+
+        for (int i = 0; i < charset.length; i++) {
+            String charsetName = charset[i].charsetName;
+
+            charsetNameToMysqlCharsetMap.put(charsetName, charset[i]);
+
+            for (String encUC : charset[i].javaEncodingsUc) {
+
+                // fill javaUcToMysqlCharsetMap
+                List<MysqlCharset> charsets = javaUcToMysqlCharsetMap.get(encUC);
+                if (charsets == null) {
+                    charsets = new ArrayList<MysqlCharset>();
+                    javaUcToMysqlCharsetMap.put(encUC, charsets);
+                }
+                charsets.add(charset[i]);
+            }
+        }
+
+        CHARSET_NAME_TO_CHARSET = Collections.unmodifiableMap(charsetNameToMysqlCharsetMap);
+        JAVA_ENCODING_UC_TO_MYSQL_CHARSET = Collections.unmodifiableMap(javaUcToMysqlCharsetMap);
+
+        // complete list of mysql collations and their corresponding character sets each element of collation[1]..collation[MAP_SIZE-1] must not be null
+        Collation[] collation = new Collation[MAP_SIZE];
+        collation[1] = new Collation(1, "big5_chinese_ci", 1, MYSQL_CHARSET_NAME_big5);
+        collation[84] = new Collation(84, "big5_bin", 0, MYSQL_CHARSET_NAME_big5);
+
+        collation[2] = new Collation(2, "latin2_czech_cs", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[9] = new Collation(9, "latin2_general_ci", 1, MYSQL_CHARSET_NAME_latin2);
+        collation[21] = new Collation(21, "latin2_hungarian_ci", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[27] = new Collation(27, "latin2_croatian_ci", 0, MYSQL_CHARSET_NAME_latin2);
+        collation[77] = new Collation(77, "latin2_bin", 0, MYSQL_CHARSET_NAME_latin2);
+
+        collation[4] = new Collation(4, "cp850_general_ci", 1, MYSQL_CHARSET_NAME_cp850);
+        collation[80] = new Collation(80, "cp850_bin", 0, MYSQL_CHARSET_NAME_cp850);
+
+        collation[5] = new Collation(5, "latin1_german1_ci", 1, MYSQL_CHARSET_NAME_latin1);
+        collation[8] = new Collation(8, "latin1_swedish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[15] = new Collation(15, "latin1_danish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[31] = new Collation(31, "latin1_german2_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[47] = new Collation(47, "latin1_bin", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[48] = new Collation(48, "latin1_general_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[49] = new Collation(49, "latin1_general_cs", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[76] = new Collation(76, "not_implemented", 0, NOT_USED);
+        collation[94] = new Collation(94, "latin1_spanish_ci", 0, MYSQL_CHARSET_NAME_latin1);
+        collation[100] = new Collation(100, "not_implemented", 0, NOT_USED);
+        collation[125] = new Collation(125, "not_implemented", 0, NOT_USED);
+        collation[126] = new Collation(126, "not_implemented", 0, NOT_USED);
+        collation[127] = new Collation(127, "not_implemented", 0, NOT_USED);
+        collation[152] = new Collation(152, "not_implemented", 0, NOT_USED);
+        collation[153] = new Collation(153, "not_implemented", 0, NOT_USED);
+        collation[154] = new Collation(154, "not_implemented", 0, NOT_USED);
+        collation[155] = new Collation(155, "not_implemented", 0, NOT_USED);
+        collation[156] = new Collation(156, "not_implemented", 0, NOT_USED);
+        collation[157] = new Collation(157, "not_implemented", 0, NOT_USED);
+        collation[158] = new Collation(158, "not_implemented", 0, NOT_USED);
+        collation[184] = new Collation(184, "not_implemented", 0, NOT_USED);
+        collation[185] = new Collation(185, "not_implemented", 0, NOT_USED);
+        collation[186] = new Collation(186, "not_implemented", 0, NOT_USED);
+        collation[187] = new Collation(187, "not_implemented", 0, NOT_USED);
+        collation[188] = new Collation(188, "not_implemented", 0, NOT_USED);
+        collation[189] = new Collation(189, "not_implemented", 0, NOT_USED);
+        collation[190] = new Collation(190, "not_implemented", 0, NOT_USED);
+        collation[191] = new Collation(191, "not_implemented", 0, NOT_USED);
+        collation[216] = new Collation(216, "not_implemented", 0, NOT_USED);
+        collation[217] = new Collation(217, "not_implemented", 0, NOT_USED);
+        collation[218] = new Collation(218, "not_implemented", 0, NOT_USED);
+        collation[219] = new Collation(219, "not_implemented", 0, NOT_USED);
+        collation[220] = new Collation(220, "not_implemented", 0, NOT_USED);
+        collation[221] = new Collation(221, "not_implemented", 0, NOT_USED);
+        collation[222] = new Collation(222, "not_implemented", 0, NOT_USED);
+        collation[248] = new Collation(248, "gb18030_chinese_ci", 1, MYSQL_CHARSET_NAME_gb18030);
+        collation[249] = new Collation(249, "gb18030_bin", 0, MYSQL_CHARSET_NAME_gb18030);
+        collation[250] = new Collation(250, "gb18030_unicode_520_ci", 0, MYSQL_CHARSET_NAME_gb18030);
+        collation[251] = new Collation(251, "not_implemented", 0, NOT_USED);
+        collation[252] = new Collation(252, "not_implemented", 0, NOT_USED);
+        collation[253] = new Collation(253, "not_implemented", 0, NOT_USED);
+        collation[254] = new Collation(254, "not_implemented", 0, NOT_USED);
+        collation[10] = new Collation(10, "swe7_swedish_ci", 0, MYSQL_CHARSET_NAME_swe7);
+        collation[82] = new Collation(82, "swe7_bin", 0, MYSQL_CHARSET_NAME_swe7);
+        collation[6] = new Collation(6, "hp8_english_ci", 0, MYSQL_CHARSET_NAME_hp8);
+        collation[72] = new Collation(72, "hp8_bin", 0, MYSQL_CHARSET_NAME_hp8);
+        collation[3] = new Collation(3, "dec8_swedish_ci", 0, MYSQL_CHARSET_NAME_dec8);
+        collation[69] = new Collation(69, "dec8_bin", 0, MYSQL_CHARSET_NAME_dec8);
+        collation[32] = new Collation(32, "armscii8_general_ci", 0, MYSQL_CHARSET_NAME_armscii8);
+        collation[64] = new Collation(64, "armscii8_bin", 0, MYSQL_CHARSET_NAME_armscii8);
+        collation[92] = new Collation(92, "geostd8_general_ci", 0, MYSQL_CHARSET_NAME_geostd8);
+        collation[93] = new Collation(93, "geostd8_bin", 0, MYSQL_CHARSET_NAME_geostd8);
+
+        collation[7] = new Collation(7, "koi8r_general_ci", 0, MYSQL_CHARSET_NAME_koi8r);
+        collation[74] = new Collation(74, "koi8r_bin", 0, MYSQL_CHARSET_NAME_koi8r);
+
+        collation[11] = new Collation(11, "ascii_general_ci", 0, MYSQL_CHARSET_NAME_ascii);
+        collation[65] = new Collation(65, "ascii_bin", 0, MYSQL_CHARSET_NAME_ascii);
+
+        collation[12] = new Collation(12, "ujis_japanese_ci", 0, MYSQL_CHARSET_NAME_ujis);
+        collation[91] = new Collation(91, "ujis_bin", 0, MYSQL_CHARSET_NAME_ujis);
+
+        collation[13] = new Collation(13, "sjis_japanese_ci", 0, MYSQL_CHARSET_NAME_sjis);
+        collation[14] = new Collation(14, "cp1251_bulgarian_ci", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[16] = new Collation(16, "hebrew_general_ci", 0, MYSQL_CHARSET_NAME_hebrew);
+        collation[17] = new Collation(17, "latin1_german1_ci", 0, MYSQL_4_0_CHARSET_NAME_win1251);    // removed since 4.1
+        collation[18] = new Collation(18, "tis620_thai_ci", 0, MYSQL_CHARSET_NAME_tis620);
+        collation[19] = new Collation(19, "euckr_korean_ci", 0, MYSQL_CHARSET_NAME_euckr);
+        collation[20] = new Collation(20, "latin7_estonian_cs", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[22] = new Collation(22, "koi8u_general_ci", 0, MYSQL_CHARSET_NAME_koi8u);
+        collation[23] = new Collation(23, "cp1251_ukrainian_ci", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[24] = new Collation(24, "gb2312_chinese_ci", 0, MYSQL_CHARSET_NAME_gb2312);
+        collation[25] = new Collation(25, "greek_general_ci", 0, MYSQL_CHARSET_NAME_greek);
+        collation[26] = new Collation(26, "cp1250_general_ci", 1, MYSQL_CHARSET_NAME_cp1250);
+        collation[28] = new Collation(28, "gbk_chinese_ci", 1, MYSQL_CHARSET_NAME_gbk);
+        collation[29] = new Collation(29, "cp1257_lithuanian_ci", 0, MYSQL_CHARSET_NAME_cp1257);
+        collation[30] = new Collation(30, "latin5_turkish_ci", 1, MYSQL_CHARSET_NAME_latin5);
+        collation[33] = new Collation(33, "utf8_general_ci", 1, MYSQL_CHARSET_NAME_utf8);
+        collation[34] = new Collation(34, "cp1250_czech_cs", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[35] = new Collation(35, "ucs2_general_ci", 1, MYSQL_CHARSET_NAME_ucs2);
+        collation[36] = new Collation(36, "cp866_general_ci", 1, MYSQL_CHARSET_NAME_cp866);
+        collation[37] = new Collation(37, "keybcs2_general_ci", 1, MYSQL_CHARSET_NAME_keybcs2);
+        collation[38] = new Collation(38, "macce_general_ci", 1, MYSQL_CHARSET_NAME_macce);
+        collation[39] = new Collation(39, "macroman_general_ci", 1, MYSQL_CHARSET_NAME_macroman);
+        collation[40] = new Collation(40, "cp852_general_ci", 1, MYSQL_CHARSET_NAME_cp852);
+        collation[41] = new Collation(41, "latin7_general_ci", 1, MYSQL_CHARSET_NAME_latin7);
+        collation[42] = new Collation(42, "latin7_general_cs", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[43] = new Collation(43, "macce_bin", 0, MYSQL_CHARSET_NAME_macce);
+        collation[44] = new Collation(44, "cp1250_croatian_ci", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[45] = new Collation(45, "utf8mb4_general_ci", 1, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[46] = new Collation(46, "utf8mb4_bin", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[50] = new Collation(50, "cp1251_bin", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[51] = new Collation(51, "cp1251_general_ci", 1, MYSQL_CHARSET_NAME_cp1251);
+        collation[52] = new Collation(52, "cp1251_general_cs", 0, MYSQL_CHARSET_NAME_cp1251);
+        collation[53] = new Collation(53, "macroman_bin", 0, MYSQL_CHARSET_NAME_macroman);
+        collation[54] = new Collation(54, "utf16_general_ci", 1, MYSQL_CHARSET_NAME_utf16);
+        collation[55] = new Collation(55, "utf16_bin", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[56] = new Collation(56, "utf16le_general_ci", 1, MYSQL_CHARSET_NAME_utf16le);
+        collation[57] = new Collation(57, "cp1256_general_ci", 1, MYSQL_CHARSET_NAME_cp1256);
+        collation[58] = new Collation(58, "cp1257_bin", 0, MYSQL_CHARSET_NAME_cp1257);
+        collation[59] = new Collation(59, "cp1257_general_ci", 1, MYSQL_CHARSET_NAME_cp1257);
+        collation[60] = new Collation(60, "utf32_general_ci", 1, MYSQL_CHARSET_NAME_utf32);
+        collation[61] = new Collation(61, "utf32_bin", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[62] = new Collation(62, "utf16le_bin", 0, MYSQL_CHARSET_NAME_utf16le);
+        collation[63] = new Collation(63, "binary", 1, MYSQL_CHARSET_NAME_binary);
+        collation[66] = new Collation(66, "cp1250_bin", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[67] = new Collation(67, "cp1256_bin", 0, MYSQL_CHARSET_NAME_cp1256);
+        collation[68] = new Collation(68, "cp866_bin", 0, MYSQL_CHARSET_NAME_cp866);
+        collation[70] = new Collation(70, "greek_bin", 0, MYSQL_CHARSET_NAME_greek);
+        collation[71] = new Collation(71, "hebrew_bin", 0, MYSQL_CHARSET_NAME_hebrew);
+        collation[73] = new Collation(73, "keybcs2_bin", 0, MYSQL_CHARSET_NAME_keybcs2);
+        collation[75] = new Collation(75, "koi8u_bin", 0, MYSQL_CHARSET_NAME_koi8u);
+        collation[78] = new Collation(78, "latin5_bin", 0, MYSQL_CHARSET_NAME_latin5);
+        collation[79] = new Collation(79, "latin7_bin", 0, MYSQL_CHARSET_NAME_latin7);
+        collation[81] = new Collation(81, "cp852_bin", 0, MYSQL_CHARSET_NAME_cp852);
+        collation[83] = new Collation(83, "utf8_bin", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[85] = new Collation(85, "euckr_bin", 0, MYSQL_CHARSET_NAME_euckr);
+        collation[86] = new Collation(86, "gb2312_bin", 0, MYSQL_CHARSET_NAME_gb2312);
+        collation[87] = new Collation(87, "gbk_bin", 0, MYSQL_CHARSET_NAME_gbk);
+        collation[88] = new Collation(88, "sjis_bin", 0, MYSQL_CHARSET_NAME_sjis);
+        collation[89] = new Collation(89, "tis620_bin", 0, MYSQL_CHARSET_NAME_tis620);
+        collation[90] = new Collation(90, "ucs2_bin", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[95] = new Collation(95, "cp932_japanese_ci", 1, MYSQL_CHARSET_NAME_cp932);
+        collation[96] = new Collation(96, "cp932_bin", 0, MYSQL_CHARSET_NAME_cp932);
+        collation[97] = new Collation(97, "eucjpms_japanese_ci", 1, MYSQL_CHARSET_NAME_eucjpms);
+        collation[98] = new Collation(98, "eucjpms_bin", 0, MYSQL_CHARSET_NAME_eucjpms);
+        collation[99] = new Collation(99, "cp1250_polish_ci", 0, MYSQL_CHARSET_NAME_cp1250);
+        collation[101] = new Collation(101, "utf16_unicode_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[102] = new Collation(102, "utf16_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[103] = new Collation(103, "utf16_latvian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[104] = new Collation(104, "utf16_romanian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[105] = new Collation(105, "utf16_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[106] = new Collation(106, "utf16_polish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[107] = new Collation(107, "utf16_estonian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[108] = new Collation(108, "utf16_spanish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[109] = new Collation(109, "utf16_swedish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[110] = new Collation(110, "utf16_turkish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[111] = new Collation(111, "utf16_czech_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[112] = new Collation(112, "utf16_danish_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[113] = new Collation(113, "utf16_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[114] = new Collation(114, "utf16_slovak_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[115] = new Collation(115, "utf16_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[116] = new Collation(116, "utf16_roman_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[117] = new Collation(117, "utf16_persian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[118] = new Collation(118, "utf16_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[119] = new Collation(119, "utf16_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[120] = new Collation(120, "utf16_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[121] = new Collation(121, "utf16_german2_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[122] = new Collation(122, "utf16_croatian_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[123] = new Collation(123, "utf16_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[124] = new Collation(124, "utf16_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf16);
+        collation[128] = new Collation(128, "ucs2_unicode_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[129] = new Collation(129, "ucs2_icelandic_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[130] = new Collation(130, "ucs2_latvian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[131] = new Collation(131, "ucs2_romanian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[132] = new Collation(132, "ucs2_slovenian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[133] = new Collation(133, "ucs2_polish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[134] = new Collation(134, "ucs2_estonian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[135] = new Collation(135, "ucs2_spanish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[136] = new Collation(136, "ucs2_swedish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[137] = new Collation(137, "ucs2_turkish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[138] = new Collation(138, "ucs2_czech_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[139] = new Collation(139, "ucs2_danish_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[140] = new Collation(140, "ucs2_lithuanian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[141] = new Collation(141, "ucs2_slovak_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[142] = new Collation(142, "ucs2_spanish2_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[143] = new Collation(143, "ucs2_roman_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[144] = new Collation(144, "ucs2_persian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[145] = new Collation(145, "ucs2_esperanto_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[146] = new Collation(146, "ucs2_hungarian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[147] = new Collation(147, "ucs2_sinhala_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[148] = new Collation(148, "ucs2_german2_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[149] = new Collation(149, "ucs2_croatian_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[150] = new Collation(150, "ucs2_unicode_520_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[151] = new Collation(151, "ucs2_vietnamese_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[159] = new Collation(159, "ucs2_general_mysql500_ci", 0, MYSQL_CHARSET_NAME_ucs2);
+        collation[160] = new Collation(160, "utf32_unicode_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[161] = new Collation(161, "utf32_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[162] = new Collation(162, "utf32_latvian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[163] = new Collation(163, "utf32_romanian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[164] = new Collation(164, "utf32_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[165] = new Collation(165, "utf32_polish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[166] = new Collation(166, "utf32_estonian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[167] = new Collation(167, "utf32_spanish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[168] = new Collation(168, "utf32_swedish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[169] = new Collation(169, "utf32_turkish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[170] = new Collation(170, "utf32_czech_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[171] = new Collation(171, "utf32_danish_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[172] = new Collation(172, "utf32_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[173] = new Collation(173, "utf32_slovak_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[174] = new Collation(174, "utf32_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[175] = new Collation(175, "utf32_roman_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[176] = new Collation(176, "utf32_persian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[177] = new Collation(177, "utf32_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[178] = new Collation(178, "utf32_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[179] = new Collation(179, "utf32_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[180] = new Collation(180, "utf32_german2_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[181] = new Collation(181, "utf32_croatian_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[182] = new Collation(182, "utf32_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[183] = new Collation(183, "utf32_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf32);
+        collation[192] = new Collation(192, "utf8_unicode_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[193] = new Collation(193, "utf8_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[194] = new Collation(194, "utf8_latvian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[195] = new Collation(195, "utf8_romanian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[196] = new Collation(196, "utf8_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[197] = new Collation(197, "utf8_polish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[198] = new Collation(198, "utf8_estonian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[199] = new Collation(199, "utf8_spanish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[200] = new Collation(200, "utf8_swedish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[201] = new Collation(201, "utf8_turkish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[202] = new Collation(202, "utf8_czech_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[203] = new Collation(203, "utf8_danish_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[204] = new Collation(204, "utf8_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[205] = new Collation(205, "utf8_slovak_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[206] = new Collation(206, "utf8_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[207] = new Collation(207, "utf8_roman_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[208] = new Collation(208, "utf8_persian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[209] = new Collation(209, "utf8_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[210] = new Collation(210, "utf8_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[211] = new Collation(211, "utf8_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[212] = new Collation(212, "utf8_german2_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[213] = new Collation(213, "utf8_croatian_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[214] = new Collation(214, "utf8_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[215] = new Collation(215, "utf8_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[223] = new Collation(223, "utf8_general_mysql500_ci", 0, MYSQL_CHARSET_NAME_utf8);
+        collation[224] = new Collation(224, "utf8mb4_unicode_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[225] = new Collation(225, "utf8mb4_icelandic_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[226] = new Collation(226, "utf8mb4_latvian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[227] = new Collation(227, "utf8mb4_romanian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[228] = new Collation(228, "utf8mb4_slovenian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[229] = new Collation(229, "utf8mb4_polish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[230] = new Collation(230, "utf8mb4_estonian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[231] = new Collation(231, "utf8mb4_spanish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[232] = new Collation(232, "utf8mb4_swedish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[233] = new Collation(233, "utf8mb4_turkish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[234] = new Collation(234, "utf8mb4_czech_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[235] = new Collation(235, "utf8mb4_danish_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[236] = new Collation(236, "utf8mb4_lithuanian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[237] = new Collation(237, "utf8mb4_slovak_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[238] = new Collation(238, "utf8mb4_spanish2_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[239] = new Collation(239, "utf8mb4_roman_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[240] = new Collation(240, "utf8mb4_persian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[241] = new Collation(241, "utf8mb4_esperanto_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[242] = new Collation(242, "utf8mb4_hungarian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[243] = new Collation(243, "utf8mb4_sinhala_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[244] = new Collation(244, "utf8mb4_german2_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[245] = new Collation(245, "utf8mb4_croatian_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[246] = new Collation(246, "utf8mb4_unicode_520_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+        collation[247] = new Collation(247, "utf8mb4_vietnamese_ci", 0, MYSQL_CHARSET_NAME_utf8mb4);
+
+        COLLATION_INDEX_TO_COLLATION_NAME = new String[MAP_SIZE];
+        COLLATION_INDEX_TO_CHARSET = new MysqlCharset[MAP_SIZE];
+
+        // Add all collations to lookup maps for easy indexing
+        for (int i = 1; i < MAP_SIZE; i++) {
+            COLLATION_INDEX_TO_COLLATION_NAME[i] = collation[i].collationName;
+            COLLATION_INDEX_TO_CHARSET[i] = collation[i].mysqlCharset;
+        }
+
+        // Sanity check
+        for (int i = 1; i < MAP_SIZE; i++) {
+            if (COLLATION_INDEX_TO_COLLATION_NAME[i] == null) {
+                throw new RuntimeException("Assertion failure: No mapping from charset index " + i + " to a mysql collation");
+            }
+            if (COLLATION_INDEX_TO_COLLATION_NAME[i] == null) {
+                throw new RuntimeException("Assertion failure: No mapping from charset index " + i + " to a Java character set");
+            }
+        }
+    }
+
+    /**
+     * MySQL charset could map to several Java encodings.
+     * So here we choose the one according to next rules:
+     * <li>if there is no static mapping for this charset then return javaEncoding value as is because this
+     * could be a custom charset for example
+     * <li>if static mapping exists and javaEncoding equals to one of Java encoding canonical names or aliases available
+     * for this mapping then javaEncoding value as is; this is required when result should match to connection encoding, for example if connection encoding is
+     * Cp943 we must avoid getting SHIFT_JIS for sjis mysql charset
+     * <li>if static mapping exists and javaEncoding doesn't match any Java encoding canonical
+     * names or aliases available for this mapping then return default Java encoding (the first in mapping list)
+     *
+     * @param collationIndex
+     * @param javaEncoding
+     */
+    public static String getJavaEncodingForCollationIndex(Integer collationIndex, String javaEncoding) {
+        String res = javaEncoding;
+        if (collationIndex != null && collationIndex > 0 && collationIndex < MAP_SIZE) {
+            MysqlCharset cs = COLLATION_INDEX_TO_CHARSET[collationIndex];
+            if (cs != null) {
+                res = cs.getMatchingJavaEncoding(javaEncoding);
+            }
+        }
+        return res;
+    }
+
+    public static String getMysqlCharsetNameForCollationIndex(Integer collationIndex) {
+        if (collationIndex != null && collationIndex > 0 && collationIndex < MAP_SIZE) {
+            return COLLATION_INDEX_TO_CHARSET[collationIndex].charsetName;
+        }
+        return null;
+    }
+
+    public static String getMysqlCharsetForJavaEncoding(String javaEncoding) {
+        if (javaEncoding != null) {
+            List<MysqlCharset> mysqlCharsets = CharsetMapping.JAVA_ENCODING_UC_TO_MYSQL_CHARSET.get(javaEncoding.toUpperCase(Locale.ENGLISH));
+
+            if (mysqlCharsets != null && !mysqlCharsets.isEmpty()) {
+                return mysqlCharsets.get(0).charsetName;
+            }
+        }
+
+        return null;
+    }
+
+    public static int getMblen(String charsetName) {
+        if (charsetName != null) {
+            MysqlCharset cs = CHARSET_NAME_TO_CHARSET.get(charsetName);
+            if (cs != null) {
+                return cs.mblen;
+            }
+        }
+        return 0;
+    }
+}
+

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/Collation.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/Collation.java
@@ -1,0 +1,33 @@
+package com.flipkart.vitess.util.charset;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+class Collation {
+    public final int index;
+    public final String collationName;
+    public final int priority;
+    public final MysqlCharset mysqlCharset;
+
+    public Collation(int index, String collationName, int priority, String charsetName) {
+        this.index = index;
+        this.collationName = collationName;
+        this.priority = priority;
+        this.mysqlCharset = CharsetMapping.CHARSET_NAME_TO_CHARSET.get(charsetName);
+    }
+
+    @Override
+    public String toString() {
+        return "[" +
+            "index=" +
+            this.index +
+            ",collationName=" +
+            this.collationName +
+            ",charsetName=" +
+            this.mysqlCharset.charsetName +
+            ",javaCharsetName=" +
+            this.mysqlCharset.getMatchingJavaEncoding(null) +
+            "]";
+    }
+}

--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/MysqlCharset.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/charset/MysqlCharset.java
@@ -1,0 +1,118 @@
+package com.flipkart.vitess.util.charset;
+
+import java.nio.charset.Charset;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * These classes were pulled from mysql-connector-java and simplified to just the parts supporting the statically available
+ * charsets
+ */
+class MysqlCharset {
+    public final String charsetName;
+    public final int mblen;
+    public final int priority;
+    public final Set<String> javaEncodingsUc = new HashSet<>();
+    private String defaultEncoding = null;
+
+    public int major = 4;
+    public int minor = 1;
+    public int subminor = 0;
+
+    /**
+     * Constructs MysqlCharset object
+     *
+     * @param charsetName   MySQL charset name
+     * @param mblen         Max number of bytes per character
+     * @param priority      MysqlCharset with highest lever of this param will be used for Java encoding --> Mysql charsets conversion.
+     * @param javaEncodings List of Java encodings corresponding to this MySQL charset; the first name in list is the default for mysql --> java data conversion
+     */
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings) {
+        this.charsetName = charsetName;
+        this.mblen = mblen;
+        this.priority = priority;
+
+        for (int i = 0; i < javaEncodings.length; i++) {
+            String encoding = javaEncodings[i];
+            try {
+                Charset cs = Charset.forName(encoding);
+                addEncodingMapping(cs.name());
+
+                Set<String> als = cs.aliases();
+                Iterator<String> ali = als.iterator();
+                while (ali.hasNext()) {
+                    addEncodingMapping(ali.next());
+                }
+            } catch (Exception e) {
+                // if there is no support of this charset in JVM it's still possible to use our converter for 1-byte charsets
+                if (mblen == 1) {
+                    addEncodingMapping(encoding);
+                }
+            }
+        }
+
+        if (this.javaEncodingsUc.size() == 0) {
+            if (mblen > 1) {
+                addEncodingMapping("UTF-8");
+            } else {
+                addEncodingMapping("Cp1252");
+            }
+        }
+    }
+
+    private void addEncodingMapping(String encoding) {
+        String encodingUc = encoding.toUpperCase(Locale.ENGLISH);
+
+        if (this.defaultEncoding == null) {
+            this.defaultEncoding = encodingUc;
+        }
+
+        if (!this.javaEncodingsUc.contains(encodingUc)) {
+            this.javaEncodingsUc.add(encodingUc);
+        }
+    }
+
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings, int major, int minor) {
+        this(charsetName, mblen, priority, javaEncodings);
+        this.major = major;
+        this.minor = minor;
+    }
+
+    public MysqlCharset(String charsetName, int mblen, int priority, String[] javaEncodings, int major, int minor, int subminor) {
+        this(charsetName, mblen, priority, javaEncodings);
+        this.major = major;
+        this.minor = minor;
+        this.subminor = subminor;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder asString = new StringBuilder();
+        asString.append("[");
+        asString.append("charsetName=");
+        asString.append(this.charsetName);
+        asString.append(",mblen=");
+        asString.append(this.mblen);
+        // asString.append(",javaEncoding=");
+        // asString.append(this.javaEncodings.toString());
+        asString.append("]");
+        return asString.toString();
+    }
+
+    /**
+     * If javaEncoding parameter value is one of available java encodings for this charset
+     * then returns javaEncoding value as is. Otherwise returns first available java encoding name.
+     *
+     * @param javaEncoding
+     * @throws SQLException
+     */
+    String getMatchingJavaEncoding(String javaEncoding) {
+        if (javaEncoding != null && this.javaEncodingsUc.contains(javaEncoding.toUpperCase(Locale.ENGLISH))) {
+            return javaEncoding;
+        }
+        return this.defaultEncoding;
+    }
+}

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/ConnectionPropertiesTest.java
@@ -15,7 +15,7 @@ import java.util.Properties;
 
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 6;
+    private static final int NUM_PROPS = 12;
 
     @Test
     public void testReflection() throws Exception {
@@ -36,8 +36,14 @@ public class ConnectionPropertiesTest {
         ConnectionProperties props = new ConnectionProperties();
         props.initializeProperties(new Properties());
 
+        Assert.assertEquals("blobsAreStrings", false, props.getBlobsAreStrings());
+        Assert.assertEquals("functionsNeverReturnBlobs", false, props.getFunctionsNeverReturnBlobs());
         Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
         Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", false, props.getUseBlobToStoreUTF8OutsideBMP());
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", null, props.getUtf8OutsideBmpIncludedColumnNamePattern());
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", null, props.getUtf8OutsideBmpExcludedColumnNamePattern());
+        Assert.assertEquals("characterEncoding", null, props.getEncoding());
         Assert.assertEquals("executeType", Constants.DEFAULT_EXECUTE_TYPE, props.getExecuteType());
         Assert.assertEquals("twopcEnabled", false, props.getTwopcEnabled());
         Assert.assertEquals("includedFields", Constants.DEFAULT_INCLUDED_FIELDS, props.getIncludedFields());
@@ -50,8 +56,14 @@ public class ConnectionPropertiesTest {
 
         ConnectionProperties props = new ConnectionProperties();
         Properties info = new Properties();
+        info.setProperty("blobsAreStrings", "yes");
+        info.setProperty("functionsNeverReturnBlobs", "yes");
         info.setProperty("tinyInt1isBit", "yes");
         info.setProperty("yearIsDateType", "yes");
+        info.setProperty("useBlobToStoreUTF8OutsideBMP", "yes");
+        info.setProperty("utf8OutsideBmpIncludedColumnNamePattern", "(foo|bar)?baz");
+        info.setProperty("utf8OutsideBmpExcludedColumnNamePattern", "(foo|bar)?baz");
+        info.setProperty("characterEncoding", "utf-8");
         info.setProperty("executeType", Constants.QueryExecuteType.STREAM.name());
         info.setProperty("twopcEnabled", "yes");
         info.setProperty("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY.name());
@@ -59,13 +71,35 @@ public class ConnectionPropertiesTest {
 
         props.initializeProperties(info);
 
+        Assert.assertEquals("blobsAreStrings", true, props.getBlobsAreStrings());
+        Assert.assertEquals("functionsNeverReturnBlobs", true, props.getFunctionsNeverReturnBlobs());
         Assert.assertEquals("tinyInt1isBit", true, props.getTinyInt1isBit());
         Assert.assertEquals("yearIsDateType", true, props.getYearIsDateType());
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", true, props.getUseBlobToStoreUTF8OutsideBMP());
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", "(foo|bar)?baz", props.getUtf8OutsideBmpIncludedColumnNamePattern());
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", "(foo|bar)?baz", props.getUtf8OutsideBmpExcludedColumnNamePattern());
+        Assert.assertEquals("characterEncoding", "utf-8", props.getEncoding());
         Assert.assertEquals("executeType", Constants.QueryExecuteType.STREAM, props.getExecuteType());
         Assert.assertEquals("twopcEnabled", true, props.getTwopcEnabled());
         Assert.assertEquals("includedFields", Query.ExecuteOptions.IncludedFields.TYPE_ONLY, props.getIncludedFields());
         Assert.assertEquals("includedFieldsCache", false, props.isIncludeAllFields());
         Assert.assertEquals("tabletType", Topodata.TabletType.BACKUP, props.getTabletType());
+    }
+
+    @Test(expected = SQLException.class)
+    public void testEncodingValidation() throws SQLException {
+        ConnectionProperties props = new ConnectionProperties();
+        Properties info = new Properties();
+
+        String fakeEncoding = "utf-12345";
+        info.setProperty("characterEncoding", fakeEncoding);
+        try {
+            props.initializeProperties(info);
+            Assert.fail("should have failed to parse encoding " + fakeEncoding);
+        } catch (SQLException e) {
+            Assert.assertEquals("Unsupported character encoding: " + fakeEncoding, e.getMessage());
+            throw e;
+        }
     }
 
     @Test
@@ -75,7 +109,7 @@ public class ConnectionPropertiesTest {
         Assert.assertEquals(NUM_PROPS, infos.length);
 
         // Test the expected fields for just 1
-        int indexForFullTest = 2;
+        int indexForFullTest = 8;
         Assert.assertEquals("executeType", infos[indexForFullTest].name);
         Assert.assertEquals("Query execution type: simple or stream",
             infos[indexForFullTest].description);
@@ -88,11 +122,16 @@ public class ConnectionPropertiesTest {
         Assert.assertArrayEquals(allowed, infos[indexForFullTest].choices);
 
         // Test that name exists for the others, as a sanity check
-        Assert.assertEquals("tinyInt1isBit", infos[0].name);
-        Assert.assertEquals("yearIsDateType", infos[1].name);
-        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[3].name);
-        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[4].name);
-        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[5].name);
+        Assert.assertEquals("functionsNeverReturnBlobs", infos[1].name);
+        Assert.assertEquals("tinyInt1isBit", infos[2].name);
+        Assert.assertEquals("yearIsDateType", infos[3].name);
+        Assert.assertEquals("useBlobToStoreUTF8OutsideBMP", infos[4].name);
+        Assert.assertEquals("utf8OutsideBmpIncludedColumnNamePattern", infos[5].name);
+        Assert.assertEquals("utf8OutsideBmpExcludedColumnNamePattern", infos[6].name);
+        Assert.assertEquals("characterEncoding", infos[7].name);
+        Assert.assertEquals(Constants.Property.TWOPC_ENABLED, infos[9].name);
+        Assert.assertEquals(Constants.Property.INCLUDED_FIELDS, infos[10].name);
+        Assert.assertEquals(Constants.Property.TABLET_TYPE, infos[11].name);
     }
 
     @Test
@@ -100,15 +139,11 @@ public class ConnectionPropertiesTest {
         ConnectionProperties props = new ConnectionProperties();
         Properties info = new Properties();
 
-        info.setProperty(Constants.Property.TWOPC_ENABLED, "true");
+        info.setProperty("blobsAreStrings", "true");
+        info.setProperty("functionsNeverReturnBlobs", "yes");
+        info.setProperty("tinyInt1isBit", "no");
+
         props.initializeProperties(info);
-        Assert.assertEquals(true, props.getTwopcEnabled());
-        info.setProperty(Constants.Property.TWOPC_ENABLED, "yes");
-        props.initializeProperties(info);
-        Assert.assertEquals(true, props.getTwopcEnabled());
-        info.setProperty(Constants.Property.TWOPC_ENABLED, "no");
-        props.initializeProperties(info);
-        Assert.assertEquals(false, props.getTwopcEnabled());
 
         info.setProperty(Constants.Property.TWOPC_ENABLED, "false-ish");
         try {

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/FieldWithMetadataTest.java
@@ -1,10 +1,14 @@
 package com.flipkart.vitess.jdbc;
 
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.proto.Query;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -14,6 +18,101 @@ import java.sql.Types;
 @PrepareForTest(FieldWithMetadata.class)
 @RunWith(PowerMockRunner.class)
 public class FieldWithMetadataTest extends BaseTest {
+
+    @Test
+    public void testImplicitTempTable() throws SQLException {
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("#sql_my_temptable")
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .setType(Query.Type.VARCHAR)
+            .setName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(getVitessConnection(), raw);
+
+        Assert.assertEquals(true, fieldWithMetadata.isImplicitTemporaryTable());
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        VitessConnection conn = getVitessConnection();
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        raw = Query.Field.newBuilder()
+            .setType(Query.Type.VARCHAR)
+            .setName("foo")
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+
+        Assert.assertEquals(false, fieldWithMetadata.isImplicitTemporaryTable());
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+    }
+
+    @Test
+    public void testBlobRemapping() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        conn.setBlobsAreStrings(true);
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("#sql_my_temptable")
+            .setCharset(/* latin1, doesn't matter just dont want utf8 for now */ 5)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .setType(Query.Type.BLOB)
+            .setName("foo")
+            .setOrgName("foo")
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setBlobsAreStrings(false);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setFunctionsNeverReturnBlobs(true);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+
+        conn.setFunctionsNeverReturnBlobs(false);
+        conn.setUseBlobToStoreUTF8OutsideBMP(true);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+
+        raw = raw.toBuilder()
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setColumnLength(MysqlDefs.LENGTH_BLOB)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUtf8OutsideBmpExcludedColumnNamePattern("^fo.*$");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARBINARY, fieldWithMetadata.getJavaType());
+        Assert.assertNotEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUtf8OutsideBmpIncludedColumnNamePattern("^foo$");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        raw = raw.toBuilder()
+            .setColumnLength(MysqlDefs.LENGTH_LONGBLOB)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("utf8_general_ci", fieldWithMetadata.getCollation());
+
+        conn.setUseBlobToStoreUTF8OutsideBMP(false);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.LONGVARBINARY, fieldWithMetadata.getJavaType());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BLOB, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(null, fieldWithMetadata.getCollation());
+    }
 
     @Test
     public void testTinyIntAsBit() throws SQLException {
@@ -38,6 +137,149 @@ public class FieldWithMetadataTest extends BaseTest {
         conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
         fieldWithMetadata = new FieldWithMetadata(conn, raw);
         Assert.assertEquals(Types.TINYINT, fieldWithMetadata.getJavaType());
+    }
+
+    @Test
+    public void testNonNumericNotDateTimeRemapping() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.VARBINARY)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(/* utf-16 UnicodeBig */35)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(/* remapped by TEXT special case */Types.VARCHAR, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("UTF-16", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.VARBINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setType(Query.Type.JSON)
+            .setColumnLength(MysqlDefs.LENGTH_LONGBLOB)
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("UTF-8", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setType(Query.Type.BIT)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("ISO-8859-1", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+
+        conn = getVitessConnection();
+        raw = raw.toBuilder()
+            .setColumnLength(1)
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals("ISO-8859-1", fieldWithMetadata.getEncoding());
+        Assert.assertEquals(true, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(Types.BIT, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(null, fieldWithMetadata.getEncoding());
+        Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
+        Assert.assertEquals(false, fieldWithMetadata.isBlob());
+        Assert.assertEquals(false, fieldWithMetadata.isBinary());
+    }
+
+    @Test
+    public void testNumericAndDateTimeEncoding() throws SQLException{
+        VitessConnection conn = getVitessConnection();
+
+        Query.Type[] types = new Query.Type[]{
+            Query.Type.INT8,
+            Query.Type.UINT8,
+            Query.Type.INT16,
+            Query.Type.UINT16,
+            Query.Type.INT24,
+            Query.Type.UINT24,
+            Query.Type.INT32,
+            Query.Type.UINT32,
+            Query.Type.INT64,
+            Query.Type.UINT64,
+            Query.Type.DECIMAL,
+            Query.Type.UINT24,
+            Query.Type.INT32,
+            Query.Type.UINT32,
+            Query.Type.FLOAT32,
+            Query.Type.FLOAT64,
+            Query.Type.DATE,
+            Query.Type.DATETIME,
+            Query.Type.TIME,
+            Query.Type.TIMESTAMP,
+            Query.Type.YEAR
+        };
+
+
+        for (Query.Type type : types) {
+            Query.Field raw = Query.Field.newBuilder()
+                .setTable("foo")
+                .setColumnLength(3)
+                .setType(type)
+                .setName("foo")
+                .setOrgName("foo")
+                .setCharset(/* utf-16 UnicodeBig */35)
+                .build();
+
+            FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+            Assert.assertEquals(type.name(),"US-ASCII", fieldWithMetadata.getEncoding());
+            Assert.assertEquals(type.name(),false, fieldWithMetadata.isSingleBit());
+        }
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+
+        for (Query.Type type : types) {
+            Query.Field raw = Query.Field.newBuilder()
+                .setTable("foo")
+                .setColumnLength(3)
+                .setType(type)
+                .setName("foo")
+                .setOrgName("foo")
+                .setCharset(/* utf-16 UnicodeBig */35)
+                .build();
+
+            FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+            Assert.assertEquals(type.name(),null, fieldWithMetadata.getEncoding());
+            Assert.assertEquals(type.name(),false, fieldWithMetadata.isSingleBit());
+        }
     }
 
     @Test
@@ -142,6 +384,45 @@ public class FieldWithMetadataTest extends BaseTest {
         Assert.assertEquals(/* just inverses isUnsigned */false, fieldWithMetadata.isSigned());
         Assert.assertEquals(false, fieldWithMetadata.isZeroFill());
 
+    }
+
+    @Test
+    public void testOpaqueBinary() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isOpaqueBinary());
+
+        raw = raw.toBuilder()
+            .setTable("#sql_foo_bar")
+            .build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        raw = raw.toBuilder()
+            .setCharset(/* short circuits collation -> encoding lookup, resulting in null */-1)
+            .build();
+
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
+
+        conn.setEncoding("binary");
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(true, fieldWithMetadata.isOpaqueBinary());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals(false, fieldWithMetadata.isOpaqueBinary());
     }
 
     @Test
@@ -253,7 +534,96 @@ public class FieldWithMetadataTest extends BaseTest {
             "columnName=foo,originalColumnName=foo," +
             "vitessType=" + Query.Type.CHAR.toString() + "(1)," +
             "flags=AUTO_INCREMENT PRIMARY_KEY UNIQUE_KEY BINARY " +
-            "BLOB MULTI_KEY UNSIGNED ZEROFILL";
+            "BLOB MULTI_KEY UNSIGNED ZEROFILL, charsetIndex=0, charsetName=null]";
         Assert.assertEquals(result, field.toString());
+    }
+
+    public void testCollations() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(33)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        String first = fieldWithMetadata.getCollation();
+        String second = fieldWithMetadata.getCollation();
+
+        Assert.assertEquals("utf8_general_ci", first);
+        Assert.assertEquals("cached response is same as first", first, second);
+
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+
+        try {
+            raw = raw.toBuilder()
+                // value chosen because it's obviously out of bounds for the underlying array
+                .setCharset(Integer.MAX_VALUE)
+                .build();
+
+            fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+            fieldWithMetadata.getCollation();
+            Assert.fail("Should have received an array index out of bounds because " +
+                "charset/collationIndex of Int.MAX is well above size of charset array");
+        } catch (SQLException e) {
+            if (e.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                Assert.assertEquals("CollationIndex '" + Integer.MAX_VALUE + "' out of bounds for " +
+                    "collationName lookup, should be within 0 and " +
+                    CharsetMapping.COLLATION_INDEX_TO_COLLATION_NAME.length,
+                    e.getMessage());
+            } else {
+                // just rethrow so we fail that way
+                throw e;
+            }
+        }
+
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+        //Mockito.verify(fieldWithMetadata, Mockito.times(1)).getCollationIndex();
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        Assert.assertEquals("null response when not including all fields", null, fieldWithMetadata.getCollation());
+
+        // We should not call this at all, because we're short circuiting due to included fields
+        //Mockito.verify(fieldWithMetadata, Mockito.never()).getCollationIndex();
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(0)).invoke("getCollationIndex");
+    }
+
+    @Test
+    public void testMaxBytesPerChar() throws Exception {
+        VitessConnection conn = PowerMockito.spy(getVitessConnection());
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setType(Query.Type.CHAR)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(33)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+
+        int first = fieldWithMetadata.getMaxBytesPerCharacter();
+        int second = fieldWithMetadata.getMaxBytesPerCharacter();
+
+        Assert.assertEquals("cached response is same as first", first, second);
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(1)).invoke("getCollationIndex");
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        fieldWithMetadata = PowerMockito.spy(new FieldWithMetadata(conn, raw));
+        Assert.assertEquals("0 return value when not including all fields", 0, fieldWithMetadata.getMaxBytesPerCharacter());
+
+        // We called getMaxBytesPerCharacter 3 times above, but should only have made 1 call to conn.getMaxBytesPerChar:
+        // first - call conn
+        // second - returne cached
+        // third - short circuit because not including all fields
+        // Will test the actual implementation/return value in VitessConnection
+        PowerMockito.verifyPrivate(conn, VerificationModeFactory.times(1)).invoke("getMaxBytesPerChar", 33, "UTF-8");
+
+        // Should not be called at all, because it's new for just this test
+        PowerMockito.verifyPrivate(fieldWithMetadata, VerificationModeFactory.times(0)).invoke("getCollationIndex");
     }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -1,6 +1,8 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.google.common.util.concurrent.Futures;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.SQLFuture;
@@ -194,12 +196,55 @@ public class VitessConnectionTest extends BaseTest {
     }
 
     @Test public void testPropertiesFromJdbcUrl() throws SQLException {
-        String url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&includedFields=type_and_name";
+        String url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&includedFields=type_and_name&blobsAreStrings=yes";
         VitessConnection conn = new VitessConnection(url, new Properties());
 
         // Properties from the url should be passed into the connection properties, and override whatever defaults we've defined
         Assert.assertEquals(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME, conn.getIncludedFields());
         Assert.assertEquals(false, conn.isIncludeAllFields());
         Assert.assertEquals(Topodata.TabletType.REPLICA, conn.getTabletType());
+        Assert.assertEquals(true, conn.getBlobsAreStrings());
+    }
+
+    @Test public void testGetEncodingForIndex() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        // No default encoding configured, and passing NO_CHARSET_INFO basically says "mysql doesn't know"
+        // which means don't try looking it up
+        Assert.assertEquals(null, conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
+        // Similarly, a null index or one landing out of bounds for the charset index should return null
+        Assert.assertEquals(null, conn.getEncodingForIndex(Integer.MAX_VALUE));
+        Assert.assertEquals(null, conn.getEncodingForIndex(-123));
+
+        // charsetIndex 25 is MYSQL_CHARSET_NAME_greek, which is a charset with multiple names, ISO8859_7 and greek
+        // Without an encoding configured in the connection, we should return the first (default) encoding for a charset,
+        // in this case ISO8859_7
+        Assert.assertEquals("ISO-8859-7", conn.getEncodingForIndex(25));
+        conn.setEncoding("greek");
+        // With an encoding configured, we should return that because it matches one of the names for the charset
+        Assert.assertEquals("greek", conn.getEncodingForIndex(25));
+
+        conn.setEncoding(null);
+        Assert.assertEquals("UTF-8", conn.getEncodingForIndex(33));
+        Assert.assertEquals("ISO-8859-1", conn.getEncodingForIndex(63));
+
+        conn.setEncoding("NOT_REAL");
+        // Same tests as the first one, but testing that when there is a default configured, it falls back to that regardless
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(Integer.MAX_VALUE));
+        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(-123));
+    }
+
+    @Test public void testGetMaxBytesPerChar() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        // Default state when no good info is passed in
+        Assert.assertEquals(0, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, null));
+        // use passed collation index
+        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, null));
+        // use first, if both are passed and valid
+        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, "UnicodeBig"));
+        // use passed default charset
+        Assert.assertEquals(2, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, "UnicodeBig"));
     }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetMetadataTest.java
@@ -1,6 +1,7 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.proto.Query;
 
 import org.junit.Assert;
@@ -22,49 +23,50 @@ public class VitessResultSetMetadataTest extends BaseTest {
     private List<Query.Field> generateFieldList() {
         List<Query.Field> fieldList = new ArrayList<>();
 
-        fieldList.add(field("col1", "tbl", Query.Type.INT8, 4)
+        fieldList.add(field("col1", "tbl", Query.Type.INT8, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary)
             .setFlags(Query.MySqlFlag.NOT_NULL_FLAG_VALUE).setOrgName("foo").setOrgTable("foo").build());
-        fieldList.add(field("col2", "tbl", Query.Type.UINT8, 3).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
-        fieldList.add(field("col3", "tbl", Query.Type.INT16, 6).build());
-        fieldList.add(field("col4", "tbl", Query.Type.UINT16, 5).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
-        fieldList.add(field("col5", "tbl", Query.Type.INT24, 9).build());
-        fieldList.add(field("col6", "tbl", Query.Type.UINT24, 8).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
-        fieldList.add(field("col7", "tbl", Query.Type.INT32, 11).build());
-        fieldList.add(field("col8", "tbl", Query.Type.UINT32, 10).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
-        fieldList.add(field("col9", "tbl", Query.Type.INT64, 20).build());
-        fieldList.add(field("col10", "tbl", Query.Type.UINT64, 20).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
-        fieldList.add(field("col11", "tbl", Query.Type.FLOAT32, 12).setDecimals(31).build());
-        fieldList.add(field("col12", "tbl", Query.Type.FLOAT64, 22).setDecimals(31).build());
-        fieldList.add(field("col13", "tbl", Query.Type.TIMESTAMP, 10).build());
-        fieldList.add(field("col14", "tbl", Query.Type.DATE, 10).build());
-        fieldList.add(field("col15", "tbl", Query.Type.TIME, 10).build());
-        fieldList.add(field("col16", "tbl", Query.Type.DATETIME, 19).build());
-        fieldList.add(field("col17", "tbl", Query.Type.YEAR, 4).build());
-        fieldList.add(field("col18", "tbl", Query.Type.DECIMAL, 7).setDecimals(2).build());
-        fieldList.add(field("col19", "tbl", Query.Type.TEXT, 765).build());
-        fieldList.add(field("col20", "tbl", Query.Type.BLOB, 65535)
+        fieldList.add(field("col2", "tbl", Query.Type.UINT8, 3, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col3", "tbl", Query.Type.INT16, 6, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col4", "tbl", Query.Type.UINT16, 5, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col5", "tbl", Query.Type.INT24, 9, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col6", "tbl", Query.Type.UINT24, 8, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col7", "tbl", Query.Type.INT32, 11, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col8", "tbl", Query.Type.UINT32, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col9", "tbl", Query.Type.INT64, 20, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col10", "tbl", Query.Type.UINT64, 20, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.UNSIGNED_FLAG_VALUE).build());
+        fieldList.add(field("col11", "tbl", Query.Type.FLOAT32, 12, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(31).build());
+        fieldList.add(field("col12", "tbl", Query.Type.FLOAT64, 22, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(31).build());
+        fieldList.add(field("col13", "tbl", Query.Type.TIMESTAMP, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col14", "tbl", Query.Type.DATE, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col15", "tbl", Query.Type.TIME, 10, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col16", "tbl", Query.Type.DATETIME, 19, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col17", "tbl", Query.Type.YEAR, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col18", "tbl", Query.Type.DECIMAL, 7, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setDecimals(2).build());
+        fieldList.add(field("col19", "tbl", Query.Type.TEXT, 765, /* utf8_bin -- not case insensitive */ 83).build());
+        fieldList.add(field("col20", "tbl", Query.Type.BLOB, 65535, CharsetMapping.MYSQL_COLLATION_INDEX_binary)
             .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE | Query.MySqlFlag.BLOB_FLAG_VALUE)
             .setDecimals(/* this is set to facilitate testing of getScale, since this is non-numeric */2).build());
-        fieldList.add(field("col21", "tbl", Query.Type.VARCHAR, 768).build());
-        fieldList.add(field("col22", "tbl", Query.Type.VARBINARY, 256).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
-        fieldList.add(field("col23", "tbl", Query.Type.CHAR, 48).build());
-        fieldList.add(field("col24", "tbl", Query.Type.BINARY, 4).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
-        fieldList.add(field("col25", "tbl", Query.Type.BIT, 8).build());
-        fieldList.add(field("col26", "tbl", Query.Type.ENUM, 3).build());
-        fieldList.add(field("col27", "tbl", Query.Type.SET, 9).build());
-        fieldList.add(field("col28", "tbl", Query.Type.TUPLE, 0).build());
-        fieldList.add(field("col29", "tbl", Query.Type.VARBINARY, 256).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
-        fieldList.add(field("col30", "tbl", Query.Type.BLOB, 65535)
+        fieldList.add(field("col21", "tbl", Query.Type.VARCHAR, 768, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col22", "tbl", Query.Type.VARBINARY, 256, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col23", "tbl", Query.Type.CHAR, 48, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col24", "tbl", Query.Type.BINARY, 4, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col25", "tbl", Query.Type.BIT, 8, CharsetMapping.MYSQL_COLLATION_INDEX_binary).build());
+        fieldList.add(field("col26", "tbl", Query.Type.ENUM, 3, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col27", "tbl", Query.Type.SET, 9, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col28", "tbl", Query.Type.TUPLE, 0, CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build());
+        fieldList.add(field("col29", "tbl", Query.Type.VARBINARY, 256, CharsetMapping.MYSQL_COLLATION_INDEX_binary).setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE).build());
+        fieldList.add(field("col30", "tbl", Query.Type.BLOB, 65535, CharsetMapping.MYSQL_COLLATION_INDEX_utf8)
             .setFlags(Query.MySqlFlag.BLOB_FLAG_VALUE).build());
         return fieldList;
     }
 
-    private Query.Field.Builder field(String name, String table, Query.Type type, int length) {
+    private Query.Field.Builder field(String name, String table, Query.Type type, int length, int charset) {
         return Query.Field.newBuilder()
             .setName(name)
             .setTable(table)
             .setType(type)
-            .setColumnLength(length);
+            .setColumnLength(length)
+            .setCharset(charset);
     }
 
     private void initializeFieldList(VitessConnection connection) throws SQLException {
@@ -159,7 +161,7 @@ public class VitessResultSetMetadataTest extends BaseTest {
         Assert.assertEquals("SMALLINT", Types.SMALLINT, vitessResultSetMetadata.getColumnType(17));
         Assert.assertEquals("DECIMAL", Types.DECIMAL, vitessResultSetMetadata.getColumnType(18));
         Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(19));
-        Assert.assertEquals("BLOB", Types.BLOB, vitessResultSetMetadata.getColumnType(20));
+        Assert.assertEquals("LONGVARBINARY", Types.LONGVARBINARY, vitessResultSetMetadata.getColumnType(20));
         Assert.assertEquals("VARCHAR", Types.VARCHAR, vitessResultSetMetadata.getColumnType(21));
         Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(22));
         Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(23));
@@ -168,7 +170,7 @@ public class VitessResultSetMetadataTest extends BaseTest {
         Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(26));
         Assert.assertEquals("CHAR", Types.CHAR, vitessResultSetMetadata.getColumnType(27));
         Assert.assertEquals("VARBINARY", Types.VARBINARY, vitessResultSetMetadata.getColumnType(29));
-        Assert.assertEquals("BLOB", Types.BLOB, vitessResultSetMetadata.getColumnType(30));
+        Assert.assertEquals("LONGVARCHAR", Types.LONGVARCHAR, vitessResultSetMetadata.getColumnType(30));
         try {
             int type = vitessResultSetMetadata.getColumnType(28);
         } catch (SQLException ex) {
@@ -252,9 +254,9 @@ public class VitessResultSetMetadataTest extends BaseTest {
         VitessResultSetMetaData vitessResultSetMetaData = new VitessResultSetMetaData(fieldList);
         Assert.assertEquals(vitessResultSetMetaData.getSchemaName(1), "");
         Assert.assertEquals(vitessResultSetMetaData.getCatalogName(1), "");
-        Assert.assertEquals(vitessResultSetMetaData.getPrecision(1), 0);
+        Assert.assertEquals(vitessResultSetMetaData.getPrecision(1), 3);
         Assert.assertEquals(vitessResultSetMetaData.getScale(1), 0);
-        Assert.assertEquals(vitessResultSetMetaData.getColumnDisplaySize(1), 0);
+        Assert.assertEquals(vitessResultSetMetaData.getColumnDisplaySize(1), 4);
         Assert.assertEquals(vitessResultSetMetaData.isCurrency(1), false);
     }
 
@@ -282,9 +284,20 @@ public class VitessResultSetMetadataTest extends BaseTest {
         Assert.assertEquals("datetime case sensitivity", false, md.isCaseSensitive(16));
         Assert.assertEquals("year case sensitivity", false, md.isCaseSensitive(17));
         Assert.assertEquals("decimal case sensitivity", false, md.isCaseSensitive(18));
-        for (int i = 18; i < fieldList.size(); i++) {
-            Assert.assertEquals(fieldList.get(i).getName() + " - non-numeric case insensitive", i != 24, md.isCaseSensitive(i + 1));
-        }
+
+        // These are handled on a case-by-case basis
+        Assert.assertEquals("text cases sensitivity", /* due to binary */true, md.isCaseSensitive(19));
+        Assert.assertEquals("blob case sensitivity", /* due to binary */true, md.isCaseSensitive(20));
+        Assert.assertEquals("varchar case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(21));
+        Assert.assertEquals("varbinary case sensitivity", /* due to binary */true, md.isCaseSensitive(22));
+        Assert.assertEquals("char case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(23));
+        Assert.assertEquals("binary case sensitivity", /* due to binary */true, md.isCaseSensitive(24));
+        Assert.assertEquals("bit case sensitivity", /* due to numeric type */false, md.isCaseSensitive(25));
+        Assert.assertEquals("enum case sensitivity", /* due to utf-8_ci */ false, md.isCaseSensitive(26));
+        Assert.assertEquals("set case sensitivity", /* due to utf-8_ci, SET == CHAR */ false, md.isCaseSensitive(27));
+        Assert.assertEquals("tuple case sensitivity", /* due to default case */ true, md.isCaseSensitive(28));
+        Assert.assertEquals("varbinary case sensitivity", /* due to binary */ true, md.isCaseSensitive(29));
+        Assert.assertEquals("text cases sensitivity", /* due to utf8_bin (not case insensitive) encoding */false, md.isCaseSensitive(30));
 
         connection.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
         // with limited included fields, we can really only know about numeric types -- those should return false.  the rest should return true
@@ -305,6 +318,89 @@ public class VitessResultSetMetadataTest extends BaseTest {
         conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
         for (int i = 0; i < fieldList.size(); i++) {
             Assert.assertEquals(fieldList.get(i).getName() + " - isNullable is columnNullableUnknown (2) for all when lack of included fields", 2, md.isNullable(i + 1));
+        }
+    }
+
+    @Test public void testDisplaySize() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+
+        Assert.assertEquals("int8 display size", 4, md.getColumnDisplaySize(1));
+        Assert.assertEquals("uint8 display size", 3, md.getColumnDisplaySize(2));
+        Assert.assertEquals("int16 display size", 6, md.getColumnDisplaySize(3));
+        Assert.assertEquals("uint16 display size", 5, md.getColumnDisplaySize(4));
+        Assert.assertEquals("int24 display size", 9, md.getColumnDisplaySize(5));
+        Assert.assertEquals("uint24 display size", 8, md.getColumnDisplaySize(6));
+        Assert.assertEquals("int32 display size", 11, md.getColumnDisplaySize(7));
+        Assert.assertEquals("uint32 display size", 10, md.getColumnDisplaySize(8));
+        Assert.assertEquals("int64 display size", 20, md.getColumnDisplaySize(9));
+        // unsigned long gets an extra digit of precision over signed, so display sizes are the same
+        Assert.assertEquals("uint64 display size", 20, md.getColumnDisplaySize(10));
+        Assert.assertEquals("float32 display size", 12, md.getColumnDisplaySize(11));
+        Assert.assertEquals("float64 display size", 22, md.getColumnDisplaySize(12));
+        Assert.assertEquals("timestamp display size", 10, md.getColumnDisplaySize(13));
+        Assert.assertEquals("date display size", 10, md.getColumnDisplaySize(14));
+        Assert.assertEquals("time display size", 10, md.getColumnDisplaySize(15));
+        Assert.assertEquals("datetime display size", 19, md.getColumnDisplaySize(16));
+        Assert.assertEquals("year display size", 4, md.getColumnDisplaySize(17));
+        Assert.assertEquals("decimal display size", 7, md.getColumnDisplaySize(18));
+        Assert.assertEquals("text display size", 255, md.getColumnDisplaySize(19));
+        Assert.assertEquals("blob display size", 65535, md.getColumnDisplaySize(20));
+        Assert.assertEquals("varchar display size", 256, md.getColumnDisplaySize(21));
+        Assert.assertEquals("varbinary display size", 256, md.getColumnDisplaySize(22));
+        Assert.assertEquals("char display size", 16, md.getColumnDisplaySize(23));
+        Assert.assertEquals("binary display size", 4, md.getColumnDisplaySize(24));
+        Assert.assertEquals("bit display size", 8, md.getColumnDisplaySize(25));
+        Assert.assertEquals("enum display size", 1, md.getColumnDisplaySize(26));
+        Assert.assertEquals("set display size", 3, md.getColumnDisplaySize(27));
+        Assert.assertEquals("tuple display size", 0, md.getColumnDisplaySize(28));
+        Assert.assertEquals("varbinary display size", 256, md.getColumnDisplaySize(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getColumnDisplaySize is 0 for all when lack of included fields", 0, md.getColumnDisplaySize(i + 1));
+        }
+    }
+
+    @Test public void testGetPrecision() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+        List<FieldWithMetadata> fieldList = getFieldList(conn);
+        VitessResultSetMetaData md = new VitessResultSetMetaData(fieldList);
+
+        Assert.assertEquals("int8 precision", 3, md.getPrecision(1));
+        Assert.assertEquals("uint8 precision", 3, md.getPrecision(2));
+        Assert.assertEquals("int16 precision", 5, md.getPrecision(3));
+        Assert.assertEquals("uint16 precision", 5, md.getPrecision(4));
+        Assert.assertEquals("int24 precision", 8, md.getPrecision(5));
+        Assert.assertEquals("uint24 precision", 8, md.getPrecision(6));
+        Assert.assertEquals("int32 precision", 10, md.getPrecision(7));
+        Assert.assertEquals("uint32 precision", 10, md.getPrecision(8));
+        Assert.assertEquals("int64 precision", 19, md.getPrecision(9));
+        Assert.assertEquals("uint64 precision", 20, md.getPrecision(10));
+        Assert.assertEquals("float32 precision", 12, md.getPrecision(11));
+        Assert.assertEquals("float64 precision", 22, md.getPrecision(12));
+        Assert.assertEquals("timestamp precision", 10, md.getPrecision(13));
+        Assert.assertEquals("date precision", 10, md.getPrecision(14));
+        Assert.assertEquals("time precision", 10, md.getPrecision(15));
+        Assert.assertEquals("datetime precision", 19, md.getPrecision(16));
+        Assert.assertEquals("year precision", 4, md.getPrecision(17));
+        Assert.assertEquals("decimal precision", 5, md.getPrecision(18)); // 7 - decimal - sign
+        Assert.assertEquals("text precision", 255, md.getPrecision(19));
+        Assert.assertEquals("blob precision", 65535, md.getPrecision(20));
+        Assert.assertEquals("varchar precision", 256, md.getPrecision(21));
+        Assert.assertEquals("varbinary precision", 256, md.getPrecision(22));
+        Assert.assertEquals("char precision", 16, md.getPrecision(23));
+        Assert.assertEquals("binary precision", 4, md.getPrecision(24));
+        Assert.assertEquals("bit precision", 8, md.getPrecision(25));
+        Assert.assertEquals("enum precision", 1, md.getPrecision(26));
+        Assert.assertEquals("set precision", 3, md.getPrecision(27));
+        Assert.assertEquals("tuple precision", 0, md.getPrecision(28));
+        Assert.assertEquals("varbinary precision", 256, md.getPrecision(29));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        for (int i = 0; i < fieldList.size(); i++) {
+            Assert.assertEquals(fieldList.get(i).getName() + " - getPrecision is 0 for all when lack of included fields", 0, md.getPrecision(i + 1));
         }
     }
 
@@ -372,7 +468,7 @@ public class VitessResultSetMetadataTest extends BaseTest {
         Assert.assertEquals("java.sql.Date", md.getColumnClassName(17));
         Assert.assertEquals("java.math.BigDecimal", md.getColumnClassName(18));
         Assert.assertEquals("java.lang.String", md.getColumnClassName(19));
-        Assert.assertEquals("java.lang.Object", md.getColumnClassName(20));
+        Assert.assertEquals("[B", md.getColumnClassName(20));
         Assert.assertEquals("java.lang.String", md.getColumnClassName(21));
         Assert.assertEquals("[B", md.getColumnClassName(22));
         Assert.assertEquals("java.lang.String", md.getColumnClassName(23));

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessResultSetTest.java
@@ -1,5 +1,8 @@
 package com.flipkart.vitess.jdbc;
 
+import com.flipkart.vitess.util.MysqlDefs;
+import com.flipkart.vitess.util.StringUtils;
+import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.google.protobuf.ByteString;
 import com.youtube.vitess.client.cursor.Cursor;
 import com.youtube.vitess.client.cursor.SimpleCursor;
@@ -7,6 +10,12 @@ import com.youtube.vitess.proto.Query;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.internal.verification.VerificationModeFactory;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -18,6 +27,8 @@ import java.sql.Timestamp;
 /**
  * Created by harshit.gangal on 19/01/16.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(VitessResultSet.class)
 public class VitessResultSetTest extends BaseTest {
 
     public Cursor getCursorWithRows() {
@@ -473,5 +484,221 @@ public class VitessResultSetTest extends BaseTest {
         Cursor cursor = getCursorWithRows();
         VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
         Assert.assertEquals(cursor.getFields().size(), vitessResultSet.getFields().size());
+    }
+
+    @Test public void testGetStringUsesEncoding() throws Exception {
+        VitessConnection conn = getVitessConnection();
+        VitessResultSet resultOne = PowerMockito.spy(new VitessResultSet(getCursorWithRows(), new VitessStatement(conn)));
+        resultOne.next();
+        // test all ways to get to convertBytesToString
+
+        // Verify that we're going through convertBytesToString for column types that return bytes (string-like),
+        // but not for those that return a real object
+        resultOne.getString("col21"); // is a string, should go through convert bytes
+        resultOne.getString("col13"); // is a datetime, should not
+        PowerMockito.verifyPrivate(resultOne, VerificationModeFactory.times(1)).invoke("convertBytesToString", Matchers.any(byte[].class), Matchers.anyString());
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        VitessResultSet resultTwo = PowerMockito.spy(new VitessResultSet(getCursorWithRows(), new VitessStatement(conn)));
+        resultTwo.next();
+
+        // neither of these should go through convertBytesToString, because we didn't include all fields
+        resultTwo.getString("col21");
+        resultTwo.getString("col13");
+        PowerMockito.verifyPrivate(resultTwo, VerificationModeFactory.times(0)).invoke("convertBytesToString", Matchers.any(byte[].class), Matchers.anyString());
+    }
+
+    @Test public void testGetObjectForBitValues() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        ByteString.Output value = ByteString.newOutput();
+        value.write(new byte[] {1});
+        value.write(new byte[] {0});
+        value.write(new byte[] {1,2,3,4});
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            .addFields(Query.Field.newBuilder().setName("col1").setColumnLength(1).setType(Query.Type.BIT))
+            .addFields(Query.Field.newBuilder().setName("col2").setColumnLength(1).setType(Query.Type.BIT))
+            .addFields(Query.Field.newBuilder().setName("col3").setColumnLength(4).setType(Query.Type.BIT))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(1)
+                .addLengths(1)
+                .addLengths(4)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        Assert.assertEquals(true, vitessResultSet.getObject(1));
+        Assert.assertEquals(false, vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(new byte[] {1,2,3,4}, (byte[]) vitessResultSet.getObject(3));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(3)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        Assert.assertArrayEquals(new byte[] { 1 }, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(new byte[] { 0 }, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(new byte[] {1,2,3,4}, (byte[]) vitessResultSet.getObject(3));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
+    }
+
+    @Test public void testGetObjectForVarBinLikeValues() throws Exception {
+        VitessConnection conn = getVitessConnection();
+
+        ByteString.Output value = ByteString.newOutput();
+
+        byte[] binary = new byte[] {1,2,3,4};
+        byte[] varbinary = new byte[] {1,2,3,4,5,6,7,8,9,10,11,12,13};
+        byte[] blob = new byte[MysqlDefs.LENGTH_BLOB];
+        for (int i = 0; i < blob.length; i++) {
+            blob[i] = 1;
+        }
+        byte[] fakeGeometry = new byte[] {2,3,4};
+
+        value.write(binary);
+        value.write(varbinary);
+        value.write(blob);
+        value.write(fakeGeometry);
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            .addFields(Query.Field.newBuilder().setName("col1")
+                .setColumnLength(4)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.BINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(13)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.VARBINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addFields(Query.Field.newBuilder().setName("col3") // should go to LONGVARBINARY due to below settings
+                .setColumnLength(MysqlDefs.LENGTH_BLOB)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+                .setType(Query.Type.BLOB))
+            .addFields(Query.Field.newBuilder().setName("col4")
+                .setType(Query.Type.GEOMETRY)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setType(Query.Type.BINARY)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(4)
+                .addLengths(13)
+                .addLengths(MysqlDefs.LENGTH_BLOB)
+                .addLengths(3)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        // All of these types should pass straight through, returning the direct bytes
+        Assert.assertArrayEquals(binary, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varbinary, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(blob, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(fakeGeometry, (byte[]) vitessResultSet.getObject(4));
+
+        // We should still call the function 4 times
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(4)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        // Same as above since this doesn't really do much but pass right through for the varbinary type
+        Assert.assertArrayEquals(binary, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varbinary, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(blob, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(fakeGeometry, (byte[]) vitessResultSet.getObject(4));
+
+        // Never call because not including all
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
+    }
+
+    @Test public void testGetObjectForStringLikeValues() throws Exception {
+        ByteString.Output value = ByteString.newOutput();
+
+        String trimmedCharStr = "wasting space";
+        String varcharStr = "i have a variable length!";
+        String masqueradingBlobStr = "look at me, im a blob";
+        String textStr = "an enthralling string of TEXT in some foreign language";
+
+        int paddedCharColLength = 20;
+        byte[] trimmedChar = StringUtils.getBytes(trimmedCharStr, "UTF-16");
+        byte[] varchar = StringUtils.getBytes(varcharStr, "UTF-8");
+        byte[] masqueradingBlob = StringUtils.getBytes(masqueradingBlobStr, "US-ASCII");
+        byte[] text = StringUtils.getBytes(textStr, "ISO8859_8");
+        byte[] opaqueBinary = new byte[] { 1,2,3,4,5,6,7,8,9};
+
+        value.write(trimmedChar);
+        value.write(varchar);
+        value.write(opaqueBinary);
+        value.write(masqueradingBlob);
+        value.write(text);
+
+        Query.QueryResult result = Query.QueryResult.newBuilder()
+            // This tests CHAR
+            .addFields(Query.Field.newBuilder().setName("col1")
+                .setColumnLength(paddedCharColLength)
+                .setCharset(/* utf-16 collation index from CharsetMapping */ 54)
+                .setType(Query.Type.CHAR))
+            // This tests VARCHAR
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(varchar.length)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_utf8)
+                .setType(Query.Type.VARCHAR))
+            // This tests VARCHAR that is an opaque binary
+            .addFields(Query.Field.newBuilder().setName("col2")
+                .setColumnLength(opaqueBinary.length)
+                .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+                .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+                .setType(Query.Type.VARCHAR))
+            // This tests LONGVARCHAR
+            .addFields(Query.Field.newBuilder().setName("col3")
+                .setColumnLength(masqueradingBlob.length)
+                .setCharset(/* us-ascii collation index from CharsetMapping */11)
+                .setType(Query.Type.BLOB))
+            // This tests TEXT, which falls through the default case of the switch
+            .addFields(Query.Field.newBuilder().setName("col4")
+                .setColumnLength(text.length)
+                .setCharset(/* corresponds to greek, from CharsetMapping */25)
+                .setType(Query.Type.TEXT))
+            .addRows(Query.Row.newBuilder()
+                .addLengths(trimmedChar.length)
+                .addLengths(varchar.length)
+                .addLengths(opaqueBinary.length)
+                .addLengths(masqueradingBlob.length)
+                .addLengths(text.length)
+                .setValues(value.toByteString()))
+            .build();
+
+        VitessConnection conn = getVitessConnection();
+        VitessResultSet vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        Assert.assertEquals(trimmedCharStr, vitessResultSet.getObject(1));
+        Assert.assertEquals(varcharStr, vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(opaqueBinary, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertEquals(masqueradingBlobStr, vitessResultSet.getObject(4));
+        Assert.assertEquals(textStr, vitessResultSet.getObject(5));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(5)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
+
+        conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
+        vitessResultSet = PowerMockito.spy(new VitessResultSet(new SimpleCursor(result), new VitessStatement(conn)));
+        vitessResultSet.next();
+
+        Assert.assertArrayEquals(trimmedChar, (byte[]) vitessResultSet.getObject(1));
+        Assert.assertArrayEquals(varchar, (byte[]) vitessResultSet.getObject(2));
+        Assert.assertArrayEquals(opaqueBinary, (byte[]) vitessResultSet.getObject(3));
+        Assert.assertArrayEquals(masqueradingBlob, (byte[]) vitessResultSet.getObject(4));
+        Assert.assertArrayEquals(text, (byte[]) vitessResultSet.getObject(5));
+
+        PowerMockito.verifyPrivate(vitessResultSet, VerificationModeFactory.times(0)).invoke("convertBytesIfPossible", Matchers.any(byte[].class), Matchers.any(FieldWithMetadata.class));
     }
 }


### PR DESCRIPTION
This is the final big PR @harshit-gangal and @ashudeep-sharma.  Almost half of the lines are tests though. As before, this takes some inspiration from mysql-connector-j.

CharsetMapping.java, Collation.java, and MysqlCharset.java come directly from mysql-connector-j. I removed some functions that we didn't use, but otherwise untouched.

Nearly 100% test coverage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/2548)
<!-- Reviewable:end -->
