### PR TITLE
New version of golang/x/text packages.

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -777,88 +777,70 @@
 			"revisionTime": "2016-07-30T22:43:56Z"
 		},
 		{
-			"checksumSHA1": "BEcyB7xMS4byueMu4LhnUl6jj/A=",
+			"checksumSHA1": "5AKasas4CO8g/Wiizgd34EGLoMQ=",
 			"path": "golang.org/x/text/collate",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "p295Maz8FV8cRQwuO1nORFtfS0M=",
+			"checksumSHA1": "gRurdsue4RAi2xYzy89YDzO2c2I=",
 			"path": "golang.org/x/text/collate/build",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "Ny6DIwANQghBAuvZx94MiMv2ppU=",
-			"path": "golang.org/x/text/collate/colltab",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
-		},
-		{
-			"checksumSHA1": "zhxOlitUyY3m9FimOyPmyX9/gwI=",
+			"checksumSHA1": "fM/n4f1c26uIh3wB9g+1flJkSAo=",
 			"path": "golang.org/x/text/internal/colltab",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "3JkLagg7UP4890bHn0Uld6GmO6M=",
+			"checksumSHA1": "ZQdHbB9VYCXwQ+9/CmZPhJv0+SM=",
 			"path": "golang.org/x/text/internal/gen",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
 			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
 			"path": "golang.org/x/text/internal/tag",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
-		},
-		{
-			"checksumSHA1": "j++juaCPEzyx7mz2X5f8yTjWkWQ=",
-			"path": "golang.org/x/text/internal/testtext",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
 			"checksumSHA1": "47nwiUyVBY2RKoEGXmCSvusY4Js=",
 			"path": "golang.org/x/text/internal/triegen",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "LyT5byg0Dq4x3OcGt6EwIDgPUpc=",
+			"checksumSHA1": "Yd5wMObzagIfCiKLpZbtBIrOUA4=",
 			"path": "golang.org/x/text/internal/ucd",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "vbYsvMa+yYFTrmD0bIVhA36DpgQ=",
+			"checksumSHA1": "Dhc7bHUc+d1uuYO/byxQf7AfW+o=",
 			"path": "golang.org/x/text/language",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "TZDHZj3zWDc5LKqpoLamOKt6Nmo=",
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
 			"path": "golang.org/x/text/transform",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "n94g6qdzv0fgQFGelH4/HXOthl0=",
+			"checksumSHA1": "ZbYsJjfj1rPbHN+0baD1rg09PXQ=",
 			"path": "golang.org/x/text/unicode/cldr",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
-			"checksumSHA1": "pDDMc5yLVQ2xeR9CajcgIJODPcw=",
+			"checksumSHA1": "gYoNrZgxCQAHutg2rGHcFoKJtpA=",
 			"path": "golang.org/x/text/unicode/norm",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
-		},
-		{
-			"checksumSHA1": "2c0iiKbdCsffuJeXG8Eh0LDdULU=",
-			"path": "golang.org/x/text/unicode/rangetable",
-			"revision": "d5d7737684e596dbabf914ecf946d2783f35bdc2",
-			"revisionTime": "2016-07-10T05:19:30Z"
+			"revision": "fc7fa097411d30e6708badff276c4c164425590c",
+			"revisionTime": "2017-03-23T10:04:54Z"
 		},
 		{
 			"checksumSHA1": "eFQDEix/mGnhwnFu/Hq63zMfrX8=",


### PR DESCRIPTION
The old version was somehow crashing in the unit tests on my WS. maybe
because I'm using go 1.8.