### PR TITLE
bootstrap.sh: detect CPUs properly on OSX

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -20,7 +20,11 @@ if [ "$1" = "--skip_root_installs" ]; then
 fi
 
 # Run parallel make, based on number of cores available.
-NB_CORES=$(grep -c '^processor' /proc/cpuinfo)
+case $(uname) in
+Linux)	NB_CORES=$(grep -c '^processor' /proc/cpuinfo);;
+Darwin)	NB_CORES=$(sysctl hw.ncpu | awk '{ print $2 }');;
+esac
+
 if [ -n "$NB_CORES" ]; then
   export MAKEFLAGS="-j$((NB_CORES+1)) -l${NB_CORES}"
 fi


### PR DESCRIPTION
Small patch related to: https://github.com/youtube/vitess/issues/2865.
