### PR TITLE
vtgate:Fix bugs for the EOF packet which assembled in the wrong order.

### DIFF
--- a/go/mysqlconn/conn.go
+++ b/go/mysqlconn/conn.go
@@ -562,8 +562,8 @@ func (c *Conn) writeOKPacketWithEOFHeader(affectedRows, lastInsertID uint64, fla
 	pos = writeByte(data, pos, EOFPacket)
 	pos = writeLenEncInt(data, pos, affectedRows)
 	pos = writeLenEncInt(data, pos, lastInsertID)
-	pos = writeUint16(data, pos, flags)
 	pos = writeUint16(data, pos, warnings)
+	pos = writeUint16(data, pos, flags)
 
 	if err := c.writeEphemeralPacket(false); err != nil {
 		return err


### PR DESCRIPTION
Fix bugs for the EOF packet which assembled in the wrong order.
MySQL protocol address: https://dev.mysql.com/doc/internals/en/packet-EOF_Packet.html