### PR TITLE
A couple fixes I came across while testing automated backups/recovery

### DIFF
--- a/go/vt/mysqlctl/s3backupstorage/s3.go
+++ b/go/vt/mysqlctl/s3backupstorage/s3.go
@@ -201,7 +201,7 @@ func (bs *S3BackupStorage) RemoveBackup(ctx context.Context, dir, name string) e
 
 	query := &s3.ListObjectsV2Input{
 		Bucket: bucket,
-		Prefix: objName(dir, ""),
+		Prefix: objName(dir, name),
 	}
 
 	for {

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -80,7 +80,6 @@ func (r *Reader) Open(dbc dbconfigs.DBConfigs) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.isOpen {
-		log.Fatalf("BUG: Reader object cannot be initialized twice without closing in between: %v", r)
 		return
 	}
 

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -101,7 +101,6 @@ func (w *Writer) Open(dbc dbconfigs.DBConfigs) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.isOpen {
-		log.Fatalf("BUG: Writer object cannot be initialized twice without closing in between: %v", w)
 		return
 	}
 	log.Info("Beginning heartbeat writes")


### PR DESCRIPTION
I'm working on automating backups (glorified cron), and came across a couple bugs in the process:

- The S3 backup code does not specify the backup name to delete when it deletes. This causes all backups for a keyspace to be deleted instead.

- With the recent change to heartbeat so that it stays running when query service shuts down, now when tablet state changes we need to allow it to call Open again. The heartbeat service may have legitimately been Closed (change from master to slave), or it may have legitimately not (stopped query service due to lag).

@sougou 