### PR TITLE
travis/install_grpc.sh: Fix system wide installation.

### DIFF
--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -33,6 +33,7 @@ if [ -n "$grpc_dist" ]; then
   $PIP install --upgrade pip
   $PIP install --upgrade --ignore-installed virtualenv
 else
+  PIP=pip
   $PIP install --upgrade pip
   # System wide installations require an explicit upgrade of
   # certain gRPC Python dependencies e.g. "six" on Debian Jessie.


### PR DESCRIPTION
This type of installation is used when generating the bootstrap images.

The variable "PIP" was not defined. We recently changed that script to allow for binaries "pip2" on systems where Python 3 is the default.