### PR TITLE
docker/lite: Avoid copying files which are not required.

### DIFF
--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -24,15 +24,6 @@ mkdir -p $lite/vt/vtdataroot
 mkdir -p $lite/vt/bin
 (cd base/vt/bin; cp mysqlctld vtctld vtgate vttablet vtworker $lite/vt/bin/)
 
-cp -R base/vt/dist lite/vt/
-
-# Remove build and test dependencies.
-rm -r lite/vt/dist/chromedriver
-rm -r lite/vt/dist/maven
-rm -r lite/vt/dist/py-mock-1.0.1
-rm -r lite/vt/dist/selenium
-
-mkdir -p $lite/$vttop/go/cmd/vtctld
 mkdir -p $lite/$vttop/web
 cp -R base/$vttop/web/vtctld $lite/$vttop/web/
 mkdir $lite/$vttop/web/vtctld2


### PR DESCRIPTION
- dist/ folder is no longer required at all.
- cmd/vtctld folder was needed in the past for template files and is no longer needed.