### PR TITLE
panic if a planbuilder test input contains invalid JSON

### DIFF
--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -211,8 +211,11 @@ func iterateExecFile(name string) (testCaseIterator chan testCase) {
 				if l[0] == '}' {
 					output = output[:len(output)-1]
 					b := bytes.NewBuffer(make([]byte, 0, 64))
-					if err := json.Compact(b, output); err == nil {
+					err := json.Compact(b, output)
+					if err == nil {
 						output = b.Bytes()
+					} else {
+						panic("Invalid JSON " + string(output) + err.Error())
 					}
 					break
 				}


### PR DESCRIPTION
Panic if the json.Compact fails when processing the test input.

When working on #2647 I ended up having a stray trailing comma in one of the json blobs in my test input file which turned out to be silently ignored by the test suite and took me some time to figure out why my json wasn't being compacted properly.
