### PR TITLE
v3: information_schema queries

### DIFF
--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -542,6 +542,21 @@
   }
 }
 
+# subquery of information_schema with itself
+"select * from information_schema.a where id in (select * from information_schema.b)"
+{
+  "Original": "select * from information_schema.a where id in (select * from information_schema.b)",
+  "Instructions": {
+    "Opcode": "ExecDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select * from information_schema.a where id in (select * from information_schema.b)",
+    "FieldQuery": "select * from information_schema.a where 1 != 1"
+  }
+}
+
 # subquery
 "select u.m from user_extra join user u where u.id in (select m2 from user where user.id = u.id and user_extra.col = user.col) and u.id in (user_extra.col, 1)"
 {

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -28,6 +28,21 @@
   }
 }
 
+# Single information_schema query
+"select col from information_schema.foo"
+{
+  "Original": "select col from information_schema.foo",
+  "Instructions": {
+    "Opcode": "ExecDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select col from information_schema.foo",
+    "FieldQuery": "select col from information_schema.foo where 1 != 1"
+  }
+}
+
 # Multi-table unsharded
 "select m1.col from unsharded as m1 join unsharded as m2"
 {
@@ -115,6 +130,21 @@
     },
     "Query": "select u1.a, u2.a from unsharded as u1, unsharded as u2",
     "FieldQuery": "select u1.a, u2.a from unsharded as u1, unsharded as u2 where 1 != 1"
+  }
+}
+
+# ',' join information_schema
+"select * from information_schema.a, information_schema.b"
+{
+  "Original": "select * from information_schema.a, information_schema.b",
+  "Instructions": {
+    "Opcode": "ExecDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select * from information_schema.a, information_schema.b",
+    "FieldQuery": "select * from information_schema.a, information_schema.b where 1 != 1"
   }
 }
 

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -615,6 +615,21 @@
   }
 }
 
+# union of information_schema
+"select * from information_schema.a union select * from information_schema.b"
+{
+  "Original": "select * from information_schema.a union select * from information_schema.b",
+  "Instructions": {
+    "Opcode": "ExecDBA",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select * from information_schema.a union select * from information_schema.b",
+    "FieldQuery": "select * from information_schema.a where 1 != 1 union select * from information_schema.b where 1 != 1"
+  }
+}
+
 # union with the same target shard
 "select * from music where user_id = 1 union select * from user where id = 1"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -63,6 +63,14 @@
 "select id from user where id = 5 and id in (select user_id from user_extra where user_extra.user_id = 4)"
 "unsupported: subquery and parent route to different shards"
 
+# join of information_schema with normal table
+"select foo from information_schema.a join unsharded"
+"unsupported: intermixing of information_schema and regular tables"
+
+# join of normal table with information_schema
+"select foo from unsharded join information_schema.a"
+"unsupported: intermixing of information_schema and regular tables"
+
 # scatter subquery in select
 "select id, (select id from user) from user"
 "unsupported: scatter subquery"
@@ -118,6 +126,14 @@
 # subqueries not supported in group by
 "select id from user group by (select id from user_extra)"
 "unsupported: subqueries in group by expression"
+
+# subquery of information_schema with normal table
+"select (select * from unsharded) from information_schema.a"
+"unsupported: intermixing of information_schema and regular tables"
+
+# subquery of normal table with information_schema
+"select (select * from information_schema.a) from unsharded"
+"unsupported: intermixing of information_schema and regular tables"
 
 # Order by uses complex expression
 "select id from user order by id+1"
@@ -298,6 +314,14 @@
 # complex expression in parenthesis with order by not supported yet
 "select * from user where (id = 4 AND name ='abc') order by id"
 "unsupported: scatter and order by"
+
+# union of information_schema with normal table
+"select * from information_schema.a union select * from unsharded"
+"unsupported: intermixing of information_schema and regular tables"
+
+# union of information_schema with normal table
+"select * from unsharded union select * from information_schema.a"
+"unsupported: intermixing of information_schema and regular tables"
 
 # multi-shard union
 "(select id from user union select id from music) union select 1 from dual"

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -49,6 +49,15 @@ type Route struct {
 	Suffix     string
 }
 
+// NewRoute creates a new Route.
+func NewRoute(opcode RouteOpcode, keyspace *vindexes.Keyspace) *Route {
+	return &Route{
+		Opcode:   opcode,
+		Keyspace: keyspace,
+		JoinVars: make(map[string]struct{}),
+	}
+}
+
 // MarshalJSON serializes the Route into a JSON representation.
 // It's used for testing and diagnostics.
 func (route *Route) MarshalJSON() ([]byte, error) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -32,6 +32,7 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
@@ -50,6 +51,28 @@ func TestSelectNext(t *testing.T) {
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
+	}
+}
+
+func TestExecDBA(t *testing.T) {
+	executor, sbc1, _, _ := createExecutorEnv()
+
+	query := "select * from information_schema.foo"
+	_, err := executor.Execute(
+		context.Background(),
+		&vtgatepb.Session{TargetString: "TestExecutor"},
+		query,
+		map[string]interface{}{},
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries := []querytypes.BoundQuery{{
+		Sql:           query,
+		BindVariables: map[string]interface{}{},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
 	}
 }
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 func TestExecutorTransactions(t *testing.T) {
@@ -289,7 +289,7 @@ func TestExecutorShow(t *testing.T) {
 
 	session = &vtgatepb.Session{}
 	qr, err = executor.Execute(context.Background(), session, "show vschema_tables", nil)
-	want := noKeyspaceErr.Error()
+	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}
@@ -382,7 +382,7 @@ func TestExecutorOther(t *testing.T) {
 	}
 
 	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "analyze", nil)
-	want := noKeyspaceErr.Error()
+	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}
@@ -444,7 +444,7 @@ func TestExecutorDDL(t *testing.T) {
 	}
 
 	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "create", nil)
-	want := noKeyspaceErr.Error()
+	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -91,6 +91,7 @@ type builder interface {
 // info about tables.
 type VSchema interface {
 	Find(tablename sqlparser.TableName) (table *vindexes.Table, err error)
+	DefaultKeyspace() (*vindexes.Keyspace, error)
 }
 
 // Build builds a plan for a query based on the specified vschema.

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -90,7 +90,7 @@ type builder interface {
 // VSchema defines the interface for this package to fetch
 // info about tables.
 type VSchema interface {
-	Find(keyspace, tablename sqlparser.TableIdent) (table *vindexes.Table, err error)
+	Find(tablename sqlparser.TableName) (table *vindexes.Table, err error)
 }
 
 // Build builds a plan for a query based on the specified vschema.

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -42,7 +42,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 	updateTable, _ := upd.Table.Expr.(sqlparser.TableName)
 
 	var err error
-	route.Table, err = vschema.Find(updateTable.Qualifier, updateTable.Name)
+	route.Table, err = vschema.Find(updateTable)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, err
 		Query: generateQuery(del),
 	}
 	var err error
-	route.Table, err = vschema.Find(del.Table.Qualifier, del.Table.Name)
+	route.Table, err = vschema.Find(del.Table)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/from.go
+++ b/go/vt/vtgate/planbuilder/from.go
@@ -155,17 +155,9 @@ func getTablePlan(tableName sqlparser.TableName, vschema VSchema) (*engine.Route
 		return nil, nil, err
 	}
 	if table.Keyspace.Sharded {
-		return &engine.Route{
-			Opcode:   engine.SelectScatter,
-			Keyspace: table.Keyspace,
-			JoinVars: make(map[string]struct{}),
-		}, table, nil
+		return engine.NewRoute(engine.SelectScatter, table.Keyspace), table, nil
 	}
-	return &engine.Route{
-		Opcode:   engine.SelectUnsharded,
-		Keyspace: table.Keyspace,
-		JoinVars: make(map[string]struct{}),
-	}, table, nil
+	return engine.NewRoute(engine.SelectUnsharded, table.Keyspace), table, nil
 }
 
 // processJoin produces a builder subtree for the given Join.

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -28,7 +28,7 @@ import (
 
 // buildInsertPlan builds the route for an INSERT statement.
 func buildInsertPlan(ins *sqlparser.Insert, vschema VSchema) (*engine.Route, error) {
-	table, err := vschema.Find(ins.Table.Qualifier, ins.Table.Name)
+	table, err := vschema.Find(ins.Table)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -146,6 +146,10 @@ func (vw *vschemaWrapper) Find(tab sqlparser.TableName) (*vindexes.Table, error)
 	return vw.v.Find(tab.Qualifier.String(), tab.Name.String())
 }
 
+func (vw *vschemaWrapper) DefaultKeyspace() (*vindexes.Keyspace, error) {
+	return vw.v.Keyspaces["main"].Keyspace, nil
+}
+
 func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {
 	for tcase := range iterateExecFile(filename) {
 		plan, err := Build(tcase.input, &vschemaWrapper{

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -142,8 +142,8 @@ type vschemaWrapper struct {
 	v *vindexes.VSchema
 }
 
-func (vw *vschemaWrapper) Find(ks, tab sqlparser.TableIdent) (*vindexes.Table, error) {
-	return vw.v.Find(ks.String(), tab.String())
+func (vw *vschemaWrapper) Find(tab sqlparser.TableName) (*vindexes.Table, error) {
+	return vw.v.Find(tab.Qualifier.String(), tab.Name.String())
 }
 
 func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -48,14 +48,13 @@ type route struct {
 	ERoute *engine.Route
 }
 
-func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, table *vindexes.Table, vschema VSchema, alias sqlparser.TableName) *route {
+func newRoute(stmt sqlparser.SelectStatement, eroute *engine.Route, vschema VSchema) *route {
 	rb := &route{
 		Select: stmt,
-		symtab: newSymtab(vschema),
 		Order:  1,
 		ERoute: eroute,
 	}
-	rb.symtab.AddAlias(alias, table, rb)
+	rb.symtab = newSymtab(vschema, rb)
 	return rb
 }
 

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -224,10 +224,9 @@ func pushSelectRoutes(selectExprs sqlparser.SelectExprs, bldr builder) ([]*resul
 				// This code is unreachable because the parser doesn't allow joins for next val statements.
 				return nil, errors.New("unsupported: SELECT NEXT query in complex join")
 			}
-			if rb.ERoute.Opcode != engine.SelectUnsharded {
-				return nil, errors.New("NEXT used on a sharded table")
+			if err := rb.SetOpcode(engine.SelectNext); err != nil {
+				return nil, err
 			}
-			rb.ERoute.Opcode = engine.SelectNext
 			resultColumns[i] = rb.PushAnonymous(node)
 		}
 	}

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -122,19 +122,23 @@ type symtab struct {
 }
 
 // newSymtab creates a new symtab initialized
-// to contain the provided table alias.
-func newSymtab(vschema VSchema) *symtab {
+// to containe just one route.
+func newSymtab(vschema VSchema, rb *route) *symtab {
 	return &symtab{
 		tables:        make(map[sqlparser.TableName]*table),
 		uniqueColumns: make(map[string]*column),
 		VSchema:       vschema,
+		singleRoute:   rb,
 	}
 }
 
-// AddAlias adds a table alias to symtab. Currently, this function
-// is only called to add the first table. Additional tables are
+// InitWithAlias initializes the symtab with a table alias.
+// It panics if symtab already contains tables. Additional tables are
 // added to the symtab through calls to Merge.
-func (st *symtab) AddAlias(alias sqlparser.TableName, vindexTable *vindexes.Table, rb *route) {
+func (st *symtab) InitWithAlias(alias sqlparser.TableName, vindexTable *vindexes.Table, rb *route) {
+	if len(st.tables) != 0 {
+		panic(fmt.Sprintf("BUG: symtab already contains tables: %v", st.tables))
+	}
 	table := &table{
 		alias:   alias,
 		columns: make(map[string]*column),

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/engine"
-	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 )
 
 func buildUnionPlan(union *sqlparser.Union, vschema VSchema) (primitive engine.Primitive, err error) {
@@ -96,17 +95,12 @@ func unionRouteMerge(union *sqlparser.Union, left, right builder, vschema VSchem
 	if err := lroute.UnionCanMerge(rroute); err != nil {
 		return nil, err
 	}
-	table := &vindexes.Table{
-		Keyspace: lroute.ERoute.Keyspace,
-	}
-	rtb := newRoute(
+	rb := newRoute(
 		&sqlparser.Union{Type: union.Type, Left: union.Left, Right: union.Right, Lock: union.Lock},
 		lroute.ERoute,
-		table,
 		vschema,
-		sqlparser.TableName{Name: sqlparser.NewTableIdent("")}, // Unions don't have an addressable table name.
 	)
-	lroute.Redirect = rtb
-	rroute.Redirect = rtb
-	return rtb, nil
+	lroute.Redirect = rb
+	rroute.Redirect = rb
+	return rb, nil
 }

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -72,15 +72,15 @@ func (vc *vcursorImpl) Find(name sqlparser.TableName) (table *vindexes.Table, er
 // DefaultKeyspace returns the default keyspace of the current request
 // if there is one. If the keyspace specified in the target cannot be
 // identified, it returns an error.
-func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.KeyspaceSchema, error) {
+func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 	if vc.target.Keyspace == "" {
-		return nil, noKeyspaceErr
+		return nil, errNoKeyspace
 	}
 	ks, ok := vc.executor.VSchema().Keyspaces[vc.target.Keyspace]
 	if !ok {
 		return nil, vterrors.Errorf(vtrpcpb.Code_NOT_FOUND, "keyspace %s not found in vschema", vc.target.Keyspace)
 	}
-	return ks, nil
+	return ks.Keyspace, nil
 }
 
 // Execute performs a V3 level execution of the query. It does not take any routing directives.

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -222,7 +222,7 @@ func (vtg *VTGate) IsHealthy() error {
 
 // Execute executes a non-streaming query. This is a V3 function.
 func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql string, bindVariables map[string]interface{}) (newSession *vtgatepb.Session, qr *sqltypes.Result, err error) {
-	target := parseTarget(session.TargetString)
+	target := vtg.executor.ParseTarget(session.TargetString)
 	statsKey := []string{"Execute", target.Keyspace, topoproto.TabletTypeLString(target.TabletType)}
 	defer vtg.timings.Record(statsKey, time.Now())
 
@@ -243,7 +243,7 @@ func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql s
 
 // ExecuteBatch executes a batch of queries. This is a V3 function.
 func (vtg *VTGate) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, sqlList []string, bindVariablesList []map[string]interface{}) (*vtgatepb.Session, []sqltypes.QueryResponse, error) {
-	target := parseTarget(session.TargetString)
+	target := vtg.executor.ParseTarget(session.TargetString)
 	statsKey := []string{"ExecuteBatch", target.Keyspace, topoproto.TabletTypeLString(target.TabletType)}
 	defer vtg.timings.Record(statsKey, time.Now())
 
@@ -263,7 +263,7 @@ func (vtg *VTGate) ExecuteBatch(ctx context.Context, session *vtgatepb.Session, 
 
 // StreamExecute executes a streaming query. This is a V3 function.
 func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session, sql string, bindVariables map[string]interface{}, callback func(*sqltypes.Result) error) error {
-	target := parseTarget(session.TargetString)
+	target := vtg.executor.ParseTarget(session.TargetString)
 	statsKey := []string{"StreamExecute", target.Keyspace, topoproto.TabletTypeLString(target.TabletType)}
 	defer vtg.timings.Record(statsKey, time.Now())
 


### PR DESCRIPTION
The first two commits in this PR show the prep needed for the third, with some drive-by cleanups. Let me know if you want to review them independently.

Summary:
* consolidate Opcode checks into route: As we add more opcodes, it's getting harder to chase down all places that reference it. This change moves all those checks into route. It should make it easier to add new ones.
* parseTaget->executor.ParseTarget. If the vschema has only one keyspace, the target is set to that. This should cover a few more use cases.
* Find: improved signature.
* newRoute does not set the table for the symtab because there are flows where there is no table (union). The setting is done only where it's required.
* AddAlias->InitWithAlias: it's a more appropriate name. The function also panics if the symtab already contains symbols.