### PR TITLE
test: local_example.sh: trap on EXIT as well.

### DIFF
--- a/test/local_example.sh
+++ b/test/local_example.sh
@@ -24,7 +24,7 @@ teardown() {
   wait
   exit $exitcode
 }
-trap teardown SIGTERM SIGINT
+trap teardown SIGTERM SIGINT EXIT
 
 # Set up servers.
 timeout $timeout ./zk-up.sh || teardown


### PR DESCRIPTION
This way a manual "exit 0" in the script (e.g. during manual debugging) will trigger a teardown as well.