### PR TITLE
Upon initial rebuild for a new keyspace, also call RebuildVSchema

### DIFF
--- a/go/vt/tabletmanager/initial_rebuild.go
+++ b/go/vt/tabletmanager/initial_rebuild.go
@@ -33,5 +33,10 @@ func (agent *ActionAgent) maybeRebuildKeyspace(cell, keyspace string) {
 
 	if err := topotools.RebuildKeyspace(agent.batchCtx, logutil.NewConsoleLogger(), agent.TopoServer, keyspace, []string{cell}); err != nil {
 		log.Warningf("RebuildKeyspace(%v,%v) failed: %v, may need to run 'vtctl RebuildKeyspaceGraph %v')", cell, keyspace, err, keyspace)
+		return
+	}
+
+	if err := topotools.RebuildVSchema(agent.batchCtx, logutil.NewConsoleLogger(), agent.TopoServer, []string{cell}); err != nil {
+		log.Warningf("RebuildVSchema(%v) failed: %v, may need to run 'vtctl RebuildVSchemaGraph --cell %v", cell, err, cell)
 	}
 }

--- a/go/vt/tabletmanager/initial_rebuild.go
+++ b/go/vt/tabletmanager/initial_rebuild.go
@@ -37,6 +37,6 @@ func (agent *ActionAgent) maybeRebuildKeyspace(cell, keyspace string) {
 	}
 
 	if err := topotools.RebuildVSchema(agent.batchCtx, logutil.NewConsoleLogger(), agent.TopoServer, []string{cell}); err != nil {
-		log.Warningf("RebuildVSchema(%v) failed: %v, may need to run 'vtctl RebuildVSchemaGraph --cell %v", cell, err, cell)
+		log.Warningf("RebuildVSchema(%v) failed: %v, may need to run 'vtctl RebuildVSchemaGraph --cells %v", cell, err, cell)
 	}
 }


### PR DESCRIPTION
This fixes https://github.com/youtube/vitess/issues/2368

I tested it internally and a newly keyspace with this code is immediately available for queries. Prior to this change, if would fail like so:

`E0217 18:31:07.368081   31600 vtctl.go:93] action failed: VtGateExecute Execute failed: keyspace Automation not found in vschema, vtgate: http://5171ab55924c:2097/`

This required calling RebuildVSchemaGraph with vtctl before being able to query the keyspace.