### PR TITLE
java/client: Remove "pluginRepositories" section from the Maven config.

### DIFF
--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -37,20 +37,6 @@
     </dependency>
   </dependencies>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <releases>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>central</id>
-      <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </pluginRepository>
-  </pluginRepositories>
-
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
It has been there since the beginning but no explanation why we need it.
Our other modules don't have this section. Therefore, I assume that we
don't need it.