### PR TITLE
tabletserver: Make the error check in tx_pool_test.go less strict.

### DIFF
--- a/go/vt/tabletserver/tx_pool_test.go
+++ b/go/vt/tabletserver/tx_pool_test.go
@@ -187,7 +187,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2006_Permanent(t *testing.T) {
 	// DBConn.Exec() will return the reconnect error as final error and not the
 	// initial connection error.
 	_, err = txPool.LocalBegin(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "Lost connection to MySQL server at 'reading initial communication packet'") {
+	if err == nil || !strings.Contains(err.Error(), "Lost connection to MySQL server at '") || !strings.Contains(err.Error(), "(errno 2013)") {
 		t.Fatalf("Begin did not return the reconnect error: %v", err)
 	}
 	if got, want := vterrors.RecoverVtErrorCode(err), vtrpcpb.ErrorCode_INTERNAL_ERROR; got != want {


### PR DESCRIPTION
Our internal MySQL client returns a different error and therefore failed
this test.