### PR TITLE
docker/lite: Fix for other flavors and improved warning output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,17 +194,17 @@ docker_base_percona57:
 docker_lite:
 	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE)
 
-docker_lite_mysql56: docker_base_mysql56
-	cd docker/lite && ./build.sh mysql56
+docker_lite_mysql56:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) mysql56
 
-docker_lite_mariadb: docker_base_mariadb
-	cd docker/lite && ./build.sh mariadb
+docker_lite_mariadb:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) mariadb
 
-docker_lite_percona: docker_base_percona
-	cd docker/lite && ./build.sh percona
+docker_lite_percona:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) percona
 
-docker_lite_percona57: docker_base_percona57
-	cd docker/lite && ./build.sh percona57
+docker_lite_percona57:
+	cd docker/lite && ./build.sh --prompt=$(PROMPT_NOTICE) percona57
 
 docker_guestbook:
 	cd examples/kubernetes/guestbook && ./build.sh

--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -82,9 +82,9 @@ chmod -R o=g lite
 # Build vitess/lite image
 
 if [[ -n "$flavor" ]]; then
-	docker build --no-cache -f Dockerfile.$flavor -t vitess/lite:$flavor .
+  docker build --no-cache -f Dockerfile.$flavor -t vitess/lite:$flavor .
 else
-	docker build --no-cache -t vitess/lite .
+  docker build --no-cache -t vitess/lite .
 fi
 
 # Clean up temporary files

--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -17,10 +17,12 @@ flavor=$1
 tag=latest
 if [[ -n "$flavor" ]]; then
   base_image=vitess/base:$flavor
+  lite_image=vitess/lite:$flavor
   tag=$flavor
 else
   echo "Flavor not specified as first argument. Building default image."
   base_image=vitess/base
+  lite_image=vitess/lite
 fi
 
 # Abort if base image does not exist.
@@ -33,7 +35,9 @@ fi
 if [[ "$prompt_notice" = true ]]; then
   cat <<END
 
-This script is going to repack and copy the existing *local* base image '$base_image' into a smaller image 'vitess/lite'.
+This script is going to repack and copy the existing *local* base image '$base_image' into a smaller image '$lite_image'.
+
+It does NOT recompile the Vitess binaries. For that you will have to rebuild or pull the base image.
 
 The 'docker images' output below shows you how old your local base image is:
 


### PR DESCRIPTION
Follow-up fixes for https://github.com/youtube/vitess/pull/2768

- `make docker_lite` no longer builds the base image before repacking the lite image. @rnavarro wasn't aware of this. This warning should help to clarify things.
- Added `PROMPT_NOTICE` to the other Makefile targets as well.
- `docker/lite/build.sh` now always logs the correct base and lite image if the non-default flavor was selected.