### PR TITLE
minor fix for deprecation warning in `kubectl port-forward`

### DIFF
--- a/examples/kubernetes/env.sh
+++ b/examples/kubernetes/env.sh
@@ -68,7 +68,7 @@ start_vtctld_forward() {
   fi
 
   tmpfile=`mktemp`
-  $KUBECTL $KUBECTL_OPTIONS port-forward -p $pod 0:15999 &> $tmpfile &
+  $KUBECTL $KUBECTL_OPTIONS port-forward $pod 0:15999 &> $tmpfile &
   vtctld_forward_pid=$!
 
   until [[ `cat $tmpfile` =~ :([0-9]+)\ -\> ]]; do :; done


### PR DESCRIPTION
Just happened to notice a deprecation notice when trying to debug something:

  -p POD is DEPRECATED and will be removed in a future version. Use port-forward POD instead.

The output is going to a tmpfile, so people wouldn't normally see it.