### PR TITLE
JDBC Resilience

### DIFF
--- a/java/client/src/main/java/io/vitess/client/RpcClientFactory.java
+++ b/java/client/src/main/java/io/vitess/client/RpcClientFactory.java
@@ -17,16 +17,15 @@
 package io.vitess.client;
 
 import io.vitess.client.grpc.tls.TlsOptions;
-import java.net.InetSocketAddress;
 
 /**
  * RpcClientFactory creates a concrete RpcClient.
  */
 public interface RpcClientFactory {
 
-  RpcClient create(Context ctx, InetSocketAddress address);
+  RpcClient create(Context ctx, String target);
 
-  RpcClient createTls(Context ctx, InetSocketAddress address, TlsOptions tlsOptions);
+  RpcClient createTls(Context ctx, String target, TlsOptions tlsOptions);
 
 }
 

--- a/java/client/src/test/java/io/vitess/client/TestUtil.java
+++ b/java/client/src/test/java/io/vitess/client/TestUtil.java
@@ -16,22 +16,24 @@
 
 package io.vitess.client;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
-import io.vitess.proto.Query;
-import io.vitess.proto.Topodata.TabletType;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.joda.time.Duration;
 import org.junit.Assert;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+
+import io.vitess.proto.Query;
+import io.vitess.proto.Topodata.TabletType;
 import vttest.Vttest.VTTestTopology;
 
 public class TestUtil {
@@ -114,7 +116,7 @@ public class TestUtil {
     // Dial timeout
     Context ctx = Context.getDefault().withDeadlineAfter(Duration.millis(5000));
     return new VTGateBlockingConn(
-        getRpcClientFactory().create(ctx, new InetSocketAddress("localhost", testEnv.getPort())),
+        getRpcClientFactory().create(ctx, "localhost:" +  testEnv.getPort()),
         testEnv.getKeyspace());
   }
 

--- a/java/example/src/main/java/io/vitess/example/VitessClientExample.java
+++ b/java/example/src/main/java/io/vitess/example/VitessClientExample.java
@@ -17,7 +17,6 @@
 package io.vitess.example;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.net.HostAndPort;
 import com.google.common.primitives.UnsignedLong;
 import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
@@ -47,12 +46,8 @@ public class VitessClientExample {
       System.exit(1);
     }
 
-    // Connect to vtgate.
-    HostAndPort hostAndPort = HostAndPort.fromString(args[0]);
-    InetSocketAddress addr =
-        new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort());
     Context ctx = Context.getDefault().withDeadlineAfter(Duration.millis(5 * 1000));
-    try (RpcClient client = new GrpcClientFactory().create(ctx, addr);
+    try (RpcClient client = new GrpcClientFactory().create(ctx, args[0]);
         VTGateBlockingConn conn = new VTGateBlockingConn(client)) {
       // Insert some messages on random pages.
       System.out.println("Inserting into master...");

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -11,6 +11,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -34,6 +38,10 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -50,7 +50,7 @@ public class GrpcClientFactory implements RpcClientFactory {
   private RetryingInterceptorConfig config;
 
   public GrpcClientFactory() {
-    this(RetryingInterceptorConfig.noopConfig());
+    this(RetryingInterceptorConfig.noOpConfig());
   }
 
   public GrpcClientFactory(RetryingInterceptorConfig config) {

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/GrpcClientFactory.java
@@ -16,19 +16,9 @@
 
 package io.vitess.client.grpc;
 
-import io.grpc.netty.GrpcSslContexts;
-import io.grpc.netty.NegotiationType;
-import io.grpc.netty.NettyChannelBuilder;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.vitess.client.Context;
-import io.vitess.client.RpcClient;
-import io.vitess.client.RpcClientFactory;
-import io.vitess.client.grpc.tls.TlsOptions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -39,24 +29,46 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Enumeration;
+
 import javax.net.ssl.SSLException;
+
+import io.grpc.netty.GrpcSslContexts;
+import io.grpc.netty.NegotiationType;
+import io.grpc.netty.NettyChannelBuilder;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.vitess.client.Context;
+import io.vitess.client.RpcClient;
+import io.vitess.client.RpcClientFactory;
+import io.vitess.client.grpc.tls.TlsOptions;
 
 /**
  * GrpcClientFactory creates RpcClients with the gRPC implementation.
  */
 public class GrpcClientFactory implements RpcClientFactory {
 
+  private RetryingInterceptorConfig config;
+
+  public GrpcClientFactory() {
+    this(RetryingInterceptorConfig.noopConfig());
+  }
+
+  public GrpcClientFactory(RetryingInterceptorConfig config) {
+    this.config = config;
+  }
+
   /**
    * Factory method to construct a gRPC client connection with no transport-layer security.
    *
    * @param ctx TODO: This parameter is not actually used, but probably SHOULD be so that timeout duration and caller ID settings aren't discarded
-   * @param address
+   * @param target
+   *    target is passed to NettyChannelBuilder which will resolve based on scheme, by default dns.
    * @return
    */
   @Override
-  public RpcClient create(Context ctx, InetSocketAddress address) {
+  public RpcClient create(Context ctx, String target) {
     return new GrpcClient(
-            NettyChannelBuilder.forAddress(address).negotiationType(NegotiationType.PLAINTEXT).build());
+            NettyChannelBuilder.forTarget(target).negotiationType(NegotiationType.PLAINTEXT).intercept(new RetryingInterceptor(config)).build());
   }
 
   /**
@@ -66,12 +78,13 @@ public class GrpcClientFactory implements RpcClientFactory {
    * always be populated.  All other fields are optional.</p>
    *
    * @param ctx TODO: This parameter is not actually used, but probably SHOULD be so that timeout duration and caller ID settings aren't discarded
-   * @param address
+   * @param target
+   *    target is passed to NettyChannelBuilder which will resolve based on scheme, by default dns.
    * @param tlsOptions
    * @return
    */
   @Override
-  public RpcClient createTls(Context ctx, InetSocketAddress address, TlsOptions tlsOptions) {
+  public RpcClient createTls(Context ctx, String target, TlsOptions tlsOptions) {
     final SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
 
     // trustManager should always be set
@@ -109,7 +122,7 @@ public class GrpcClientFactory implements RpcClientFactory {
     }
 
     return new GrpcClient(
-        NettyChannelBuilder.forAddress(address).negotiationType(NegotiationType.TLS).sslContext(sslContext).build());
+        NettyChannelBuilder.forTarget(target).negotiationType(NegotiationType.TLS).sslContext(sslContext).intercept(new RetryingInterceptor(config)).build());
   }
 
   /**

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
@@ -22,6 +22,15 @@ import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.internal.SharedResourceHolder;
 
+/**
+ * RetryingInterceptor is used for retrying certain classes of failed requests in the underlying gRPC connection.
+ * At this time it handles {@link MethodDescriptor.MethodType.UNARY} requests with status {@link Status.Code.UNAVAILABLE}, which is
+ * according to the spec meant to be a transient error. This class can be configured with {@link RetryingInterceptorConfig} to
+ * determine what level of exponential backoff to apply to the handled types of failing requests.
+ *
+ * When enabled, this interceptor will retry valid requests with an exponentially increasing backoff time up to the maximum
+ * time defined by the {@link io.grpc.Deadline} in the call's {@link CallOptions}.
+ */
 public class RetryingInterceptor implements ClientInterceptor {
   private static Logger logger = Logger.getLogger(RetryingInterceptor.class.getName());
 

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
@@ -32,7 +32,6 @@ import io.grpc.internal.SharedResourceHolder;
  * time defined by the {@link io.grpc.Deadline} in the call's {@link CallOptions}.
  */
 public class RetryingInterceptor implements ClientInterceptor {
-  private static Logger logger = Logger.getLogger(RetryingInterceptor.class.getName());
 
   private final RetryingInterceptorConfig config;
 
@@ -166,7 +165,6 @@ public class RetryingInterceptor implements ClientInterceptor {
       }
 
       latestResponse = attempt;
-      logger.warning("Retrying after " + nextBackoffMillis + " millis");
       retryTask = scheduledExecutor.schedule(context.wrap(new Runnable() {
         @Override
         public void run() {

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptor.java
@@ -1,0 +1,225 @@
+package io.vitess.client.grpc;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.grpc.internal.GrpcUtil.TIMER_SERVICE;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import javax.annotation.Nullable;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.internal.SharedResourceHolder;
+
+public class RetryingInterceptor implements ClientInterceptor {
+  private static Logger logger = Logger.getLogger(RetryingInterceptor.class.getName());
+
+  private final RetryingInterceptorConfig config;
+
+  RetryingInterceptor(RetryingInterceptorConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+    // Only UNARY calls can be retried, streaming call errors should be handled by user.
+    if (method.getType() != MethodDescriptor.MethodType.UNARY || config.isDisabled()) {
+      return next.newCall(method, callOptions);
+    }
+
+    return new RetryingCall<ReqT, RespT>(method, callOptions, next, Context.current(), config);
+  }
+
+  private class RetryingCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+    private final MethodDescriptor<ReqT, RespT> method;
+    private final CallOptions callOptions;
+    private final Channel channel;
+    private final Context context;
+    private final ScheduledExecutorService scheduledExecutor;
+    private Listener<RespT> responseListener;
+    private Metadata requestHeaders;
+    private ReqT requestMessage;
+    private boolean compressionEnabled;
+    private final Queue<AttemptListener> attemptListeners =
+        new ConcurrentLinkedQueue<AttemptListener>();
+    private volatile AttemptListener latestResponse;
+    private volatile ScheduledFuture<?> retryTask;
+
+    private volatile long nextBackoffMillis = 5;
+    private final long maxBackoffMillis;
+    private final double backoffMultiplier;
+
+    RetryingCall(MethodDescriptor<ReqT, RespT> method,
+                 CallOptions callOptions, Channel channel, Context context,
+                 RetryingInterceptorConfig config) {
+      this.method = method;
+      this.callOptions = callOptions;
+      this.channel = channel;
+      this.context = context;
+      this.nextBackoffMillis = config.getInitialBackoffMillis();
+      this.maxBackoffMillis = config.getMaxBackoffMillis();
+      this.backoffMultiplier = config.getBackoffMultiplier();
+      this.scheduledExecutor = SharedResourceHolder.get(TIMER_SERVICE);
+    }
+
+    @Override
+    public void start(Listener<RespT> listener, Metadata headers) {
+      checkState(attemptListeners.isEmpty());
+      checkState(responseListener == null);
+      checkState(requestHeaders == null);
+      responseListener = listener;
+      requestHeaders = headers;
+      ClientCall<ReqT, RespT> firstCall = channel.newCall(method, callOptions);
+      AttemptListener attemptListener = new AttemptListener(firstCall);
+      attemptListeners.add(attemptListener);
+      firstCall.start(attemptListener, headers);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      lastCall().request(numMessages);
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+      for (AttemptListener attempt : attemptListeners) {
+        attempt.call.cancel(message, cause);
+      }
+      if (retryTask != null) {
+        retryTask.cancel(true);
+      }
+    }
+
+    @Override
+    public void halfClose() {
+      lastCall().halfClose();
+    }
+
+    @Override
+    public void sendMessage(ReqT message) {
+      checkState(requestMessage == null);
+      requestMessage = message;
+      lastCall().sendMessage(message);
+    }
+
+    @Override
+    public boolean isReady() {
+      return lastCall().isReady();
+    }
+
+    @Override
+    public void setMessageCompression(boolean enabled) {
+      compressionEnabled = enabled;
+      lastCall().setMessageCompression(enabled);
+    }
+
+    private long computeSleepTime() {
+      long currentBackoff = nextBackoffMillis;
+      nextBackoffMillis = Math.min((long) ( currentBackoff * backoffMultiplier), maxBackoffMillis);
+      return currentBackoff;
+    }
+
+    private void maybeRetry(AttemptListener attempt) {
+      Status status = attempt.responseStatus;
+
+      if (status.isOk() || status.getCode() != Status.Code.UNAVAILABLE) {
+        useResponse(attempt);
+        return;
+      }
+
+      long nextBackoffMillis = computeSleepTime();
+      long deadlineMillis = Long.MIN_VALUE;
+      if (callOptions.getDeadline() != null) {
+        deadlineMillis = callOptions.getDeadline().timeRemaining(TimeUnit.MILLISECONDS);
+      }
+
+      if (deadlineMillis > Long.MIN_VALUE && deadlineMillis < nextBackoffMillis) {
+        AttemptListener latest = latestResponse;
+        if (latest != null) {
+          useResponse(latest);
+        } else {
+          useResponse(attempt);
+        }
+        return;
+      }
+
+      latestResponse = attempt;
+      logger.warning("Retrying after " + nextBackoffMillis + " millis");
+      retryTask = scheduledExecutor.schedule(context.wrap(new Runnable() {
+        @Override
+        public void run() {
+          ClientCall<ReqT, RespT> nextCall = channel.newCall(method, callOptions);
+          AttemptListener nextAttemptListener = new AttemptListener(nextCall);
+          attemptListeners.add(nextAttemptListener);
+          nextCall.start(nextAttemptListener, requestHeaders);
+          nextCall.setMessageCompression(compressionEnabled);
+          nextCall.sendMessage(requestMessage);
+          nextCall.request(1);
+          nextCall.halfClose();
+        }
+      }), nextBackoffMillis, TimeUnit.MILLISECONDS);
+    }
+
+    private void useResponse(AttemptListener attempt) {
+      responseListener.onHeaders(attempt.responseHeaders);
+      if (attempt.responseMessage != null) {
+        responseListener.onMessage(attempt.responseMessage);
+      }
+      responseListener.onClose(attempt.responseStatus, attempt.responseTrailers);
+    }
+
+    private ClientCall<ReqT, RespT> lastCall() {
+      checkState(!attemptListeners.isEmpty());
+      return attemptListeners.peek().call;
+    }
+
+    private class AttemptListener extends ClientCall.Listener<RespT> {
+      final ClientCall<ReqT, RespT> call;
+      Metadata responseHeaders;
+      RespT responseMessage;
+      Status responseStatus;
+      Metadata responseTrailers;
+
+      AttemptListener(ClientCall<ReqT, RespT> call) {
+        this.call = call;
+      }
+
+      @Override
+      public void onHeaders(Metadata headers) {
+        responseHeaders = headers;
+      }
+
+      @Override
+      public void onMessage(RespT message) {
+        responseMessage = message;
+      }
+
+      @Override
+      public void onClose(Status status, Metadata trailers) {
+        responseStatus = status;
+        responseTrailers = trailers;
+        maybeRetry(this);
+      }
+
+      @Override
+      public void onReady() {
+        // Pass-through to original listener.
+        responseListener.onReady();
+      }
+    }
+  }
+
+}

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
@@ -1,5 +1,9 @@
 package io.vitess.client.grpc;
 
+/**
+ * This class defines what level of exponential backoff to apply in the {@link RetryingInterceptor}. It can be
+ * disabled with the {@link #noopConfig()}.
+ */
 public class RetryingInterceptorConfig {
 
   private static final long DISABLED = -1;
@@ -14,10 +18,22 @@ public class RetryingInterceptorConfig {
     this.backoffMultiplier = backoffMultiplier;
   }
 
+  /**
+   * Returns a no-op config which will not do any retries.
+   */
   public static RetryingInterceptorConfig noopConfig() {
     return new RetryingInterceptorConfig(DISABLED, DISABLED, 0);
   }
 
+  /**
+   * Returns an exponential config with the given values to determine how aggressive of a backoff is needed
+   * @param initialBackoffMillis
+   *    how long in millis to backoff off for the first attempt
+   * @param maxBackoffMillis
+   *    the maximum value the backoff time can grow to, at which point all future retries will backoff at this amount
+   * @param backoffMultiplier
+   *    how quickly the backoff time should grow
+   */
   public static RetryingInterceptorConfig exponentialConfig(long initialBackoffMillis, long maxBackoffMillis, double backoffMultiplier) {
     return new RetryingInterceptorConfig(initialBackoffMillis, maxBackoffMillis, backoffMultiplier);
   }

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
@@ -1,0 +1,40 @@
+package io.vitess.client.grpc;
+
+public class RetryingInterceptorConfig {
+
+  private static final long DISABLED = -1;
+
+  private final long initialBackoffMillis;
+  private final long maxBackoffMillis;
+  private final double backoffMultiplier;
+
+  private RetryingInterceptorConfig(long initialBackoffMillis, long maxBackoffMillis, double backoffMultiplier) {
+    this.initialBackoffMillis = initialBackoffMillis;
+    this.maxBackoffMillis = maxBackoffMillis;
+    this.backoffMultiplier = backoffMultiplier;
+  }
+
+  public static RetryingInterceptorConfig noopConfig() {
+    return new RetryingInterceptorConfig(DISABLED, DISABLED, 0);
+  }
+
+  public static RetryingInterceptorConfig exponentialConfig(long initialBackoffMillis, long maxBackoffMillis, double backoffMultiplier) {
+    return new RetryingInterceptorConfig(initialBackoffMillis, maxBackoffMillis, backoffMultiplier);
+  }
+
+  boolean isDisabled() {
+    return initialBackoffMillis == DISABLED || maxBackoffMillis == DISABLED;
+  }
+
+  long getInitialBackoffMillis() {
+    return initialBackoffMillis;
+  }
+
+  long getMaxBackoffMillis() {
+    return maxBackoffMillis;
+  }
+
+  double getBackoffMultiplier() {
+    return backoffMultiplier;
+  }
+}

--- a/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
+++ b/java/grpc-client/src/main/java/io/vitess/client/grpc/RetryingInterceptorConfig.java
@@ -2,7 +2,7 @@ package io.vitess.client.grpc;
 
 /**
  * This class defines what level of exponential backoff to apply in the {@link RetryingInterceptor}. It can be
- * disabled with the {@link #noopConfig()}.
+ * disabled with the {@link #noOpConfig()}.
  */
 public class RetryingInterceptorConfig {
 
@@ -21,7 +21,7 @@ public class RetryingInterceptorConfig {
   /**
    * Returns a no-op config which will not do any retries.
    */
-  public static RetryingInterceptorConfig noopConfig() {
+  public static RetryingInterceptorConfig noOpConfig() {
     return new RetryingInterceptorConfig(DISABLED, DISABLED, 0);
   }
 

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsClientAuthTest.java
@@ -16,22 +16,23 @@
 
 package io.client.grpc;
 
-import com.google.common.io.Files;
-import io.vitess.client.Context;
-import io.vitess.client.RpcClientTest;
-import io.vitess.client.grpc.GrpcClientFactory;
-import io.vitess.client.grpc.tls.TlsOptions;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
+
 import org.joda.time.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import com.google.common.io.Files;
+
+import io.vitess.client.Context;
+import io.vitess.client.RpcClientTest;
+import io.vitess.client.grpc.GrpcClientFactory;
+import io.vitess.client.grpc.tls.TlsOptions;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest), over an SSL connection with client
@@ -176,7 +177,7 @@ public class GrpcClientTlsClientAuthTest extends RpcClientTest {
         client = new GrpcClientFactory()
                 .createTls(
                         Context.getDefault().withDeadlineAfter(Duration.millis(5000)),
-                        new InetSocketAddress("localhost", port),
+                        "localhost:" + port,
                         tlsOptions
                 );
     }

--- a/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
+++ b/java/grpc-client/src/test/java/io/client/grpc/GrpcClientTlsTest.java
@@ -16,22 +16,23 @@
 
 package io.client.grpc;
 
-import com.google.common.io.Files;
-import io.vitess.client.Context;
-import io.vitess.client.RpcClientTest;
-import io.vitess.client.grpc.GrpcClientFactory;
-import io.vitess.client.grpc.tls.TlsOptions;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
+
 import org.joda.time.Duration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import com.google.common.io.Files;
+
+import io.vitess.client.Context;
+import io.vitess.client.RpcClientTest;
+import io.vitess.client.grpc.GrpcClientFactory;
+import io.vitess.client.grpc.tls.TlsOptions;
 
 /**
  * This tests GrpcClient with a mock vtgate server (go/cmd/vtgateclienttest), over an SSL connection.
@@ -159,7 +160,7 @@ public class GrpcClientTlsTest extends RpcClientTest {
         client = new GrpcClientFactory()
                 .createTls(
                         Context.getDefault().withDeadlineAfter(Duration.millis(5000)),
-                        new InetSocketAddress("localhost", port),
+                        "localhost:" + port,
                         tlsOptions
                 );
     }

--- a/java/grpc-client/src/test/java/io/vitess/client/grpc/RetryingInterceptorTest.java
+++ b/java/grpc-client/src/test/java/io/vitess/client/grpc/RetryingInterceptorTest.java
@@ -28,7 +28,7 @@ public class RetryingInterceptorTest {
   public void testNoopConfigPassesThrough() throws ExecutionException, InterruptedException {
     ForceRetryNTimesInterceptor forceRetryNTimesInterceptor = new ForceRetryNTimesInterceptor(3);
 
-    ManagedChannelImpl channel = InProcessChannelBuilder.forName("foo").intercept(new RetryingInterceptor(RetryingInterceptorConfig.noopConfig()), forceRetryNTimesInterceptor).build();
+    ManagedChannelImpl channel = InProcessChannelBuilder.forName("foo").intercept(new RetryingInterceptor(RetryingInterceptorConfig.noOpConfig()), forceRetryNTimesInterceptor).build();
     VitessGrpc.VitessFutureStub stub = VitessGrpc.newFutureStub(channel);
     ListenableFuture<Vtgate.ExecuteResponse> resp = stub.execute(Vtgate.ExecuteRequest.getDefaultInstance());
     try {

--- a/java/grpc-client/src/test/java/io/vitess/client/grpc/RetryingInterceptorTest.java
+++ b/java/grpc-client/src/test/java/io/vitess/client/grpc/RetryingInterceptorTest.java
@@ -1,0 +1,133 @@
+package io.vitess.client.grpc;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.internal.ManagedChannelImpl;
+import io.vitess.proto.Vtgate;
+import io.vitess.proto.grpc.VitessGrpc;
+
+public class RetryingInterceptorTest {
+
+  @Test
+  public void testNoopConfigPassesThrough() throws ExecutionException, InterruptedException {
+    ForceRetryNTimesInterceptor forceRetryNTimesInterceptor = new ForceRetryNTimesInterceptor(3);
+
+    ManagedChannelImpl channel = InProcessChannelBuilder.forName("foo").intercept(new RetryingInterceptor(RetryingInterceptorConfig.noopConfig()), forceRetryNTimesInterceptor).build();
+    VitessGrpc.VitessFutureStub stub = VitessGrpc.newFutureStub(channel);
+    ListenableFuture<Vtgate.ExecuteResponse> resp = stub.execute(Vtgate.ExecuteRequest.getDefaultInstance());
+    try {
+      resp.get();
+      Assert.fail("Should have failed after 1 attempt");
+    } catch (Exception e) {
+      Assert.assertEquals(1, forceRetryNTimesInterceptor.getNumRetryableFailures());
+    }
+  }
+
+  @Test
+  public void testRetryAfterBackoff() throws ExecutionException, InterruptedException {
+    ForceRetryNTimesInterceptor forceRetryNTimesInterceptor = new ForceRetryNTimesInterceptor(3);
+    RetryingInterceptorConfig retryingInterceptorConfig = RetryingInterceptorConfig.exponentialConfig(5, 60, 2);
+    ManagedChannelImpl channel = InProcessChannelBuilder.forName("foo").intercept(forceRetryNTimesInterceptor, new RetryingInterceptor(retryingInterceptorConfig)).build();
+    VitessGrpc.VitessFutureStub stub = VitessGrpc.newFutureStub(channel);
+    ListenableFuture<Vtgate.ExecuteResponse> resp = stub.execute(Vtgate.ExecuteRequest.getDefaultInstance());
+    try {
+      resp.get();
+      Assert.fail("Should have failed after 3 attempt");
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.assertEquals(3, forceRetryNTimesInterceptor.getNumRetryableFailures());
+    }
+  }
+
+  @Test
+  public void testRetryDeadlineExceeded() throws ExecutionException, InterruptedException {
+    ForceRetryNTimesInterceptor forceRetryNTimesInterceptor = new ForceRetryNTimesInterceptor(3);
+    RetryingInterceptorConfig retryingInterceptorConfig = RetryingInterceptorConfig.exponentialConfig(5, 60, 2);
+    ManagedChannelImpl channel = InProcessChannelBuilder.forName("foo").intercept(forceRetryNTimesInterceptor, new RetryingInterceptor(retryingInterceptorConfig)).build();
+    VitessGrpc.VitessFutureStub stub = VitessGrpc.newFutureStub(channel).withDeadlineAfter(1, TimeUnit.MILLISECONDS);
+    ListenableFuture<Vtgate.ExecuteResponse> resp = stub.execute(Vtgate.ExecuteRequest.getDefaultInstance());
+    try {
+      resp.get();
+      Assert.fail("Should have failed");
+    } catch (Exception e) {
+      Assert.assertEquals(1, forceRetryNTimesInterceptor.getNumRetryableFailures());
+    }
+  }
+
+  public class ForceRetryNTimesInterceptor implements ClientInterceptor {
+
+    private final int timesToForceRetry;
+
+    private int numRetryableFailures = 0;
+
+    ForceRetryNTimesInterceptor(int timesToForceRetry) {
+      this.timesToForceRetry = timesToForceRetry;
+    }
+
+    int getNumRetryableFailures() {
+      return numRetryableFailures;
+    }
+
+    @Override
+    public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+
+      System.out.println("Num failures: " + numRetryableFailures);
+      if (numRetryableFailures < timesToForceRetry) {
+        numRetryableFailures++;
+        return new FailingCall<ReqT, RespT>(Status.UNAVAILABLE);
+      }
+
+      return new FailingCall<>(Status.ABORTED);
+    }
+  }
+
+  private class FailingCall<ReqT, RespT> extends ClientCall<ReqT, RespT> {
+
+    private final Status statusToFailWith;
+
+    public FailingCall(Status statusToFailWith) {
+      this.statusToFailWith = statusToFailWith;
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      responseListener.onClose(statusToFailWith, null);
+    }
+
+    @Override
+    public void request(int numMessages) {
+      // no op, will fail immediately on start
+    }
+
+    @Override
+    public void cancel(@Nullable String message, @Nullable Throwable cause) {
+      // no op, will fail immediately on start
+    }
+
+    @Override
+    public void halfClose() {
+      // no op, will fail immediately on start
+    }
+
+    @Override
+    public void sendMessage(ReqT message) {
+      // no op, will fail immediately on start
+    }
+  }
+}

--- a/java/hadoop/src/main/java/io/vitess/hadoop/VitessRecordReader.java
+++ b/java/hadoop/src/main/java/io/vitess/hadoop/VitessRecordReader.java
@@ -16,7 +16,18 @@
 
 package io.vitess.hadoop;
 
-import com.google.common.net.HostAndPort;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.joda.time.Duration;
+
 import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.RpcClientFactory;
@@ -27,17 +38,6 @@ import io.vitess.proto.Query;
 import io.vitess.proto.Query.BoundQuery;
 import io.vitess.proto.Topodata.TabletType;
 import io.vitess.proto.Vtgate.SplitQueryResponse;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
-import org.apache.hadoop.io.NullWritable;
-import org.apache.hadoop.mapreduce.InputSplit;
-import org.apache.hadoop.mapreduce.RecordReader;
-import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.joda.time.Duration;
 
 public class VitessRecordReader extends RecordReader<NullWritable, RowWritable> {
   private VitessInputSplit split;
@@ -62,11 +62,10 @@ public class VitessRecordReader extends RecordReader<NullWritable, RowWritable> 
           (Class<? extends RpcClientFactory>) Class.forName(conf.getRpcFactoryClass());
       List<String> addressList = Arrays.asList(conf.getHosts().split(","));
       int index = new Random().nextInt(addressList.size());
-      HostAndPort hostAndPort = HostAndPort.fromString(addressList.get(index));
 
       RpcClient rpcClient = rpcFactoryClass.newInstance().create(
           Context.getDefault().withDeadlineAfter(Duration.millis(conf.getTimeoutMs())),
-          new InetSocketAddress(hostAndPort.getHostText(), hostAndPort.getPort()));
+          addressList.get(index));
       vtgate = new VTGateBlockingConn(rpcClient);
       includedFields = conf.getIncludedFields();
     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessJDBCUrl.java
@@ -70,6 +70,11 @@ public class VitessJDBCUrl {
         public int getPort() {
             return port;
         }
+
+        @Override
+        public String toString() {
+            return hostname + ":" + port;
+        }
     }
 
     /**

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -25,7 +25,6 @@ import io.vitess.client.grpc.tls.TlsOptions;
 import io.vitess.util.CommonUtils;
 import io.vitess.util.Constants;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -148,7 +147,7 @@ public class VitessVTGateManager {
 
     private static RetryingInterceptorConfig getRetryingInterceptorConfig(VitessConnection conn) {
         if (!conn.getGrpcRetriesEnabled()) {
-            return RetryingInterceptorConfig.noopConfig();
+            return RetryingInterceptorConfig.noOpConfig();
         }
 
         return RetryingInterceptorConfig.exponentialConfig(conn.getGrpcRetryInitialBackoffMillis(), conn.getGrpcRetryMaxBackoffMillis(), conn.getGrpcRetryBackoffMultiplier());

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -29,7 +29,7 @@ import org.mockito.Mockito;
 
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 20;
+    private static final int NUM_PROPS = 24;
 
     @Test
     public void testReflection() throws Exception {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessVTGateManagerTest.java
@@ -16,20 +16,21 @@
 
 package io.vitess.jdbc;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.joda.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+
 import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConn;
 import io.vitess.client.grpc.GrpcClientFactory;
 import io.vitess.proto.Vtrpc;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
-import java.sql.SQLException;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
 
 /**
  * Created by naveen.nahata on 29/02/16.
@@ -40,7 +41,7 @@ public class VitessVTGateManagerTest {
         Vtrpc.CallerID callerId = Vtrpc.CallerID.newBuilder().setPrincipal("username").build();
         Context ctx =
             Context.getDefault().withDeadlineAfter(Duration.millis(500)).withCallerId(callerId);
-        RpcClient client = new GrpcClientFactory().create(ctx, new InetSocketAddress("host", 80));
+        RpcClient client = new GrpcClientFactory().create(ctx, "host:80");
         return new VTGateConn(client);
     }
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -115,6 +115,11 @@
         <version>${grpc.version}</version>
       </dependency>
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>4.1.6.Final</version>


### PR DESCRIPTION
I've run into a few issues recently while chaos monkey testing vitess. With the current approach, if I kill a VTGate that a client is connected to, the client will fail and not recover. There are 2 problems here:

- We pre-resolve the DNS at VitessConnection creation time, creating an InetSocketAddress
- We have no retries.

gRPC does not have native retry support, but it does have native DNS support in our version. This change moves us to using the built-in DNS Support (change to `forTarget` instead of `forAddress`), and adds a ClientInterceptor for retries with exponential backoff.

The retry logic is tested in 2 new test classes. The logic was pulled and simplified from https://github.com/grpc/grpc-java/pull/1570, which has been superseded by a somewhat-stalled https://github.com/grpc/grpc-java/pull/1590.  If they make progress on that issue in the future we can remove the retry interceptor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/2820)
<!-- Reviewable:end -->
