### PR TITLE
truncate long queries in ui

### DIFF
--- a/go/vt/sqlparser/parsed_query.go
+++ b/go/vt/sqlparser/parsed_query.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/utils"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -51,8 +52,9 @@ func (pq *ParsedQuery) GenerateQuery(bindVariables map[string]interface{}) ([]by
 }
 
 // MarshalJSON is a custom JSON marshaler for ParsedQuery.
+// Note that any queries longer that 512 bytes will be truncated.
 func (pq *ParsedQuery) MarshalJSON() ([]byte, error) {
-	return json.Marshal(pq.Query)
+	return json.Marshal(utils.TruncateQuery(pq.Query))
 }
 
 // EncodeValue encodes one bind variable value into the query.

--- a/go/vt/utils/utils.go
+++ b/go/vt/utils/utils.go
@@ -10,3 +10,12 @@ func CloneBindVariables(bindVariables map[string]interface{}) map[string]interfa
 	}
 	return result
 }
+
+// Truncate all long query strings to a maximum length of 512 to keep logs
+// and debug UI output to be a sane length.
+func TruncateQuery(query string) string {
+	if (len(query) <= 512){
+		return query;
+	}
+	return query[:500] + " [TRUNCATED]";
+}

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -34,6 +34,7 @@ import (
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/txserializer"
+	"github.com/youtube/vitess/go/vt/utils"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
@@ -472,7 +473,7 @@ func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, reques
 	response.Header().Set("Content-Type", "text/plain")
 	response.Write([]byte(fmt.Sprintf("Length: %d\n", len(keys))))
 	for _, v := range keys {
-		response.Write([]byte(fmt.Sprintf("%#v\n", v)))
+		response.Write([]byte(fmt.Sprintf("%#v\n", utils.TruncateQuery(v))))
 		if plan := qe.peekQuery(v); plan != nil {
 			if b, err := json.MarshalIndent(plan.Plan, "", "  "); err != nil {
 				response.Write([]byte(err.Error()))
@@ -491,7 +492,7 @@ func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, reques
 	for _, v := range keys {
 		if plan := qe.peekQuery(v); plan != nil {
 			var pqstats perQueryStats
-			pqstats.Query = unicoded(v)
+			pqstats.Query = unicoded(utils.TruncateQuery(v))
 			pqstats.Table = plan.TableName().String()
 			pqstats.Plan = plan.PlanID
 			pqstats.QueryCount, pqstats.Time, pqstats.MysqlTime, pqstats.RowCount, pqstats.ErrorCount = plan.Stats()

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -17,6 +17,7 @@ import (
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/vt/logz"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/utils"
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 	querylogzFuncMap = template.FuncMap{
 		"stampMicro":   func(t time.Time) string { return t.Format(time.StampMicro) },
 		"cssWrappable": logz.Wrappable,
+		"truncateQuery": utils.TruncateQuery,
 		"unquote":      func(s string) string { return strings.Trim(s, "\"") },
 	}
 	querylogzTmpl = template.Must(template.New("example").Funcs(querylogzFuncMap).Parse(`
@@ -60,7 +62,7 @@ var (
 			<td>{{.MysqlResponseTime.Seconds}}</td>
 			<td>{{.WaitingForConnection.Seconds}}</td>
 			<td>{{.PlanType}}</td>
-			<td>{{.OriginalSQL | unquote | cssWrappable}}</td>
+			<td>{{.OriginalSQL | truncateQuery | unquote | cssWrappable}}</td>
 			<td>{{.NumberOfQueries}}</td>
 			<td>{{.FmtQuerySources}}</td>
 			<td>{{.RowsAffected}}</td>

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -15,6 +15,7 @@ import (
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/vt/logz"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
+	"github.com/youtube/vitess/go/vt/utils"
 )
 
 var (
@@ -137,7 +138,7 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		Value := &queryzRow{
-			Query:  logz.Wrappable(v),
+			Query:  logz.Wrappable(utils.TruncateQuery(v)),
 			Table:  plan.TableName().String(),
 			Plan:   plan.PlanID,
 			Reason: plan.Reason,


### PR DESCRIPTION
*WIP looking for feedback*

In some cases we are doing large bulk insert queries into vitess in which we put in potentially thousands of rows at a time, resulting in very long query strings (sometimes in the MBs), which ends up making the various debugging UIs unusable.

This PR adds some sanity truncation of the query strings to make the debug UIs usable albeit possibly losing some information.

Questions:
1. I somewhat arbitrarily chose 512 bytes as the truncation point. This could be customizable if that were useful.
2. Since there are cases in which we marshal data structures that have nested `sqlparser.ParsedQuery` structs, I ended up overriding `MarshalJSON` to do the truncation. This will obviously NOT work if the JSON representation of the original SQL in a query plan is needed for something other than unit tests, but I don't yet know the code base well enough to determine whether or not this is the case.


