### PR TITLE
messages: multi-column support

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -492,8 +492,7 @@
   "PKValues": [
     1,
     2
-  ],
-  "MessageReloaderQuery": "select time_next, epoch, id, message from msg where :#pk"
+  ]
 }
 
 # message insert with no time_schedule
@@ -506,8 +505,7 @@
   "PKValues": [
     ":#time_now",
     2
-  ],
-  "MessageReloaderQuery": "select time_next, epoch, id, message from msg where :#pk"
+  ]
 }
 
 # message multi-value insert
@@ -526,8 +524,7 @@
       2,
       4
     ]
-  ],
-  "MessageReloaderQuery": "select time_next, epoch, id, message from msg where :#pk"
+  ]
 }
 
 # message insert subquery
@@ -565,10 +562,6 @@
 # message insert id missing
 "insert into msg(message) values('aa')"
 "id must be specified for message insert"
-
-# message insert message missing
-"insert into msg(id) values(1)"
-"message must be specified for message insert"
 
 # multi-row
 "replace into b (eid, id) values (1, 2), (3, 4)"

--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -186,6 +186,13 @@ var tableACLConfig = `{
       "admins": ["dev"]
     },
     {
+      "name": "vitess_message3",
+      "table_names_or_prefixes": ["vitess_message3"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
       "name": "vitess_acl_unmatched",
       "table_names_or_prefixes": ["vitess_acl_unmatched"],
       "readers": ["dev"],

--- a/go/vt/vttablet/endtoend/message_test.go
+++ b/go/vt/vttablet/endtoend/message_test.go
@@ -180,6 +180,111 @@ func TestMessage(t *testing.T) {
 	}
 }
 
+var createThreeColMessage = `create table vitess_message3(
+	time_scheduled bigint,
+	id bigint,
+	time_next bigint,
+	epoch bigint,
+	time_created bigint,
+	time_acked bigint,
+	msg1 varchar(128),
+	msg2 bigint,
+	primary key(time_scheduled, id),
+	unique index id_idx(id),
+	index next_idx(time_next, epoch))
+comment 'vitess_message,vt_ack_wait=1,vt_purge_after=3,vt_batch_size=2,vt_cache_size=10,vt_poller_interval=1'`
+
+func TestThreeColMessage(t *testing.T) {
+	ch := make(chan *sqltypes.Result)
+	done := make(chan struct{})
+	client := framework.NewClient()
+	if _, err := client.Execute(createThreeColMessage, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer client.Execute("drop table vitess_message3", nil)
+
+	go func() {
+		if err := client.MessageStream("vitess_message3", func(qr *sqltypes.Result) error {
+			select {
+			case <-done:
+				return io.EOF
+			default:
+			}
+			ch <- qr
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		close(ch)
+	}()
+	// Once the test is done, consume any left-over pending
+	// messages. Some could make it into the pipeline and get
+	// stuck forever causing vttablet shutdown to hang.
+	defer func() {
+		go func() {
+			for range ch {
+			}
+		}()
+	}()
+
+	// Verify fields.
+	got := <-ch
+	want := &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: sqltypes.Int64,
+		}, {
+			Name: "msg1",
+			Type: sqltypes.VarChar,
+		}, {
+			Name: "msg2",
+			Type: sqltypes.Int64,
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("message(field) received:\n%v, want\n%v", got, want)
+	}
+	runtime.Gosched()
+	defer func() { close(done) }()
+	err := client.Begin(false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = client.Execute("insert into vitess_message3(id, msg1, msg2) values(1, 'hello world', 3)", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = client.Commit()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Verify row.
+	got = <-ch
+	want = &sqltypes.Result{
+		Rows: [][]sqltypes.Value{{
+			sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+			sqltypes.MakeTrusted(sqltypes.VarChar, []byte("hello world")),
+			sqltypes.MakeTrusted(sqltypes.Int64, []byte("3")),
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("message received:\n%v, want\n%v", got, want)
+	}
+
+	// Verify Ack.
+	count, err := client.MessageAck("vitess_message3", []string{"1"})
+	if err != nil {
+		t.Error(err)
+	}
+	if count != 1 {
+		t.Errorf("count: %d, want 1", count)
+	}
+}
+
 func getTimeEpoch(qr *sqltypes.Result) (int64, int64) {
 	if len(qr.Rows) != 1 {
 		return 0, 0

--- a/go/vt/vttablet/tabletserver/messager/cache_test.go
+++ b/go/vt/vttablet/tabletserver/messager/cache_test.go
@@ -28,41 +28,41 @@ func TestMessagerCacheOrder(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 2,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row02")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row02"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 2,
 		Epoch:    1,
-		ID:       sqltypes.MakeString([]byte("row12")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row12"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    1,
-		ID:       sqltypes.MakeString([]byte("row11")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row11"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 3,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row03")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row03"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	var rows []string
 	for i := 0; i < 5; i++ {
-		rows = append(rows, mc.Pop().ID.String())
+		rows = append(rows, mc.Pop().Row[0].String())
 	}
 	want := []string{
 		"row03",
@@ -81,14 +81,14 @@ func TestMessagerCacheDupKey(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Error("Add(dup): returned false, want true")
 	}
@@ -96,7 +96,7 @@ func TestMessagerCacheDupKey(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Error("Add(dup): returned false, want true")
 	}
@@ -104,7 +104,7 @@ func TestMessagerCacheDupKey(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
@@ -115,22 +115,22 @@ func TestMessagerCacheDiscard(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	mc.Discard([]string{"row01"})
 	if row := mc.Pop(); row != nil {
-		t.Errorf("Pop: want nil, got %s", row.ID.String())
+		t.Errorf("Pop: want nil, got %s", row.Row[0].String())
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
-	if row := mc.Pop(); row == nil || row.ID.String() != "row01" {
+	if row := mc.Pop(); row == nil || row.Row[0].String() != "row01" {
 		t.Errorf("Pop: want row01, got %v", row)
 	}
 
@@ -138,12 +138,12 @@ func TestMessagerCacheDiscard(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if row := mc.Pop(); row != nil {
-		t.Errorf("Pop: want nil, got %s", row.ID.String())
+		t.Errorf("Pop: want nil, got %s", row.Row[0].String())
 	}
 	mc.Discard([]string{"row01"})
 
@@ -151,11 +151,11 @@ func TestMessagerCacheDiscard(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
-	if row := mc.Pop(); row == nil || row.ID.String() != "row01" {
+	if row := mc.Pop(); row == nil || row.Row[0].String() != "row01" {
 		t.Errorf("Pop: want row01, got %v", row)
 	}
 }
@@ -165,21 +165,21 @@ func TestMessagerCacheFull(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if !mc.Add(&MessageRow{
 		TimeNext: 2,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row02")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row02"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
 	if mc.Add(&MessageRow{
 		TimeNext: 2,
 		Epoch:    1,
-		ID:       sqltypes.MakeString([]byte("row12")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row12"))},
 	}) {
 		t.Error("Add(full): returned true, want false")
 	}
@@ -190,7 +190,7 @@ func TestMessagerCacheEmpty(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}
@@ -201,7 +201,7 @@ func TestMessagerCacheEmpty(t *testing.T) {
 	if !mc.Add(&MessageRow{
 		TimeNext: 1,
 		Epoch:    0,
-		ID:       sqltypes.MakeString([]byte("row01")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("row01"))},
 	}) {
 		t.Fatal("Add returned false")
 	}

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -172,6 +173,18 @@ func (me *Engine) UpdateCaches(newMessages map[string][]*MessageRow, changedMess
 		}
 		mm.cache.Discard(ids)
 	}
+}
+
+// GenerateLoadMessagesQuery returns the ParsedQuery for loading messages by pk.
+// The results of the query can be used in a BuildMessageRow call.
+func (me *Engine) GenerateLoadMessagesQuery(name string) (*sqlparser.ParsedQuery, error) {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+	mm := me.managers[name]
+	if mm == nil {
+		return nil, fmt.Errorf("message table %s not found in schema", name)
+	}
+	return mm.loadMessagesQuery, nil
 }
 
 // GenerateAckQuery returns the query and bind vars for acking a message.

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
@@ -108,8 +109,8 @@ func TestSubscribe(t *testing.T) {
 	<-ch1
 	engine.Subscribe("t2", f2)
 	<-ch2
-	engine.managers["t1"].Add(&MessageRow{ID: sqltypes.MakeString([]byte("1"))})
-	engine.managers["t2"].Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
+	engine.managers["t1"].Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1"))}})
+	engine.managers["t2"].Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2"))}})
 	<-ch1
 	<-ch2
 
@@ -136,11 +137,11 @@ func TestLockDB(t *testing.T) {
 	<-ch1
 
 	row1 := &MessageRow{
-		ID: sqltypes.MakeString([]byte("1")),
+		Row: []sqltypes.Value{sqltypes.MakeString([]byte("1"))},
 	}
 	row2 := &MessageRow{
 		TimeNext: time.Now().UnixNano() + int64(10*time.Minute),
-		ID:       sqltypes.MakeString([]byte("2")),
+		Row:      []sqltypes.Value{sqltypes.MakeString([]byte("2"))},
 	}
 	newMessages := map[string][]*MessageRow{"t1": {row1, row2}, "t3": {row1}}
 	unlock := engine.LockDB(newMessages, nil)
@@ -164,7 +165,7 @@ func TestLockDB(t *testing.T) {
 	})
 	<-ch2
 	mm := engine.managers["t2"]
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("1"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1"))}})
 	// Make sure the message is enqueued.
 	for {
 		runtime.Gosched()
@@ -174,7 +175,7 @@ func TestLockDB(t *testing.T) {
 		}
 	}
 	// "2" will be in the cache.
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2"))}})
 	changedMessages := map[string][]string{"t2": {"2"}, "t3": {"2"}}
 	unlock = engine.LockDB(nil, changedMessages)
 	// This should delete "2".
@@ -187,6 +188,28 @@ func TestLockDB(t *testing.T) {
 	case mr := <-ch2:
 		t.Errorf("Unexpected message: %v", mr)
 	default:
+	}
+}
+
+func TestGenerateLoadMessagesQuery(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	engine := newTestEngine(db)
+	defer engine.Close()
+
+	table := *meTable
+	table.Name = sqlparser.NewTableIdent("t1")
+	engine.schemaChanged(map[string]*schema.Table{
+		"t1": &table,
+	}, []string{"t1"}, nil, nil)
+
+	q, err := engine.GenerateLoadMessagesQuery("t1")
+	if err != nil {
+		t.Error(err)
+	}
+	want := "select time_next, epoch, id, message from t1 where :#pk"
+	if q.Query != want {
+		t.Errorf("GenerateLoadMessagesQuery: %s, want %s", q.Query, want)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -179,7 +179,7 @@ func TestMessageManagerAdd(t *testing.T) {
 	defer mm.Close()
 
 	row1 := &MessageRow{
-		ID: sqltypes.MakeString([]byte("1")),
+		Row: []sqltypes.Value{sqltypes.MakeString([]byte("1"))},
 	}
 	if mm.Add(row1) {
 		t.Error("Add(no receivers): true, want false")
@@ -194,10 +194,10 @@ func TestMessageManagerAdd(t *testing.T) {
 	// Make sure message is enqueued.
 	r1.WaitForCount(2)
 	// This will fill up the cache.
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2"))}})
 
 	// The third add has to fail.
-	if mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("3"))}) {
+	if mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("3"))}}) {
 		t.Error("Add(cache full): true, want false")
 	}
 	// Drain the receiver to prevent hangs.
@@ -225,7 +225,7 @@ func TestMessageManagerSend(t *testing.T) {
 	// Set the channel to verify call to Postpone.
 	ch := make(chan string)
 	tsv.SetChannel(ch)
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("1"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1")), sqltypes.NULL}})
 	want = &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
 			sqltypes.MakeString([]byte("1")),
@@ -251,8 +251,8 @@ func TestMessageManagerSend(t *testing.T) {
 	r2 := newTestReceiver(1)
 	mm.Subscribe(r2.rcv)
 	<-r2.ch
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("3"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2"))}})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("3"))}})
 	// Send should be round-robin.
 	<-r1.ch
 	<-r2.ch
@@ -260,9 +260,9 @@ func TestMessageManagerSend(t *testing.T) {
 	r2.WaitForDone()
 	// One of these messages will fail to send
 	// because r1 will return EOF.
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("4"))})
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("5"))})
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("6"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("4"))}})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("5"))}})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("6"))}})
 	// Only r1 should be receiving.
 	<-r1.ch
 	<-r1.ch
@@ -280,7 +280,7 @@ func TestMessageManagerBatchSend(t *testing.T) {
 	mm.Subscribe(r1.rcv)
 	<-r1.ch
 	row1 := &MessageRow{
-		ID: sqltypes.MakeString([]byte("1")),
+		Row: []sqltypes.Value{sqltypes.MakeString([]byte("1")), sqltypes.NULL},
 	}
 	mm.Add(row1)
 	want := &sqltypes.Result{
@@ -293,8 +293,8 @@ func TestMessageManagerBatchSend(t *testing.T) {
 		t.Errorf("Received: %v, want %v", got, row1)
 	}
 	mm.mu.Lock()
-	mm.cache.Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
-	mm.cache.Add(&MessageRow{ID: sqltypes.MakeString([]byte("3"))})
+	mm.cache.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2")), sqltypes.NULL}})
+	mm.cache.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("3")), sqltypes.NULL}})
 	mm.cond.Broadcast()
 	mm.mu.Unlock()
 	want = &sqltypes.Result{
@@ -416,12 +416,12 @@ func TestMessagesPending1(t *testing.T) {
 	mm.Subscribe(r1.rcv)
 	<-r1.ch
 
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("1"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1"))}})
 	// Make sure the first message is enqueued.
 	r1.WaitForCount(2)
 	// This will fill up the cache.
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("2"))})
-	mm.Add(&MessageRow{ID: sqltypes.MakeString([]byte("3"))})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("2"))}})
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("3"))}})
 
 	// Trigger the poller. It should do nothing.
 	mm.pollerTicks.Trigger()

--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -470,12 +470,6 @@ func analyzeInsertMessage(ins *sqlparser.Insert, plan *Plan, table *schema.Table
 		return nil, fmt.Errorf("%s must be specified for message insert", col.String())
 	}
 
-	col = sqlparser.NewColIdent("message")
-	num = findCol(col, ins.Columns)
-	if num < 0 {
-		return nil, fmt.Errorf("%s must be specified for message insert", col.String())
-	}
-
 	pkColumnNumbers := getInsertPKColumns(ins.Columns, table)
 	pkValues, err := getInsertPKValues(pkColumnNumbers, rowList, table)
 	if err != nil {
@@ -490,7 +484,6 @@ func analyzeInsertMessage(ins *sqlparser.Insert, plan *Plan, table *schema.Table
 	plan.PKValues = pkValues
 	plan.PlanID = PlanInsertMessage
 	plan.OuterQuery = sqlparser.GenerateParsedQuery(ins)
-	plan.MessageReloaderQuery = GenerateLoadMessagesQuery(ins)
 	return plan, nil
 }
 

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -233,9 +233,6 @@ type Plan struct {
 
 	// For PlanInsertSubquery: pk columns in the subquery result.
 	SubqueryPKColumns []int
-
-	// For PlanInsertMessage. Query used to reload inserted messages.
-	MessageReloaderQuery *sqlparser.ParsedQuery
 }
 
 // TableName returns the table name for the plan.

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -41,35 +41,33 @@ import (
 // golden files e.g. data/test/tabletserver/exec_cases.txt.)
 func toJSON(p *Plan) ([]byte, error) {
 	mplan := struct {
-		PlanID               PlanType
-		Reason               ReasonType             `json:",omitempty"`
-		TableName            sqlparser.TableIdent   `json:",omitempty"`
-		FieldQuery           *sqlparser.ParsedQuery `json:",omitempty"`
-		FullQuery            *sqlparser.ParsedQuery `json:",omitempty"`
-		OuterQuery           *sqlparser.ParsedQuery `json:",omitempty"`
-		Subquery             *sqlparser.ParsedQuery `json:",omitempty"`
-		UpsertQuery          *sqlparser.ParsedQuery `json:",omitempty"`
-		ColumnNumbers        []int                  `json:",omitempty"`
-		PKValues             []interface{}          `json:",omitempty"`
-		SecondaryPKValues    []interface{}          `json:",omitempty"`
-		WhereClause          *sqlparser.ParsedQuery `json:",omitempty"`
-		SubqueryPKColumns    []int                  `json:",omitempty"`
-		MessageReloaderQuery *sqlparser.ParsedQuery `json:",omitempty"`
+		PlanID            PlanType
+		Reason            ReasonType             `json:",omitempty"`
+		TableName         sqlparser.TableIdent   `json:",omitempty"`
+		FieldQuery        *sqlparser.ParsedQuery `json:",omitempty"`
+		FullQuery         *sqlparser.ParsedQuery `json:",omitempty"`
+		OuterQuery        *sqlparser.ParsedQuery `json:",omitempty"`
+		Subquery          *sqlparser.ParsedQuery `json:",omitempty"`
+		UpsertQuery       *sqlparser.ParsedQuery `json:",omitempty"`
+		ColumnNumbers     []int                  `json:",omitempty"`
+		PKValues          []interface{}          `json:",omitempty"`
+		SecondaryPKValues []interface{}          `json:",omitempty"`
+		WhereClause       *sqlparser.ParsedQuery `json:",omitempty"`
+		SubqueryPKColumns []int                  `json:",omitempty"`
 	}{
-		PlanID:               p.PlanID,
-		Reason:               p.Reason,
-		TableName:            p.TableName(),
-		FieldQuery:           p.FieldQuery,
-		FullQuery:            p.FullQuery,
-		OuterQuery:           p.OuterQuery,
-		Subquery:             p.Subquery,
-		UpsertQuery:          p.UpsertQuery,
-		ColumnNumbers:        p.ColumnNumbers,
-		PKValues:             p.PKValues,
-		SecondaryPKValues:    p.SecondaryPKValues,
-		WhereClause:          p.WhereClause,
-		SubqueryPKColumns:    p.SubqueryPKColumns,
-		MessageReloaderQuery: p.MessageReloaderQuery,
+		PlanID:            p.PlanID,
+		Reason:            p.Reason,
+		TableName:         p.TableName(),
+		FieldQuery:        p.FieldQuery,
+		FullQuery:         p.FullQuery,
+		OuterQuery:        p.OuterQuery,
+		Subquery:          p.Subquery,
+		UpsertQuery:       p.UpsertQuery,
+		ColumnNumbers:     p.ColumnNumbers,
+		PKValues:          p.PKValues,
+		SecondaryPKValues: p.SecondaryPKValues,
+		WhereClause:       p.WhereClause,
+		SubqueryPKColumns: p.SubqueryPKColumns,
 	}
 	return json.Marshal(&mplan)
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/query_gen.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/query_gen.go
@@ -80,13 +80,6 @@ func GenerateInsertOuterQuery(ins *sqlparser.Insert) *sqlparser.ParsedQuery {
 	return buf.ParsedQuery()
 }
 
-// GenerateLoadMessagesQuery generates the query to load messages after insert.
-func GenerateLoadMessagesQuery(ins *sqlparser.Insert) *sqlparser.ParsedQuery {
-	buf := sqlparser.NewTrackedBuffer(nil)
-	buf.Myprintf("select time_next, epoch, id, message from %v where %a", ins.Table, ":#pk")
-	return buf.ParsedQuery()
-}
-
 // GenerateUpdateOuterQuery generates the outer query for updates.
 func GenerateUpdateOuterQuery(upd *sqlparser.Update) *sqlparser.ParsedQuery {
 	buf := sqlparser.NewTrackedBuffer(nil)

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1840,7 +1840,7 @@ func TestMessageStream(t *testing.T) {
 	// Skip first result (field info).
 	newMessages := map[string][]*messager.MessageRow{
 		"msg": {
-			&messager.MessageRow{ID: sqltypes.MakeString([]byte("1"))},
+			&messager.MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1")), sqltypes.NULL}},
 		},
 	}
 	// We may have to iterate a few times before the stream kicks in.


### PR DESCRIPTION
Extend messages to support multiple user-defined columns.
All 'non-internal' coulmns that are defined for a message
table are treated as user-defined and returned as part of
the message stream.

BUG=38422743