### PR TITLE
Retain heartbeat when the tabletserver goes to NOT_SERVING

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -486,6 +486,8 @@ func (tsv *TabletServer) StopService() {
 	tsv.waitForShutdown()
 	tsv.qe.Close()
 	tsv.se.Close()
+	tsv.hw.Close()
+	tsv.hr.Close()
 	log.Infof("Shutdown complete.")
 	tsv.transition(StateNotConnected)
 }
@@ -498,8 +500,6 @@ func (tsv *TabletServer) waitForShutdown() {
 	// transactions.
 	tsv.txRequests.Wait()
 	tsv.messager.Close()
-	tsv.hr.Close()
-	tsv.hw.Close()
 	tsv.te.Close(false)
 	tsv.qe.streamQList.TerminateAll()
 	tsv.updateStreamList.Stop()


### PR DESCRIPTION
I noticed just now that if I create a new tablet from a backup, it comes up very lagged. This causes the healthcheck to complain:

```
Disabling query service because of health-check failure...
```

This causes the serving state to go to NOT_SERVING, which used to shut down the heartbeat thread. The healthcheck chooses the most lagged reporter to determine the lag of the server. So at this point the heartbeat lag is never updating and perpetually in a state of lagged.

This change keeps the heartbeat thread running, so that as replication catches up it can bring the query service back online. I thought it made sense to do the same for the writer thread.