### PR TITLE
don't try to roll back on a nonexistent session

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -65,7 +65,9 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysqlconn.Conn) {
 	// Rollback if there is an ongoing transaction. Ignore error.
 	ctx := context.Background()
 	session, _ := c.ClientData.(*vtgatepb.Session)
-	_, _, _ = vh.vtg.Execute(ctx, session, "rollback", make(map[string]interface{}))
+	if (session != nil) {
+		_, _, _ = vh.vtg.Execute(ctx, session, "rollback", make(map[string]interface{}))
+	}
 }
 
 func (vh *vtgateHandler) ComQuery(c *mysqlconn.Conn, query string) (*sqltypes.Result, error) {


### PR DESCRIPTION
Fix a bug in which the mysql protocol handling in vtgate will panic if a connection is closed before being properly established, e.g.:

```
E0508 16:35:43.813587   16199 server.go:148] Cannot read client handshake response: invalid sequence, expected 1 got 10
E0508 16:35:43.813692   16199 server.go:128] mysql_server caught panic:
runtime error: invalid memory address or nil pointer dereference
/mnt/jenkinsslave/workspace/slack-vitess/workdir/go/src/runtime/panic.go:489 (0x42c23f)
/mnt/jenkinsslave/workspace/slack-vitess/workdir/go/src/runtime/panic.go:63 (0x42b0ee)
/mnt/jenkinsslave/workspace/slack-vitess/workdir/go/src/runtime/signal_unix.go:290 (0x44154f)
/mnt/jenkinsslave/workspace/slack-vitess/go_workspace/src/github.com/youtube/vitess/go/vt/vtgate/vtgate.go:301 (0x928793)
/mnt/jenkinsslave/workspace/slack-vitess/go_workspace/src/github.com/youtube/vitess/go/vt/vtgate/vtgate.go:227 (0x927b10)
/mnt/jenkinsslave/workspace/slack-vitess/go_workspace/src/github.com/youtube/vitess/go/vt/vtgate/plugin_mysql_server.go:52 (0x913c0e)
/mnt/jenkinsslave/workspace/slack-vitess/go_workspace/src/github.com/youtube/vitess/go/mysqlconn/server.go:149 (0x816297)
/mnt/jenkinsslave/workspace/slack-vitess/workdir/go/src/runtime/asm_amd64.s:2197 (0x45b401)
```
