### PR TITLE
tabletserver: fix deadlock in test

### DIFF
--- a/go/vt/tabletserver/message_manager_test.go
+++ b/go/vt/tabletserver/message_manager_test.go
@@ -582,6 +582,12 @@ func TestMessagesPending2(t *testing.T) {
 	if d := time.Now().Sub(start); d > 15*time.Second {
 		t.Errorf("pending work trigger did not happen. Duration: %v", d)
 	}
+	// Consume the rest of the messages asynchronously to
+	// prevent hangs.
+	go func() {
+		for range r1.ch {
+		}
+	}()
 }
 
 func TestMMGenerate(t *testing.T) {


### PR DESCRIPTION
I saw this deadlock recently that causes the safety panic to
be triggered. This is a fix for it.