### PR TITLE
vtgate/buffer: Fix bug that keyspaces were not logged at startup.

### DIFF
--- a/go/vt/vtgate/buffer/buffer.go
+++ b/go/vt/vtgate/buffer/buffer.go
@@ -99,13 +99,13 @@ func New() *Buffer {
 		header := "Buffering limited to configured "
 		limited := ""
 		if len(keyspaces) > 0 {
-			limited = "keyspaces: " + setToString(keyspaces)
+			limited += "keyspaces: " + setToString(keyspaces)
 		}
 		if len(shards) > 0 {
 			if limited == "" {
 				limited += " and "
 			}
-			limited = "shards: " + setToString(shards)
+			limited += "shards: " + setToString(shards)
 		}
 		if limited != "" {
 			limited = header + limited


### PR DESCRIPTION
This happened only when shards were included as well.