### PR TITLE
Removing the cap on the # of iterations of SplitQuery.

### DIFF
--- a/go/vt/vttablet/tabletserver/splitquery/full_scan_algorithm.go
+++ b/go/vt/vttablet/tabletserver/splitquery/full_scan_algorithm.go
@@ -77,14 +77,11 @@ func (a *FullScanAlgorithm) generateBoundaries() ([]tuple, error) {
 	}
 	result := make([]tuple, 0, a.splitParams.splitCount)
 	var iteration int64
-	// We have to allow for more than splitCount query-parts since we use an estimated
-	// tableSize in the equation 'numRowsPerQueryPart * splitCount = tableSize'.
-	maxIterations := 10 * a.splitParams.splitCount
+	// We used to have a safety check that makes sure the number of iterations does not
+	// exceed 10*a.splitParams.splitCount. The splitCount parameter was calculated from
+	// the estimated number of rows in the information schema, which could have been grossly
+	// inaccurate (more than 10 times too low).
 	for iteration = 0; prevTuple != nil; iteration++ {
-		if iteration > maxIterations {
-			panic(fmt.Sprintf("splitquery.FullScanAlgorithm.generateBoundaries(): didn't terminate"+
-				" after %v iterations (=10*splitCount). FullScanAlgorithm: %v", maxIterations, a))
-		}
 		result = append(result, prevTuple)
 		a.populatePrevTupleInBindVariables(prevTuple, a.noninitialQuery.BindVariables)
 		prevTuple, err = a.executeQuery(a.noninitialQuery)


### PR DESCRIPTION
@sougou I've decided to remove the cap on the maximum number of iterations, since it's pointless to do if the information schema estimate has no bounds on its accuracy.
