### PR TITLE
Auth work for MySQL Server code.

### DIFF
--- a/examples/kubernetes/vtgate-controller-template.yaml
+++ b/examples/kubernetes/vtgate-controller-template.yaml
@@ -43,6 +43,7 @@ spec:
               -port 15001
               -grpc_port 15991
               -mysql_server_port {{mysql_server_port}}
+              -mysql_auth_server_config_string '{\"mysql_user\":{\"Password\":\"mysql_password\"}}'
               -service_map 'grpc-vtgateservice'
               -cells_to_watch {{cell}}
               -tablet_types_to_wait MASTER,REPLICA

--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -46,6 +46,7 @@ $VTROOT/bin/vtgate \
   -port $web_port \
   -grpc_port $grpc_port \
   -mysql_server_port $mysql_server_port \
+  -mysql_auth_server_config_string '{"mysql_user":{"Password":"mysql_password"}}' \
   -cell $cell \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \

--- a/go/mysqlconn/auth_server.go
+++ b/go/mysqlconn/auth_server.go
@@ -1,0 +1,111 @@
+package mysqlconn
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+
+	log "github.com/golang/glog"
+)
+
+// AuthServer is the interface that servers must implement to validate
+// users and passwords. It has two modes:
+//
+// 1. using salt the way MySQL native auth does it. In that case, the
+// password is not sent in the clear, but the salt is used to hash the
+// password both on the client and server side, and the result is sent
+// and compared.
+//
+// 2. sending the user / password in the clear (using MySQL Cleartext
+// method). The server then gets access to both user and password, and
+// can authenticate using any method. If SSL is not used, it means the
+// password is sent in the clear. That may not be suitable for some
+// use cases.
+type AuthServer interface {
+	// UseClearText returns true is Cleartext auth is used.
+	// - If it is not set, Salt() and ValidateHash() are called.
+	// The server starts up in mysql_native_password mode.
+	// (but ValidateClearText can also be called, if client
+	// switched to Cleartext).
+	// - If it is set, ValidateClearText() is called.
+	// The server starts up in mysql_clear_password mode.
+	UseClearText() bool
+
+	// Salt returns the salt to use for a connection.
+	// It should be 20 bytes of data.
+	Salt() ([]byte, error)
+
+	// ValidateHash validates the data sent by the client matches
+	// what the server computes.  It also returns the user data.
+	ValidateHash(salt []byte, user string, authResponse []byte) (string, error)
+
+	// ValidateClearText validates a user / password is correct.
+	// It also returns the user data.
+	ValidateClearText(user, password string) (string, error)
+}
+
+// authServers is a registry of AuthServer implementations.
+var authServers = make(map[string]AuthServer)
+
+// RegisterAuthServerImpl registers an implementations of AuthServer.
+func RegisterAuthServerImpl(name string, authServer AuthServer) {
+	if _, ok := authServers[name]; ok {
+		log.Fatalf("AuthServer named %v already exists", name)
+	}
+	authServers[name] = authServer
+}
+
+// GetAuthServer returns an AuthServer by name, or log.Fatalf.
+func GetAuthServer(name string) AuthServer {
+	authServer, ok := authServers[name]
+	if !ok {
+		log.Fatalf("no AuthServer name %v registered", name)
+	}
+	return authServer
+}
+
+// newSalt returns a 20 character salt.
+func newSalt() ([]byte, error) {
+	salt := make([]byte, 20)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+
+	// Salt must be a legal UTF8 string.
+	for i := 0; i < len(salt); i++ {
+		salt[i] &= 0x7f
+		if salt[i] == '\x00' || salt[i] == '$' {
+			salt[i]++
+		}
+	}
+
+	return salt, nil
+}
+
+// scramblePassword computes the hash of the password using 4.1+ method.
+func scramblePassword(salt, password []byte) []byte {
+	if len(password) == 0 {
+		return nil
+	}
+
+	// stage1Hash = SHA1(password)
+	crypt := sha1.New()
+	crypt.Write(password)
+	stage1 := crypt.Sum(nil)
+
+	// scrambleHash = SHA1(salt + SHA1(stage1Hash))
+	// inner Hash
+	crypt.Reset()
+	crypt.Write(stage1)
+	hash := crypt.Sum(nil)
+	// outer Hash
+	crypt.Reset()
+	crypt.Write(salt)
+	crypt.Write(hash)
+	scramble := crypt.Sum(nil)
+
+	// token = scrambleHash XOR stage1Hash
+	for i := range scramble {
+		scramble[i] ^= stage1[i]
+	}
+	return scramble
+}

--- a/go/mysqlconn/auth_server_config.go
+++ b/go/mysqlconn/auth_server_config.go
@@ -1,0 +1,73 @@
+package mysqlconn
+
+import (
+	"bytes"
+
+	"github.com/youtube/vitess/go/sqldb"
+)
+
+// AuthServerConfig implements AuthServer using a static configuration.
+type AuthServerConfig struct {
+	// ClearText can be set to force the use of ClearText auth.
+	ClearText bool
+
+	// Entries contains the users, passwords and user data.
+	Entries map[string]*AuthServerConfigEntry
+}
+
+// AuthServerConfigEntry stores the values for a given user.
+type AuthServerConfigEntry struct {
+	Password string
+	UserData string
+}
+
+// NewAuthServerConfig returns a new empty AuthServerConfig.
+func NewAuthServerConfig() *AuthServerConfig {
+	return &AuthServerConfig{
+		ClearText: false,
+		Entries:   make(map[string]*AuthServerConfigEntry),
+	}
+}
+
+// UseClearText is part of the AuthServer interface.
+func (a *AuthServerConfig) UseClearText() bool {
+	return a.ClearText
+}
+
+// Salt is part of the AuthServer interface.
+func (a *AuthServerConfig) Salt() ([]byte, error) {
+	return newSalt()
+}
+
+// ValidateHash is part of the AuthServer interface.
+func (a *AuthServerConfig) ValidateHash(salt []byte, user string, authResponse []byte) (string, error) {
+	// Find the entry.
+	entry, ok := a.Entries[user]
+	if !ok {
+		return "", sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", user)
+	}
+
+	// Validate the password.
+	computedAuthResponse := scramblePassword(salt, []byte(entry.Password))
+	if bytes.Compare(authResponse, computedAuthResponse) != 0 {
+		return "", sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", user)
+	}
+
+	return entry.UserData, nil
+}
+
+// ValidateClearText is part of the AuthServer interface.
+func (a *AuthServerConfig) ValidateClearText(user, password string) (string, error) {
+	// Find the entry.
+	entry, ok := a.Entries[user]
+	if !ok {
+		return "", sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", user)
+	}
+
+	// Validate the password.
+	if entry.Password != password {
+		return "", sqldb.NewSQLError(ERAccessDeniedError, SSAccessDeniedError, "Access denied for user '%v'", user)
+	}
+
+	return entry.UserData, nil
+}

--- a/go/mysqlconn/client.go
+++ b/go/mysqlconn/client.go
@@ -253,7 +253,8 @@ func (c *Conn) clientHandshake(characterSet uint8, params *sqldb.ConnParams) err
 	}
 	switch response[0] {
 	case OKPacket:
-		// OK packet, we are authenticated. We keep going.
+		// OK packet, we are authenticated. Save the user, keep going.
+		c.User = params.Uname
 	case ErrPacket:
 		return parseErrorPacket(response)
 	default:

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -155,7 +155,7 @@ func newConn(conn net.Conn) *Conn {
 
 // readPacketDirect attempts to read a packet from the socket directly.
 // It needs to be used for the first handshake packet the server receives,
-// so we do't buffer the SSL negociation packet. As a shortcut, only
+// so we do't buffer the SSL negotiation packet. As a shortcut, only
 // packets smaller than MaxPacketSize can be read here.
 func (c *Conn) readPacketDirect() ([]byte, error) {
 	var header [4]byte

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -60,7 +60,7 @@ type Conn struct {
 	// Capabilities is the current set of features this connection
 	// is using.  It is the features that are both supported by
 	// the client and the server, and currently in use.
-	// It is set after the initial handshake.
+	// It is set during the initial handshake.
 	//
 	// It is only used for CapabilityClientDeprecateEOF.
 	Capabilities uint32
@@ -70,6 +70,14 @@ type Conn struct {
 	// It is set during the initial handshake.
 	// See the values in constants.go.
 	CharacterSet uint8
+
+	// User is the name used by the client to connect.
+	// It is set during the initial handshake.
+	User string
+
+	// UserData is custom data returned by the AuthServer module.
+	// It is set during the initial handshake.
+	UserData string
 
 	// SchemaName is the default database name to use. It is set
 	// during handshake, and by ComInitDb packets. Both client and

--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -505,6 +505,11 @@ func (c *Conn) writeComQuit() error {
 	return nil
 }
 
+// RemoteAddr returns the underlying socket RemoteAddr().
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
+}
+
 // Close closes the connection. It can be called from a different go
 // routine to interrupt the current connection.
 func (c *Conn) Close() {

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -10,9 +10,15 @@ const (
 	// protocolVersion is the current version of the protocol.
 	// Always 10.
 	protocolVersion = 10
+)
 
-	// mysqlNativePassword is the auth form we use.
+// Supported auth forms.
+const (
+	// mysqlNativePassword uses a salt and transmits a hash on the wire.
 	mysqlNativePassword = "mysql_native_password"
+
+	// mysqlClearPassword transmits the password in the clear.
+	mysqlClearPassword = "mysql_clear_password"
 )
 
 // Capability flags.

--- a/go/mysqlconn/constants.go
+++ b/go/mysqlconn/constants.go
@@ -147,6 +147,9 @@ const (
 	// EOFPacket is the header of the EOF packet.
 	EOFPacket = 0xfe
 
+	// AuthSwitchRequestPacket is used to switch auth method.
+	AuthSwitchRequestPacket = 0xfe
+
 	// ErrPacket is the header of the error packet.
 	ErrPacket = 0xff
 

--- a/go/mysqlconn/doc.go
+++ b/go/mysqlconn/doc.go
@@ -54,7 +54,7 @@ If our server's AuthServer UseClearText() returns true, and the
 client's auth method is not mysql_clear_password, we will
 re-negotiate.
 
-If any of these methods doesn't work for the server, it will re-negociate
+If any of these methods doesn't work for the server, it will re-negotiate
 by sending an Authentication Method Switch Request Packet.
 The client will then handle that if it can.
 --

--- a/go/mysqlconn/doc.go
+++ b/go/mysqlconn/doc.go
@@ -36,10 +36,27 @@ message to set the database.
 --
 PLUGABLE AUTHENTICATION:
 
-We only support mysql_native_password for now, both client and server
-side. It wouldn't be a lot of work to add SHA256 for instance, or clear text
-authentication.
+See https://dev.mysql.com/doc/internals/en/authentication-method-mismatch.html
+for more information on this.
 
+Our server side always starts by using mysql_native_password, like a
+real MySQL server.
+
+Our client will expect the server to always use mysql_native_password
+in its initial handshake. This is what a real server always does, even though
+it's not technically mandatory.
+
+Our server can then use the client's auth methods right away:
+- mysql_native_password
+- mysql_clear_password
+
+If our server's AuthServer UseClearText() returns true, and the
+client's auth method is not mysql_clear_password, we will
+re-negotiate.
+
+If any of these methods doesn't work for the server, it will re-negociate
+by sending an Authentication Method Switch Request Packet.
+The client will then handle that if it can.
 --
 Maximum Packet Size:
 

--- a/go/mysqlconn/fakesqldb/server.go
+++ b/go/mysqlconn/fakesqldb/server.go
@@ -73,14 +73,18 @@ func New(t *testing.T) *DB {
 		connections:  make(map[uint32]*mysqlconn.Conn),
 	}
 
+	authServer := mysqlconn.NewAuthServerConfig()
+	authServer.Entries["user1"] = &mysqlconn.AuthServerConfigEntry{
+		Password: "password1",
+	}
+
 	// Start listening.
 	var err error
-	db.listener, err = mysqlconn.NewListener("tcp", ":0", db)
+	db.listener, err = mysqlconn.NewListener("tcp", ":0", authServer, db)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
 
-	db.listener.PasswordMap["user1"] = "password1"
 	db.acceptWG.Add(1)
 	go func() {
 		defer db.acceptWG.Done()

--- a/go/mysqlconn/handshake_test.go
+++ b/go/mysqlconn/handshake_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/youtube/vitess/go/sqldb"
@@ -15,6 +16,63 @@ import (
 )
 
 // This file tests the handshake scenarios between our client and our server.
+
+func TestClearTextClientAuth(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerConfig()
+	authServer.Entries["user1"] = &AuthServerConfigEntry{
+		Password: "password1",
+	}
+	authServer.ClearText = true
+
+	// Create the listener.
+	l, err := NewListener("tcp", ":0", authServer, th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &sqldb.ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	// Connection should fail, as server requires SSL for clear text auth.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err == nil || !strings.Contains(err.Error(), "Cannot use clear text authentication over non-SSL connections") {
+		t.Fatalf("unexpected connection error: %v", err)
+	}
+
+	// Change server side to allow clear text without auth.
+	l.AllowClearTextWithoutTLS = true
+	conn, err = Connect(ctx, params)
+	if err != nil {
+		t.Fatalf("unexpected connection error: %v", err)
+	}
+	defer conn.Close()
+
+	// Run a 'select rows' command with results.
+	result, err := conn.ExecuteFetch("select rows", 10000, true)
+	if err != nil {
+		t.Fatalf("ExecuteFetch failed: %v", err)
+	}
+	if !reflect.DeepEqual(result, selectRowsResult) {
+		t.Errorf("Got wrong result from ExecuteFetch(select rows): %v", result)
+	}
+
+	// Send a ComQuit to avoid the error message on the server side.
+	conn.writeComQuit()
+}
 
 // TestSSLConnection creates a server with TLS support, a client that
 // also has SSL support, and connects them.
@@ -71,6 +129,43 @@ func TestSSLConnection(t *testing.T) {
 		SslKey:  path.Join(root, "client-key.pem"),
 	}
 
+	t.Run("Basics", func(t *testing.T) {
+		testSSLConnectionBasics(t, params)
+	})
+
+	// Make sure clear text auth works over SSL.
+	t.Run("ClearText", func(t *testing.T) {
+		l.authServer.(*AuthServerConfig).ClearText = true
+		testSSLConnectionClearText(t, params)
+	})
+}
+
+func testSSLConnectionClearText(t *testing.T, params *sqldb.ConnParams) {
+	// Create a client connection, connect.
+	ctx := context.Background()
+	conn, err := Connect(ctx, params)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer conn.Close()
+	if conn.User != "user1" {
+		t.Errorf("Invalid conn.User, got %v was expecting user1", conn.User)
+	}
+
+	// Make sure this went through SSL.
+	result, err := conn.ExecuteFetch("ssl echo", 10000, true)
+	if err != nil {
+		t.Fatalf("ExecuteFetch failed: %v", err)
+	}
+	if result.Rows[0][0].String() != "ON" {
+		t.Errorf("Got wrong result from ExecuteFetch(ssl echo): %v", result)
+	}
+
+	// Send a ComQuit to avoid the error message on the server side.
+	conn.writeComQuit()
+}
+
+func testSSLConnectionBasics(t *testing.T, params *sqldb.ConnParams) {
 	// Create a client connection, connect.
 	ctx := context.Background()
 	conn, err := Connect(ctx, params)

--- a/go/mysqlconn/handshake_test.go
+++ b/go/mysqlconn/handshake_test.go
@@ -78,6 +78,9 @@ func TestSSLConnection(t *testing.T) {
 		t.Fatalf("Connect failed: %v", err)
 	}
 	defer conn.Close()
+	if conn.User != "user1" {
+		t.Errorf("Invalid conn.User, got %v was expecting user1", conn.User)
+	}
 
 	// Run a 'select rows' command with results.
 	result, err := conn.ExecuteFetch("select rows", 10000, true)

--- a/go/mysqlconn/handshake_test.go
+++ b/go/mysqlconn/handshake_test.go
@@ -21,8 +21,13 @@ import (
 func TestSSLConnection(t *testing.T) {
 	th := &testHandler{}
 
+	authServer := NewAuthServerConfig()
+	authServer.Entries["user1"] = &AuthServerConfigEntry{
+		Password: "password1",
+	}
+
 	// Create the listener, so we can get its host.
-	l, err := NewListener("tcp", ":0", th)
+	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
 	}
@@ -49,7 +54,6 @@ func TestSSLConnection(t *testing.T) {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
 	l.TLSConfig = serverConfig
-	l.PasswordMap["user1"] = "password1"
 	go func() {
 		l.Accept()
 	}()

--- a/go/mysqlconn/query_benchmark_test.go
+++ b/go/mysqlconn/query_benchmark_test.go
@@ -128,12 +128,16 @@ func benchmarkOldParallelReads(b *testing.B, params sqldb.ConnParams, parallelCo
 func BenchmarkParallelShortQueries(b *testing.B) {
 	th := &testHandler{}
 
-	l, err := NewListener("tcp", ":0", th)
+	authServer := NewAuthServerConfig()
+	authServer.Entries["user1"] = &AuthServerConfigEntry{
+		Password: "password1",
+	}
+
+	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
 		b.Fatalf("NewListener failed: %v", err)
 	}
 	defer l.Close()
-	l.PasswordMap["user1"] = "password1"
 
 	go func() {
 		l.Accept()

--- a/go/mysqlconn/server.go
+++ b/go/mysqlconn/server.go
@@ -142,7 +142,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 	}
 
 	// Wait for the client response. This has to be a direct read,
-	// so we don't buffer the TLS negociation packets.
+	// so we don't buffer the TLS negotiation packets.
 	response, err := c.readPacketDirect()
 	if err != nil {
 		log.Errorf("Cannot read client handshake response: %v", err)
@@ -208,7 +208,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		renegotiateWithClearText = true
 	}
 
-	// If we need to re-negociate with clear text, do it.
+	// If we need to re-negotiate with clear text, do it.
 	if renegotiateWithClearText {
 		// Check error conditions.
 		if !l.AllowClearTextWithoutTLS && c.Capabilities&CapabilityClientSSL == 0 {

--- a/go/mysqlconn/server_test.go
+++ b/go/mysqlconn/server_test.go
@@ -299,6 +299,10 @@ func TestClearTextServer(t *testing.T) {
 	if ok {
 		t.Fatalf("mysql should have failed but returned: %v", output)
 	}
+	if strings.Contains(output, "No such file or directory") {
+		t.Logf("skipping mysql clear text tests, as the clear text plugin cannot be loaded: %v", err)
+		return
+	}
 	if !strings.Contains(output, "plugin not enabled") {
 		t.Errorf("Unexpected output for 'select rows': %v", output)
 	}

--- a/go/vt/callerid/callerid.go
+++ b/go/vt/callerid/callerid.go
@@ -18,7 +18,7 @@ type callerIDKey int
 
 var (
 	// internal Context key for immediate CallerID
-	immediateCallerIDKey callerIDKey = 0
+	immediateCallerIDKey callerIDKey
 	// internal Context key for effective CallerID
 	effectiveCallerIDKey callerIDKey = 1
 )
@@ -65,7 +65,7 @@ func GetComponent(ef *vtrpcpb.CallerID) string {
 	return ef.Component
 }
 
-// GetSubcomponent returns a component inisde the process of effective caller,
+// GetSubcomponent returns a component inside the process of effective caller,
 // which is responsible for generating this request. Suggested values are a
 // servlet name or an API endpoint name.
 func GetSubcomponent(ef *vtrpcpb.CallerID) string {

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -22,10 +22,11 @@ import (
 )
 
 var (
-	mysqlServerPort             = flag.Int("mysql_server_port", 0, "If set, also listen for MySQL binary protocol connections on this port.")
-	mysqlAuthServerImpl         = flag.String("mysql_auth_server_impl", "config", "Which auth server implementation to use.")
-	mysqlAuthServerConfigFile   = flag.String("mysql_auth_server_config_file", "", "JSON File to read the users/passwords from.")
-	mysqlAuthServerConfigString = flag.String("mysql_auth_server_config_string", "", "JSON representation of the users/passwords config.")
+	mysqlServerPort               = flag.Int("mysql_server_port", 0, "If set, also listen for MySQL binary protocol connections on this port.")
+	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "config", "Which auth server implementation to use.")
+	mysqlAuthServerConfigFile     = flag.String("mysql_auth_server_config_file", "", "JSON File to read the users/passwords from.")
+	mysqlAuthServerConfigString   = flag.String("mysql_auth_server_config_string", "", "JSON representation of the users/passwords config.")
+	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
 )
 
 // Handles initializing the AuthServerConfig if necessary.
@@ -195,6 +196,7 @@ func init() {
 		if err != nil {
 			log.Fatalf("mysqlconn.NewListener failed: %v", err)
 		}
+		listener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
 
 		// And starts listening.
 		go func() {

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -1,10 +1,8 @@
 package vtgate
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"strings"
 
@@ -42,24 +40,8 @@ func initAuthServerConfig() {
 		log.Fatalf("Both mysql_auth_server_config_file and mysql_auth_server_config_string specified, can only use one.")
 	}
 
-	// Read file if necessary.
-	authServerConfig := mysqlconn.NewAuthServerConfig()
-	jsonConfig := []byte(*mysqlAuthServerConfigString)
-	if *mysqlAuthServerConfigFile != "" {
-		data, err := ioutil.ReadFile(*mysqlAuthServerConfigFile)
-		if err != nil {
-			log.Fatalf("Failed to read mysql_auth_server_config_file file: %v", err)
-		}
-		jsonConfig = data
-	}
-
-	// Parse JSON config.
-	if err := json.Unmarshal(jsonConfig, &authServerConfig.Entries); err != nil {
-		log.Fatalf("Error parsing auth server config: %v", err)
-	}
-
-	// And register the server.
-	mysqlconn.RegisterAuthServerImpl("config", authServerConfig)
+	// Create and register auth server.
+	mysqlconn.RegisterAuthServerConfigFromParams(*mysqlAuthServerConfigFile, *mysqlAuthServerConfigString)
 }
 
 // vtgateHandler implements the Listener interface.

--- a/test/config.json
+++ b/test/config.json
@@ -219,6 +219,15 @@
 			"RetryMax": 0,
 			"Tags": []
 		},
+		"mysql_server": {
+			"File": "mysql_server_test.py",
+			"Args": [],
+			"Command": [],
+			"Manual": false,
+			"Shard": 1,
+			"RetryMax": 0,
+			"Tags": []
+		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
 			"Args": [],

--- a/test/mysql_server_test.py
+++ b/test/mysql_server_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+#
+# Copyright 2013, Google Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can
+# be found in the LICENSE file.
+
+"""Ensures the vtgate MySQL server protocol plugin works as expected.
+
+We use table ACLs to verify the user name authenticated by the connector is
+set properly.
+"""
+
+
+import unittest
+
+import MySQLdb
+
+import environment
+import utils
+import tablet
+
+# single shard / 2 tablets
+shard_0_master = tablet.Tablet()
+shard_0_slave = tablet.Tablet()
+
+table_acl_config = environment.tmproot + '/table_acl_config.json'
+mysql_auth_server_config = (environment.tmproot +
+                            '/mysql_auth_server_config.json')
+
+
+def setUpModule():
+  try:
+    environment.topo_server().setup()
+
+    # setup all processes
+    setup_procs = [
+        shard_0_master.init_mysql(),
+        shard_0_slave.init_mysql(),
+        ]
+    utils.wait_procs(setup_procs)
+
+    utils.run_vtctl(['CreateKeyspace', 'test_keyspace'])
+
+    shard_0_master.init_tablet('replica', 'test_keyspace', '0')
+    shard_0_slave.init_tablet('replica', 'test_keyspace', '0')
+
+    # create databases so vttablet can start behaving normally
+    shard_0_master.create_db('vt_test_keyspace')
+    shard_0_slave.create_db('vt_test_keyspace')
+
+  except:
+    tearDownModule()
+    raise
+
+
+def tearDownModule():
+  utils.required_teardown()
+  if utils.options.skip_teardown:
+    return
+
+  shard_0_master.kill_vttablet()
+  shard_0_slave.kill_vttablet()
+
+  teardown_procs = [
+      shard_0_master.teardown_mysql(),
+      shard_0_slave.teardown_mysql(),
+      ]
+  utils.wait_procs(teardown_procs, raise_on_error=False)
+
+  environment.topo_server().teardown()
+  utils.kill_sub_processes()
+  utils.remove_tmp_files()
+
+  shard_0_master.remove_tree()
+  shard_0_slave.remove_tree()
+
+
+create_vt_insert_test = '''create table vt_insert_test (
+id bigint auto_increment,
+msg varchar(64),
+keyspace_id bigint(20) unsigned NOT NULL,
+primary key (id)
+) Engine=InnoDB'''
+
+
+class TestMySQL(unittest.TestCase):
+  """This test makes sure the MySQL server connector is correct.
+  """
+
+  def test_mysql_connector(self):
+    with open(table_acl_config, 'w') as fd:
+      fd.write("""{
+      "table_groups": [
+          {
+             "table_names_or_prefixes": ["vt_insert_test"],
+             "readers": ["vtgate client 1"],
+             "writers": ["vtgate client 1"],
+             "admins": ["vtgate client 1"]
+          }
+      ]
+}
+""")
+
+    with open(mysql_auth_server_config, 'w') as fd:
+      fd.write("""{
+      "testuser1": {
+        "Password": "testpassword1",
+        "UserData": "vtgate client 1"
+      },
+      "testuser2": {
+        "Password": "testpassword2",
+        "UserData": "vtgate client 2"
+      }
+}
+""")
+
+    # start the tablets
+    shard_0_master.start_vttablet(wait_for_state='NOT_SERVING',
+                                  table_acl_config=table_acl_config)
+    shard_0_slave.start_vttablet(wait_for_state='NOT_SERVING',
+                                 table_acl_config=table_acl_config)
+
+    # setup replication
+    utils.run_vtctl(['InitShardMaster', '-force', 'test_keyspace/0',
+                     shard_0_master.tablet_alias], auto_log=True)
+    utils.run_vtctl(['ApplySchema', '-sql', create_vt_insert_test,
+                     'test_keyspace'])
+    for t in [shard_0_master, shard_0_slave]:
+      utils.run_vtctl(['RunHealthCheck', t.tablet_alias])
+
+    # start vtgate
+    utils.VtGate(mysql_server=True).start(
+        extra_args=['-mysql_auth_server_impl', 'config',
+                    '-mysql_auth_server_config_file', mysql_auth_server_config])
+    params = dict(host='::',
+                  port=utils.vtgate.mysql_port,
+                  user='testuser1',
+                  passwd='testpassword1',
+                  db='test_keyspace')
+
+    # 'vtgate client 1' is authorized to access vt_insert_test
+    conn = MySQLdb.Connect(**params)
+    cursor = conn.cursor()
+    cursor.execute('select * from vt_insert_test', {})
+    conn.close()
+
+    # 'vtgate client 2' is not authorized to access vt_insert_test
+    params['user'] = 'testuser2'
+    params['passwd'] = 'testpassword2'
+    conn = MySQLdb.Connect(**params)
+    try:
+      cursor = conn.cursor()
+      cursor.execute('select * from vt_insert_test', {})
+      self.fail('Execute went through')
+    except MySQLdb.OperationalError, e:
+      s = str(e)
+      self.assertIn('table acl error', s)
+      self.assertIn('cannot run PASS_SELECT on table', s)
+    conn.close()
+
+
+if __name__ == '__main__':
+  utils.main()

--- a/test/utils.py
+++ b/test/utils.py
@@ -527,12 +527,15 @@ vtgate = None
 class VtGate(object):
   """VtGate object represents a vtgate process."""
 
-  def __init__(self, port=None):
+  def __init__(self, port=None, mysql_server=False):
     """Creates the Vtgate instance and reserve the ports if necessary."""
     self.port = port or environment.reserve_ports(1)
     if protocols_flavor().vtgate_protocol() == 'grpc':
       self.grpc_port = environment.reserve_ports(1)
     self.proc = None
+    self.mysql_port = None
+    if mysql_server:
+      self.mysql_port = environment.reserve_ports(1)
 
   def start(self, cell='test_nj', retry_count=2,
             topo_impl=None, cache_ttl='1s',
@@ -576,6 +579,8 @@ class VtGate(object):
       args.extend(environment.topo_server().flags())
     if extra_args:
       args.extend(extra_args)
+    if self.mysql_port:
+      args.extend(['-mysql_server_port', str(self.mysql_port)])
 
     self.proc = run_bg(args)
     wait_for_vars('vtgate', self.port)


### PR DESCRIPTION
The following changes are included:

* Add plugin for server auth support.

* Add client and server support for clear text authentication plugin. Client support is enabled by default. Server support requires SSL by default, but that's controlled by a flag.

*  unit tests for most scenarios (except some pre MySQL 4.1 error conditions).

* linking it all in vtgate.