### PR TITLE
Handle VARBINARYs that arent actually binary

### DIFF
--- a/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
@@ -247,14 +247,14 @@ public class FieldWithMetadataTest extends BaseTest {
             .setType(Query.Type.VARBINARY)
             .setName("foo")
             .setOrgName("foo")
-            .setCharset(/* binary */63)
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
             .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
             .build();
 
         FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
         Assert.assertEquals("no remapping - base case", Types.VARBINARY, fieldWithMetadata.getJavaType());
 
-        raw = raw.toBuilder().setCharset(/* utf-8 */33).build();
+        raw = raw.toBuilder().setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build();
         fieldWithMetadata = new FieldWithMetadata(conn, raw);
         Assert.assertEquals("remap to varchar due to non-binary encoding", Types.VARCHAR, fieldWithMetadata.getJavaType());
     }
@@ -691,8 +691,8 @@ public class FieldWithMetadataTest extends BaseTest {
         Assert.assertEquals("greek", field.getEncodingForIndex(25));
 
         field.getConnectionProperties().setEncoding(null);
-        Assert.assertEquals("UTF-8", field.getEncodingForIndex(33));
-        Assert.assertEquals("ISO-8859-1", field.getEncodingForIndex(63));
+        Assert.assertEquals("UTF-8", field.getEncodingForIndex(CharsetMapping.MYSQL_COLLATION_INDEX_utf8));
+        Assert.assertEquals("ISO-8859-1", field.getEncodingForIndex(CharsetMapping.MYSQL_COLLATION_INDEX_binary));
 
         field.getConnectionProperties().setEncoding("NOT_REAL");
         // Same tests as the first one, but testing that when there is a default configured, it falls back to that regardless


### PR DESCRIPTION
I recently discovered internally a situation where we weren't properly converting bytes to string. For us this was for any column that used `COLLATE ascii_bin`. Digging into it I discovered that MySQL has 2 methods for determining whether something is "binary":

- the `binary` flag (on the flags bitmap with value 128)
- the `binary` collation (collationIndex = 63, returned per field)

If Vitess sees the `binary` flag, it converts a `VARCHAR` to `VARBINARY` before sending to JDBC. The oracle JDBC does similar when talking directly to MySQL, however it has an additional check of the collationIndex to determine if the encoding is binary or not. We weren't doing that.

Also, I simplified the check to remove the `LONGVARBINARY` case. It's impossible to get this from Vitess. It's possible to get remapped to it above, but only if the collation is binary -- so the check is irrelevant.