### PR TITLE
Cipher must be a legal UTF8 string.

### DIFF
--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -268,6 +268,14 @@ func (c *Conn) writeHandshakeV10(serverVersion string) ([]byte, error) {
 	if _, err := rand.Read(cipher); err != nil {
 		return nil, err
 	}
+
+        // Cipher must be a legal UTF8 string.
+	for i := 0; i < len(cipher); i++ {
+		cipher[i] &= 0x7f
+		if cipher[i] == '\x00' || cipher[i] == '$' {
+			cipher[i] += 1
+		}
+	}
 	pos += copy(data[pos:], cipher[:8])
 
 	// One filler byte, always 0.


### PR DESCRIPTION
The cipher generated by vtgate on initial handshake must be a legal UTF8 string. Otherwise, use the  vanilla jdbc driver to connect to the vtgate will get a permission error.