### PR TITLE
docker: Avoid that "vitess/base" will be automatically built when run…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,11 @@ docker_base_percona57:
 	chmod -R o=g *
 	docker build -f Dockerfile.percona57 -t vitess/base:percona57 .
 
-docker_lite: docker_base
-	cd docker/lite && ./build.sh
+# Run "make docker_lite PROMPT_NOTICE=false" to avoid that the script
+# prompts you to press ENTER and confirm that the vitess/base image is not
+# rebuild by this target as well.
+docker_lite:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE)
 
 docker_lite_mysql56: docker_base_mysql56
 	cd docker/lite && ./build.sh mysql56

--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -3,13 +3,48 @@
 # This is the script to build the vitess/lite Docker image by extracting
 # the pre-built binaries from a vitess/base image.
 
+# Parse command line arguments.
+prompt_notice=true
+if [[ "$1" == "--prompt"* ]]; then
+  if [[ "$1" == "--prompt=false" ]]; then
+    prompt_notice=false
+  fi
+  shift
+fi
+
 flavor=$1
 
+tag=latest
 if [[ -n "$flavor" ]]; then
   base_image=vitess/base:$flavor
+  tag=$flavor
 else
   echo "Flavor not specified as first argument. Building default image."
   base_image=vitess/base
+fi
+
+# Abort if base image does not exist.
+if ! docker inspect $base_image &>/dev/null; then
+  echo "ERROR: Dependent image $base_image does not exist. Run 'make docker_base' to build it locally or 'docker pull $base_image' to fetch it from Docker Hub."
+  exit 1
+fi
+
+# Educate the user that they have to build or pull vitess/base themselves.
+if [[ "$prompt_notice" = true ]]; then
+  cat <<END
+
+This script is going to repack and copy the existing *local* base image '$base_image' into a smaller image 'vitess/lite'.
+
+The 'docker images' output below shows you how old your local base image is:
+
+$(docker images vitess/base | grep -E "(CREATED|$tag)")
+
+If you need a newer base image, you will have to manually run 'make docker_base' to build it locally
+or 'docker pull $base_image' to fetch it from Docker Hub.
+
+Press ENTER to continue building 'vitess/lite' or Ctrl-C to cancel.
+END
+  read
 fi
 
 # Extract files from vitess/base image


### PR DESCRIPTION
…ning "make docker_lite".

Instead, show a prompt and educate the user to understand what's going on. Optionally, the user can skip the prompt by passing PROMPT_NOTICE=false to "make".

This is better because:
- docker/lite/build.sh can be executed directly. Before this change the user would not notice that they forgot to build or fetch the base image (This happened recently.)
- Building the base image may take longer and fail. By running it separately, the user has more control and can retry it separately.