### PR TITLE
docker: Stop using "sudo" for building images.

### DIFF
--- a/docker/etcd-lite/build.sh
+++ b/docker/etcd-lite/build.sh
@@ -8,14 +8,14 @@ version="v2.0.13"
 set -e
 
 # Build a fresh base vitess/etcd image
-(cd ../etcd ; sudo docker build -t vitess/etcd:$version .)
+(cd ../etcd ; docker build -t vitess/etcd:$version .)
 
 # Extract files from vitess/etcd image
 mkdir base
-sudo docker run -ti --rm -v $PWD/base:/base -u root vitess/etcd:$version bash -c 'cp -R /go/bin/* /base/'
+docker run -ti --rm -v $PWD/base:/base -u $UID vitess/etcd:$version bash -c 'cp -R /go/bin/* /base/'
 
 # Build vitess/etcd-lite image
-sudo docker build -t vitess/etcd:$version-lite .
+docker build -t vitess/etcd:$version-lite .
 
 # Clean up temporary files
-sudo rm -rf base
+rm -rf base

--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -14,7 +14,9 @@ fi
 
 # Extract files from vitess/base image
 mkdir base
-sudo docker run -ti --rm -v $PWD/base:/base -u root $base_image bash -c 'cp -R /vt /base/'
+# Ignore permission errors. They occur for directories we do not care e.g. ".git".
+# (Copying them fails because they are owned by root and not $UID and have stricter permissions.)
+docker run -ti --rm -v $PWD/base:/base -u $UID $base_image bash -c 'cp -R /vt /base/ 2>&1 | grep -v "Permission denied"'
 
 # Grab only what we need
 lite=$PWD/lite
@@ -42,7 +44,7 @@ mkdir -p $lite/$vttop/config
 cp -R base/$vttop/config/* $lite/$vttop/config/
 ln -s /$vttop/config $lite/vt/config
 
-sudo rm -rf base
+rm -rf base
 
 # Fix permissions for AUFS workaround
 chmod -R o=g lite
@@ -50,9 +52,9 @@ chmod -R o=g lite
 # Build vitess/lite image
 
 if [[ -n "$flavor" ]]; then
-	sudo docker build --no-cache -f Dockerfile.$flavor -t vitess/lite:$flavor .
+	docker build --no-cache -f Dockerfile.$flavor -t vitess/lite:$flavor .
 else
-	sudo docker build --no-cache -t vitess/lite .
+	docker build --no-cache -t vitess/lite .
 fi
 
 # Clean up temporary files


### PR DESCRIPTION
It looks like we used "sudo" in the past because we copied files out
from existing images as user "root" and therefore they were owned by
user "root". By running the copy as $UID instead, we no longer have this
problem and can avoid using sudo.

This simplifies the release process because the releaser no longer has
to baby sit the docker build and wait for the sudo prompt.