### PR TITLE
Don't require log-error config in mycnf

### DIFF
--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -174,7 +174,7 @@ func ReadMycnf(cnfFile string) (mycnf *Mycnf, err error) {
 	mycnf.InnodbLogGroupHomeDir = mycnf.lookupAndCheck("innodb_log_group_home_dir")
 	mycnf.SocketFile = mycnf.lookupAndCheck("socket")
 	mycnf.GeneralLogPath = mycnf.lookup("general_log_file")
-	mycnf.ErrorLogPath = mycnf.lookupAndCheck("log-error")
+	mycnf.ErrorLogPath = mycnf.lookup("log-error")
 	mycnf.SlowLogPath = mycnf.lookupAndCheck("slow-query-log-file")
 	mycnf.RelayLogPath = mycnf.lookupAndCheck("relay-log")
 	mycnf.RelayLogIndexPath = mycnf.lookupAndCheck("relay-log-index")

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -480,7 +480,7 @@ func (mysqld *Mysqld) Init(ctx context.Context, initDBSQLFile string) error {
 	// Start mysqld. We do not use Start, as we have to wait using
 	// the root user.
 	if err = mysqld.startNoWait(ctx); err != nil {
-		log.Errorf("failed starting mysqld (check %v for more info): %v", mysqld.config.ErrorLogPath, err)
+		log.Errorf("failed starting mysqld (check mysql error log %v for more info): %v", mysqld.config.ErrorLogPath, err)
 		return err
 	}
 
@@ -492,7 +492,7 @@ func (mysqld *Mysqld) Init(ctx context.Context, initDBSQLFile string) error {
 		UnixSocket: mysqld.config.SocketFile,
 	}
 	if err = mysqld.wait(ctx, params); err != nil {
-		log.Errorf("failed starting mysqld in time (check %v for more info): %v", mysqld.config.ErrorLogPath, err)
+		log.Errorf("failed starting mysqld in time (check mysyql error log %v for more info): %v", mysqld.config.ErrorLogPath, err)
 		return err
 	}
 


### PR DESCRIPTION
When running in kubernetes it is nice to not set `log-error`. In this case mysql defaults to `stderr`, which kubernetes routes through its logging system.

This change still allows it but doesn't require it to be set. I modified the couple of error messages that referenced it to make them at least not so cryptic if this value is empty.