### PR TITLE
vttablet: Fix mentioned hot row protection debug URL in comments.

### DIFF
--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -152,7 +152,7 @@ func (t *TxSerializer) lockLocked(ctx context.Context, key, table string) (bool,
 	if q.size > q.max {
 		q.max = q.size
 	}
-	// Publish the number of waits at /hotrows.
+	// Publish the number of waits at /debug/hotrows.
 	t.Record(key)
 	if q.size == 2 {
 		// Include first transaction in the count. (It was not recorded on purpose

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -95,7 +95,7 @@ func waitForPending(txs *TxSerializer, key string, i int) error {
 }
 
 func testHTTPHandler(txs *TxSerializer, count int) error {
-	req, err := http.NewRequest("GET", "/hotrows", nil)
+	req, err := http.NewRequest("GET", "/path-is-ignored-in-test", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's /debug/hotrows and not /hotrows.