### PR TITLE
unify call path so both new mycnf's and loaded mycfn's inherit the same defaults

### DIFF
--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -59,6 +59,7 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfi
 // installation that already exists. This will look for an existing my.cnf file
 // and use that to call NewMysqld().
 func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
+	// We pass a port of 0, this will be read and overwritten from the path on disk
 	mycnf, err := ReadMycnf(NewMycnf(tabletUID, 0))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read my.cnf file: %v", err)

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -59,7 +59,7 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfi
 // installation that already exists. This will look for an existing my.cnf file
 // and use that to call NewMysqld().
 func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
-	mycnf, err := ReadMycnf(MycnfFile(tabletUID))
+	mycnf, err := ReadMycnf(NewMycnf(tabletUID, 0))
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read my.cnf file: %v", err)
 	}

--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strconv"
 )
 
@@ -113,12 +112,19 @@ func (cnf *Mycnf) lookup(key string) string {
 	return cnf.mycnfMap[key]
 }
 
-func (cnf *Mycnf) lookupAndCheck(key string) string {
+func (cnf *Mycnf) lookupWithDefault(key, defaultVal string) string {
 	val := cnf.lookup(key)
 	if val == "" {
-		panic(fmt.Errorf("Value for key '%v' not set", key))
+		if defaultVal == "" {
+			panic(fmt.Errorf("Value for key '%v' not set and no default value set", key))
+		}
+		return defaultVal
 	}
 	return val
+}
+
+func (cnf *Mycnf) lookupAndCheck(key string) string {
+	return cnf.lookupWithDefault(key, "")
 }
 
 func normKey(bkey []byte) string {
@@ -128,22 +134,21 @@ func normKey(bkey []byte) string {
 }
 
 // ReadMycnf will read an existing my.cnf from disk, and create a Mycnf object.
-func ReadMycnf(cnfFile string) (mycnf *Mycnf, err error) {
+func ReadMycnf(mycnf *Mycnf) (*Mycnf, error) {
+	var err error
 	defer func(err *error) {
 		if x := recover(); x != nil {
 			*err = x.(error)
 		}
 	}(&err)
 
-	f, err := os.Open(cnfFile)
+	f, err := os.Open(mycnf.path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
 
 	buf := bufio.NewReader(f)
-	mycnf = new(Mycnf)
-	mycnf.path, err = filepath.Abs(cnfFile)
 	if err != nil {
 		return nil, err
 	}
@@ -181,21 +186,21 @@ func ReadMycnf(cnfFile string) (mycnf *Mycnf, err error) {
 	}
 
 	mycnf.MysqlPort = int32(port)
-	mycnf.DataDir = mycnf.lookupAndCheck("datadir")
-	mycnf.InnodbDataHomeDir = mycnf.lookupAndCheck("innodb_data_home_dir")
-	mycnf.InnodbLogGroupHomeDir = mycnf.lookupAndCheck("innodb_log_group_home_dir")
-	mycnf.SocketFile = mycnf.lookupAndCheck("socket")
-	mycnf.GeneralLogPath = mycnf.lookup("general_log_file")
-	mycnf.ErrorLogPath = mycnf.lookup("log-error")
-	mycnf.SlowLogPath = mycnf.lookupAndCheck("slow-query-log-file")
-	mycnf.RelayLogPath = mycnf.lookupAndCheck("relay-log")
-	mycnf.RelayLogIndexPath = mycnf.lookupAndCheck("relay-log-index")
-	mycnf.RelayLogInfoPath = mycnf.lookupAndCheck("relay-log-info-file")
-	mycnf.BinLogPath = mycnf.lookupAndCheck("log-bin")
-	mycnf.MasterInfoFile = mycnf.lookupAndCheck("master-info-file")
-	mycnf.PidFile = mycnf.lookupAndCheck("pid-file")
-	mycnf.TmpDir = mycnf.lookupAndCheck("tmpdir")
-	mycnf.SlaveLoadTmpDir = mycnf.lookupAndCheck("slave_load_tmpdir")
+	mycnf.DataDir = mycnf.lookupWithDefault("datadir", mycnf.DataDir)
+	mycnf.InnodbDataHomeDir = mycnf.lookupWithDefault("innodb_data_home_dir", mycnf.InnodbDataHomeDir)
+	mycnf.InnodbLogGroupHomeDir = mycnf.lookupWithDefault("innodb_log_group_home_dir", mycnf.InnodbLogGroupHomeDir)
+	mycnf.SocketFile = mycnf.lookupWithDefault("socket", mycnf.SocketFile)
+	mycnf.GeneralLogPath = mycnf.lookupWithDefault("general_log_file", mycnf.GeneralLogPath)
+	mycnf.ErrorLogPath = mycnf.lookupWithDefault("log-error", mycnf.ErrorLogPath)
+	mycnf.SlowLogPath = mycnf.lookupWithDefault("slow-query-log-file", mycnf.SlowLogPath)
+	mycnf.RelayLogPath = mycnf.lookupWithDefault("relay-log", mycnf.RelayLogPath)
+	mycnf.RelayLogIndexPath = mycnf.lookupWithDefault("relay-log-index", mycnf.RelayLogIndexPath)
+	mycnf.RelayLogInfoPath = mycnf.lookupWithDefault("relay-log-info-file", mycnf.RelayLogInfoPath)
+	mycnf.BinLogPath = mycnf.lookupWithDefault("log-bin", mycnf.BinLogPath)
+	mycnf.MasterInfoFile = mycnf.lookupWithDefault("master-info-file", mycnf.MasterInfoFile)
+	mycnf.PidFile = mycnf.lookupWithDefault("pid-file", mycnf.PidFile)
+	mycnf.TmpDir = mycnf.lookupWithDefault("tmpdir", mycnf.TmpDir)
+	mycnf.SlaveLoadTmpDir = mycnf.lookupWithDefault("slave_load_tmpdir", mycnf.SlaveLoadTmpDir)
 
 	return mycnf, nil
 }

--- a/go/vt/mysqlctl/mycnf.go
+++ b/go/vt/mysqlctl/mycnf.go
@@ -133,7 +133,8 @@ func normKey(bkey []byte) string {
 	return string(bytes.Replace(bytes.TrimSpace(bkey), []byte("_"), []byte("-"), -1))
 }
 
-// ReadMycnf will read an existing my.cnf from disk, and create a Mycnf object.
+// ReadMycnf will read an existing my.cnf from disk, and update the passed in Mycnf object
+// with values from the my.cnf on disk.
 func ReadMycnf(mycnf *Mycnf) (*Mycnf, error) {
 	var err error
 	defer func(err *error) {

--- a/go/vt/mysqlctl/mycnf_flag.go
+++ b/go/vt/mysqlctl/mycnf_flag.go
@@ -127,5 +127,7 @@ func NewMycnfFromFlags(uid uint32) (mycnf *Mycnf, err error) {
 	} else {
 		log.Infof("No mycnf_server_id specified, using mycnf-file file %v", *flagMycnfFile)
 	}
-	return ReadMycnf(*flagMycnfFile)
+	mycnf = NewMycnf(uid, 0)
+	mycnf.path = *flagMycnfFile
+	return ReadMycnf(mycnf)
 }

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -30,7 +30,8 @@ var MycnfPath = "/tmp/my.cnf"
 
 func TestMycnf(t *testing.T) {
 	os.Setenv("MYSQL_FLAVOR", "MariaDB")
-	cnf := NewMycnf(11111, 6802)
+	uid := uint32(11111)
+	cnf := NewMycnf(uid, 6802)
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
@@ -58,7 +59,7 @@ func TestMycnf(t *testing.T) {
 		t.Errorf("failed reading, err %v", err)
 		return
 	}
-	mycnf, err := ReadMycnf(MycnfPath)
+	mycnf, err := ReadMycnf(MycnfPath, Defaults(uid))
 	if err != nil {
 		t.Errorf("failed reading, err %v", err)
 	} else {

--- a/go/vt/mysqlctl/mycnf_test.go
+++ b/go/vt/mysqlctl/mycnf_test.go
@@ -59,7 +59,9 @@ func TestMycnf(t *testing.T) {
 		t.Errorf("failed reading, err %v", err)
 		return
 	}
-	mycnf, err := ReadMycnf(MycnfPath, Defaults(uid))
+	mycnf := NewMycnf(uid, 0)
+	mycnf.path = MycnfPath
+	mycnf, err = ReadMycnf(mycnf)
 	if err != nil {
 		t.Errorf("failed reading, err %v", err)
 	} else {


### PR DESCRIPTION
@sougou @rnavarro 

I tested this on one of my keyspaces -- deleting the tmpdir from my existing my.cnf to simulate not having a value there.  This appropriately sets the tmp dir to the default value. 