### PR TITLE
Etcd{,2} fix for watches.

### DIFF
--- a/go/vt/etcdtopo/watch.go
+++ b/go/vt/etcdtopo/watch.go
@@ -76,7 +76,11 @@ func (s *Server) Watch(ctx context.Context, cellName, filePath string) (*topo.Wa
 	watchChannel := make(chan *etcd.Response)
 	watchError := make(chan error)
 	go func(stop chan bool) {
-		versionToWatch := initial.Node.ModifiedIndex + 1
+		// We start watching from the etcd version we got
+		// during the get, and not from the ModifiedIndex of
+		// the node, as the node might be older than the
+		// retention period of the server.
+		versionToWatch := initial.EtcdIndex + 1
 		_, err := cell.Client.Watch(filePath, versionToWatch, false /* recursive */, watchChannel, stop)
 		// Watch will only return a non-nil error, otherwise
 		// it keeps on watching. Send the error down.

--- a/go/vt/topo/etcd2topo/watch.go
+++ b/go/vt/topo/etcd2topo/watch.go
@@ -37,8 +37,10 @@ func (s *Server) Watch(ctx context.Context, cell, filePath string) (*topo.WatchD
 	// Create a context, will be used to cancel the watch.
 	watchCtx, watchCancel := context.WithCancel(context.Background())
 
-	// Create the Watcher.
-	watcher := s.global.cli.Watch(watchCtx, nodePath, clientv3.WithRev(initial.Kvs[0].ModRevision))
+	// Create the Watcher.  We start watching from the response we
+	// got, not from the file original version, as the server may
+	// not have that much history.
+	watcher := s.global.cli.Watch(watchCtx, nodePath, clientv3.WithRev(initial.Header.Revision))
 	if watcher == nil {
 		return &topo.WatchData{Err: fmt.Errorf("Watch failed")}, nil, nil
 	}


### PR DESCRIPTION
When we start to watch a file, we need to start from the version at the time of the original 'Get', not from the version of the file. The server may have compacted its history and lost the changes.

@rnavarro this should be your fix.