### PR TITLE
vterrors: handle special cases

### DIFF
--- a/go/vt/logutil/throttled.go
+++ b/go/vt/logutil/throttled.go
@@ -46,7 +46,7 @@ func (tl *ThrottledLogger) log(logF logFunc, format string, v ...interface{}) {
 	logWaitTime := tl.maxInterval - (now.Sub(tl.lastlogTime))
 	if logWaitTime < 0 {
 		tl.lastlogTime = now
-		logF(2, fmt.Sprintf(tl.name+":"+format, v...))
+		logF(2, fmt.Sprintf(tl.name+": "+format, v...))
 		return
 	}
 	// If this is the first message to be skipped, start a goroutine

--- a/go/vt/logutil/throttled_test.go
+++ b/go/vt/logutil/throttled_test.go
@@ -24,7 +24,7 @@ func TestThrottledLogger(t *testing.T) {
 	start := time.Now()
 
 	go tl.Infof("test %v", 1)
-	if got, want := <-log, "name:test 1"; got != want {
+	if got, want := <-log, "name: test 1"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 
@@ -40,7 +40,7 @@ func TestThrottledLogger(t *testing.T) {
 	}
 
 	go tl.Infof("test %v", 3)
-	if got, want := <-log, "name:test 3"; got != want {
+	if got, want := <-log, "name: test 3"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
 	if got, want := skippedCount(tl), 0; got != want {

--- a/go/vt/vterrors/aggregate_test.go
+++ b/go/vt/vterrors/aggregate_test.go
@@ -35,16 +35,16 @@ func TestAggregateVtGateErrorCodes(t *testing.T) {
 			expected: vtrpcpb.Code_INVALID_ARGUMENT,
 		},
 		{
-			// aggregate two codes to the highest priority
+			// OK should be converted to INTERNAL
 			input: []error{
 				errFromCode(vtrpcpb.Code_OK),
 				errFromCode(vtrpcpb.Code_UNAVAILABLE),
 			},
-			expected: vtrpcpb.Code_UNAVAILABLE,
+			expected: vtrpcpb.Code_INTERNAL,
 		},
 		{
+			// aggregate two codes to the highest priority
 			input: []error{
-				errFromCode(vtrpcpb.Code_OK),
 				errFromCode(vtrpcpb.Code_UNAVAILABLE),
 				errFromCode(vtrpcpb.Code_INVALID_ARGUMENT),
 			},
@@ -53,7 +53,6 @@ func TestAggregateVtGateErrorCodes(t *testing.T) {
 		{
 			// unknown errors map to the unknown code
 			input: []error{
-				errFromCode(vtrpcpb.Code_OK),
 				fmt.Errorf("unknown error"),
 			},
 			expected: vtrpcpb.Code_UNKNOWN,
@@ -79,14 +78,12 @@ func TestAggregateVtGateErrors(t *testing.T) {
 		},
 		{
 			input: []error{
-				errFromCode(vtrpcpb.Code_OK),
 				errFromCode(vtrpcpb.Code_UNAVAILABLE),
 				errFromCode(vtrpcpb.Code_INVALID_ARGUMENT),
 			},
 			expected: New(
 				vtrpcpb.Code_INVALID_ARGUMENT,
 				aggregateErrors([]error{
-					errors.New(errGeneric),
 					errors.New(errGeneric),
 					errors.New(errGeneric),
 				}),

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -2,9 +2,16 @@ package vterrors
 
 import (
 	"fmt"
+	"io"
+	"time"
 
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/logutil"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
+
+var logger = logutil.NewThrottledLogger("vterror", 5*time.Second)
 
 type vtError struct {
 	code vtrpcpb.Code
@@ -13,6 +20,10 @@ type vtError struct {
 
 // New creates a new error using the code and input string.
 func New(code vtrpcpb.Code, in string) error {
+	if code == vtrpcpb.Code_OK {
+		logger.Errorf("Converting invalid code OK to INTERNAL error: %s", in)
+		code = vtrpcpb.Code_INTERNAL
+	}
 	return &vtError{
 		code: code,
 		err:  in,
@@ -21,10 +32,7 @@ func New(code vtrpcpb.Code, in string) error {
 
 // Errorf returns a new error built using Printf style arguments.
 func Errorf(code vtrpcpb.Code, format string, args ...interface{}) error {
-	return &vtError{
-		code: code,
-		err:  fmt.Sprintf(format, args...),
-	}
+	return New(code, fmt.Sprintf(format, args...))
 }
 
 func (e *vtError) Error() string {
@@ -39,6 +47,13 @@ func Code(err error) vtrpcpb.Code {
 	}
 	if err, ok := err.(*vtError); ok {
 		return err.code
+	}
+	// Handle some special cases.
+	switch {
+	case err == io.EOF || err == context.Canceled:
+		return vtrpcpb.Code_CANCELED
+	case err == context.DeadlineExceeded:
+		return vtrpcpb.Code_DEADLINE_EXCEEDED
 	}
 	return vtrpcpb.Code_UNKNOWN
 }

--- a/go/vt/vterrors/vterrors_test.go
+++ b/go/vt/vterrors/vterrors_test.go
@@ -2,7 +2,6 @@ package vterrors
 
 import (
 	"errors"
-	"io"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -20,6 +19,7 @@ func TestCreation(t *testing.T) {
 		in:   vtrpcpb.Code_UNKNOWN,
 		want: vtrpcpb.Code_UNKNOWN,
 	}, {
+		// Invalid code OK should be converted to INTERNAL.
 		in:   vtrpcpb.Code_OK,
 		want: vtrpcpb.Code_INTERNAL,
 	}}
@@ -45,9 +45,6 @@ func TestCode(t *testing.T) {
 		want: vtrpcpb.Code_UNKNOWN,
 	}, {
 		in:   New(vtrpcpb.Code_CANCELED, "generic"),
-		want: vtrpcpb.Code_CANCELED,
-	}, {
-		in:   io.EOF,
 		want: vtrpcpb.Code_CANCELED,
 	}, {
 		in:   context.Canceled,

--- a/go/vt/vterrors/vterrors_test.go
+++ b/go/vt/vterrors/vterrors_test.go
@@ -1,0 +1,64 @@
+package vterrors
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+func TestCreation(t *testing.T) {
+	testcases := []struct {
+		in, want vtrpcpb.Code
+	}{{
+		in:   vtrpcpb.Code_CANCELED,
+		want: vtrpcpb.Code_CANCELED,
+	}, {
+		in:   vtrpcpb.Code_UNKNOWN,
+		want: vtrpcpb.Code_UNKNOWN,
+	}, {
+		in:   vtrpcpb.Code_OK,
+		want: vtrpcpb.Code_INTERNAL,
+	}}
+	for _, tcase := range testcases {
+		if got := Code(New(tcase.in, "")); got != tcase.want {
+			t.Errorf("Code(New(%v)): %v, want %v", tcase.in, got, tcase.want)
+		}
+		if got := Code(Errorf(tcase.in, "")); got != tcase.want {
+			t.Errorf("Code(Errorf(%v)): %v, want %v", tcase.in, got, tcase.want)
+		}
+	}
+}
+
+func TestCode(t *testing.T) {
+	testcases := []struct {
+		in   error
+		want vtrpcpb.Code
+	}{{
+		in:   nil,
+		want: vtrpcpb.Code_OK,
+	}, {
+		in:   errors.New("generic"),
+		want: vtrpcpb.Code_UNKNOWN,
+	}, {
+		in:   New(vtrpcpb.Code_CANCELED, "generic"),
+		want: vtrpcpb.Code_CANCELED,
+	}, {
+		in:   io.EOF,
+		want: vtrpcpb.Code_CANCELED,
+	}, {
+		in:   context.Canceled,
+		want: vtrpcpb.Code_CANCELED,
+	}, {
+		in:   context.DeadlineExceeded,
+		want: vtrpcpb.Code_DEADLINE_EXCEEDED,
+	}}
+	for _, tcase := range testcases {
+		if got := Code(tcase.in); got != tcase.want {
+			t.Errorf("Code(%v): %v, want %v", tcase.in, got, tcase.want)
+		}
+	}
+}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -894,8 +894,10 @@ func recordAndAnnotateError(err error, statsKey []string, request map[string]int
 	errorCounts.Add(fullKey, 1)
 	// Most errors are not logged by vtgate beecause they're either too spammy or logged elsewhere.
 	switch ec {
-	case vtrpcpb.Code_UNAVAILABLE, vtrpcpb.Code_UNKNOWN, vtrpcpb.Code_INTERNAL, vtrpcpb.Code_DATA_LOSS:
+	case vtrpcpb.Code_UNKNOWN, vtrpcpb.Code_INTERNAL, vtrpcpb.Code_DATA_LOSS:
 		logger.Errorf("%v, request: %+v", err, request)
+	case vtrpcpb.Code_UNAVAILABLE:
+		logger.Infof("%v, request: %+v", err, request)
 	}
 	return vterrors.Errorf(vterrors.Code(err), "vtgate: %s: %v", servenv.ListeningURL.String(), err)
 }

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -894,7 +894,7 @@ func recordAndAnnotateError(err error, statsKey []string, request map[string]int
 	errorCounts.Add(fullKey, 1)
 	// Most errors are not logged by vtgate beecause they're either too spammy or logged elsewhere.
 	switch ec {
-	case vtrpcpb.Code_UNKNOWN, vtrpcpb.Code_INTERNAL, vtrpcpb.Code_DATA_LOSS:
+	case vtrpcpb.Code_UNAVAILABLE, vtrpcpb.Code_UNKNOWN, vtrpcpb.Code_INTERNAL, vtrpcpb.Code_DATA_LOSS:
 		logger.Errorf("%v, request: %+v", err, request)
 	}
 	return vterrors.Errorf(vterrors.Code(err), "vtgate: %s: %v", servenv.ListeningURL.String(), err)


### PR DESCRIPTION
* Disallow creation of error with OK as status code.
  Auto-convert to INTERNAL and log error.
* Handle io.EOF and context errors as special-case.
  Return more appropriate error code instead of UNKNOWN.
* Also log UNAVAILABLE errors in vtgate because they're
  often due to unreachable vttablets.