### PR TITLE
vendor: Pin the Protobuf Go generator to the latest version.

### DIFF
--- a/go/vt/proto/automation/automation.pb.go
+++ b/go/vt/proto/automation/automation.pb.go
@@ -105,11 +105,32 @@ func (m *ClusterOperation) String() string            { return proto.CompactText
 func (*ClusterOperation) ProtoMessage()               {}
 func (*ClusterOperation) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *ClusterOperation) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
 func (m *ClusterOperation) GetSerialTasks() []*TaskContainer {
 	if m != nil {
 		return m.SerialTasks
 	}
 	return nil
+}
+
+func (m *ClusterOperation) GetState() ClusterOperationState {
+	if m != nil {
+		return m.State
+	}
+	return ClusterOperationState_UNKNOWN_CLUSTER_OPERATION_STATE
+}
+
+func (m *ClusterOperation) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
 }
 
 // TaskContainer holds one or more task which may be executed in parallel.
@@ -131,6 +152,13 @@ func (m *TaskContainer) GetParallelTasks() []*Task {
 	return nil
 }
 
+func (m *TaskContainer) GetConcurrency() int32 {
+	if m != nil {
+		return m.Concurrency
+	}
+	return 0
+}
+
 // Task represents a specific task which should be automatically executed.
 type Task struct {
 	// Task specification.
@@ -150,11 +178,46 @@ func (m *Task) String() string            { return proto.CompactTextString(m) }
 func (*Task) ProtoMessage()               {}
 func (*Task) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *Task) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *Task) GetParameters() map[string]string {
 	if m != nil {
 		return m.Parameters
 	}
 	return nil
+}
+
+func (m *Task) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+func (m *Task) GetState() TaskState {
+	if m != nil {
+		return m.State
+	}
+	return TaskState_UNKNOWN_TASK_STATE
+}
+
+func (m *Task) GetOutput() string {
+	if m != nil {
+		return m.Output
+	}
+	return ""
+}
+
+func (m *Task) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
 }
 
 type EnqueueClusterOperationRequest struct {
@@ -166,6 +229,13 @@ func (m *EnqueueClusterOperationRequest) Reset()                    { *m = Enque
 func (m *EnqueueClusterOperationRequest) String() string            { return proto.CompactTextString(m) }
 func (*EnqueueClusterOperationRequest) ProtoMessage()               {}
 func (*EnqueueClusterOperationRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *EnqueueClusterOperationRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
 
 func (m *EnqueueClusterOperationRequest) GetParameters() map[string]string {
 	if m != nil {
@@ -183,6 +253,13 @@ func (m *EnqueueClusterOperationResponse) String() string            { return pr
 func (*EnqueueClusterOperationResponse) ProtoMessage()               {}
 func (*EnqueueClusterOperationResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
+func (m *EnqueueClusterOperationResponse) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
 type GetClusterOperationStateRequest struct {
 	Id string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
 }
@@ -191,6 +268,13 @@ func (m *GetClusterOperationStateRequest) Reset()                    { *m = GetC
 func (m *GetClusterOperationStateRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetClusterOperationStateRequest) ProtoMessage()               {}
 func (*GetClusterOperationStateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+func (m *GetClusterOperationStateRequest) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
 
 type GetClusterOperationStateResponse struct {
 	State ClusterOperationState `protobuf:"varint,1,opt,name=state,enum=automation.ClusterOperationState" json:"state,omitempty"`
@@ -203,6 +287,13 @@ func (*GetClusterOperationStateResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{6}
 }
 
+func (m *GetClusterOperationStateResponse) GetState() ClusterOperationState {
+	if m != nil {
+		return m.State
+	}
+	return ClusterOperationState_UNKNOWN_CLUSTER_OPERATION_STATE
+}
+
 type GetClusterOperationDetailsRequest struct {
 	Id string `protobuf:"bytes,1,opt,name=id" json:"id,omitempty"`
 }
@@ -212,6 +303,13 @@ func (m *GetClusterOperationDetailsRequest) String() string { return proto.Compa
 func (*GetClusterOperationDetailsRequest) ProtoMessage()    {}
 func (*GetClusterOperationDetailsRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{7}
+}
+
+func (m *GetClusterOperationDetailsRequest) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
 }
 
 type GetClusterOperationDetailsResponse struct {

--- a/go/vt/proto/binlogdata/binlogdata.pb.go
+++ b/go/vt/proto/binlogdata/binlogdata.pb.go
@@ -98,6 +98,27 @@ func (m *Charset) String() string            { return proto.CompactTextString(m)
 func (*Charset) ProtoMessage()               {}
 func (*Charset) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Charset) GetClient() int32 {
+	if m != nil {
+		return m.Client
+	}
+	return 0
+}
+
+func (m *Charset) GetConn() int32 {
+	if m != nil {
+		return m.Conn
+	}
+	return 0
+}
+
+func (m *Charset) GetServer() int32 {
+	if m != nil {
+		return m.Server
+	}
+	return 0
+}
+
 // BinlogTransaction describes a transaction inside the binlogs.
 // It is streamed by vttablet for filtered replication, used during resharding.
 type BinlogTransaction struct {
@@ -140,9 +161,23 @@ func (m *BinlogTransaction_Statement) String() string            { return proto.
 func (*BinlogTransaction_Statement) ProtoMessage()               {}
 func (*BinlogTransaction_Statement) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1, 0} }
 
+func (m *BinlogTransaction_Statement) GetCategory() BinlogTransaction_Statement_Category {
+	if m != nil {
+		return m.Category
+	}
+	return BinlogTransaction_Statement_BL_UNRECOGNIZED
+}
+
 func (m *BinlogTransaction_Statement) GetCharset() *Charset {
 	if m != nil {
 		return m.Charset
+	}
+	return nil
+}
+
+func (m *BinlogTransaction_Statement) GetSql() []byte {
+	if m != nil {
+		return m.Sql
 	}
 	return nil
 }
@@ -161,6 +196,13 @@ func (m *StreamKeyRangeRequest) Reset()                    { *m = StreamKeyRange
 func (m *StreamKeyRangeRequest) String() string            { return proto.CompactTextString(m) }
 func (*StreamKeyRangeRequest) ProtoMessage()               {}
 func (*StreamKeyRangeRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+
+func (m *StreamKeyRangeRequest) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
 
 func (m *StreamKeyRangeRequest) GetKeyRange() *topodata.KeyRange {
 	if m != nil {
@@ -207,6 +249,20 @@ func (m *StreamTablesRequest) Reset()                    { *m = StreamTablesRequ
 func (m *StreamTablesRequest) String() string            { return proto.CompactTextString(m) }
 func (*StreamTablesRequest) ProtoMessage()               {}
 func (*StreamTablesRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *StreamTablesRequest) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
+func (m *StreamTablesRequest) GetTables() []string {
+	if m != nil {
+		return m.Tables
+	}
+	return nil
+}
 
 func (m *StreamTablesRequest) GetCharset() *Charset {
 	if m != nil {

--- a/go/vt/proto/logutil/logutil.pb.go
+++ b/go/vt/proto/logutil/logutil.pb.go
@@ -73,6 +73,20 @@ func (m *Time) String() string            { return proto.CompactTextString(m) }
 func (*Time) ProtoMessage()               {}
 func (*Time) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Time) GetSeconds() int64 {
+	if m != nil {
+		return m.Seconds
+	}
+	return 0
+}
+
+func (m *Time) GetNanoseconds() int32 {
+	if m != nil {
+		return m.Nanoseconds
+	}
+	return 0
+}
+
 // Event is a single logging event
 type Event struct {
 	Time  *Time  `protobuf:"bytes,1,opt,name=time" json:"time,omitempty"`
@@ -92,6 +106,34 @@ func (m *Event) GetTime() *Time {
 		return m.Time
 	}
 	return nil
+}
+
+func (m *Event) GetLevel() Level {
+	if m != nil {
+		return m.Level
+	}
+	return Level_INFO
+}
+
+func (m *Event) GetFile() string {
+	if m != nil {
+		return m.File
+	}
+	return ""
+}
+
+func (m *Event) GetLine() int64 {
+	if m != nil {
+		return m.Line
+	}
+	return 0
+}
+
+func (m *Event) GetValue() string {
+	if m != nil {
+		return m.Value
+	}
+	return ""
 }
 
 func init() {

--- a/go/vt/proto/mysqlctl/mysqlctl.pb.go
+++ b/go/vt/proto/mysqlctl/mysqlctl.pb.go
@@ -49,6 +49,13 @@ func (m *StartRequest) String() string            { return proto.CompactTextStri
 func (*StartRequest) ProtoMessage()               {}
 func (*StartRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *StartRequest) GetMysqldArgs() []string {
+	if m != nil {
+		return m.MysqldArgs
+	}
+	return nil
+}
+
 type StartResponse struct {
 }
 
@@ -65,6 +72,13 @@ func (m *ShutdownRequest) Reset()                    { *m = ShutdownRequest{} }
 func (m *ShutdownRequest) String() string            { return proto.CompactTextString(m) }
 func (*ShutdownRequest) ProtoMessage()               {}
 func (*ShutdownRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+
+func (m *ShutdownRequest) GetWaitForMysqld() bool {
+	if m != nil {
+		return m.WaitForMysqld
+	}
+	return false
+}
 
 type ShutdownResponse struct {
 }

--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -490,6 +490,27 @@ func (m *Target) String() string            { return proto.CompactTextString(m) 
 func (*Target) ProtoMessage()               {}
 func (*Target) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Target) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *Target) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
+func (m *Target) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
 // VTGateCallerID is sent by VTGate to VTTablet to describe the
 // caller. If possible, this information is secure. For instance,
 // if using unique certificates that guarantee that VTGate->VTTablet
@@ -506,6 +527,13 @@ func (m *VTGateCallerID) Reset()                    { *m = VTGateCallerID{} }
 func (m *VTGateCallerID) String() string            { return proto.CompactTextString(m) }
 func (*VTGateCallerID) ProtoMessage()               {}
 func (*VTGateCallerID) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+
+func (m *VTGateCallerID) GetUsername() string {
+	if m != nil {
+		return m.Username
+	}
+	return ""
+}
 
 // EventToken is a structure that describes a point in time in a
 // replication stream on one shard. The most recent known replication
@@ -527,6 +555,27 @@ func (m *EventToken) String() string            { return proto.CompactTextString
 func (*EventToken) ProtoMessage()               {}
 func (*EventToken) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *EventToken) GetTimestamp() int64 {
+	if m != nil {
+		return m.Timestamp
+	}
+	return 0
+}
+
+func (m *EventToken) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
+func (m *EventToken) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 // Value represents a typed value.
 type Value struct {
 	Type  Type   `protobuf:"varint,1,opt,name=type,enum=query.Type" json:"type,omitempty"`
@@ -537,6 +586,20 @@ func (m *Value) Reset()                    { *m = Value{} }
 func (m *Value) String() string            { return proto.CompactTextString(m) }
 func (*Value) ProtoMessage()               {}
 func (*Value) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *Value) GetType() Type {
+	if m != nil {
+		return m.Type
+	}
+	return Type_NULL_TYPE
+}
+
+func (m *Value) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
 
 // BindVariable represents a single bind variable in a Query.
 type BindVariable struct {
@@ -550,6 +613,20 @@ func (m *BindVariable) Reset()                    { *m = BindVariable{} }
 func (m *BindVariable) String() string            { return proto.CompactTextString(m) }
 func (*BindVariable) ProtoMessage()               {}
 func (*BindVariable) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *BindVariable) GetType() Type {
+	if m != nil {
+		return m.Type
+	}
+	return Type_NULL_TYPE
+}
+
+func (m *BindVariable) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
 
 func (m *BindVariable) GetValues() []*Value {
 	if m != nil {
@@ -570,6 +647,13 @@ func (m *BoundQuery) Reset()                    { *m = BoundQuery{} }
 func (m *BoundQuery) String() string            { return proto.CompactTextString(m) }
 func (*BoundQuery) ProtoMessage()               {}
 func (*BoundQuery) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+func (m *BoundQuery) GetSql() string {
+	if m != nil {
+		return m.Sql
+	}
+	return ""
+}
 
 func (m *BoundQuery) GetBindVariables() map[string]*BindVariable {
 	if m != nil {
@@ -597,11 +681,25 @@ func (m *ExecuteOptions) String() string            { return proto.CompactTextSt
 func (*ExecuteOptions) ProtoMessage()               {}
 func (*ExecuteOptions) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
 
+func (m *ExecuteOptions) GetIncludeEventToken() bool {
+	if m != nil {
+		return m.IncludeEventToken
+	}
+	return false
+}
+
 func (m *ExecuteOptions) GetCompareEventToken() *EventToken {
 	if m != nil {
 		return m.CompareEventToken
 	}
 	return nil
+}
+
+func (m *ExecuteOptions) GetIncludedFields() ExecuteOptions_IncludedFields {
+	if m != nil {
+		return m.IncludedFields
+	}
+	return ExecuteOptions_TYPE_AND_NAME
 }
 
 // Field describes a single column returned by a query
@@ -632,6 +730,76 @@ func (m *Field) String() string            { return proto.CompactTextString(m) }
 func (*Field) ProtoMessage()               {}
 func (*Field) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
 
+func (m *Field) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Field) GetType() Type {
+	if m != nil {
+		return m.Type
+	}
+	return Type_NULL_TYPE
+}
+
+func (m *Field) GetTable() string {
+	if m != nil {
+		return m.Table
+	}
+	return ""
+}
+
+func (m *Field) GetOrgTable() string {
+	if m != nil {
+		return m.OrgTable
+	}
+	return ""
+}
+
+func (m *Field) GetDatabase() string {
+	if m != nil {
+		return m.Database
+	}
+	return ""
+}
+
+func (m *Field) GetOrgName() string {
+	if m != nil {
+		return m.OrgName
+	}
+	return ""
+}
+
+func (m *Field) GetColumnLength() uint32 {
+	if m != nil {
+		return m.ColumnLength
+	}
+	return 0
+}
+
+func (m *Field) GetCharset() uint32 {
+	if m != nil {
+		return m.Charset
+	}
+	return 0
+}
+
+func (m *Field) GetDecimals() uint32 {
+	if m != nil {
+		return m.Decimals
+	}
+	return 0
+}
+
+func (m *Field) GetFlags() uint32 {
+	if m != nil {
+		return m.Flags
+	}
+	return 0
+}
+
 // Row is a database row.
 type Row struct {
 	// lengths contains the length of each value in values.
@@ -647,6 +815,20 @@ func (m *Row) Reset()                    { *m = Row{} }
 func (m *Row) String() string            { return proto.CompactTextString(m) }
 func (*Row) ProtoMessage()               {}
 func (*Row) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
+
+func (m *Row) GetLengths() []int64 {
+	if m != nil {
+		return m.Lengths
+	}
+	return nil
+}
+
+func (m *Row) GetValues() []byte {
+	if m != nil {
+		return m.Values
+	}
+	return nil
+}
 
 // ResultExtras contains optional out-of-band information. Usually the
 // extras are requested by adding ExecuteOptions flags.
@@ -669,6 +851,13 @@ func (m *ResultExtras) GetEventToken() *EventToken {
 		return m.EventToken
 	}
 	return nil
+}
+
+func (m *ResultExtras) GetFresher() bool {
+	if m != nil {
+		return m.Fresher
+	}
+	return false
 }
 
 // QueryResult is returned by Execute and ExecuteStream.
@@ -698,6 +887,20 @@ func (m *QueryResult) GetFields() []*Field {
 		return m.Fields
 	}
 	return nil
+}
+
+func (m *QueryResult) GetRowsAffected() uint64 {
+	if m != nil {
+		return m.RowsAffected
+	}
+	return 0
+}
+
+func (m *QueryResult) GetInsertId() uint64 {
+	if m != nil {
+		return m.InsertId
+	}
+	return 0
 }
 
 func (m *QueryResult) GetRows() []*Row {
@@ -760,6 +963,20 @@ func (m *StreamEvent_Statement) String() string            { return proto.Compac
 func (*StreamEvent_Statement) ProtoMessage()               {}
 func (*StreamEvent_Statement) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{11, 0} }
 
+func (m *StreamEvent_Statement) GetCategory() StreamEvent_Statement_Category {
+	if m != nil {
+		return m.Category
+	}
+	return StreamEvent_Statement_Error
+}
+
+func (m *StreamEvent_Statement) GetTableName() string {
+	if m != nil {
+		return m.TableName
+	}
+	return ""
+}
+
 func (m *StreamEvent_Statement) GetPrimaryKeyFields() []*Field {
 	if m != nil {
 		return m.PrimaryKeyFields
@@ -770,6 +987,13 @@ func (m *StreamEvent_Statement) GetPrimaryKeyFields() []*Field {
 func (m *StreamEvent_Statement) GetPrimaryKeyValues() []*Row {
 	if m != nil {
 		return m.PrimaryKeyValues
+	}
+	return nil
+}
+
+func (m *StreamEvent_Statement) GetSql() []byte {
+	if m != nil {
+		return m.Sql
 	}
 	return nil
 }
@@ -815,6 +1039,13 @@ func (m *ExecuteRequest) GetQuery() *BoundQuery {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *ExecuteRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
 }
 
 func (m *ExecuteRequest) GetOptions() *ExecuteOptions {
@@ -912,6 +1143,20 @@ func (m *ExecuteBatchRequest) GetQueries() []*BoundQuery {
 		return m.Queries
 	}
 	return nil
+}
+
+func (m *ExecuteBatchRequest) GetAsTransaction() bool {
+	if m != nil {
+		return m.AsTransaction
+	}
+	return false
+}
+
+func (m *ExecuteBatchRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
 }
 
 func (m *ExecuteBatchRequest) GetOptions() *ExecuteOptions {
@@ -1047,6 +1292,13 @@ func (m *BeginResponse) String() string            { return proto.CompactTextStr
 func (*BeginResponse) ProtoMessage()               {}
 func (*BeginResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{20} }
 
+func (m *BeginResponse) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
 // CommitRequest is the payload to Commit
 type CommitRequest struct {
 	EffectiveCallerId *vtrpc.CallerID `protobuf:"bytes,1,opt,name=effective_caller_id,json=effectiveCallerId" json:"effective_caller_id,omitempty"`
@@ -1079,6 +1331,13 @@ func (m *CommitRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *CommitRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
 }
 
 // CommitResponse is the returned value from Commit
@@ -1122,6 +1381,13 @@ func (m *RollbackRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *RollbackRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
 }
 
 // RollbackResponse is the returned value from Rollback
@@ -1168,6 +1434,20 @@ func (m *PrepareRequest) GetTarget() *Target {
 	return nil
 }
 
+func (m *PrepareRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
+func (m *PrepareRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
 // PrepareResponse is the returned value from Prepare
 type PrepareResponse struct {
 }
@@ -1209,6 +1489,13 @@ func (m *CommitPreparedRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *CommitPreparedRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
 }
 
 // CommitPreparedResponse is the returned value from CommitPrepared
@@ -1255,6 +1542,20 @@ func (m *RollbackPreparedRequest) GetTarget() *Target {
 	return nil
 }
 
+func (m *RollbackPreparedRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
+func (m *RollbackPreparedRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
 // RollbackPreparedResponse is the returned value from RollbackPrepared
 type RollbackPreparedResponse struct {
 }
@@ -1297,6 +1598,13 @@ func (m *CreateTransactionRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *CreateTransactionRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
 }
 
 func (m *CreateTransactionRequest) GetParticipants() []*Target {
@@ -1350,6 +1658,20 @@ func (m *StartCommitRequest) GetTarget() *Target {
 	return nil
 }
 
+func (m *StartCommitRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
+func (m *StartCommitRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
 // StartCommitResponse is the returned value from StartCommit
 type StartCommitResponse struct {
 }
@@ -1392,6 +1714,20 @@ func (m *SetRollbackRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *SetRollbackRequest) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
+func (m *SetRollbackRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
 }
 
 // SetRollbackResponse is the returned value from SetRollback
@@ -1437,6 +1773,13 @@ func (m *ConcludeTransactionRequest) GetTarget() *Target {
 	return nil
 }
 
+func (m *ConcludeTransactionRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
 // ConcludeTransactionResponse is the returned value from ConcludeTransaction
 type ConcludeTransactionResponse struct {
 }
@@ -1478,6 +1821,13 @@ func (m *ReadTransactionRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *ReadTransactionRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
 }
 
 // ReadTransactionResponse is the returned value from ReadTransaction
@@ -1576,6 +1926,13 @@ func (m *BeginExecuteResponse) GetResult() *QueryResult {
 	return nil
 }
 
+func (m *BeginExecuteResponse) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
 // BeginExecuteBatchRequest is the payload to BeginExecuteBatch
 type BeginExecuteBatchRequest struct {
 	EffectiveCallerId *vtrpc.CallerID `protobuf:"bytes,1,opt,name=effective_caller_id,json=effectiveCallerId" json:"effective_caller_id,omitempty"`
@@ -1619,6 +1976,13 @@ func (m *BeginExecuteBatchRequest) GetQueries() []*BoundQuery {
 	return nil
 }
 
+func (m *BeginExecuteBatchRequest) GetAsTransaction() bool {
+	if m != nil {
+		return m.AsTransaction
+	}
+	return false
+}
+
 func (m *BeginExecuteBatchRequest) GetOptions() *ExecuteOptions {
 	if m != nil {
 		return m.Options
@@ -1656,6 +2020,13 @@ func (m *BeginExecuteBatchResponse) GetResults() []*QueryResult {
 	return nil
 }
 
+func (m *BeginExecuteBatchResponse) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
+}
+
 // MessageStreamRequest is the request payload for MessageStream.
 type MessageStreamRequest struct {
 	EffectiveCallerId *vtrpc.CallerID `protobuf:"bytes,1,opt,name=effective_caller_id,json=effectiveCallerId" json:"effective_caller_id,omitempty"`
@@ -1689,6 +2060,13 @@ func (m *MessageStreamRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *MessageStreamRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
 }
 
 // MessageStreamResponse is a response for MessageStream.
@@ -1742,6 +2120,13 @@ func (m *MessageAckRequest) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *MessageAckRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
 }
 
 func (m *MessageAckRequest) GetIds() []*Value {
@@ -1818,6 +2203,34 @@ func (m *SplitQueryRequest) GetQuery() *BoundQuery {
 	return nil
 }
 
+func (m *SplitQueryRequest) GetSplitColumn() []string {
+	if m != nil {
+		return m.SplitColumn
+	}
+	return nil
+}
+
+func (m *SplitQueryRequest) GetSplitCount() int64 {
+	if m != nil {
+		return m.SplitCount
+	}
+	return 0
+}
+
+func (m *SplitQueryRequest) GetNumRowsPerQueryPart() int64 {
+	if m != nil {
+		return m.NumRowsPerQueryPart
+	}
+	return 0
+}
+
+func (m *SplitQueryRequest) GetAlgorithm() SplitQueryRequest_Algorithm {
+	if m != nil {
+		return m.Algorithm
+	}
+	return SplitQueryRequest_EQUAL_SPLITS
+}
+
 // QuerySplit represents one query to execute on the tablet
 type QuerySplit struct {
 	// query is the query to execute
@@ -1836,6 +2249,13 @@ func (m *QuerySplit) GetQuery() *BoundQuery {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *QuerySplit) GetRowCount() int64 {
+	if m != nil {
+		return m.RowCount
+	}
+	return 0
 }
 
 // SplitQueryResponse is returned by SplitQuery and represents all the queries
@@ -1901,6 +2321,48 @@ func (m *RealtimeStats) String() string            { return proto.CompactTextStr
 func (*RealtimeStats) ProtoMessage()               {}
 func (*RealtimeStats) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{53} }
 
+func (m *RealtimeStats) GetHealthError() string {
+	if m != nil {
+		return m.HealthError
+	}
+	return ""
+}
+
+func (m *RealtimeStats) GetSecondsBehindMaster() uint32 {
+	if m != nil {
+		return m.SecondsBehindMaster
+	}
+	return 0
+}
+
+func (m *RealtimeStats) GetBinlogPlayersCount() int32 {
+	if m != nil {
+		return m.BinlogPlayersCount
+	}
+	return 0
+}
+
+func (m *RealtimeStats) GetSecondsBehindMasterFilteredReplication() int64 {
+	if m != nil {
+		return m.SecondsBehindMasterFilteredReplication
+	}
+	return 0
+}
+
+func (m *RealtimeStats) GetCpuUsage() float64 {
+	if m != nil {
+		return m.CpuUsage
+	}
+	return 0
+}
+
+func (m *RealtimeStats) GetQps() float64 {
+	if m != nil {
+		return m.Qps
+	}
+	return 0
+}
+
 // StreamHealthResponse is streamed by StreamHealth on a regular basis
 type StreamHealthResponse struct {
 	// target is the current server type. Only queries with that exact Target
@@ -1930,6 +2392,20 @@ func (m *StreamHealthResponse) GetTarget() *Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *StreamHealthResponse) GetServing() bool {
+	if m != nil {
+		return m.Serving
+	}
+	return false
+}
+
+func (m *StreamHealthResponse) GetTabletExternallyReparentedTimestamp() int64 {
+	if m != nil {
+		return m.TabletExternallyReparentedTimestamp
+	}
+	return 0
 }
 
 func (m *StreamHealthResponse) GetRealtimeStats() *RealtimeStats {
@@ -1980,6 +2456,20 @@ func (m *UpdateStreamRequest) GetTarget() *Target {
 	return nil
 }
 
+func (m *UpdateStreamRequest) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
+func (m *UpdateStreamRequest) GetTimestamp() int64 {
+	if m != nil {
+		return m.Timestamp
+	}
+	return 0
+}
+
 // UpdateStreamResponse is returned by UpdateStream
 type UpdateStreamResponse struct {
 	Event *StreamEvent `protobuf:"bytes,1,opt,name=event" json:"event,omitempty"`
@@ -2009,6 +2499,27 @@ func (m *TransactionMetadata) Reset()                    { *m = TransactionMetad
 func (m *TransactionMetadata) String() string            { return proto.CompactTextString(m) }
 func (*TransactionMetadata) ProtoMessage()               {}
 func (*TransactionMetadata) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{57} }
+
+func (m *TransactionMetadata) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
+func (m *TransactionMetadata) GetState() TransactionState {
+	if m != nil {
+		return m.State
+	}
+	return TransactionState_UNKNOWN
+}
+
+func (m *TransactionMetadata) GetTimeCreated() int64 {
+	if m != nil {
+		return m.TimeCreated
+	}
+	return 0
+}
 
 func (m *TransactionMetadata) GetParticipants() []*Target {
 	if m != nil {

--- a/go/vt/proto/replicationdata/replicationdata.pb.go
+++ b/go/vt/proto/replicationdata/replicationdata.pb.go
@@ -45,6 +45,55 @@ func (m *Status) String() string            { return proto.CompactTextString(m) 
 func (*Status) ProtoMessage()               {}
 func (*Status) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Status) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
+func (m *Status) GetSlaveIoRunning() bool {
+	if m != nil {
+		return m.SlaveIoRunning
+	}
+	return false
+}
+
+func (m *Status) GetSlaveSqlRunning() bool {
+	if m != nil {
+		return m.SlaveSqlRunning
+	}
+	return false
+}
+
+func (m *Status) GetSecondsBehindMaster() uint32 {
+	if m != nil {
+		return m.SecondsBehindMaster
+	}
+	return 0
+}
+
+func (m *Status) GetMasterHost() string {
+	if m != nil {
+		return m.MasterHost
+	}
+	return ""
+}
+
+func (m *Status) GetMasterPort() int32 {
+	if m != nil {
+		return m.MasterPort
+	}
+	return 0
+}
+
+func (m *Status) GetMasterConnectRetry() int32 {
+	if m != nil {
+		return m.MasterConnectRetry
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*Status)(nil), "replicationdata.Status")
 }

--- a/go/vt/proto/tableacl/tableacl.pb.go
+++ b/go/vt/proto/tableacl/tableacl.pb.go
@@ -44,6 +44,41 @@ func (m *TableGroupSpec) String() string            { return proto.CompactTextSt
 func (*TableGroupSpec) ProtoMessage()               {}
 func (*TableGroupSpec) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *TableGroupSpec) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *TableGroupSpec) GetTableNamesOrPrefixes() []string {
+	if m != nil {
+		return m.TableNamesOrPrefixes
+	}
+	return nil
+}
+
+func (m *TableGroupSpec) GetReaders() []string {
+	if m != nil {
+		return m.Readers
+	}
+	return nil
+}
+
+func (m *TableGroupSpec) GetWriters() []string {
+	if m != nil {
+		return m.Writers
+	}
+	return nil
+}
+
+func (m *TableGroupSpec) GetAdmins() []string {
+	if m != nil {
+		return m.Admins
+	}
+	return nil
+}
+
 type Config struct {
 	TableGroups []*TableGroupSpec `protobuf:"bytes,1,rep,name=table_groups,json=tableGroups" json:"table_groups,omitempty"`
 }

--- a/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
+++ b/go/vt/proto/tabletmanagerdata/tabletmanagerdata.pb.go
@@ -144,6 +144,55 @@ func (m *TableDefinition) String() string            { return proto.CompactTextS
 func (*TableDefinition) ProtoMessage()               {}
 func (*TableDefinition) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *TableDefinition) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *TableDefinition) GetSchema() string {
+	if m != nil {
+		return m.Schema
+	}
+	return ""
+}
+
+func (m *TableDefinition) GetColumns() []string {
+	if m != nil {
+		return m.Columns
+	}
+	return nil
+}
+
+func (m *TableDefinition) GetPrimaryKeyColumns() []string {
+	if m != nil {
+		return m.PrimaryKeyColumns
+	}
+	return nil
+}
+
+func (m *TableDefinition) GetType() string {
+	if m != nil {
+		return m.Type
+	}
+	return ""
+}
+
+func (m *TableDefinition) GetDataLength() uint64 {
+	if m != nil {
+		return m.DataLength
+	}
+	return 0
+}
+
+func (m *TableDefinition) GetRowCount() uint64 {
+	if m != nil {
+		return m.RowCount
+	}
+	return 0
+}
+
 type SchemaDefinition struct {
 	DatabaseSchema   string             `protobuf:"bytes,1,opt,name=database_schema,json=databaseSchema" json:"database_schema,omitempty"`
 	TableDefinitions []*TableDefinition `protobuf:"bytes,2,rep,name=table_definitions,json=tableDefinitions" json:"table_definitions,omitempty"`
@@ -155,11 +204,25 @@ func (m *SchemaDefinition) String() string            { return proto.CompactText
 func (*SchemaDefinition) ProtoMessage()               {}
 func (*SchemaDefinition) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
+func (m *SchemaDefinition) GetDatabaseSchema() string {
+	if m != nil {
+		return m.DatabaseSchema
+	}
+	return ""
+}
+
 func (m *SchemaDefinition) GetTableDefinitions() []*TableDefinition {
 	if m != nil {
 		return m.TableDefinitions
 	}
 	return nil
+}
+
+func (m *SchemaDefinition) GetVersion() string {
+	if m != nil {
+		return m.Version
+	}
+	return ""
 }
 
 type SchemaChangeResult struct {
@@ -203,6 +266,27 @@ func (m *UserPermission) String() string            { return proto.CompactTextSt
 func (*UserPermission) ProtoMessage()               {}
 func (*UserPermission) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
 
+func (m *UserPermission) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+func (m *UserPermission) GetUser() string {
+	if m != nil {
+		return m.User
+	}
+	return ""
+}
+
+func (m *UserPermission) GetPasswordChecksum() uint64 {
+	if m != nil {
+		return m.PasswordChecksum
+	}
+	return 0
+}
+
 func (m *UserPermission) GetPrivileges() map[string]string {
 	if m != nil {
 		return m.Privileges
@@ -223,6 +307,27 @@ func (m *DbPermission) Reset()                    { *m = DbPermission{} }
 func (m *DbPermission) String() string            { return proto.CompactTextString(m) }
 func (*DbPermission) ProtoMessage()               {}
 func (*DbPermission) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *DbPermission) GetHost() string {
+	if m != nil {
+		return m.Host
+	}
+	return ""
+}
+
+func (m *DbPermission) GetDb() string {
+	if m != nil {
+		return m.Db
+	}
+	return ""
+}
+
+func (m *DbPermission) GetUser() string {
+	if m != nil {
+		return m.User
+	}
+	return ""
+}
 
 func (m *DbPermission) GetPrivileges() map[string]string {
 	if m != nil {
@@ -268,6 +373,20 @@ func (m *BlpPosition) String() string            { return proto.CompactTextStrin
 func (*BlpPosition) ProtoMessage()               {}
 func (*BlpPosition) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
 
+func (m *BlpPosition) GetUid() uint32 {
+	if m != nil {
+		return m.Uid
+	}
+	return 0
+}
+
+func (m *BlpPosition) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type PingRequest struct {
 	Payload string `protobuf:"bytes,1,opt,name=payload" json:"payload,omitempty"`
 }
@@ -276,6 +395,13 @@ func (m *PingRequest) Reset()                    { *m = PingRequest{} }
 func (m *PingRequest) String() string            { return proto.CompactTextString(m) }
 func (*PingRequest) ProtoMessage()               {}
 func (*PingRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
+
+func (m *PingRequest) GetPayload() string {
+	if m != nil {
+		return m.Payload
+	}
+	return ""
+}
 
 type PingResponse struct {
 	Payload string `protobuf:"bytes,1,opt,name=payload" json:"payload,omitempty"`
@@ -286,6 +412,13 @@ func (m *PingResponse) String() string            { return proto.CompactTextStri
 func (*PingResponse) ProtoMessage()               {}
 func (*PingResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
 
+func (m *PingResponse) GetPayload() string {
+	if m != nil {
+		return m.Payload
+	}
+	return ""
+}
+
 type SleepRequest struct {
 	// duration is in nanoseconds
 	Duration int64 `protobuf:"varint,1,opt,name=duration" json:"duration,omitempty"`
@@ -295,6 +428,13 @@ func (m *SleepRequest) Reset()                    { *m = SleepRequest{} }
 func (m *SleepRequest) String() string            { return proto.CompactTextString(m) }
 func (*SleepRequest) ProtoMessage()               {}
 func (*SleepRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
+
+func (m *SleepRequest) GetDuration() int64 {
+	if m != nil {
+		return m.Duration
+	}
+	return 0
+}
 
 type SleepResponse struct {
 }
@@ -315,6 +455,20 @@ func (m *ExecuteHookRequest) String() string            { return proto.CompactTe
 func (*ExecuteHookRequest) ProtoMessage()               {}
 func (*ExecuteHookRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{11} }
 
+func (m *ExecuteHookRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *ExecuteHookRequest) GetParameters() []string {
+	if m != nil {
+		return m.Parameters
+	}
+	return nil
+}
+
 func (m *ExecuteHookRequest) GetExtraEnv() map[string]string {
 	if m != nil {
 		return m.ExtraEnv
@@ -333,6 +487,27 @@ func (m *ExecuteHookResponse) String() string            { return proto.CompactT
 func (*ExecuteHookResponse) ProtoMessage()               {}
 func (*ExecuteHookResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{12} }
 
+func (m *ExecuteHookResponse) GetExitStatus() int64 {
+	if m != nil {
+		return m.ExitStatus
+	}
+	return 0
+}
+
+func (m *ExecuteHookResponse) GetStdout() string {
+	if m != nil {
+		return m.Stdout
+	}
+	return ""
+}
+
+func (m *ExecuteHookResponse) GetStderr() string {
+	if m != nil {
+		return m.Stderr
+	}
+	return ""
+}
+
 type GetSchemaRequest struct {
 	Tables        []string `protobuf:"bytes,1,rep,name=tables" json:"tables,omitempty"`
 	IncludeViews  bool     `protobuf:"varint,2,opt,name=include_views,json=includeViews" json:"include_views,omitempty"`
@@ -343,6 +518,27 @@ func (m *GetSchemaRequest) Reset()                    { *m = GetSchemaRequest{} 
 func (m *GetSchemaRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetSchemaRequest) ProtoMessage()               {}
 func (*GetSchemaRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{13} }
+
+func (m *GetSchemaRequest) GetTables() []string {
+	if m != nil {
+		return m.Tables
+	}
+	return nil
+}
+
+func (m *GetSchemaRequest) GetIncludeViews() bool {
+	if m != nil {
+		return m.IncludeViews
+	}
+	return false
+}
+
+func (m *GetSchemaRequest) GetExcludeTables() []string {
+	if m != nil {
+		return m.ExcludeTables
+	}
+	return nil
+}
 
 type GetSchemaResponse struct {
 	SchemaDefinition *SchemaDefinition `protobuf:"bytes,1,opt,name=schema_definition,json=schemaDefinition" json:"schema_definition,omitempty"`
@@ -425,6 +621,13 @@ func (m *ChangeTypeRequest) String() string            { return proto.CompactTex
 func (*ChangeTypeRequest) ProtoMessage()               {}
 func (*ChangeTypeRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{21} }
 
+func (m *ChangeTypeRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
 type ChangeTypeResponse struct {
 }
 
@@ -474,6 +677,13 @@ func (m *IgnoreHealthErrorRequest) String() string            { return proto.Com
 func (*IgnoreHealthErrorRequest) ProtoMessage()               {}
 func (*IgnoreHealthErrorRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{27} }
 
+func (m *IgnoreHealthErrorRequest) GetPattern() string {
+	if m != nil {
+		return m.Pattern
+	}
+	return ""
+}
+
 type IgnoreHealthErrorResponse struct {
 }
 
@@ -494,6 +704,13 @@ func (m *ReloadSchemaRequest) String() string            { return proto.CompactT
 func (*ReloadSchemaRequest) ProtoMessage()               {}
 func (*ReloadSchemaRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{29} }
 
+func (m *ReloadSchemaRequest) GetWaitPosition() string {
+	if m != nil {
+		return m.WaitPosition
+	}
+	return ""
+}
+
 type ReloadSchemaResponse struct {
 }
 
@@ -510,6 +727,13 @@ func (m *PreflightSchemaRequest) Reset()                    { *m = PreflightSche
 func (m *PreflightSchemaRequest) String() string            { return proto.CompactTextString(m) }
 func (*PreflightSchemaRequest) ProtoMessage()               {}
 func (*PreflightSchemaRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{31} }
+
+func (m *PreflightSchemaRequest) GetChanges() []string {
+	if m != nil {
+		return m.Changes
+	}
+	return nil
+}
 
 type PreflightSchemaResponse struct {
 	// change_results has for each change the schema before and after it.
@@ -541,6 +765,27 @@ func (m *ApplySchemaRequest) Reset()                    { *m = ApplySchemaReques
 func (m *ApplySchemaRequest) String() string            { return proto.CompactTextString(m) }
 func (*ApplySchemaRequest) ProtoMessage()               {}
 func (*ApplySchemaRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{33} }
+
+func (m *ApplySchemaRequest) GetSql() string {
+	if m != nil {
+		return m.Sql
+	}
+	return ""
+}
+
+func (m *ApplySchemaRequest) GetForce() bool {
+	if m != nil {
+		return m.Force
+	}
+	return false
+}
+
+func (m *ApplySchemaRequest) GetAllowReplication() bool {
+	if m != nil {
+		return m.AllowReplication
+	}
+	return false
+}
 
 func (m *ApplySchemaRequest) GetBeforeSchema() *SchemaDefinition {
 	if m != nil {
@@ -593,6 +838,41 @@ func (m *ExecuteFetchAsDbaRequest) String() string            { return proto.Com
 func (*ExecuteFetchAsDbaRequest) ProtoMessage()               {}
 func (*ExecuteFetchAsDbaRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{35} }
 
+func (m *ExecuteFetchAsDbaRequest) GetQuery() []byte {
+	if m != nil {
+		return m.Query
+	}
+	return nil
+}
+
+func (m *ExecuteFetchAsDbaRequest) GetDbName() string {
+	if m != nil {
+		return m.DbName
+	}
+	return ""
+}
+
+func (m *ExecuteFetchAsDbaRequest) GetMaxRows() uint64 {
+	if m != nil {
+		return m.MaxRows
+	}
+	return 0
+}
+
+func (m *ExecuteFetchAsDbaRequest) GetDisableBinlogs() bool {
+	if m != nil {
+		return m.DisableBinlogs
+	}
+	return false
+}
+
+func (m *ExecuteFetchAsDbaRequest) GetReloadSchema() bool {
+	if m != nil {
+		return m.ReloadSchema
+	}
+	return false
+}
+
 type ExecuteFetchAsDbaResponse struct {
 	Result *query.QueryResult `protobuf:"bytes,1,opt,name=result" json:"result,omitempty"`
 }
@@ -621,6 +901,34 @@ func (m *ExecuteFetchAsAllPrivsRequest) String() string            { return prot
 func (*ExecuteFetchAsAllPrivsRequest) ProtoMessage()               {}
 func (*ExecuteFetchAsAllPrivsRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{37} }
 
+func (m *ExecuteFetchAsAllPrivsRequest) GetQuery() []byte {
+	if m != nil {
+		return m.Query
+	}
+	return nil
+}
+
+func (m *ExecuteFetchAsAllPrivsRequest) GetDbName() string {
+	if m != nil {
+		return m.DbName
+	}
+	return ""
+}
+
+func (m *ExecuteFetchAsAllPrivsRequest) GetMaxRows() uint64 {
+	if m != nil {
+		return m.MaxRows
+	}
+	return 0
+}
+
+func (m *ExecuteFetchAsAllPrivsRequest) GetReloadSchema() bool {
+	if m != nil {
+		return m.ReloadSchema
+	}
+	return false
+}
+
 type ExecuteFetchAsAllPrivsResponse struct {
 	Result *query.QueryResult `protobuf:"bytes,1,opt,name=result" json:"result,omitempty"`
 }
@@ -646,6 +954,20 @@ func (m *ExecuteFetchAsAppRequest) Reset()                    { *m = ExecuteFetc
 func (m *ExecuteFetchAsAppRequest) String() string            { return proto.CompactTextString(m) }
 func (*ExecuteFetchAsAppRequest) ProtoMessage()               {}
 func (*ExecuteFetchAsAppRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{39} }
+
+func (m *ExecuteFetchAsAppRequest) GetQuery() []byte {
+	if m != nil {
+		return m.Query
+	}
+	return nil
+}
+
+func (m *ExecuteFetchAsAppRequest) GetMaxRows() uint64 {
+	if m != nil {
+		return m.MaxRows
+	}
+	return 0
+}
 
 type ExecuteFetchAsAppResponse struct {
 	Result *query.QueryResult `protobuf:"bytes,1,opt,name=result" json:"result,omitempty"`
@@ -704,6 +1026,13 @@ func (m *MasterPositionResponse) String() string            { return proto.Compa
 func (*MasterPositionResponse) ProtoMessage()               {}
 func (*MasterPositionResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{44} }
 
+func (m *MasterPositionResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type StopSlaveRequest struct {
 }
 
@@ -730,6 +1059,20 @@ func (m *StopSlaveMinimumRequest) String() string            { return proto.Comp
 func (*StopSlaveMinimumRequest) ProtoMessage()               {}
 func (*StopSlaveMinimumRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{47} }
 
+func (m *StopSlaveMinimumRequest) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
+func (m *StopSlaveMinimumRequest) GetWaitTimeout() int64 {
+	if m != nil {
+		return m.WaitTimeout
+	}
+	return 0
+}
+
 type StopSlaveMinimumResponse struct {
 	Position string `protobuf:"bytes,1,opt,name=position" json:"position,omitempty"`
 }
@@ -738,6 +1081,13 @@ func (m *StopSlaveMinimumResponse) Reset()                    { *m = StopSlaveMi
 func (m *StopSlaveMinimumResponse) String() string            { return proto.CompactTextString(m) }
 func (*StopSlaveMinimumResponse) ProtoMessage()               {}
 func (*StopSlaveMinimumResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{48} }
+
+func (m *StopSlaveMinimumResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
 
 type StartSlaveRequest struct {
 }
@@ -767,6 +1117,13 @@ func (m *TabletExternallyReparentedRequest) String() string { return proto.Compa
 func (*TabletExternallyReparentedRequest) ProtoMessage()    {}
 func (*TabletExternallyReparentedRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{51}
+}
+
+func (m *TabletExternallyReparentedRequest) GetExternalId() string {
+	if m != nil {
+		return m.ExternalId
+	}
+	return ""
 }
 
 type TabletExternallyReparentedResponse struct {
@@ -814,6 +1171,13 @@ func (m *GetSlavesResponse) String() string            { return proto.CompactTex
 func (*GetSlavesResponse) ProtoMessage()               {}
 func (*GetSlavesResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{56} }
 
+func (m *GetSlavesResponse) GetAddrs() []string {
+	if m != nil {
+		return m.Addrs
+	}
+	return nil
+}
+
 type WaitBlpPositionRequest struct {
 	BlpPosition *BlpPosition `protobuf:"bytes,1,opt,name=blp_position,json=blpPosition" json:"blp_position,omitempty"`
 	WaitTimeout int64        `protobuf:"varint,2,opt,name=wait_timeout,json=waitTimeout" json:"wait_timeout,omitempty"`
@@ -829,6 +1193,13 @@ func (m *WaitBlpPositionRequest) GetBlpPosition() *BlpPosition {
 		return m.BlpPosition
 	}
 	return nil
+}
+
+func (m *WaitBlpPositionRequest) GetWaitTimeout() int64 {
+	if m != nil {
+		return m.WaitTimeout
+	}
+	return 0
 }
 
 type WaitBlpPositionResponse struct {
@@ -896,6 +1267,13 @@ func (m *RunBlpUntilRequest) GetBlpPositions() []*BlpPosition {
 	return nil
 }
 
+func (m *RunBlpUntilRequest) GetWaitTimeout() int64 {
+	if m != nil {
+		return m.WaitTimeout
+	}
+	return 0
+}
+
 type RunBlpUntilResponse struct {
 	Position string `protobuf:"bytes,1,opt,name=position" json:"position,omitempty"`
 }
@@ -904,6 +1282,13 @@ func (m *RunBlpUntilResponse) Reset()                    { *m = RunBlpUntilRespo
 func (m *RunBlpUntilResponse) String() string            { return proto.CompactTextString(m) }
 func (*RunBlpUntilResponse) ProtoMessage()               {}
 func (*RunBlpUntilResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{64} }
+
+func (m *RunBlpUntilResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
 
 type ResetReplicationRequest struct {
 }
@@ -938,6 +1323,13 @@ func (m *InitMasterResponse) String() string            { return proto.CompactTe
 func (*InitMasterResponse) ProtoMessage()               {}
 func (*InitMasterResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{68} }
 
+func (m *InitMasterResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type PopulateReparentJournalRequest struct {
 	TimeCreatedNs       int64                 `protobuf:"varint,1,opt,name=time_created_ns,json=timeCreatedNs" json:"time_created_ns,omitempty"`
 	ActionName          string                `protobuf:"bytes,2,opt,name=action_name,json=actionName" json:"action_name,omitempty"`
@@ -950,11 +1342,32 @@ func (m *PopulateReparentJournalRequest) String() string            { return pro
 func (*PopulateReparentJournalRequest) ProtoMessage()               {}
 func (*PopulateReparentJournalRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{69} }
 
+func (m *PopulateReparentJournalRequest) GetTimeCreatedNs() int64 {
+	if m != nil {
+		return m.TimeCreatedNs
+	}
+	return 0
+}
+
+func (m *PopulateReparentJournalRequest) GetActionName() string {
+	if m != nil {
+		return m.ActionName
+	}
+	return ""
+}
+
 func (m *PopulateReparentJournalRequest) GetMasterAlias() *topodata.TabletAlias {
 	if m != nil {
 		return m.MasterAlias
 	}
 	return nil
+}
+
+func (m *PopulateReparentJournalRequest) GetReplicationPosition() string {
+	if m != nil {
+		return m.ReplicationPosition
+	}
+	return ""
 }
 
 type PopulateReparentJournalResponse struct {
@@ -985,6 +1398,20 @@ func (m *InitSlaveRequest) GetParent() *topodata.TabletAlias {
 	return nil
 }
 
+func (m *InitSlaveRequest) GetReplicationPosition() string {
+	if m != nil {
+		return m.ReplicationPosition
+	}
+	return ""
+}
+
+func (m *InitSlaveRequest) GetTimeCreatedNs() int64 {
+	if m != nil {
+		return m.TimeCreatedNs
+	}
+	return 0
+}
+
 type InitSlaveResponse struct {
 }
 
@@ -1010,6 +1437,13 @@ func (m *DemoteMasterResponse) String() string            { return proto.Compact
 func (*DemoteMasterResponse) ProtoMessage()               {}
 func (*DemoteMasterResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{74} }
 
+func (m *DemoteMasterResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type PromoteSlaveWhenCaughtUpRequest struct {
 	Position string `protobuf:"bytes,1,opt,name=position" json:"position,omitempty"`
 }
@@ -1021,6 +1455,13 @@ func (*PromoteSlaveWhenCaughtUpRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{75}
 }
 
+func (m *PromoteSlaveWhenCaughtUpRequest) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type PromoteSlaveWhenCaughtUpResponse struct {
 	Position string `protobuf:"bytes,1,opt,name=position" json:"position,omitempty"`
 }
@@ -1030,6 +1471,13 @@ func (m *PromoteSlaveWhenCaughtUpResponse) String() string { return proto.Compac
 func (*PromoteSlaveWhenCaughtUpResponse) ProtoMessage()    {}
 func (*PromoteSlaveWhenCaughtUpResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{76}
+}
+
+func (m *PromoteSlaveWhenCaughtUpResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
 }
 
 type SlaveWasPromotedRequest struct {
@@ -1064,6 +1512,20 @@ func (m *SetMasterRequest) GetParent() *topodata.TabletAlias {
 		return m.Parent
 	}
 	return nil
+}
+
+func (m *SetMasterRequest) GetTimeCreatedNs() int64 {
+	if m != nil {
+		return m.TimeCreatedNs
+	}
+	return 0
+}
+
+func (m *SetMasterRequest) GetForceStartSlave() bool {
+	if m != nil {
+		return m.ForceStartSlave
+	}
+	return false
 }
 
 type SetMasterResponse struct {
@@ -1144,6 +1606,13 @@ func (m *PromoteSlaveResponse) String() string            { return proto.Compact
 func (*PromoteSlaveResponse) ProtoMessage()               {}
 func (*PromoteSlaveResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{86} }
 
+func (m *PromoteSlaveResponse) GetPosition() string {
+	if m != nil {
+		return m.Position
+	}
+	return ""
+}
+
 type BackupRequest struct {
 	Concurrency int64 `protobuf:"varint,1,opt,name=concurrency" json:"concurrency,omitempty"`
 }
@@ -1152,6 +1621,13 @@ func (m *BackupRequest) Reset()                    { *m = BackupRequest{} }
 func (m *BackupRequest) String() string            { return proto.CompactTextString(m) }
 func (*BackupRequest) ProtoMessage()               {}
 func (*BackupRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{87} }
+
+func (m *BackupRequest) GetConcurrency() int64 {
+	if m != nil {
+		return m.Concurrency
+	}
+	return 0
+}
 
 type BackupResponse struct {
 	Event *logutil.Event `protobuf:"bytes,1,opt,name=event" json:"event,omitempty"`

--- a/go/vt/proto/throttlerdata/throttlerdata.pb.go
+++ b/go/vt/proto/throttlerdata/throttlerdata.pb.go
@@ -76,6 +76,13 @@ func (m *SetMaxRateRequest) String() string            { return proto.CompactTex
 func (*SetMaxRateRequest) ProtoMessage()               {}
 func (*SetMaxRateRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *SetMaxRateRequest) GetRate() int64 {
+	if m != nil {
+		return m.Rate
+	}
+	return 0
+}
+
 // SetMaxRateResponse is returned by the SetMaxRate RPC.
 type SetMaxRateResponse struct {
 	// names is the list of throttler names which were updated.
@@ -86,6 +93,13 @@ func (m *SetMaxRateResponse) Reset()                    { *m = SetMaxRateRespons
 func (m *SetMaxRateResponse) String() string            { return proto.CompactTextString(m) }
 func (*SetMaxRateResponse) ProtoMessage()               {}
 func (*SetMaxRateResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *SetMaxRateResponse) GetNames() []string {
+	if m != nil {
+		return m.Names
+	}
+	return nil
+}
 
 // Configuration holds the configuration parameters for the
 // MaxReplicationLagModule which adaptively adjusts the throttling rate based on
@@ -175,6 +189,104 @@ func (m *Configuration) String() string            { return proto.CompactTextStr
 func (*Configuration) ProtoMessage()               {}
 func (*Configuration) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
+func (m *Configuration) GetTargetReplicationLagSec() int64 {
+	if m != nil {
+		return m.TargetReplicationLagSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetMaxReplicationLagSec() int64 {
+	if m != nil {
+		return m.MaxReplicationLagSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetInitialRate() int64 {
+	if m != nil {
+		return m.InitialRate
+	}
+	return 0
+}
+
+func (m *Configuration) GetMaxIncrease() float64 {
+	if m != nil {
+		return m.MaxIncrease
+	}
+	return 0
+}
+
+func (m *Configuration) GetEmergencyDecrease() float64 {
+	if m != nil {
+		return m.EmergencyDecrease
+	}
+	return 0
+}
+
+func (m *Configuration) GetMinDurationBetweenIncreasesSec() int64 {
+	if m != nil {
+		return m.MinDurationBetweenIncreasesSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetMaxDurationBetweenIncreasesSec() int64 {
+	if m != nil {
+		return m.MaxDurationBetweenIncreasesSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetMinDurationBetweenDecreasesSec() int64 {
+	if m != nil {
+		return m.MinDurationBetweenDecreasesSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetSpreadBacklogAcrossSec() int64 {
+	if m != nil {
+		return m.SpreadBacklogAcrossSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetIgnoreNSlowestReplicas() int32 {
+	if m != nil {
+		return m.IgnoreNSlowestReplicas
+	}
+	return 0
+}
+
+func (m *Configuration) GetIgnoreNSlowestRdonlys() int32 {
+	if m != nil {
+		return m.IgnoreNSlowestRdonlys
+	}
+	return 0
+}
+
+func (m *Configuration) GetAgeBadRateAfterSec() int64 {
+	if m != nil {
+		return m.AgeBadRateAfterSec
+	}
+	return 0
+}
+
+func (m *Configuration) GetBadRateIncrease() float64 {
+	if m != nil {
+		return m.BadRateIncrease
+	}
+	return 0
+}
+
+func (m *Configuration) GetMaxRateApproachThreshold() float64 {
+	if m != nil {
+		return m.MaxRateApproachThreshold
+	}
+	return 0
+}
+
 // GetConfigurationRequest is the payload for the GetConfiguration RPC.
 type GetConfigurationRequest struct {
 	// throttler_name specifies which throttler to select. If empty, all active
@@ -186,6 +298,13 @@ func (m *GetConfigurationRequest) Reset()                    { *m = GetConfigura
 func (m *GetConfigurationRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetConfigurationRequest) ProtoMessage()               {}
 func (*GetConfigurationRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+func (m *GetConfigurationRequest) GetThrottlerName() string {
+	if m != nil {
+		return m.ThrottlerName
+	}
+	return ""
+}
 
 // GetConfigurationResponse is returned by the GetConfiguration RPC.
 type GetConfigurationResponse struct {
@@ -223,11 +342,25 @@ func (m *UpdateConfigurationRequest) String() string            { return proto.C
 func (*UpdateConfigurationRequest) ProtoMessage()               {}
 func (*UpdateConfigurationRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
 
+func (m *UpdateConfigurationRequest) GetThrottlerName() string {
+	if m != nil {
+		return m.ThrottlerName
+	}
+	return ""
+}
+
 func (m *UpdateConfigurationRequest) GetConfiguration() *Configuration {
 	if m != nil {
 		return m.Configuration
 	}
 	return nil
+}
+
+func (m *UpdateConfigurationRequest) GetCopyZeroValues() bool {
+	if m != nil {
+		return m.CopyZeroValues
+	}
+	return false
 }
 
 // UpdateConfigurationResponse is returned by the UpdateConfiguration RPC.
@@ -241,6 +374,13 @@ func (m *UpdateConfigurationResponse) String() string            { return proto.
 func (*UpdateConfigurationResponse) ProtoMessage()               {}
 func (*UpdateConfigurationResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
 
+func (m *UpdateConfigurationResponse) GetNames() []string {
+	if m != nil {
+		return m.Names
+	}
+	return nil
+}
+
 // ResetConfigurationRequest is the payload for the ResetConfiguration RPC.
 type ResetConfigurationRequest struct {
 	// throttler_name specifies which throttler to reset. If empty, all active
@@ -253,6 +393,13 @@ func (m *ResetConfigurationRequest) String() string            { return proto.Co
 func (*ResetConfigurationRequest) ProtoMessage()               {}
 func (*ResetConfigurationRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
 
+func (m *ResetConfigurationRequest) GetThrottlerName() string {
+	if m != nil {
+		return m.ThrottlerName
+	}
+	return ""
+}
+
 // ResetConfigurationResponse is returned by the ResetConfiguration RPC.
 type ResetConfigurationResponse struct {
 	// names is the list of throttler names which were updated.
@@ -263,6 +410,13 @@ func (m *ResetConfigurationResponse) Reset()                    { *m = ResetConf
 func (m *ResetConfigurationResponse) String() string            { return proto.CompactTextString(m) }
 func (*ResetConfigurationResponse) ProtoMessage()               {}
 func (*ResetConfigurationResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{10} }
+
+func (m *ResetConfigurationResponse) GetNames() []string {
+	if m != nil {
+		return m.Names
+	}
+	return nil
+}
 
 func init() {
 	proto.RegisterType((*MaxRatesRequest)(nil), "throttlerdata.MaxRatesRequest")

--- a/go/vt/proto/topodata/topodata.pb.go
+++ b/go/vt/proto/topodata/topodata.pb.go
@@ -146,6 +146,20 @@ func (m *KeyRange) String() string            { return proto.CompactTextString(m
 func (*KeyRange) ProtoMessage()               {}
 func (*KeyRange) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *KeyRange) GetStart() []byte {
+	if m != nil {
+		return m.Start
+	}
+	return nil
+}
+
+func (m *KeyRange) GetEnd() []byte {
+	if m != nil {
+		return m.End
+	}
+	return nil
+}
+
 // TabletAlias is a globally unique tablet identifier.
 type TabletAlias struct {
 	// cell is the cell (or datacenter) the tablet is in
@@ -159,6 +173,20 @@ func (m *TabletAlias) Reset()                    { *m = TabletAlias{} }
 func (m *TabletAlias) String() string            { return proto.CompactTextString(m) }
 func (*TabletAlias) ProtoMessage()               {}
 func (*TabletAlias) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+
+func (m *TabletAlias) GetCell() string {
+	if m != nil {
+		return m.Cell
+	}
+	return ""
+}
+
+func (m *TabletAlias) GetUid() uint32 {
+	if m != nil {
+		return m.Uid
+	}
+	return 0
+}
 
 // Tablet represents information about a running instance of vttablet.
 type Tablet struct {
@@ -198,6 +226,20 @@ func (m *Tablet) GetAlias() *TabletAlias {
 	return nil
 }
 
+func (m *Tablet) GetHostname() string {
+	if m != nil {
+		return m.Hostname
+	}
+	return ""
+}
+
+func (m *Tablet) GetIp() string {
+	if m != nil {
+		return m.Ip
+	}
+	return ""
+}
+
 func (m *Tablet) GetPortMap() map[string]int32 {
 	if m != nil {
 		return m.PortMap
@@ -205,11 +247,39 @@ func (m *Tablet) GetPortMap() map[string]int32 {
 	return nil
 }
 
+func (m *Tablet) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *Tablet) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
 func (m *Tablet) GetKeyRange() *KeyRange {
 	if m != nil {
 		return m.KeyRange
 	}
 	return nil
+}
+
+func (m *Tablet) GetType() TabletType {
+	if m != nil {
+		return m.Type
+	}
+	return TabletType_UNKNOWN
+}
+
+func (m *Tablet) GetDbNameOverride() string {
+	if m != nil {
+		return m.DbNameOverride
+	}
+	return ""
 }
 
 func (m *Tablet) GetTags() map[string]string {
@@ -282,6 +352,13 @@ func (m *Shard) GetSourceShards() []*Shard_SourceShard {
 	return nil
 }
 
+func (m *Shard) GetCells() []string {
+	if m != nil {
+		return m.Cells
+	}
+	return nil
+}
+
 func (m *Shard) GetTabletControls() []*Shard_TabletControl {
 	if m != nil {
 		return m.TabletControls
@@ -299,6 +376,20 @@ func (m *Shard_ServedType) Reset()                    { *m = Shard_ServedType{} 
 func (m *Shard_ServedType) String() string            { return proto.CompactTextString(m) }
 func (*Shard_ServedType) ProtoMessage()               {}
 func (*Shard_ServedType) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3, 0} }
+
+func (m *Shard_ServedType) GetTabletType() TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return TabletType_UNKNOWN
+}
+
+func (m *Shard_ServedType) GetCells() []string {
+	if m != nil {
+		return m.Cells
+	}
+	return nil
+}
 
 // SourceShard represents a data source for filtered replication
 // accross shards. When this is used in a destination shard, the master
@@ -321,9 +412,37 @@ func (m *Shard_SourceShard) String() string            { return proto.CompactTex
 func (*Shard_SourceShard) ProtoMessage()               {}
 func (*Shard_SourceShard) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3, 1} }
 
+func (m *Shard_SourceShard) GetUid() uint32 {
+	if m != nil {
+		return m.Uid
+	}
+	return 0
+}
+
+func (m *Shard_SourceShard) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *Shard_SourceShard) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
 func (m *Shard_SourceShard) GetKeyRange() *KeyRange {
 	if m != nil {
 		return m.KeyRange
+	}
+	return nil
+}
+
+func (m *Shard_SourceShard) GetTables() []string {
+	if m != nil {
+		return m.Tables
 	}
 	return nil
 }
@@ -343,6 +462,34 @@ func (m *Shard_TabletControl) String() string            { return proto.CompactT
 func (*Shard_TabletControl) ProtoMessage()               {}
 func (*Shard_TabletControl) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3, 2} }
 
+func (m *Shard_TabletControl) GetTabletType() TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return TabletType_UNKNOWN
+}
+
+func (m *Shard_TabletControl) GetCells() []string {
+	if m != nil {
+		return m.Cells
+	}
+	return nil
+}
+
+func (m *Shard_TabletControl) GetDisableQueryService() bool {
+	if m != nil {
+		return m.DisableQueryService
+	}
+	return false
+}
+
+func (m *Shard_TabletControl) GetBlacklistedTables() []string {
+	if m != nil {
+		return m.BlacklistedTables
+	}
+	return nil
+}
+
 // A Keyspace contains data about a keyspace.
 type Keyspace struct {
 	// name of the column used for sharding
@@ -360,6 +507,20 @@ func (m *Keyspace) Reset()                    { *m = Keyspace{} }
 func (m *Keyspace) String() string            { return proto.CompactTextString(m) }
 func (*Keyspace) ProtoMessage()               {}
 func (*Keyspace) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *Keyspace) GetShardingColumnName() string {
+	if m != nil {
+		return m.ShardingColumnName
+	}
+	return ""
+}
+
+func (m *Keyspace) GetShardingColumnType() KeyspaceIdType {
+	if m != nil {
+		return m.ShardingColumnType
+	}
+	return KeyspaceIdType_UNSET
+}
 
 func (m *Keyspace) GetServedFroms() []*Keyspace_ServedFrom {
 	if m != nil {
@@ -383,6 +544,27 @@ func (m *Keyspace_ServedFrom) Reset()                    { *m = Keyspace_ServedF
 func (m *Keyspace_ServedFrom) String() string            { return proto.CompactTextString(m) }
 func (*Keyspace_ServedFrom) ProtoMessage()               {}
 func (*Keyspace_ServedFrom) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4, 0} }
+
+func (m *Keyspace_ServedFrom) GetTabletType() TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return TabletType_UNKNOWN
+}
+
+func (m *Keyspace_ServedFrom) GetCells() []string {
+	if m != nil {
+		return m.Cells
+	}
+	return nil
+}
+
+func (m *Keyspace_ServedFrom) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
 
 // ShardReplication describes the MySQL replication relationships
 // whithin a cell.
@@ -433,6 +615,13 @@ func (m *ShardReference) String() string            { return proto.CompactTextSt
 func (*ShardReference) ProtoMessage()               {}
 func (*ShardReference) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{6} }
 
+func (m *ShardReference) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *ShardReference) GetKeyRange() *KeyRange {
 	if m != nil {
 		return m.KeyRange
@@ -462,6 +651,20 @@ func (m *SrvKeyspace) GetPartitions() []*SrvKeyspace_KeyspacePartition {
 	return nil
 }
 
+func (m *SrvKeyspace) GetShardingColumnName() string {
+	if m != nil {
+		return m.ShardingColumnName
+	}
+	return ""
+}
+
+func (m *SrvKeyspace) GetShardingColumnType() KeyspaceIdType {
+	if m != nil {
+		return m.ShardingColumnType
+	}
+	return KeyspaceIdType_UNSET
+}
+
 func (m *SrvKeyspace) GetServedFrom() []*SrvKeyspace_ServedFrom {
 	if m != nil {
 		return m.ServedFrom
@@ -481,6 +684,13 @@ func (m *SrvKeyspace_KeyspacePartition) String() string { return proto.CompactTe
 func (*SrvKeyspace_KeyspacePartition) ProtoMessage()    {}
 func (*SrvKeyspace_KeyspacePartition) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{7, 0}
+}
+
+func (m *SrvKeyspace_KeyspacePartition) GetServedType() TabletType {
+	if m != nil {
+		return m.ServedType
+	}
+	return TabletType_UNKNOWN
 }
 
 func (m *SrvKeyspace_KeyspacePartition) GetShardReferences() []*ShardReference {
@@ -504,6 +714,20 @@ func (m *SrvKeyspace_ServedFrom) String() string            { return proto.Compa
 func (*SrvKeyspace_ServedFrom) ProtoMessage()               {}
 func (*SrvKeyspace_ServedFrom) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7, 1} }
 
+func (m *SrvKeyspace_ServedFrom) GetTabletType() TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return TabletType_UNKNOWN
+}
+
+func (m *SrvKeyspace_ServedFrom) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 // CellInfo contains information about a cell. CellInfo objects are
 // stored in the global topology server, and describe how to reach
 // local topology servers.
@@ -522,6 +746,20 @@ func (m *CellInfo) Reset()                    { *m = CellInfo{} }
 func (m *CellInfo) String() string            { return proto.CompactTextString(m) }
 func (*CellInfo) ProtoMessage()               {}
 func (*CellInfo) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
+
+func (m *CellInfo) GetServerAddress() string {
+	if m != nil {
+		return m.ServerAddress
+	}
+	return ""
+}
+
+func (m *CellInfo) GetRoot() string {
+	if m != nil {
+		return m.Root
+	}
+	return ""
+}
 
 func init() {
 	proto.RegisterType((*KeyRange)(nil), "topodata.KeyRange")

--- a/go/vt/proto/vschema/vschema.pb.go
+++ b/go/vt/proto/vschema/vschema.pb.go
@@ -46,6 +46,13 @@ func (m *Keyspace) String() string            { return proto.CompactTextString(m
 func (*Keyspace) ProtoMessage()               {}
 func (*Keyspace) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Keyspace) GetSharded() bool {
+	if m != nil {
+		return m.Sharded
+	}
+	return false
+}
+
 func (m *Keyspace) GetVindexes() map[string]*Vindex {
 	if m != nil {
 		return m.Vindexes
@@ -82,11 +89,25 @@ func (m *Vindex) String() string            { return proto.CompactTextString(m) 
 func (*Vindex) ProtoMessage()               {}
 func (*Vindex) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
+func (m *Vindex) GetType() string {
+	if m != nil {
+		return m.Type
+	}
+	return ""
+}
+
 func (m *Vindex) GetParams() map[string]string {
 	if m != nil {
 		return m.Params
 	}
 	return nil
+}
+
+func (m *Vindex) GetOwner() string {
+	if m != nil {
+		return m.Owner
+	}
+	return ""
 }
 
 // Table is the table info for a Keyspace.
@@ -105,6 +126,13 @@ func (m *Table) Reset()                    { *m = Table{} }
 func (m *Table) String() string            { return proto.CompactTextString(m) }
 func (*Table) ProtoMessage()               {}
 func (*Table) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
+
+func (m *Table) GetType() string {
+	if m != nil {
+		return m.Type
+	}
+	return ""
+}
 
 func (m *Table) GetColumnVindexes() []*ColumnVindex {
 	if m != nil {
@@ -132,6 +160,20 @@ func (m *ColumnVindex) String() string            { return proto.CompactTextStri
 func (*ColumnVindex) ProtoMessage()               {}
 func (*ColumnVindex) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
 
+func (m *ColumnVindex) GetColumn() string {
+	if m != nil {
+		return m.Column
+	}
+	return ""
+}
+
+func (m *ColumnVindex) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 // Autoincrement is used to designate a column as auto-inc.
 type AutoIncrement struct {
 	Column string `protobuf:"bytes,1,opt,name=column" json:"column,omitempty"`
@@ -143,6 +185,20 @@ func (m *AutoIncrement) Reset()                    { *m = AutoIncrement{} }
 func (m *AutoIncrement) String() string            { return proto.CompactTextString(m) }
 func (*AutoIncrement) ProtoMessage()               {}
 func (*AutoIncrement) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
+
+func (m *AutoIncrement) GetColumn() string {
+	if m != nil {
+		return m.Column
+	}
+	return ""
+}
+
+func (m *AutoIncrement) GetSequence() string {
+	if m != nil {
+		return m.Sequence
+	}
+	return ""
+}
 
 // SrvVSchema is the roll-up of all the Keyspace schema for a cell.
 type SrvVSchema struct {

--- a/go/vt/proto/vtctldata/vtctldata.pb.go
+++ b/go/vt/proto/vtctldata/vtctldata.pb.go
@@ -42,6 +42,20 @@ func (m *ExecuteVtctlCommandRequest) String() string            { return proto.C
 func (*ExecuteVtctlCommandRequest) ProtoMessage()               {}
 func (*ExecuteVtctlCommandRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *ExecuteVtctlCommandRequest) GetArgs() []string {
+	if m != nil {
+		return m.Args
+	}
+	return nil
+}
+
+func (m *ExecuteVtctlCommandRequest) GetActionTimeout() int64 {
+	if m != nil {
+		return m.ActionTimeout
+	}
+	return 0
+}
+
 // ExecuteVtctlCommandResponse is streamed back by ExecuteVtctlCommand.
 type ExecuteVtctlCommandResponse struct {
 	Event *logutil.Event `protobuf:"bytes,1,opt,name=event" json:"event,omitempty"`

--- a/go/vt/proto/vtgate/vtgate.pb.go
+++ b/go/vt/proto/vtgate/vtgate.pb.go
@@ -89,11 +89,25 @@ func (m *Session) String() string            { return proto.CompactTextString(m)
 func (*Session) ProtoMessage()               {}
 func (*Session) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Session) GetInTransaction() bool {
+	if m != nil {
+		return m.InTransaction
+	}
+	return false
+}
+
 func (m *Session) GetShardSessions() []*Session_ShardSession {
 	if m != nil {
 		return m.ShardSessions
 	}
 	return nil
+}
+
+func (m *Session) GetSingleDb() bool {
+	if m != nil {
+		return m.SingleDb
+	}
+	return false
 }
 
 type Session_ShardSession struct {
@@ -111,6 +125,13 @@ func (m *Session_ShardSession) GetTarget() *query.Target {
 		return m.Target
 	}
 	return nil
+}
+
+func (m *Session_ShardSession) GetTransactionId() int64 {
+	if m != nil {
+		return m.TransactionId
+	}
+	return 0
 }
 
 // ExecuteRequest is the payload to Execute.
@@ -157,6 +178,27 @@ func (m *ExecuteRequest) GetQuery() *query.BoundQuery {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *ExecuteRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteRequest) GetNotInTransaction() bool {
+	if m != nil {
+		return m.NotInTransaction
+	}
+	return false
+}
+
+func (m *ExecuteRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
 }
 
 func (m *ExecuteRequest) GetOptions() *query.ExecuteOptions {
@@ -250,6 +292,34 @@ func (m *ExecuteShardsRequest) GetQuery() *query.BoundQuery {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *ExecuteShardsRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *ExecuteShardsRequest) GetShards() []string {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
+}
+
+func (m *ExecuteShardsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteShardsRequest) GetNotInTransaction() bool {
+	if m != nil {
+		return m.NotInTransaction
+	}
+	return false
 }
 
 func (m *ExecuteShardsRequest) GetOptions() *query.ExecuteOptions {
@@ -346,6 +416,34 @@ func (m *ExecuteKeyspaceIdsRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *ExecuteKeyspaceIdsRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *ExecuteKeyspaceIdsRequest) GetKeyspaceIds() [][]byte {
+	if m != nil {
+		return m.KeyspaceIds
+	}
+	return nil
+}
+
+func (m *ExecuteKeyspaceIdsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteKeyspaceIdsRequest) GetNotInTransaction() bool {
+	if m != nil {
+		return m.NotInTransaction
+	}
+	return false
+}
+
 func (m *ExecuteKeyspaceIdsRequest) GetOptions() *query.ExecuteOptions {
 	if m != nil {
 		return m.Options
@@ -440,11 +538,32 @@ func (m *ExecuteKeyRangesRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *ExecuteKeyRangesRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *ExecuteKeyRangesRequest) GetKeyRanges() []*topodata.KeyRange {
 	if m != nil {
 		return m.KeyRanges
 	}
 	return nil
+}
+
+func (m *ExecuteKeyRangesRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteKeyRangesRequest) GetNotInTransaction() bool {
+	if m != nil {
+		return m.NotInTransaction
+	}
+	return false
 }
 
 func (m *ExecuteKeyRangesRequest) GetOptions() *query.ExecuteOptions {
@@ -543,11 +662,39 @@ func (m *ExecuteEntityIdsRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *ExecuteEntityIdsRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *ExecuteEntityIdsRequest) GetEntityColumnName() string {
+	if m != nil {
+		return m.EntityColumnName
+	}
+	return ""
+}
+
 func (m *ExecuteEntityIdsRequest) GetEntityKeyspaceIds() []*ExecuteEntityIdsRequest_EntityId {
 	if m != nil {
 		return m.EntityKeyspaceIds
 	}
 	return nil
+}
+
+func (m *ExecuteEntityIdsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteEntityIdsRequest) GetNotInTransaction() bool {
+	if m != nil {
+		return m.NotInTransaction
+	}
+	return false
 }
 
 func (m *ExecuteEntityIdsRequest) GetOptions() *query.ExecuteOptions {
@@ -571,6 +718,27 @@ func (m *ExecuteEntityIdsRequest_EntityId) String() string { return proto.Compac
 func (*ExecuteEntityIdsRequest_EntityId) ProtoMessage()    {}
 func (*ExecuteEntityIdsRequest_EntityId) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{9, 0}
+}
+
+func (m *ExecuteEntityIdsRequest_EntityId) GetType() query.Type {
+	if m != nil {
+		return m.Type
+	}
+	return query.Type_NULL_TYPE
+}
+
+func (m *ExecuteEntityIdsRequest_EntityId) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
+func (m *ExecuteEntityIdsRequest_EntityId) GetKeyspaceId() []byte {
+	if m != nil {
+		return m.KeyspaceId
+	}
+	return nil
 }
 
 // ExecuteEntityIdsResponse is the returned value from ExecuteEntityIds.
@@ -660,6 +828,27 @@ func (m *ExecuteBatchRequest) GetQueries() []*query.BoundQuery {
 	return nil
 }
 
+func (m *ExecuteBatchRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteBatchRequest) GetAsTransaction() bool {
+	if m != nil {
+		return m.AsTransaction
+	}
+	return false
+}
+
+func (m *ExecuteBatchRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *ExecuteBatchRequest) GetOptions() *query.ExecuteOptions {
 	if m != nil {
 		return m.Options
@@ -729,6 +918,20 @@ func (m *BoundShardQuery) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *BoundShardQuery) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *BoundShardQuery) GetShards() []string {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
+}
+
 // ExecuteBatchShardsRequest is the payload to ExecuteBatchShards
 type ExecuteBatchShardsRequest struct {
 	// caller_id identifies the caller. This is the effective caller ID,
@@ -773,6 +976,20 @@ func (m *ExecuteBatchShardsRequest) GetQueries() []*BoundShardQuery {
 		return m.Queries
 	}
 	return nil
+}
+
+func (m *ExecuteBatchShardsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteBatchShardsRequest) GetAsTransaction() bool {
+	if m != nil {
+		return m.AsTransaction
+	}
+	return false
 }
 
 func (m *ExecuteBatchShardsRequest) GetOptions() *query.ExecuteOptions {
@@ -845,6 +1062,20 @@ func (m *BoundKeyspaceIdQuery) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *BoundKeyspaceIdQuery) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *BoundKeyspaceIdQuery) GetKeyspaceIds() [][]byte {
+	if m != nil {
+		return m.KeyspaceIds
+	}
+	return nil
+}
+
 // ExecuteBatchKeyspaceIdsRequest is the payload to ExecuteBatchKeyspaceId.
 type ExecuteBatchKeyspaceIdsRequest struct {
 	// caller_id identifies the caller. This is the effective caller ID,
@@ -888,6 +1119,20 @@ func (m *ExecuteBatchKeyspaceIdsRequest) GetQueries() []*BoundKeyspaceIdQuery {
 		return m.Queries
 	}
 	return nil
+}
+
+func (m *ExecuteBatchKeyspaceIdsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *ExecuteBatchKeyspaceIdsRequest) GetAsTransaction() bool {
+	if m != nil {
+		return m.AsTransaction
+	}
+	return false
 }
 
 func (m *ExecuteBatchKeyspaceIdsRequest) GetOptions() *query.ExecuteOptions {
@@ -971,6 +1216,20 @@ func (m *StreamExecuteRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *StreamExecuteRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *StreamExecuteRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *StreamExecuteRequest) GetOptions() *query.ExecuteOptions {
 	if m != nil {
 		return m.Options
@@ -1032,6 +1291,27 @@ func (m *StreamExecuteShardsRequest) GetQuery() *query.BoundQuery {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *StreamExecuteShardsRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *StreamExecuteShardsRequest) GetShards() []string {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
+}
+
+func (m *StreamExecuteShardsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
 }
 
 func (m *StreamExecuteShardsRequest) GetOptions() *query.ExecuteOptions {
@@ -1100,6 +1380,27 @@ func (m *StreamExecuteKeyspaceIdsRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *StreamExecuteKeyspaceIdsRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *StreamExecuteKeyspaceIdsRequest) GetKeyspaceIds() [][]byte {
+	if m != nil {
+		return m.KeyspaceIds
+	}
+	return nil
+}
+
+func (m *StreamExecuteKeyspaceIdsRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
 func (m *StreamExecuteKeyspaceIdsRequest) GetOptions() *query.ExecuteOptions {
 	if m != nil {
 		return m.Options
@@ -1166,11 +1467,25 @@ func (m *StreamExecuteKeyRangesRequest) GetQuery() *query.BoundQuery {
 	return nil
 }
 
+func (m *StreamExecuteKeyRangesRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *StreamExecuteKeyRangesRequest) GetKeyRanges() []*topodata.KeyRange {
 	if m != nil {
 		return m.KeyRanges
 	}
 	return nil
+}
+
+func (m *StreamExecuteKeyRangesRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
 }
 
 func (m *StreamExecuteKeyRangesRequest) GetOptions() *query.ExecuteOptions {
@@ -1222,6 +1537,13 @@ func (m *BeginRequest) GetCallerId() *vtrpc.CallerID {
 	return nil
 }
 
+func (m *BeginRequest) GetSingleDb() bool {
+	if m != nil {
+		return m.SingleDb
+	}
+	return false
+}
+
 // BeginResponse is the returned value from Begin.
 type BeginResponse struct {
 	// session is the initial session information to use for subsequent queries.
@@ -1269,6 +1591,13 @@ func (m *CommitRequest) GetSession() *Session {
 		return m.Session
 	}
 	return nil
+}
+
+func (m *CommitRequest) GetAtomic() bool {
+	if m != nil {
+		return m.Atomic
+	}
+	return false
 }
 
 // CommitResponse is the returned value from Commit.
@@ -1338,6 +1667,13 @@ func (m *ResolveTransactionRequest) GetCallerId() *vtrpc.CallerID {
 	return nil
 }
 
+func (m *ResolveTransactionRequest) GetDtid() string {
+	if m != nil {
+		return m.Dtid
+	}
+	return ""
+}
+
 // MessageStreamRequest is the request payload for MessageStream.
 type MessageStreamRequest struct {
 	// caller_id identifies the caller. This is the effective caller ID,
@@ -1365,11 +1701,32 @@ func (m *MessageStreamRequest) GetCallerId() *vtrpc.CallerID {
 	return nil
 }
 
+func (m *MessageStreamRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *MessageStreamRequest) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
 func (m *MessageStreamRequest) GetKeyRange() *topodata.KeyRange {
 	if m != nil {
 		return m.KeyRange
 	}
 	return nil
+}
+
+func (m *MessageStreamRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
 }
 
 // MessageAckRequest is the request payload for MessageAck.
@@ -1395,6 +1752,20 @@ func (m *MessageAckRequest) GetCallerId() *vtrpc.CallerID {
 		return m.CallerId
 	}
 	return nil
+}
+
+func (m *MessageAckRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *MessageAckRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
 }
 
 func (m *MessageAckRequest) GetIds() []*query.Value {
@@ -1516,11 +1887,53 @@ func (m *SplitQueryRequest) GetCallerId() *vtrpc.CallerID {
 	return nil
 }
 
+func (m *SplitQueryRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *SplitQueryRequest) GetQuery() *query.BoundQuery {
 	if m != nil {
 		return m.Query
 	}
 	return nil
+}
+
+func (m *SplitQueryRequest) GetSplitColumn() []string {
+	if m != nil {
+		return m.SplitColumn
+	}
+	return nil
+}
+
+func (m *SplitQueryRequest) GetSplitCount() int64 {
+	if m != nil {
+		return m.SplitCount
+	}
+	return 0
+}
+
+func (m *SplitQueryRequest) GetNumRowsPerQueryPart() int64 {
+	if m != nil {
+		return m.NumRowsPerQueryPart
+	}
+	return 0
+}
+
+func (m *SplitQueryRequest) GetAlgorithm() query.SplitQueryRequest_Algorithm {
+	if m != nil {
+		return m.Algorithm
+	}
+	return query.SplitQueryRequest_EQUAL_SPLITS
+}
+
+func (m *SplitQueryRequest) GetUseSplitQueryV2() bool {
+	if m != nil {
+		return m.UseSplitQueryV2
+	}
+	return false
 }
 
 // SplitQueryResponse is the returned value from SplitQuery.
@@ -1555,6 +1968,13 @@ func (*SplitQueryResponse_KeyRangePart) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{38, 0}
 }
 
+func (m *SplitQueryResponse_KeyRangePart) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
 func (m *SplitQueryResponse_KeyRangePart) GetKeyRanges() []*topodata.KeyRange {
 	if m != nil {
 		return m.KeyRanges
@@ -1574,6 +1994,20 @@ func (m *SplitQueryResponse_ShardPart) String() string { return proto.CompactTex
 func (*SplitQueryResponse_ShardPart) ProtoMessage()    {}
 func (*SplitQueryResponse_ShardPart) Descriptor() ([]byte, []int) {
 	return fileDescriptor0, []int{38, 1}
+}
+
+func (m *SplitQueryResponse_ShardPart) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *SplitQueryResponse_ShardPart) GetShards() []string {
+	if m != nil {
+		return m.Shards
+	}
+	return nil
 }
 
 type SplitQueryResponse_Part struct {
@@ -1614,6 +2048,13 @@ func (m *SplitQueryResponse_Part) GetShardPart() *SplitQueryResponse_ShardPart {
 	return nil
 }
 
+func (m *SplitQueryResponse_Part) GetSize() int64 {
+	if m != nil {
+		return m.Size
+	}
+	return 0
+}
+
 // GetSrvKeyspaceRequest is the payload to GetSrvKeyspace.
 type GetSrvKeyspaceRequest struct {
 	// keyspace name to fetch.
@@ -1624,6 +2065,13 @@ func (m *GetSrvKeyspaceRequest) Reset()                    { *m = GetSrvKeyspace
 func (m *GetSrvKeyspaceRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetSrvKeyspaceRequest) ProtoMessage()               {}
 func (*GetSrvKeyspaceRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{39} }
+
+func (m *GetSrvKeyspaceRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
 
 // GetSrvKeyspaceResponse is the returned value from GetSrvKeyspace.
 type GetSrvKeyspaceResponse struct {
@@ -1679,11 +2127,39 @@ func (m *UpdateStreamRequest) GetCallerId() *vtrpc.CallerID {
 	return nil
 }
 
+func (m *UpdateStreamRequest) GetKeyspace() string {
+	if m != nil {
+		return m.Keyspace
+	}
+	return ""
+}
+
+func (m *UpdateStreamRequest) GetShard() string {
+	if m != nil {
+		return m.Shard
+	}
+	return ""
+}
+
 func (m *UpdateStreamRequest) GetKeyRange() *topodata.KeyRange {
 	if m != nil {
 		return m.KeyRange
 	}
 	return nil
+}
+
+func (m *UpdateStreamRequest) GetTabletType() topodata.TabletType {
+	if m != nil {
+		return m.TabletType
+	}
+	return topodata.TabletType_UNKNOWN
+}
+
+func (m *UpdateStreamRequest) GetTimestamp() int64 {
+	if m != nil {
+		return m.Timestamp
+	}
+	return 0
 }
 
 func (m *UpdateStreamRequest) GetEvent() *query.EventToken {
@@ -1715,6 +2191,13 @@ func (m *UpdateStreamResponse) GetEvent() *query.StreamEvent {
 		return m.Event
 	}
 	return nil
+}
+
+func (m *UpdateStreamResponse) GetResumeTimestamp() int64 {
+	if m != nil {
+		return m.ResumeTimestamp
+	}
+	return 0
 }
 
 func init() {

--- a/go/vt/proto/vtrpc/vtrpc.pb.go
+++ b/go/vt/proto/vtrpc/vtrpc.pb.go
@@ -316,6 +316,27 @@ func (m *CallerID) String() string            { return proto.CompactTextString(m
 func (*CallerID) ProtoMessage()               {}
 func (*CallerID) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *CallerID) GetPrincipal() string {
+	if m != nil {
+		return m.Principal
+	}
+	return ""
+}
+
+func (m *CallerID) GetComponent() string {
+	if m != nil {
+		return m.Component
+	}
+	return ""
+}
+
+func (m *CallerID) GetSubcomponent() string {
+	if m != nil {
+		return m.Subcomponent
+	}
+	return ""
+}
+
 // RPCError is an application-level error structure returned by
 // VtTablet (and passed along by VtGate if appropriate).
 // We use this so the clients don't have to parse the error messages,
@@ -330,6 +351,27 @@ func (m *RPCError) Reset()                    { *m = RPCError{} }
 func (m *RPCError) String() string            { return proto.CompactTextString(m) }
 func (*RPCError) ProtoMessage()               {}
 func (*RPCError) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+
+func (m *RPCError) GetLegacyCode() LegacyErrorCode {
+	if m != nil {
+		return m.LegacyCode
+	}
+	return LegacyErrorCode_SUCCESS_LEGACY
+}
+
+func (m *RPCError) GetMessage() string {
+	if m != nil {
+		return m.Message
+	}
+	return ""
+}
+
+func (m *RPCError) GetCode() Code {
+	if m != nil {
+		return m.Code
+	}
+	return Code_OK
+}
 
 func init() {
 	proto.RegisterType((*CallerID)(nil), "vtrpc.CallerID")

--- a/go/vt/proto/vttest/vttest.pb.go
+++ b/go/vt/proto/vttest/vttest.pb.go
@@ -47,6 +47,20 @@ func (m *Shard) String() string            { return proto.CompactTextString(m) }
 func (*Shard) ProtoMessage()               {}
 func (*Shard) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Shard) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Shard) GetDbNameOverride() string {
+	if m != nil {
+		return m.DbNameOverride
+	}
+	return ""
+}
+
 // Keyspace describes a single keyspace.
 type Keyspace struct {
 	// name has to be unique in a VTTestTopology.
@@ -70,11 +84,53 @@ func (m *Keyspace) String() string            { return proto.CompactTextString(m
 func (*Keyspace) ProtoMessage()               {}
 func (*Keyspace) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
 
+func (m *Keyspace) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
 func (m *Keyspace) GetShards() []*Shard {
 	if m != nil {
 		return m.Shards
 	}
 	return nil
+}
+
+func (m *Keyspace) GetShardingColumnName() string {
+	if m != nil {
+		return m.ShardingColumnName
+	}
+	return ""
+}
+
+func (m *Keyspace) GetShardingColumnType() string {
+	if m != nil {
+		return m.ShardingColumnType
+	}
+	return ""
+}
+
+func (m *Keyspace) GetServedFrom() string {
+	if m != nil {
+		return m.ServedFrom
+	}
+	return ""
+}
+
+func (m *Keyspace) GetReplicaCount() int32 {
+	if m != nil {
+		return m.ReplicaCount
+	}
+	return 0
+}
+
+func (m *Keyspace) GetRdonlyCount() int32 {
+	if m != nil {
+		return m.RdonlyCount
+	}
+	return 0
 }
 
 // VTTestTopology describes the keyspaces in the topology.
@@ -93,6 +149,13 @@ func (*VTTestTopology) Descriptor() ([]byte, []int) { return fileDescriptor0, []
 func (m *VTTestTopology) GetKeyspaces() []*Keyspace {
 	if m != nil {
 		return m.Keyspaces
+	}
+	return nil
+}
+
+func (m *VTTestTopology) GetCells() []string {
+	if m != nil {
+		return m.Cells
 	}
 	return nil
 }

--- a/go/vt/proto/vtworkerdata/vtworkerdata.pb.go
+++ b/go/vt/proto/vtworkerdata/vtworkerdata.pb.go
@@ -40,6 +40,13 @@ func (m *ExecuteVtworkerCommandRequest) String() string            { return prot
 func (*ExecuteVtworkerCommandRequest) ProtoMessage()               {}
 func (*ExecuteVtworkerCommandRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *ExecuteVtworkerCommandRequest) GetArgs() []string {
+	if m != nil {
+		return m.Args
+	}
+	return nil
+}
+
 // ExecuteVtworkerCommandResponse is streamed back by ExecuteVtworkerCommand.
 type ExecuteVtworkerCommandResponse struct {
 	Event *logutil.Event `protobuf:"bytes,1,opt,name=event" json:"event,omitempty"`

--- a/go/vt/proto/workflow/workflow.pb.go
+++ b/go/vt/proto/workflow/workflow.pb.go
@@ -123,6 +123,62 @@ func (m *Workflow) String() string            { return proto.CompactTextString(m
 func (*Workflow) ProtoMessage()               {}
 func (*Workflow) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Workflow) GetUuid() string {
+	if m != nil {
+		return m.Uuid
+	}
+	return ""
+}
+
+func (m *Workflow) GetFactoryName() string {
+	if m != nil {
+		return m.FactoryName
+	}
+	return ""
+}
+
+func (m *Workflow) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+func (m *Workflow) GetState() WorkflowState {
+	if m != nil {
+		return m.State
+	}
+	return WorkflowState_NotStarted
+}
+
+func (m *Workflow) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
+func (m *Workflow) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
+}
+
+func (m *Workflow) GetStartTime() int64 {
+	if m != nil {
+		return m.StartTime
+	}
+	return 0
+}
+
+func (m *Workflow) GetEndTime() int64 {
+	if m != nil {
+		return m.EndTime
+	}
+	return 0
+}
+
 type WorkflowCheckpoint struct {
 	// code_version is used to detect incompabilities between the version of the
 	// running workflow and the one which wrote the checkpoint. If they don't
@@ -141,6 +197,13 @@ func (m *WorkflowCheckpoint) Reset()                    { *m = WorkflowCheckpoin
 func (m *WorkflowCheckpoint) String() string            { return proto.CompactTextString(m) }
 func (*WorkflowCheckpoint) ProtoMessage()               {}
 func (*WorkflowCheckpoint) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{1} }
+
+func (m *WorkflowCheckpoint) GetCodeVersion() int32 {
+	if m != nil {
+		return m.CodeVersion
+	}
+	return 0
+}
 
 func (m *WorkflowCheckpoint) GetTasks() map[string]*Task {
 	if m != nil {
@@ -169,11 +232,32 @@ func (m *Task) String() string            { return proto.CompactTextString(m) }
 func (*Task) ProtoMessage()               {}
 func (*Task) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *Task) GetId() string {
+	if m != nil {
+		return m.Id
+	}
+	return ""
+}
+
+func (m *Task) GetState() TaskState {
+	if m != nil {
+		return m.State
+	}
+	return TaskState_TaskNotStarted
+}
+
 func (m *Task) GetAttributes() map[string]string {
 	if m != nil {
 		return m.Attributes
 	}
 	return nil
+}
+
+func (m *Task) GetError() string {
+	if m != nil {
+		return m.Error
+	}
+	return ""
 }
 
 func init() {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -385,32 +385,32 @@
 		{
 			"checksumSHA1": "ZIqcmeEc/EU9HsKJHuJ1Iy+ZNgE=",
 			"path": "github.com/golang/protobuf/protoc-gen-go",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
+			"revisionTime": "2017-02-17T23:44:32Z"
 		},
 		{
-			"checksumSHA1": "juNiTc9bfhQYo4BkWc83sW4Z5gw=",
+			"checksumSHA1": "AjyXQ5eohrCPS/jSWZFPn5E8wnQ=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
+			"revisionTime": "2017-02-17T23:44:32Z"
 		},
 		{
-			"checksumSHA1": "lPJ5a2uV2CPHch++4zKkJ1au0sw=",
+			"checksumSHA1": "T/EqMkqzvjQUL1c+yN32kketgfE=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/generator",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
+			"revisionTime": "2017-02-17T23:44:32Z"
 		},
 		{
 			"checksumSHA1": "u5V5OglAZoibucYHK3OtIFYM+w0=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/grpc",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
+			"revisionTime": "2017-02-17T23:44:32Z"
 		},
 		{
 			"checksumSHA1": "zps2+aJoFhpFf2F8TsU9zCGXL2c=",
 			"path": "github.com/golang/protobuf/protoc-gen-go/plugin",
-			"revision": "2bc9827a78f95c6665b5fe0abd1fd66b496ae2d8",
-			"revisionTime": "2016-11-03T22:44:32Z"
+			"revision": "69b215d01a5606c843240eab4937eab3acee6530",
+			"revisionTime": "2017-02-17T23:44:32Z"
 		},
 		{
 			"checksumSHA1": "/vLtyN6HK5twSZIFerD199YTmjk=",


### PR DESCRIPTION
I've also regenerated all protobuf files.

Note that the new version has added getters for primitive types. Do NOT
use these getters and instead always use the field names instead.