### PR TITLE
tabletserver: Protect Transaction Pool against hot rows.

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -578,7 +578,8 @@
   "FullQuery": "update b set eid = 1",
   "OuterQuery": "update b set eid = 1 where :#pk",
   "Subquery": "select eid, id from b limit :#maxLimit for update",
-  "SecondaryPKValues": [1, null]
+  "SecondaryPKValues": [1, null],
+  "WhereClause": ""
 }
 
 # type mismatch
@@ -591,7 +592,8 @@
   "PlanID": "PASS_DML",
   "Reason": "PK_CHANGE",
   "TableName": "b",
-  "FullQuery": "update b set eid = foo()"
+  "FullQuery": "update b set eid = foo()",
+  "WhereClause": ""
 }
 
 # update subquery
@@ -601,7 +603,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo'",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a limit :#maxLimit for update"
+  "Subquery": "select eid, id from a limit :#maxLimit for update",
+  "WhereClause": ""
 }
 
 # update complex where clause
@@ -611,7 +614,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid + 1 = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid + 1 = 1"
 }
 
 # pk
@@ -621,7 +625,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid = 1 and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "PKValues": [1, 1]
+  "PKValues": [1, 1],
+  "WhereClause": " where eid = 1 and id = 1"
 }
 
 # partial pk
@@ -631,7 +636,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1"
 }
 
 # bad pk
@@ -641,7 +647,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid = 1.0 and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1.0 and id = 1"
 }
 
 # partial pk with limit
@@ -651,7 +658,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid = 1 limit 10",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a where eid = 1 limit 10 for update"
+  "Subquery": "select eid, id from a where eid = 1 limit 10 for update",
+  "WhereClause": " where eid = 1"
 }
 
 # non-pk
@@ -661,7 +669,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where eid = 1 and name = 'foo'",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update",
+  "WhereClause": " where eid = 1 and name = 'foo'"
 }
 
 # no index
@@ -670,7 +679,8 @@
   "PlanID": "PASS_DML",
   "Reason": "TABLE_NOINDEX",
   "TableName": "c",
-  "FullQuery": "update c set eid = 1"
+  "FullQuery": "update c set eid = 1",
+  "WhereClause": ""
 }
 
 # complex expression in where
@@ -680,7 +690,8 @@
   "TableName":"a",
   "FullQuery":"update a set name = 'foo' where eid + 1 = 1 and id = 1",
   "OuterQuery":"update a set name = 'foo' where :#pk",
-  "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid + 1 = 1 and id = 1"
 }
 
 # parenthesized expressions in where
@@ -690,7 +701,8 @@
   "TableName": "a",
   "FullQuery": "update a set name = 'foo' where (eid = 1) and id = 1",
   "OuterQuery": "update a set name = 'foo' where :#pk",
-  "PKValues": [1, 1]
+  "PKValues": [1, 1],
+  "WhereClause": " where (eid = 1) and id = 1"
 }
 
 # in clause expression in where
@@ -700,7 +712,8 @@
   "TableName":"a",
   "FullQuery":"update a set name = 'foo' where eid in (1, 2) and id = 1",
   "OuterQuery":"update a set name = 'foo' where :#pk",
-  "PKValues":[[1,2],1]
+  "PKValues":[[1,2],1],
+  "WhereClause": " where eid in (1, 2) and id = 1"
 }
 
 # double in clause
@@ -710,7 +723,8 @@
   "TableName":"a",
   "FullQuery":"update a set name = 'foo' where eid in (1, 2) and id in (1, 2)",
   "OuterQuery":"update a set name = 'foo' where :#pk",
-  "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update",
+  "WhereClause": " where eid in (1, 2) and id in (1, 2)"
 }
 
 # double use of pk
@@ -720,7 +734,8 @@
   "TableName":"a",
   "FullQuery":"update a set name = 'foo' where eid = 1 and eid = 2",
   "OuterQuery":"update a set name = 'foo' where :#pk",
-  "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1 and eid = 2"
 }
 
 # delete cross-db
@@ -739,7 +754,8 @@
   "TableName": "a",
   "FullQuery": "delete from a",
   "OuterQuery": "delete from a where :#pk",
-  "Subquery": "select eid, id from a limit :#maxLimit for update"
+  "Subquery": "select eid, id from a limit :#maxLimit for update",
+  "WhereClause": ""
 }
 
 # delete complex where clause
@@ -749,7 +765,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where eid + 1 = 1",
   "OuterQuery": "delete from a where :#pk",
-  "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid + 1 = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid + 1 = 1"
 }
 
 # pk
@@ -759,7 +776,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where eid = 1 and id = 1",
   "OuterQuery": "delete from a where :#pk",
-  "PKValues": [1, 1]
+  "PKValues": [1, 1],
+  "WhereClause": " where eid = 1 and id = 1"
 }
 
 # partial pk
@@ -769,7 +787,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where eid = 1",
   "OuterQuery": "delete from a where :#pk",
-  "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1"
 }
 
 # bad pk value delete
@@ -779,7 +798,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where eid = 1.0 and id = 1",
   "OuterQuery": "delete from a where :#pk",
-  "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1.0 and id = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1.0 and id = 1"
 }
 
 # non-pk
@@ -789,7 +809,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where eid = 1 and name = 'foo'",
   "OuterQuery": "delete from a where :#pk",
-  "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update"
+  "Subquery": "select eid, id from a where eid = 1 and name = 'foo' limit :#maxLimit for update",
+  "WhereClause": " where eid = 1 and name = 'foo'"
 }
 
 # no index
@@ -798,7 +819,8 @@
   "PlanID": "PASS_DML",
   "Reason": "TABLE_NOINDEX",
   "TableName": "c",
-  "FullQuery": "delete from c"
+  "FullQuery": "delete from c",
+  "WhereClause": ""
 }
 
 # delete complex expression in where
@@ -808,7 +830,8 @@
   "TableName":"a",
   "FullQuery":"delete from a where eid + 1 = 1 and id = 1",
   "OuterQuery":"delete from a where :#pk",
-  "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid + 1 = 1 and id = 1 limit :#maxLimit for update",
+  "WhereClause": " where eid + 1 = 1 and id = 1"
 }
 
 # parenthesized expressions in where
@@ -818,7 +841,8 @@
   "TableName": "a",
   "FullQuery": "delete from a where (eid = 1) and id = 1",
   "OuterQuery": "delete from a where :#pk",
-  "PKValues": [1, 1]
+  "PKValues": [1, 1],
+  "WhereClause": " where (eid = 1) and id = 1"
 }
 
 # delete in clause expression in where
@@ -828,7 +852,8 @@
   "TableName":"a",
   "FullQuery":"delete from a where eid in (1, 2) and id = 1",
   "OuterQuery":"delete from a where :#pk",
-  "PKValues":[[1,2],1]
+  "PKValues":[[1,2],1],
+  "WhereClause": " where eid in (1, 2) and id = 1"
 }
 
 # delete double in clause
@@ -838,7 +863,8 @@
   "TableName":"a",
   "FullQuery":"delete from a where eid in (1, 2) and id in (1, 2)",
   "OuterQuery":"delete from a where :#pk",
-  "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid in (1, 2) and id in (1, 2) limit :#maxLimit for update",
+  "WhereClause": " where eid in (1, 2) and id in (1, 2)"
 }
 
 # delete double use of pk
@@ -848,7 +874,8 @@
   "TableName":"a",
   "FullQuery":"delete from a where eid = 1 and eid = 2",
   "OuterQuery":"delete from a where :#pk",
-  "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update"
+  "Subquery":"select eid, id from a where eid = 1 and eid = 2 limit :#maxLimit for update",
+  "WhereClause": " where eid = 1 and eid = 2"
 }
 
 # single value sequence

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -43,12 +43,17 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	mysqlctl.RegisterFlags()
 	flag.Parse()
-	tabletenv.Init()
 	if len(flag.Args()) > 0 {
 		flag.Usage()
 		log.Errorf("vttablet doesn't take any positional arguments")
 		exit.Return(1)
 	}
+	if err := tabletenv.VerifyConfig(); err != nil {
+		log.Errorf("invalid config: %v", err)
+		exit.Return(1)
+	}
+
+	tabletenv.Init()
 
 	servenv.Init()
 

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/servenv"
@@ -36,8 +35,6 @@ func init() {
 }
 
 func main() {
-	defer exit.Recover()
-
 	dbconfigFlags := dbconfigs.AppConfig | dbconfigs.AllPrivsConfig | dbconfigs.DbaConfig |
 		dbconfigs.FilteredConfig | dbconfigs.ReplConfig
 	dbconfigs.RegisterFlags(dbconfigFlags)
@@ -45,12 +42,10 @@ func main() {
 	flag.Parse()
 	if len(flag.Args()) > 0 {
 		flag.Usage()
-		log.Errorf("vttablet doesn't take any positional arguments")
-		exit.Return(1)
+		log.Exit("vttablet doesn't take any positional arguments")
 	}
 	if err := tabletenv.VerifyConfig(); err != nil {
-		log.Errorf("invalid config: %v", err)
-		exit.Return(1)
+		log.Exitf("invalid config: %v", err)
 	}
 
 	tabletenv.Init()
@@ -58,19 +53,16 @@ func main() {
 	servenv.Init()
 
 	if *tabletPath == "" {
-		log.Errorf("tabletPath required")
-		exit.Return(1)
+		log.Exit("tabletPath required")
 	}
 	tabletAlias, err := topoproto.ParseTabletAlias(*tabletPath)
 	if err != nil {
-		log.Error(err)
-		exit.Return(1)
+		log.Exitf("failed to parse -tablet-path: %v", err)
 	}
 
 	mycnf, err := mysqlctl.NewMycnfFromFlags(tabletAlias.Uid)
 	if err != nil {
-		log.Errorf("mycnf read failed: %v", err)
-		exit.Return(1)
+		log.Exitf("mycnf read failed: %v", err)
 	}
 
 	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
@@ -95,8 +87,7 @@ func main() {
 		// To override default simpleacl, other ACL plugins must set themselves to be default ACL factory
 		tableacl.Register("simpleacl", &simpleacl.Factory{})
 	} else if *enforceTableACLConfig {
-		log.Error("table acl config has to be specified with table-acl-config flag because enforce-tableacl-config is set.")
-		exit.Return(1)
+		log.Exit("table acl config has to be specified with table-acl-config flag because enforce-tableacl-config is set.")
 	}
 	// tabletacl.Init loads ACL from file if *tableACLConfig is not empty
 	err = tableacl.Init(
@@ -108,8 +99,7 @@ func main() {
 	if err != nil {
 		log.Errorf("Fail to initialize Table ACL: %v", err)
 		if *enforceTableACLConfig {
-			log.Error("Need a valid initial Table ACL when enforce-tableacl-config is set, exiting.")
-			exit.Return(1)
+			log.Exit("Need a valid initial Table ACL when enforce-tableacl-config is set, exiting.")
 		}
 	}
 
@@ -126,8 +116,7 @@ func main() {
 	}
 	agent, err = tabletmanager.NewActionAgent(context.Background(), ts, mysqld, qsc, tabletAlias, *dbcfgs, mycnf, int32(*servenv.Port), gRPCPort)
 	if err != nil {
-		log.Error(err)
-		exit.Return(1)
+		log.Exitf("NewActionAgent() failed: %v", err)
 	}
 
 	servenv.OnClose(func() {

--- a/go/sync2/consolidator_test.go
+++ b/go/sync2/consolidator_test.go
@@ -8,12 +8,12 @@ func TestConsolidator(t *testing.T) {
 
 	orig, added := con.Create(sql)
 	if !added {
-		t.Errorf("expected consolidator to register a new entry")
+		t.Fatalf("expected consolidator to register a new entry")
 	}
 
 	dup, added := con.Create(sql)
 	if added {
-		t.Errorf("did not expect consolidator to register a new entry")
+		t.Fatalf("did not expect consolidator to register a new entry")
 	}
 
 	result := 1
@@ -27,13 +27,13 @@ func TestConsolidator(t *testing.T) {
 		t.Errorf("failed to pass result")
 	}
 	if *orig.Result.(*int) != *dup.Result.(*int) {
-		t.Errorf("failed to share the result")
+		t.Fatalf("failed to share the result")
 	}
 
 	// Running the query again should add a new entry since the original
 	// query execution completed
 	_, added = con.Create(sql)
 	if !added {
-		t.Errorf("expected consolidator to register a new entry")
+		t.Fatalf("expected consolidator to register a new entry")
 	}
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -29,6 +29,11 @@ func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan
 		return nil, err
 	}
 
+	// Store the WHERE clause as string for the hot row protection (txserializer).
+	buf := sqlparser.NewTrackedBuffer(nil)
+	buf.Myprintf("%v", upd.Where)
+	plan.WhereClause = buf.ParsedQuery()
+
 	if !table.HasPrimary() {
 		log.Warningf("no primary key for table %s", tableName)
 		plan.Reason = ReasonTableNoIndex
@@ -72,6 +77,11 @@ func analyzeDelete(del *sqlparser.Delete, tables map[string]*schema.Table) (plan
 	if err != nil {
 		return nil, err
 	}
+
+	// Store the WHERE clause as string for the hot row protection (txserializer).
+	buf := sqlparser.NewTrackedBuffer(nil)
+	buf.Myprintf("%v", del.Where)
+	plan.WhereClause = buf.ParsedQuery()
 
 	if !table.HasPrimary() {
 		log.Warningf("no primary key for table %s", tableName)

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -211,6 +211,10 @@ type Plan struct {
 	// For update: set clause if pk is changing.
 	SecondaryPKValues []interface{}
 
+	// WhereClause is set for DMLs. It is used by the hot row protection
+	// to serialize e.g. UPDATEs going to the same row.
+	WhereClause *sqlparser.ParsedQuery
+
 	// For PlanInsertSubquery: pk columns in the subquery result.
 	SubqueryPKColumns []int
 

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -37,6 +37,7 @@ func (ep *Plan) MarshalJSON() ([]byte, error) {
 		ColumnNumbers        []int                  `json:",omitempty"`
 		PKValues             []interface{}          `json:",omitempty"`
 		SecondaryPKValues    []interface{}          `json:",omitempty"`
+		WhereClause          *sqlparser.ParsedQuery `json:",omitempty"`
 		SubqueryPKColumns    []int                  `json:",omitempty"`
 		MessageReloaderQuery *sqlparser.ParsedQuery `json:",omitempty"`
 	}{
@@ -51,6 +52,7 @@ func (ep *Plan) MarshalJSON() ([]byte, error) {
 		ColumnNumbers:        ep.ColumnNumbers,
 		PKValues:             ep.PKValues,
 		SecondaryPKValues:    ep.SecondaryPKValues,
+		WhereClause:          ep.WhereClause,
 		SubqueryPKColumns:    ep.SubqueryPKColumns,
 		MessageReloaderQuery: ep.MessageReloaderQuery,
 	}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -27,12 +27,13 @@ import (
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	tacl "github.com/youtube/vitess/go/vt/tableacl/acl"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/rules"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
-	"github.com/youtube/vitess/go/vt/vterrors"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/txserializer"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
@@ -109,6 +110,12 @@ type QueryEngine struct {
 
 	// Services
 	consolidator *sync2.Consolidator
+	// txSerializer protects vttablet from applications which try to concurrently
+	// UPDATE (or DELETE) a "hot" row (or range of rows).
+	// Such queries would be serialized by MySQL anyway. This serializer prevents
+	// that we start more than one transaction per hot row (range).
+	// For implementation details, please see BeginExecute() in tabletserver.go.
+	txSerializer *txserializer.TxSerializer
 	streamQList  *QueryList
 
 	// Vars
@@ -158,6 +165,8 @@ func NewQueryEngine(checker MySQLChecker, se *schema.Engine, config tabletenv.Ta
 	)
 
 	qe.consolidator = sync2.NewConsolidator()
+	qe.txSerializer = txserializer.New(config.EnableHotRowProtectionDryRun,
+		config.HotRowProtectionMaxQueueSize, config.HotRowProtectionMaxGlobalQueueSize)
 	qe.streamQList = NewQueryList()
 
 	qe.strictMode.Set(config.StrictMode)
@@ -202,6 +211,7 @@ func NewQueryEngine(checker MySQLChecker, se *schema.Engine, config tabletenv.Ta
 		_ = stats.NewMultiCountersFunc("QueryErrorCounts", []string{"Table", "Plan"}, qe.getQueryErrorCount)
 
 		http.Handle("/debug/consolidations", qe.consolidator)
+		http.Handle("/debug/hotrows", qe.txSerializer)
 
 		endpoints := []string{
 			"/debug/tablet_plans",

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -1,0 +1,253 @@
+// Package txserializer provides the vttablet hot row protection.
+// See the TxSerializer struct for details.
+package txserializer
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/sync2"
+	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/vterrors"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+var (
+	// waits stores how many times a transaction was queued because another
+	// transaction was already in flight for the same row (range).
+	// The key of the map is the table name of the query.
+	waits = stats.NewCounters("TxSerializerWaits")
+	// waitsDryRun is similar as "waits": In dry-run mode it records how many
+	// transactions would have been queued.
+	// The key of the map is the table name of the query.
+	waitsDryRun = stats.NewCounters("TxSerializerWaitsDryRun")
+
+	// queueExceeded counts per table how many transactions were rejected because
+	// the max queue size per row (range) was exceeded.
+	queueExceeded = stats.NewCounters("TxSerializerQueueExceeded")
+	// queueExceededDryRun counts in dry-run mode how many transactions would have
+	// been rejected due to exceeding the max queue size per row (range).
+	queueExceededDryRun = stats.NewCounters("TxSerializerQueueExceededDryRun")
+	// globalQueueExceeded is the same as queueExceeded but for the global queue.
+	globalQueueExceeded       = stats.NewInt("TxSerializerGlobalQueueExceeded")
+	globalQueueExceededDryRun = stats.NewInt("TxSerializerGlobalQueueExceededDryRun")
+)
+
+// TxSerializer serializes incoming transactions which target the same row range
+// i.e. table name and WHERE clause are identical.
+// Additional transactions are queued and woken up in arrival order.
+//
+// This implementation has some parallels to the sync2.Consolidator class.
+// However, there are many substantial differences:
+// - Results are not shared between queued transactions.
+// - Only one waiting transaction and not all are notified when the current one
+//   has finished.
+// - Waiting transactions are woken up in FIFO order.
+// - Waiting transactions are unblocked if their context is done.
+// - Both the local queue (per row range) and global queue (whole process) are
+//   limited to avoid that queued transactions can consume the full capacity
+//   of vttablet. This is important if the capaciy is finite. For example, the
+//   number of RPCs in flight could be limited by the RPC subsystem.
+type TxSerializer struct {
+	*sync2.ConsolidatorCache
+
+	// Immutable fields.
+	dryRun             bool
+	maxQueueSize       int
+	maxGlobalQueueSize int
+
+	log                          *logutil.ThrottledLogger
+	logDryRun                    *logutil.ThrottledLogger
+	logWaitsDryRun               *logutil.ThrottledLogger
+	logQueueExceededDryRun       *logutil.ThrottledLogger
+	logGlobalQueueExceededDryRun *logutil.ThrottledLogger
+
+	mu         sync.Mutex
+	queues     map[string]*queue
+	globalSize int
+}
+
+// New returns a TxSerializer object.
+func New(dryRun bool, maxQueueSize, maxGlobalQueueSize int) *TxSerializer {
+	return &TxSerializer{
+		ConsolidatorCache:            sync2.NewConsolidatorCache(1000),
+		dryRun:                       dryRun,
+		maxQueueSize:                 maxQueueSize,
+		maxGlobalQueueSize:           maxGlobalQueueSize,
+		log:                          logutil.NewThrottledLogger("HotRowProtection", 5*time.Second),
+		logDryRun:                    logutil.NewThrottledLogger("HotRowProtection DryRun", 5*time.Second),
+		logWaitsDryRun:               logutil.NewThrottledLogger("HotRowProtection Waits DryRun", 5*time.Second),
+		logQueueExceededDryRun:       logutil.NewThrottledLogger("HotRowProtection QueueExceeded DryRun", 5*time.Second),
+		logGlobalQueueExceededDryRun: logutil.NewThrottledLogger("HotRowProtection GlobalQueueExceeded DryRun", 5*time.Second),
+		queues: make(map[string]*queue),
+	}
+}
+
+// DoneFunc is returned by Wait() and must be called by the caller.
+type DoneFunc func()
+
+// Wait blocks if another transaction for the same range is already in flight.
+// It returns when this transaction has its turn.
+// "done" is != nil if err == nil and must be called once the transaction is
+// done and the next waiting transaction can be unblocked.
+// "waited" is true if Wait() had to wait for other transactions.
+// "err" is not nil if a) the context is done or b) a queue limit was reached.
+func (t *TxSerializer) Wait(ctx context.Context, key, table string) (done DoneFunc, waited bool, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	waited, err = t.lockLocked(ctx, key, table)
+	if err != nil {
+		if waited {
+			// Waiting failed early e.g. due a canceled context and we did NOT get the
+			// token. Call "done" now because we don't return it to the caller.
+			t.unlockLocked(key, false /* returnToken */)
+		}
+		return nil, waited, err
+	}
+	return func() { t.unlock(key) }, waited, nil
+}
+
+// lockLocked queues this transaction. It will unblock immediately if this
+// transaction is the first in the queue or when it got the token (queue.lock).
+// The method has the suffix "Locked" to clarify that "t.mu" must be locked.
+func (t *TxSerializer) lockLocked(ctx context.Context, key, table string) (bool, error) {
+	q, ok := t.queues[key]
+	if !ok {
+		// First transaction in the queue i.e. we don't wait and return immediately.
+		t.queues[key] = newQueue(t.maxQueueSize)
+		t.globalSize++
+		return false, nil
+	}
+
+	if t.globalSize >= t.maxGlobalQueueSize {
+		if t.dryRun {
+			globalQueueExceededDryRun.Add(1)
+			t.logGlobalQueueExceededDryRun.Warningf("Would have rejected BeginExecute RPC because there are too many queued transactions (%d >= %d)", t.globalSize, t.maxGlobalQueueSize)
+		} else {
+			globalQueueExceeded.Add(1)
+			return false, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED,
+				"hot row protection: too many queued transactions (%d >= %d)", t.globalSize, t.maxGlobalQueueSize)
+		}
+	}
+	t.globalSize++
+
+	if q.size >= t.maxQueueSize {
+		if t.dryRun {
+			queueExceededDryRun.Add(table, 1)
+			t.logQueueExceededDryRun.Warningf("Would have rejected BeginExecute RPC because there are too many queued transactions (%d >= %d) for the same row (table + WHERE clause: '%v')", q.size, t.maxQueueSize, key)
+		} else {
+			// Decrement global queue size again because we return early.
+			t.globalSize--
+			queueExceeded.Add(table, 1)
+			return false, vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED,
+				"hot row protection: too many queued transactions (%d >= %d) for the same row (table + WHERE clause: '%v')", q.size, t.maxQueueSize, key)
+		}
+	}
+	q.size++
+	q.count++
+	if q.size > q.max {
+		q.max = q.size
+	}
+	// Publish the number of waits at /hotrows.
+	t.Record(key)
+	if q.size == 2 {
+		// Include first transaction in the count. (It was not recorded on purpose
+		// because it did not wait.)
+		t.Record(key)
+	}
+
+	if t.dryRun {
+		waitsDryRun.Add(table, 1)
+		t.logWaitsDryRun.Warningf("Would have queued BeginExecute RPC for row (range): '%v' because another transaction to the same range is already in progress.", key)
+		return false, nil
+	}
+
+	// Unlock before the wait and relock before returning because our caller
+	// Wait() hold the lock and assumes it still has it.
+	t.mu.Unlock()
+	defer t.mu.Lock()
+
+	waits.Add(table, 1)
+	select {
+	case <-q.lock:
+		return true, nil
+	case <-ctx.Done():
+		return true, ctx.Err()
+	}
+}
+
+func (t *TxSerializer) unlock(key string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.unlockLocked(key, true)
+}
+
+func (t *TxSerializer) unlockLocked(key string, returnToken bool) {
+	q := t.queues[key]
+	q.size--
+	t.globalSize--
+	if q.size == 0 {
+		delete(t.queues, key)
+
+		if q.max > 1 {
+			if t.dryRun {
+				t.logDryRun.Infof("%v simultaneous transactions (%v in total) for the same row range (%v) would have been queued.", q.max, q.count, key)
+			} else {
+				t.log.Infof("%v simultaneous transactions (%v in total) for the same row range (%v) were queued.", q.max, q.count, key)
+			}
+		}
+	}
+
+	// Return token to queue. Wakes up the next queued transaction.
+	if !t.dryRun && returnToken {
+		q.lock <- struct{}{}
+	}
+}
+
+// Pending returns the number of queued transactions (including the one which
+// is currently in flight.)
+func (t *TxSerializer) Pending(key string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	q, ok := t.queues[key]
+	if !ok {
+		return 0
+	}
+	return q.size
+}
+
+// queue reprents the local queue for a particular row (range).
+//
+// Note that we don't use a dedicated queue structure for all waiting
+// transactions. Instead, we leverage that Go routines waiting for a channel
+// are woken up in the order they are queued up. The "lock" field is said
+// channel which has exactly one element, a token. All queued transactions are
+// competing for this token.
+type queue struct {
+	// NOTE: The following fields are guarded by TxSerializer.mu.
+	// size counts how many transactions are queued (includes the one
+	// transaction which is not waiting.)
+	size int
+	// count is the same as "size", but never gets decremented.
+	count int
+	// max is the max of "size", i.e. the maximum number of transactions which
+	// were simultaneously queued for the same row range.
+	max int
+
+	lock chan struct{}
+}
+
+func newQueue(max int) *queue {
+	return &queue{
+		size:  1,
+		count: 1,
+		max:   1,
+		lock:  make(chan struct{}, 1),
+	}
+}

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -1,0 +1,307 @@
+package txserializer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/vterrors"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+func resetVariables() {
+	waitsDryRun.Reset()
+	queueExceededDryRun.Reset()
+	globalQueueExceededDryRun.Set(0)
+}
+
+func TestTxSerializer(t *testing.T) {
+	resetVariables()
+	txs := New(false, 2, 3)
+
+	// tx1.
+	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if waited1 {
+		t.Fatalf("first transaction must never wait: %v", waited1)
+	}
+
+	// tx2 (gets queued and must wait).
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		done2, waited2, err2 := txs.Wait(context.Background(), "t1 where1", "t1")
+		if err2 != nil {
+			t.Fatal(err2)
+		}
+		if !waited2 {
+			t.Fatalf("second transaction must wait: %v", waited2)
+		}
+		if got, want := waits.Counts()["t1"], int64(1); got != want {
+			t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+		}
+
+		done2()
+	}()
+	// Wait until tx2 is waiting before we try tx3.
+	if err := waitForPending(txs, "t1 where1", 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// tx3 (gets rejected because it would exceed the local queue).
+	_, _, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if got, want := vterrors.Code(err3), vtrpcpb.Code_RESOURCE_EXHAUSTED; got != want {
+		t.Fatalf("wrong error code: got = %v, want = %v", got, want)
+	}
+	if got, want := err3.Error(), "hot row protection: too many queued transactions (2 >= 2) for the same row (table + WHERE clause: 't1 where1')"; got != want {
+		t.Fatalf("transaction rejected with wrong error: got = %v, want = %v", got, want)
+	}
+
+	done1()
+	// tx2 must have been unblocked.
+	wg.Wait()
+
+	if txs.queues["t1 where1"] != nil {
+		t.Fatal("queue object was not deleted after last transaction")
+	}
+
+	if err := testHTTPHandler(txs, 2); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitForPending(txs *TxSerializer, key string, i int) error {
+	start := time.Now()
+	for {
+		got, want := txs.Pending(key), i
+		if got == want {
+			return nil
+		}
+
+		if time.Since(start) > 10*time.Second {
+			return fmt.Errorf("wait for TxSerializer.Pending() = %d timed out: got = %v, want = %v", i, got, want)
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+func testHTTPHandler(txs *TxSerializer, count int) error {
+	req, err := http.NewRequest("GET", "/hotrows", nil)
+	if err != nil {
+		return err
+	}
+	rr := httptest.NewRecorder()
+	txs.ServeHTTP(rr, req)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		return fmt.Errorf("wrong status code: got = %v, want = %v", got, want)
+	}
+	want := fmt.Sprintf(`Length: 1
+%d: t1 where1
+`, count)
+	if got := rr.Body.String(); got != want {
+		return fmt.Errorf("wrong content: got = \n%v\n want = \n%v", got, want)
+	}
+
+	return nil
+}
+
+// TestTxSerializerCancel runs 3 pending transactions. tx2 will get canceled
+// and tx3 will be unblocked once tx1 is done.
+func TestTxSerializerCancel(t *testing.T) {
+	resetVariables()
+	txs := New(false, 3, 3)
+
+	// tx2 and tx3 will record their number once they're done waiting.
+	txDone := make(chan int)
+
+	// tx1.
+	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if waited1 {
+		t.Fatalf("first transaction must never wait: %v", waited1)
+	}
+
+	// tx2 (gets queued and must wait).
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, _, err2 := txs.Wait(ctx2, "t1 where1", "t1")
+		if err2 != context.Canceled {
+			t.Fatal(err2)
+		}
+
+		txDone <- 2
+	}()
+	// Wait until tx2 is waiting before we try tx3.
+	if err := waitForPending(txs, "t1 where1", 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// tx3 (gets queued and must wait as well).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		done3, waited3, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
+		if err3 != nil {
+			t.Fatal(err3)
+		}
+		if !waited3 {
+			t.Fatalf("third transaction must wait: %v", waited3)
+		}
+
+		txDone <- 3
+
+		done3()
+	}()
+	// Wait until tx3 is waiting before we start to cancel tx2.
+	if err := waitForPending(txs, "t1 where1", 3); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel tx2.
+	cancel2()
+	if got := <-txDone; got != 2 {
+		t.Fatalf("tx2 should have been unblocked after the cancel: %v", got)
+	}
+	// Finish tx1.
+	done1()
+	// Wait for tx3.
+	if got := <-txDone; got != 3 {
+		t.Fatalf("wrong tx was unblocked after tx1: %v", got)
+	}
+
+	wg.Wait()
+
+	if txs.queues["t1 where1"] != nil {
+		t.Fatal("queue object was not deleted after last transaction")
+	}
+
+	if err := testHTTPHandler(txs, 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTxSerializerDryRun verifies that the dry-run mode does not serialize
+// the two concurrent transactions for the same key.
+func TestTxSerializerDryRun(t *testing.T) {
+	resetVariables()
+	txs := New(true, 1, 2)
+
+	// tx1.
+	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if waited1 {
+		t.Fatalf("first transaction must never wait: %v", waited1)
+	}
+
+	// tx2 (would wait and exceed the local queue).
+	done2, waited2, err2 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if waited2 {
+		t.Fatalf("second transaction must never wait in dry-run mode: %v", waited2)
+	}
+	if got, want := waitsDryRun.Counts()["t1"], int64(1); got != want {
+		t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+	}
+	if got, want := queueExceededDryRun.Counts()["t1"], int64(1); got != want {
+		t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+	}
+
+	// tx3 (would wait and exceed the global queue).
+	done3, waited3, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err3 != nil {
+		t.Fatal(err3)
+	}
+	if waited3 {
+		t.Fatalf("any transaction must never wait in dry-run mode: %v", waited3)
+	}
+	if got, want := waitsDryRun.Counts()["t1"], int64(2); got != want {
+		t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+	}
+	if got, want := globalQueueExceededDryRun.Get(), int64(1); got != want {
+		t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+	}
+
+	if got, want := txs.Pending("t1 where1"), 3; got != want {
+		t.Fatalf("wrong number of pending transactions: got = %v, want = %v", got, want)
+	}
+
+	done1()
+	done2()
+	done3()
+
+	if txs.queues["t1 where1"] != nil {
+		t.Fatal("queue object was not deleted after last transaction")
+	}
+
+	if err := testHTTPHandler(txs, 3); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestTxSerializerGlobalQueueOverflow shows that the global queue can exceed
+// its limit without rejecting errors. This is the case when all transactions
+// are the first first one for their row range.
+// This is done on purpose to avoid that a too low global queue limit would
+// reject transactions although they may succeed within the txpool constraints
+// and RPC deadline.
+func TestTxSerializerGlobalQueueOverflow(t *testing.T) {
+	txs := New(false, 1, 1 /* maxGlobalQueueSize */)
+
+	// tx1.
+	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if waited1 {
+		t.Fatalf("first transaction must never wait: %v", waited1)
+	}
+
+	// tx2.
+	done2, waited2, err2 := txs.Wait(context.Background(), "t1 where2", "t1")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if waited2 {
+		t.Fatalf("second transaction for different row range must not wait: %v", waited2)
+	}
+
+	// tx3 (same row range as tx1).
+	_, _, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if got, want := vterrors.Code(err3), vtrpcpb.Code_RESOURCE_EXHAUSTED; got != want {
+		t.Fatalf("wrong error code: got = %v, want = %v", got, want)
+	}
+	if got, want := err3.Error(), "hot row protection: too many queued transactions (2 >= 1)"; got != want {
+		t.Fatalf("transaction rejected with wrong error: got = %v, want = %v", got, want)
+	}
+
+	done1()
+	done2()
+}
+
+func TestTxSerializerPending(t *testing.T) {
+	txs := New(false, 1, 1)
+	if got, want := txs.Pending("t1 where1"), 0; got != want {
+		t.Fatalf("there should be no pending transaction: got = %v, want = %v", got, want)
+	}
+}


### PR DESCRIPTION
During BeginExecute() do not start a second transaction if another BeginExecute() for the same row is already in progress. This avoids that updates targeted for a single row can consume all transaction pool slots.

Note that the serialization is bound to the lifetime of the BeginExecute() call and not to the lifetime of the transaction. This made the implementation simpler since no additional plumbing was required. Due to the additional MySQL locking, this should result into two transaction pool slots per row at most. (One pending on COMMIT, one waiting for MySQL in BEGIN+EXECUTE.) If this is not effective enough, we will have to revise this decision.

This change reuses the Consolidator object (but it does not set and reuse the "Result" field of the Consolidator.)

Other change:
- Extended fakesqldb to run a callback before it responds to MySQL. This is required to properly synchronize the concurrent transactions. Without, they may not race and get serialized.