### PR TITLE
v3: orderedAggregate planbuilder phase

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -1,0 +1,650 @@
+# Test cases in this file follow the code in ordered_aggregate.go.
+
+# Aggregate on unsharded
+"select count(*), col from unsharded"
+{
+  "Original": "select count(*), col from unsharded",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select count(*), col from unsharded",
+    "FieldQuery": "select count(*), col from unsharded where 1 != 1"
+  }
+}
+
+# Aggregate on unique sharded
+"select count(*), col from user where id = 1"
+{
+  "Original": "select count(*), col from user where id = 1",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select count(*), col from user where id = 1",
+    "FieldQuery": "select count(*), col from user where 1 != 1",
+    "Vindex": "user_index",
+    "Values": 1
+  }
+}
+
+# Aggregate detection (distinct)
+"select distinct user.a from user join user_extra"
+"unsupported: cross-shard query with aggregates"
+
+# Aggregate detection (function)
+"select count(*) from user join user_extra"
+"unsupported: cross-shard query with aggregates"
+
+# Aggregate detection (non-aggregate function)
+"select fun(1), col from user"
+{
+  "Original": "select fun(1), col from user",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select fun(1), col from user",
+    "FieldQuery": "select fun(1), col from user where 1 != 1"
+  }
+}
+
+# Aggregate detection (group_concat)
+"select group_concat(user.a) from user join user_extra"
+"unsupported: cross-shard query with aggregates"
+
+# Aggregate detection (group by)
+"select user.a from user join user_extra group by user.a"
+"unsupported: cross-shard query with aggregates"
+
+# select distinct with unique vindex for scatter route.
+"select distinct col1, id from user"
+{
+  "Original": "select distinct col1, id from user",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select distinct col1, id from user",
+    "FieldQuery": "select col1, id from user where 1 != 1"
+  }
+}
+
+# simple aggregate
+"select count(*) from user"
+{
+  "Original": "select count(*) from user",
+  "Instructions": {
+    "Results": [
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select count(*) from user",
+      "FieldQuery": "select count(*) from user where 1 != 1"
+    }
+  }
+}
+
+# aggregate on RHS subquery (tests symbol table merge)
+"select user.a, t.b from user join (select count(*) b from unsharded) as t"
+{
+  "Original": "select user.a, t.b from user join (select count(*) b from unsharded) as t",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select user.a from user",
+      "FieldQuery": "select user.a from user where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select t.b from (select count(*) as b from unsharded) as t",
+      "FieldQuery": "select t.b from (select count(*) as b from unsharded where 1 != 1) as t where 1 != 1"
+    },
+    "Cols": [
+      -1,
+      1
+    ]
+  }
+}
+
+# scatter aggregate in a subquery
+"select a from (select count(*) as a from user) t"
+{
+  "Original": "select a from (select count(*) as a from user) t",
+  "Instructions": {
+    "Cols": [
+      0
+    ],
+    "Subquery": {
+      "Results": [
+        -1
+      ],
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 0
+        }
+      ],
+      "Keys": null,
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select count(*) as a from user",
+        "FieldQuery": "select count(*) as a from user where 1 != 1"
+      }
+    }
+  }
+}
+
+# scatter aggregate with non-aggregate expressions.
+"select id, count(*) from user"
+{
+  "Original": "select id, count(*) from user",
+  "Instructions": {
+    "Results": [
+      0,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 1
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select id, count(*) from user",
+      "FieldQuery": "select id, count(*) from user where 1 != 1"
+    }
+  }
+}
+
+# scatter aggregate using distinct
+"select distinct col from user"
+{
+  "Original": "select distinct col from user",
+  "Instructions": {
+    "Results": [
+      0
+    ],
+    "Aggregates": null,
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select distinct col from user order by col asc",
+      "FieldQuery": "select col from user where 1 != 1"
+    }
+  }
+}
+
+# scatter aggregate group by select col
+"select col from user group by col"
+{
+  "Original": "select col from user group by col",
+  "Instructions": {
+    "Results": [
+      0
+    ],
+    "Aggregates": null,
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user group by col order by col asc",
+      "FieldQuery": "select col from user where 1 != 1 group by col"
+    }
+  }
+}
+
+# scatter aggregate group by aggregate function
+" select count(*) b from user group by b"
+"group by expression cannot reference an aggregate function: b"
+
+# scatter aggregate multiple group by (columns)
+"select a, b, count(*) from user group by b, a"
+{
+  "Original": "select a, b, count(*) from user group by b, a",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 2
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, count(*) from user group by b, a order by b asc, a asc",
+      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by b, a"
+    }
+  }
+}
+
+# scatter aggregate multiple group by (numbers)
+"select a, b, count(*) from user group by 2, 1"
+{
+  "Original": "select a, b, count(*) from user group by 2, 1",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 2
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, count(*) from user group by 2, 1 order by b asc, a asc",
+      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by 2, 1"
+    }
+  }
+}
+
+# scatter aggregate group by column number
+"select col from user group by 1"
+{
+  "Original": "select col from user group by 1",
+  "Instructions": {
+    "Results": [
+      0
+    ],
+    "Aggregates": null,
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user group by 1 order by col asc",
+      "FieldQuery": "select col from user where 1 != 1 group by 1"
+    }
+  }
+}
+
+
+# scatter aggregate group by invalid column number
+"select col from user group by 2"
+"column number out of range: 2"
+
+# scatter aggregate group by invalid column number
+"select col from user group by col+1"
+"unsupported: in scatter query: only simple references allowed"
+
+# scatter aggregate with ambiguous column names
+"select col1, col2 as col1 from user group by col1"
+"unsupported: in group by: ambiguous symbol reference: col1"
+
+# scatter aggregate order by null
+"select count(*) from user order by null"
+{
+  "Original": "select count(*) from user order by null",
+  "Instructions": {
+    "Results": [
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select count(*) from user",
+      "FieldQuery": "select count(*) from user where 1 != 1"
+    }
+  }
+}
+
+# scatter aggregate with complex select list (can't build order by)
+"select distinct a+1 from user"
+"generating order by clause: cannot reference a complex expression"
+
+# scatter aggregate with ambiguous aliases
+"select distinct a, b as a from user"
+"generating order by clause: ambiguous symbol reference: a"
+
+# scatter aggregate with numbered order by columns
+"select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1, 2, 3"
+{
+  "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1, 2, 3",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      2,
+      3,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 4
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1 asc, 2 asc, 3 asc",
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3"
+    }
+  }
+}
+
+# scatter aggregate with named order by columns
+"select a, b, c, d, count(*) from user group by 1, 2, 3 order by a, b, c"
+{
+  "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by a, b, c",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      2,
+      3,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 4
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by a asc, b asc, c asc",
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3"
+    }
+  }
+}
+
+# scatter aggregate with jumbled order by columns
+"select a, b, c, d, count(*) from user group by 1, 2, 3, 4 order by d, b, a, c"
+{
+  "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3, 4 order by d, b, a, c",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      2,
+      3,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 4
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3, 4 order by d asc, b asc, a asc, c asc",
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3, 4"
+    }
+  }
+}
+
+# scatter aggregate with jumbled group by and order by columns
+"select a, b, c, d, count(*) from user group by 3, 2, 1, 4 order by d, b, a, c"
+{
+  "Original": "select a, b, c, d, count(*) from user group by 3, 2, 1, 4 order by d, b, a, c",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      2,
+      3,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 4
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      },
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, c, d, count(*) from user group by 3, 2, 1, 4 order by d asc, b asc, a asc, c asc",
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 3, 2, 1, 4"
+    }
+  }
+}
+
+# scatter aggregate with some descending order by cols
+"select a, b, c, count(*) from user group by 3, 2, 1 order by 1 desc, 3 desc, b"
+{
+  "Original": "select a, b, c, count(*) from user group by 3, 2, 1 order by 1 desc, 3 desc, b",
+  "Instructions": {
+    "Results": [
+      0,
+      1,
+      2,
+      -1
+    ],
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 3
+      }
+    ],
+    "Keys": [
+      {
+        "Col": 0,
+        "Desc": true
+      },
+      {
+        "Col": 2,
+        "Desc": true
+      },
+      {
+        "Col": 1,
+        "Desc": false
+      }
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select a, b, c, count(*) from user group by 3, 2, 1 order by 1 desc, 3 desc, b asc",
+      "FieldQuery": "select a, b, c, count(*) from user where 1 != 1 group by 3, 2, 1"
+    }
+  }
+}
+
+# Group by with collate operator
+"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci"
+{
+   "Original":"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
+   "Instructions":{
+      "Opcode":"SelectEqualUnique",
+      "Keyspace":{
+         "Name":"user",
+         "Sharded":true
+      },
+      "Query":"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
+      "FieldQuery":"select user.col1 as a from user where 1 != 1 group by a collate utf8_general_ci",
+      "Vindex":"user_index",
+      "Values":5
+   }
+}

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -1146,10 +1146,6 @@
 "select user.id from user join user_extra user on user.id = user.user_id"
 "duplicate symbol: user"
 
-# error in subquery
-"select c from (select count(*) from user) as t"
-"unsupported: scatter with aggregates"
-
 # non-existent table
 "select c from t"
 "table t not found"

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -1,79 +1,3 @@
-# Group by with aggregation
-"select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc"
-{
-  "Original": "select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc",
-  "Instructions": {
-    "Opcode": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "Query": "select col1, count(col2) as col2_count from unsharded group by col1 order by col2_count asc",
-    "FieldQuery": "select col1, count(col2) as col2_count from unsharded where 1 != 1 group by col1"
-  }
-}
-# Group by unsharded
-"select col1, col2 from unsharded group by col2"
-{
-  "Original": "select col1, col2 from unsharded group by col2",
-  "Instructions": {
-    "Opcode": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "Query": "select col1, col2 from unsharded group by col2",
-    "FieldQuery": "select col1, col2 from unsharded where 1 != 1 group by col2"
-  }
-}
-
-# Group by on unique sharded
-"select col1, col2 from user where id = 1 group by col2"
-{
-  "Original": "select col1, col2 from user where id = 1 group by col2",
-  "Instructions": {
-    "Opcode": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select col1, col2 from user where id = 1 group by col2",
-    "FieldQuery": "select col1, col2 from user where 1 != 1 group by col2",
-    "Vindex": "user_index",
-    "Values": 1
-  }
-}
-
-# Group by on unique vindex
-"select col1, id from user group by id"
-{
-  "Original": "select col1, id from user group by id",
-  "Instructions": {
-    "Opcode": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select col1, id from user group by id",
-    "FieldQuery": "select col1, id from user where 1 != 1 group by id"
-  }
-}
-
-# Group by implicitly references table col
-"select id from user group by id, col"
-{
-  "Original": "select id from user group by id, col",
-  "Instructions": {
-    "Opcode": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select id from user group by id, col",
-    "FieldQuery": "select id from user where 1 != 1 group by id, col"
-  }
-}
-
 # HAVING implicitly references table col
 "select user.col1 from user having col2 = 2"
 {
@@ -345,11 +269,11 @@
 
 # Order by, invalid column number
 "select col from user order by 18446744073709551616"
-"error parsing order by clause: 18446744073709551616"
+"error parsing column number: 18446744073709551616"
 
 # Order by, out of range column number
 "select col from user order by 2"
-"order by column number out of range"
+"column number out of range: 2"
 
 # Order by, '*' expression with qualified reference and using collate
 "select * from user where id = 5 order by user.col collate utf8_general_ci"
@@ -366,40 +290,6 @@
     "Vindex": "user_index",
     "Values": 5
   }
-}
-
-# Group by with collate operator
-"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci"
-{
-   "Original":"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
-   "Instructions":{
-      "Opcode":"SelectEqualUnique",
-      "Keyspace":{
-         "Name":"user",
-         "Sharded":true
-      },
-      "Query":"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
-      "FieldQuery":"select user.col1 as a from user where 1 != 1 group by a collate utf8_general_ci",
-      "Vindex":"user_index",
-      "Values":5
-   }
-}
-
-#Order by with aggregates
-"select * from user where id = 5 order by count(id)"
-{
-   "Original":"select * from user where id = 5 order by count(id)",
-   "Instructions":{
-      "Opcode":"SelectEqualUnique",
-      "Keyspace":{
-         "Name":"user",
-         "Sharded":true
-      },
-      "Query":"select * from user where id = 5 order by count(id) asc",
-      "FieldQuery":"select * from user where 1 != 1",
-      "Vindex":"user_index",
-      "Values":5
-   }
 }
 
 #Order by with math functions

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -285,68 +285,6 @@
   }
 }
 
-# Aggregate on unsharded
-"select count(*), col from unsharded"
-{
-  "Original": "select count(*), col from unsharded",
-  "Instructions": {
-    "Opcode": "SelectUnsharded",
-    "Keyspace": {
-      "Name": "main",
-      "Sharded": false
-    },
-    "Query": "select count(*), col from unsharded",
-    "FieldQuery": "select count(*), col from unsharded where 1 != 1"
-  }
-}
-
-# Aggregate on unique sharded
-"select count(*), col from user where id = 1"
-{
-  "Original": "select count(*), col from user where id = 1",
-  "Instructions": {
-    "Opcode": "SelectEqualUnique",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select count(*), col from user where id = 1",
-    "FieldQuery": "select count(*), col from user where 1 != 1",
-    "Vindex": "user_index",
-    "Values": 1
-  }
-}
-
-# Non-aggregate function on sharded with no colvindex
-"select fun(1), col from user"
-{
-  "Original": "select fun(1), col from user",
-  "Instructions": {
-    "Opcode": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select fun(1), col from user",
-    "FieldQuery": "select fun(1), col from user where 1 != 1"
-  }
-}
-
-# Distinct
-"select distinct col, id from user"
-{
-  "Original": "select distinct col, id from user",
-  "Instructions": {
-    "Opcode": "SelectScatter",
-    "Keyspace": {
-      "Name": "user",
-      "Sharded": true
-    },
-    "Query": "select distinct col, id from user",
-    "FieldQuery": "select col, id from user where 1 != 1"
-  }
-}
-
 # Comments
 "select /* comment */ user.col from user join user_extra"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -131,7 +131,7 @@
 "select distinct a from user group by a"
 "unsupported: distinct and group by in the same query"
 
-# group by must reference select lit
+# group by must reference select list
 "select a from user group by b"
 "unsupported: in scatter query: group by column must reference column in SELECT list"
 

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -37,7 +37,7 @@
 
 # subquery with join primitive (expressions)
 "select * from user where id in (select user.id from user join user_extra)"
-"unsupported: cross-shard join in subqueries"
+"unsupported: cross-shard query in subqueries"
 
 # subquery keyspace different from outer query
 "select * from user where id in (select m from unsharded)"
@@ -65,7 +65,7 @@
 
 # filtering on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t where id=5"
-"unsupported: filtering on results of a cross-shard subquery"
+"unsupported: filtering on results of cross-shard subquery"
 
 # expression on a cross-shard subquery
 "select id+1 from (select user.id, user.col from user join user_extra) as t"
@@ -117,35 +117,71 @@
 
 # * expresson not allowed for cross-shard joins
 "select * from user join user_extra"
-"unsupported: '*' expression in cross-shard join"
+"unsupported: '*' expression in cross-shard query"
 
-# Aggregate on sharded with colvindex
-"select count(*), id from user"
-"unsupported: scatter with aggregates"
+# Filtering on scatter aggregates
+"select count(*) a from user having a >10"
+"unsupported: filtering on results of aggregates"
+
+# distinct and aggregate functions
+"select distinct a, count(*) from user"
+"unsupported: distinct cannot be combined with aggregate functions"
+
+# distinct and group by
+"select distinct a from user group by a"
+"unsupported: distinct and group by in the same query"
+
+# group by must reference select lit
+"select a from user group by b"
+"unsupported: in scatter query: group by column must reference column in SELECT list"
+
+# complex group by expression
+"select a from user group by a+1"
+"unsupported: in scatter query: only simple references allowed"
+
+# Complex aggregate expression on scatter
+"select 1+count(*) from user"
+"unsupported: in scatter query: complex aggregate expression"
+
+# scatter aggregate group by doesn't reference select list
+"select id from user group by col"
+"unsupported: in scatter query: group by column must reference column in SELECT list"
+
+# scatter aggregate invalid order by number
+"select id from user group by id order by 2"
+"in order by: column number out of range: 2"
+
+# scatter aggregate order by (number) references aggregate function.
+"select id, count(*) from user group by id order by 2"
+"unsupported: in scatter query: order by expression cannot reference an aggregate function: 2"
+
+# scatter aggregate symtab lookup error
+"select id, b as id, count(*) from user order by id"
+"in order by: ambiguous symbol reference: id"
+
+# scatter aggregate complex order by
+"select id from user group by id order by id+1"
+"unsupported: in scatter query: complex order by expression: id + 1"
+
+# scatter aggregate order by does not reference group by
+"select a, b, count(*) from user group by a order by b"
+"unsupported: in scatter query: order by column must reference group by expression: b asc"
 
 # Aggregates and joins
 "select count(*) from user join user_extra"
-"unsupported: cross-shard join with aggregates"
-
-# Aggregates and scatter
-"select count(*) from user"
-"unsupported: scatter with aggregates"
+"unsupported: cross-shard query with aggregates"
 
 # group by and joins
 "select user.id from user join user_extra group by id"
-"unsupported: cross-shard join with aggregates"
+"unsupported: cross-shard query with aggregates"
 
 # group by and ',' joins
 "select user.id from user, user_extra group by id"
-"unsupported: cross-shard join with aggregates"
-
-# Group by and scatter
-"select col from user group by col"
-"unsupported: scatter with aggregates"
+"unsupported: cross-shard query with aggregates"
 
 # subqueries not supported in group by
 "select id from user group by id, (select id from user_extra)"
-"unsupported: subqueries in group by expression"
+"unsupported: in group by: subqueries disallowed"
 
 # subquery of information_schema with normal table
 "select (select * from unsharded) from information_schema.a"
@@ -179,9 +215,13 @@
 "select user.col1 as a, user_extra.col2 as b from user join user_extra on user_extra.user_id = 5 where user.id = 5 order by a+b"
 "unsupported: order by spans across shards"
 
+# Order by has subqueries
+"select id from unsharded order by (select id from unsharded)"
+"unsupported: order by has subquery"
+
 # limit for joins
 "select user.col from user join user_extra limit 1"
-"unsupported: limits with cross-shard joins"
+"unsupported: limits with cross-shard query"
 
 # limit for scatter
 "select col from user limit 1"

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+var _ Primitive = (*OrderedAggregate)(nil)
+
+// OrderedAggregate is a primitive that expects the underlying primitive
+// to feed results in an order sorted by the Keys. Rows with duplicate
+// keys are aggregated using the Aggregate functions. The assumption
+// is that the underlying primitive is a scatter select with pre-sorted
+// rows.
+type OrderedAggregate struct {
+	// Results specifies where to get the value from. If the number is
+	// >=0, then the result is taken from the input primitive. If it's
+	// negative then the result is pulled from the aggregate function
+	// at -index-1.
+	Results []int
+
+	// Aggregates specifies the aggregation parameters for each
+	// aggregation function: function opcode and input column number.
+	// The negative indexes of Results point to this slice.
+	Aggregates []AggregateParams
+
+	// Keys specifies the input values that must be used for
+	// the aggregation key.
+	Keys []AggregateKey
+
+	// Input is the primitive that will feed into this Primitive.
+	// TODO(sougou): still need to work out the sorting mechanism.
+	Input Primitive
+}
+
+// AggregateParams specify the parameters for each aggregation.
+// It contains the opcode and input column number.
+type AggregateParams struct {
+	Opcode AggregateOpcode
+	Col    int
+}
+
+// AggregateOpcode is the aggregation Opcode.
+type AggregateOpcode int
+
+// These constants list the possible aggregate opcodes.
+const (
+	AggregateCount = AggregateOpcode(iota)
+	AggregateSum
+	AggregateMin
+	AggregateMax
+)
+
+// SupportedAggregates maps the list of supported aggregate
+// functions to their opcodes.
+var SupportedAggregates = map[string]AggregateOpcode{
+	"count": AggregateCount,
+	"sum":   AggregateSum,
+	"min":   AggregateMin,
+	"max":   AggregateMax,
+}
+
+func (code AggregateOpcode) String() string {
+	for k, v := range SupportedAggregates {
+		if v == code {
+			return k
+		}
+	}
+	panic("unreachable")
+}
+
+// MarshalJSON serializes the AggregateOpcode as a JSON string.
+// It's used for testing and diagnostics.
+func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
+	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
+}
+
+// AggregateKey specifies the each input value to build the
+// key and if the sorting on it is ascending or descending.
+type AggregateKey struct {
+	Col  int
+	Desc bool
+}
+
+// Execute is a Primitive function.
+func (oa *OrderedAggregate) Execute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	return nil, errors.New("unimplemented")
+}
+
+// StreamExecute is a Primitive function.
+func (oa *OrderedAggregate) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool, callback func(*sqltypes.Result) error) error {
+	return errors.New("unimplemented")
+}
+
+// GetFields is a Primitive function.
+func (oa *OrderedAggregate) GetFields(vcursor VCursor, bindVars, joinVars map[string]interface{}) (*sqltypes.Result, error) {
+	return nil, errors.New("unimplemented")
+}

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -93,7 +93,7 @@ func (code AggregateOpcode) MarshalJSON() ([]byte, error) {
 	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
 }
 
-// AggregateKey specifies the each input value to build the
+// AggregateKey specifies the input value to build the
 // key and if the sorting on it is ascending or descending.
 type AggregateKey struct {
 	Col  int

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -83,7 +83,7 @@ func findOrigin(expr sqlparser.Expr, bldr builder) (origin columnOriginator, err
 			case *sqlparser.Union:
 				subplan, err = processUnion(stmt, bldr.Symtab().VSchema, bldr)
 			default:
-				panic("BUG: unexpcted SELECT type")
+				panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", node))
 			}
 			if err != nil {
 				return false, err

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -83,14 +83,14 @@ func findOrigin(expr sqlparser.Expr, bldr builder) (origin columnOriginator, err
 			case *sqlparser.Union:
 				subplan, err = processUnion(stmt, bldr.Symtab().VSchema, bldr)
 			default:
-				panic("unreachable")
+				panic("BUG: unexpcted SELECT type")
 			}
 			if err != nil {
 				return false, err
 			}
 			subroute, isRoute := subplan.(*route)
 			if !isRoute {
-				return false, errors.New("unsupported: cross-shard join in subqueries")
+				return false, errors.New("unsupported: cross-shard query in subqueries")
 			}
 			for _, extern := range subroute.Symtab().Externs {
 				// No error expected. These are resolved externs.

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -74,7 +74,7 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic("BUG: unexpected construct in insert")
+		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", rows))
 	}
 	if eRoute.Table.AutoIncrement == nil {
 		eRoute.Query = generateQuery(ins)
@@ -126,7 +126,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic("BUG: unexpected construct in insert")
+		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", rows))
 	}
 	for _, value := range values {
 		if len(ins.Columns) != len(value) {

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -74,7 +74,7 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic("unexpected construct in insert")
+		panic("BUG: unexpected construct in insert")
 	}
 	if eRoute.Table.AutoIncrement == nil {
 		eRoute.Query = generateQuery(ins)
@@ -126,7 +126,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic("unexpected construct in insert")
+		panic("BUG: unexpected construct in insert")
 	}
 	for _, value := range values {
 		if len(ins.Columns) != len(value) {

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -1,0 +1,359 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+)
+
+var _ builder = (*orderedAggregate)(nil)
+
+// orderedAggregate is the builder for engine.OrderedAggregate.
+// This gets built if there are aggregations on a SelectScatter
+// route. Then this primitve pushes down the aggregation to all
+// shards and forces the results to be ordered. This will allow
+// for the engine code to merge sort and aggregate the results
+// as they come.
+// orderedAggregate relies on the values of eaggr, mainly Results
+// and Keys. To understand this code, it will be important to keep
+// in mind that the numbers in those fields are indexes into the
+// underlying 'input' primitive.
+type orderedAggregate struct {
+	symtab        *symtab
+	resultColumns []*resultColumn
+	order         int
+	input         *route
+	eaggr         *engine.OrderedAggregate
+}
+
+// checkAggregates analyzes the select expresstion for aggregates. If it determines
+// that a primitive is needed to handle the aggregation, it builds an orderedAggregate
+// primitive and returns it.
+func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
+	rb, isRoute := bldr.(*route)
+	if isRoute && rb.IsSingle() {
+		return bldr, nil
+	}
+
+	// Check if we can allow aggregates.
+	hasAggregates := false
+	if sel.Distinct != "" {
+		hasAggregates = true
+	} else {
+		hasAggregates = nodeHasAggregates(sel.SelectExprs)
+	}
+	if len(sel.GroupBy) > 0 {
+		hasAggregates = true
+	}
+	if !hasAggregates {
+		return bldr, nil
+	}
+	if hasAggregates && !isRoute {
+		return bldr, errors.New("unsupported: cross-shard query with aggregates")
+	}
+
+	// If there is a distinct clause, we can check the select list
+	// to see if it has a unique vindex reference. The group by clause
+	// could also have this property, but it cannot be analyzed until
+	// the symbol table has been updated with select expressions.
+	if sel.Distinct != "" {
+		for _, selectExpr := range sel.SelectExprs {
+			switch selectExpr := selectExpr.(type) {
+			case *sqlparser.AliasedExpr:
+				vindex := bldr.Symtab().Vindex(selectExpr.Expr, rb)
+				if vindex != nil && vindexes.IsUnique(vindex) {
+					return bldr, nil
+				}
+			}
+		}
+	}
+
+	// The group by clause could also reference a unique vindex, but
+	// it cannot be analyzed until the symbol table has been
+	// updated with select expressions. In such cases, we'll live with
+	// an orderedAggregate because it's not a very common use case.
+
+	// We need an aggregator primitive.
+	return &orderedAggregate{
+		symtab: rb.Symtab(),
+		order:  rb.Order() + 1,
+		input:  rb,
+		eaggr:  &engine.OrderedAggregate{},
+	}, nil
+}
+
+func nodeHasAggregates(node sqlparser.SQLNode) bool {
+	hasAggregates := false
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.FuncExpr:
+			if node.IsAggregate() {
+				hasAggregates = true
+				return false, errors.New("dummy")
+			}
+		case *sqlparser.GroupConcatExpr:
+			hasAggregates = true
+			return false, errors.New("dummy")
+		case *sqlparser.Subquery:
+			// Subqueries are analyzed by themselves.
+			return false, nil
+		}
+		return true, nil
+	}, node)
+	return hasAggregates
+}
+
+// Symtab satisfies the builder interface.
+func (oa *orderedAggregate) Symtab() *symtab {
+	return oa.symtab
+}
+
+// MaxOrder satisfies the builder interface.
+func (oa *orderedAggregate) MaxOrder() int {
+	return oa.order
+}
+
+// Order returns the order.
+func (oa *orderedAggregate) Order() int {
+	return oa.order
+}
+
+// SetOrder satisfies the builder interface.
+func (oa *orderedAggregate) SetOrder(order int) {
+	panic("BUG: reordering can only happen within the FROM clause")
+}
+
+// Primitive satisfies the builder interface.
+func (oa *orderedAggregate) Primitive() engine.Primitive {
+	oa.eaggr.Input = oa.input.Primitive()
+	return oa.eaggr
+}
+
+// Leftmost satisfies the builder interface.
+func (oa *orderedAggregate) Leftmost() columnOriginator {
+	return oa.input.Leftmost()
+}
+
+// ResultColumns satisfies the builder interface.
+func (oa *orderedAggregate) ResultColumns() []*resultColumn {
+	return oa.resultColumns
+}
+
+// PushFilter satisfies the builder interface.
+func (oa *orderedAggregate) PushFilter(_ sqlparser.Expr, whereType string, _ columnOriginator) error {
+	return errors.New("unsupported: filtering on results of aggregates")
+}
+
+// PushSelect satisfies the builder interface.
+func (oa *orderedAggregate) PushSelect(expr *sqlparser.AliasedExpr, origin columnOriginator) (rc *resultColumn, colnum int, err error) {
+	if inner, ok := expr.Expr.(*sqlparser.FuncExpr); ok {
+		if opcode, ok := engine.SupportedAggregates[inner.Name.Lowered()]; ok {
+			innerRC, innerCol, _ := oa.input.PushSelect(expr, origin)
+
+			// Add to Aggregates.
+			oa.eaggr.Aggregates = append(oa.eaggr.Aggregates, engine.AggregateParams{
+				Opcode: opcode,
+				Col:    innerCol,
+			})
+
+			// Add to Results.
+			// Build a new rc with oa as origin because it's semantically different
+			// from the expression we pushed down.
+			rc := &resultColumn{alias: innerRC.alias, column: &column{origin: oa}}
+			oa.resultColumns = append(oa.resultColumns, rc)
+			// Index should be made negative to indicate aggregate function.
+			oa.eaggr.Results = append(oa.eaggr.Results, -len(oa.eaggr.Aggregates))
+			return rc, len(oa.resultColumns) - 1, nil
+		}
+	}
+
+	// Ensure that there are no aggregates in the expression.
+	if nodeHasAggregates(expr.Expr) {
+		return nil, 0, errors.New("unsupported: in scatter query: complex aggregate expression")
+	}
+
+	innerRC, innerCol, _ := oa.input.PushSelect(expr, origin)
+	oa.resultColumns = append(oa.resultColumns, innerRC)
+	oa.eaggr.Results = append(oa.eaggr.Results, innerCol)
+	return innerRC, len(oa.resultColumns) - 1, nil
+}
+
+func (oa *orderedAggregate) MakeDistinct() error {
+	for i := range oa.resultColumns {
+		if oa.eaggr.Results[i] < 0 {
+			return errors.New("unsupported: distinct cannot be combined with aggregate functions")
+		}
+		oa.eaggr.Keys = append(oa.eaggr.Keys, engine.AggregateKey{Col: oa.eaggr.Results[i]})
+	}
+	return oa.input.MakeDistinct()
+}
+
+// SetGroupBy satisfies the builder interface.
+func (oa *orderedAggregate) SetGroupBy(groupBy sqlparser.GroupBy) error {
+outer:
+	for _, expr := range groupBy {
+		switch node := expr.(type) {
+		case *sqlparser.ColName:
+			c := node.Metadata.(*column)
+			for i, rc := range oa.resultColumns {
+				if rc.column == c {
+					if oa.eaggr.Results[i] < 0 {
+						return fmt.Errorf("group by expression cannot reference an aggregate function: %v", sqlparser.String(node))
+					}
+					oa.eaggr.Keys = append(oa.eaggr.Keys, engine.AggregateKey{Col: oa.eaggr.Results[i]})
+					continue outer
+				}
+			}
+			return errors.New("unsupported: in scatter query: group by column must reference column in SELECT list")
+		case *sqlparser.SQLVal:
+			num, err := oa.Symtab().ResultFromNumber(node)
+			if err != nil {
+				return err
+			}
+			oa.eaggr.Keys = append(oa.eaggr.Keys, engine.AggregateKey{Col: oa.eaggr.Results[num]})
+		default:
+			return errors.New("unsupported: in scatter query: only simple references allowed")
+		}
+	}
+
+	return oa.input.SetGroupBy(groupBy)
+}
+
+// PushOrderBy satisfies the builder interface.
+func (oa *orderedAggregate) PushOrderBy(orderBy sqlparser.OrderBy) error {
+	// Treat order by null as nil order by.
+	if len(orderBy) == 1 {
+		if _, ok := orderBy[0].Expr.(*sqlparser.NullVal); ok {
+			orderBy = nil
+		}
+	}
+
+	// If no order by was specified, we specify the ordering to be
+	// the same as the group by keys.
+	if orderBy == nil {
+		if len(oa.eaggr.Keys) == 0 {
+			return nil
+		}
+		for _, key := range oa.eaggr.Keys {
+			// Since the aggregation can be caused by a group by or distinct,
+			// it will be confusing to reuse those AST elements. It's also
+			// possible that those references are ambiguous. So, it's better
+			// to build brand new non-ambiguous AST elements that are safe
+			// to push down. See the test cases that shows how BuildColName
+			// can fail.
+			col, err := oa.input.BuildColName(key.Col)
+			if err != nil {
+				return fmt.Errorf("generating order by clause: %v", err)
+			}
+			order := &sqlparser.Order{Expr: col, Direction: sqlparser.AscScr}
+			oa.input.PushOrderBy(order)
+		}
+		return nil
+	}
+
+	// An order by was specified. Reorder the group by keys to match
+	// the specified ordering. This requires that the order by columns
+	// be present in the group by list also.
+	for i, order := range orderBy {
+		// Identify the order by column.
+		var orderByCol *column
+		switch expr := order.Expr.(type) {
+		case *sqlparser.SQLVal:
+			num, err := oa.Symtab().ResultFromNumber(expr)
+			if err != nil {
+				return fmt.Errorf("in order by: %v", err)
+			}
+			inputCol := oa.eaggr.Results[num]
+			if inputCol < 0 {
+				return fmt.Errorf("unsupported: in scatter query: order by expression cannot reference an aggregate function: %v", sqlparser.String(expr))
+			}
+			orderByCol = oa.input.ResultColumns()[inputCol].column
+		case *sqlparser.ColName:
+			_, _, err := oa.Symtab().Find(expr)
+			if err != nil {
+				return fmt.Errorf("in order by: %v", err)
+			}
+			orderByCol = expr.Metadata.(*column)
+		default:
+			return fmt.Errorf("unsupported: in scatter query: complex order by expression: %v", sqlparser.String(expr))
+		}
+
+		// Match orderByCol against the group by columns
+		// and reorder the group by keys accordingly. This
+		// will ensure that the merge-sort performed by vtgate
+		// will follow the same order as the input results.
+		found := false
+		for j := i; j < len(oa.eaggr.Keys); j++ {
+			key := oa.eaggr.Keys[j]
+			inputForKey := oa.input.ResultColumns()[key.Col]
+			if inputForKey.column != orderByCol {
+				continue
+			}
+
+			found = true
+			for k := i; k <= j; k++ {
+				key, oa.eaggr.Keys[k] = oa.eaggr.Keys[k], key
+			}
+			break
+		}
+		if !found {
+			return fmt.Errorf("unsupported: in scatter query: order by column must reference group by expression: %v", sqlparser.String(order))
+		}
+
+		// At this point, we're guaranteed that Keys[i] represents
+		// the same column as the order by expression.
+		if order.Direction == sqlparser.DescScr {
+			oa.eaggr.Keys[i].Desc = true
+		}
+
+		// Push down the order by.
+		// It's ok to push the original AST down because all references
+		// should point to the route. Only aggregate functions are originated
+		// by oa, and we currently don't allow the ORDER BY to reference them.
+		oa.input.PushOrderBy(order)
+	}
+	return nil
+}
+
+// PushOrderByNull satisfies the builder interface.
+func (oa *orderedAggregate) PushOrderByNull() {
+}
+
+// PushMisc satisfies the builder interface.
+func (oa *orderedAggregate) PushMisc(sel *sqlparser.Select) {
+	oa.input.PushMisc(sel)
+}
+
+// Wireup satisfies the builder interface.
+func (oa *orderedAggregate) Wireup(bldr builder, jt *jointab) error {
+	return oa.input.Wireup(bldr, jt)
+}
+
+// SupplyVar satisfies the builder interface.
+func (oa *orderedAggregate) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	panic("BUG: orderedAggregate should only have atomic nodes under it")
+}
+
+// SupplyCol satisfies the builder interface.
+func (oa *orderedAggregate) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	panic("BUG: nothing should depend on orderedAggregate")
+}

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -112,6 +112,7 @@ func TestPlan(t *testing.T) {
 	// the column is named as Id. This is to make sure that
 	// column names are case-preserved, but treated as
 	// case-insensitive even if they come from the vschema.
+	testFile(t, "aggr_cases.txt", vschema)
 	testFile(t, "from_cases.txt", vschema)
 	testFile(t, "filter_cases.txt", vschema)
 	testFile(t, "select_cases.txt", vschema)
@@ -163,7 +164,7 @@ func testFile(t *testing.T, filename string, vschema *vindexes.VSchema) {
 			out = string(bout)
 		}
 		if out != tcase.output {
-			t.Errorf("File: %s, Line:%v\ngot  = %s\nwant = %s", filename, tcase.lineno, out, tcase.output)
+			t.Errorf("File: %s, Line:%v\n%s, want\n%s", filename, tcase.lineno, out, tcase.output)
 			// Uncomment these lines to re-generate input files
 			if err != nil {
 				out = fmt.Sprintf("\"%s\"", out)

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -29,7 +29,11 @@ import (
 // groupByHandler is a primitive that can handle a group by expression.
 type groupByHandler interface {
 	builder
+	// SetGroupBy makes the primitive handle the group by clause.
+	// The primitive may outsource some of its work to an underlying
+	// primitive that is also a groupByHandler (like a route).
 	SetGroupBy(sqlparser.GroupBy) error
+	// MakeDistinct makes the primitive handle the distinct clause.
 	MakeDistinct() error
 }
 
@@ -62,6 +66,7 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 	if oa, ok := bldr.(*orderedAggregate); ok {
 		return oa.PushOrderBy(orderBy)
 	}
+
 	switch len(orderBy) {
 	case 0:
 		return nil

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -19,40 +19,39 @@ package planbuilder
 import (
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 )
 
 // This file has functions to analyze postprocessing
-// clauses like GROUP BY, etc.
+// clauses like ORDER BY, etc.
+
+// groupByHandler is a primitive that can handle a group by expression.
+type groupByHandler interface {
+	builder
+	SetGroupBy(sqlparser.GroupBy) error
+	MakeDistinct() error
+}
 
 // pushGroupBy processes the group by clause. It resolves all symbols,
 // and ensures that there are no subqueries.
-func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
-	if groupBy == nil {
-		return nil
-	}
-	err := sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-		switch node := node.(type) {
-		case *sqlparser.ColName:
-			_, _, err := bldr.Symtab().Find(node)
-			if err != nil {
-				return false, err
-			}
-		case *sqlparser.Subquery:
-			return false, errors.New("unsupported: subqueries in group by expression")
+func pushGroupBy(sel *sqlparser.Select, bldr builder) error {
+	if sel.Distinct != "" {
+		if len(sel.GroupBy) != 0 {
+			return errors.New("unsupported: distinct and group by in the same query")
 		}
-		return true, nil
-	}, groupBy)
-	if err != nil {
-		return err
+		return bldr.(groupByHandler).MakeDistinct()
 	}
 
-	// We can be here only if it was a route. All sanity checks have been
-	// performed by checkAggregates.
-	bldr.(*route).SetGroupBy(groupBy)
-	return nil
+	if sel.GroupBy == nil {
+		return nil
+	}
+	if err := bldr.Symtab().ResolveSymbols(sel.GroupBy); err != nil {
+		return fmt.Errorf("unsupported: in group by: %v", err)
+	}
+
+	// We can be here only if the builder could handle a group by.
+	return bldr.(groupByHandler).SetGroupBy(sel.GroupBy)
 }
 
 // pushOrderBy pushes the order by clause to the appropriate route.
@@ -60,6 +59,9 @@ func pushGroupBy(groupBy sqlparser.GroupBy, bldr builder) error {
 // order by references columns of the left-most route. Otherwise, the
 // function returns an unsupported error.
 func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
+	if oa, ok := bldr.(*orderedAggregate); ok {
+		return oa.PushOrderBy(orderBy)
+	}
 	switch len(orderBy) {
 	case 0:
 		return nil
@@ -76,17 +78,14 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		return errors.New("unsupported: cannot order by on a cross-shard subquery")
 	}
 	for _, order := range orderBy {
-		if node, ok := order.Expr.(*sqlparser.SQLVal); ok && node.Type == sqlparser.IntVal {
+		if node, ok := order.Expr.(*sqlparser.SQLVal); ok {
 			// This block handles constructs that use ordinals for 'ORDER BY'. For example:
 			// SELECT a, b, c FROM t1, t2 ORDER BY 1, 2, 3.
-			num, err := strconv.ParseInt(string(node.Val), 0, 64)
+			num, err := bldr.Symtab().ResultFromNumber(node)
 			if err != nil {
-				return fmt.Errorf("error parsing order by clause: %s", sqlparser.String(node))
+				return err
 			}
-			if num < 1 || num > int64(len(bldr.Symtab().ResultColumns)) {
-				return errors.New("order by column number out of range")
-			}
-			target := bldr.Symtab().ResultColumns[num-1].column.Origin()
+			target := bldr.Symtab().ResultColumns[num].column.Origin()
 			if target != leftmostRB {
 				return errors.New("unsupported: order by spans across shards")
 			}
@@ -103,6 +102,8 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 					if target != leftmostRB {
 						return false, errors.New("unsupported: order by spans across shards")
 					}
+				case *sqlparser.Subquery:
+					return false, errors.New("unsupported: order by has subquery")
 				}
 				return true, nil
 			}, order.Expr)
@@ -117,9 +118,7 @@ func pushOrderBy(orderBy sqlparser.OrderBy, bldr builder) error {
 		if !leftmostRB.IsSingle() {
 			return errors.New("unsupported: scatter and order by")
 		}
-		if err := bldr.PushOrderBy(order, leftmostRB); err != nil {
-			return err
-		}
+		leftmostRB.PushOrderBy(order)
 	}
 	return nil
 }
@@ -130,7 +129,7 @@ func pushLimit(limit *sqlparser.Limit, bldr builder) error {
 	}
 	rb, ok := bldr.(*route)
 	if !ok {
-		return errors.New("unsupported: limits with cross-shard joins")
+		return errors.New("unsupported: limits with cross-shard query")
 	}
 	if !rb.IsSingle() {
 		return errors.New("unsupported: limits with scatter")

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -226,6 +226,7 @@ func (rb *route) isSameRoute(rhs *route, filter sqlparser.Expr) bool {
 }
 
 // PushFilter satisfies the builder interface.
+// The primitive will be updated if the new filter improves the plan.
 func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ columnOriginator) error {
 	sel := rb.Select.(*sqlparser.Select)
 	switch whereType {
@@ -502,7 +503,7 @@ func (rb *route) procureValues(bldr builder, jt *jointab, val interface{}) (inte
 	case sqlparser.Expr:
 		return valConvert(val)
 	}
-	panic("BUG: unrecognized symbol")
+	panic(fmt.Sprintf("BUG: unrecognized symbol: %T", val))
 }
 
 func (rb *route) isLocal(col *sqlparser.ColName) bool {
@@ -676,7 +677,7 @@ func (rb *route) SetOpcode(code engine.RouteOpcode) error {
 			return errors.New("NEXT used on a sharded table")
 		}
 	default:
-		panic("BUG: unrecognized transition")
+		panic(fmt.Sprintf("BUG: unrecognized transition: %v", code))
 	}
 	rb.ERoute.Opcode = code
 	return nil

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -18,6 +18,7 @@ package planbuilder
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/engine"
@@ -73,7 +74,7 @@ func (rb *route) Resolve() *route {
 	return rb
 }
 
-// Symtab returns the associated symtab.
+// Symtab satisfies the builder interface.
 func (rb *route) Symtab() *symtab {
 	return rb.symtab.Resolve()
 }
@@ -83,27 +84,27 @@ func (rb *route) Order() int {
 	return rb.order
 }
 
-// MaxOrder returns the max order of the node.
+// MaxOrder satisfies the builder interface.
 func (rb *route) MaxOrder() int {
 	return rb.order
 }
 
-// SetOrder sets the order to one above the specified number.
+// SetOrder satisfies the builder interface.
 func (rb *route) SetOrder(order int) {
 	rb.order = order + 1
 }
 
-// Primitve returns the built primitive.
+// Primitive satisfies the builder interface.
 func (rb *route) Primitive() engine.Primitive {
 	return rb.ERoute
 }
 
-// Leftmost returns the current route.
+// Leftmost satisfies the builder interface.
 func (rb *route) Leftmost() columnOriginator {
 	return rb
 }
 
-// ResultColumns returns the result columns.
+// ResultColumns satisfies the builder interface.
 func (rb *route) ResultColumns() []*resultColumn {
 	return rb.resultColumns
 }
@@ -224,9 +225,8 @@ func (rb *route) isSameRoute(rhs *route, filter sqlparser.Expr) bool {
 	return true
 }
 
-// PushFilter pushes the filter into the route. The primitive will
-// be updated if the new filter improves the plan.
-func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ *route) error {
+// PushFilter satisfies the builder interface.
+func (rb *route) PushFilter(filter sqlparser.Expr, whereType string, _ columnOriginator) error {
 	sel := rb.Select.(*sqlparser.Select)
 	switch whereType {
 	case sqlparser.WhereStr:
@@ -352,7 +352,7 @@ func (rb *route) exprIsValue(expr sqlparser.Expr) bool {
 	return sqlparser.IsValue(expr)
 }
 
-// PushSelect pushes the select expression into the route.
+// PushSelect satisfies the builder interface.
 func (rb *route) PushSelect(expr *sqlparser.AliasedExpr, _ columnOriginator) (rc *resultColumn, colnum int, err error) {
 	sel := rb.Select.(*sqlparser.Select)
 	sel.SelectExprs = append(sel.SelectExprs, expr)
@@ -379,19 +379,20 @@ func (rb *route) PushAnonymous(expr sqlparser.SelectExpr) *resultColumn {
 }
 
 // MakeDistinct sets the DISTINCT property to the select.
-func (rb *route) MakeDistinct() {
+func (rb *route) MakeDistinct() error {
 	rb.Select.(*sqlparser.Select).Distinct = sqlparser.DistinctStr
+	return nil
 }
 
 // SetGroupBy sets the GROUP BY clause for the route.
-func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) {
+func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) error {
 	rb.Select.(*sqlparser.Select).GroupBy = groupBy
+	return nil
 }
 
-// PushOrderBy adds an ORDER BY expression to the route.
-func (rb *route) PushOrderBy(order *sqlparser.Order, _ *route) error {
+// PushOrderBy sets the order by for the route.
+func (rb *route) PushOrderBy(order *sqlparser.Order) {
 	rb.Select.AddOrder(order)
-	return nil
 }
 
 // SetLimit adds a LIMIT clause to the route.
@@ -399,18 +400,18 @@ func (rb *route) SetLimit(limit *sqlparser.Limit) {
 	rb.Select.SetLimit(limit)
 }
 
-// PushOrderByNull updates the comments & 'for update' sections of the route.
+// PushOrderByNull satisfies the builder interface.
 func (rb *route) PushOrderByNull() {
 	rb.Select.(*sqlparser.Select).OrderBy = sqlparser.OrderBy{&sqlparser.Order{Expr: &sqlparser.NullVal{}}}
 }
 
-// PushMisc updates the comments & 'for update' sections of the route.
+// PushMisc satisfies the builder interface.
 func (rb *route) PushMisc(sel *sqlparser.Select) {
 	rb.Select.(*sqlparser.Select).Comments = sel.Comments
 	rb.Select.(*sqlparser.Select).Lock = sel.Lock
 }
 
-// Wireup performs the wire-up tasks.
+// Wireup satisfies the builder interface.
 func (rb *route) Wireup(bldr builder, jt *jointab) error {
 	// Resolve values stored in the builder.
 	var err error
@@ -501,7 +502,7 @@ func (rb *route) procureValues(bldr builder, jt *jointab, val interface{}) (inte
 	case sqlparser.Expr:
 		return valConvert(val)
 	}
-	panic("unrecognized symbol")
+	panic("BUG: unrecognized symbol")
 }
 
 func (rb *route) isLocal(col *sqlparser.ColName) bool {
@@ -532,14 +533,14 @@ func (rb *route) generateFieldQuery(sel sqlparser.SelectStatement, jt *jointab) 
 	return sqlparser.NewTrackedBuffer(formatter).WriteNode(sel).ParsedQuery().Query
 }
 
-// SupplyVar should be unreachable.
+// SupplyVar satisfies the builder interface.
 func (rb *route) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
-	panic("unreachable")
+	// route is an atomic primitive. So, SupplyVar cannot be
+	// called on it.
+	panic("BUG: route is an atomic node.")
 }
 
-// SupplyCol changes the executor to supply the requested column
-// name, and returns the result column number. If the column
-// is already in the list, it's reused.
+// SupplyCol satisfies the builder interface.
 func (rb *route) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
 	c := col.Metadata.(*column)
 	for i, rc := range rb.resultColumns {
@@ -554,6 +555,28 @@ func (rb *route) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int
 	sel := rb.Select.(*sqlparser.Select)
 	sel.SelectExprs = append(sel.SelectExprs, &sqlparser.AliasedExpr{Expr: col})
 	return rc, len(rb.resultColumns) - 1
+}
+
+// BuildColName builds a *sqlparser.ColName for the resultColumn specified
+// by the index. The built ColName will correctly reference the resultColumn
+// it was built from, which is safe to push down into the route.
+func (rb *route) BuildColName(index int) (*sqlparser.ColName, error) {
+	alias := rb.resultColumns[index].alias
+	if alias.IsEmpty() {
+		return nil, errors.New("cannot reference a complex expression")
+	}
+	for i, rc := range rb.resultColumns {
+		if i == index {
+			continue
+		}
+		if rc.alias.Equal(alias) {
+			return nil, fmt.Errorf("ambiguous symbol reference: %v", alias)
+		}
+	}
+	return &sqlparser.ColName{
+		Metadata: rb.resultColumns[index].column,
+		Name:     alias,
+	}, nil
 }
 
 // IsSingle returns true if the route targets only one database.
@@ -653,7 +676,7 @@ func (rb *route) SetOpcode(code engine.RouteOpcode) error {
 			return errors.New("NEXT used on a sharded table")
 		}
 	default:
-		panic("unreachable")
+		panic("BUG: unrecognized transition")
 	}
 	rb.ERoute.Opcode = code
 	return nil

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -175,7 +175,7 @@ func pushSelectRoutes(selectExprs sqlparser.SelectExprs, bldr builder) ([]*resul
 			}
 			resultColumns[i] = rb.PushAnonymous(node)
 		default:
-			panic("BUG: unexpcted select expression type")
+			panic(fmt.Sprintf("BUG: unexpceted select expression type: %T", node))
 		}
 	}
 	return resultColumns, nil

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -71,6 +71,7 @@ func newSubquery(alias sqlparser.TableIdent, bldr builder, vschema VSchema) *sub
 
 	// Populate the table with those columns and add it to symtab.
 	t.columns = cols
+	// AddTable will not fail because symtab is empty.
 	_ = sq.symtab.AddTable(t)
 	return sq
 }

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -129,12 +129,6 @@ func (st *symtab) AddVindexTable(alias sqlparser.TableName, vindexTable *vindexe
 // analysis for the FROM clause. At that time, there should be
 // no ResultColumns or Externs.
 func (st *symtab) Merge(newsyms *symtab) error {
-	if st.ResultColumns != nil || newsyms.ResultColumns != nil {
-		panic("BUG: unexpected ResultColumns")
-	}
-	if st.Externs != nil || newsyms.Externs != nil {
-		panic("BUG: unexpected Externs")
-	}
 	for _, t := range newsyms.tables {
 		if err := st.AddTable(t); err != nil {
 			return err

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -17,7 +17,9 @@ limitations under the License.
 package planbuilder
 
 import (
+	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
@@ -128,10 +130,10 @@ func (st *symtab) AddVindexTable(alias sqlparser.TableName, vindexTable *vindexe
 // no ResultColumns or Externs.
 func (st *symtab) Merge(newsyms *symtab) error {
 	if st.ResultColumns != nil || newsyms.ResultColumns != nil {
-		panic("unexpected ResultColumns")
+		panic("BUG: unexpected ResultColumns")
 	}
 	if st.Externs != nil || newsyms.Externs != nil {
-		panic("unexpected Externs")
+		panic("BUG: unexpected Externs")
 	}
 	for _, t := range newsyms.tables {
 		if err := st.AddTable(t); err != nil {
@@ -345,6 +347,22 @@ func (st *symtab) NewResultColumn(expr *sqlparser.AliasedExpr, origin columnOrig
 	return rc
 }
 
+// ResultFromNumber returns the result column index based on the column
+// order expression.
+func (st *symtab) ResultFromNumber(val *sqlparser.SQLVal) (int, error) {
+	if val.Type != sqlparser.IntVal {
+		return 0, errors.New("column number is not an int")
+	}
+	num, err := strconv.ParseInt(string(val.Val), 0, 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing column number: %s", sqlparser.String(val))
+	}
+	if num < 1 || num > int64(len(st.ResultColumns)) {
+		return 0, fmt.Errorf("column number out of range: %d", num)
+	}
+	return int(num - 1), nil
+}
+
 // Vindex returns the vindex if the expression is a plain column reference
 // that is part of the specified route, and has an associated vindex.
 func (st *symtab) Vindex(expr sqlparser.Expr, scope *route) vindexes.Vindex {
@@ -363,6 +381,24 @@ func (st *symtab) Vindex(expr sqlparser.Expr, scope *route) vindexes.Vindex {
 		return nil
 	}
 	return c.Vindex
+}
+
+// ResolveSymbols resolves all column references against symtab.
+// This makes sure that they all have their Metadata initialized.
+// If a symbol cannot be resolved or if the expression contains
+// a subquery, an error is returned.
+func (st *symtab) ResolveSymbols(node sqlparser.SQLNode) error {
+	return sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+		switch node := node.(type) {
+		case *sqlparser.ColName:
+			if _, _, err := st.Find(node); err != nil {
+				return false, err
+			}
+		case *sqlparser.Subquery:
+			return false, errors.New("subqueries disallowed")
+		}
+		return true, nil
+	}, node)
 }
 
 // table is part of symtab.

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -18,6 +18,7 @@ package planbuilder
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/engine"
@@ -75,7 +76,7 @@ func processPart(part sqlparser.SelectStatement, vschema VSchema, outer builder)
 	case *sqlparser.ParenSelect:
 		bldr, err = processPart(part.Select, vschema, outer)
 	default:
-		panic("BUG: unexpected SELECT type")
+		panic(fmt.Sprintf("BUG: unexpected SELECT type: %T", part))
 	}
 	if err != nil {
 		return nil, err

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -75,7 +75,7 @@ func processPart(part sqlparser.SelectStatement, vschema VSchema, outer builder)
 	case *sqlparser.ParenSelect:
 		bldr, err = processPart(part.Select, vschema, outer)
 	default:
-		panic("unreachable")
+		panic("BUG: unexpected SELECT type")
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR has the planbuilder part of orderedAggregate. This primitive
is for performing aggregations through merge-sort of results
that are already ordered or streamed in an ordered fashion.
They work for scatter queries where each shard returns sorted
results.

Some implementation notes:
* I have a new aggr_cases.txt file to cover the new tests.
* This is the initial cut with very conservative restrictions.
  Capabilities will be extended in later iterations.
* PushOrderBy has been removed from builder. It didn't make
  sense after all, at least not for the current context.
* Comments are made uniform for all primitives that implement
  builder, and builder describes the contract for those functions.
* All panics have a "BUG:" in front of their message.