### PR TITLE
Remove unnecessary port forwarding steps.

### DIFF
--- a/test/cluster/sandbox/example_sandbox.yaml
+++ b/test/cluster/sandbox/example_sandbox.yaml
@@ -22,6 +22,7 @@ sandbox:
   application:
     vtgate_count: 1
     enable_orchestrator: True
+    enable_guestbook: True
     etcd_count: 3
     cells:
       - test1
@@ -40,10 +41,6 @@ sandbox:
     mysql_cpu: 500m
     vtgate_ram: 512Mi
     vtgate_cpu: 500m
-    port_forwarding:
-      vtgate: 15001
-      vtctld: 15000
-      guestbook: 80
     backup_flags:
       backup_storage_implementation: gcs
       gcs_backup_storage_bucket: 'my-builtin-backup'

--- a/test/cluster/sandbox/vitess_kubernetes_sandbox.py
+++ b/test/cluster/sandbox/vitess_kubernetes_sandbox.py
@@ -27,30 +27,13 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
   def __init__(self, sandbox_options):
     super(VitessKubernetesSandbox, self).__init__(sandbox_options)
 
-  def generate_firewall_sandlet(self):
-    """Generates sandlet for firewall rules."""
-    firewall_sandlet = sandlet.Sandlet('firewall')
-
-    if 'vtctld' in self.app_options.port_forwarding:
-      firewall_sandlet.components.add_component(
-          self.cluster_env.Port('%s-vtctld' % self.name,
-                                self.app_options.port_forwarding['vtctld']))
-    if 'vtgate' in self.app_options.port_forwarding:
-      for cell in self.app_options.cells:
-        firewall_sandlet.components.add_component(
-            self.cluster_env.Port('%s-vtgate-%s' % (self.name, cell),
-                                  self.app_options.port_forwarding['vtgate']))
-    if 'guestbook' in self.app_options.port_forwarding:
-      firewall_sandlet.components.add_component(
-          self.cluster_env.Port('%s-guestbook' % self.name,
-                                self.app_options.port_forwarding['guestbook']))
-    self.sandlets.add_component(firewall_sandlet)
-
   def generate_guestbook_sandlet(self):
     """Creates a sandlet encompassing the guestbook app built on Vitess."""
     guestbook_sandlet = sandlet.Sandlet('guestbook')
     guestbook_sandlet.dependencies = ['helm']
     template_dir = os.path.join(os.environ['VTTOP'], 'examples/kubernetes')
+    guestbook_sandlet.components.add_component(
+        self.cluster_env.Port('%s-guestbook' % self.name, 80))
     for keyspace in self.app_options.keyspaces:
       create_schema_subprocess = subprocess_component.Subprocess(
           'create_schema_%s' % keyspace['name'], self.name, 'create_schema.py',
@@ -249,26 +232,21 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
         'Struct', self.sandbox_options['application'].keys())(
             *self.sandbox_options['application'].values())
 
-    if any(k in self.app_options.port_forwarding
-           for k in ['vtgate', 'vtctld', 'guestbook']):
-      self.generate_firewall_sandlet()
     self.generate_helm_sandlet()
-    if 'guestbook' in self.app_options.port_forwarding:
+    if self.app_options.enable_guestbook:
       self.generate_guestbook_sandlet()
 
   def print_banner(self):
     logging.info('Fetching forwarded ports.')
     banner = '\nVitess Sandbox Info:\n'
-    vtctld_port = self.app_options.port_forwarding['vtctld']
-    vtgate_port = self.app_options.port_forwarding['vtgate']
     vtctld_ip = kubernetes_components.get_forwarded_ip(
         'vtctld', self.name)
-    banner += '  vtctld: http://%s:%d\n' % (vtctld_ip, vtctld_port)
+    banner += '  vtctld: http://%s:15000\n' % vtctld_ip
     for cell in self.app_options.cells:
       vtgate_ip = kubernetes_components.get_forwarded_ip(
           'vtgate-%s' % cell, self.name)
-      banner += '  vtgate-%s: http://%s:%d\n' % (cell, vtgate_ip, vtgate_port)
-    if 'guestbook' in self.app_options.port_forwarding:
+      banner += '  vtgate-%s: http://%s:15001\n' % (cell, vtgate_ip)
+    if self.app_options.enable_guestbook:
       guestbook_ip = kubernetes_components.get_forwarded_ip(
           'guestbook', self.name)
       banner += '  guestbook: http://%s:80\n' % guestbook_ip


### PR DESCRIPTION
I had forgotten that if I set the service type of a kubernetes service to LoadBalancer (which it is for vtgate/vtctld within the sandbox), then I don't need to forward a port. I'm keeping the port forwarding for the guestbook because the service is not currently configurable to be a LoadBalancer. This reduces the startup/teardown time by about a minute.

Also updated the sandbox configuration to have an explicit param for enabling the guestbook.

@wangyipei01, you'll have to update your resharding_sandbox.yaml configuration after I merge this PR.