### PR TITLE
v3: remove obsolete QualifiedName

### DIFF
--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -295,16 +295,6 @@ type colsym struct {
 	// column, then the base name of the column will be used as the alias.
 	Alias sqlparser.ColIdent
 
-	// QualfiedName will represent the fully qualified column name,
-	// if the expression is a simple column reference. If the column
-	// expression does not reference a table (or alias), a fully
-	// qualified name will be generated based on the table alias
-	// the column references.
-	// Alias or QualifiedName or both could be blank if such names
-	// could not be generated. If so, those expressions cannot be
-	// referenced by other clauses of the SQL statement.
-	QualifiedName *sqlparser.ColName
-
 	route      *route
 	symtab     *symtab
 	Underlying colref


### PR DESCRIPTION
In the new symbol resolution rules, we always search the tabsyms
if there's no match in colsyms. This make the QualifiedName field
of the colsyms redundant because qualified references will be
matched when searching the tabsyms. In fact, that's what makes
the colsyms legitimate.
It turns out that QualifiedName was already not being used after
the change. So, we can just drop it.