### PR TITLE
vtworker: Fix throttler panic when SplitClone fails.

### DIFF
--- a/go/vt/worker/utils_test.go
+++ b/go/vt/worker/utils_test.go
@@ -25,7 +25,12 @@ import (
 // This file contains common test helper.
 
 func runCommand(t *testing.T, wi *Instance, wr *wrangler.Wrangler, args []string) error {
-	worker, done, err := wi.RunCommand(context.Background(), args, wr, false /* runFromCli */)
+	// Limit the scope of the context e.g. to implicitly terminate stray Go
+	// routines.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	worker, done, err := wi.RunCommand(ctx, args, wr, false /* runFromCli */)
 	if err != nil {
 		return fmt.Errorf("Worker creation failed: %v", err)
 	}


### PR DESCRIPTION
There was a race where the throttlers were closed before ThreadFinished() on each throttler was called.

Therefore, ThreadFinished() did panic. This crashed vtworker and hid the actual error why SplitClone failed.