### PR TITLE
Properly account for mysql time when auto-commit is enabled

### DIFF
--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -197,16 +197,17 @@ func (qre *QueryExecutor) execAsTransaction(f func(conn *TxConnection) (*sqltype
 
 	reply, err = f(conn)
 
+	start := time.Now()
 	if err != nil {
 		qre.tsv.te.txPool.LocalConclude(qre.ctx, conn)
-		qre.logStats.AddRewrittenSQL("rollback", time.Now())
+		qre.logStats.AddRewrittenSQL("rollback", start)
 		return nil, err
 	}
 	err = qre.tsv.te.txPool.LocalCommit(qre.ctx, conn, qre.tsv.messager)
 	if err != nil {
 		return nil, err
 	}
-	qre.logStats.AddRewrittenSQL("commit", time.Now())
+	qre.logStats.AddRewrittenSQL("commit", start)
 	return reply, nil
 }
 

--- a/go/vt/tabletserver/query_executor.go
+++ b/go/vt/tabletserver/query_executor.go
@@ -204,10 +204,10 @@ func (qre *QueryExecutor) execAsTransaction(f func(conn *TxConnection) (*sqltype
 		return nil, err
 	}
 	err = qre.tsv.te.txPool.LocalCommit(qre.ctx, conn, qre.tsv.messager)
+	qre.logStats.AddRewrittenSQL("commit", start)
 	if err != nil {
 		return nil, err
 	}
-	qre.logStats.AddRewrittenSQL("commit", start)
 	return reply, nil
 }
 


### PR DESCRIPTION
When auto-commit is enabled, the timing reported on the query stats pages all show an order of magnitude difference between MySQL time and Vitess time. This is because for writes some of the work does not happen until the commit actually is executed. 

Deferred the call to AddRewrittenSQL for the LocalCommit and LocalConclude cases, and internally our numbers look much closer now.

@sougou 