### PR TITLE
fix for #2821

### DIFF
--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -219,7 +219,12 @@ func (mysqld *Mysqld) startNoWait(ctx context.Context, mysqldArgs ...string) err
 		}
 		name, err = binaryPath(dir, "mysqld_safe")
 		if err != nil {
-			return err
+			log.Warningf("%v: trying to launch mysqld instead", err)
+			name, err = binaryPath(dir, "mysqld")
+			// If this also fails, return an error.
+			if err != nil {
+				return err
+			}
 		}
 		arg := []string{
 			"--defaults-file=" + mysqld.config.path}


### PR DESCRIPTION
Some installs of mysql don't have mysqld_safe. Update mysqlctl
to directly launch mysqld if mysqld_safe cannot be found.

I've tested this manually by renaming mysqld_safe.