### PR TITLE
Support JDBC DatabaseMetaData getImportedKeys function

### DIFF
--- a/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
+++ b/java/jdbc/src/main/java/com/flipkart/vitess/util/StringUtils.java
@@ -6,7 +6,11 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -17,8 +21,31 @@ public class StringUtils {
     private static final String platformEncoding = System.getProperty("file.encoding");
     private static final ConcurrentHashMap<String, Charset> charsetsByAlias = new ConcurrentHashMap<String, Charset>();
 
+    // length of MySQL version reference in comments of type '/*![00000] */'
+    private static final int NON_COMMENTS_MYSQL_VERSION_REF_LENGTH = 5;
+
+
     private StringUtils() {
     }
+
+    public enum SearchMode {
+        ALLOW_BACKSLASH_ESCAPE, SKIP_BETWEEN_MARKERS, SKIP_BLOCK_COMMENTS, SKIP_LINE_COMMENTS, SKIP_WHITE_SPACE;
+    }
+
+    /*
+     * Convenience EnumSets for several SearchMode combinations
+     */
+
+    /**
+     * Full search mode: allow backslash escape, skip between markers, skip block comments, skip line comments and skip white space.
+     */
+    public static final Set<SearchMode> SEARCH_MODE__ALL = Collections.unmodifiableSet(EnumSet.allOf(SearchMode.class));
+
+    /**
+     * Search mode: skip between markers, skip block comments, skip line comments and skip white space.
+     */
+    public static final Set<SearchMode> SEARCH_MODE__MRK_COM_WS = Collections.unmodifiableSet(
+      EnumSet.of(SearchMode.SKIP_BETWEEN_MARKERS, SearchMode.SKIP_BLOCK_COMMENTS, SearchMode.SKIP_LINE_COMMENTS, SearchMode.SKIP_WHITE_SPACE));
 
     /**
      * Determines whether or not the string 'searchIn' contains the string
@@ -71,6 +98,10 @@ public class StringUtils {
      */
     public static boolean startsWithIgnoreCase(String searchIn, int startAt, String searchFor) {
         return searchIn.regionMatches(true, startAt, searchFor, 0, searchFor.length());
+    }
+
+    private static boolean isCharEqualIgnoreCase(char charToCompare, char compareToCharUC, char compareToCharLC) {
+        return Character.toLowerCase(charToCompare) == compareToCharLC || Character.toUpperCase(charToCompare) == compareToCharUC;
     }
 
     public static boolean isNullOrEmptyWithoutWS(String string) {
@@ -444,5 +475,360 @@ public class StringUtils {
         } catch (IllegalArgumentException iae) {
             throw new UnsupportedEncodingException(alias);
         }
+    }
+
+    /**
+     * Searches for a quoteChar in the searchIn string
+     * @param searchIn
+     * @param quoteChar
+     * @param startFrom
+     * @return
+     */
+    public static int indexOfQuoteDoubleAware(String searchIn, String quoteChar, int startFrom) {
+        if (searchIn == null || quoteChar == null || quoteChar.length() == 0 || startFrom > searchIn.length()) {
+            return -1;
+        }
+        int lastIndex = searchIn.length() - 1;
+        int beginPos = startFrom;
+        int pos = -1;
+        boolean next = true;
+        while (next) {
+            pos = searchIn.indexOf(quoteChar, beginPos);
+            if (pos == -1 || pos == lastIndex || !searchIn.startsWith(quoteChar, pos + 1)) {
+                next = false;
+            } else {
+                beginPos = pos + 2;
+            }
+        }
+        return pos;
+    }
+
+    /**
+     * Quotes an identifier, escaping any dangling quotes within
+     * @param identifier
+     * @param quoteChar
+     * @return
+     */
+    public static String quoteIdentifier(String identifier, String quoteChar) {
+        if (identifier == null) {
+            return null;
+        }
+        identifier = identifier.trim();
+        int quoteCharLength = quoteChar.length();
+        if (quoteCharLength == 0 || " ".equals(quoteChar)) {
+            return identifier;
+        }
+
+        if (identifier.startsWith(quoteChar) && identifier.endsWith(quoteChar)) {
+            String identifierQuoteTrimmed = identifier.substring(quoteCharLength, identifier.length() - quoteCharLength);
+            int quoteCharPos = identifierQuoteTrimmed.indexOf(quoteChar);
+            while (quoteCharPos >= 0) {
+                int quoteCharNextExpectedPos = quoteCharPos + quoteCharLength;
+                int quoteCharNextPosition = identifierQuoteTrimmed.indexOf(quoteChar, quoteCharNextExpectedPos);
+
+                if (quoteCharNextPosition == quoteCharNextExpectedPos) {
+                    quoteCharPos = identifierQuoteTrimmed.indexOf(quoteChar, quoteCharNextPosition + quoteCharLength);
+                } else {
+                    // Not a pair of quotes!
+                    break;
+                }
+            }
+
+            if (quoteCharPos < 0) {
+                return identifier;
+            }
+        }
+
+        return quoteChar + identifier.replaceAll(quoteChar, quoteChar + quoteChar) + quoteChar;
+    }
+
+    /**
+     * Convenience function for {@link #indexOfIgnoreCase(int, String, String, String, String, Set)}, passing {@link #SEARCH_MODE__ALL}
+     */
+    public static int indexOfIgnoreCase(int startingPosition, String searchIn, String searchFor, String openingMarkers, String closingMarkers) {
+        return indexOfIgnoreCase(startingPosition, searchIn, searchFor, openingMarkers, closingMarkers, SEARCH_MODE__ALL);
+    }
+
+    /**
+     * Finds the position of a substring within a string, ignoring case, with the option to skip text delimited by given markers or within comments.
+     *
+     * @param startingPosition
+     *            the position to start the search from
+     * @param searchIn
+     *            the string to search in
+     * @param searchFor
+     *            the string to search for
+     * @param openingMarkers
+     *            characters which delimit the beginning of a text block to skip
+     * @param closingMarkers
+     *            characters which delimit the end of a text block to skip
+     * @param searchMode
+     *            a <code>Set</code>, ideally an <code>EnumSet</code>, containing the flags from the enum <code>StringUtils.SearchMode</code> that determine the
+     *            behavior of the search
+     * @return the position where <code>searchFor</code> is found within <code>searchIn</code> starting from <code>startingPosition</code>.
+     */
+    public static int indexOfIgnoreCase(int startingPosition, String searchIn, String searchFor, String openingMarkers, String closingMarkers,
+                                        Set<SearchMode> searchMode) {
+        if (searchIn == null || searchFor == null) {
+            return -1;
+        }
+
+        int searchInLength = searchIn.length();
+        int searchForLength = searchFor.length();
+        int stopSearchingAt = searchInLength - searchForLength;
+
+        if (startingPosition > stopSearchingAt || searchForLength == 0) {
+            return -1;
+        }
+
+        if (searchMode.contains(SearchMode.SKIP_BETWEEN_MARKERS)
+          && (openingMarkers == null || closingMarkers == null || openingMarkers.length() != closingMarkers.length())) {
+            throw new IllegalArgumentException("Must specify a valid openingMarkers and closingMarkers");
+        }
+
+        // Some locales don't follow upper-case rule, so need to check both
+        char firstCharOfSearchForUc = Character.toUpperCase(searchFor.charAt(0));
+        char firstCharOfSearchForLc = Character.toLowerCase(searchFor.charAt(0));
+
+        if (Character.isWhitespace(firstCharOfSearchForLc) && searchMode.contains(SearchMode.SKIP_WHITE_SPACE)) {
+            // Can't skip white spaces if first searchFor char is one
+            searchMode = EnumSet.copyOf(searchMode);
+            searchMode.remove(SearchMode.SKIP_WHITE_SPACE);
+        }
+
+        for (int i = startingPosition; i <= stopSearchingAt; i++) {
+            i = indexOfNextChar(i, stopSearchingAt, searchIn, openingMarkers, closingMarkers, searchMode);
+
+            if (i == -1) {
+                return -1;
+            }
+
+            char c = searchIn.charAt(i);
+
+            if (isCharEqualIgnoreCase(c, firstCharOfSearchForUc, firstCharOfSearchForLc) && startsWithIgnoreCase(searchIn, i, searchFor)) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Finds the position the next character from a string, possibly skipping white space, comments and text between markers.
+     *
+     * @param startingPosition
+     *            the position to start the search from
+     * @param stopPosition
+     *            the position where to stop the search (inclusive)
+     * @param searchIn
+     *            the string to search in
+     * @param openingMarkers
+     *            characters which delimit the beginning of a text block to skip
+     * @param closingMarkers
+     *            characters which delimit the end of a text block to skip
+     * @param searchMode
+     *            a <code>Set</code>, ideally an <code>EnumSet</code>, containing the flags from the enum <code>StringUtils.SearchMode</code> that determine the
+     *            behavior of the search
+     * @return the position where <code>searchFor</code> is found within <code>searchIn</code> starting from <code>startingPosition</code>.
+     */
+    private static int indexOfNextChar(int startingPosition, int stopPosition, String searchIn, String openingMarkers, String closingMarkers,
+                                       Set<SearchMode> searchMode) {
+        if (searchIn == null) {
+            return -1;
+        }
+
+        int searchInLength = searchIn.length();
+        if (startingPosition >= searchInLength) {
+            return -1;
+        }
+
+        char c0 = Character.MIN_VALUE; // current char
+        char c1 = searchIn.charAt(startingPosition); // lookahead(1)
+        char c2 = startingPosition + 1 < searchInLength ? searchIn.charAt(startingPosition + 1) : Character.MIN_VALUE; // lookahead(2)
+
+        for (int i = startingPosition; i <= stopPosition; i++) {
+            c0 = c1;
+            c1 = c2;
+            c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+
+            boolean dashDashCommentImmediateEnd = false;
+            int markerIndex = -1;
+            if (searchMode.contains(SearchMode.ALLOW_BACKSLASH_ESCAPE) && c0 == '\\') {
+                i++; // next char is escaped, skip it
+                // reset lookahead
+                c1 = c2;
+                c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+            } else if (searchMode.contains(SearchMode.SKIP_BETWEEN_MARKERS) && (markerIndex = openingMarkers.indexOf(c0)) != -1) {
+                // marker found, skip until closing, while being aware of nested markers if opening and closing markers are distinct
+                int nestedMarkersCount = 0;
+                char openingMarker = c0;
+                char closingMarker = closingMarkers.charAt(markerIndex);
+                while (++i <= stopPosition && ((c0 = searchIn.charAt(i)) != closingMarker || nestedMarkersCount != 0)) {
+                    if (c0 == openingMarker) {
+                        nestedMarkersCount++;
+                    } else if (c0 == closingMarker) {
+                        nestedMarkersCount--;
+                    } else if (searchMode.contains(SearchMode.ALLOW_BACKSLASH_ESCAPE) && c0 == '\\') {
+                        i++; // next char is escaped, skip it
+                    }
+                }
+                // reset lookahead
+                c1 = i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE;
+                c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+
+            } else if (searchMode.contains(SearchMode.SKIP_BLOCK_COMMENTS) && c0 == '/' && c1 == '*') {
+                if (c2 != '!') {
+                    // comments block found, skip until end of block ("*/") (backslash escape doesn't work on comments)
+                    i++; // move to next char ('*')
+                    while (++i <= stopPosition
+                      && (searchIn.charAt(i) != '*' || (i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE) != '/')) {
+                        // continue
+                    }
+                    i++; // move to next char ('/')
+                } else {
+                    // special non-comments block found, move to end of opening marker ("/*![12345]")
+                    i++; // move to next char ('*')
+                    i++; // move to next char ('!')
+                    // check if a 5 digits MySQL version reference follows, if so skip them
+                    int j = 1;
+                    for (; j <= NON_COMMENTS_MYSQL_VERSION_REF_LENGTH; j++) {
+                        if (i + j >= searchInLength || !Character.isDigit(searchIn.charAt(i + j))) {
+                            break;
+                        }
+                    }
+                    if (j == NON_COMMENTS_MYSQL_VERSION_REF_LENGTH) {
+                        i += NON_COMMENTS_MYSQL_VERSION_REF_LENGTH;
+                    }
+                }
+                // reset lookahead
+                c1 = i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE;
+                c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+            } else if (searchMode.contains(SearchMode.SKIP_BLOCK_COMMENTS) && c0 == '*' && c1 == '/') {
+                // special non-comments block closing marker ("*/") found - assume that if we get it here it's because it
+                // belongs to a non-comments block ("/*!"), otherwise the query should be misspelled as nesting comments isn't allowed.
+                i++; // move to next char ('/')
+                // reset lookahead
+                c1 = c2;
+                c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+            } else if (searchMode.contains(SearchMode.SKIP_LINE_COMMENTS)
+              && ((c0 == '-' && c1 == '-' && (Character.isWhitespace(c2) || (dashDashCommentImmediateEnd = c2 == ';') || c2 == Character.MIN_VALUE))
+              || c0 == '#')) {
+                if (dashDashCommentImmediateEnd) {
+                    // comments line found but closed immediately by query delimiter marker
+                    i++; // move to next char ('-')
+                    i++; // move to next char (';')
+                    // reset lookahead
+                    c1 = i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE;
+                    c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+                } else {
+                    // comments line found, skip until eol (backslash escape doesn't work on comments)
+                    while (++i <= stopPosition && (c0 = searchIn.charAt(i)) != '\n' && c0 != '\r') {
+                        // continue
+                    }
+                    // reset lookahead
+                    c1 = i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE;
+                    if (c0 == '\r' && c1 == '\n') {
+                        // \r\n sequence found
+                        i++; // skip next char ('\n')
+                        c1 = i + 1 < searchInLength ? searchIn.charAt(i + 1) : Character.MIN_VALUE;
+                    }
+                    c2 = i + 2 < searchInLength ? searchIn.charAt(i + 2) : Character.MIN_VALUE;
+                }
+            } else if (!searchMode.contains(SearchMode.SKIP_WHITE_SPACE) || !Character.isWhitespace(c0)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Trims identifier, removes quote chars from first and last positions
+     * and replaces double occurrences of quote char from entire identifier,
+     * i.e converts quoted identifier into form as it is stored in database.
+     *
+     * @param identifier
+     * @param quoteChar
+     *            ` or "
+     * @return
+     *         <ul>
+     *         <li>null -> null</li>
+     *         <li>abc -> abc</li>
+     *         <li>`abc` -> abc</li>
+     *         <li>`ab``c` -> ab`c</li>
+     *         <li>`"ab`c"` -> "ab`c"</li>
+     *         <li>`ab"c` -> ab"c</li>
+     *         <li>"abc" -> abc</li>
+     *         <li>"`ab""c`" -> `ab"c`</li>
+     *         <li>"ab`c" -> ab`c</li>
+     *         </ul>
+     */
+    public static String unQuoteIdentifier(String identifier, String quoteChar) {
+        if (identifier == null) {
+            return null;
+        }
+        identifier = identifier.trim();
+        int quoteCharLength = quoteChar.length();
+        if (quoteCharLength == 0 || " ".equals(quoteChar)) {
+            return identifier;
+        }
+
+        // Check if the identifier is really quoted or if it simply contains quote chars in it (assuming that the value is a valid identifier).
+        if (identifier.startsWith(quoteChar) && identifier.endsWith(quoteChar)) {
+            String identifierQuoteTrimmed = identifier.substring(quoteCharLength, identifier.length() - quoteCharLength);
+            // Check for pairs of quotes.
+            int quoteCharPos = identifierQuoteTrimmed.indexOf(quoteChar);
+            while (quoteCharPos >= 0) {
+                int quoteCharNextExpectedPos = quoteCharPos + quoteCharLength;
+                int quoteCharNextPosition = identifierQuoteTrimmed.indexOf(quoteChar, quoteCharNextExpectedPos);
+
+                if (quoteCharNextPosition == quoteCharNextExpectedPos) {
+                    quoteCharPos = identifierQuoteTrimmed.indexOf(quoteChar, quoteCharNextPosition + quoteCharLength);
+                } else {
+                    // Not a pair of quotes! Return as it is...
+                    return identifier;
+                }
+            }
+            return identifier.substring(quoteCharLength, (identifier.length() - quoteCharLength)).replaceAll(quoteChar + quoteChar, quoteChar);
+        }
+        return identifier;
+    }
+
+    /**
+     * Splits stringToSplit into a list, using the given delimiter (skipping delimiters within quotes)
+     *
+     * @param stringToSplit
+     *            the string to split
+     * @param delimiter
+     *            the string to split on
+     * @param markers
+     *            the marker for the beginning of a text block to skip, when looking for a delimiter
+     * @param markerCloses
+     *            the marker for the end of a text block to skip, when looking for a delimiter
+     * @return the list of strings, split by delimiter
+     *
+     * @throws IllegalArgumentException
+     */
+    public static List<String> split(String stringToSplit, String delimiter, String markers, String markerCloses) {
+        if (stringToSplit == null) {
+            return new ArrayList<>();
+        }
+        if (delimiter == null) {
+            throw new IllegalArgumentException();
+        }
+
+        int delimPos = 0;
+        int currentPos = 0;
+        List<String> splitTokens = new ArrayList<>();
+        while ((delimPos = indexOfIgnoreCase(currentPos, stringToSplit, delimiter, markers, markerCloses, SEARCH_MODE__MRK_COM_WS)) != -1) {
+            String token = stringToSplit.substring(currentPos, delimPos);
+            splitTokens.add(token);
+            currentPos = delimPos + 1;
+        }
+
+        if (currentPos < stringToSplit.length()) {
+            String token = stringToSplit.substring(currentPos);
+            splitTokens.add(token);
+        }
+        return splitTokens;
     }
 }

--- a/java/jdbc/src/test/java/com/flipkart/vitess/util/StringUtilsTest.java
+++ b/java/jdbc/src/test/java/com/flipkart/vitess/util/StringUtilsTest.java
@@ -1,0 +1,105 @@
+package com.flipkart.vitess.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class StringUtilsTest {
+
+
+  @Test
+  public void indexOfQuoteDoubleAwareTest() {
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware("this is a test", "'", 0));
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware("this is a test", "", 0));
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware("this is a test", "", 30));
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware("this is a test", null, 30));
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware(null, "'", 30));
+    Assert.assertEquals(8, StringUtils.indexOfQuoteDoubleAware("this is 'a' test", "'", 0));
+    Assert.assertEquals(11, StringUtils.indexOfQuoteDoubleAware("this is ''a' test", "'", 0));
+    Assert.assertEquals(-1, StringUtils.indexOfQuoteDoubleAware("this is ''a'' test", "'", 0));
+  }
+
+  @Test
+  public void quoteIdentifierTest() {
+    Assert.assertEquals("'this is a test'", StringUtils.quoteIdentifier("this is a test", "'"));
+    Assert.assertEquals("'this is a test'", StringUtils.quoteIdentifier("'this is a test'", "'"));
+    Assert.assertEquals("'this is'' a test'", StringUtils.quoteIdentifier("this is' a test", "'"));
+    Assert.assertEquals("'this is'''' a test'", StringUtils.quoteIdentifier("this is'' a test", "'"));
+    Assert.assertEquals("'this is'' a test'", StringUtils.quoteIdentifier("'this is'' a test'", "'"));
+    Assert.assertEquals("'this is a ''test'''", StringUtils.quoteIdentifier("this is a 'test'", "'"));
+    Assert.assertEquals("'this is a ''test'''", StringUtils.quoteIdentifier("'this is a ''test'''", "'"));
+    Assert.assertEquals(null, StringUtils.quoteIdentifier(null, "'"));
+    Assert.assertEquals("this is a test", StringUtils.quoteIdentifier("this is a test", ""));
+    Assert.assertEquals("this is a test", StringUtils.quoteIdentifier("this is a test", " "));
+  }
+
+  @Test
+  public void unQuoteIdentifierTest() {
+    Assert.assertEquals(null, StringUtils.unQuoteIdentifier(null, "'"));
+    Assert.assertEquals("'this is a test'", StringUtils.unQuoteIdentifier("'this is a test'", ""));
+    Assert.assertEquals("'this is a test'", StringUtils.unQuoteIdentifier("'this is a test'", " "));
+    Assert.assertEquals("'this is a test'", StringUtils.unQuoteIdentifier("'this is a test'", "\""));
+    Assert.assertEquals("this is a test'", StringUtils.unQuoteIdentifier("this is a test'", "'"));
+    Assert.assertEquals("this is a test", StringUtils.unQuoteIdentifier("'this is a test'", "'"));
+    Assert.assertEquals("this is 'a' test", StringUtils.unQuoteIdentifier("'this is ''a'' test'", "'"));
+    Assert.assertEquals("this is 'a'' test", StringUtils.unQuoteIdentifier("'this is ''a'''' test'", "'"));
+    Assert.assertEquals("'this is a test'", StringUtils.unQuoteIdentifier("'''this is a test'''", "'"));
+    Assert.assertEquals("this is a test", StringUtils.unQuoteIdentifier("``this is a test``", "``"));
+    Assert.assertEquals("``this is ``a test``", StringUtils.unQuoteIdentifier("``this is ``a test``", "``"));
+    Assert.assertEquals("this is ``a test", StringUtils.unQuoteIdentifier("``this is ````a test``", "``"));
+    Assert.assertEquals("'this is ''a' test'", StringUtils.unQuoteIdentifier("'this is ''a' test'", "'"));
+  }
+
+  @Test
+  public void indexOfIgnoreCaseTestDefault() {
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, null, "a", "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, "this is a test", "", "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, "this is a test", null, "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(8, "this is a test", "this", "`", "`"));
+    Assert.assertEquals(7, StringUtils.indexOfIgnoreCase(0, "this is a test", " a ", "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, "this is `a` test", "a", "`", "`"));
+    Assert.assertEquals(10, StringUtils.indexOfIgnoreCase(0, "this is \\`a\\` test", "a", "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, "this `is \\`a` test", "a", "`", "`"));
+    Assert.assertEquals(-1, StringUtils.indexOfIgnoreCase(0, "th'is' `is` a test", "is", "`'", "`'"));
+    Assert.assertEquals(10, StringUtils.indexOfIgnoreCase(0, "this is a test", "TEST", "`", "`"));
+    Assert.assertEquals(10, StringUtils.indexOfIgnoreCase(0, "this is ``a` test", "a", "`", "`"));
+
+    try {
+      StringUtils.indexOfIgnoreCase(0, "test is a test", "a", "'", "''");
+      Assert.fail();
+    } catch (IllegalArgumentException ignored) {
+      // expected
+    }
+    try {
+      StringUtils.indexOfIgnoreCase(0, "this is a test", "a", null, null);
+      Assert.fail();
+    } catch (IllegalArgumentException ignored) {
+      // expected
+    }
+  }
+
+  @Test
+  public void splitTest() {
+    Assert.assertEquals(Lists.newArrayList(), StringUtils.split(null, ",", "`", "`"));
+    try {
+      StringUtils.split("one,two", null, "`", "`");
+      Assert.fail();
+    } catch (IllegalArgumentException ignored) {
+      // expected
+    }
+    Assert.assertEquals(Lists.newArrayList("one", "two", "three"), StringUtils.split("one,two,three", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "`two,three`"), StringUtils.split("one,`two,three`", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "{tw{o,t}hree}"), StringUtils.split("one,{tw{o,t}hree}", ",", "{", "}"));
+    Assert.assertEquals(Lists.newArrayList("one", "/*two,three*/"), StringUtils.split("one,/*two,three*/", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "-- two,three\n", "four"), StringUtils.split("one,-- two,three\n,four", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "-- two,three\r\n", "four"), StringUtils.split("one,-- two,three\r\n,four", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "#two,three\n", "four"), StringUtils.split("one,#two,three\n,four", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "--;two", "three", "four"), StringUtils.split("one,--;two,three,four", ",", "`", "`"));
+    // split doesn't use ALLOW_BACKSLASH_ESCAPE, so escaping delimiter doesn't work
+    Assert.assertEquals(Lists.newArrayList("one", "two\\", "three", "four"), StringUtils.split("one,two\\,three,four", ",", "`", "`"));
+    // the following comment is a special non-comment block, and it should be split
+    Assert.assertEquals(Lists.newArrayList("one", "/*!50110 one", " two */two", "three", "four"), StringUtils.split("one,/*!50110 one, two */two,three,four", ",", "`", "`"));
+    Assert.assertEquals(Lists.newArrayList("one", "/*!5011 one", " two */two", "three", "four"), StringUtils.split("one,/*!5011 one, two */two,three,four", ",", "`", "`"));
+  }
+}

--- a/java/jdbc/src/test/resources/extractForeignKeyForTableTestCases.sql
+++ b/java/jdbc/src/test/resources/extractForeignKeyForTableTestCases.sql
@@ -1,0 +1,145 @@
+-- The items in the below lists correspond to the following column names:
+-- PKTABLE_CAT, PKTABLE_SCHEM, PKTABLE_NAME, PKCOLUMN_NAME, FKTABLE_CAT, FKTABLE_SCHEM, FKTABLE_NAME, FKCOLUMN_NAME
+-- KEY_SEQ, UPDATE_RULE, DELETE_RULE, FK_NAME, PK_NAME, DEFERRABILITY
+
+-- Four of those columns are integers. Three other columns should always be null.
+-- The first group has 3 integers, i.e. `1, 3, 3`. This represents KEY_SEQ, UPDATE_RULE, and DELETE_RULE, in order.
+-- KEY_SEQ should increment for each column in a key, so 1 for the first, 2 for the second, etc, within a single constraint.
+-- UPDATE_RULE and DELETE_RULE correspond to one of:
+--   DatabaseMetaData.importedKeyCascade (0), importedKeyRestrict (1), importedKeySetNull (2), or importedKeyNoAction (3)
+-- The fourth integer is the last value in the list. This should be DatabaseMetaData.importedKeyNotDeferrable (7) for all cases.
+
+-- name: single fk constraint no update/delete references
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`)
+) ENGINE=InnoDB
+
+-- name: single fk reference different schema/catalog
+-- expected: [[otherCatalog, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `otherCatalog`.`fTable` (`id`)
+) ENGINE=InnoDB
+
+-- name: single fk constraint delete cascade
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 0, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB
+
+-- name: single fk constraint on update restrict
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 1, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`) ON UPDATE RESTRICT
+) ENGINE=InnoDB
+
+-- name: single fk constraint update and delete
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 2, 0, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`) ON DELETE CASCADE ON UPDATE SET NULL
+) ENGINE=InnoDB
+
+-- name: no constraint name
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, not_available, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`)
+) ENGINE=InnoDB
+
+-- name: multiple fk constraints delete cascade
+-- expected: [[test, null, fTableOne, id, test, null, testA, fIdOne, 1, 3, 0, fk_testA_fTableTwo, null, 7], [test, null, fTableTwo, id, test, null, testA, fIdTwo, 1, 3, 0, fk_testA_fTableOne, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA_fTableTwo` FOREIGN KEY (`fIdOne`) REFERENCES `fTableOne` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_testA_fTableOne` FOREIGN KEY (`fIdTwo`) REFERENCES `fTableTwo` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB
+
+-- name: multiple fk constraints and multiple columns in keys delete cascade
+-- expected: [[test, null, fTableOne, id, test, null, testA, fIdOne, 1, 3, 0, fk_testA_fTableOne, null, 7], [test, null, fTableOne, other, test, null, testA, fIdTwo, 2, 3, 0, fk_testA_fTableOne, null, 7], [test, null, fTableTwo, id, test, null, testA, fIdThree, 1, 3, 0, fk_testA_fTableTwo, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA_fTableOne` FOREIGN KEY (`fIdOne`, `fIdTwo`) REFERENCES `fTableOne` (`id`, `other`) ON DELETE CASCADE
+  CONSTRAINT `fk_testA_fTableTwo` FOREIGN KEY (`fIdThree`) REFERENCES `fTableTwo` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB
+
+-- name: single fk constraint, multiple keys
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, fk_testA, null, 7], [test, null, fTable, other, test, null, testA, fIdTwo, 2, 3, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`, `fIdTwo`) REFERENCES `fTable` (`id`, `other`)
+) ENGINE=InnoDB
+
+-- name: with index name
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY `idx_fk_testA` (`fIdOne`) REFERENCES `fTable` (`id`)
+) ENGINE=InnoDB
+
+-- name: double quote constraint name
+-- expected: [[test, null, fTable, id, test, null, testA, fIdOne, 1, 3, 3, fk_testA, null, 7]]
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT "fk_testA" FOREIGN KEY (fIdOne) REFERENCES fTable (id)
+) ENGINE=InnoDB
+
+-- name: no quotes on constraint name
+-- expected: []
+-- constraint is required to be quoted, so no match found
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT fk_testA FOREIGN KEY (fIdOne) REFERENCES fTable (id)
+) ENGINE=InnoDB

--- a/java/jdbc/src/test/resources/getImportedKeysTestCase.sql
+++ b/java/jdbc/src/test/resources/getImportedKeysTestCase.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `testA` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `fIdOne` bigint(20) unsigned NOT NULL,
+  `fIdTwo` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_testA` (`fIdOne`,`fIdTwo`),
+  CONSTRAINT `fk_testA` FOREIGN KEY (`fIdOne`) REFERENCES `fTable` (`id`)
+) ENGINE=InnoDB


### PR DESCRIPTION
This is required for external library integration, for example Liquibase. 

I ported and simplified from mysql-connector-j. I also had to port a number of StringUtils functions, which I copied verbatim. However I've gone over those functions and have 100% coverage on them in the new StringUtilsTest.java.

Much of the lines here are for the tests and test cases.

@ashudeep-sharma @harshit-gangal 
