### PR TITLE
Sandbox reliability updates and cleanup.

### DIFF
--- a/test/cluster/k8s_environment.py
+++ b/test/cluster/k8s_environment.py
@@ -31,9 +31,9 @@ class K8sEnvironment(base_environment.BaseEnvironment):
           'kubectl not found, please install by visiting kubernetes.io or '
           'running gcloud components update kubectl if using compute engine.')
 
-    vtctld_addr = kubernetes_components.get_forwarded_ip(
+    vtctld_ip = kubernetes_components.get_forwarded_ip(
         'vtctld', instance_name)
-    self.vtctl_addr = '%s:15999' % vtctld_addr
+    self.vtctl_addr = '%s:15999' % vtctld_ip
 
     self.vtctl_helper = vtctl_helper.VtctlHelper('grpc', self.vtctl_addr)
     self.cluster_name = instance_name
@@ -92,9 +92,9 @@ class K8sEnvironment(base_environment.BaseEnvironment):
 
     self.vtgate_addrs = {}
     for cell in self.cells:
-      vtgate_addr = kubernetes_components.get_forwarded_ip(
+      vtgate_ip = kubernetes_components.get_forwarded_ip(
           'vtgate-%s' % cell, instance_name)
-      self.vtgate_addrs[cell] = '%s:15991' % vtgate_addr
+      self.vtgate_addrs[cell] = '%s:15991' % vtgate_ip
     super(K8sEnvironment, self).use_named(instance_name)
 
   def create(self, **kwargs):

--- a/test/cluster/sandbox/kubernetes_components.py
+++ b/test/cluster/sandbox/kubernetes_components.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import time
 
 import sandbox
@@ -32,15 +33,25 @@ class HelmComponent(sandlet.SandletComponent):
   def __init__(self, name, sandbox_name, helm_config):
     super(HelmComponent, self).__init__(name, sandbox_name)
     self.helm_config = helm_config
+    try:
+      subprocess.check_output(['helm'], stderr=subprocess.STDOUT)
+    except OSError:
+      raise sandbox.SandboxError(
+          'Could not find helm binary. Please visit '
+          'https://github.com/kubernetes/helm to download helm.')
 
   def start(self):
     logging.info('Initializing helm.')
-    with open(os.devnull, 'w') as devnull:
-      subprocess.call(['helm', 'init'], stdout=devnull)
-      start_time = time.time()
+    try:
+      subprocess.check_output(['helm', 'init'], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+      raise sandbox.SandboxError('Failed to initialize helm: %s', e.output)
 
-      # helm init on a fresh cluster takes a while to be ready.
-      # Wait until 'helm list' returns cleanly.
+    start_time = time.time()
+
+    # helm init on a fresh cluster takes a while to be ready.
+    # Wait until 'helm list' returns cleanly.
+    with open(os.devnull, 'w') as devnull:
       while time.time() - start_time < 120:
         try:
           subprocess.check_call(['helm', 'list'], stdout=devnull,
@@ -52,12 +63,16 @@ class HelmComponent(sandlet.SandletComponent):
       else:
         raise sandbox.SandboxError(
             'Timed out waiting for helm to become ready.')
-      logging.info('Installing helm.')
-      subprocess.call(
+    logging.info('Installing helm.')
+    try:
+      subprocess.check_output(
           ['helm', 'install', os.path.join(os.environ['VTTOP'], 'helm/vitess'),
            '-n', self.sandbox_name, '--namespace', self.sandbox_name,
-           '--replace', '--values', self.helm_config], stdout=devnull)
-      logging.info('Finished installing helm.')
+           '--replace', '--values', self.helm_config],
+          stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+      raise sandbox.SandboxError('Failed to install helm: %s' % e.output)
+    logging.info('Finished installing helm.')
 
   def stop(self):
     subprocess.call(['helm', 'delete', self.sandbox_name, '--purge'])
@@ -83,17 +98,23 @@ class KubernetesResource(sandlet.SandletComponent):
     with open(self.template_file, 'r') as template_file:
       template = template_file.read()
     for name, value in self.template_params.items():
-      template = re.sub('{{%s}}' % name, value, template)
-    os.system('echo "%s" | kubectl create -f - --namespace %s' % (
-        template, self.sandbox_name))
+      template = re.sub('{{%s}}' % name, str(value), template)
+    with tempfile.NamedTemporaryFile() as f:
+      f.write(template)
+      f.flush()
+      os.system('kubectl create --namespace %s -f %s' % (
+          self.sandbox_name, f.name))
 
   def stop(self):
     with open(self.template_file, 'r') as template_file:
       template = template_file.read()
     for name, value in self.template_params.items():
-      template = re.sub('{{%s}}' % name, value, template)
-    os.system('echo "%s" | kubectl delete -f - --namespace %s' % (
-        template, self.sandbox_name))
+      template = re.sub('{{%s}}' % name, str(value), template)
+    with tempfile.NamedTemporaryFile() as f:
+      f.write(template)
+      f.flush()
+      os.system('kubectl delete --namespace %s -f %s' % (
+          self.sandbox_name, f.name))
 
     super(KubernetesResource, self).stop()
 

--- a/test/cluster/sandbox/kubernetes_components.py
+++ b/test/cluster/sandbox/kubernetes_components.py
@@ -47,11 +47,11 @@ class HelmComponent(sandlet.SandletComponent):
     except subprocess.CalledProcessError as e:
       raise sandbox.SandboxError('Failed to initialize helm: %s', e.output)
 
-    start_time = time.time()
 
     # helm init on a fresh cluster takes a while to be ready.
     # Wait until 'helm list' returns cleanly.
     with open(os.devnull, 'w') as devnull:
+      start_time = time.time()
       while time.time() - start_time < 120:
         try:
           subprocess.check_call(['helm', 'list'], stdout=devnull,
@@ -63,6 +63,7 @@ class HelmComponent(sandlet.SandletComponent):
       else:
         raise sandbox.SandboxError(
             'Timed out waiting for helm to become ready.')
+
     logging.info('Installing helm.')
     try:
       subprocess.check_output(

--- a/test/cluster/sandbox/vitess_kubernetes_sandbox.py
+++ b/test/cluster/sandbox/vitess_kubernetes_sandbox.py
@@ -109,7 +109,9 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
           shard['tablets'].append(dict(
               type='rdonly',
               uidBase=uid_base + ks['replica_count'],
-              replicas=ks['rdonly_count']))
+              vttablet=dict(
+                  replicas=ks['rdonly_count'],
+              )))
         keyspace['shards'].append(shard)
     return keyspaces
 
@@ -248,20 +250,19 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
   def print_banner(self):
     logging.info('Fetching forwarded ports.')
     banner = '\nVitess Sandbox Info:\n'
-    vtctld_addr = ''
     vtctld_port = self.app_options.port_forwarding['vtctld']
     vtgate_port = self.app_options.port_forwarding['vtgate']
-    vtctld_addr = kubernetes_components.get_forwarded_ip(
+    vtctld_ip = kubernetes_components.get_forwarded_ip(
         'vtctld', self.name)
-    banner += '  vtctld: http://%s:%d\n' % (vtctld_addr, vtctld_port)
+    banner += '  vtctld: http://%s:%d\n' % (vtctld_ip, vtctld_port)
     for cell in self.app_options.cells:
-      vtgate_addr = kubernetes_components.get_forwarded_ip(
+      vtgate_ip = kubernetes_components.get_forwarded_ip(
           'vtgate-%s' % cell, self.name)
-      banner += '  vtgate-%s: http://%s:%d\n' % (cell, vtgate_addr, vtgate_port)
+      banner += '  vtgate-%s: http://%s:%d\n' % (cell, vtgate_ip, vtgate_port)
     if 'guestbook' in self.app_options.port_forwarding:
-      guestbook_addr = kubernetes_components.get_forwarded_ip(
+      guestbook_ip = kubernetes_components.get_forwarded_ip(
           'guestbook', self.name)
-      banner += '  guestbook: http://%s:80\n' % guestbook_addr
+      banner += '  guestbook: http://%s:80\n' % guestbook_ip
     banner += '  logs dir: %s\n' % self.log_dir
     logging.info(banner)
 

--- a/test/cluster/sandbox/vitess_kubernetes_sandbox.py
+++ b/test/cluster/sandbox/vitess_kubernetes_sandbox.py
@@ -62,13 +62,11 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
     guestbook_sandlet.components.add_component(
         kubernetes_components.KubernetesResource(
             'guestbook-service', self.name,
-            os.path.join(template_dir, 'guestbook-service.yaml'),
-            namespace=self.name))
+            os.path.join(template_dir, 'guestbook-service.yaml')))
     guestbook_sandlet.components.add_component(
         kubernetes_components.KubernetesResource(
             'guestbook-controller', self.name,
-            os.path.join(template_dir, 'guestbook-controller.yaml'),
-            namespace=self.name))
+            os.path.join(template_dir, 'guestbook-controller.yaml'))
     self.sandlets.add_component(guestbook_sandlet)
 
   def _generate_helm_keyspaces(self):
@@ -144,6 +142,7 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
                     cpu=self.app_options.mysql_cpu,
                 ),
             ),
+            controllerType='None',
         ),
         vtgate=dict(
             serviceType='LoadBalancer',  # Allows port forwarding.
@@ -199,6 +198,7 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
     with tempfile.NamedTemporaryFile(delete=False) as f:
       f.write(yaml.dump(yaml_values, default_flow_style=False))
       yaml_filename = f.name
+    logging.info('Helm config generated at %s', yaml_filename)
     return yaml_filename
 
   def generate_helm_sandlet(self):
@@ -216,7 +216,9 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
       wait_for_mysql_subprocess = subprocess_component.Subprocess(
           'wait_for_mysql_%s' % name, self.name, 'wait_for_mysql.py',
           self.log_dir, namespace=self.name,
-          cells=','.join(self.app_options.cells))
+          cells=','.join(self.app_options.cells),
+          tablet_count=(shard_count * (
+              keyspace['replica_count'] + keyspace['rdonly_count'])))
       wait_for_mysql_subprocess.dependencies = ['helm']
       initial_reparent_subprocess = subprocess_component.Subprocess(
           'initial_reparent_%s' % name, self.name,
@@ -244,23 +246,22 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
 
   def print_banner(self):
     logging.info('Fetching forwarded ports.')
+    banner = '\nVitess Sandbox Info:\n'
     vtctld_addr = ''
     vtctld_port = self.app_options.port_forwarding['vtctld']
     vtgate_port = self.app_options.port_forwarding['vtgate']
-    vtgate_addrs = []
     vtctld_addr = kubernetes_components.get_forwarded_ip(
         'vtctld', self.name)
+    banner += '  vtctld: http://%s:%d\n' % (vtctld_addr, vtctld_port)
     for cell in self.app_options.cells:
       vtgate_addr = kubernetes_components.get_forwarded_ip(
           'vtgate-%s' % cell, self.name)
-      vtgate_addrs.append('%s %s:%d' % (cell, vtgate_addr, vtgate_port))
-    banner = """
-        Vitess Sandbox Info:
-          vtctld: %s:%d
-          vtgate: %s
-          logs dir: %s""" % (
-              vtctld_addr, vtctld_port, ', '.join(vtgate_addrs),
-              self.log_dir)
+      banner += '  vtgate-%s: http://%s:%d\n' % (cell, vtgate_addr, vtgate_port)
+    if 'guestbook' in self.app_options.port_forwarding:
+      guestbook_addr = kubernetes_components.get_forwarded_ip(
+          'guestbook', self.name)
+      banner += '  guestbook: http://%s:80\n' % guestbook_addr
+    banner += '  logs dir: %s\n' % self.log_dir
     logging.info(banner)
 
 

--- a/test/cluster/sandbox/vitess_kubernetes_sandbox.py
+++ b/test/cluster/sandbox/vitess_kubernetes_sandbox.py
@@ -66,7 +66,8 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
     guestbook_sandlet.components.add_component(
         kubernetes_components.KubernetesResource(
             'guestbook-controller', self.name,
-            os.path.join(template_dir, 'guestbook-controller.yaml'))
+            os.path.join(template_dir, 'guestbook-controller-template.yaml'),
+            port=8080, cell=self.app_options.cells[0], vtgate_port=15991))
     self.sandlets.add_component(guestbook_sandlet)
 
   def _generate_helm_keyspaces(self):


### PR DESCRIPTION
New stuff:
  - Add ability to specify cluster_version for GKE clusters.
  - Add timeout/failure logic for initial_reparent script.
  - Add failure modes for helm component.
  - While waiting for mysql to be healthy, ensure the expected tablet count is correct.
Some refactoring:
  - Reuse kubernetes get_forwarded_ip logic.
  - Refactor banner printing code.

@michael-berlin 
