### PR TITLE
Upgrade gson to 2.8.0 in java driver

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.6.2</version>
+      <version>2.8.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
2.6.2 has a bug when trying to compile with java 8, and is also a year old. The bug was fixed in 2.7 and 2.8.0.

https://github.com/google/gson/pull/820/files

@harshit-gangal @ashudeep-sharma 