### PR TITLE
java/jdbc: Change the artifactId to "jdbc".

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>client</artifactId>
+  <artifactId>vitess-client</artifactId>
 
   <dependencies>
     <dependency>

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -8,22 +8,22 @@
     <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>example</artifactId>
+  <artifactId>vitess-example</artifactId>
 
   <dependencies>
     <dependency>
       <groupId>io.vitess</groupId>
-      <artifactId>vitess-connector-java</artifactId>
+      <artifactId>vitess-jdbc</artifactId>
       <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
-      <artifactId>client</artifactId>
+      <artifactId>vitess-client</artifactId>
       <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
-      <artifactId>grpc-client</artifactId>
+      <artifactId>vitess-grpc-client</artifactId>
       <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -8,17 +8,17 @@
     <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>grpc-client</artifactId>
+  <artifactId>vitess-grpc-client</artifactId>
 
   <dependencies>
     <dependency>
       <groupId>io.vitess</groupId>
-      <artifactId>client</artifactId>
+      <artifactId>vitess-client</artifactId>
       <version>1.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
-      <artifactId>client</artifactId>
+      <artifactId>vitess-client</artifactId>
       <version>1.1.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/java/hadoop/pom.xml
+++ b/java/hadoop/pom.xml
@@ -9,24 +9,24 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>hadoop</artifactId>
+    <artifactId>vitess-hadoop</artifactId>
 
     <dependencies>
       <dependency>
         <groupId>io.vitess</groupId>
-        <artifactId>client</artifactId>
+        <artifactId>vitess-client</artifactId>
         <version>1.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId>
-        <artifactId>client</artifactId>
+        <artifactId>vitess-client</artifactId>
         <version>1.1.0-SNAPSHOT</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId>
-        <artifactId>grpc-client</artifactId>
+        <artifactId>vitess-grpc-client</artifactId>
         <version>1.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -11,7 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.vitess</groupId>
-    <artifactId>vitess-connector-java</artifactId>
+    <artifactId>vitess-jdbc</artifactId>
 
     <dependencies>
         <dependency>
@@ -31,12 +31,12 @@
         </dependency>
         <dependency>
             <groupId>io.vitess</groupId>
-            <artifactId>client</artifactId>
+            <artifactId>vitess-client</artifactId>
             <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.vitess</groupId>
-            <artifactId>grpc-client</artifactId>
+            <artifactId>vitess-grpc-client</artifactId>
             <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,6 +10,8 @@
     <url>https://github.com/youtube/vitess/</url>
     <description>Umbrella project for all Java activities for Vitess</description>
     <inceptionYear>2014</inceptionYear>
+    <!-- NOTE: The artifactId of each module has the prefix "vitess-".
+         For example, for the JDBC driver it is "vitess-jdbc". -->
     <modules>
         <module>client</module>
         <module>example</module>


### PR DESCRIPTION
This aligns the configuration with the other Maven configurations which also use the directory name as artifactId.

After this change, the Eclipse project will change from the old name "vitess-connector-java" to "jdbc".

There are probably other places as well where this name is relevant.