### PR TITLE
Bugfix: Vitess backup restore process when using relay-log-info-repository = TABLE

### DIFF
--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -853,15 +853,5 @@ func Restore(
 		return replication.Position{}, err
 	}
 
-	cmds, err := mysqld.ResetSlaveCommands()
-	if err != nil {
-		return replication.Position{}, err
-	}
-
-	err = mysqld.ExecuteSuperQueryList(ctx, cmds)
-	if err != nil {
-		return replication.Position{}, err
-	}
-
 	return bm.Position, nil
 }

--- a/go/vt/mysqlctl/backup.go
+++ b/go/vt/mysqlctl/backup.go
@@ -853,5 +853,15 @@ func Restore(
 		return replication.Position{}, err
 	}
 
+	cmds, err := mysqld.ResetSlaveCommands()
+	if err != nil {
+		return replication.Position{}, err
+	}
+
+	err = mysqld.ExecuteSuperQueryList(ctx, cmds)
+	if err != nil {
+		return replication.Position{}, err
+	}
+
 	return bm.Position, nil
 }

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -53,6 +53,9 @@ type MysqlDaemon interface {
 	SetMasterCommands(masterHost string, masterPort int) ([]string, error)
 	WaitForReparentJournal(ctx context.Context, timeCreatedNS int64) error
 
+	// Used for backup restoration, to ensure we have a clean slate
+	ResetSlaveCommands() ([]string, error)
+
 	// DemoteMaster waits for all current transactions to finish,
 	// and returns the current replication position. It will not
 	// change the read_only state of the server.
@@ -122,6 +125,12 @@ type FakeMysqlDaemon struct {
 
 	// ResetReplicationError is returned by ResetReplication
 	ResetReplicationError error
+
+	// ResetSlaveResult is returned by ResetSlave
+	ResetSlaveResult []string
+
+	// ResetSlaveError is returned by ResetSlave
+	ResetSlaveError error
 
 	// CurrentMasterPosition is returned by MasterPosition
 	// and SlaveStatus
@@ -292,6 +301,11 @@ func (fmd *FakeMysqlDaemon) SlaveStatus() (Status, error) {
 // ResetReplicationCommands is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) ResetReplicationCommands() ([]string, error) {
 	return fmd.ResetReplicationResult, fmd.ResetReplicationError
+}
+
+// ResetSlaveCommands is part of the MysqlDaemon interface
+func (fmd *FakeMysqlDaemon) ResetSlaveCommands() ([]string, error) {
+	return fmd.ResetSlaveResult, fmd.ResetSlaveError
 }
 
 // MasterPosition is part of the MysqlDaemon interface

--- a/go/vt/mysqlctl/mysql_flavor.go
+++ b/go/vt/mysqlctl/mysql_flavor.go
@@ -36,6 +36,10 @@ type MysqlFlavor interface {
 	// replication on the host.
 	ResetReplicationCommands() []string
 
+	// ResetSlaveCommands returns the commands to reset just slave
+	// settings on the host.
+	ResetSlaveCommands() []string
+
 	// PromoteSlaveCommands returns the commands to run to change
 	// a slave into a master.
 	PromoteSlaveCommands() []string

--- a/go/vt/mysqlctl/mysql_flavor_mariadb.go
+++ b/go/vt/mysqlctl/mysql_flavor_mariadb.go
@@ -102,6 +102,14 @@ func (*mariaDB10) ResetReplicationCommands() []string {
 	}
 }
 
+// ResetSlaveCommands implements MysqlFlavor.ResetSlaveCommands().
+func (*mariaDB10) ResetSlaveCommands() []string {
+	return []string{
+		"STOP SLAVE",
+		"RESET SLAVE ALL", // "ALL" makes it forget the master host:port.
+	}
+}
+
 // PromoteSlaveCommands implements MysqlFlavor.PromoteSlaveCommands().
 func (*mariaDB10) PromoteSlaveCommands() []string {
 	return []string{

--- a/go/vt/mysqlctl/mysql_flavor_mysql56.go
+++ b/go/vt/mysqlctl/mysql_flavor_mysql56.go
@@ -107,6 +107,14 @@ func (*mysql56) ResetReplicationCommands() []string {
 	}
 }
 
+// ResetSlaveCommands implements MysqlFlavor.ResetSlaveCommands().
+func (*mysql56) ResetSlaveCommands() []string {
+	return []string{
+		"STOP SLAVE",
+		"RESET SLAVE ALL", // "ALL" makes it forget the master host:port.
+	}
+}
+
 // PromoteSlaveCommands implements MysqlFlavor.PromoteSlaveCommands().
 func (*mysql56) PromoteSlaveCommands() []string {
 	return []string{

--- a/go/vt/mysqlctl/mysql_flavor_test.go
+++ b/go/vt/mysqlctl/mysql_flavor_test.go
@@ -19,6 +19,7 @@ type fakeMysqlFlavor string
 func (f fakeMysqlFlavor) VersionMatch(version string) bool                 { return version == string(f) }
 func (fakeMysqlFlavor) PromoteSlaveCommands() []string                     { return nil }
 func (fakeMysqlFlavor) ResetReplicationCommands() []string                 { return nil }
+func (fakeMysqlFlavor) ResetSlaveCommands() []string                       { return nil }
 func (fakeMysqlFlavor) ParseGTID(string) (replication.GTID, error)         { return nil, nil }
 func (fakeMysqlFlavor) MakeBinlogEvent(buf []byte) replication.BinlogEvent { return nil }
 func (fakeMysqlFlavor) ParseReplicationPosition(string) (replication.Position, error) {

--- a/go/vt/mysqlctl/replication.go
+++ b/go/vt/mysqlctl/replication.go
@@ -237,6 +237,15 @@ func (mysqld *Mysqld) ResetReplicationCommands() ([]string, error) {
 	return flavor.ResetReplicationCommands(), nil
 }
 
+// ResetSlaveCommands returns the commands to run to reset just slave settings for this host
+func (mysqld *Mysqld) ResetSlaveCommands() ([]string, error) {
+	flavor, err := mysqld.flavor()
+	if err != nil {
+		return nil, fmt.Errorf("ResetReplicationCommands needs flavor: %v", err)
+	}
+	return flavor.ResetSlaveCommands(), nil
+}
+
 // +------+---------+---------------------+------+-------------+------+----------------------------------------------------------------+------------------+
 // | Id   | User    | Host                | db   | Command     | Time | State                                                          | Info             |
 // +------+---------+---------------------+------+-------------+------+----------------------------------------------------------------+------------------+

--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -108,8 +108,17 @@ func (agent *ActionAgent) restoreDataLocked(ctx context.Context, logger logutil.
 }
 
 func (agent *ActionAgent) startReplication(ctx context.Context, pos replication.Position, tabletType topodatapb.TabletType) error {
+	cmds, err := agent.MysqlDaemon.ResetSlaveCommands()
+	if err != nil {
+		return err
+	}
+
+	if err := agent.MysqlDaemon.ExecuteSuperQueryList(ctx, cmds); err != nil {
+		return fmt.Errorf("failed to reset slave: %v", err)
+	}
+
 	// Set the position at which to resume from the master.
-	cmds, err := agent.MysqlDaemon.SetSlavePositionCommands(pos)
+	cmds, err = agent.MysqlDaemon.SetSlavePositionCommands(pos)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The default value for `relay-log-info-repository` is FILE, and vitess does not override that in its my.cnf files. However, TABLE is good to use because it protects you from unexpected halts in the slave. See https://dev.mysql.com/doc/refman/5.7/en/replication-options-slave.html#option_mysqld_relay-log-info-repository. We run with TABLE and have seen the issues below.

The backup process for Vitess skips backing up relay log files, and does not copy the repository file. For those of us using `relay-log-info-repository = TABLE`, our relay log position gets carried along in the backup. This causes the restore to fail with: `Slave failed to initialize relay log info structure from the repository`. This is because the `mysql.slave_relay_log_info` table points to a relay log file and position that does not exist in a newly restored tablet.

There were 3 options I could think of (open to others):

- Exclude the `mysql/slave_relay_log_info.idb` and `mysql/slave_relay_log_info.frm` files from the backup. This looked like it would be pretty hacky based on the current code, and I'm not totally sure it would be enough.
- Delete the above files from the restored files before starting up mysql. Same points above apply, but seems even more hacky.
- Run `RESET SLAVE` before starting up a newly restored tablet.

The `RESET SLAVE` approach is what I went with because it seemed the least hacky and most robust. It shouldn't cause an issue for those without `TABLE` and fully sets the stage for the new slave to pick up with AUTO_POSITION=1 in the parent code.
