### PR TITLE
vtgate/buffer: Fix leakage of buffer pool slots due to canceled requests.

### DIFF
--- a/go/sync2/semaphore.go
+++ b/go/sync2/semaphore.go
@@ -66,3 +66,8 @@ func (sem *Semaphore) TryAcquire() bool {
 func (sem *Semaphore) Release() {
 	sem.slots <- struct{}{}
 }
+
+// Size returns the current number of available slots.
+func (sem *Semaphore) Size() int {
+	return len(sem.slots)
+}

--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -28,6 +28,7 @@ func resetFlagsForTesting() {
 	// Set all flags to their default value.
 	flag.Set("enable_buffer", "false")
 	flag.Set("enable_buffer_dry_run", "false")
+	flag.Set("buffer_size", "10")
 	flag.Set("buffer_window", "10s")
 	flag.Set("buffer_keyspace_shards", "")
 	flag.Set("buffer_max_failover_duration", "20s")


### PR DESCRIPTION
Canceled requests, e.g. those with a deadline shorter than the failover duration, would not return their buffer pool slot. Eventually, all slots would have leaked and the buffer would start and stop buffering as usual but reject all requests immediately because it assumed there are other pending failovers which are holding the needed slots.

Previously, the code path for canceled requests differed from the common method unblockAndWait() which would unblock a request and also release its buffer pool slot after the request finished its retry. This made this oversight possible. I've changed this now: canceled requests also use unblockAndWait() now.

The code was also out of sync with the documentation for WaitForFailoverEnd(): The RetryDoneFunc() must not be returned when the function returns an error as well. However, for canceled requests both were returned.