### PR TITLE
tweak lint checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ install:
   - ./bootstrap.sh
 before_script:
   - source dev.env
+  - tools/check-lint.sh
   # Travis only tests. Run only on the first shard.
   # Part of "before_script" because in "script" the job would not fail immediately if a command fails.
   - |

--- a/misc/git/hooks/gofmt
+++ b/misc/git/hooks/gofmt
@@ -13,13 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # git gofmt pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
 #
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gofiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 
 [ -z "$gofiles" ] && exit 0
 unformatted=$(gofmt -s -l $gofiles 2>&1)

--- a/misc/git/hooks/goimports
+++ b/misc/git/hooks/goimports
@@ -13,13 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # git goimports pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
 # it has execute permissions.
 #
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gofiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 
 [ -z "$gofiles" ] && exit 0
 unformatted=$(goimports -l=true $gofiles 2>&1 | awk -F: '{print $1}')

--- a/misc/git/hooks/golint
+++ b/misc/git/hooks/golint
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # git golint pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
@@ -29,7 +33,7 @@ if [ -z "$(which golint)" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
+gofiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 
 errors=
 

--- a/misc/git/hooks/govet
+++ b/misc/git/hooks/govet
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # git go vet pre-commit hook
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
@@ -24,7 +28,7 @@ if [ -z "$GOPATH" ]; then
 fi
 
 # This script does not handle file names that contain spaces.
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$')
+gofiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '^go/.*\.go$')
 
 # If any checks are found to be useless, they can be disabled here.
 # See the output of "go tool vet" for a list of flags.

--- a/misc/git/hooks/pylint
+++ b/misc/git/hooks/pylint
@@ -16,6 +16,10 @@
 # This file is based on the Go linter precommit hook
 # "golint". Therefore, both files are very similar.
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # misc/git/hooks/pylint
 #
 # To use, store as .git/hooks/pre-commit inside your repository and make sure
@@ -29,7 +33,7 @@ PYLINT=/usr/bin/gpylint
 pylint_script=$VTTOP/tools/pylint.sh
 
 # This script does not handle file names that contain spaces.
-pyfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.py$' | grep -v '^py/vtproto/')
+pyfiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '.*\.py$' | grep -v '^py/vtproto/')
 if [ -z "$pyfiles" ] ; then
   exit 0
 fi

--- a/misc/git/hooks/pylint
+++ b/misc/git/hooks/pylint
@@ -31,7 +31,6 @@ pylint_script=$VTTOP/tools/pylint.sh
 # This script does not handle file names that contain spaces.
 pyfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '.*\.py$' | grep -v '^py/vtproto/')
 if [ -z "$pyfiles" ] ; then
-  msg "No python files changed."
   exit 0
 fi
 

--- a/misc/git/hooks/tslint
+++ b/misc/git/hooks/tslint
@@ -2,10 +2,15 @@
 #
 # Precommit hook which runs 'tslint' to lint TypeScript code.
 #
+
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # It gets only triggered when a file below $vtctld_web_src was changed.
 vtctld_web="web/vtctld2"
 
-git diff --cached --name-only --diff-filter=ACM | grep -q "^${vtctld_web}/src"
+git diff $GIT_BASE --name-only --diff-filter=ACM | grep -q "^${vtctld_web}/src"
 if [ $? -ne 0 ]; then
   # No potential TypeScript file changed. Return early.
   exit 0

--- a/misc/git/hooks/unused
+++ b/misc/git/hooks/unused
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# By default diff against cached files for commit, but also support diff
+# against another base (e.g. origin/master)
+: ${GIT_BASE:="--cached"}
+
 # git unused pre-commit hook
 
 if [ -z "$GOPATH" ]; then
@@ -14,7 +18,7 @@ fi
 
 # This script does not handle file names that contain spaces.
 # Exclude auto-generated files (from proto or yacc compile).
-gofiles=$(git diff --cached --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
+gofiles=$(git diff $GIT_BASE --name-only --diff-filter=ACM | grep '^go/.*\.go$' | grep -v '^go/vt/proto/' | grep -v 'go/vt/sqlparser/sql.go')
 if [ "$gofiles" = "" ]; then
   exit 0
 fi

--- a/tools/check-lint.sh
+++ b/tools/check-lint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Runs all the hooks in misc/git/hooks against the specified base branch
+# (default origin/master), and exits if any of them fail.
+set -e
+
+: ${GIT_BASE:="origin/master"}
+export GIT_BASE
+
+# This is necessary because the Emacs extensions don't set GIT_DIR.
+if [ -z "$GIT_DIR" ]; then
+  DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+  GIT_DIR="${DIR}/.."
+fi
+for hook in $GIT_DIR/misc/git/hooks/*; do
+  $hook
+done


### PR DESCRIPTION
Add support to all the lint checks to check for GIT_BASE and if set, use that instead of --cached to figure out the set of files to lint against.

Also add tools/check-lint.sh script to run the checks against a specified base revision, which defaults to `origin/master`.

Finally, add this check to travis so that by default we run the lint checks on all the PRs.


