### PR TITLE
discovery: Unify labels for stat vars grouped by keyspace and shard.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -40,8 +40,8 @@ import (
 )
 
 var (
-	hcErrorCounters          = stats.NewMultiCounters("HealthcheckErrors", []string{"keyspace", "shardname", "tablettype"})
-	hcMasterPromotedCounters = stats.NewMultiCounters("HealthcheckMasterPromoted", []string{"keyspace", "shardname"})
+	hcErrorCounters          = stats.NewMultiCounters("HealthcheckErrors", []string{"Keyspace", "ShardName", "TabletType"})
+	hcMasterPromotedCounters = stats.NewMultiCounters("HealthcheckMasterPromoted", []string{"Keyspace", "ShardName"})
 )
 
 // See the documentation for NewHealthCheck below for an explanation of these parameters.
@@ -293,7 +293,7 @@ func NewHealthCheck(connTimeout, retryDelay, healthCheckTimeout time.Duration) H
 
 // RegisterStats registers the connection counts stats
 func (hc *HealthCheckImpl) RegisterStats() {
-	stats.NewMultiCountersFunc("HealthcheckConnections", []string{"keyspace", "shardname", "tablettype"}, hc.servingConnStats)
+	stats.NewMultiCountersFunc("HealthcheckConnections", []string{"Keyspace", "ShardName", "TabletType"}, hc.servingConnStats)
 }
 
 // servingConnStats returns the number of serving tablets per keyspace/shard/tablet type.

--- a/go/vt/worker/worker.go
+++ b/go/vt/worker/worker.go
@@ -53,7 +53,7 @@ var (
 	// statsThrottledCounters is the number of times a write has been throttled,
 	// grouped by (keyspace, shard, threadID). Mainly used for testing.
 	// If throttling is enabled, this should always be non-zero for all threads.
-	statsThrottledCounters = stats.NewMultiCounters("WorkerThrottledCounters", []string{"keyspace", "shardname", "thread_id"})
+	statsThrottledCounters = stats.NewMultiCounters("WorkerThrottledCounters", []string{"Keyspace", "ShardName", "ThreadId"})
 	// statsStateDurations tracks for each state how much time was spent in it. Mainly used for testing.
 	statsStateDurationsNs = stats.NewCounters("WorkerStateDurations")
 


### PR DESCRIPTION
This renames the label "shardname" to "ShardName" which will result into
a different internal label name ("shardname" vs. "shard-name").

Unifying this is important in order to operate e.g. on variables from
the discovery package and the vtgate/buffer package without relabeling.