### PR TITLE
Getting to the bottom of the 2006/2013 mystery.

### DIFF
--- a/go/vt/wrangler/testlib/fake_tablet.go
+++ b/go/vt/wrangler/testlib/fake_tablet.go
@@ -109,10 +109,6 @@ func NewFakeTablet(t *testing.T, wr *wrangler.Wrangler, cell string, uid uint32,
 		t.Fatalf("uid has to be between 0 and 99: %v", uid)
 	}
 	mysqlPort := int32(3300 + uid)
-	if db != nil {
-		mysqlPort = int32(db.Port())
-	}
-
 	tablet := &topodatapb.Tablet{
 		Alias:    &topodatapb.TabletAlias{Cell: cell, Uid: uid},
 		Hostname: fmt.Sprintf("%vhost", cell),
@@ -139,7 +135,7 @@ func NewFakeTablet(t *testing.T, wr *wrangler.Wrangler, cell string, uid uint32,
 
 	// create a FakeMysqlDaemon with the right information by default
 	fakeMysqlDaemon := mysqlctl.NewFakeMysqlDaemon(db)
-	fakeMysqlDaemon.MysqlPort = 3300 + int32(uid)
+	fakeMysqlDaemon.MysqlPort = mysqlPort
 
 	return &FakeTablet{
 		Tablet:          tablet,


### PR DESCRIPTION
Well, to some parts of it:
- switching the fakesqldb package to use a Unix socket to talk to the
fake server. That way it's the same most common use case as in
production. This fixes the 2006 test cases added by Michael for all
platforms.
- adding a test to make sure we get a 2006 when the server closes the
connection. This is now guaranteed (as opposed to TCP, see below).
- document the behavior better in code, that is:

ExecuteFetch is the same as sqldb.Conn.ExecuteFetch.
Returns a sqldb.SQLError. Depending on the transport used, the error
returned might be different for the same condition:

1. if the server closes the connection when no command is in flight:

  1.1 unix: writeComQuery will fail with a 'broken pipe', and we'll
      return CRServerGone(2006).
  1.2 tcp: writeComQuery will most likely work, but ReadComQueryResponse
      will fail, and we'll return CRServerLost(2013).

      This is because closing a TCP socket on the server side sends
      a FIN to the client (telling the client the server is done
      writing), but on most platforms doesn't send a RST.  So the
      client has no idea it can't write. So it succeeds writing data, which
      *then* triggers the server to send a RST back, received a bit
      later. By then, the client has already started waiting for
      the response, and will just return a CRServerLost(2013).
      So CRServerGone(2006) will almost never be seen with TCP.

2. if the server closes the connection when a command is in flight,
   readComQueryResponse will fail, and we'll return CRServerLost(2013).