### PR TITLE
Fix utils.py to not try to decode None.

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -1151,10 +1151,10 @@ def check_srv_keyspace(cell, keyspace, expected, keyspace_id_type='uint64',
       if 'key_range' in shard:
         if 'start' in shard['key_range']:
           s = shard['key_range']['start']
-          s = base64.b64decode(s).encode('hex')
+          s = base64.b64decode(s).encode('hex') if s else ''
         if 'end' in shard['key_range']:
           e = shard['key_range']['end']
-          e = base64.b64decode(e).encode('hex')
+          e = base64.b64decode(e).encode('hex') if e else ''
       r += ' %s-%s' % (s, e)
     pmap[tablet_type] = r + '\n'
   for tablet_type in sorted(pmap):


### PR DESCRIPTION
Some recent changes in python base64 library made it reject attempts to decode
None, which sometimes happens in tests.