### PR TITLE
Validate shard served types for resharding sandboxes.

### DIFF
--- a/test/cluster/sandbox/fix_served_types.py
+++ b/test/cluster/sandbox/fix_served_types.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+"""Fixes served types for each keyspace.
+
+This is only useful in the scenario where multiple keyspaces with the same name
+are created. This will happen in resharding tests. Since helm brings up all
+vttablets at the same time, there is a race condition that determines which
+shards are considered serving. In a resharding test, the unsharded keyspace
+should be serving, and the sharded keyspace should not be.
+
+This script iterates through all keyspaces, and ensures that for any set of
+keyspaces that have the same name, the keyspace with the fewest shards will be
+set to serving.
+"""
+
+import collections
+import json
+import logging
+import optparse
+import sys
+from vtproto import topodata_pb2
+from vttest import sharding_utils
+import vtctl_sandbox
+
+# Use OrderedDict in order to ensure master is set last.
+tablet_types = collections.OrderedDict([
+    (topodata_pb2.REPLICA, 'replica'),
+    (topodata_pb2.RDONLY, 'rdonly'),
+    (topodata_pb2.MASTER, 'master'),
+])
+
+
+def get_vtctl_commands(keyspace, shards):
+  """Gets a list of vtctl SetShardServedTypes commands.
+
+  Args:
+    keyspace: (string) Keyspace name to obtain commands for.
+    shards: (json) Struct containing sharding info from FindAllShardsInKeyspace
+            vtctl command.
+
+  Returns:
+    List of vtctl commands.
+  """
+  # Skip keyspaces with non-overlapping sharding schemes.
+  lowest_sharding_count = min([
+      sharding_utils.get_shard_index(x)[1] for x in shards.keys()])
+  if lowest_sharding_count == len(shards):
+    return []
+
+  logging.info('Keyspace %s has overlapping sharding schemes', keyspace)
+  vtctl_commands = []
+  for shard_name, shard_info in shards.iteritems():
+    served_tablet_types = [
+        x['tablet_type'] for x in shard_info.get('served_types', [])]
+    _, num_shards = sharding_utils.get_shard_index(shard_name)
+    is_lowest_sharding = num_shards == lowest_sharding_count
+
+    for tablet_type, tablet_type_name in tablet_types.iteritems():
+      # Setting served types when a shard is already serving is allowable,
+      # but only remove served types from the more sharded keyspace shards if
+      # they are serving.
+      if not (is_lowest_sharding or tablet_type in served_tablet_types):
+        continue
+
+      vtctl_command = [
+          'SetShardServedTypes', '%s/%s' % (keyspace, shard_name),
+          tablet_type_name]
+      if not is_lowest_sharding:
+        vtctl_command.insert(1, '--remove')
+
+      vtctl_commands.append(vtctl_command)
+
+  return vtctl_commands
+
+
+def fix_served_types(keyspaces, namespace):
+  """Ensures the least-sharded keyspace is serving.
+
+  Args:
+    keyspaces: [string], list of keyspaces to fix.
+    namespace: string, Kubernetes namespace for vtctld calls.
+
+  Returns:
+    0 for success, 1 for failure
+  """
+  for keyspace in keyspaces:
+    output, success = vtctl_sandbox.execute_vtctl_command(
+        ['FindAllShardsInKeyspace', keyspace], namespace=namespace)
+
+    if not success:
+      logging.error('Failed to execute FindAllShardsInKeyspace: %s', output)
+      return 1
+
+    for cmd in get_vtctl_commands(keyspace, json.loads(output)):
+      logging.info('Executing %s', ' '.join(cmd))
+      vtctl_sandbox.execute_vtctl_command(cmd, namespace=namespace)
+
+    logging.info('Rebuilding keyspace %s', keyspace)
+    vtctl_sandbox.execute_vtctl_command(
+        ['RebuildKeyspaceGraph', keyspace], namespace=namespace)
+  return 0
+
+
+def main():
+  parser = optparse.OptionParser(usage='usage: %prog [options] [test_names]')
+  parser.add_option('-n', '--namespace', help='Kubernetes namespace',
+                    default='vitess')
+  parser.add_option('-k', '--keyspaces', help='Comma delimited keyspaces',
+                    default='test_keyspace')
+  logging.getLogger().setLevel(logging.INFO)
+
+  options, _ = parser.parse_args()
+  sys.exit(
+      fix_served_types(set(options.keyspaces.split(',')), options.namespace))
+
+
+if __name__ == '__main__':
+  main()

--- a/test/cluster/sandbox/fix_served_types.py
+++ b/test/cluster/sandbox/fix_served_types.py
@@ -12,7 +12,6 @@ shards within the same keyspace, the set with the fewest shards will be set to
 serving.
 """
 
-import collections
 import json
 import logging
 import optparse
@@ -21,12 +20,11 @@ from vtproto import topodata_pb2
 from vttest import sharding_utils
 import vtctl_sandbox
 
-# Use OrderedDict in order to ensure master is set last.
-tablet_types = collections.OrderedDict([
+TABLET_TYPES = [
     (topodata_pb2.REPLICA, 'replica'),
     (topodata_pb2.RDONLY, 'rdonly'),
     (topodata_pb2.MASTER, 'master'),
-])
+]
 
 
 def get_vtctl_commands(keyspace, shards):
@@ -34,14 +32,14 @@ def get_vtctl_commands(keyspace, shards):
 
   Args:
     keyspace: (string) Keyspace name to obtain commands for.
-    shards: (json) Struct containing sharding info from FindAllShardsInKeyspace
-            vtctl command.
+    shards: Dict from shard name to shard info object from
+            FindAllShardsInKeyspace vtctl command.
 
   Returns:
     List of vtctl commands.
   """
-  lowest_sharding_count = min([
-      sharding_utils.get_shard_index(x)[1] for x in shards.keys()])
+  lowest_sharding_count = min(
+      sharding_utils.get_shard_index(x)[1] for x in shards.keys())
   if lowest_sharding_count == len(shards):
     # Skip keyspaces with non-overlapping shards.
     return []
@@ -54,7 +52,7 @@ def get_vtctl_commands(keyspace, shards):
     _, num_shards = sharding_utils.get_shard_index(shard_name)
     is_lowest_sharding = num_shards == lowest_sharding_count
 
-    for tablet_type, tablet_type_name in tablet_types.iteritems():
+    for tablet_type, tablet_type_name in TABLET_TYPES:
       # Setting served types when a shard is already serving is allowable,
       # but only remove served types from the sharded set if they are serving.
       if not (is_lowest_sharding or tablet_type in served_tablet_types):

--- a/test/cluster/sandbox/fix_served_types_test.py
+++ b/test/cluster/sandbox/fix_served_types_test.py
@@ -5,20 +5,20 @@ import unittest
 from vtproto import topodata_pb2
 import fix_served_types
 
-_all_types = dict(
+_ALL_TYPES = dict(
     served_types=[
         dict(tablet_type=topodata_pb2.REPLICA),
         dict(tablet_type=topodata_pb2.RDONLY),
         dict(tablet_type=topodata_pb2.MASTER),
     ])
 
-_no_master = dict(
+_NO_MASTER = dict(
     served_types=[
         dict(tablet_type=topodata_pb2.REPLICA),
         dict(tablet_type=topodata_pb2.RDONLY),
     ])
 
-_just_master = dict(
+_JUST_MASTER = dict(
     served_types=[
         dict(tablet_type=topodata_pb2.MASTER),
     ])
@@ -26,57 +26,78 @@ _just_master = dict(
 
 class FixServedTypesTest(unittest.TestCase):
 
-  def test_get_vtctl_commands(self):
-    tests = [collections.OrderedDict(x) for x in [
-        [('-80', _all_types), ('80-', {}), ('0', _all_types)],
-        [('-80', _all_types), ('80-', _all_types), ('0', {})],
-        [('-80', {}), ('80-', {}), ('0', _all_types)],
-        [('-80', {}), ('80-', _all_types), ('0', _all_types)],
-        [('-80', _no_master), ('80-', _no_master), ('0', _just_master)]
-    ]]
+  def test_partial_serving_overlap_shard_1(self):
+    """Source shard and destination shard 1 are serving all types."""
+    shards = collections.OrderedDict(
+        [('-80', _ALL_TYPES), ('80-', {}), ('0', _ALL_TYPES)])
+    expected_result = [
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
+        ['SetShardServedTypes', 'foo/0', 'replica'],
+        ['SetShardServedTypes', 'foo/0', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'master']]
+    self.assertEquals(
+        fix_served_types.get_vtctl_commands('foo', shards), expected_result)
 
-    expected_results = [
-        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
-         ['SetShardServedTypes', 'foo/0', 'replica'],
-         ['SetShardServedTypes', 'foo/0', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'master']],
+  def test_destination_shards_serving(self):
+    """Destination shards are serving all types."""
+    shards = collections.OrderedDict(
+        [('-80', _ALL_TYPES), ('80-', _ALL_TYPES), ('0', {})])
+    expected_result = [
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
+        ['SetShardServedTypes', 'foo/0', 'replica'],
+        ['SetShardServedTypes', 'foo/0', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'master']]
+    self.assertEquals(
+        fix_served_types.get_vtctl_commands('foo', shards), expected_result)
 
-        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
-         ['SetShardServedTypes', 'foo/0', 'replica'],
-         ['SetShardServedTypes', 'foo/0', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'master']],
+  def test_source_shards_serving(self):
+    """Nominal case where the source shard is serving all types."""
+    shards = collections.OrderedDict(
+        [('-80', {}), ('80-', {}), ('0', _ALL_TYPES)])
+    expected_result = [
+        ['SetShardServedTypes', 'foo/0', 'replica'],
+        ['SetShardServedTypes', 'foo/0', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'master']]
+    self.assertEquals(
+        fix_served_types.get_vtctl_commands('foo', shards), expected_result)
 
-        [['SetShardServedTypes', 'foo/0', 'replica'],
-         ['SetShardServedTypes', 'foo/0', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'master']],
+  def test_partial_serving_overlap_shard_2(self):
+    """Source shard and destination shard 2 are serving all types."""
+    shards = collections.OrderedDict(
+        [('-80', {}), ('80-', _ALL_TYPES), ('0', _ALL_TYPES)])
+    expected_result = [
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
+        ['SetShardServedTypes', 'foo/0', 'replica'],
+        ['SetShardServedTypes', 'foo/0', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'master']]
+    self.assertEquals(
+        fix_served_types.get_vtctl_commands('foo', shards), expected_result)
 
-        [['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
-         ['SetShardServedTypes', 'foo/0', 'replica'],
-         ['SetShardServedTypes', 'foo/0', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'master']],
-
-        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'replica'],
-         ['SetShardServedTypes', 'foo/0', 'rdonly'],
-         ['SetShardServedTypes', 'foo/0', 'master']],
-    ]
-
-    for test, expected_result in zip(tests, expected_results):
-      self.assertEquals(
-          fix_served_types.get_vtctl_commands('foo', test), expected_result)
+  def test_mixed_serving_types(self):
+    """Source shard serves some types, destination shards serve other types."""
+    shards = collections.OrderedDict(
+        [('-80', _NO_MASTER), ('80-', _NO_MASTER), ('0', _JUST_MASTER)])
+    expected_result = [
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+        ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'replica'],
+        ['SetShardServedTypes', 'foo/0', 'rdonly'],
+        ['SetShardServedTypes', 'foo/0', 'master']]
+    self.assertEquals(
+        fix_served_types.get_vtctl_commands('foo', shards), expected_result)
 
 
 if __name__ == '__main__':
   unittest.main()
+

--- a/test/cluster/sandbox/fix_served_types_test.py
+++ b/test/cluster/sandbox/fix_served_types_test.py
@@ -1,0 +1,73 @@
+"""Tests for fix_served_types."""
+
+import collections
+import unittest
+from vtproto import topodata_pb2
+import fix_served_types
+
+_all_types = dict(
+    served_types=[
+        dict(tablet_type=topodata_pb2.REPLICA),
+        dict(tablet_type=topodata_pb2.RDONLY),
+        dict(tablet_type=topodata_pb2.MASTER),
+    ])
+
+
+class FixServedTypesTest(unittest.TestCase):
+
+  def test_get_vtctl_commands(self):
+    tests = [collections.OrderedDict(x) for x in [
+        [('-80', _all_types), ('80-', {}), ('0', _all_types)],
+        [('-80', _all_types), ('80-', _all_types), ('0', {})],
+        [('-80', {}), ('80-', {}), ('0', _all_types)],
+        [('-80', _all_types), ('80-', _all_types), ('0', _all_types)],
+        [('-80', {}), ('80-', _all_types), ('0', _all_types)]
+    ]]
+
+    expected_results = [
+        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
+         ['SetShardServedTypes', 'foo/0', 'replica'],
+         ['SetShardServedTypes', 'foo/0', 'rdonly'],
+         ['SetShardServedTypes', 'foo/0', 'master']],
+
+        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
+         ['SetShardServedTypes', 'foo/0', 'replica'],
+         ['SetShardServedTypes', 'foo/0', 'rdonly'],
+         ['SetShardServedTypes', 'foo/0', 'master']],
+
+        [['SetShardServedTypes', 'foo/0', 'replica'],
+         ['SetShardServedTypes', 'foo/0', 'rdonly'],
+         ['SetShardServedTypes', 'foo/0', 'master']],
+
+        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
+         ['SetShardServedTypes', 'foo/0', 'replica'],
+         ['SetShardServedTypes', 'foo/0', 'rdonly'],
+         ['SetShardServedTypes', 'foo/0', 'master']],
+
+        [['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
+         ['SetShardServedTypes', 'foo/0', 'replica'],
+         ['SetShardServedTypes', 'foo/0', 'rdonly'],
+         ['SetShardServedTypes', 'foo/0', 'master']],
+    ]
+
+    for test, expected_result in zip(tests, expected_results):
+      self.assertEquals(
+          fix_served_types.get_vtctl_commands('foo', test), expected_result)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/test/cluster/sandbox/fix_served_types_test.py
+++ b/test/cluster/sandbox/fix_served_types_test.py
@@ -12,6 +12,12 @@ _all_types = dict(
         dict(tablet_type=topodata_pb2.MASTER),
     ])
 
+_no_master = dict(
+    served_types=[
+        dict(tablet_type=topodata_pb2.REPLICA),
+        dict(tablet_type=topodata_pb2.RDONLY),
+    ])
+
 
 class FixServedTypesTest(unittest.TestCase):
 
@@ -20,8 +26,8 @@ class FixServedTypesTest(unittest.TestCase):
         [('-80', _all_types), ('80-', {}), ('0', _all_types)],
         [('-80', _all_types), ('80-', _all_types), ('0', {})],
         [('-80', {}), ('80-', {}), ('0', _all_types)],
-        [('-80', _all_types), ('80-', _all_types), ('0', _all_types)],
-        [('-80', {}), ('80-', _all_types), ('0', _all_types)]
+        [('-80', {}), ('80-', _all_types), ('0', _all_types)],
+        [('-80', {}), ('80-', _no_master), ('0', _all_types)]
     ]]
 
     expected_results = [
@@ -46,10 +52,7 @@ class FixServedTypesTest(unittest.TestCase):
          ['SetShardServedTypes', 'foo/0', 'rdonly'],
          ['SetShardServedTypes', 'foo/0', 'master']],
 
-        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/-80', 'master'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+        [['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
          ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
          ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
          ['SetShardServedTypes', 'foo/0', 'replica'],
@@ -58,7 +61,6 @@ class FixServedTypesTest(unittest.TestCase):
 
         [['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
          ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
-         ['SetShardServedTypes', '--remove', 'foo/80-', 'master'],
          ['SetShardServedTypes', 'foo/0', 'replica'],
          ['SetShardServedTypes', 'foo/0', 'rdonly'],
          ['SetShardServedTypes', 'foo/0', 'master']],

--- a/test/cluster/sandbox/fix_served_types_test.py
+++ b/test/cluster/sandbox/fix_served_types_test.py
@@ -18,6 +18,11 @@ _no_master = dict(
         dict(tablet_type=topodata_pb2.RDONLY),
     ])
 
+_just_master = dict(
+    served_types=[
+        dict(tablet_type=topodata_pb2.MASTER),
+    ])
+
 
 class FixServedTypesTest(unittest.TestCase):
 
@@ -27,7 +32,7 @@ class FixServedTypesTest(unittest.TestCase):
         [('-80', _all_types), ('80-', _all_types), ('0', {})],
         [('-80', {}), ('80-', {}), ('0', _all_types)],
         [('-80', {}), ('80-', _all_types), ('0', _all_types)],
-        [('-80', {}), ('80-', _no_master), ('0', _all_types)]
+        [('-80', _no_master), ('80-', _no_master), ('0', _just_master)]
     ]]
 
     expected_results = [
@@ -59,7 +64,9 @@ class FixServedTypesTest(unittest.TestCase):
          ['SetShardServedTypes', 'foo/0', 'rdonly'],
          ['SetShardServedTypes', 'foo/0', 'master']],
 
-        [['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
+        [['SetShardServedTypes', '--remove', 'foo/-80', 'replica'],
+         ['SetShardServedTypes', '--remove', 'foo/-80', 'rdonly'],
+         ['SetShardServedTypes', '--remove', 'foo/80-', 'replica'],
          ['SetShardServedTypes', '--remove', 'foo/80-', 'rdonly'],
          ['SetShardServedTypes', 'foo/0', 'replica'],
          ['SetShardServedTypes', 'foo/0', 'rdonly'],

--- a/test/cluster/sandbox/vitess_kubernetes_sandbox.py
+++ b/test/cluster/sandbox/vitess_kubernetes_sandbox.py
@@ -230,7 +230,7 @@ class VitessKubernetesSandbox(sandbox.Sandbox):
     helm_sandlet.components.add_component(wait_for_mysql_subprocess)
 
     # Add a subprocess task to ensure serving types are correct. This is useful
-    # for resharding sandboxes where multiple keyspaces share a name.
+    # for resharding sandboxes where keyspaces have overlapping sets of shards.
     fix_served_types_subprocess = subprocess_component.Subprocess(
         'fix_served_types', self.name, 'fix_served_types.py', self.log_dir,
         namespace=self.name,


### PR DESCRIPTION
This should fix the issue @wangyipei01 was facing with resharding sandboxes.

I went ahead and made an executive decision with regards to our potential solutions to the issue by running a script as part of the sandbox turnup. It checks the shard served types for keyspaces with overlapping shards, and ensures that the bigger shards are serving.