### PR TITLE
travis: Exclude more generated Java files from the Travis cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,13 @@ before_cache:
   # Delete these files because they keep changing (having the latest timestamp
   # of an update) and trigger a lengthy update of the cache (~25 seconds).
   - rm $HOME/.m2/repository/io/vitess/*/maven-metadata-local.xml
-  - rm $HOME/.m2/repository/io/vitess/*/*-SNAPSHOT/*-SNAPSHOT.jar
+  - rm $HOME/.m2/repository/io/vitess/*/*-SNAPSHOT/*-SNAPSHOT*.jar
   - rm $HOME/.m2/repository/io/vitess/*/*-SNAPSHOT/_remote.repositories
   - rm $HOME/.m2/repository/io/vitess/*/*-SNAPSHOT/maven-metadata-local.xml
   - rm $HOME/.m2/repository/io/vitess/*/*-SNAPSHOT/resolver-status.properties
+  - rm $HOME/.m2/repository/io/grpc/grpc-core/resolver-status.properties
   - rm $HOME/.m2/repository/io/grpc/protoc-gen-grpc-java/*/protoc-gen-grpc-java-*.pom.lastUpdated
+  - rm $HOME/.m2/repository/io/netty/netty-codec-http2/resolver-status.properties
   # Don't cache unnecessary PHP files.
   - rm $HOME/.phpenv/versions/*/sbin/*
   - rm $HOME/.phpenv/versions/*/bin/php-cgi


### PR DESCRIPTION
These files unnecessarily trigger an update of the cache which prolongs the test build by ~30 seconds.

I had to generalize the path for the SNAPSHOT jar files because these two files were not matched:
- $HOME/.m2/repository/io/vitess/vitess-client/1.1.0-SNAPSHOT/vitess-client-1.1.0-SNAPSHOT-tests.jar
- $HOME/.m2/repository/io/vitess/vitess-jdbc/1.1.0-SNAPSHOT/vitess-jdbc-1.1.0-SNAPSHOT-fatjar.jar