### PR TITLE
JDBC bugfix: Don't reuse a defunct databaseMetaData

### DIFF
--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -215,11 +215,11 @@ public class VitessConnection extends ConnectionProperties implements Connection
 
     public DatabaseMetaData getMetaData() throws SQLException {
         checkOpen();
-        if (!metadataNullOrDefunct()) {
+        if (!metadataNullOrClosed()) {
             return databaseMetaData;
         } else {
             synchronized (VitessConnection.class) {
-                if (metadataNullOrDefunct()) {
+                if (metadataNullOrClosed()) {
                     String dbEngine = initializeDBProperties();
                     if (dbEngine.equals("mariadb")) {
                         databaseMetaData = new VitessMariaDBDatabaseMetadata(this);
@@ -232,7 +232,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         }
     }
 
-    private boolean metadataNullOrDefunct() throws SQLException {
+    private boolean metadataNullOrClosed() throws SQLException {
         return null == databaseMetaData || null == databaseMetaData.getConnection() || databaseMetaData.getConnection().isClosed();
     }
 
@@ -790,7 +790,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         HashMap<String, String> dbVariables = new HashMap<>();
         String dbEngine = null;
 
-        if (metadataNullOrDefunct()) {
+        if (metadataNullOrClosed()) {
             String versionValue;
             ResultSet resultSet = null;
             VitessStatement vitessStatement = new VitessStatement(this);

--- a/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/jdbc/VitessConnection.java
@@ -215,11 +215,11 @@ public class VitessConnection extends ConnectionProperties implements Connection
 
     public DatabaseMetaData getMetaData() throws SQLException {
         checkOpen();
-        if (null != databaseMetaData) {
+        if (!metadataNullOrDefunct()) {
             return databaseMetaData;
         } else {
             synchronized (VitessConnection.class) {
-                if (null == databaseMetaData) {
+                if (metadataNullOrDefunct()) {
                     String dbEngine = initializeDBProperties();
                     if (dbEngine.equals("mariadb")) {
                         databaseMetaData = new VitessMariaDBDatabaseMetadata(this);
@@ -230,6 +230,10 @@ public class VitessConnection extends ConnectionProperties implements Connection
             }
             return databaseMetaData;
         }
+    }
+
+    private boolean metadataNullOrDefunct() throws SQLException {
+        return null == databaseMetaData || null == databaseMetaData.getConnection() || databaseMetaData.getConnection().isClosed();
     }
 
     public boolean isReadOnly() throws SQLException {
@@ -786,7 +790,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         HashMap<String, String> dbVariables = new HashMap<>();
         String dbEngine = null;
 
-        if (null == databaseMetaData) {
+        if (metadataNullOrDefunct()) {
             String versionValue;
             ResultSet resultSet = null;
             VitessStatement vitessStatement = new VitessStatement(this);


### PR DESCRIPTION
I'm not sure why databaseMetaData is a static variable. It looks to have been that way since the very beginning. But I recently ran into an issue where if you create multiple VitessConnections and close the first one, all of the other VitessConnections reference what is effectively a defunct databaseMetadata. That is, the databaseMetadata references a connection which is closed, and so nothing can be called on it.

This is very easily reproducible for anyone who uses hikari or other jdbc pooling libraries.

This fixes to ensure we don't re-use such databaseMetadata values. I'd also be happy to make this non-static, if preferred.

@harshit-gangal @ashudeep-sharma 