### PR TITLE
vttablet: deprecate StrictMode in favor of RBR

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -120,7 +120,6 @@ type QueryEngine struct {
 	streamQList  *QueryList
 
 	// Vars
-	strictMode       sync2.AtomicBool
 	binlogFormat     connpool.BinlogFormat
 	autoCommit       sync2.AtomicBool
 	maxResultSize    sync2.AtomicInt64
@@ -171,7 +170,6 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		config.HotRowProtectionMaxQueueSize, config.HotRowProtectionMaxGlobalQueueSize)
 	qe.streamQList = NewQueryList()
 
-	qe.strictMode.Set(config.StrictMode)
 	qe.autoCommit.Set(config.EnableAutoCommit)
 	qe.strictTableACL = config.StrictTableACL
 	qe.enableTableACLDryRun = config.EnableTableACLDryRun

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -20,26 +20,6 @@ import (
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
-func TestStrictMode(t *testing.T) {
-	db := fakesqldb.New(t)
-	defer db.Close()
-	for query, result := range schematest.Queries() {
-		db.AddQuery(query, result)
-	}
-	db.AddRejectedQuery("select @@global.sql_mode", errRejected)
-
-	qe := newTestQueryEngine(10, 10*time.Second, true)
-	testUtils := newTestUtils()
-	dbconfigs := testUtils.newDBConfigs(db)
-	qe.se.Open(db.ConnParams())
-
-	err := qe.Open(dbconfigs)
-	want := "could not verify mode"
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("se.Open: %v, must contain %s", err, want)
-	}
-}
-
 func TestGetPlanPanicDuetoEmptyQuery(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
@@ -144,6 +124,5 @@ func newTestQueryEngine(queryCacheSize int, idleTimeout time.Duration, strict bo
 	config := tabletenv.DefaultQsConfig
 	config.QueryCacheSize = queryCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	config.StrictMode = strict
 	return NewQueryEngine(DummyChecker, schema.NewEngine(DummyChecker, config), config)
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -90,7 +90,7 @@ func (qre *QueryExecutor) Execute() (reply *sqltypes.Result, err error) {
 		defer conn.Recycle()
 		switch qre.plan.PlanID {
 		case planbuilder.PlanPassDML:
-			if qre.tsv.qe.strictMode.Get() {
+			if qre.tsv.qe.binlogFormat != connpool.BinlogFormatRow {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "DML too complex")
 			}
 			return qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)
@@ -168,7 +168,7 @@ func (qre *QueryExecutor) execDmlAutoCommit() (reply *sqltypes.Result, err error
 	return qre.execAsTransaction(func(conn *TxConnection) (reply *sqltypes.Result, err error) {
 		switch qre.plan.PlanID {
 		case planbuilder.PlanPassDML:
-			if qre.tsv.qe.strictMode.Get() {
+			if qre.tsv.qe.binlogFormat != connpool.BinlogFormatRow {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "DML too complex")
 			}
 			reply, err = qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -42,7 +42,7 @@ func TestQueryExecutorPlanDDL(t *testing.T) {
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanDDL, qre.plan.PlanID)
@@ -55,17 +55,19 @@ func TestQueryExecutorPlanDDL(t *testing.T) {
 	}
 }
 
-func TestQueryExecutorPlanPassDmlStrictMode(t *testing.T) {
+func TestQueryExecutorPlanPassDmlRBR(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	query := "update test_table set pk = foo()"
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	// non strict mode
+	// RBR mode
 	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
+	tsv.qe.binlogFormat = connpool.BinlogFormatRow
 	checkPlanID(t, planbuilder.PlanPassDML, qre.plan.PlanID)
 	got, err := qre.Execute()
 	if err != nil {
@@ -79,31 +81,28 @@ func TestQueryExecutorPlanPassDmlStrictMode(t *testing.T) {
 	if !reflect.DeepEqual(gotqueries, wantqueries) {
 		t.Errorf("queries: %v, want %v", gotqueries, wantqueries)
 	}
-	testCommitHelper(t, tsv, qre)
-	tsv.StopService()
 
-	// strict mode
-	tsv = newTestTabletServer(ctx, enableStrict, db)
-	qre = newTestQueryExecutor(ctx, tsv, query, newTransaction(tsv))
-	defer tsv.StopService()
-	defer testCommitHelper(t, tsv, qre)
-	checkPlanID(t, planbuilder.PlanPassDML, qre.plan.PlanID)
+	// Statement mode
+	tsv.qe.binlogFormat = connpool.BinlogFormatStatement
 	_, err = qre.Execute()
 	if code := vterrors.Code(err); code != vtrpcpb.Code_INVALID_ARGUMENT {
 		t.Fatalf("qre.Execute: %v, want %v", code, vtrpcpb.Code_INVALID_ARGUMENT)
 	}
+	testCommitHelper(t, tsv, qre)
 }
 
-func TestQueryExecutorPlanPassDmlStrictModeAutoCommit(t *testing.T) {
+func TestQueryExecutorPlanPassDmlAutoCommitRBR(t *testing.T) {
 	db := setUpQueryExecutorTest(t)
 	defer db.Close()
 	query := "update test_table set pk = foo()"
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
-	// non strict mode
 	ctx := context.Background()
+	// RBR mode
 	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
+	tsv.qe.binlogFormat = connpool.BinlogFormatRow
 	checkPlanID(t, planbuilder.PlanPassDML, qre.plan.PlanID)
 	got, err := qre.Execute()
 	if err != nil {
@@ -112,14 +111,9 @@ func TestQueryExecutorPlanPassDmlStrictModeAutoCommit(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got: %v, want: %v", got, want)
 	}
-	tsv.StopService()
 
-	// strict mode
-	// update should fail because strict mode is not enabled
-	tsv = newTestTabletServer(ctx, enableStrict, db)
-	qre = newTestQueryExecutor(ctx, tsv, query, 0)
-	defer tsv.StopService()
-	checkPlanID(t, planbuilder.PlanPassDML, qre.plan.PlanID)
+	// Statement mode
+	tsv.qe.binlogFormat = connpool.BinlogFormatStatement
 	_, err = qre.Execute()
 	if code := vterrors.Code(err); code != vtrpcpb.Code_INVALID_ARGUMENT {
 		t.Fatalf("qre.Execute: %v, want %v", code, vtrpcpb.Code_INVALID_ARGUMENT)
@@ -133,7 +127,7 @@ func TestQueryExecutorPlanInsertPk(t *testing.T) {
 	want := &sqltypes.Result{}
 	query := "insert into test_table values(1)"
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanInsertPK, qre.plan.PlanID)
@@ -171,7 +165,7 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 	want := &sqltypes.Result{}
 	query := "insert into msg(time_scheduled, id, message) values(1, 2, 3)"
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanInsertMessage, qre.plan.PlanID)
@@ -238,7 +232,7 @@ func TestQueryExecutorPlanInsertSubQueryAutoCommmit(t *testing.T) {
 
 	db.AddQuery(insertQuery, &sqltypes.Result{})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanInsertSubquery, qre.plan.PlanID)
@@ -273,7 +267,7 @@ func TestQueryExecutorPlanInsertSubQuery(t *testing.T) {
 
 	db.AddQuery(insertQuery, &sqltypes.Result{})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 
@@ -316,7 +310,7 @@ func TestQueryExecutorPlanInsertSubQueryRBR(t *testing.T) {
 
 	db.AddQuery(insertQuery, &sqltypes.Result{})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	tsv.qe.binlogFormat = connpool.BinlogFormatRow
@@ -345,7 +339,7 @@ func TestQueryExecutorPlanUpsertPk(t *testing.T) {
 	want := &sqltypes.Result{}
 	query := "insert into test_table values(1) on duplicate key update val=1"
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -430,7 +424,7 @@ func TestQueryExecutorPlanUpsertPkRBR(t *testing.T) {
 	db.AddQuery(query, &sqltypes.Result{})
 	want := &sqltypes.Result{}
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	tsv.qe.binlogFormat = connpool.BinlogFormatRow
@@ -458,7 +452,7 @@ func TestQueryExecutorPlanUpsertPkAutoCommit(t *testing.T) {
 	want := &sqltypes.Result{}
 	query := "insert into test_table values(1) on duplicate key update val=1"
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanUpsertPK, qre.plan.PlanID)
@@ -515,7 +509,7 @@ func TestQueryExecutorPlanDmlPk(t *testing.T) {
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -542,7 +536,7 @@ func TestQueryExecutorPlanDmlPkRBR(t *testing.T) {
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	tsv.qe.binlogFormat = connpool.BinlogFormatRow
@@ -581,7 +575,7 @@ func TestQueryExecutorPlanDmlMessage(t *testing.T) {
 	})
 	db.AddQuery("update msg set time_acked = 2, time_next = null where (time_scheduled = 12 and id = 1) /* _stream msg (time_scheduled id ) (12 1 ); */", want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -609,7 +603,7 @@ func TestQueryExecutorPlanDmlAutoCommit(t *testing.T) {
 	want := &sqltypes.Result{}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanDMLPK, qre.plan.PlanID)
@@ -641,7 +635,7 @@ func TestQueryExecutorPlanDmlSubQuery(t *testing.T) {
 	updateQuery := "update test_table set addr = 3 where pk in (2) /* _stream test_table (pk ) (2 ); */"
 	db.AddQuery(updateQuery, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -680,7 +674,7 @@ func TestQueryExecutorPlanDmlSubQueryRBR(t *testing.T) {
 	updateQuery := "update test_table set addr = 3 where pk in (2)"
 	db.AddQuery(updateQuery, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	tsv.qe.binlogFormat = connpool.BinlogFormatRow
@@ -710,7 +704,7 @@ func TestQueryExecutorPlanDmlSubQueryAutoCommit(t *testing.T) {
 	db.AddQuery(query, want)
 	db.AddQuery(expandedQuery, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanDMLSubquery, qre.plan.PlanID)
@@ -732,7 +726,7 @@ func TestQueryExecutorPlanOtherWithinATransaction(t *testing.T) {
 	}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -774,7 +768,7 @@ func TestQueryExecutorPlanPassSelectWithInATransaction(t *testing.T) {
 		Fields: fields,
 	})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	txid := newTransaction(tsv)
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
@@ -810,7 +804,7 @@ func TestQueryExecutorPlanPassSelectWithLockOutsideATransaction(t *testing.T) {
 		Fields: getTestTableFields(),
 	})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanSelectLock, qre.plan.PlanID)
@@ -832,7 +826,7 @@ func TestQueryExecutorPlanPassSelect(t *testing.T) {
 		Fields: getTestTableFields(),
 	})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanPassSelect, qre.plan.PlanID)
@@ -856,7 +850,7 @@ func TestQueryExecutorPlanSet(t *testing.T) {
 	setQuery := "set unknown_key = 1"
 	db.AddQuery(setQuery, &sqltypes.Result{})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	defer tsv.StopService()
 	qre := newTestQueryExecutor(ctx, tsv, setQuery, 0)
 	checkPlanID(t, planbuilder.PlanSet, qre.plan.PlanID)
@@ -899,7 +893,7 @@ func TestQueryExecutorPlanOther(t *testing.T) {
 	}
 	db.AddQuery(query, want)
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanOther, qre.plan.PlanID)
@@ -935,7 +929,7 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 	updateQuery := "update seq set next_id = 4 where id = 0"
 	db.AddQuery(updateQuery, &sqltypes.Result{})
 	ctx := context.Background()
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	defer tsv.StopService()
 	qre := newTestQueryExecutor(ctx, tsv, "select next value from seq", 0)
 	checkPlanID(t, planbuilder.PlanNextval, qre.plan.PlanID)
@@ -1079,7 +1073,7 @@ func TestQueryExecutorTableAcl(t *testing.T) {
 		t.Fatalf("unable to load tableacl config, error: %v", err)
 	}
 
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanPassSelect, qre.plan.PlanID)
@@ -1129,7 +1123,7 @@ func TestQueryExecutorTableAclNoPermission(t *testing.T) {
 		t.Fatalf("unable to load tableacl config, error: %v", err)
 	}
 	// without enabling Config.StrictTableAcl
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	checkPlanID(t, planbuilder.PlanPassSelect, qre.plan.PlanID)
 	got, err := qre.Execute()
@@ -1147,7 +1141,7 @@ func TestQueryExecutorTableAclNoPermission(t *testing.T) {
 	tsv.StopService()
 
 	// enable Config.StrictTableAcl
-	tsv = newTestTabletServer(ctx, enableStrict|enableStrictTableACL, db)
+	tsv = newTestTabletServer(ctx, enableStrictTableACL, db)
 	qre = newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanPassSelect, qre.plan.PlanID)
@@ -1197,7 +1191,7 @@ func TestQueryExecutorTableAclExemptACL(t *testing.T) {
 	}
 
 	// enable Config.StrictTableAcl
-	tsv := newTestTabletServer(ctx, enableStrict|enableStrictTableACL, db)
+	tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
 	checkPlanID(t, planbuilder.PlanPassSelect, qre.plan.PlanID)
@@ -1271,7 +1265,7 @@ func TestQueryExecutorTableAclDryRun(t *testing.T) {
 		username,
 	}, ".")
 	// enable Config.StrictTableAcl
-	tsv := newTestTabletServer(ctx, enableStrict|enableStrictTableACL, db)
+	tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
 	tsv.qe.enableTableACLDryRun = true
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
@@ -1322,7 +1316,7 @@ func TestQueryExecutorBlacklistQRFail(t *testing.T) {
 		User:   bannedUser,
 	}
 	ctx := callinfo.NewContext(context.Background(), callInfo)
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
 	tsv.qe.queryRuleSources.RegisterSource(rulesName)
 	defer tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
@@ -1376,7 +1370,7 @@ func TestQueryExecutorBlacklistQRRetry(t *testing.T) {
 		User:   bannedUser,
 	}
 	ctx := callinfo.NewContext(context.Background(), callInfo)
-	tsv := newTestTabletServer(ctx, enableStrict, db)
+	tsv := newTestTabletServer(ctx, 0, db)
 	tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
 	tsv.qe.queryRuleSources.RegisterSource(rulesName)
 	defer tsv.qe.queryRuleSources.UnRegisterSource(rulesName)
@@ -1398,9 +1392,8 @@ func TestQueryExecutorBlacklistQRRetry(t *testing.T) {
 type executorFlags int64
 
 const (
-	noFlags      executorFlags = 0
-	enableStrict               = 1 << iota
-	enableStrictTableACL
+	noFlags              executorFlags = 0
+	enableStrictTableACL               = 1 << iota
 	smallTxPool
 	noTwopc
 	shortTwopcAge
@@ -1418,12 +1411,6 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 		config.TransactionCap = 100
 	}
 	config.EnableAutoCommit = true
-
-	if flags&enableStrict > 0 {
-		config.StrictMode = true
-	} else {
-		config.StrictMode = false
-	}
 	if flags&enableStrictTableACL > 0 {
 		config.StrictTableACL = true
 	} else {

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -415,6 +415,5 @@ func newEngine(queryCacheSize int, reloadTime time.Duration, idleTimeout time.Du
 	config.QueryCacheSize = queryCacheSize
 	config.SchemaReloadTime = float64(reloadTime) / 1e9
 	config.IdleTimeout = float64(idleTimeout) / 1e9
-	config.StrictMode = strict
 	return NewEngine(DummyChecker, config)
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -47,7 +47,6 @@ func init() {
 	flag.Float64Var(&Config.QueryTimeout, "queryserver-config-query-timeout", DefaultQsConfig.QueryTimeout, "query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed.")
 	flag.Float64Var(&Config.TxPoolTimeout, "queryserver-config-txpool-timeout", DefaultQsConfig.TxPoolTimeout, "query server transaction pool timeout, it is how long vttablet waits if tx pool is full")
 	flag.Float64Var(&Config.IdleTimeout, "queryserver-config-idle-timeout", DefaultQsConfig.IdleTimeout, "query server idle timeout (in seconds), vttablet manages various mysql connection pools. This config means if a connection has not been used in given idle timeout, this connection will be removed from pool. This effectively manages number of connection objects and optimize the pool performance.")
-	flag.BoolVar(&Config.StrictMode, "queryserver-config-strict-mode", DefaultQsConfig.StrictMode, "allow only predictable DMLs and enforces MySQL's STRICT_TRANS_TABLES")
 	// tableacl related configurations.
 	flag.BoolVar(&Config.StrictTableACL, "queryserver-config-strict-table-acl", DefaultQsConfig.StrictTableACL, "only allow queries that pass table acl checks")
 	flag.BoolVar(&Config.EnableTableACLDryRun, "queryserver-config-enable-table-acl-dry-run", DefaultQsConfig.EnableTableACLDryRun, "If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results")
@@ -94,7 +93,6 @@ type TabletConfig struct {
 	QueryTimeout            float64
 	TxPoolTimeout           float64
 	IdleTimeout             float64
-	StrictMode              bool
 	StrictTableACL          bool
 	TerseErrors             bool
 	EnableAutoCommit        bool
@@ -141,7 +139,6 @@ var DefaultQsConfig = TabletConfig{
 	TxPoolTimeout:           1,
 	IdleTimeout:             30 * 60,
 	StreamBufferSize:        32 * 1024,
-	StrictMode:              true,
 	StrictTableACL:          false,
 	TerseErrors:             false,
 	EnableAutoCommit:        false,

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1781,14 +1781,6 @@ func (tsv *TabletServer) QueryCacheCap() int {
 	return int(tsv.qe.QueryCacheCap())
 }
 
-// SetStrictMode sets strict mode on or off.
-// This only sets the mode for QueryEngine, but not
-// for schema.Engine.
-// This function should only be used for testing.
-func (tsv *TabletServer) SetStrictMode(strict bool) {
-	tsv.qe.strictMode.Set(strict)
-}
-
 // SetAutoCommit sets autocommit on or off.
 // This function should only be used for testing.
 func (tsv *TabletServer) SetAutoCommit(auto bool) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2273,11 +2273,6 @@ func TestConfigChanges(t *testing.T) {
 		t.Errorf("tsv.qe.QueryCacheCap: %d, want %d", val, newSize)
 	}
 
-	tsv.SetStrictMode(false)
-	if val := tsv.qe.strictMode.Get(); val {
-		t.Errorf("tsv.qe.strictMode.Get: %d, want false", val)
-	}
-
 	tsv.SetAutoCommit(true)
 	if val := tsv.qe.autoCommit.Get(); !val {
 		t.Errorf("tsv.qe.autoCommit.Get: %d, want true", val)


### PR DESCRIPTION
StrictMode was an old flag and pretty much unsafe to turn off.
It's now been removed. Instead, if we detect that we're in RBR
mode, we use that to just pass-through queries that are otherwise
too complex.