### PR TITLE
sandbox: issue of Bringing up 3 shards

### DIFF
--- a/test/cluster/sandbox/example_sandbox.yaml
+++ b/test/cluster/sandbox/example_sandbox.yaml
@@ -24,13 +24,16 @@ sandbox:
     enable_orchestrator: True
     etcd_count: 3
     cells:
-      - test1
-      - test2
+      - test
     keyspaces:
       - name: {{sandbox_name}}
         shard_count: 1
-        replica_count: 3
-        rdonly_count: 0
+        replica_count: 2
+        rdonly_count: 1
+      - name: {{sandbox_name}}
+        shard_count: 2
+        replica_count: 2
+        rdonly_count: 1
     vtctld_image: vitess/root
     vttablet_image: vitess/root
     vtgate_image: vitess/root
@@ -46,4 +49,4 @@ sandbox:
       guestbook: 80
     backup_flags:
       backup_storage_implementation: gcs
-      gcs_backup_storage_bucket: 'my-builtin-backup'
+      gcs_backup_storage_bucket: 'my-builtin-backup2'


### PR DESCRIPTION
Ends up with 3 non-serving shards.

vttablet has error when rebuildKeyspace; keyrange inconsistent for different tablet_serve_type. (-80 and 0)