### PR TITLE
sqlparser: TableName: pointer->value

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -102,7 +102,7 @@ func IsDML(sql string) bool {
 // GetTableName returns the table name from the SimpleTableExpr
 // only if it's a simple expression. Otherwise, it returns "".
 func GetTableName(node SimpleTableExpr) TableIdent {
-	if n, ok := node.(*TableName); ok && n.Qualifier.IsEmpty() {
+	if n, ok := node.(TableName); ok && n.Qualifier.IsEmpty() {
 		return n.Name
 	}
 	// sub-select or '.' expression
@@ -232,7 +232,7 @@ func ExtractSetValues(sql string) (map[string]interface{}, error) {
 	}
 	result := make(map[string]interface{})
 	for _, expr := range setStmt.Exprs {
-		if expr.Name.Qualifier != nil {
+		if !expr.Name.Qualifier.IsEmpty() {
 			return nil, fmt.Errorf("invalid syntax: %v", String(expr.Name))
 		}
 		key := expr.Name.Name.Lowered()

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -219,45 +219,6 @@ func TestColNameEqual(t *testing.T) {
 	}
 }
 
-func TestTableNameEqual(t *testing.T) {
-	var t1, t2 *TableName
-	if !t1.Equal(t2) {
-		t.Error("nil tables unequal, want equal")
-	}
-	t2 = &TableName{}
-	if !t1.Equal(t2) {
-		t.Error("nil and empty table unequal, want equal")
-	}
-	if !t2.Equal(t1) {
-		t.Error("empty and nil table unequal, want equal")
-	}
-	t1 = &TableName{}
-	if !t1.Equal(t2) {
-		t.Error("empty and empty table unequal, want equal")
-	}
-	t2 = &TableName{
-		Qualifier: NewTableIdent("aa"),
-		Name:      NewTableIdent("bb"),
-	}
-	if t1.Equal(t2) {
-		t.Error("empty and non-empty table equal, want unequal")
-	}
-	if t2.Equal(t1) {
-		t.Error("non-empty and empty table equal, want unequal")
-	}
-	t1 = &TableName{
-		Qualifier: NewTableIdent("bb"),
-		Name:      NewTableIdent("bb"),
-	}
-	if t1.Equal(t2) {
-		t.Error("non-empty and non-empty table equal, want unequal")
-	}
-	t1.Qualifier = NewTableIdent("aa")
-	if !t1.Equal(t2) {
-		t.Error("tables are unequal, want equal")
-	}
-}
-
 func TestColIdent(t *testing.T) {
 	str := NewColIdent("Ab")
 	if str.String() != "Ab" {

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -45,7 +45,7 @@ type yySymType struct {
 	colName          *ColName
 	tableExprs       TableExprs
 	tableExpr        TableExpr
-	tableName        *TableName
+	tableName        TableName
 	indexHints       *IndexHints
 	expr             Expr
 	exprs            Exprs
@@ -1918,13 +1918,13 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:557
 		{
-			yyVAL.selectExpr = &StarExpr{TableName: &TableName{Name: yyDollar[1].tableIdent}}
+			yyVAL.selectExpr = &StarExpr{TableName: TableName{Name: yyDollar[1].tableIdent}}
 		}
 	case 76:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:561
 		{
-			yyVAL.selectExpr = &StarExpr{TableName: &TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}}
+			yyVAL.selectExpr = &StarExpr{TableName: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}}
 		}
 	case 77:
 		yyDollar = yyS[yypt-0 : yypt+1]
@@ -1954,7 +1954,7 @@ yydefault:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:586
 		{
-			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: &TableName{Name: NewTableIdent("dual")}}}
+			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
 		}
 	case 83:
 		yyDollar = yyS[yypt-2 : yypt+1]
@@ -2138,13 +2138,13 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:740
 		{
-			yyVAL.tableName = &TableName{Name: yyDollar[1].tableIdent}
+			yyVAL.tableName = TableName{Name: yyDollar[1].tableIdent}
 		}
 	case 116:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:744
 		{
-			yyVAL.tableName = &TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}
+			yyVAL.tableName = TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}
 		}
 	case 117:
 		yyDollar = yyS[yypt-0 : yypt+1]
@@ -2918,13 +2918,13 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:1341
 		{
-			yyVAL.colName = &ColName{Qualifier: &TableName{Name: yyDollar[1].tableIdent}, Name: yyDollar[3].colIdent}
+			yyVAL.colName = &ColName{Qualifier: TableName{Name: yyDollar[1].tableIdent}, Name: yyDollar[3].colIdent}
 		}
 	case 249:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		//line ./go/vt/sqlparser/sql.y:1345
 		{
-			yyVAL.colName = &ColName{Qualifier: &TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}, Name: yyDollar[5].colIdent}
+			yyVAL.colName = &ColName{Qualifier: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}, Name: yyDollar[5].colIdent}
 		}
 	case 250:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -58,7 +58,7 @@ func forceEOF(yylex interface{}) {
   colName     *ColName
   tableExprs  TableExprs
   tableExpr   TableExpr
-  tableName   *TableName
+  tableName   TableName
   indexHints  *IndexHints
   expr        Expr
   exprs       Exprs
@@ -555,11 +555,11 @@ select_expression:
   }
 | table_id '.' '*'
   {
-    $$ = &StarExpr{TableName: &TableName{Name: $1}}
+    $$ = &StarExpr{TableName: TableName{Name: $1}}
   }
 | table_id '.' reserved_table_id '.' '*'
   {
-    $$ = &StarExpr{TableName: &TableName{Qualifier: $1, Name: $3}}
+    $$ = &StarExpr{TableName: TableName{Qualifier: $1, Name: $3}}
   }
 
 as_ci_opt:
@@ -584,7 +584,7 @@ col_alias:
 
 from_opt:
   {
-    $$ = TableExprs{&AliasedTableExpr{Expr:&TableName{Name: NewTableIdent("dual")}}}
+    $$ = TableExprs{&AliasedTableExpr{Expr:TableName{Name: NewTableIdent("dual")}}}
   }
 | FROM table_references
   {
@@ -738,11 +738,11 @@ into_table_name:
 table_name:
   table_id
   {
-    $$ = &TableName{Name: $1}
+    $$ = TableName{Name: $1}
   }
 | table_id '.' reserved_table_id
   {
-    $$ = &TableName{Qualifier: $1, Name: $3}
+    $$ = TableName{Qualifier: $1, Name: $3}
   }
 
 index_hint_list:
@@ -1339,11 +1339,11 @@ column_name:
   }
 | table_id '.' reserved_sql_id
   {
-    $$ = &ColName{Qualifier: &TableName{Name: $1}, Name: $3}
+    $$ = &ColName{Qualifier: TableName{Name: $1}, Name: $3}
   }
 | table_id '.' reserved_table_id '.' reserved_sql_id
   {
-    $$ = &ColName{Qualifier: &TableName{Qualifier: $1, Name: $3}, Name: $5}
+    $$ = &ColName{Qualifier: TableName{Qualifier: $1, Name: $3}, Name: $5}
   }
 
 value:

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -27,7 +27,7 @@ import (
 // dmlFormatter strips out keyspace name from dmls.
 func dmlFormatter(buf *sqlparser.TrackedBuffer, node sqlparser.SQLNode) {
 	switch node := node.(type) {
-	case *sqlparser.TableName:
+	case sqlparser.TableName:
 		node.Name.Format(buf)
 		return
 	}
@@ -39,7 +39,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 	route := &engine.Route{
 		Query: generateQuery(upd),
 	}
-	updateTable, _ := upd.Table.Expr.(*sqlparser.TableName)
+	updateTable, _ := upd.Table.Expr.(sqlparser.TableName)
 
 	var err error
 	route.Table, err = vschema.Find(updateTable.Qualifier, updateTable.Name)

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -80,7 +80,7 @@ func processTableExpr(tableExpr sqlparser.TableExpr, vschema VSchema) (builder, 
 // support complex joins in subqueries yet.
 func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema VSchema) (builder, error) {
 	switch expr := tableExpr.Expr.(type) {
-	case *sqlparser.TableName:
+	case sqlparser.TableName:
 		eroute, table, err := getTablePlan(expr, vschema)
 		if err != nil {
 			return nil, err
@@ -88,7 +88,7 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema VSchema)
 		alias := expr
 		astName := expr.Name
 		if !tableExpr.As.IsEmpty() {
-			alias = &sqlparser.TableName{Name: tableExpr.As}
+			alias = sqlparser.TableName{Name: tableExpr.As}
 			astName = tableExpr.As
 		}
 		return newRoute(
@@ -141,7 +141,7 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema VSchema)
 			subroute.ERoute,
 			table,
 			vschema,
-			&sqlparser.TableName{Name: tableExpr.As},
+			sqlparser.TableName{Name: tableExpr.As},
 			tableExpr.As,
 		)
 		subroute.Redirect = rtb
@@ -153,7 +153,7 @@ func processAliasedTable(tableExpr *sqlparser.AliasedTableExpr, vschema VSchema)
 // getTablePlan produces the initial engine.Route for the specified TableName.
 // It also returns the associated vschema info (*Table) so that
 // it can be used to create the symbol table entry.
-func getTablePlan(tableName *sqlparser.TableName, vschema VSchema) (*engine.Route, *vindexes.Table, error) {
+func getTablePlan(tableName sqlparser.TableName, vschema VSchema) (*engine.Route, *vindexes.Table, error) {
 	table, err := vschema.Find(tableName.Qualifier, tableName.Name)
 	if err != nil {
 		return nil, nil, err

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -48,7 +48,7 @@ type route struct {
 	ERoute *engine.Route
 }
 
-func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, table *vindexes.Table, vschema VSchema, alias *sqlparser.TableName, astName sqlparser.TableIdent) *route {
+func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, table *vindexes.Table, vschema VSchema, alias sqlparser.TableName, astName sqlparser.TableIdent) *route {
 	// We have some circular pointer references here:
 	// The route points to the symtab idicating
 	// the symtab that should be used to resolve symbols
@@ -472,7 +472,7 @@ func (rb *route) Wireup(bldr builder, jt *jointab) error {
 				buf.Myprintf("%a", ":"+joinVar)
 				return
 			}
-		case *sqlparser.TableName:
+		case sqlparser.TableName:
 			node.Name.Format(buf)
 			return
 		}
@@ -529,7 +529,7 @@ func (rb *route) generateFieldQuery(sel sqlparser.SelectStatement, jt *jointab) 
 				buf.Myprintf("%a", ":"+joinVar)
 				return
 			}
-		case *sqlparser.TableName:
+		case sqlparser.TableName:
 			node.Name.Format(buf)
 			return
 		}
@@ -560,7 +560,7 @@ func (rb *route) SupplyCol(ref colref) int {
 		&sqlparser.NonStarExpr{
 			Expr: &sqlparser.ColName{
 				Metadata:  ref.Meta,
-				Qualifier: &sqlparser.TableName{Name: ref.Meta.(*tabsym).ASTName},
+				Qualifier: sqlparser.TableName{Name: ref.Meta.(*tabsym).ASTName},
 				Name:      ref.Name(),
 			},
 		},

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -74,7 +74,7 @@ func newSymtab(vschema VSchema) *symtab {
 }
 
 // AddAlias adds a table alias to symtab.
-func (st *symtab) AddAlias(alias *sqlparser.TableName, astName sqlparser.TableIdent, table *vindexes.Table, rb *route) {
+func (st *symtab) AddAlias(alias sqlparser.TableName, astName sqlparser.TableIdent, table *vindexes.Table, rb *route) {
 	st.tables = append(st.tables, &tabsym{
 		Alias:          alias,
 		ASTName:        astName,
@@ -107,9 +107,9 @@ func (st *symtab) Merge(newsyms *symtab) error {
 	return nil
 }
 
-func (st *symtab) findTable(alias *sqlparser.TableName) *tabsym {
+func (st *symtab) findTable(alias sqlparser.TableName) *tabsym {
 	for i, t := range st.tables {
-		if t.Alias.Equal(alias) {
+		if t.Alias == alias {
 			return st.tables[i]
 		}
 	}
@@ -260,7 +260,7 @@ type sym interface {
 // from the table name, which is something that VTTablet and MySQL
 // can't recognize.
 type tabsym struct {
-	Alias          *sqlparser.TableName
+	Alias          sqlparser.TableName
 	ASTName        sqlparser.TableIdent
 	route          *route
 	symtab         *symtab

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -104,7 +104,7 @@ func unionRouteMerge(union *sqlparser.Union, left, right builder, vschema VSchem
 		lroute.ERoute,
 		table,
 		vschema,
-		&sqlparser.TableName{Name: sqlparser.NewTableIdent("")}, // Unions don't have an addressable table name.
+		sqlparser.TableName{Name: sqlparser.NewTableIdent("")}, // Unions don't have an addressable table name.
 		sqlparser.NewTableIdent(""),
 	)
 	lroute.Redirect = rtb

--- a/go/vt/vttablet/tabletserver/planbuilder/ddl.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/ddl.go
@@ -24,8 +24,8 @@ import (
 // DDLPlan provides a plan for DDLs.
 type DDLPlan struct {
 	Action    string
-	TableName *sqlparser.TableName
-	NewName   *sqlparser.TableName
+	TableName sqlparser.TableName
+	NewName   sqlparser.TableName
 }
 
 // DDLParse parses a DDL and produces a DDLPlan.
@@ -47,9 +47,8 @@ func DDLParse(sql string) (plan *DDLPlan) {
 
 func analyzeDDL(ddl *sqlparser.DDL, tables map[string]*schema.Table) *Plan {
 	// TODO(sougou): Add support for sequences.
-	plan := &Plan{PlanID: PlanDDL}
-	if ddl.Table != nil {
-		plan.Table = tables[ddl.Table.Name.String()]
+	return &Plan{
+		PlanID: PlanDDL,
+		Table:  tables[ddl.Table.Name.String()],
 	}
-	return plan
 }

--- a/go/vt/vttablet/tabletserver/splitquery/full_scan_algorithm.go
+++ b/go/vt/vttablet/tabletserver/splitquery/full_scan_algorithm.go
@@ -196,7 +196,7 @@ func convertColumnsToSelectExprs(columns []*schema.TableColumn) sqlparser.Select
 func buildFromClause(splitTableName sqlparser.TableIdent) sqlparser.TableExprs {
 	return sqlparser.TableExprs{
 		&sqlparser.AliasedTableExpr{
-			Expr: &sqlparser.TableName{Name: splitTableName},
+			Expr: sqlparser.TableName{Name: splitTableName},
 			Hints: &sqlparser.IndexHints{
 				Type:    sqlparser.ForceStr,
 				Indexes: []sqlparser.ColIdent{sqlparser.NewColIdent("PRIMARY")},


### PR DESCRIPTION
TableName introduced many unnecessary nil checks. Code is simpler
if it's used as value. Also, this allows for TableName to be used
as map key, which simplifies the v3 refactor.