### PR TITLE
Fix WARNING text if GOROOT not set properly

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -69,7 +69,7 @@ export PATH=$(prepend_path $PATH $VTROOT/dist/node/bin)
 go_bin=`which go`
 go_env=`go env | grep GOROOT | cut -f 2 -d\"`
 if [ "$go_bin" -a "$go_bin" != "$go_env/bin/go" ]; then
-  echo "WARNING: \$GOROOT may not compatible with the used go binary"
+  echo "WARNING: \$GOROOT may not be compatible with the used go binary"
   echo "Please make sure 'go' comes from \$GOROOT/bin"
   echo "go_env: $go_env"
   echo "go_bin: $go_bin"


### PR DESCRIPTION
Tiny patch as the warning text did not quite make sense.