### PR TITLE
SSL: mysqlconn TLS support, better tests.

### DIFF
--- a/go/cmd/vttlstest/vttlstest.go
+++ b/go/cmd/vttlstest/vttlstest.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/tlstest"
+)
+
+var doc = `
+vttlstest is a tool for generating test certificates and keys for TLS tests.
+
+To create a toplevel CA, use:
+  $ vttlstest -root /tmp CreateCA
+
+To create an intermediate or leaf CA, use:
+  $ vttlstest -root /tmp CreateSignedCert servers
+  $ vttlstest -root /tmp CreateSignedCert -parent servers server
+
+To get help on a command, use:
+  $ vttlstest <command> -help
+`
+
+type cmdFunc func(subFlags *flag.FlagSet, args []string)
+
+var cmdMap map[string]cmdFunc
+
+func init() {
+	cmdMap = map[string]cmdFunc{
+		"CreateCA":         cmdCreateCA,
+		"CreateSignedCert": cmdCreateSignedCert,
+	}
+}
+
+var (
+	root = flag.String("root", ".", "root directory for certificates and keys")
+)
+
+func cmdCreateCA(subFlags *flag.FlagSet, args []string) {
+	subFlags.Parse(args)
+	if subFlags.NArg() > 0 {
+		log.Fatalf("CreateCA command doesn't take any parameter")
+	}
+
+	tlstest.CreateCA(*root)
+}
+
+func cmdCreateSignedCert(subFlags *flag.FlagSet, args []string) {
+	parent := subFlags.String("parent", "ca", "Parent cert name to use. Use 'ca' for the toplevel CA.")
+	serial := subFlags.String("serial", "01", "Serial number for the certificate to create. Should be different for two certificates with the same parent.")
+	commonName := subFlags.String("common_name", "", "Common name for the certificate. If empty, uses the name.")
+
+	subFlags.Parse(args)
+	if subFlags.NArg() != 1 {
+		log.Fatalf("CreateSignedCert command takes a single name as a parameter")
+	}
+	if *commonName == "" {
+		*commonName = subFlags.Arg(0)
+	}
+
+	tlstest.CreateSignedCert(*root, *parent, *serial, subFlags.Arg(0), *commonName)
+}
+
+func main() {
+	defer exit.Recover()
+	defer logutil.Flush()
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %v:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, doc)
+	}
+	flag.Parse()
+	args := flag.Args()
+	if len(args) == 0 {
+		flag.Usage()
+		exit.Return(1)
+	}
+
+	cmdName := args[0]
+	args = args[1:]
+	cmd, ok := cmdMap[cmdName]
+	if !ok {
+		log.Fatalf("Unknown command %v", cmdName)
+	}
+	subFlags := flag.NewFlagSet(cmdName, flag.ExitOnError)
+
+	// Run the command.
+	cmd(subFlags, args)
+}

--- a/go/mysqlconn/client.go
+++ b/go/mysqlconn/client.go
@@ -208,13 +208,18 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 		}
 
 		// The ServerName to verify depends on what the hostname is.
+		// - If using a socket, we use "localhost".
 		// - If it is an IP address, we need to prefix it with 'IP:'.
 		// - If not, we can just use it as is.
 		// We may need to add a ServerName field to ConnParams to
 		// make this more explicit.
-		serverName := params.Host
-		if net.ParseIP(params.Host) != nil {
-			serverName = "IP:" + params.Host
+		serverName := "localhost"
+		if params.Host != "" {
+			if net.ParseIP(params.Host) != nil {
+				serverName = "IP:" + params.Host
+			} else {
+				serverName = params.Host
+			}
 		}
 
 		// Build the TLS config.

--- a/go/mysqlconn/client_test.go
+++ b/go/mysqlconn/client_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path"
 	"strings"
 	"sync"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/vt/tlstest"
 	"github.com/youtube/vitess/go/vt/vttest"
 )
 
@@ -169,13 +171,65 @@ func testDupEntryWithRealDatabase(t *testing.T, params *sqldb.ConnParams) {
 	assertSQLError(t, err, ERDupEntry, SSDupKey, "Duplicate entry")
 }
 
+// testTLS tests our client can connect via SSL.
+func testTLS(t *testing.T, params *sqldb.ConnParams) {
+	// First make sure the official 'mysql' client can connect.
+	output, ok := runMysql(t, params, "status")
+	if !ok {
+		t.Fatalf("'mysql -e status' failed: %v", output)
+	}
+	if !strings.Contains(output, "Cipher in use is") {
+		t.Fatalf("cannot connect via SSL: %v", output)
+	}
+
+	// Now connect with our client.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	result, err := conn.ExecuteFetch("SHOW STATUS LIKE 'Ssl_cipher'", 10, true)
+	if err != nil {
+		t.Fatalf("SHOW STATUS LIKE 'Ssl_cipher' failed: %v", err)
+	}
+	if len(result.Rows) != 1 || result.Rows[0][0].String() != "Ssl_cipher" ||
+		result.Rows[0][1].String() == "" {
+		t.Fatalf("SHOW STATUS LIKE 'Ssl_cipher' returned unexpected result: %v", result)
+	}
+}
+
 // TestWithRealDatabase runs a real MySQL database, and runs all kinds
 // of tests on it. To minimize overhead, we only run one database, and
 // run all the tests on it.
 func TestWithRealDatabase(t *testing.T) {
+	// Create the certs.
+	root, err := ioutil.TempDir("", "TestTLSServer")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "localhost")
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the extra SSL my.cnf lines.
+	cnf := fmt.Sprintf(`
+ssl-ca=%v/ca-cert.pem
+ssl-cert=%v/server-cert.pem
+ssl-key=%v/server-key.pem
+`, root, root, root)
+	extraMyCnf := path.Join(root, "ssl_my.cnf")
+	if err := ioutil.WriteFile(extraMyCnf, []byte(cnf), os.ModePerm); err != nil {
+		t.Fatalf("ioutil.WriteFile(%v) failed: %v", extraMyCnf, err)
+	}
+
+	// Launch MySQL.
 	hdl, err := vttest.LaunchVitess(
 		vttest.MySQLOnly("vttest"),
-		vttest.NoStderr())
+		vttest.NoStderr(),
+		vttest.ExtraMyCnf(extraMyCnf))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,4 +278,17 @@ func TestWithRealDatabase(t *testing.T) {
 	t.Run("Schema", func(t *testing.T) {
 		testSchema(t, &params)
 	})
+
+	// Test SSL. First we make sure a real 'mysql' client gets it.
+	params.Flags = CapabilityClientSSL
+	params.SslCa = path.Join(root, "ca-cert.pem")
+	params.SslCert = path.Join(root, "client-cert.pem")
+	params.SslKey = path.Join(root, "client-key.pem")
+	t.Run("TLS", func(t *testing.T) {
+		testTLS(t, &params)
+	})
+
+	// Uncomment to sleep and be able to connect to MySQL
+	// fmt.Printf("Connect to MySQL using parameters: %v\n", params)
+	// time.Sleep(10 * time.Minute)
 }

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -146,6 +146,46 @@ func newConn(conn net.Conn) *Conn {
 	}
 }
 
+// readPacketDirect attempts to read a packet from the socket directly.
+// It needs to be used for the first handshake packet the server receives,
+// so we do't buffer the SSL negociation packet. As a shortcut, only
+// packets smaller than MaxPacketSize can be read here.
+func (c *Conn) readPacketDirect() ([]byte, error) {
+	var header [4]byte
+	if _, err := io.ReadFull(c.conn, header[:]); err != nil {
+		return nil, fmt.Errorf("io.ReadFull(header size) failed: %v", err)
+	}
+
+	sequence := uint8(header[3])
+	if sequence != c.sequence {
+		return nil, fmt.Errorf("invalid sequence, expected %v got %v", c.sequence, sequence)
+	}
+
+	c.sequence++
+
+	length := int(uint32(header[0]) | uint32(header[1])<<8 | uint32(header[2])<<16)
+	if length <= cap(c.buffer) {
+		// Fast path: read into buffer, we're good.
+		c.buffer = c.buffer[:length]
+		if _, err := io.ReadFull(c.conn, c.buffer); err != nil {
+			return nil, fmt.Errorf("io.ReadFull(direct packet body of length %v) failed: %v", length, err)
+		}
+		return c.buffer, nil
+	}
+
+	// Sanity check
+	if length == MaxPacketSize {
+		return nil, fmt.Errorf("readPacketDirect doesn't support more than one packet")
+	}
+
+	// Slow path, revert to allocating.
+	data := make([]byte, length)
+	if _, err := io.ReadFull(c.conn, data); err != nil {
+		return nil, fmt.Errorf("io.ReadFull(packet body of length %v) failed: %v", length, err)
+	}
+	return data, nil
+}
+
 // readEphemeralPacket attempts to read a packet into c.buffer.  Do
 // not use this method if the contents of the packet needs to be kept
 // after the next readEphemeralPacket.  If the packet is bigger than

--- a/go/mysqlconn/conn_test.go
+++ b/go/mysqlconn/conn_test.go
@@ -121,13 +121,22 @@ func verifyPacketCommsSpecific(t *testing.T, cConn *Conn, data []byte,
 // Write a packet on one side, read it on the other, check it's
 // correct.  We use all possible read and write methods.
 func verifyPacketComms(t *testing.T, cConn, sConn *Conn, data []byte) {
+	// All three writes, with ReadPacket.
 	verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.ReadPacket)
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.ReadPacket)
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.ReadPacket)
 
+	// All three writes, with readEphemeralPacket.
 	verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readEphemeralPacket)
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readEphemeralPacket)
 	verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readEphemeralPacket)
+
+	// All three writes, with readPacketDirect, if size allows it.
+	if len(data) < MaxPacketSize {
+		verifyPacketCommsSpecific(t, cConn, data, useWritePacket, sConn.readPacketDirect)
+		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacket, sConn.readPacketDirect)
+		verifyPacketCommsSpecific(t, cConn, data, useWriteEphemeralPacketDirect, sConn.readPacketDirect)
+	}
 }
 
 func TestPackets(t *testing.T) {

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -58,7 +58,6 @@ const (
 
 	// CapabilityClientSSL is CLIENT_SSL.
 	// Switch to SSL after handshake.
-	// Not supported yet, but checked.
 	CapabilityClientSSL = 1 << 11
 
 	// CLIENT_IGNORE_SIGPIPE 1 << 12

--- a/go/mysqlconn/doc.go
+++ b/go/mysqlconn/doc.go
@@ -34,15 +34,11 @@ server should ignore it anyway), and then should send a COM_INIT_DB
 message to set the database.
 
 --
-CLIENT_SSL:
-
-SSL is not supported yet, in neither client nor server. It is not a lot to add.
-
---
 PLUGABLE AUTHENTICATION:
 
 We only support mysql_native_password for now, both client and server
-side. It wouldn't be a lot of work to add SHA256 for instance.
+side. It wouldn't be a lot of work to add SHA256 for instance, or clear text
+authentication.
 
 --
 Maximum Packet Size:

--- a/go/mysqlconn/handshake_test.go
+++ b/go/mysqlconn/handshake_test.go
@@ -1,0 +1,98 @@
+package mysqlconn
+
+import (
+	"context"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqldb"
+	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/tlstest"
+)
+
+// This file tests the handshake scenarios between our client and our server.
+
+// TestSSLConnection creates a server with TLS support, a client that
+// also has SSL support, and connects them.
+func TestSSLConnection(t *testing.T) {
+	th := &testHandler{}
+
+	// Create the listener, so we can get its host.
+	l, err := NewListener("tcp", ":0", th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root, err := ioutil.TempDir("", "TestSSLConnection")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", "IP:"+host)
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := grpcutils.TLSServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		path.Join(root, "ca-cert.pem"))
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	l.TLSConfig = serverConfig
+	l.PasswordMap["user1"] = "password1"
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &sqldb.ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		// SSL flags.
+		Flags:   CapabilityClientSSL,
+		SslCa:   path.Join(root, "ca-cert.pem"),
+		SslCert: path.Join(root, "client-cert.pem"),
+		SslKey:  path.Join(root, "client-key.pem"),
+	}
+
+	// Create a client connection, connect.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Run a 'select rows' command with results.
+	result, err := conn.ExecuteFetch("select rows", 10000, true)
+	if err != nil {
+		t.Fatalf("ExecuteFetch failed: %v", err)
+	}
+	if !reflect.DeepEqual(result, selectRowsResult) {
+		t.Errorf("Got wrong result from ExecuteFetch(select rows): %v", result)
+	}
+
+	// Make sure this went through SSL.
+	result, err = conn.ExecuteFetch("ssl echo", 10000, true)
+	if err != nil {
+		t.Fatalf("ExecuteFetch failed: %v", err)
+	}
+	if result.Rows[0][0].String() != "ON" {
+		t.Errorf("Got wrong result from ExecuteFetch(ssl echo): %v", result)
+	}
+
+	// Send a ComQuit to avoid the error message on the server side.
+	conn.writeComQuit()
+}

--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -3,6 +3,7 @@ package mysqlconn
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/tls"
 	"fmt"
 	"net"
 
@@ -59,6 +60,10 @@ type Listener struct {
 
 	// ServerVersion is the version we will advertise.
 	ServerVersion string
+
+	// TLSConfig is the server TLS config. If set, we will advertise
+	// that we support SSL.
+	TLSConfig *tls.Config
 
 	// PasswordMap maps users to passwords.
 	PasswordMap map[string]string
@@ -126,7 +131,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 	defer l.handler.ConnectionClosed(c)
 
 	// First build and send the server handshake packet.
-	cipher, err := c.writeHandshakeV10(l.ServerVersion)
+	cipher, err := c.writeHandshakeV10(l.ServerVersion, l.TLSConfig != nil)
 	if err != nil {
 		log.Errorf("Cannot send HandshakeV10 packet: %v", err)
 		return
@@ -138,10 +143,24 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		log.Errorf("Cannot read client handshake response: %v", err)
 		return
 	}
-	username, authResponse, err := l.parseClientHandshakePacket(c, response)
+	username, authResponse, err := l.parseClientHandshakePacket(c, true, response)
 	if err != nil {
 		log.Errorf("Cannot parse client handshake response: %v", err)
 		return
+	}
+	if c.Capabilities&CapabilityClientSSL > 0 {
+		// SSL was enabled. We need to re-read the auth packet.
+		response, err = c.readEphemeralPacket()
+		if err != nil {
+			log.Errorf("Cannot read post-SSL client handshake response: %v", err)
+			return
+		}
+
+		username, authResponse, err = l.parseClientHandshakePacket(c, false, response)
+		if err != nil {
+			log.Errorf("Cannot parse post-SSL client handshake response: %v", err)
+			return
+		}
 	}
 
 	// Find the user in our map
@@ -225,7 +244,7 @@ func (l *Listener) Close() {
 
 // writeHandshakeV10 writes the Initial Handshake Packet, server side.
 // It returns the cipher data.
-func (c *Conn) writeHandshakeV10(serverVersion string) ([]byte, error) {
+func (c *Conn) writeHandshakeV10(serverVersion string, enableTLS bool) ([]byte, error) {
 	capabilities := CapabilityClientLongPassword |
 		CapabilityClientLongFlag |
 		CapabilityClientConnectWithDB |
@@ -235,6 +254,9 @@ func (c *Conn) writeHandshakeV10(serverVersion string) ([]byte, error) {
 		CapabilityClientPluginAuth |
 		CapabilityClientPluginAuthLenencClientData |
 		CapabilityClientDeprecateEOF
+	if enableTLS {
+		capabilities |= CapabilityClientSSL
+	}
 
 	length :=
 		1 + // protocol version
@@ -314,7 +336,7 @@ func (c *Conn) writeHandshakeV10(serverVersion string) ([]byte, error) {
 
 // parseClientHandshakePacket parses the handshake sent by the client.
 // Returns the username, auth-data, error.
-func (l *Listener) parseClientHandshakePacket(c *Conn, data []byte) (string, []byte, error) {
+func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []byte) (string, []byte, error) {
 	pos := 0
 
 	// Client flags, 4 bytes.
@@ -326,12 +348,15 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, data []byte) (string, []b
 		return "", nil, fmt.Errorf("parseClientHandshakePacket: only support protocol 4.1")
 	}
 
-	// Remember a subset of the capabilities, so we can use them later in the protocol.
-	c.Capabilities = clientFlags & (CapabilityClientDeprecateEOF)
+	// Remember a subset of the capabilities, so we can use them
+	// later in the protocol. If we re-received the handshake packet
+	// after SSL negotiation, do not overwrite capabilities.
+	if firstTime {
+		c.Capabilities = clientFlags & (CapabilityClientDeprecateEOF)
+	}
 
 	// Max packet size. Don't do anything with this now.
 	// See doc.go for more information.
-	/*maxPacketSize*/
 	_, pos, ok = readUint32(data, pos)
 	if !ok {
 		return "", nil, fmt.Errorf("parseClientHandshakePacket: can't read maxPacketSize")
@@ -346,6 +371,17 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, data []byte) (string, []b
 
 	// 23x reserved zero bytes.
 	pos += 23
+
+	// Check for SSL.
+	if firstTime && l.TLSConfig != nil && clientFlags&CapabilityClientSSL > 0 {
+		// Need to switch to TLS, and then re-read the packet.
+		conn := tls.Server(c.conn, l.TLSConfig)
+		c.conn = conn
+		c.reader.Reset(conn)
+		c.writer.Reset(conn)
+		c.Capabilities |= CapabilityClientSSL
+		return "", nil, nil
+	}
 
 	// username
 	username, pos, ok := readNullString(data, pos)

--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -137,8 +137,9 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		return
 	}
 
-	// Wait for the client response.
-	response, err := c.readEphemeralPacket()
+	// Wait for the client response. This has to be a direct read,
+	// so we don't buffer the TLS negociation packets.
+	response, err := c.readPacketDirect()
 	if err != nil {
 		log.Errorf("Cannot read client handshake response: %v", err)
 		return

--- a/go/mysqlconn/server_test.go
+++ b/go/mysqlconn/server_test.go
@@ -40,6 +40,7 @@ var selectRowsResult = &sqltypes.Result{
 			sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte("nicer name")),
 		},
 	},
+	RowsAffected: 2,
 }
 
 type testHandler struct{}
@@ -219,7 +220,7 @@ func TestTLSServer(t *testing.T) {
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.
-	root, err := ioutil.TempDir("", "tlstest")
+	root, err := ioutil.TempDir("", "TestTLSServer")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}

--- a/go/mysqlconn/server_test.go
+++ b/go/mysqlconn/server_test.go
@@ -2,6 +2,7 @@ package mysqlconn
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -12,6 +13,8 @@ import (
 	"github.com/youtube/vitess/go/sqldb"
 	"github.com/youtube/vitess/go/sqltypes"
 	vtenv "github.com/youtube/vitess/go/vt/env"
+	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/tlstest"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -78,6 +81,27 @@ func (th *testHandler) ComQuery(c *Conn, query string) (*sqltypes.Result, error)
 			Rows: [][]sqltypes.Value{
 				{
 					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(c.SchemaName)),
+				},
+			},
+		}, nil
+	}
+
+	if query == "ssl echo" {
+		value := "OFF"
+		if c.Capabilities&CapabilityClientSSL > 0 {
+			value = "ON"
+		}
+		return &sqltypes.Result{
+
+			Fields: []*querypb.Field{
+				{
+					Name: "ssl_flag",
+					Type: querypb.Type_VARCHAR,
+				},
+			},
+			Rows: [][]sqltypes.Value{
+				{
+					sqltypes.MakeTrusted(querypb.Type_VARCHAR, []byte(value)),
 				},
 			},
 		}, nil
@@ -162,9 +186,96 @@ func TestServer(t *testing.T) {
 		t.Errorf("Unexpected output for 'schema echo'")
 	}
 
+	// Sanity check: make sure this didn't go through SSL
+	output, ok = runMysql(t, params, "ssl echo")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	if !strings.Contains(output, "ssl_flag") ||
+		!strings.Contains(output, "OFF") ||
+		!strings.Contains(output, "1 row in set") {
+		t.Errorf("Unexpected output for 'ssl echo': %v", output)
+	}
 	// Uncomment to leave setup up for a while, to run tests manually.
 	//	fmt.Printf("Listening to server on host '%v' port '%v'.\n", host, port)
 	//	time.Sleep(60 * time.Minute)
+}
+
+// TestTLSServer creates a Server with TLS support, then uses mysql
+// client to connect to it.
+func TestTLSServer(t *testing.T) {
+	th := &testHandler{}
+
+	// Create the listener, so we can get its host.
+	// Below, we are enabling --ssl-verify-server-cert, which adds
+	// a check that the common name of the certificate matches the
+	// server host name we connect to.
+	l, err := NewListener("tcp", ":0", th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Create the certs.
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+	tlstest.CreateCA(root)
+	tlstest.CreateSignedCert(root, tlstest.CA, "01", "server", host)
+	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
+
+	// Create the server with TLS config.
+	serverConfig, err := grpcutils.TLSServerConfig(
+		path.Join(root, "server-cert.pem"),
+		path.Join(root, "server-key.pem"),
+		path.Join(root, "ca-cert.pem"))
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	l.TLSConfig = serverConfig
+	l.PasswordMap["user1"] = "password1"
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &sqldb.ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+		// SSL flags.
+		Flags:   CapabilityClientSSL,
+		SslCa:   path.Join(root, "ca-cert.pem"),
+		SslCert: path.Join(root, "client-cert.pem"),
+		SslKey:  path.Join(root, "client-key.pem"),
+	}
+
+	// Run a 'select rows' command with results.
+	output, ok := runMysql(t, params, "select rows")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	if !strings.Contains(output, "nice name") ||
+		!strings.Contains(output, "nicer name") ||
+		!strings.Contains(output, "2 rows in set") {
+		t.Errorf("Unexpected output for 'select rows'")
+	}
+
+	// make sure this went through SSL
+	output, ok = runMysql(t, params, "ssl echo")
+	if !ok {
+		t.Fatalf("mysql failed: %v", output)
+	}
+	if !strings.Contains(output, "ssl_flag") ||
+		!strings.Contains(output, "ON") ||
+		!strings.Contains(output, "1 row in set") {
+		t.Errorf("Unexpected output for 'ssl echo': %v", output)
+	}
 }
 
 // runMysql forks a mysql command line process connecting to the provided server.
@@ -205,6 +316,15 @@ func runMysql(t *testing.T, params *sqldb.ConnParams, command string) (string, b
 	if params.DbName != "" {
 		args = append(args, []string{
 			"-D", params.DbName,
+		}...)
+	}
+	if params.Flags&CapabilityClientSSL > 0 {
+		args = append(args, []string{
+			"--ssl",
+			"--ssl-ca", params.SslCa,
+			"--ssl-cert", params.SslCert,
+			"--ssl-key", params.SslKey,
+			"--ssl-verify-server-cert",
 		}...)
 	}
 	env := []string{

--- a/go/vt/servenv/grpcutils/server_tls.go
+++ b/go/vt/servenv/grpcutils/server_tls.go
@@ -1,0 +1,38 @@
+package grpcutils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+)
+
+// TLSServerConfig returns the TLS config to use for a server to
+// accept client connections.
+func TLSServerConfig(cert, key, ca string) (*tls.Config, error) {
+	config := &tls.Config{}
+
+	// Load the server cert and key.
+	crt, err := tls.LoadX509KeyPair(cert, key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load cert/key: %v", err)
+	}
+	config.Certificates = []tls.Certificate{crt}
+
+	// if specified, load ca to validate client,
+	// and enforce clients present valid certs.
+	if ca != "" {
+		b, err := ioutil.ReadFile(ca)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to read ca file: %v", err)
+		}
+		cp := x509.NewCertPool()
+		if !cp.AppendCertsFromPEM(b) {
+			return nil, fmt.Errorf("Failed to append certificates")
+		}
+		config.ClientCAs = cp
+		config.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	return config, nil
+}

--- a/go/vt/tlstest/tlstest.go
+++ b/go/vt/tlstest/tlstest.go
@@ -1,0 +1,118 @@
+// Package tlstest contains utility methods to create test certificates.
+// It is not meant to be used in production.
+package tlstest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+
+	log "github.com/golang/glog"
+)
+
+const (
+	// CA is the name of the CA toplevel cert.
+	CA = "ca"
+
+	caConfig = `
+[ req ]
+ default_bits           = 1024
+ default_keyfile        = keyfile.pem
+ distinguished_name     = req_distinguished_name
+ attributes             = req_attributes
+ prompt                 = no
+ output_password        = mypass
+[ req_distinguished_name ]
+ C                      = US
+ ST                     = California
+ L                      = Mountain View
+ O                      = Google
+ OU                     = Vitess
+ CN                     = CA
+ emailAddress           = test@email.address
+[ req_attributes ]
+ challengePassword      = A challenge password
+`
+
+	certConfig = `
+[ req ]
+ default_bits           = 1024
+ default_keyfile        = keyfile.pem
+ distinguished_name     = req_distinguished_name
+ attributes             = req_attributes
+ prompt                 = no
+ output_password        = mypass
+[ req_distinguished_name ]
+ C                      = US
+ ST                     = California
+ L                      = Mountain View
+ O                      = Google
+ OU                     = Vitess
+ CN                     = %s
+ emailAddress           = test@email.address
+[ req_attributes ]
+ challengePassword      = A challenge password
+`
+)
+
+// openssl runs the openssl binary with the provided command.
+func openssl(argv ...string) {
+	cmd := exec.Command("openssl", argv...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatalf("openssl %v failed: %v", argv, err)
+	}
+	if len(output) > 0 {
+		log.Infof("openssl %v returned:\n%v", argv, string(output))
+	}
+}
+
+// CreateCA creates the toplevel 'ca' certificate and key, and places it
+// in the provided directory. Temporary files are also created in that
+// directory.
+func CreateCA(root string) {
+	log.Infof("Creating test root CA in %v", root)
+	key := path.Join(root, "ca-key.pem")
+	cert := path.Join(root, "ca-cert.pem")
+	openssl("genrsa", "-out", key)
+
+	config := path.Join(root, "ca.config")
+	if err := ioutil.WriteFile(config, []byte(caConfig), os.ModePerm); err != nil {
+		log.Fatalf("cannot write file %v: %v", config, err)
+	}
+	openssl("req", "-new", "-x509", "-nodes", "-days", "3600", "-batch",
+		"-config", config,
+		"-key", key,
+		"-out", cert)
+}
+
+// CreateSignedCert creates a new certificate signed by the provided parent,
+// with the provided serial number, name and common name.
+// name is the file name to use. Common Name is the certificate common name.
+func CreateSignedCert(root, parent, serial, name, commonName string) {
+	log.Infof("Creating signed cert and key %v", commonName)
+	caKey := path.Join(root, parent+"-key.pem")
+	caCert := path.Join(root, parent+"-cert.pem")
+	key := path.Join(root, name+"-key.pem")
+	cert := path.Join(root, name+"-cert.pem")
+	req := path.Join(root, name+"-req.pem")
+
+	config := path.Join(root, name+".config")
+	if err := ioutil.WriteFile(config, []byte(fmt.Sprintf(certConfig, commonName)), os.ModePerm); err != nil {
+		log.Fatalf("cannot write file %v: %v", config, err)
+	}
+	openssl("req", "-newkey", "rsa:2048", "-days", "3600", "-nodes",
+		"-batch",
+		"-config", config,
+		"-keyout", key, "-out", req)
+	openssl("rsa", "-in", key, "-out", key)
+	openssl("x509", "-req",
+		"-in", req,
+		"-days", "3600",
+		"-CA", caCert,
+		"-CAkey", caKey,
+		"-set_serial", serial,
+		"-out", cert)
+}

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -1,0 +1,134 @@
+package tlstest
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+)
+
+// TestClientServer generates:
+// - a root CA
+// - a server intermediate CA, with a server.
+// - a client intermediate CA, with a client.
+// And then performs a few tests on them.
+func TestClientServer(t *testing.T) {
+	// Our test root.
+	root, err := ioutil.TempDir("", "tlstest")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(root)
+
+	// Create the certs and configs.
+	CreateCA(root)
+
+	CreateSignedCert(root, CA, "01", "servers", "Servers CA")
+	CreateSignedCert(root, "servers", "01", "server-instance", "Server Instance")
+
+	CreateSignedCert(root, CA, "02", "clients", "Clients CA")
+	CreateSignedCert(root, "clients", "01", "client-instance", "Client Instance")
+	serverConfig, err := grpcutils.TLSServerConfig(
+		path.Join(root, "server-instance-cert.pem"),
+		path.Join(root, "server-instance-key.pem"),
+		path.Join(root, "clients-cert.pem"))
+	if err != nil {
+		t.Fatalf("TLSServerConfig failed: %v", err)
+	}
+	clientConfig, err := grpcutils.TLSClientConfig(
+		path.Join(root, "client-instance-cert.pem"),
+		path.Join(root, "client-instance-key.pem"),
+		path.Join(root, "servers-cert.pem"),
+		"Server Instance")
+	if err != nil {
+		t.Fatalf("TLSClientConfig failed: %v", err)
+	}
+
+	// Create a TLS server listener.
+	listener, err := tls.Listen("tcp", ":0", serverConfig)
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	addr := listener.Addr().String()
+	defer listener.Close()
+
+	wg := sync.WaitGroup{}
+
+	//
+	// Positive case: accept on server side, connect a client, send data.
+	//
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		clientConn, err := tls.Dial("tcp", addr, clientConfig)
+		if err != nil {
+			t.Fatalf("Dial failed: %v", err)
+		}
+
+		clientConn.Write([]byte{42})
+		clientConn.Close()
+	}()
+
+	serverConn, err := listener.Accept()
+	if err != nil {
+		t.Fatalf("Accept failed: %v", err)
+	}
+
+	result := make([]byte, 1)
+	if n, err := serverConn.Read(result); (err != nil && err != io.EOF) || n != 1 {
+		t.Fatalf("Read failed: %v %v", n, err)
+	}
+	if result[0] != 42 {
+		t.Fatalf("Read returned wrong result: %v", result)
+	}
+	serverConn.Close()
+
+	wg.Wait()
+
+	//
+	// Negative case: connect a client with wrong cert (using the
+	// server cert on the client side).
+	//
+
+	badClientConfig, err := grpcutils.TLSClientConfig(
+		path.Join(root, "server-instance-cert.pem"),
+		path.Join(root, "server-instance-key.pem"),
+		path.Join(root, "servers-cert.pem"),
+		"Server Instance")
+	if err != nil {
+		t.Fatalf("TLSClientConfig failed: %v", err)
+	}
+
+	wg.Add(1)
+	go func() {
+		// We expect the Accept to work, but the first read to fail.
+		defer wg.Done()
+		serverConn, err := listener.Accept()
+		if err != nil {
+			t.Fatalf("Connection failed: %v", err)
+		}
+
+		// This will fail.
+		result := make([]byte, 1)
+		if n, err := serverConn.Read(result); err == nil {
+			fmt.Printf("Was able to read from server: %v\n", n)
+		}
+		serverConn.Close()
+	}()
+
+	if _, err = tls.Dial("tcp", addr, badClientConfig); err == nil {
+		t.Fatalf("Dial was expected to fail")
+	}
+	if !strings.Contains(err.Error(), "bad certificate") {
+		t.Errorf("Wrong error returned: %v", err)
+	}
+	t.Logf("Dial returned: %v", err)
+}

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -176,6 +176,17 @@ func Schema(schema string) VitessOption {
 	}
 }
 
+// ExtraMyCnf adds one or more 'my.cnf'-style config files to MySQL.
+// (if more than one, the ':' separator should be used).
+func ExtraMyCnf(extraMyCnf string) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			hdl.cmd.Args = append(hdl.cmd.Args, "--extra_my_cnf", extraMyCnf)
+			return nil
+		},
+	}
+}
+
 // InitDataOptions contain the command line arguments that configure
 // initialization of vttest with random data. See the documentation of
 // the corresponding command line flags in py/vttest/run_local_database.py

--- a/py/vttest/run_local_database.py
+++ b/py/vttest/run_local_database.py
@@ -84,6 +84,10 @@ def main(cmdline_options):
     init_data_opts.max_table_shard_size = cmdline_options.max_table_shard_size
     init_data_opts.null_probability = cmdline_options.null_probability
 
+  extra_my_cnf = os.path.join(os.environ['VTTOP'], 'config/mycnf/vtcombo.cnf')
+  if cmdline_options.extra_my_cnf:
+    extra_my_cnf += ':' + cmdline_options.extra_my_cnf
+
   with local_database.LocalDatabase(
       topology,
       cmdline_options.schema_dir,
@@ -92,8 +96,7 @@ def main(cmdline_options):
       web_dir=cmdline_options.web_dir,
       web_dir2=cmdline_options.web_dir2,
       default_schema_dir=cmdline_options.default_schema_dir,
-      extra_my_cnf=os.path.join(
-          os.environ['VTTOP'], 'config/mycnf/vtcombo.cnf')) as local_db:
+      extra_my_cnf=extra_my_cnf) as local_db:
     print json.dumps(local_db.config())
     sys.stdout.flush()
     try:
@@ -167,6 +170,9 @@ if __name__ == '__main__':
   parser.add_option(
       '--web_dir2',
       help='location of the vtctld2 web server files.')
+  parser.add_option(
+      '-f', '--extra_my_cnf',
+      help='extra files to add to the config, separated by ":"')
   parser.add_option(
       '-v', '--verbose', action='store_true',
       help='Display extra error messages.')


### PR DESCRIPTION
This change contains the following:

* adding client and server side support for TLS in mysqlconn.

* Generating test certs is annoying. Adding a go library to do it, and a go binary that calls the library. Using it in the go mysqlconn unit tests, and in the python tests. We can also use it in the java / bash tests if we want.