### PR TITLE
java: Fix import order.

### DIFF
--- a/java/client/src/main/java/io/vitess/client/Context.java
+++ b/java/client/src/main/java/io/vitess/client/Context.java
@@ -1,11 +1,9 @@
 package io.vitess.client;
 
 import io.vitess.proto.Vtrpc.CallerID;
-
+import javax.annotation.Nullable;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
-
-import javax.annotation.Nullable;
 
 /**
  * Context is an immutable object that carries per-request info.

--- a/java/client/src/main/java/io/vitess/client/Proto.java
+++ b/java/client/src/main/java/io/vitess/client/Proto.java
@@ -16,8 +16,6 @@ import io.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
 import io.vitess.proto.Vtgate.BoundShardQuery;
 import io.vitess.proto.Vtgate.ExecuteEntityIdsRequest.EntityId;
 import io.vitess.proto.Vtrpc.RPCError;
-
-import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -30,6 +28,7 @@ import java.sql.SQLTransientException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Proto contains methods for working with Vitess protobuf messages.

--- a/java/client/src/main/java/io/vitess/client/RpcClient.java
+++ b/java/client/src/main/java/io/vitess/client/RpcClient.java
@@ -1,7 +1,6 @@
 package io.vitess.client;
 
 import com.google.common.util.concurrent.ListenableFuture;
-
 import io.vitess.proto.Query.QueryResult;
 import io.vitess.proto.Vtgate;
 import io.vitess.proto.Vtgate.BeginRequest;
@@ -32,7 +31,6 @@ import io.vitess.proto.Vtgate.StreamExecuteKeyRangesRequest;
 import io.vitess.proto.Vtgate.StreamExecuteKeyspaceIdsRequest;
 import io.vitess.proto.Vtgate.StreamExecuteRequest;
 import io.vitess.proto.Vtgate.StreamExecuteShardsRequest;
-
 import java.io.Closeable;
 import java.sql.SQLException;
 

--- a/java/client/src/main/java/io/vitess/client/SQLFuture.java
+++ b/java/client/src/main/java/io/vitess/client/SQLFuture.java
@@ -2,7 +2,6 @@ package io.vitess.client;
 
 import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture;
 import com.google.common.util.concurrent.ListenableFuture;
-
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.SQLException;

--- a/java/client/src/main/java/io/vitess/client/VTGateBlockingConn.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateBlockingConn.java
@@ -10,14 +10,13 @@ import io.vitess.proto.Topodata.TabletType;
 import io.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
 import io.vitess.proto.Vtgate.BoundShardQuery;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
-
-import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A synchronous wrapper around a VTGate connection.

--- a/java/client/src/main/java/io/vitess/client/VTGateBlockingTx.java
+++ b/java/client/src/main/java/io/vitess/client/VTGateBlockingTx.java
@@ -7,11 +7,10 @@ import io.vitess.proto.Topodata.KeyRange;
 import io.vitess.proto.Topodata.TabletType;
 import io.vitess.proto.Vtgate.BoundKeyspaceIdQuery;
 import io.vitess.proto.Vtgate.BoundShardQuery;
-
-import javax.annotation.Nullable;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * A synchronous wrapper around a VTGate transaction.

--- a/java/client/src/main/java/io/vitess/client/cursor/Cursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/Cursor.java
@@ -4,12 +4,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.vitess.proto.Query.Field;
 import io.vitess.proto.Query.QueryResult;
-
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.List;
-
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 

--- a/java/client/src/main/java/io/vitess/client/cursor/FieldMap.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/FieldMap.java
@@ -4,15 +4,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
-
 import io.vitess.proto.Query.Field;
-
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
-
 import java.util.List;
 import java.util.Map;
-
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 /**
  * A wrapper for {@code List<Field>} that also facilitates lookup by field name.

--- a/java/client/src/main/java/io/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/Row.java
@@ -145,7 +145,7 @@ public class Row {
 
   /**
    * Returns the raw {@link ByteString} for a column.
-   * 
+   *
    * @param columnLabel case-insensitive column label
    */
   public ByteString getRawValue(String columnLabel) throws SQLException {
@@ -513,14 +513,14 @@ public class Row {
    * distinguish between 0 and SQL NULL. For example:
    *
    * <blockquote>
-   * 
+   *
    * <pre>
    * Long value = row.getObject(0, Long.class);
    * if (value == null) {
    *   // The value was SQL NULL, not 0.
    * }
    * </pre>
-   * 
+   *
    * </blockquote>
    *
    * @param columnIndex 1-based column number (0 is invalid)
@@ -544,14 +544,14 @@ public class Row {
    * distinguish between 0 and SQL NULL. For example:
    *
    * <blockquote>
-   * 
+   *
    * <pre>
    * Long value = row.getObject("col0", Long.class);
    * if (value == null) {
    *   // The value was SQL NULL, not 0.
    * }
    * </pre>
-   * 
+   *
    * </blockquote>
    *
    * @param columnLabel case-insensitive column label

--- a/java/client/src/main/java/io/vitess/client/cursor/SimpleCursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/SimpleCursor.java
@@ -3,11 +3,9 @@ package io.vitess.client.cursor;
 import io.vitess.proto.Query;
 import io.vitess.proto.Query.Field;
 import io.vitess.proto.Query.QueryResult;
-
 import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.List;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**

--- a/java/client/src/main/java/io/vitess/client/cursor/StreamCursor.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/StreamCursor.java
@@ -4,13 +4,11 @@ import io.vitess.client.StreamIterator;
 import io.vitess.proto.Query;
 import io.vitess.proto.Query.Field;
 import io.vitess.proto.Query.QueryResult;
-
 import java.sql.SQLDataException;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Iterator;
 import java.util.List;
-
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**

--- a/java/client/src/main/java/io/vitess/mysql/DateTime.java
+++ b/java/client/src/main/java/io/vitess/mysql/DateTime.java
@@ -1,7 +1,6 @@
 package io.vitess.mysql;
 
 import com.google.common.math.IntMath;
-
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;

--- a/java/client/src/test/java/io/vitess/client/BindVarTest.java
+++ b/java/client/src/test/java/io/vitess/client/BindVarTest.java
@@ -6,15 +6,13 @@ import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import io.vitess.proto.Query;
 import io.vitess.proto.Query.BindVariable;
-
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
 public class BindVarTest {

--- a/java/client/src/test/java/io/vitess/client/EntityIdTest.java
+++ b/java/client/src/test/java/io/vitess/client/EntityIdTest.java
@@ -6,14 +6,12 @@ import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import io.vitess.proto.Query;
 import io.vitess.proto.Vtgate.ExecuteEntityIdsRequest.EntityId;
-
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
 public class EntityIdTest {

--- a/java/client/src/test/java/io/vitess/client/ProtoTest.java
+++ b/java/client/src/test/java/io/vitess/client/ProtoTest.java
@@ -1,12 +1,11 @@
 package io.vitess.client;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.Map;
 
 @RunWith(JUnit4.class)
 public class ProtoTest {

--- a/java/client/src/test/java/io/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/io/vitess/client/RpcClientTest.java
@@ -16,12 +16,6 @@ import io.vitess.proto.Topodata.SrvKeyspace.KeyspacePartition;
 import io.vitess.proto.Topodata.TabletType;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
 import io.vitess.proto.Vtrpc.CallerID;
-
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
@@ -36,6 +30,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * RpcClientTest tests a given implementation of RpcClient against a mock vtgate server

--- a/java/client/src/test/java/io/vitess/client/TestEnv.java
+++ b/java/client/src/test/java/io/vitess/client/TestEnv.java
@@ -1,14 +1,12 @@
 package io.vitess.client;
 
-import org.apache.commons.io.FileUtils;
-
-import vttest.Vttest.VTTestTopology;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
+import vttest.Vttest.VTTestTopology;
 
 /**
  * Helper class to hold the configurations for VtGate setup used in integration tests

--- a/java/client/src/test/java/io/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/io/vitess/client/TestUtil.java
@@ -5,12 +5,6 @@ import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import io.vitess.proto.Query;
 import io.vitess.proto.Topodata.TabletType;
-
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.joda.time.Duration;
-import org.junit.Assert;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
@@ -18,7 +12,10 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.joda.time.Duration;
+import org.junit.Assert;
 import vttest.Vttest.VTTestTopology;
 
 public class TestUtil {

--- a/java/client/src/test/java/io/vitess/mysql/DateTimeTest.java
+++ b/java/client/src/test/java/io/vitess/mysql/DateTimeTest.java
@@ -4,10 +4,6 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.sql.Date;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -15,6 +11,9 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DateTimeTest {

--- a/java/example/src/main/java/io/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/io/vitess/example/VitessClientExample.java
@@ -12,13 +12,11 @@ import io.vitess.client.cursor.Row;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.proto.Query;
 import io.vitess.proto.Topodata.TabletType;
-
-import org.joda.time.Duration;
-import org.joda.time.Instant;
-
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.Random;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 
 /**
  * VitessClientExample.java is a sample for using the Vitess low-level Java Client.

--- a/java/example/src/main/java/io/vitess/example/VitessJDBCExample.java
+++ b/java/example/src/main/java/io/vitess/example/VitessJDBCExample.java
@@ -1,7 +1,5 @@
 package io.vitess.example;
 
-import org.joda.time.Instant;
-
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -10,6 +8,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Random;
+import org.joda.time.Instant;
 
 /**
  * Created by harshit.gangal on 10/03/16.

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClient.java
@@ -3,11 +3,13 @@ package io.vitess.client.grpc;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import io.vitess.proto.Query.QueryResult;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
 import io.vitess.client.Context;
 import io.vitess.client.Proto;
 import io.vitess.client.RpcClient;
 import io.vitess.client.StreamIterator;
+import io.vitess.proto.Query.QueryResult;
 import io.vitess.proto.Vtgate;
 import io.vitess.proto.Vtgate.BeginRequest;
 import io.vitess.proto.Vtgate.BeginResponse;
@@ -44,10 +46,6 @@ import io.vitess.proto.Vtgate.StreamExecuteShardsResponse;
 import io.vitess.proto.grpc.VitessGrpc;
 import io.vitess.proto.grpc.VitessGrpc.VitessFutureStub;
 import io.vitess.proto.grpc.VitessGrpc.VitessStub;
-import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
-import org.joda.time.Duration;
-
 import java.io.IOException;
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -58,6 +56,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLTimeoutException;
 import java.sql.SQLTransientException;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.Duration;
 
 /**
  * GrpcClient is a gRPC-based implementation of Vitess Rpcclient.

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -9,7 +9,6 @@ import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.RpcClientFactory;
 import io.vitess.client.grpc.tls.TlsOptions;
-import javax.net.ssl.SSLException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -24,6 +23,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
+import javax.net.ssl.SSLException;
 
 /**
  * GrpcClientFactory creates RpcClients with the gRPC implementation.

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTest.java
@@ -3,15 +3,14 @@ package io.client.grpc;
 import io.vitess.client.Context;
 import io.vitess.client.RpcClientTest;
 import io.vitess.client.grpc.GrpcClientFactory;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Arrays;
 import org.joda.time.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-import java.util.Arrays;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest).

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
@@ -5,18 +5,17 @@ import io.vitess.client.Context;
 import io.vitess.client.RpcClientTest;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.client.grpc.tls.TlsOptions;
-import org.joda.time.Duration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.Duration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest), over an SSL connection with client

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
@@ -5,18 +5,17 @@ import io.vitess.client.Context;
 import io.vitess.client.RpcClientTest;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.client.grpc.tls.TlsOptions;
-import org.joda.time.Duration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
+import org.joda.time.Duration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest), over an SSL connection.

--- a/java/hadoop/src/main/java/io/vitess/hadoop/RowWritable.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/RowWritable.java
@@ -6,9 +6,6 @@ import com.google.gson.Gson;
 import io.vitess.client.cursor.Row;
 import io.vitess.proto.Query;
 import io.vitess.proto.Query.Field;
-
-import org.apache.hadoop.io.Writable;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -16,6 +13,7 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.hadoop.io.Writable;
 
 public class RowWritable implements Writable {
   private Row row;

--- a/java/hadoop/src/main/java/io/vitess/hadoop/VitessConf.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/VitessConf.java
@@ -3,10 +3,8 @@ package io.vitess.hadoop;
 import io.vitess.client.RpcClientFactory;
 import io.vitess.proto.Query;
 import io.vitess.proto.Query.SplitQueryRequest;
-
-import org.apache.hadoop.conf.Configuration;
-
 import java.util.Collection;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * Collection of configuration properties used for {@link VitessInputFormat}

--- a/java/hadoop/src/main/java/io/vitess/hadoop/VitessInputFormat.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/VitessInputFormat.java
@@ -10,7 +10,13 @@ import io.vitess.client.RpcClientFactory;
 import io.vitess.client.VTGateBlockingConn;
 import io.vitess.proto.Query.SplitQueryRequest.Algorithm;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
-
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -19,14 +25,6 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.joda.time.Duration;
-
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
 
 /**
  * {@link VitessInputFormat} is the {@link org.apache.hadoop.mapreduce.InputFormat} for tables in

--- a/java/hadoop/src/main/java/io/vitess/hadoop/VitessInputSplit.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/VitessInputSplit.java
@@ -2,12 +2,11 @@ package io.vitess.hadoop;
 
 import com.google.common.io.BaseEncoding;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
-import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.mapreduce.InputSplit;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputSplit;
 
 public class VitessInputSplit extends InputSplit implements Writable {
   private String[] locations;

--- a/java/hadoop/src/main/java/io/vitess/hadoop/VitessRecordReader.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/VitessRecordReader.java
@@ -11,19 +11,17 @@ import io.vitess.proto.Query;
 import io.vitess.proto.Query.BoundQuery;
 import io.vitess.proto.Topodata.TabletType;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
-
-import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.RecordReader;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.joda.time.Duration;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.joda.time.Duration;
 
 public class VitessRecordReader extends RecordReader<NullWritable, RowWritable> {
   private VitessInputSplit split;

--- a/java/hadoop/src/test/java/io/vitess/hadoop/MapReduceIT.java
+++ b/java/hadoop/src/test/java/io/vitess/hadoop/MapReduceIT.java
@@ -6,9 +6,15 @@ import com.google.gson.reflect.TypeToken;
 import io.vitess.client.TestEnv;
 import io.vitess.client.TestUtil;
 import io.vitess.proto.Query.SplitQueryRequest.Algorithm;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 import junit.extensions.TestSetup;
 import junit.framework.TestSuite;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -21,18 +27,9 @@ import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.Reducer;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-
 import vttest.Vttest.Keyspace;
 import vttest.Vttest.Shard;
 import vttest.Vttest.VTTestTopology;
-
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
 
 
 

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessMariaDBDatabaseMetadata.java
@@ -1,5 +1,7 @@
 package io.vitess.jdbc;
 
+import io.vitess.proto.Query;
+import io.vitess.util.Constants;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -7,8 +9,6 @@ import java.sql.RowIdLifetime;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
-import io.vitess.proto.Query;
-import io.vitess.util.Constants;
 
 /**
  * Created by ashudeep.sharma on 15/02/16.

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessMySQLDatabaseMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessMySQLDatabaseMetadata.java
@@ -1,5 +1,9 @@
 package io.vitess.jdbc;
 
+import com.google.common.annotations.VisibleForTesting;
+import io.vitess.proto.Query;
+import io.vitess.util.Constants;
+import io.vitess.util.MysqlDefs;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -18,12 +22,7 @@ import java.util.SortedMap;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.logging.Logger;
-
 import org.apache.commons.lang.StringUtils;
-import com.google.common.annotations.VisibleForTesting;
-import io.vitess.proto.Query;
-import io.vitess.util.Constants;
-import io.vitess.util.MysqlDefs;
 
 /**
  * Created by ashudeep.sharma on 15/02/16.

--- a/java/jdbc/src/main/java/io/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/io/vitess/util/MysqlDefs.java
@@ -1,7 +1,6 @@
 package io.vitess.util;
 
 import io.vitess.proto.Query;
-
 import java.sql.Connection;
 import java.sql.Types;
 import java.util.HashMap;

--- a/java/jdbc/src/test/java/io/vitess/jdbc/BaseTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/BaseTest.java
@@ -1,9 +1,9 @@
 package io.vitess.jdbc;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
 import java.sql.SQLException;
 import java.util.Properties;
+import org.junit.Assert;
+import org.junit.BeforeClass;
 
 public class BaseTest {
     String dbURL = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace";

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -3,14 +3,13 @@ package io.vitess.jdbc;
 import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class ConnectionPropertiesTest {
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
@@ -3,6 +3,8 @@ package io.vitess.jdbc;
 import io.vitess.proto.Query;
 import io.vitess.util.MysqlDefs;
 import io.vitess.util.charset.CharsetMapping;
+import java.sql.SQLException;
+import java.sql.Types;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -11,9 +13,6 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.sql.SQLException;
-import java.sql.Types;
 
 @PrepareForTest(FieldWithMetadata.class)
 @RunWith(PowerMockRunner.class)

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessConnectionTest.java
@@ -7,15 +7,14 @@ import io.vitess.client.VTGateTx;
 import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.powermock.api.mockito.PowerMockito;
-
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
 
 /**
  * Created by harshit.gangal on 19/01/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessDatabaseMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessDatabaseMetadataTest.java
@@ -1,5 +1,12 @@
 package io.vitess.jdbc;
 
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
+import com.google.protobuf.ByteString;
+import io.vitess.client.cursor.Cursor;
+import io.vitess.client.cursor.SimpleCursor;
+import io.vitess.proto.Query;
+import io.vitess.util.Constants;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -12,20 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import com.google.common.base.Charsets;
-import com.google.common.io.CharStreams;
-import com.google.protobuf.ByteString;
-import io.vitess.client.cursor.Cursor;
-import io.vitess.client.cursor.SimpleCursor;
-import io.vitess.proto.Query;
-import io.vitess.util.Constants;
 
 /**
  * Created by ashudeep.sharma on 08/03/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessDriverTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessDriverTest.java
@@ -1,14 +1,13 @@
 package io.vitess.jdbc;
 
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Properties;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Created by harshit.gangal on 19/01/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessJDBCUrlTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessJDBCUrlTest.java
@@ -2,11 +2,10 @@ package io.vitess.jdbc;
 
 import io.vitess.proto.Topodata;
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.sql.SQLException;
 import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Created by naveen.nahata on 18/02/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessParameterMetaDataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessParameterMetaDataTest.java
@@ -1,5 +1,8 @@
 package io.vitess.jdbc;
 
+import java.sql.ParameterMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -7,9 +10,6 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import java.sql.ParameterMetaData;
-import java.sql.SQLException;
-import java.sql.Types;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(VitessParameterMetaData.class)

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessPreparedStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessPreparedStatementTest.java
@@ -11,14 +11,6 @@ import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import io.vitess.proto.Vtrpc;
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Matchers;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.sql.BatchUpdateException;
@@ -34,6 +26,13 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 
 /**

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetMetadataTest.java
@@ -3,14 +3,13 @@ package io.vitess.jdbc;
 import io.vitess.proto.Query;
 import io.vitess.util.Constants;
 import io.vitess.util.charset.CharsetMapping;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Created by ashudeep.sharma on 08/02/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetTest.java
@@ -7,6 +7,12 @@ import io.vitess.proto.Query;
 import io.vitess.util.MysqlDefs;
 import io.vitess.util.StringUtils;
 import io.vitess.util.charset.CharsetMapping;
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,13 +21,6 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import java.io.UnsupportedEncodingException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.sql.SQLException;
-import java.sql.Time;
-import java.sql.Timestamp;
 
 /**
  * Created by harshit.gangal on 19/01/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
@@ -10,14 +10,6 @@ import io.vitess.proto.Query;
 import io.vitess.proto.Topodata;
 import io.vitess.proto.Vtrpc;
 import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Matchers;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
 import java.lang.reflect.Field;
 import java.sql.BatchUpdateException;
 import java.sql.ResultSet;
@@ -25,6 +17,13 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * Created by harshit.gangal on 19/01/16.

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -5,16 +5,15 @@ import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConn;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.proto.Vtrpc;
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.sql.SQLException;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Created by naveen.nahata on 29/02/16.

--- a/java/jdbc/src/test/java/io/vitess/util/StringUtilsTest.java
+++ b/java/jdbc/src/test/java/io/vitess/util/StringUtilsTest.java
@@ -1,9 +1,8 @@
 package io.vitess.util;
 
+import com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.collect.Lists;
 
 public class StringUtilsTest {
 


### PR DESCRIPTION
The Google Java Style Guide requires exactly one block for all non-static imports: https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing