### PR TITLE
travis: Increase the Travis per test timeout from 5 to 8 minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,13 @@ env:
     # As of 07/2015 this value works best in a Travis CI container.
     - VT_GO_PARALLEL_VALUE=4
     - PATH="$HOME/.phpenv/bin:$PATH"
-    # Add -follow to TEST_FLAGS below to print as the test runs, to diagnose stuck tests.
-    - TEST_FLAGS="-docker=false -timeout=5m -print-log -remote-stats=http://enisoc.com:15123/travis/stats"
+    # Note: The per test timeout must always be < 10 minutes because test.go
+    #       does not produce any log output while running and Travis kills a
+    #       build after 10 minutes without log output.
+    #       See: https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts
+    # To diagnose stuck tests, add "-follow" to TEST_FLAGS below. Then test.go
+    # will print the test's output.
+    - TEST_FLAGS="-docker=false -timeout=8m -print-log -remote-stats=http://enisoc.com:15123/travis/stats"
     - CC=gcc-4.8
     - CXX=g++-4.8
     # TODO: uncomment when php crashing is fixed


### PR DESCRIPTION
This is necessary because the "backup" test exceeded 5 minutes occasionally in the past.

BUG=36712757