### PR TITLE
java/client: Wait until the "vtgateclienttest" binary responds to RPC…

### DIFF
--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
@@ -144,7 +144,6 @@ public class GrpcClientTlsClientAuthTest extends RpcClientTest {
                 vtRoot + "/bin/vtgateclienttest", cert, key, caCert, Integer.toString(port));
         System.out.println(vtgateCommand);
         vtgateclienttest = new ProcessBuilder(vtgateCommand.split(" ")).inheritIO().start();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
     }
 
     private static void createClientConnection() throws Exception {

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
@@ -132,7 +132,6 @@ public class GrpcClientTlsTest extends RpcClientTest {
         );
         System.out.println(vtgate);
         vtgateclienttest = new ProcessBuilder().inheritIO().command(vtgate.split(" ")).start();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
     }
 
     private static void createClientConnection() throws Exception {


### PR DESCRIPTION
…s before starting the test.

This fixes flakiness seen on Travis where starting the binary takes longer and the test fails with "Connection refused" errors.

Nominating @steve-perkins as reviewer.