### PR TITLE
fix travis build failure

### DIFF
--- a/travis/download_mariadb.sh
+++ b/travis/download_mariadb.sh
@@ -19,15 +19,15 @@ set -e
 
 # As of 07/2015, this mirror is the fastest for the Travis CI workers.
 DEB_PACKAGES="
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.30+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.30+maria-1~precise_all.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.30+maria-1~precise_amd64.deb
-http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.30+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mysql-common_10.0.31+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-common_10.0.31+maria-1~precise_all.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmysqlclient18_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient18_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/libmariadbclient-dev_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-core-10.0_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-client-10.0_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-core-10.0_10.0.31+maria-1~precise_amd64.deb
+http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu/pool/main/m/mariadb-10.0/mariadb-server-10.0_10.0.31+maria-1~precise_amd64.deb
 "
 
 mkdir -p $MYSQL_ROOT


### PR DESCRIPTION
MariaDB version has been bumped from 10.0.30 to 10.0.31.
I'll push this through if the build passes. Otherwise, all builds
are broken right now.