### PR TITLE
tabletserver: Fix the bug that BEGIN does not pass the INTERNAL error code for connection errors.

### DIFF
--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -33,7 +33,6 @@ type Conn struct {
 	// - at Connect() time for clients, with the value returned by
 	// the server.
 	// - at accept time for the server.
-	// If Close() or Shutdown() was called, this is reset to 0.
 	ConnectionID uint32
 
 	// Capabilities is the current set of features this connection
@@ -252,7 +251,6 @@ func (c *Conn) flush() error {
 
 // Close closes the connection.
 func (c *Conn) Close() {
-	c.ConnectionID = 0
 	c.conn.Close()
 }
 

--- a/go/mysqlconn/fakesqldb/server.go
+++ b/go/mysqlconn/fakesqldb/server.go
@@ -217,7 +217,7 @@ func (db *DB) ComQuery(c *mysqlconn.Conn, query string) (*sqltypes.Result, error
 	// Check if we should close the connection and provoke errno 2013.
 	if db.shouldClose {
 		c.Close()
-		return nil, nil
+		return &sqltypes.Result{}, nil
 	}
 
 	// Using special handling for 'SET NAMES utf8'.  The driver

--- a/go/mysqlconn/fakesqldb/server.go
+++ b/go/mysqlconn/fakesqldb/server.go
@@ -15,8 +15,7 @@ import (
 )
 
 // DB is a fake database and all its methods are thread safe.  It
-// creates a mysqlconn.Listener and implements the mysqlconn.Hanlder
-// interface.
+// creates a mysqlconn.Listener and implements the mysqlconn.Handler interface.
 type DB struct {
 	// Fields set at construction time.
 

--- a/go/mysqlconn/fakesqldb/server.go
+++ b/go/mysqlconn/fakesqldb/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/youtube/vitess/go/mysqlconn"
 	"github.com/youtube/vitess/go/sqldb"
@@ -39,6 +40,10 @@ type DB struct {
 	mu sync.Mutex
 	// isConnFail trigger a panic in the connection handler.
 	isConnFail bool
+	// shouldClose, if true, tells ComQuery() to close the connection when
+	// processing the next query. This will trigger a MySQL client error with
+	// errno 2013 ("server lost").
+	shouldClose bool
 	// data maps tolower(query) to a result.
 	data map[string]*sqltypes.Result
 	// rejectedData maps tolower(query) to an error.
@@ -47,6 +52,9 @@ type DB struct {
 	patternData []exprResult
 	// queryCalled keeps track of how many times a query was called.
 	queryCalled map[string]int
+	// connections tracks all open connections.
+	// The key for the map is the value of mysql.Conn.ConnectionID.
+	connections map[uint32]*mysqlconn.Conn
 }
 
 type exprResult struct {
@@ -63,6 +71,7 @@ func New(t *testing.T) *DB {
 		data:         make(map[string]*sqltypes.Result),
 		rejectedData: make(map[string]error),
 		queryCalled:  make(map[string]int),
+		connections:  make(map[uint32]*mysqlconn.Conn),
 	}
 
 	// Start listening.
@@ -93,6 +102,52 @@ func (db *DB) SetName(name string) *DB {
 func (db *DB) Close() {
 	db.listener.Close()
 	db.acceptWG.Wait()
+
+	db.CloseAllConnections()
+}
+
+// CloseAllConnections can be used to provoke MySQL client errors for open
+// connections.
+// Make sure to call WaitForShutdown() as well.
+func (db *DB) CloseAllConnections() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	for _, c := range db.connections {
+		c.Close()
+	}
+}
+
+// WaitForClose should be used after CloseAllConnections() is closed and
+// you want to provoke a MySQL client error with errno 2006.
+//
+// If you don't call this function and execute the next query right away, you
+// will very likely see errno 2013 instead due to timing issues.
+// That's because the following can happen:
+//
+// 1. vttablet MySQL client is able to send the query to this fake server.
+// 2. The fake server sees the query and calls the ComQuery() callback.
+// 3. The fake server tries to write the response back on the connection.
+// => This will finally fail because the connection is already closed.
+// In this example, the client would have been able to send off the query and
+// therefore return errno 2013 ("server lost").
+// Instead, if step 1 already fails, the client returns errno 2006 ("gone away").
+// By waiting for the connections to close, you make sure of that.
+func (db *DB) WaitForClose(timeout time.Duration) error {
+	start := time.Now()
+	for {
+		db.mu.Lock()
+		count := len(db.connections)
+		db.mu.Unlock()
+
+		if count == 0 {
+			return nil
+		}
+		if d := time.Since(start); d > timeout {
+			return fmt.Errorf("connections were not correctly closed after %v: %v are left", d, count)
+		}
+		time.Sleep(1 * time.Microsecond)
+	}
 }
 
 // Host returns the host we're listening on.
@@ -122,23 +177,48 @@ func (db *DB) ConnParams() *sqldb.ConnParams {
 
 // NewConnection is part of the mysqlconn.Handler interface.
 func (db *DB) NewConnection(c *mysqlconn.Conn) {
+	db.t.Logf("NewConnection(%v): client %v", db.name, c.ConnectionID)
+
 	if db.IsConnFail() {
 		panic(fmt.Errorf("simulating a connection failure"))
 	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if conn, ok := db.connections[c.ConnectionID]; ok {
+		db.t.Fatalf("BUG: connection with id: %v is already active. existing conn: %v new conn: %v", c.ConnectionID, conn, c)
+	}
+	db.connections[c.ConnectionID] = c
 }
 
 // ConnectionClosed is part of the mysqlconn.Handler interface.
 func (db *DB) ConnectionClosed(c *mysqlconn.Conn) {
+	db.t.Logf("ConnectionClosed(%v): client %v", db.name, c.ConnectionID)
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if _, ok := db.connections[c.ConnectionID]; !ok {
+		db.t.Fatalf("BUG: Cannot delete connection from list of open connections because it is not registered. ID: %v Conn: %v", c.ConnectionID, c)
+	}
+	delete(db.connections, c.ConnectionID)
 }
 
 // ComQuery is part of the mysqlconn.Handler interface.
 func (db *DB) ComQuery(c *mysqlconn.Conn, query string) (*sqltypes.Result, error) {
-	db.t.Logf("ComQuery(%v): %v", db.name, query)
+	db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
 
 	key := strings.ToLower(query)
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	db.queryCalled[key]++
+
+	// Check if we should close the connection and provoke errno 2013.
+	if db.shouldClose {
+		c.Close()
+		return nil, nil
+	}
 
 	// Using special handling for 'SET NAMES utf8'.  The driver
 	// may send this at connection time, and we don't want it to
@@ -255,4 +335,11 @@ func (db *DB) IsConnFail() bool {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	return db.isConnFail
+}
+
+// EnableShouldClose closes the connection when processing the next query.
+func (db *DB) EnableShouldClose() {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.shouldClose = true
 }

--- a/go/vt/tabletserver/tx_pool.go
+++ b/go/vt/tabletserver/tx_pool.go
@@ -152,6 +152,11 @@ func (axp *TxPool) Begin(ctx context.Context) (int64, error) {
 	}
 	if _, err := conn.Exec(ctx, "begin", 1, false); err != nil {
 		conn.Recycle()
+		if _, ok := err.(*tabletenv.TabletError); ok {
+			// Exec() already returned a TabletError. Don't wrap err into another
+			// TabletError and instead preserve the error code.
+			return 0, err
+		}
 		return 0, tabletenv.NewTabletErrorSQL(vtrpcpb.ErrorCode_UNKNOWN_ERROR, err)
 	}
 	transactionID := axp.lastID.Add(1)

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/youtube/vitess/go/mysqlconn/fakesqldb"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vterrors"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 func TestTxPoolExecuteRollback(t *testing.T) {
@@ -148,7 +151,7 @@ func TestTxPoolBeginWithPoolConnectionError(t *testing.T) {
 	}
 }
 
-func TestTxPoolBeginWithExecError(t *testing.T) {
+func TestTxPoolBeginWithError(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddRejectedQuery("begin", errRejected)
@@ -160,6 +163,9 @@ func TestTxPoolBeginWithExecError(t *testing.T) {
 	want := "error: rejected"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Begin: %v, want %s", err, want)
+	}
+	if got, want := vterrors.RecoverVtErrorCode(err), vtrpcpb.ErrorCode_UNKNOWN_ERROR; got != want {
+		t.Errorf("wrong error code for Begin error: got = %v, want = %v", got, want)
 	}
 }
 

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -202,7 +202,7 @@ func TestTxPoolRollbackFail(t *testing.T) {
 	}
 }
 
-func TestTxPoolGetConnFail(t *testing.T) {
+func TestTxPoolGetConnNonExistentTransaction(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	txPool := newTxPool()

--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -120,9 +120,10 @@ func TestTxPoolBeginAfterConnPoolClosed(t *testing.T) {
 	txPool := newTxPool()
 	txPool.SetTimeout(time.Duration(10))
 	txPool.Open(db.ConnParams(), db.ConnParams())
+
 	txPool.Close()
-	ctx := context.Background()
-	_, err := txPool.Begin(ctx)
+
+	_, err := txPool.Begin(context.Background())
 	if err == nil {
 		t.Fatalf("expect to get an error")
 	}


### PR DESCRIPTION
I recommend to review the changes one commit at a time.

Note that I'm not changing DBConn.Exec() yet: If both attempts failed, we're still returning the first error.