### PR TITLE
CodeClimate: Ignore generated Go code.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,3 +9,9 @@ engines:
 ratings:
   paths:
     - "**.go"
+
+# Ignore generated code.
+exclude_paths:
+- "go/vt/proto/"
+- "go/vt/sqlparser/sql.go"
+


### PR DESCRIPTION
This list is currently in sync with the exceptions which we have in our
precommit hooks.