### PR TITLE
Do not return OK error code for buffer errors.

### DIFF
--- a/go/vt/vtgate/gateway/discoverygateway.go
+++ b/go/vt/vtgate/gateway/discoverygateway.go
@@ -179,7 +179,7 @@ func (dg *discoveryGateway) withRetry(ctx context.Context, target *querypb.Targe
 			if bufferErr != nil {
 				// Buffering failed e.g. buffer is already full. Do not retry.
 				err = vterrors.Errorf(
-					vterrors.Code(err),
+					vterrors.Code(bufferErr),
 					"failed to automatically buffer and retry failed request during failover: %v original err (type=%T): %v",
 					bufferErr, err, err)
 				break


### PR DESCRIPTION
NOTE: This is an automated export. Changes were already LGTM'd internally.