### PR TITLE
Small jsonpb usage cleanup.

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 
@@ -86,13 +85,6 @@ func handleCollection(collection string, getFunc func(*http.Request) (interface{
 				return nil
 			}
 			return fmt.Errorf("can't get %v: %v", collection, err)
-		}
-
-		// JSON marshals a nil slice as "null", but we prefer "[]".
-		if val := reflect.ValueOf(obj); val.Kind() == reflect.Slice && val.IsNil() {
-			w.Header().Set("Content-Type", jsonContentType)
-			w.Write([]byte("[]"))
-			return nil
 		}
 
 		// JSON encode response.

--- a/go/vt/vtctld/api_test.go
+++ b/go/vt/vtctld/api_test.go
@@ -164,6 +164,7 @@ func TestAPI(t *testing.T) {
 		{"GET", "tablets/?shard=ks1%2F-80&cell=cell2", "", `[
 				{"cell":"cell2","uid":200}
 			]`},
+		{"GET", "tablets/?shard=ks1%2F80-&cell=cell1", "", `[]`},
 		{"GET", "tablets/cell1-100", "", `{
 				"alias": {"cell": "cell1", "uid": 100},
 				"hostname": "",


### PR DESCRIPTION
One special case is not necessary any more, as we emit empty arrays properly now.