### PR TITLE
Add charset/snapshot_file to vttest.

### DIFF
--- a/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/com/youtube/vitess/client/TestUtil.java
@@ -47,10 +47,10 @@ public class TestUtil {
         continue;
       }
       try {
-        Type mapType = new TypeToken<Map<String, Integer>>() {}.getType();
-        Map<String, Integer> map = new Gson().fromJson(line, mapType);
+        Type mapType = new TypeToken<Map<String, Object>>() {}.getType();
+        Map<String, Object> map = new Gson().fromJson(line, mapType);
         testEnv.setPythonScriptProcess(p);
-        testEnv.setPort(map.get(System.getProperty(PROPERTY_KEY_CLIENT_TEST_PORT)));
+        testEnv.setPort(((Double)map.get(System.getProperty(PROPERTY_KEY_CLIENT_TEST_PORT))).intValue());
         return;
       } catch (JsonSyntaxException e) {
         logger.error("JsonSyntaxException parsing setup command output: " + line, e);

--- a/py/vttest/mysql_db.py
+++ b/py/vttest/mysql_db.py
@@ -9,10 +9,11 @@
 class MySqlDB(object):
   """A MySqlDB contains basic info about a MySQL instance."""
 
-  def __init__(self, directory, port, extra_my_cnf=None):
+  def __init__(self, directory, port, extra_my_cnf=None, snapshot_file=None):
     self._directory = directory
     self._port = port
     self._extra_my_cnf = extra_my_cnf
+    self._snapshot_file = snapshot_file
 
   def setup(self, port):
     """Starts the MySQL database."""

--- a/py/vttest/mysql_db_mysqlctl.py
+++ b/py/vttest/mysql_db_mysqlctl.py
@@ -18,8 +18,9 @@ from vttest.mysql_flavor import mysql_flavor
 class MySqlDBMysqlctl(mysql_db.MySqlDB):
   """Contains data and methods to manage a MySQL instance using mysqlctl."""
 
-  def __init__(self, directory, port, extra_my_cnf):
-    super(MySqlDBMysqlctl, self).__init__(directory, port, extra_my_cnf)
+  def __init__(self, directory, port, extra_my_cnf, snapshot_file=None):
+    super(MySqlDBMysqlctl, self).__init__(
+        directory, port, extra_my_cnf, snapshot_file)
 
   def setup(self):
     cmd = [

--- a/py/vttest/run_local_database.py
+++ b/py/vttest/run_local_database.py
@@ -34,17 +34,16 @@ import optparse
 import os
 import sys
 
-from vtdb import prefer_vtroot_imports  # pylint: disable=unused-import
 
 from google.protobuf import text_format
 
+from vtproto import vttest_pb2
+from vtdb import prefer_vtroot_imports  # pylint: disable=unused-import
 from vttest import environment
+from vttest import init_data_options
 from vttest import local_database
 from vttest import mysql_flavor
-from vttest import init_data_options
 from vttest import sharding_utils
-
-from vtproto import vttest_pb2
 
 
 def main(cmdline_options):
@@ -96,7 +95,9 @@ def main(cmdline_options):
       web_dir=cmdline_options.web_dir,
       web_dir2=cmdline_options.web_dir2,
       default_schema_dir=cmdline_options.default_schema_dir,
-      extra_my_cnf=extra_my_cnf) as local_db:
+      extra_my_cnf=extra_my_cnf,
+      charset=cmdline_options.charset,
+      snapshot_file=cmdline_options.snapshot_file) as local_db:
     print json.dumps(local_db.config())
     sys.stdout.flush()
     try:
@@ -186,6 +187,9 @@ if __name__ == '__main__':
                     help='Replica tablets per shard (includes master)')
   parser.add_option('--rdonly_count', type='int', default=1,
                     help='Rdonly tablets per shard')
+  parser.add_option('--charset', default='utf8', help='MySQL charset')
+  parser.add_option(
+      '--snapshot_file', default=None, help='A MySQL DB snapshot file')
   (options, args) = parser.parse_args()
   if options.verbose:
     logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
This helps for testing efforts that require restoring from a snapshot. Also, setting charset is already allowed via start_vt_processes, so this PR just exposes it through run_local_database.