### PR TITLE
vtgate/buffer: Always initialize all stat variables.

### DIFF
--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -33,7 +33,7 @@ var (
 
 	statsKeyJoined = fmt.Sprintf("%s.%s", keyspace, shard)
 
-	statsKeyJoinedFailoverEndDetected = statsKeyJoined + "." + string(stopReasonFailoverEndDetected)
+	statsKeyJoinedFailoverEndDetected = statsKeyJoined + "." + string(stopFailoverEndDetected)
 
 	statsKeyJoinedWindowExceeded = statsKeyJoined + "." + string(evictedWindowExceeded)
 

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -459,14 +459,14 @@ func (sb *shardBuffer) recordExternallyReparentedTimestamp(timestamp int64) {
 		// First non-zero value after startup. Remember it.
 		sb.externallyReparentedAfterStart = timestamp
 	}
-	sb.stopBufferingLocked(stopReasonFailoverEndDetected, "failover end detected")
+	sb.stopBufferingLocked(stopFailoverEndDetected, "failover end detected")
 }
 
 func (sb *shardBuffer) stopBufferingDueToMaxDuration() {
 	sb.mu.Lock()
 	defer sb.mu.Unlock()
 
-	sb.stopBufferingLocked(stopReasonMaxFailoverDurationExceeded,
+	sb.stopBufferingLocked(stopMaxFailoverDurationExceeded,
 		fmt.Sprintf("stopping buffering because failover did not finish in time (%v)", *maxFailoverDuration))
 }
 

--- a/go/vt/vtgate/buffer/shard_buffer.go
+++ b/go/vt/vtgate/buffer/shard_buffer.go
@@ -97,12 +97,15 @@ type entry struct {
 }
 
 func newShardBuffer(mode bufferMode, keyspace, shard string, bufferSizeSema *sync2.Semaphore) *shardBuffer {
+	statsKey := []string{keyspace, shard}
+	initVariablesForShard(statsKey)
+
 	return &shardBuffer{
 		mode:           mode,
 		keyspace:       keyspace,
 		shard:          shard,
 		bufferSizeSema: bufferSizeSema,
-		statsKey:       []string{keyspace, shard},
+		statsKey:       statsKey,
 		statsKeyJoined: fmt.Sprintf("%s.%s", keyspace, shard),
 		logTooRecent:   logutil.NewThrottledLogger(fmt.Sprintf("FailoverTooRecent-%v", topoproto.KeyspaceShardString(keyspace, shard)), 5*time.Second),
 		state:          stateIdle,

--- a/go/vt/vtgate/buffer/variables.go
+++ b/go/vt/vtgate/buffer/variables.go
@@ -58,9 +58,9 @@ var (
 type stopReason string
 
 const (
-	stopReasonFailoverEndDetected         stopReason = "NewMasterSeen"
-	stopReasonMaxFailoverDurationExceeded            = "MaxDurationExceeded"
-	stopShutdown                                     = "Shutdown"
+	stopFailoverEndDetected         stopReason = "NewMasterSeen"
+	stopMaxFailoverDurationExceeded            = "MaxDurationExceeded"
+	stopShutdown                               = "Shutdown"
 )
 
 // evictedReason is used in "requestsEvicted" as "Reason" label.

--- a/go/vt/vtgate/buffer/variables_test.go
+++ b/go/vt/vtgate/buffer/variables_test.go
@@ -1,8 +1,13 @@
 package buffer
 
 import (
+	"context"
 	"flag"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/youtube/vitess/go/stats"
 )
 
 func TestVariables(t *testing.T) {
@@ -15,4 +20,63 @@ func TestVariables(t *testing.T) {
 	if got, want := bufferSize.Get(), int64(23); got != want {
 		t.Fatalf("BufferSize variable not set during initilization: got = %v, want = %v", got, want)
 	}
+}
+
+func TestVariablesAreInitialized(t *testing.T) {
+	// Create a new buffer and make a call which will create the shardBuffer object.
+	// After that, the variables should be initialized for that shard.
+	b := New()
+	_, err := b.WaitForFailoverEnd(context.Background(), "init_test", "0", nil /* err */)
+	if err != nil {
+		t.Fatalf("buffer should just passthrough and not return an error: %v", err)
+	}
+
+	statsKey := []string{"init_test", "0"}
+	type testCase struct {
+		desc     string
+		counter  *stats.MultiCounters
+		statsKey []string
+	}
+	testCases := []testCase{
+		{"starts", starts, statsKey},
+		{"failoverDurationSumMs", failoverDurationSumMs, statsKey},
+		{"utilizationSum", utilizationSum, statsKey},
+		{"utilizationDryRunSum", utilizationDryRunSum, statsKey},
+		{"requestsBuffered", requestsBuffered, statsKey},
+		{"requestsBufferedDryRun", requestsBufferedDryRun, statsKey},
+		{"requestsDrained", requestsDrained, statsKey},
+	}
+	for _, r := range stopReasons {
+		testCases = append(testCases, testCase{"stops", stops, append(statsKey, string(r))})
+	}
+	for _, r := range evictReasons {
+		testCases = append(testCases, testCase{"evicted", requestsEvicted, append(statsKey, string(r))})
+	}
+	for _, r := range skippedReasons {
+		testCases = append(testCases, testCase{"skipped", requestsSkipped, append(statsKey, string(r))})
+	}
+
+	for _, tc := range testCases {
+		wantValue := 0
+		if len(tc.statsKey) == 3 && tc.statsKey[2] == string(skippedDisabled) {
+			// The request passed through above was registered as skipped.
+			wantValue = 1
+		}
+		if err := checkEntry(tc.counter, tc.statsKey, wantValue); err != nil {
+			t.Fatalf("variable: %v not correctly initialized: %v", tc.desc, err)
+		}
+	}
+}
+
+func checkEntry(counters *stats.MultiCounters, statsKey []string, want int) error {
+	name := strings.Join(statsKey, ".")
+	got, ok := counters.Counts()[name]
+	if !ok {
+		return fmt.Errorf("no entry for: %v", name)
+	}
+	if got != int64(want) {
+		return fmt.Errorf("wrong value for entry: %v got = %v, want = %v", name, got, want)
+	}
+
+	return nil
 }


### PR DESCRIPTION
If we don't do this, monitoring frameworks may not correctly calculate rates for the first failover of the shard because they see a transition from "no value for this label set (NaN)" to "a value".