### PR TITLE
java: Dedup the version string in all Maven configurations.

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>client</artifactId>

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>example</artifactId>
@@ -14,17 +14,17 @@
     <dependency>
       <groupId>io.vitess</groupId>
       <artifactId>vitess-connector-java</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
       <artifactId>client</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
       <artifactId>grpc-client</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>${project.version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>grpc-client</artifactId>
@@ -14,12 +14,12 @@
     <dependency>
       <groupId>io.vitess</groupId>
       <artifactId>client</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vitess</groupId>
       <artifactId>client</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>

--- a/java/hadoop/pom.xml
+++ b/java/hadoop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vitess-parent</artifactId>
         <groupId>io.vitess</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>${project.version}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,19 +15,19 @@
       <dependency>
         <groupId>io.vitess</groupId>
         <artifactId>client</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId>
         <artifactId>client</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>${project.version}</version>
         <type>test-jar</type>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.vitess</groupId>
         <artifactId>grpc-client</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>vitess-parent</artifactId>
         <groupId>io.vitess</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>${project.version}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -32,12 +32,12 @@
         <dependency>
             <groupId>io.vitess</groupId>
             <artifactId>client</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.vitess</groupId>
             <artifactId>grpc-client</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>


### PR DESCRIPTION
After this change, the version is defined in a single place in the Maven config.