### PR TITLE
v3: symtab refactor

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -518,8 +518,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.id from user",
-      "FieldQuery": "select user.id from user where 1 != 1"
+      "Query": "select user.Id from user",
+      "FieldQuery": "select user.Id from user where 1 != 1"
     },
     "Right": {
       "Opcode": "SelectUnsharded",

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -547,8 +547,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col, user.id from user",
-      "FieldQuery": "select user.col, user.id from user where 1 != 1"
+      "Query": "select user.col, user.Id from user",
+      "FieldQuery": "select user.col, user.Id from user where 1 != 1"
     },
     "Right": {
       "Opcode": "SelectScatter",
@@ -647,8 +647,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col, user.id from user",
-      "FieldQuery": "select user.col, user.id from user where 1 != 1"
+      "Query": "select user.col, user.Id from user",
+      "FieldQuery": "select user.col, user.Id from user where 1 != 1"
     },
     "Right": {
       "Opcode": "SelectScatter",

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -247,8 +247,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by a asc, user.col2 desc",
-      "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+      "Query": "select user.col1 as a, user.col2, user.Id from user where user.id = 1 order by a asc, user.col2 desc",
+      "FieldQuery": "select user.col1 as a, user.col2, user.Id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": 1
     },
@@ -289,8 +289,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by null",
-      "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+      "Query": "select user.col1 as a, user.col2, user.Id from user where user.id = 1 order by null",
+      "FieldQuery": "select user.col1 as a, user.col2, user.Id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": 1
     },
@@ -331,8 +331,8 @@
         "Name": "user",
         "Sharded": true
       },
-      "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by 1 asc, 2 desc",
-      "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
+      "Query": "select user.col1 as a, user.col2, user.Id from user where user.id = 1 order by 1 asc, 2 desc",
+      "FieldQuery": "select user.col1 as a, user.col2, user.Id from user where 1 != 1",
       "Vindex": "user_index",
       "Values": 1
     },

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -34,13 +34,16 @@ type builder interface {
 	// SetSymtab sets the symtab for the current node and
 	// its non-subquery children.
 	SetSymtab(*symtab)
-	// Order is a number that signifies execution order.
-	// A lower Order number Route is executed before a
-	// higher one. For a node that contains other nodes,
-	// the Order represents the highest order of the leaf
-	// nodes. This function is used to travel from a root
-	// node to a target node.
-	Order() int
+	// MaxOrder must return the order number of the
+	// highest route within the current sub-tree.
+	// The routes are numbered by their execution order.
+	// When two trees are brought together into a join,
+	// the MaxOrder from the left is used as starting point
+	// to renumber the routes on the right. Execution order
+	// always goes from left to right. A node that contains
+	// sub-nodes (like a join), can cache these values
+	// and use them for efficient b-tree style traversal.
+	MaxOrder() int
 	// SetOrder sets the order for the underlying routes.
 	SetOrder(int)
 	// Primitve returns the underlying primitive.

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -56,12 +56,12 @@ type builder interface {
 	// to subqueries.
 	SetRHS()
 	// PushSelect pushes the select expression through the tree
-	// all the way to the route that colsym points to.
+	// all the way to the route that resultColumn points to.
 	// PushSelect is similar to SupplyCol except that it always
 	// adds a new column, whereas SupplyCol can reuse an existing
-	// column. The function must return a colsym for the expression
+	// column. The function must return a resultColumn for the expression
 	// and the column number of the result.
-	PushSelect(expr *sqlparser.NonStarExpr, rb *route) (colsym *colsym, colnum int, err error)
+	PushSelect(expr *sqlparser.NonStarExpr, rb *route) (rc *resultColumn, colnum int, err error)
 	// PushOrderByNull pushes the special case ORDER By NULL to
 	// all routes. It's safe to push down this clause because it's
 	// just on optimization hint.
@@ -78,10 +78,10 @@ type builder interface {
 	SupplyVar(from, to int, col *sqlparser.ColName, varname string)
 	// SupplyCol will be used for the wire-up process. This function
 	// takes a column reference as input, changes the primitive
-	// to supply the requested column and returns the column number of
-	// the result for it. The request is passed down recursively
+	// to supply the requested column and returns the resultColumn and
+	// column number of the result. The request is passed down recursively
 	// as needed.
-	SupplyCol(ref colref) int
+	SupplyCol(c *column) (rc *resultColumn, colnum int)
 }
 
 // VSchema defines the interface for this package to fetch

--- a/go/vt/vtgate/planbuilder/doc.go
+++ b/go/vt/vtgate/planbuilder/doc.go
@@ -52,19 +52,6 @@ the original request into a Route. If it's not possible,
 we see if we can build a primitive for it. If none exist,
 we return an error.
 
-The primitives are built as an execution tree.
-In order to traverse the tree
-to reach a certain node, we use a numbering system
-where every node is assigned an order. The lowest level
-nodes are assigned numbers based on their execution
-order. The higher level nodes inherit the highest
-order of the nodes they encompass, and this goes
-recursively up until the root node, whose order will
-always be the same as the last route. Primitives may
-themselves store additional information for efficient
-traversal. For example, join stores LeftOrder and
-RightOrder. Its usage is explained in the join type.
-
 The central design element for analyzing queries and
 building plans is the symbol table (symtab). This data
 structure evolves as a query is analyzed. Therefore,

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -69,7 +69,7 @@ func findRoute(expr sqlparser.Expr, bldr builder) (rb *route, err error) {
 			if err != nil {
 				return false, err
 			}
-			if isLocal && newRoute.Order() > highestRoute.Order() {
+			if isLocal && newRoute.Order > highestRoute.Order {
 				highestRoute = newRoute
 			}
 		case *sqlparser.Subquery:
@@ -92,7 +92,7 @@ func findRoute(expr sqlparser.Expr, bldr builder) (rb *route, err error) {
 			for _, extern := range subroute.Symtab().Externs {
 				// No error expected. These are resolved externs.
 				newRoute, isLocal, _ := bldr.Symtab().Find(extern, false)
-				if isLocal && newRoute.Order() > highestRoute.Order() {
+				if isLocal && newRoute.Order > highestRoute.Order {
 					highestRoute = newRoute
 				}
 			}

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -165,7 +165,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 // for the current route. External references are treated as value.
 func exprIsValue(expr sqlparser.Expr, rb *route) bool {
 	if node, ok := expr.(*sqlparser.ColName); ok {
-		return node.Metadata.(sym).Route() != rb
+		return node.Metadata.(*column).Route() != rb
 	}
 	return sqlparser.IsValue(expr)
 }
@@ -174,7 +174,7 @@ func valEqual(a, b interface{}) bool {
 	switch a := a.(type) {
 	case *sqlparser.ColName:
 		if b, ok := b.(*sqlparser.ColName); ok {
-			return newColref(a) == newColref(b)
+			return a.Metadata == b.Metadata
 		}
 	case *sqlparser.SQLVal:
 		b, ok := b.(*sqlparser.SQLVal)

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -71,5 +71,5 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 // the join var name if one has already been assigned for it.
 func (jt *jointab) Lookup(col *sqlparser.ColName) (order int, joinVar string) {
 	c := col.Metadata.(*column)
-	return c.Route().Order(), jt.refs[c]
+	return c.Route().Order, jt.refs[c]
 }

--- a/go/vt/vtgate/planbuilder/jointab.go
+++ b/go/vt/vtgate/planbuilder/jointab.go
@@ -25,7 +25,7 @@ import (
 // jointab manages procurement and naming of join
 // variables across primitives.
 type jointab struct {
-	refs map[colref]string
+	refs map[*column]string
 	vars map[string]struct{}
 }
 
@@ -35,7 +35,7 @@ type jointab struct {
 // it generates don't collide with those already in use.
 func newJointab(bindvars map[string]struct{}) *jointab {
 	return &jointab{
-		refs: make(map[colref]string),
+		refs: make(map[*column]string),
 		vars: bindvars,
 	}
 }
@@ -44,7 +44,7 @@ func newJointab(bindvars map[string]struct{}) *jointab {
 // and returns the join var name for it.
 func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string {
 	from, joinVar := jt.Lookup(col)
-	// If joinVar is empty, jterate a unique name.
+	// If joinVar is empty, generate a unique name.
 	if joinVar == "" {
 		suffix := ""
 		i := 0
@@ -61,7 +61,7 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 			suffix = strconv.Itoa(i)
 		}
 		jt.vars[joinVar] = struct{}{}
-		jt.refs[newColref(col)] = joinVar
+		jt.refs[col.Metadata.(*column)] = joinVar
 	}
 	bldr.SupplyVar(from, to, col, joinVar)
 	return joinVar
@@ -70,6 +70,6 @@ func (jt *jointab) Procure(bldr builder, col *sqlparser.ColName, to int) string 
 // Lookup returns the order of the route that supplies the column and
 // the join var name if one has already been assigned for it.
 func (jt *jointab) Lookup(col *sqlparser.ColName) (order int, joinVar string) {
-	ref := newColref(col)
-	return ref.Route().Order(), jt.refs[ref]
+	c := col.Metadata.(*column)
+	return c.Route().Order(), jt.refs[c]
 }

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -106,6 +106,12 @@ func init() {
 func TestPlan(t *testing.T) {
 	vschema := loadSchema(t, "schema_test.json")
 
+	// You will notice that some tests expect user.Id instead of user.id.
+	// This is because we now pre-create vindex columns in the symbol
+	// table, which come from vschema. In the test vschema,
+	// the column is named as Id. This is to make sure that
+	// column names are case-preserved, but treated as
+	// case-insensitive even if they come from the vschema.
 	testFile(t, "from_cases.txt", vschema)
 	testFile(t, "filter_cases.txt", vschema)
 	testFile(t, "select_cases.txt", vschema)

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -147,14 +147,14 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		if rb == nil {
 			return errors.New("unsupported: complex order by")
 		}
-		if rb.Order() < routeNumber {
+		if rb.Order < routeNumber {
 			return errors.New("unsupported: complex join and out of sequence order by")
 		}
 		if !rb.IsSingle() {
 			return errors.New("unsupported: scatter and order by")
 		}
-		routeNumber = rb.Order()
-		if err := rb.AddOrder(pushOrder); err != nil {
+		routeNumber = rb.Order
+		if err := rb.AddOrderBy(pushOrder); err != nil {
 			return err
 		}
 	}

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -40,7 +40,7 @@ type route struct {
 	// Select is the AST for the query fragment that will be
 	// executed by this route.
 	Select sqlparser.SelectStatement
-	order  int
+	Order  int
 	symtab *symtab
 	// ResultColumns represent the columns returned by this route.
 	ResultColumns []*resultColumn
@@ -52,7 +52,7 @@ func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, table *vinde
 	rb := &route{
 		Select: stmt,
 		symtab: newSymtab(vschema),
-		order:  1,
+		Order:  1,
 		ERoute: eroute,
 	}
 	rb.symtab.AddAlias(alias, table, rb)
@@ -78,14 +78,14 @@ func (rb *route) SetSymtab(symtab *symtab) {
 	rb.symtab = symtab
 }
 
-// Order returns the order of the node.
-func (rb *route) Order() int {
-	return rb.order
+// MaxOrder returns the max order of the node.
+func (rb *route) MaxOrder() int {
+	return rb.Order
 }
 
 // SetOrder sets the order to one above the specified number.
 func (rb *route) SetOrder(order int) {
-	rb.order = order + 1
+	rb.Order = order + 1
 }
 
 // Primitve returns the built primitive.
@@ -373,8 +373,8 @@ func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) {
 	rb.Select.(*sqlparser.Select).GroupBy = groupBy
 }
 
-// AddOrder adds an ORDER BY expression to the route.
-func (rb *route) AddOrder(order *sqlparser.Order) error {
+// AddOrderBy adds an ORDER BY expression to the route.
+func (rb *route) AddOrderBy(order *sqlparser.Order) error {
 	if rb.IsRHS {
 		return errors.New("unsupported: complex left join and order by")
 	}
@@ -444,7 +444,7 @@ func (rb *route) Wireup(bldr builder, jt *jointab) error {
 		switch node := node.(type) {
 		case *sqlparser.ColName:
 			if !rb.isLocal(node) {
-				joinVar := jt.Procure(bldr, node, rb.Order())
+				joinVar := jt.Procure(bldr, node, rb.Order)
 				rb.ERoute.JoinVars[joinVar] = struct{}{}
 				buf.Myprintf("%a", ":"+joinVar)
 				return
@@ -479,7 +479,7 @@ func (rb *route) procureValues(bldr builder, jt *jointab, val interface{}) (inte
 		}
 		return vals, nil
 	case *sqlparser.ColName:
-		joinVar := jt.Procure(bldr, val, rb.Order())
+		joinVar := jt.Procure(bldr, val, rb.Order)
 		rb.ERoute.JoinVars[joinVar] = struct{}{}
 		return ":" + joinVar, nil
 	case sqlparser.ListArg:

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -105,7 +105,6 @@ func unionRouteMerge(union *sqlparser.Union, left, right builder, vschema VSchem
 		table,
 		vschema,
 		sqlparser.TableName{Name: sqlparser.NewTableIdent("")}, // Unions don't have an addressable table name.
-		sqlparser.NewTableIdent(""),
 	)
 	lroute.Redirect = rtb
 	rroute.Redirect = rtb


### PR DESCRIPTION
This is prep work for being able to allow more constructs to
be recognized as pass-through, especially for unsharded keyspaces.

The fundamental intent behind this change is to allow for a symbol
to be associated to just a route without knowing which table it's
coming from. So, if you have a query like 'select a from t1, t2'
where t1 and t2 are from the same keyspace, then we can still
push-down 'a' into that route without knowing which table it comes
from.

Additionally, the concept of colRef was confusing because it had
different interpretations depending on whether it was a select
column or table column. Colsym was another confusing name because
it wasn't really a column symbol.

The new scheme is actually easier to understand if studied fresh:
symtab contains tables, and tables contain columns.
A table column pointer uniquely identifies the column.
symtab also contains result columns. A result column contains a
column reference. If it's a real column, then it points to the
actual table column. Otherwise, it's a unique anonymous reference
that just points to the originating route.

This column reference is saved as Metadata in ColName elements
where they previously used to store colRef. This results in
some simplification. More importantly, a 'column' can now be
anonymous, which should let us support more constructs.