### PR TITLE
java/client: Variable declarations should declare only one variable.

### DIFF
--- a/java/client/src/main/java/io/vitess/mysql/DateTime.java
+++ b/java/client/src/main/java/io/vitess/mysql/DateTime.java
@@ -84,7 +84,10 @@ public class DateTime {
     // MySQL TIME can be negative and have hours > 24,
     // because it can also represent elapsed time.
     // So we just parse the integers rather than using DateFormat.
-    long hours = 0, minutes = 0, seconds = 0, millis = 0;
+    long hours = 0;
+    long minutes = 0;
+    long seconds = 0;
+    long millis = 0;
 
     try {
       // Hours


### PR DESCRIPTION
See also: https://google.github.io/styleguide/javaguide.html#s4.8.2-variable-declarations

This was found by our internal lint tools.