### PR TITLE
vtclient: Allow to run queries repeatedly and in parallel (-count, -parallel).

### DIFF
--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -104,6 +104,10 @@ func main() {
 		flag.Usage()
 		exit.Return(1)
 	}
+	if len(args) > 1 {
+		fmt.Fprintln(os.Stderr, "ERROR: No additional arguments after the query allowed.")
+		exit.Return(1)
+	}
 
 	c := vitessdriver.Configuration{
 		Protocol:   *vtgateconn.VtgateProtocol,

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -9,13 +9,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	log "github.com/golang/glog"
 	"github.com/olekukonko/tablewriter"
 	"github.com/youtube/vitess/go/exit"
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vitessdriver"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 )
@@ -92,13 +92,6 @@ func newBindvars(name, usage string) *bindvars {
 	return &bv
 }
 
-// FIXME(alainjobart) this is a cheap trick. Should probably use the
-// query parser if we needed this to be 100% reliable.
-func isDml(sql string) bool {
-	lower := strings.TrimSpace(strings.ToLower(sql))
-	return strings.HasPrefix(lower, "insert") || strings.HasPrefix(lower, "update") || strings.HasPrefix(lower, "delete")
-}
-
 func main() {
 	defer exit.Recover()
 	defer logutil.Flush()
@@ -133,7 +126,7 @@ func main() {
 	startTime := time.Now()
 
 	// handle dml
-	if isDml(args[0]) {
+	if sqlparser.IsDML(args[0]) {
 		tx, err := db.Begin()
 		if err != nil {
 			log.Errorf("begin failed: %v", err)

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -27,6 +27,12 @@ Version 3 of the API is used, we do not send any hint to the server.
 
 For query bound variables, we assume place-holders in the query string
 in the form of :v1, :v2, etc.
+
+Examples:
+
+  $ vtclient -server vtgate:15991 "SELECT * FROM messages"
+
+  $ vtclient -server vtgate:15991 -tablet_type master -bind_variables '[ 12345, 1, "msg 12345" ]' "INSERT INTO messages (page,time_created_ns,message) VALUES (:v1, :v2, :v3)"
 `
 	server        = flag.String("server", "", "vtgate server to connect to")
 	tabletType    = flag.String("tablet_type", "rdonly", "tablet type to direct queries to")

--- a/go/cmd/vtclient/vtclient.go
+++ b/go/cmd/vtclient/vtclient.go
@@ -130,7 +130,7 @@ func main() {
 			exit.Return(1)
 		}
 
-		result, err := db.Exec(args[0], []interface{}(*bindVariables)...)
+		result, err := tx.Exec(args[0], []interface{}(*bindVariables)...)
 		if err != nil {
 			log.Errorf("exec failed: %v", err)
 			exit.Return(1)

--- a/go/cmd/vtclient/vtclient_test.go
+++ b/go/cmd/vtclient/vtclient_test.go
@@ -82,11 +82,6 @@ func TestVtclient(t *testing.T) {
 			rowsAffected: 1,
 		},
 		{
-			args: []string{"-tablet_type", "master", "-parallel", "10", "-count", "10",
-				"UPDATE table1 SET i = (i + 1)"},
-			rowsAffected: 100,
-		},
-		{
 			args: []string{"-tablet_type", "master",
 				"SELECT * FROM table1"},
 			rowsAffected: 1,

--- a/go/cmd/vtclient/vtclient_test.go
+++ b/go/cmd/vtclient/vtclient_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/vttest"
+
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
+	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
+)
+
+func TestVtclient(t *testing.T) {
+	topology := &vttestpb.VTTestTopology{
+		Keyspaces: []*vttestpb.Keyspace{
+			{
+				Name: "test_keyspace",
+				Shards: []*vttestpb.Shard{
+					{
+						Name: "0",
+					},
+				},
+			},
+		},
+	}
+	schema := `CREATE TABLE table1 (
+	  id BIGINT(20) UNSIGNED NOT NULL,
+	  i INT NOT NULL,
+	  PRIMARY KEY (id)
+	) ENGINE=InnoDB`
+	vschema := &vschemapb.Keyspace{
+		Sharded: true,
+		Vindexes: map[string]*vschemapb.Vindex{
+			"hash": {
+				Type: "hash",
+			},
+		},
+		Tables: map[string]*vschemapb.Table{
+			"table1": {
+				ColumnVindexes: []*vschemapb.ColumnVindex{
+					{
+						Column: "id",
+						Name:   "hash",
+					},
+				},
+			},
+		},
+	}
+
+	hdl, err := vttest.LaunchVitess(vttest.ProtoTopo(topology), vttest.Schema(schema), vttest.VSchema(vschema))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = hdl.TearDown()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	vtgateAddr, err := hdl.VtgateAddress()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queries := []struct {
+		args         []string
+		rowsAffected int64
+	}{
+		{
+			args: []string{"SELECT * FROM table1"},
+		},
+		{
+			args: []string{"-tablet_type", "master", "-bind_variables", `[ 1, 100 ]`,
+				"INSERT INTO table1 (id, i) VALUES (:v1, :v2)"},
+			rowsAffected: 1,
+		},
+		{
+			args: []string{"-tablet_type", "master",
+				"UPDATE table1 SET i = (i + 1)"},
+			rowsAffected: 1,
+		},
+		{
+			args: []string{"-tablet_type", "master", "-parallel", "10", "-count", "10",
+				"UPDATE table1 SET i = (i + 1)"},
+			rowsAffected: 100,
+		},
+		{
+			args: []string{"-tablet_type", "master",
+				"SELECT * FROM table1"},
+			rowsAffected: 1,
+		},
+		{
+			args: []string{"-tablet_type", "master", "-bind_variables", `[ 1 ]`,
+				"DELETE FROM table1 WHERE id = :v1"},
+			rowsAffected: 1,
+		},
+		{
+			args: []string{"-tablet_type", "master",
+				"SELECT * FROM table1"},
+			rowsAffected: 0,
+		},
+	}
+
+	// Change ErrorHandling from ExitOnError to panicking.
+	flag.CommandLine.Init("vtclient_test.go", flag.PanicOnError)
+	for _, q := range queries {
+		// Run main function directly and not as external process. To achieve this,
+		// overwrite os.Args which is used by flag.Parse().
+		os.Args = []string{"vtclient_test.go", "-server", vtgateAddr}
+		os.Args = append(os.Args, q.args...)
+
+		results, err := run()
+		if err != nil {
+			t.Fatalf("vtclient %v failed: %v", os.Args[1:], err)
+		}
+
+		if got, want := results.rowsAffected, q.rowsAffected; got != want {
+			t.Fatalf("wrong rows affected for query: %v got = %v, want = %v", os.Args[1:], got, want)
+		}
+	}
+}

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -38,6 +38,25 @@ type Handle struct {
 	dbname string
 }
 
+// VtgateAddress returns the address under which vtgate is reachable e.g.
+// "localhost:15991".
+// An error is returned if the data is not available.
+func (hdl *Handle) VtgateAddress() (string, error) {
+	if hdl.Data == nil {
+		return "", errors.New("Data field in Handle is empty")
+	}
+	portName := "port"
+	if vtgateProtocol() == "grpc" {
+		portName = "grpc_port"
+	}
+	fport, ok := hdl.Data[portName]
+	if !ok {
+		return "", fmt.Errorf("port %v not found in map", portName)
+	}
+	port := int(fport.(float64))
+	return fmt.Sprintf("localhost:%d", port), nil
+}
+
 // VitessOption is the type for generic options to be passed in to LaunchVitess.
 type VitessOption struct {
 	// beforeRun is executed before we start run_local_database.py.

--- a/go/vt/vttest/local_cluster_test.go
+++ b/go/vt/vttest/local_cluster_test.go
@@ -5,7 +5,6 @@
 package vttest
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -48,22 +47,13 @@ func TestVitess(t *testing.T) {
 			return
 		}
 	}()
-	if hdl.Data == nil {
-		t.Error("map is nil")
-		return
-	}
-	portName := "port"
-	if vtgateProtocol() == "grpc" {
-		portName = "grpc_port"
-	}
-	fport, ok := hdl.Data[portName]
-	if !ok {
-		t.Errorf("port %v not found in map", portName)
-		return
-	}
-	port := int(fport.(float64))
 	ctx := context.Background()
-	conn, err := vtgateconn.DialProtocol(ctx, vtgateProtocol(), fmt.Sprintf("localhost:%d", port), 5*time.Second, "")
+	vtgateAddr, err := hdl.VtgateAddress()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	conn, err := vtgateconn.DialProtocol(ctx, vtgateProtocol(), vtgateAddr, 5*time.Second, "")
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
I've used this new functionality to verify manually that the hot row protection is working as intended.

Other changes:
- Fixed DML mode.
- Added unit test which uses the "vttest" package and a real MySQL instance (test takes 8s).
- Refactored vtclient code.
- Added VSchema() option to "vttest" package.