### PR TITLE
enable refreshing config on restart of mysqlctld

### DIFF
--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -30,9 +30,8 @@ var (
 	mysqlSocket = flag.String("mysql_socket", "", "path to the mysql socket")
 
 	// mysqlctl init flags
-	waitTime           = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
-	initDBSQLFile      = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
-	allowRefreshConfig = flag.Bool("allow_refresh_config", false, "if enabled, try to update existing my.cnf from template on start")
+	waitTime      = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
+	initDBSQLFile = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
 )
 
 func init() {
@@ -87,12 +86,10 @@ func main() {
 		}
 		mysqld.OnTerm(onTermFunc)
 
-		if *allowRefreshConfig {
-			err = mysqld.RefreshConfig()
-			if err != nil {
-				log.Errorf("failed to refresh config: %v", err)
-				exit.Return(1)
-			}
+		err = mysqld.RefreshConfig()
+		if err != nil {
+			log.Errorf("failed to refresh config: %v", err)
+			exit.Return(1)
 		}
 
 		if err := mysqld.Start(ctx); err != nil {

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -30,8 +30,9 @@ var (
 	mysqlSocket = flag.String("mysql_socket", "", "path to the mysql socket")
 
 	// mysqlctl init flags
-	waitTime      = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
-	initDBSQLFile = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
+	waitTime           = flag.Duration("wait_time", 5*time.Minute, "how long to wait for mysqld startup or shutdown")
+	initDBSQLFile      = flag.String("init_db_sql_file", "", "path to .sql file to run after mysql_install_db")
+	allowRefreshConfig = flag.Bool("allow_refresh_config", false, "if enabled, try to update existing my.cnf from template on start")
 )
 
 func init() {
@@ -85,6 +86,14 @@ func main() {
 			exit.Return(1)
 		}
 		mysqld.OnTerm(onTermFunc)
+
+		if *allowRefreshConfig {
+			err = mysqld.RefreshConfig()
+			if err != nil {
+				log.Errorf("failed to refresh config: %v", err)
+				exit.Return(1)
+			}
+		}
 
 		if err := mysqld.Start(ctx); err != nil {
 			log.Errorf("failed to start mysqld: %v", err)

--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -182,6 +182,8 @@ func ReadMycnf(cnfFile string) (mycnf *Mycnf, err error) {
 	mycnf.BinLogPath = mycnf.lookupAndCheck("log-bin")
 	mycnf.MasterInfoFile = mycnf.lookupAndCheck("master-info-file")
 	mycnf.PidFile = mycnf.lookupAndCheck("pid-file")
+	mycnf.TmpDir = mycnf.lookupAndCheck("tmpdir")
+	mycnf.SlaveLoadTmpDir = mycnf.lookupAndCheck("slave_load_tmpdir")
 
 	return mycnf, nil
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -626,7 +626,7 @@ func (mysqld *Mysqld) RefreshConfig() error {
 		return fmt.Errorf("Could not read updated file %v: %v", f.Name(), err)
 	}
 
-	if res := bytes.Compare(existing, updated); res == 0 {
+	if bytes.Equal(existing, updated) {
 		log.Infof("No changes to my.cnf. Continuing.")
 		return nil
 	}


### PR DESCRIPTION
In kubernetes we keep the my.cnf in a configmap, and when changes are needed we update that and restart the pod. This way, mysqctld will regenerate the config from that template when it starts back up again.