### PR TITLE
Adds support for decoding bytes in metadata calls

### DIFF
--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -3,7 +3,6 @@ package com.flipkart.vitess.jdbc;
 import com.flipkart.vitess.util.CommonUtils;
 import com.flipkart.vitess.util.Constants;
 import com.flipkart.vitess.util.MysqlDefs;
-import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.VTGateConn;
 import com.youtube.vitess.client.VTGateTx;
@@ -845,28 +844,5 @@ public class VitessConnection extends ConnectionProperties implements Connection
 
     public String getUsername() {
         return this.vitessJDBCUrl.getUsername();
-    }
-
-    public String getEncodingForIndex(int charsetIndex) {
-        String javaEncoding = null;
-        if (charsetIndex != MysqlDefs.NO_CHARSET_INFO) {
-            javaEncoding = CharsetMapping.getJavaEncodingForCollationIndex(charsetIndex, getEncoding());
-        }
-        // If nothing, get default based on configuration, may still be null
-        if (javaEncoding == null) {
-            javaEncoding = getEncoding();
-        }
-        return javaEncoding;
-    }
-
-    public int getMaxBytesPerChar(Integer charsetIndex, String javaCharsetName) {
-        // if we can get it by charsetIndex just doing it
-        String charset = CharsetMapping.getMysqlCharsetNameForCollationIndex(charsetIndex);
-        // if we didn't find charset name by its full name
-        if (charset == null) {
-            charset = CharsetMapping.getMysqlCharsetForJavaEncoding(javaCharsetName);
-        }
-        // checking against static maps
-        return CharsetMapping.getMblen(charset);
     }
 }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
@@ -418,7 +418,7 @@ public class VitessMariaDBDatabaseMetadata extends VitessDatabaseMetaData
                 {"TIMESTAMP", "93", "27", "'", "'", "[(M)]", "1", "0", "3", "0", "0", "0",
                     "TIMESTAMP", "0", "0", "0", "0", "10"}};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(columnNames, columnTypes, data, this.connection);
     }
 
     public ResultSet getIndexInfo(String catalog, String schema, String table, boolean unique,

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMySQLDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessMySQLDatabaseMetadata.java
@@ -454,13 +454,13 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(columnNames, columnTypes, data, this.connection);
     }
 
     public ResultSet getSchemas() throws SQLException {
         String[] columnNames = {"TABLE_SCHEM", "TABLE_CATALOG"};
         Query.Type[] columnType = {Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getCatalogs() throws SQLException {
@@ -487,7 +487,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         vitessStatement.close();
         String[] columnName = new String[] {"TABLE_CAT"};
         Query.Type[] columntype = new Query.Type[] {Query.Type.CHAR};
-        return new VitessResultSet(columnName, columntype, data);
+        return new VitessResultSet(columnName, columntype, data, this.connection);
     }
 
     public ResultSet getTableTypes() throws SQLException {
@@ -496,7 +496,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         String[][] data =
             new String[][] {{"LOCAL TEMPORARY"}, {"SYSTEM TABLES"}, {"SYSTEM VIEW"}, {"TABLE"},
                 {"VIEW"}};
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(columnNames, columnType, data, this.connection);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getColumns(String catalog,
@@ -700,7 +700,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.INT32, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.CHAR, Query.Type.INT16, Query.Type.CHAR, Query.Type.CHAR};
 
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(columnNames, columnType, data, this.connection);
     }
 
     public ResultSet getColumnPrivileges(String catalog, String schema, String table,
@@ -791,7 +791,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             }
             vitessStatement.close();
         }
-        return new VitessResultSet(columnName, columnType, data);
+        return new VitessResultSet(columnName, columnType, data, this.connection);
     }
 
     public ResultSet getVersionColumns(String catalog, String schema, String table)
@@ -846,7 +846,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             new Query.Type[] {Query.Type.INT16, Query.Type.CHAR, Query.Type.INT32, Query.Type.CHAR,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT16, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, data);
+        return new VitessResultSet(columnNames, columnType, data, this.connection);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getPrimaryKeys(
@@ -902,7 +902,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             new Query.Type[] {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.INT16, Query.Type.CHAR};
 
-        return new VitessResultSet(columnNames, columnType, sortedData);
+        return new VitessResultSet(columnNames, columnType, sortedData, this.connection);
     }
 
     public ResultSet getImportedKeys(String catalog, String schema, String table)
@@ -1019,7 +1019,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 {"TIMESTAMP", "93", "0", "'", "'", "[(M)]", "1", "false", "3", "false", "false",
                     "false", "TIMESTAMP", "0", "0", "0", "0", "10"}};
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(columnNames, columnTypes, data, this.connection);
     }
 
     @SuppressWarnings("StringBufferReplaceableByString") public ResultSet getIndexInfo(
@@ -1088,7 +1088,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT32, Query.Type.INT32,
                 Query.Type.CHAR};
 
-        return new VitessResultSet(columnName, columnType, data);
+        return new VitessResultSet(columnName, columnType, data, this.connection);
     }
 
     public boolean ownUpdatesAreVisible(int type) throws SQLException {
@@ -1131,7 +1131,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             {Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.INT32, Query.Type.VARCHAR, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern)
@@ -1142,7 +1142,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         Query.Type[] columnType =
             {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR,
                 Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern)
@@ -1150,7 +1150,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
         String[] columnNames = {"TABLE_CAT", "TYPE_SCHEM", "TABLE_NAME", "SUPERTABLE_NAME"};
         Query.Type[] columnType =
             {Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern,
@@ -1167,7 +1167,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
                 Query.Type.INT32, Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT32,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT32, Query.Type.CHAR,
                 Query.Type.CHAR, Query.Type.CHAR, Query.Type.CHAR, Query.Type.INT16};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public int getSQLStateType() throws SQLException {
@@ -1186,14 +1186,14 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
         String[] columnNames = {"TABLE_CAT", "TABLE_CATALOG"};
         Query.Type[] columnType = {Query.Type.CHAR, Query.Type.CHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getClientInfoProperties() throws SQLException {
         String[] columnNames = {"NAME", "MAX_LEN", "DEFAULT_VALUE", "DESCRIPTION"};
         Query.Type[] columnType =
             {Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR, Query.Type.VARCHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
@@ -1218,7 +1218,7 @@ public class VitessMySQLDatabaseMetadata extends VitessDatabaseMetaData
             {Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.VARCHAR,
                 Query.Type.INT32, Query.Type.INT32, Query.Type.INT32, Query.Type.INT32,
                 Query.Type.VARCHAR, Query.Type.VARCHAR, Query.Type.INT32, Query.Type.VARCHAR};
-        return new VitessResultSet(columnNames, columnType, new String[][] {});
+        return new VitessResultSet(columnNames, columnType, new String[][] {}, this.connection);
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -82,7 +82,7 @@ public class VitessResultSet implements ResultSet {
         }
     }
 
-    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes, String[][] data, VitessConnection connection)
+    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes, String[][] data, ConnectionProperties connection)
         throws SQLException {
 
         if (columnNames.length != columnTypes.length) {
@@ -158,7 +158,7 @@ public class VitessResultSet implements ResultSet {
         this.currentRow = 0;
     }
 
-    private List<FieldWithMetadata> enhancedFieldsFromCursor(VitessConnection connection) throws SQLException {
+    private List<FieldWithMetadata> enhancedFieldsFromCursor(ConnectionProperties connection) throws SQLException {
         if (cursor == null|| cursor.getFields() == null) {
             throw new SQLException(Constants.SQLExceptionMessages.CURSOR_NULL);
         }

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -71,7 +71,7 @@ public class VitessResultSet implements ResultSet {
         this.cursor = cursor;
         this.vitessStatement = vitessStatement;
         try {
-            this.fields = enhancedFieldsFromCursor();
+            this.fields = enhancedFieldsFromCursor(vitessStatement == null ? null : vitessStatement.getConnection());
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
@@ -82,7 +82,7 @@ public class VitessResultSet implements ResultSet {
         }
     }
 
-    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes, String[][] data)
+    public VitessResultSet(String[] columnNames, Query.Type[] columnTypes, String[][] data, VitessConnection connection)
         throws SQLException {
 
         if (columnNames.length != columnTypes.length) {
@@ -112,7 +112,7 @@ public class VitessResultSet implements ResultSet {
         this.cursor = new SimpleCursor(queryResultBuilder.build());
         this.vitessStatement = null;
         try {
-            this.fields = enhancedFieldsFromCursor();
+            this.fields = enhancedFieldsFromCursor(connection);
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
@@ -120,7 +120,7 @@ public class VitessResultSet implements ResultSet {
     }
 
     public VitessResultSet(String[] columnNames, Query.Type[] columnTypes,
-        ArrayList<ArrayList<String>> data) throws SQLException {
+        ArrayList<ArrayList<String>> data, VitessConnection connection) throws SQLException {
 
         if (columnNames.length != columnTypes.length) {
             throw new SQLException(Constants.SQLExceptionMessages.INVALID_RESULT_SET);
@@ -151,18 +151,17 @@ public class VitessResultSet implements ResultSet {
         this.cursor = new SimpleCursor(queryResultBuilder.build());
         this.vitessStatement = null;
         try {
-            this.fields = enhancedFieldsFromCursor();
+            this.fields = enhancedFieldsFromCursor(connection);
         } catch (SQLException e) {
             throw new SQLException(Constants.SQLExceptionMessages.RESULT_SET_INIT_ERROR, e);
         }
         this.currentRow = 0;
     }
 
-    private List<FieldWithMetadata> enhancedFieldsFromCursor() throws SQLException {
+    private List<FieldWithMetadata> enhancedFieldsFromCursor(VitessConnection connection) throws SQLException {
         if (cursor == null|| cursor.getFields() == null) {
             throw new SQLException(Constants.SQLExceptionMessages.CURSOR_NULL);
         }
-        VitessConnection connection = vitessStatement == null ? null : vitessStatement.getConnection();
         List<Query.Field> rawFields = cursor.getFields();
         List<FieldWithMetadata> fields = new ArrayList<>(rawFields.size());
         for (Query.Field field : rawFields) {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSet.java
@@ -221,7 +221,7 @@ public class VitessResultSet implements ResultSet {
         object = this.row.getObject(columnIndex);
         if (object instanceof byte[]) {
             FieldWithMetadata field = this.fields.get(columnIndex - 1);
-            if (field.hasConnection() && field.getConnection().isIncludeAllFields()) {
+            if (field.hasConnectionProperties() && field.getConnectionProperties().isIncludeAllFields()) {
                 columnValue = convertBytesToString((byte[]) object, field.getEncoding());
             } else {
                 columnValue = new String((byte[]) object);
@@ -557,7 +557,7 @@ public class VitessResultSet implements ResultSet {
         Object retVal = this.row.getObject(columnIndex);
 
         FieldWithMetadata field = this.fields.get(columnIndex - 1);
-        if (field.hasConnection() && field.getConnection().isIncludeAllFields() && retVal instanceof byte[]) {
+        if (field.hasConnectionProperties() && field.getConnectionProperties().isIncludeAllFields() && retVal instanceof byte[]) {
             retVal = convertBytesIfPossible((byte[]) retVal, field);
         }
 

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessResultSetMetaData.java
@@ -52,7 +52,7 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
             case Types.CHAR:
             case Types.VARCHAR:
             case Types.LONGVARCHAR:
-                if (field.isBinary() || !field.getConnection().isIncludeAllFields()) {
+                if (field.isBinary() || !field.getConnectionProperties().isIncludeAllFields()) {
                     return true;
                 }
                 try {
@@ -88,7 +88,7 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
      */
     public int isNullable(int column) throws SQLException {
         FieldWithMetadata field = getField(column);
-        if (!field.getConnection().isIncludeAllFields()) {
+        if (!field.getConnectionProperties().isIncludeAllFields()) {
             return ResultSetMetaData.columnNullableUnknown;
         }
         return field.isNotNull() ? ResultSetMetaData.columnNoNulls : ResultSetMetaData.columnNullable;
@@ -100,7 +100,7 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
 
     public int getColumnDisplaySize(int column) throws SQLException {
         FieldWithMetadata field = getField(column);
-        if (!field.getConnection().isIncludeAllFields()) {
+        if (!field.getConnectionProperties().isIncludeAllFields()) {
             return 0;
         }
         // If we can't find a charset, we'll return 0. In that case assume 1 byte per char
@@ -121,7 +121,7 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
 
     public int getPrecision(int column) throws SQLException {
         FieldWithMetadata field = getField(column);
-        if (!field.getConnection().isIncludeAllFields()) {
+        if (!field.getConnectionProperties().isIncludeAllFields()) {
             return 0;
         }
         if (isDecimalType(field.getJavaType(), field.getVitessTypeValue())) {
@@ -289,11 +289,11 @@ public class VitessResultSetMetaData implements ResultSetMetaData {
 
     public String getColumnClassName(int column) throws SQLException {
         FieldWithMetadata field = getField(column);
-        if (!field.getConnection().isIncludeAllFields()) {
+        if (!field.getConnectionProperties().isIncludeAllFields()) {
             return null;
         }
         return getClassNameForJavaType(field.getJavaType(), field.getVitessTypeValue(), field.isUnsigned(),
-            field.isBinary() || field.isBlob(), field.isOpaqueBinary(), field.getConnection().getYearIsDateType());
+            field.isBinary() || field.isBlob(), field.isOpaqueBinary(), field.getConnectionProperties().getYearIsDateType());
     }
 
     public <T> T unwrap(Class<T> iface) throws SQLException {

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessStatement.java
@@ -386,7 +386,7 @@ public class VitessStatement implements Statement {
             }
         }
 
-        return new VitessResultSet(columnNames, columnTypes, data);
+        return new VitessResultSet(columnNames, columnTypes, data, this.vitessConnection);
     }
 
     /**

--- a/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/jdbc/VitessConnectionTest.java
@@ -1,8 +1,6 @@
 package com.flipkart.vitess.jdbc;
 
 import com.flipkart.vitess.util.Constants;
-import com.flipkart.vitess.util.MysqlDefs;
-import com.flipkart.vitess.util.charset.CharsetMapping;
 import com.google.common.util.concurrent.Futures;
 import com.youtube.vitess.client.Context;
 import com.youtube.vitess.client.SQLFuture;
@@ -204,47 +202,5 @@ public class VitessConnectionTest extends BaseTest {
         Assert.assertEquals(false, conn.isIncludeAllFields());
         Assert.assertEquals(Topodata.TabletType.REPLICA, conn.getTabletType());
         Assert.assertEquals(true, conn.getBlobsAreStrings());
-    }
-
-    @Test public void testGetEncodingForIndex() throws SQLException {
-        VitessConnection conn = getVitessConnection();
-
-        // No default encoding configured, and passing NO_CHARSET_INFO basically says "mysql doesn't know"
-        // which means don't try looking it up
-        Assert.assertEquals(null, conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
-        // Similarly, a null index or one landing out of bounds for the charset index should return null
-        Assert.assertEquals(null, conn.getEncodingForIndex(Integer.MAX_VALUE));
-        Assert.assertEquals(null, conn.getEncodingForIndex(-123));
-
-        // charsetIndex 25 is MYSQL_CHARSET_NAME_greek, which is a charset with multiple names, ISO8859_7 and greek
-        // Without an encoding configured in the connection, we should return the first (default) encoding for a charset,
-        // in this case ISO8859_7
-        Assert.assertEquals("ISO-8859-7", conn.getEncodingForIndex(25));
-        conn.setEncoding("greek");
-        // With an encoding configured, we should return that because it matches one of the names for the charset
-        Assert.assertEquals("greek", conn.getEncodingForIndex(25));
-
-        conn.setEncoding(null);
-        Assert.assertEquals("UTF-8", conn.getEncodingForIndex(33));
-        Assert.assertEquals("ISO-8859-1", conn.getEncodingForIndex(63));
-
-        conn.setEncoding("NOT_REAL");
-        // Same tests as the first one, but testing that when there is a default configured, it falls back to that regardless
-        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(MysqlDefs.NO_CHARSET_INFO));
-        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(Integer.MAX_VALUE));
-        Assert.assertEquals("NOT_REAL", conn.getEncodingForIndex(-123));
-    }
-
-    @Test public void testGetMaxBytesPerChar() throws SQLException {
-        VitessConnection conn = getVitessConnection();
-
-        // Default state when no good info is passed in
-        Assert.assertEquals(0, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, null));
-        // use passed collation index
-        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, null));
-        // use first, if both are passed and valid
-        Assert.assertEquals(3, conn.getMaxBytesPerChar(CharsetMapping.MYSQL_COLLATION_INDEX_utf8, "UnicodeBig"));
-        // use passed default charset
-        Assert.assertEquals(2, conn.getMaxBytesPerChar(MysqlDefs.NO_CHARSET_INFO, "UnicodeBig"));
     }
 }


### PR DESCRIPTION
Even though we're passing strings into the ResultSets, the implementation of Row.getObject turns many of them into bytes because their type is CHAR or VARCHAR ([here](https://github.com/youtube/vitess/blob/master/java/client/src/main/java/com/youtube/vitess/client/cursor/Row.java#L658)). Upstream libraries (like liquibase) expect result.getObject to return Strings for things like TABLE_CAT, etc and are throwing exceptions when trying to cast the Object to a String.

This very simple change passes through the Connection into the ResultSet objects created by Metadata requests. This way when we call getObject, the recently added charset decoding code can detect the byte[] and convert them to strings where appropriate. This also makes the constructors more consistent, in my opinion.

This is a bugfix which fixes the following exception for users of Liquibase:

`java.lang.ClassCastException: [B cannot be cast to java.lang.String`