### PR TITLE
workflow: Add WaitUntilRunning() method to Manager API.

### DIFF
--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -135,6 +135,7 @@ func (m *Manager) Run(ctx context.Context) {
 	// the manager is running.
 	m.mu.Lock()
 	if m.ctx != nil {
+		m.mu.Unlock()
 		panic("Manager is already running")
 	}
 	m.ctx = ctx

--- a/go/vt/workflow/manager.go
+++ b/go/vt/workflow/manager.go
@@ -69,6 +69,10 @@ type Manager struct {
 	// shut down, either at startup or shutdown, or is not the
 	// elected master.
 	ctx context.Context
+	// started is used to signal that the manager is running i.e. Run() has been
+	// successfully called and the manager can start workflows.
+	// This channel is closed and re-created every time Run() is called.
+	started chan struct{}
 	// workflows is a map from job UUID to runningWorkflow.
 	workflows map[string]*runningWorkflow
 }
@@ -105,6 +109,7 @@ func NewManager(ts topo.Server) *Manager {
 	return &Manager{
 		ts:          ts,
 		nodeManager: NewNodeManager(),
+		started:     make(chan struct{}),
 		workflows:   make(map[string]*runningWorkflow),
 	}
 }
@@ -140,6 +145,9 @@ func (m *Manager) Run(ctx context.Context) {
 	}
 	m.ctx = ctx
 	m.loadAndStartJobsLocked()
+	// Signal the successful startup.
+	close(m.started)
+	m.started = make(chan struct{})
 	m.mu.Unlock()
 
 	// Wait for the context to be canceled.
@@ -163,6 +171,25 @@ func (m *Manager) Run(ctx context.Context) {
 		select {
 		case <-rw.done:
 		}
+	}
+}
+
+// WaitUntilRunning blocks until Run() has progressed to a state where the
+// manager can start workflows. It is mainly used by tests.
+func (m *Manager) WaitUntilRunning() {
+	for {
+		m.mu.Lock()
+
+		if m.ctx != nil {
+			m.mu.Unlock()
+			return
+		}
+
+		started := m.started
+		m.mu.Unlock()
+
+		// Block until we have been started.
+		<-started
 	}
 }
 


### PR DESCRIPTION
This allows test to block until the manager is fully up and running.

Alain, I've exported this functionality such that Yipei can use it in her "resharding" package.