### PR TITLE
vttablet: rbr support

### DIFF
--- a/go/vt/dbconnpool/connection.go
+++ b/go/vt/dbconnpool/connection.go
@@ -6,7 +6,6 @@ package dbconnpool
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/youtube/vitess/go/sqldb"
@@ -102,37 +101,6 @@ func (dbc *DBConnection) ExecuteStreamFetch(query string, callback func(*sqltype
 		}
 	}
 
-	return nil
-}
-
-var (
-	getModeSQL    = "select @@global.sql_mode"
-	getAutocommit = "select @@autocommit"
-)
-
-// VerifyMode is a helper method to verify mysql is running with
-// sql_mode = STRICT_TRANS_TABLES and autocommit=ON.
-func (dbc *DBConnection) VerifyMode() error {
-	qr, err := dbc.ExecuteFetch(getModeSQL, 2, false)
-	if err != nil {
-		return fmt.Errorf("could not verify mode: %v", err)
-	}
-	if len(qr.Rows) != 1 {
-		return fmt.Errorf("incorrect rowcount received for %s: %d", getModeSQL, len(qr.Rows))
-	}
-	if !strings.Contains(qr.Rows[0][0].String(), "STRICT_TRANS_TABLES") {
-		return fmt.Errorf("require sql_mode to be STRICT_TRANS_TABLES: got %s", qr.Rows[0][0].String())
-	}
-	qr, err = dbc.ExecuteFetch(getAutocommit, 2, false)
-	if err != nil {
-		return fmt.Errorf("could not verify mode: %v", err)
-	}
-	if len(qr.Rows) != 1 {
-		return fmt.Errorf("incorrect rowcount received for %s: %d", getAutocommit, len(qr.Rows))
-	}
-	if !strings.Contains(qr.Rows[0][0].String(), "1") {
-		return fmt.Errorf("require autocommit to be 1: got %s", qr.Rows[0][0].String())
-	}
 	return nil
 }
 

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -45,6 +45,18 @@ func Queries() map[string]*sqltypes.Result {
 				{sqltypes.MakeString([]byte("1"))},
 			},
 		},
+		"show variables like 'binlog_format'": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.VarChar,
+			}, {
+				Type: sqltypes.VarChar,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeString([]byte("binlog_format")),
+				sqltypes.MakeString([]byte("STATEMENT")),
+			}},
+		},
 		mysqlconn.BaseShowTables: {
 			Fields:       mysqlconn.BaseShowTablesFields,
 			RowsAffected: 3,

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2392,6 +2392,18 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				{sqltypes.MakeString([]byte("1"))},
 			},
 		},
+		"show variables like 'binlog_format'": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.VarChar,
+			}, {
+				Type: sqltypes.VarChar,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeString([]byte("binlog_format")),
+				sqltypes.MakeString([]byte("STATEMENT")),
+			}},
+		},
 		"select * from test_table where 1 != 1": {
 			Fields: []*querypb.Field{{
 				Name: "pk",


### PR DESCRIPTION
@bbeaudreault @tirsen 

Addresses #2530

This change makes VTTablet recognize that MySQL is running in RBR
mode. If this mode is detected, VTTablet will not rewrite
INSERT...ON DUPLICATE KEY constructs. It will just pass them
through instead. This allows MySQL to be run with CLIENT_FOUND_ROWS
option turned on, and the returned RowsAffected will be the
same as MySQL.

Additionally, if this mode is detected, VTTablet will also
skip adding update stream comments to other DMLs because
they're unnecessary.