### PR TITLE
just skip any unparseable rbr events

### DIFF
--- a/go/mysqlconn/replication/binlog_event_make_test.go
+++ b/go/mysqlconn/replication/binlog_event_make_test.go
@@ -317,11 +317,11 @@ func TestRowsEvent(t *testing.T) {
 
 	// Test the Rows we just created, to be sure.
 	// 1076895760 is 0x40302010.
-	identifies := rows.StringIdentifies(tm, 0)
+	identifies, err := rows.StringIdentifies(tm, 0)
 	if expected := []string{"1076895760", "abc"}; !reflect.DeepEqual(identifies, expected) {
 		t.Fatalf("bad Rows idenfity, got %v expected %v", identifies, expected)
 	}
-	values := rows.StringValues(tm, 0)
+	values, err := rows.StringValues(tm, 0)
 	if expected := []string{"1076895760", "abcd"}; !reflect.DeepEqual(values, expected) {
 		t.Fatalf("bad Rows data, got %v expected %v", values, expected)
 	}
@@ -334,7 +334,7 @@ func TestRowsEvent(t *testing.T) {
 		t.Fatalf("NewRowsEvent().IsUpdateRows() if false")
 	}
 
-	event, _, err := event.StripChecksum(f)
+	event, _, err = event.StripChecksum(f)
 	if err != nil {
 		t.Fatalf("StripChecksum failed: %v", err)
 	}

--- a/go/mysqlconn/replication_test.go
+++ b/go/mysqlconn/replication_test.go
@@ -543,7 +543,7 @@ func testRowReplicationWithRealDatabase(t *testing.T, params *sqldb.ConnParams) 
 			}
 
 			// Check it has 2 rows, and first value is '10', second value is 'nice name'.
-			values := wr.StringValues(tableMap, 0)
+			values, _ := wr.StringValues(tableMap, 0)
 			t.Logf("Got WriteRows event data: %v %v", wr, values)
 			if expected := []string{"10", "nice name"}; !reflect.DeepEqual(values, expected) {
 				t.Fatalf("StringValues returned %v, expected %v", values, expected)
@@ -560,14 +560,14 @@ func testRowReplicationWithRealDatabase(t *testing.T, params *sqldb.ConnParams) 
 			}
 
 			// Check it has 2 identify rows, and first value is '10', second value is 'nice name'.
-			values := ur.StringIdentifies(tableMap, 0)
+			values, _ := ur.StringIdentifies(tableMap, 0)
 			t.Logf("Got UpdateRows event identify: %v %v", ur, values)
 			if expected := []string{"10", "nice name"}; !reflect.DeepEqual(values, expected) {
 				t.Fatalf("StringIdentifies returned %v, expected %v", values, expected)
 			}
 
 			// Check it has 2 values rows, and first value is '10', second value is 'nicer name'.
-			values = ur.StringValues(tableMap, 0)
+			values, _ = ur.StringValues(tableMap, 0)
 			t.Logf("Got UpdateRows event data: %v %v", ur, values)
 			if expected := []string{"10", "nicer name"}; !reflect.DeepEqual(values, expected) {
 				t.Fatalf("StringValues returned %v, expected %v", values, expected)
@@ -584,7 +584,7 @@ func testRowReplicationWithRealDatabase(t *testing.T, params *sqldb.ConnParams) 
 			}
 
 			// Check it has 2 rows, and first value is '10', second value is 'nicer name'.
-			values := dr.StringIdentifies(tableMap, 0)
+			values, _ := dr.StringIdentifies(tableMap, 0)
 			t.Logf("Got DeleteRows event identify: %v %v", dr, values)
 			if expected := []string{"10", "nicer name"}; !reflect.DeepEqual(values, expected) {
 				t.Fatalf("StringIdentifies returned %v, expected %v", values, expected)

--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -388,8 +388,16 @@ func (bls *Streamer) parseEvents(ctx context.Context, events <-chan replication.
 			}
 			statements = append(statements, setTimestamp)
 			for i := range rows.Rows {
-				identifies := rows.StringIdentifies(tm, i)
-				values := rows.StringValues(tm, i)
+				identifies, err := rows.StringIdentifies(tm, i)
+				if err != nil {
+					log.Warningf("Failed to parse UPDATE due to error %v", err)
+					continue
+				}
+				values, err := rows.StringValues(tm, i)
+				if err != nil {
+					log.Warningf("Failed to parse UPDATE due to error %v", err)
+					continue
+				}
 				update := &binlogdatapb.BinlogTransaction_Statement{
 					Category: binlogdatapb.BinlogTransaction_Statement_BL_UPDATE,
 					Sql:      []byte(fmt.Sprintf("WIP: update table %v set values = %v where identifies = %v", tm.Name, values, identifies)),


### PR DESCRIPTION
@alainjobart not sure if this is what you had in mind. I kept the panic for the NYI types, since I figured that may have other consequences.