### PR TITLE
vtgate/buffer: Rename "vtgate_" from all command line flags.

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -62,7 +62,7 @@ type Buffer struct {
 	shards map[string]bool
 
 	// bufferSizeSema limits how many requests can be buffered
-	// ("-vtgate_buffer_size") and is shared by all shardBuffer instances.
+	// ("-buffer_size") and is shared by all shardBuffer instances.
 	bufferSizeSema *sync2.Semaphore
 
 	// mu guards all fields in this group.
@@ -70,7 +70,7 @@ type Buffer struct {
 	// - 1. Requests which may buffer (RLock, can be run in parallel)
 	// - 2. Request which starts buffering (based on the seen error)
 	// - 3. HealthCheck listener ("StatsUpdate") which stops buffering
-	// - 4. Timer which may stop buffering after -vtgate_buffer_max_failover_duration
+	// - 4. Timer which may stop buffering after -buffer_max_failover_duration
 	mu sync.RWMutex
 	// buffers holds a shardBuffer object per shard, even if no failover is in
 	// progress.

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -11,52 +11,52 @@ import (
 )
 
 var (
-	enabled       = flag.Bool("enable_vtgate_buffer", false, "Enable buffering (stalling) of master traffic during failovers.")
-	enabledDryRun = flag.Bool("enable_vtgate_buffer_dry_run", false, "Detect and log failover events, but do not actually buffer requests.")
+	enabled       = flag.Bool("enable_buffer", false, "Enable buffering (stalling) of master traffic during failovers.")
+	enabledDryRun = flag.Bool("enable_buffer_dry_run", false, "Detect and log failover events, but do not actually buffer requests.")
 
-	window                  = flag.Duration("vtgate_buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
-	size                    = flag.Int("vtgate_buffer_size", 10, "Maximum number of buffered requests in flight (across all ongoing failovers).")
-	maxFailoverDuration     = flag.Duration("vtgate_buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
-	minTimeBetweenFailovers = flag.Duration("vtgate_buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one. Faster consecutive failovers will not trigger buffering.")
+	window                  = flag.Duration("buffer_window", 10*time.Second, "Duration for how long a request should be buffered at most.")
+	size                    = flag.Int("buffer_size", 10, "Maximum number of buffered requests in flight (across all ongoing failovers).")
+	maxFailoverDuration     = flag.Duration("buffer_max_failover_duration", 20*time.Second, "Stop buffering completely if a failover takes longer than this duration.")
+	minTimeBetweenFailovers = flag.Duration("buffer_min_time_between_failovers", 1*time.Minute, "Minimum time between the end of a failover and the start of the next one. Faster consecutive failovers will not trigger buffering.")
 
-	drainConcurrency = flag.Int("vtgate_buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously.")
+	drainConcurrency = flag.Int("buffer_drain_concurrency", 1, "Maximum number of requests retried simultaneously.")
 
-	shards = flag.String("vtgate_buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_vtgate_buffer=true.")
+	shards = flag.String("buffer_keyspace_shards", "", "If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.")
 )
 
 func resetFlagsForTesting() {
 	// Set all flags to their default value.
-	flag.Set("enable_vtgate_buffer", "false")
-	flag.Set("enable_vtgate_buffer_dry_run", "false")
-	flag.Set("vtgate_buffer_window", "10s")
-	flag.Set("vtgate_buffer_keyspace_shards", "")
-	flag.Set("vtgate_buffer_max_failover_duration", "20s")
-	flag.Set("vtgate_buffer_min_time_between_failovers", "5m")
+	flag.Set("enable_buffer", "false")
+	flag.Set("enable_buffer_dry_run", "false")
+	flag.Set("buffer_window", "10s")
+	flag.Set("buffer_keyspace_shards", "")
+	flag.Set("buffer_max_failover_duration", "20s")
+	flag.Set("buffer_min_time_between_failovers", "5m")
 }
 
 func verifyFlags() error {
 	if *window < 1*time.Second {
-		return fmt.Errorf("-vtgate_buffer_window must be >= 1s (specified value: %v)", *window)
+		return fmt.Errorf("-buffer_window must be >= 1s (specified value: %v)", *window)
 	}
 	if *window > *maxFailoverDuration {
-		return fmt.Errorf("-vtgate_buffer_window must be <= -vtgate_buffer_max_failover_duration: %v vs. %v", *window, *maxFailoverDuration)
+		return fmt.Errorf("-buffer_window must be <= -buffer_max_failover_duration: %v vs. %v", *window, *maxFailoverDuration)
 	}
 	if *size < 1 {
-		return fmt.Errorf("-vtgate_buffer_size must be >= 1 (specified value: %d)", *size)
+		return fmt.Errorf("-buffer_size must be >= 1 (specified value: %d)", *size)
 	}
 	if *minTimeBetweenFailovers < *maxFailoverDuration*time.Duration(2) {
-		return fmt.Errorf("-vtgate_buffer_min_time_between_failovers should be at least twice the length of -vtgate_buffer_max_failover_duration: %v vs. %v", *minTimeBetweenFailovers, *maxFailoverDuration)
+		return fmt.Errorf("-buffer_min_time_between_failovers should be at least twice the length of -buffer_max_failover_duration: %v vs. %v", *minTimeBetweenFailovers, *maxFailoverDuration)
 	}
 
 	if *drainConcurrency < 1 {
-		return fmt.Errorf("-vtgate_buffer_drain_concurrency must be >= 1 (specified value: %d)", *drainConcurrency)
+		return fmt.Errorf("-buffer_drain_concurrency must be >= 1 (specified value: %d)", *drainConcurrency)
 	}
 
 	if *shards != "" && !*enabled {
-		return fmt.Errorf("-vtgate_buffer_keyspace_shards=%v also requires that -enable_vtgate_buffer is set", *shards)
+		return fmt.Errorf("-buffer_keyspace_shards=%v also requires that -enable_buffer is set", *shards)
 	}
 	if *enabled && *enabledDryRun && *shards == "" {
-		return errors.New("both the dry-run mode and actual buffering is enabled. To avoid ambiguity, keyspaces and shards for actual buffering must be explicitly listed in --vtgate_buffer_keyspace_shards")
+		return errors.New("both the dry-run mode and actual buffering is enabled. To avoid ambiguity, keyspaces and shards for actual buffering must be explicitly listed in --buffer_keyspace_shards")
 	}
 
 	keyspaces, shards := keyspaceShardsToSets(*shards)
@@ -66,7 +66,7 @@ func verifyFlags() error {
 			return err
 		}
 		if keyspaces[keyspace] {
-			return fmt.Errorf("-vtgate_buffer_keyspace_shards has overlapping entries (keyspace only vs. keyspace/shard): %v vs. %v Please remove one or the other", keyspace, s)
+			return fmt.Errorf("-buffer_keyspace_shards has overlapping entries (keyspace only vs. keyspace/shard): %v vs. %v Please remove one or the other", keyspace, s)
 		}
 	}
 

--- a/go/vt/vtgate/buffer/flags_test.go
+++ b/go/vt/vtgate/buffer/flags_test.go
@@ -10,28 +10,28 @@ func TestVerifyFlags(t *testing.T) {
 	// Verify that the non-allowed (non-trivial) flag combinations are caught.
 	defer resetFlagsForTesting()
 
-	flag.Set("vtgate_buffer_keyspace_shards", "ks1/0")
+	flag.Set("buffer_keyspace_shards", "ks1/0")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "also requires that") {
-		t.Fatalf("List of shards requires --enable_vtgate_buffer. err: %v", err)
+		t.Fatalf("List of shards requires --enable_buffer. err: %v", err)
 	}
 
 	resetFlagsForTesting()
-	flag.Set("enable_vtgate_buffer", "true")
-	flag.Set("enable_vtgate_buffer_dry_run", "true")
+	flag.Set("enable_buffer", "true")
+	flag.Set("enable_buffer_dry_run", "true")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "To avoid ambiguity") {
 		t.Fatalf("Dry-run and non-dry-run mode together require an explicit list of shards for actual buffering. err: %v", err)
 	}
 
 	resetFlagsForTesting()
-	flag.Set("enable_vtgate_buffer", "true")
-	flag.Set("vtgate_buffer_keyspace_shards", "ks1//0")
+	flag.Set("enable_buffer", "true")
+	flag.Set("buffer_keyspace_shards", "ks1//0")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "Invalid shard path") {
 		t.Fatalf("Invalid shard names are not allowed. err: %v", err)
 	}
 
 	resetFlagsForTesting()
-	flag.Set("enable_vtgate_buffer", "true")
-	flag.Set("vtgate_buffer_keyspace_shards", "ks1,ks1/0")
+	flag.Set("enable_buffer", "true")
+	flag.Set("buffer_keyspace_shards", "ks1,ks1/0")
 	if err := verifyFlags(); err == nil || !strings.Contains(err.Error(), "has overlapping entries") {
 		t.Fatalf("Listed keyspaces and shards must not overlap. err: %v", err)
 	}

--- a/go/vt/vtgate/buffer/timeout_thread.go
+++ b/go/vt/vtgate/buffer/timeout_thread.go
@@ -12,7 +12,7 @@ import (
 type timeoutThread struct {
 	sb *shardBuffer
 	// maxDuration enforces that a failover stops after
-	// -vtgate_buffer_max_failover_duration at most.
+	// -buffer_max_failover_duration at most.
 	maxDuration *time.Timer
 	// stopChan will be closed when the thread should stop e.g. before the drain.
 	stopChan chan struct{}

--- a/go/vt/vtgate/buffer/variables_test.go
+++ b/go/vt/vtgate/buffer/variables_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestVariables(t *testing.T) {
-	flag.Set("vtgate_buffer_size", "23")
+	flag.Set("buffer_size", "23")
 	defer resetFlagsForTesting()
 
 	// Create new buffer which will the flags.

--- a/test/vtgate_buffer.py
+++ b/test/vtgate_buffer.py
@@ -242,11 +242,11 @@ def tearDownModule():
 
 def start_vtgate():
   utils.VtGate().start(extra_args=[
-      '-enable_vtgate_buffer',
+      '-enable_buffer',
       # Long timeout in case failover is slow.
-      '-vtgate_buffer_window', '10m',
-      '-vtgate_buffer_max_failover_duration', '10m',
-      '-vtgate_buffer_min_time_between_failovers', '20m'],
+      '-buffer_window', '10m',
+      '-buffer_max_failover_duration', '10m',
+      '-buffer_min_time_between_failovers', '20m'],
                        tablets=all_tablets)
 
 
@@ -376,7 +376,7 @@ class TestBuffer(TestBufferBase):
   def setUp(self):
     utils.vtgate.kill()
     # Restart vtgate between each test or the feature
-    # --vtgate_buffer_min_time_between_failovers
+    # --buffer_min_time_between_failovers
     # will ignore subsequent failovers.
     start_vtgate()
 


### PR DESCRIPTION
Having "vtgate_" in there is redundant because the package is only going to be used by vtgate binaries.

BUG=26755052