### PR TITLE
java/client: Use immutable instead of interface type.

### DIFF
--- a/java/client/src/test/java/com/youtube/vitess/mysql/DateTimeTest.java
+++ b/java/client/src/test/java/com/youtube/vitess/mysql/DateTimeTest.java
@@ -23,7 +23,7 @@ public class DateTimeTest {
   private static final Calendar PST = Calendar.getInstance(TimeZone.getTimeZone("GMT-8"));
   private static final Calendar IST = Calendar.getInstance(TimeZone.getTimeZone("GMT+0530"));
 
-  private static final Map<String, Date> TEST_DATES =
+  private static final ImmutableMap<String, Date> TEST_DATES =
       new ImmutableMap.Builder<String, Date>()
           .put("1970-01-01", new Date(0L))
           .put("2008-01-02", new Date(1199232000000L))

--- a/java/grpc-client/src/test/java/com/youtube/vitess/client/grpc/GrpcClientTest.java
+++ b/java/grpc-client/src/test/java/com/youtube/vitess/client/grpc/GrpcClientTest.java
@@ -12,7 +12,6 @@ import org.junit.runners.JUnit4;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest).


### PR DESCRIPTION
This is recommended by the Guava docs:

"For field types and method return types, you should generally use the immutable type (such as ImmutableList) instead of the general collection interface type (such as List). This communicates to your callers all of the semantic guarantees listed above, which is almost always very useful information."

From: https://google.github.io/guava/releases/21.0/api/docs/com/google/common/collect/ImmutableCollection.html