### PR TITLE
go tool yacc -> goyacc changes for golang1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 	go install $(VT_GO_PARALLEL) -ldflags "$(tools/build_version_flags.sh)" ./go/...
 
 parser:
-	goyacc -o ./go/vt/sqlparser/sql.go -v ./go/vt/sqlparser/sql.output ./go/vt/sqlparser/sql.y
+	make -C go/vt/sqlparser
 
 # To pass extra flags, run test.go manually.
 # For example: go run test.go -docker=false -- --extra-flag

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ ifndef NOBANNER
 endif
 	go install $(VT_GO_PARALLEL) -ldflags "$(tools/build_version_flags.sh)" ./go/...
 
+parser:
+	goyacc -o ./go/vt/sqlparser/sql.go -v ./go/vt/sqlparser/sql.output ./go/vt/sqlparser/sql.y
+
 # To pass extra flags, run test.go manually.
 # For example: go run test.go -docker=false -- --extra-flag
 # For more info see: go run test.go -help

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -136,6 +136,7 @@ gotools=" \
        github.com/golang/mock/mockgen \
        github.com/kardianos/govendor \
        golang.org/x/tools/cmd/goimports \
+       golang.org/x/tools/cmd/goyacc \
        honnef.co/go/tools/cmd/unused \
 "
 


### PR DESCRIPTION
since we need goyacc in compilation for parser changes, add it to bootstrap.sh
also, for convenience, 'make parser' will now call goyacc with the usual incantation