### PR TITLE
Suppress output when checking for python2 binaries.

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -36,11 +36,11 @@ export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test)
 export PYTHONPATH=$(prepend_path $PYTHONPATH $VTTOP/test/cluster/sandbox)
 
 # Ensure bootstrap and install_grpc use python2 on systems which default to python3
-command -v python2  && PYTHON=python2 || PYTHON=python
+command -v python2 >/dev/null && PYTHON=python2 || PYTHON=python
 export PYTHON
-command -v pip2 && PIP=pip2 || PIP=pip
+command -v pip2 >/dev/null && PIP=pip2 || PIP=pip
 export PIP
-command -v virtualenv2 && VIRTUALENV=virtualenv2 || VIRTUALENV=virtualenv
+command -v virtualenv2 >/dev/null && VIRTUALENV=virtualenv2 || VIRTUALENV=virtualenv
 export VIRTUALENV
 
 selenium_dist=$VTROOT/dist/selenium


### PR DESCRIPTION
The check did print output like this:
/usr/bin/python2
/usr/bin/pip2

If you did source dev.env in your .bashrc, you would see it in every new shell.