### PR TITLE
v3: arithmetics: Add, NullsafeCompare

### DIFF
--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -1,0 +1,294 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// numeric represents a numeric value extracted from
+// a Value, used for arithmetic operations.
+type numeric struct {
+	typ  querypb.Type
+	ival int64
+	uval uint64
+	fval float64
+}
+
+// Add adds two Values. A numeric value is first built
+// from each input: Signed->int64, Unsigned->uint64, Float->float64.
+// Otherwise the 'best type fit' is chosen for the number: int64 or float64.
+// Addition is performed by upgrading types as needed, or in case
+// of overflow: int64->uint64, int64->float64, uint64->float64.
+// Unsigned ints can only be added to positive ints. After the
+// addition, if one of the input types was Decimal, then
+// a Decimal is built. Otherwise, the final type of the
+// result is preserved. If any value is NULL, the result is NULL.
+func Add(v1, v2 Value, resultType querypb.Type) (Value, error) {
+	if v1.IsNull() || v2.IsNull() {
+		return NULL, nil
+	}
+	lv1, err := newNumeric(v1)
+	if err != nil {
+		return NULL, err
+	}
+	lv2, err := newNumeric(v2)
+	if err != nil {
+		return NULL, err
+	}
+	lresult, err := addNumeric(lv1, lv2)
+	if err != nil {
+		return NULL, err
+	}
+	return castFromNumeric(lresult, resultType)
+}
+
+// NullsafeCompare returns 0 if v1==v2, -1 if v1<v2, and 1 if v1>v2.
+// NULL is the lowest value. If any value is
+// numeric, then a numeric comparison is performed after
+// necessary conversions. If none are numeric, then it's
+// a simple binary comparison. Text values return an error.
+func NullsafeCompare(v1, v2 Value) (int, error) {
+	if v1.IsNull() {
+		if v2.IsNull() {
+			return 0, nil
+		}
+		return -1, nil
+	}
+	if v2.IsNull() {
+		return 1, nil
+	}
+	if v1.IsText() || v2.IsText() {
+		return 0, errors.New("text fields cannot be compared")
+	}
+	if isNumber(v1.typ) || isNumber(v2.typ) {
+		lv1, err := newNumeric(v1)
+		if err != nil {
+			return 0, err
+		}
+		lv2, err := newNumeric(v2)
+		if err != nil {
+			return 0, err
+		}
+		return compareNumeric(lv1, lv2), nil
+	}
+	return bytes.Compare(v1.Raw(), v2.Raw()), nil
+}
+
+func newNumeric(v Value) (result numeric, err error) {
+	str := v.String()
+	switch {
+	case v.IsSigned():
+		result.ival, err = strconv.ParseInt(str, 10, 64)
+		result.typ = Int64
+		return
+	case v.IsUnsigned():
+		result.uval, err = strconv.ParseUint(str, 10, 64)
+		result.typ = Uint64
+		return
+	case v.IsFloat():
+		result.fval, err = strconv.ParseFloat(str, 64)
+		result.typ = Float64
+		return
+	}
+
+	// For other types, do best effort.
+	result.ival, err = strconv.ParseInt(str, 10, 64)
+	if err == nil {
+		result.typ = Int64
+		return
+	}
+	result.fval, err = strconv.ParseFloat(str, 64)
+	if err == nil {
+		result.typ = Float64
+		return
+	}
+	err = fmt.Errorf("could not parse value: %s", str)
+	return
+}
+
+func addNumeric(v1, v2 numeric) (numeric, error) {
+	v1, v2 = prioritize(v1, v2)
+	switch v1.typ {
+	case Int64:
+		return intPlusInt(v1.ival, v2.ival), nil
+	case Uint64:
+		switch v2.typ {
+		case Int64:
+			return uintPlusInt(v1.uval, v2.ival)
+		case Uint64:
+			return uintPlusUint(v1.uval, v2.uval), nil
+		}
+	case Float64:
+		return floatPlusAny(v1.fval, v2), nil
+	}
+	panic("unreachable")
+}
+
+// prioritize reorders the input parameters
+// to be Float64, Uint64, Int64.
+func prioritize(v1, v2 numeric) (altv1, altv2 numeric) {
+	switch v1.typ {
+	case Int64:
+		if v2.typ == Uint64 || v2.typ == Float64 {
+			return v2, v1
+		}
+	case Uint64:
+		if v2.typ == Float64 {
+			return v2, v1
+		}
+	}
+	return v1, v2
+}
+
+func intPlusInt(v1, v2 int64) numeric {
+	result := v1 + v2
+	if v1 > 0 && v2 > 0 && result < 0 {
+		goto overflow
+	}
+	if v1 < 0 && v2 < 0 && result > 0 {
+		goto overflow
+	}
+	return numeric{typ: Int64, ival: result}
+
+overflow:
+	return numeric{typ: Float64, fval: float64(v1) + float64(v2)}
+}
+
+func uintPlusInt(v1 uint64, v2 int64) (numeric, error) {
+	if v2 < 0 {
+		return numeric{}, fmt.Errorf("cannot add a negative number to an unsigned integer: %d, %d", v1, v2)
+	}
+	return uintPlusUint(v1, uint64(v2)), nil
+}
+
+func uintPlusUint(v1, v2 uint64) numeric {
+	result := v1 + v2
+	if result < v2 {
+		return numeric{typ: Float64, fval: float64(v1) + float64(v2)}
+	}
+	return numeric{typ: Uint64, uval: result}
+}
+
+func floatPlusAny(v1 float64, v2 numeric) numeric {
+	switch v2.typ {
+	case Int64:
+		v2.fval = float64(v2.ival)
+	case Uint64:
+		v2.fval = float64(v2.uval)
+	}
+	return numeric{typ: Float64, fval: v1 + v2.fval}
+}
+
+func castFromNumeric(v numeric, resultType querypb.Type) (Value, error) {
+	switch resultType {
+	case Int64:
+		switch v.typ {
+		case Int64:
+			return MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10)), nil
+		case Uint64, Float64:
+			return NULL, fmt.Errorf("unexpected type conversion: %v to %v", v.typ, resultType)
+		}
+	case Uint64:
+		switch v.typ {
+		case Uint64:
+			return MakeTrusted(resultType, strconv.AppendUint(nil, v.uval, 10)), nil
+		case Int64, Float64:
+			return NULL, fmt.Errorf("unexpected type conversion: %v to %v", v.typ, resultType)
+		}
+	case Float64, Decimal:
+		switch v.typ {
+		case Int64:
+			return MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10)), nil
+		case Uint64:
+			return MakeTrusted(resultType, strconv.AppendUint(nil, v.uval, 10)), nil
+		case Float64:
+			format := byte('g')
+			if resultType == Decimal {
+				format = 'f'
+			}
+			return MakeTrusted(resultType, strconv.AppendFloat(nil, v.fval, format, -1, 64)), nil
+		}
+	}
+	return NULL, fmt.Errorf("unexpected type conversion to non-numeric: %v", resultType)
+}
+
+func compareNumeric(v1, v2 numeric) int {
+	// Equalize the types.
+	switch v1.typ {
+	case Int64:
+		switch v2.typ {
+		case Uint64:
+			if v1.ival < 0 {
+				return -1
+			}
+			v1 = numeric{typ: Uint64, uval: uint64(v1.ival)}
+		case Float64:
+			v1 = numeric{typ: Float64, fval: float64(v1.ival)}
+		}
+	case Uint64:
+		switch v2.typ {
+		case Int64:
+			if v2.ival < 0 {
+				return 1
+			}
+			v2 = numeric{typ: Uint64, uval: uint64(v2.ival)}
+		case Float64:
+			v1 = numeric{typ: Float64, fval: float64(v1.uval)}
+		}
+	case Float64:
+		switch v2.typ {
+		case Int64:
+			v2 = numeric{typ: Float64, fval: float64(v2.ival)}
+		case Uint64:
+			v2 = numeric{typ: Float64, fval: float64(v2.uval)}
+		}
+	}
+
+	// Both values are of the same type.
+	switch v1.typ {
+	case Int64:
+		switch {
+		case v1.ival == v2.ival:
+			return 0
+		case v1.ival < v2.ival:
+			return -1
+		}
+	case Uint64:
+		switch {
+		case v1.uval == v2.uval:
+			return 0
+		case v1.uval < v2.uval:
+			return -1
+		}
+	case Float64:
+		switch {
+		case v1.fval == v2.fval:
+			return 0
+		case v1.fval < v2.fval:
+			return -1
+		}
+	}
+
+	// v1>v2
+	return 1
+}

--- a/go/sqltypes/arithmetic_test.go
+++ b/go/sqltypes/arithmetic_test.go
@@ -1,0 +1,626 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestAdd(t *testing.T) {
+	tcases := []struct {
+		v1, v2 Value
+		out    Value
+		err    string
+	}{{
+		// All nulls.
+		v1:  NULL,
+		v2:  NULL,
+		out: NULL,
+	}, {
+		// One null.
+		v1:  makeInt(1),
+		v2:  NULL,
+		out: NULL,
+	}, {
+		// Normal case.
+		v1:  makeInt(1),
+		v2:  makeInt(2),
+		out: makeInt(3),
+	}, {
+		// Make sure underlying error is returned for LHS.
+		v1:  makeAny(Int64, "1.2"),
+		v2:  makeInt(2),
+		err: "strconv.ParseInt: parsing \"1.2\": invalid syntax",
+	}, {
+		// Make sure underlying error is returned for RHS.
+		v1:  makeInt(2),
+		v2:  makeAny(Int64, "1.2"),
+		err: "strconv.ParseInt: parsing \"1.2\": invalid syntax",
+	}, {
+		// Make sure underlying error is returned while adding.
+		v1:  makeInt(-1),
+		v2:  makeUint(2),
+		err: "cannot add a negative number to an unsigned integer: 2, -1",
+	}, {
+		// Make sure underlying error is returned while converting.
+		v1:  makeFloat(1),
+		v2:  makeFloat(2),
+		err: "unexpected type conversion: FLOAT64 to INT64",
+	}}
+	for _, tcase := range tcases {
+		got, err := Add(tcase.v1, tcase.v2, Int64)
+		errstr := ""
+		if err != nil {
+			errstr = err.Error()
+		}
+		if errstr != tcase.err {
+			t.Errorf("Add(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), err, tcase.err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("Add(%v, %v): %v, want %v", printValue(tcase.v1), printValue(tcase.v2), printValue(got), printValue(tcase.out))
+		}
+	}
+}
+
+func TestNullsafeCompare(t *testing.T) {
+	tcases := []struct {
+		v1, v2 Value
+		out    int
+		err    string
+	}{{
+		// All nulls.
+		v1:  NULL,
+		v2:  NULL,
+		out: 0,
+	}, {
+		// LHS null.
+		v1:  NULL,
+		v2:  makeInt(1),
+		out: -1,
+	}, {
+		// RHS null.
+		v1:  makeInt(1),
+		v2:  NULL,
+		out: 1,
+	}, {
+		// LHS Text
+		v1:  makeAny(VarChar, "abcd"),
+		v2:  makeInt(1),
+		err: "text fields cannot be compared",
+	}, {
+		// Make sure underlying error is returned for LHS.
+		v1:  makeAny(Int64, "1.2"),
+		v2:  makeInt(2),
+		err: "strconv.ParseInt: parsing \"1.2\": invalid syntax",
+	}, {
+		// Make sure underlying error is returned for RHS.
+		v1:  makeInt(2),
+		v2:  makeAny(Int64, "1.2"),
+		err: "strconv.ParseInt: parsing \"1.2\": invalid syntax",
+	}, {
+		// Numeric equal.
+		v1:  makeInt(1),
+		v2:  makeUint(1),
+		out: 0,
+	}, {
+		// Numeric unequal.
+		v1:  makeInt(1),
+		v2:  makeUint(2),
+		out: -1,
+	}, {
+		// Non-numeric equal
+		v1:  makeAny(VarBinary, "abcd"),
+		v2:  makeAny(Binary, "abcd"),
+		out: 0,
+	}, {
+		// Non-numeric unequal
+		v1:  makeAny(VarBinary, "abcd"),
+		v2:  makeAny(Binary, "bcde"),
+		out: -1,
+	}}
+	for _, tcase := range tcases {
+		got, err := NullsafeCompare(tcase.v1, tcase.v2)
+		errstr := ""
+		if err != nil {
+			errstr = err.Error()
+		}
+		if errstr != tcase.err {
+			t.Errorf("NullsafeLess(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), err, tcase.err)
+		}
+		if got != tcase.out {
+			t.Errorf("NullsafeLess(%v, %v): %v, want %v", printValue(tcase.v1), printValue(tcase.v2), got, tcase.out)
+		}
+	}
+}
+
+func TestNewNumeric(t *testing.T) {
+	tcases := []struct {
+		v   Value
+		out numeric
+		err string
+	}{{
+		v:   makeInt(1),
+		out: numeric{typ: Int64, ival: 1},
+	}, {
+		v:   makeUint(1),
+		out: numeric{typ: Uint64, uval: 1},
+	}, {
+		v:   makeFloat(1),
+		out: numeric{typ: Float64, fval: 1},
+	}, {
+		// For non-number type, Int64 is the default.
+		v:   makeAny(VarChar, "1"),
+		out: numeric{typ: Int64, ival: 1},
+	}, {
+		// If Int64 can't work, we use Float64.
+		v:   makeAny(VarChar, "1.2"),
+		out: numeric{typ: Float64, fval: 1.2},
+	}, {
+		// Only valid Int64 allowed if type is Int64.
+		v:   makeAny(Int64, "1.2"),
+		err: "strconv.ParseInt: parsing \"1.2\": invalid syntax",
+	}, {
+		// Only valid Uint64 allowed if type is Uint64.
+		v:   makeAny(Uint64, "1.2"),
+		err: "strconv.ParseUint: parsing \"1.2\": invalid syntax",
+	}, {
+		// Only valid Float64 allowed if type is Float64.
+		v:   makeAny(Float64, "abcd"),
+		err: "strconv.ParseFloat: parsing \"abcd\": invalid syntax",
+	}, {
+		v:   makeAny(VarChar, "abcd"),
+		err: "could not parse value: abcd",
+	}}
+	for _, tcase := range tcases {
+		got, err := newNumeric(tcase.v)
+		errstr := ""
+		if err != nil {
+			errstr = err.Error()
+		}
+		if errstr != tcase.err {
+			t.Errorf("newNumeric(%s) error: %v, want %v", printValue(tcase.v), err, tcase.err)
+		}
+		if tcase.err == "" && got != tcase.out {
+			t.Errorf("newNumeric(%s): %v, want %v", printValue(tcase.v), got, tcase.out)
+		}
+	}
+}
+
+func TestAddNumeric(t *testing.T) {
+	tcases := []struct {
+		v1, v2 numeric
+		out    numeric
+		err    string
+	}{{
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Int64, ival: 2},
+		out: numeric{typ: Int64, ival: 3},
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: numeric{typ: Uint64, uval: 3},
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: numeric{typ: Float64, fval: 3},
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: numeric{typ: Uint64, uval: 3},
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: numeric{typ: Float64, fval: 3},
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: numeric{typ: Float64, fval: 3},
+	}, {
+		// Int64 overflow.
+		v1:  numeric{typ: Int64, ival: 9223372036854775807},
+		v2:  numeric{typ: Int64, ival: 2},
+		out: numeric{typ: Float64, fval: 9223372036854775809},
+	}, {
+		// Int64 underflow.
+		v1:  numeric{typ: Int64, ival: -9223372036854775807},
+		v2:  numeric{typ: Int64, ival: -2},
+		out: numeric{typ: Float64, fval: -9223372036854775809},
+	}, {
+		v1:  numeric{typ: Int64, ival: -1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		err: "cannot add a negative number to an unsigned integer: 2, -1",
+	}, {
+		// Uint64 overflow.
+		v1:  numeric{typ: Uint64, uval: 18446744073709551615},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: numeric{typ: Float64, fval: 18446744073709551617},
+	}}
+	for _, tcase := range tcases {
+		got, err := addNumeric(tcase.v1, tcase.v2)
+		errstr := ""
+		if err != nil {
+			errstr = err.Error()
+		}
+		if errstr != tcase.err {
+			t.Errorf("addNumeric(%v, %v) error: %v, want %v", tcase.v1, tcase.v2, err, tcase.err)
+		}
+		if got != tcase.out {
+			t.Errorf("addNumeric(%v, %v): %v, want %v", tcase.v1, tcase.v2, got, tcase.out)
+		}
+	}
+}
+
+func TestPrioritize(t *testing.T) {
+	ival := numeric{typ: Int64}
+	uval := numeric{typ: Uint64}
+	fval := numeric{typ: Float64}
+
+	tcases := []struct {
+		v1, v2     numeric
+		out1, out2 numeric
+	}{{
+		v1:   ival,
+		v2:   uval,
+		out1: uval,
+		out2: ival,
+	}, {
+		v1:   ival,
+		v2:   fval,
+		out1: fval,
+		out2: ival,
+	}, {
+		v1:   uval,
+		v2:   ival,
+		out1: uval,
+		out2: ival,
+	}, {
+		v1:   uval,
+		v2:   fval,
+		out1: fval,
+		out2: uval,
+	}, {
+		v1:   fval,
+		v2:   ival,
+		out1: fval,
+		out2: ival,
+	}, {
+		v1:   fval,
+		v2:   uval,
+		out1: fval,
+		out2: uval,
+	}}
+	for _, tcase := range tcases {
+		got1, got2 := prioritize(tcase.v1, tcase.v2)
+		if got1 != tcase.out1 || got2 != tcase.out2 {
+			t.Errorf("prioritize(%v, %v): (%v, %v) , want (%v, %v)", tcase.v1.typ, tcase.v2.typ, got1.typ, got2.typ, tcase.out1.typ, tcase.out2.typ)
+		}
+	}
+}
+
+func TestCastFromNumeric(t *testing.T) {
+	tcases := []struct {
+		typ querypb.Type
+		v   numeric
+		out Value
+		err string
+	}{{
+		typ: Int64,
+		v:   numeric{typ: Int64, ival: 1},
+		out: makeInt(1),
+	}, {
+		typ: Int64,
+		v:   numeric{typ: Uint64, uval: 1},
+		err: "unexpected type conversion: UINT64 to INT64",
+	}, {
+		typ: Int64,
+		v:   numeric{typ: Float64, fval: 1.2e-16},
+		err: "unexpected type conversion: FLOAT64 to INT64",
+	}, {
+		typ: Uint64,
+		v:   numeric{typ: Int64, ival: 1},
+		err: "unexpected type conversion: INT64 to UINT64",
+	}, {
+		typ: Uint64,
+		v:   numeric{typ: Uint64, uval: 1},
+		out: makeUint(1),
+	}, {
+		typ: Uint64,
+		v:   numeric{typ: Float64, fval: 1.2e-16},
+		err: "unexpected type conversion: FLOAT64 to UINT64",
+	}, {
+		typ: Float64,
+		v:   numeric{typ: Int64, ival: 1},
+		out: makeAny(Float64, "1"),
+	}, {
+		typ: Float64,
+		v:   numeric{typ: Uint64, uval: 1},
+		out: makeAny(Float64, "1"),
+	}, {
+		typ: Float64,
+		v:   numeric{typ: Float64, fval: 1.2e-16},
+		out: makeAny(Float64, "1.2e-16"),
+	}, {
+		typ: Decimal,
+		v:   numeric{typ: Int64, ival: 1},
+		out: makeAny(Decimal, "1"),
+	}, {
+		typ: Decimal,
+		v:   numeric{typ: Uint64, uval: 1},
+		out: makeAny(Decimal, "1"),
+	}, {
+		// For float, we should not use scientific notation.
+		typ: Decimal,
+		v:   numeric{typ: Float64, fval: 1.2e-16},
+		out: makeAny(Decimal, "0.00000000000000012"),
+	}, {
+		typ: VarBinary,
+		v:   numeric{typ: Int64, ival: 1},
+		err: "unexpected type conversion to non-numeric: VARBINARY",
+	}}
+	for _, tcase := range tcases {
+		got, err := castFromNumeric(tcase.v, tcase.typ)
+		errstr := ""
+		if err != nil {
+			errstr = err.Error()
+		}
+		if errstr != tcase.err {
+			t.Errorf("castFromNumeric(%v, %v) error: %v, want %v", tcase.v, tcase.typ, err, tcase.err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("castFromNumeric(%v, %v): %s, want %s", tcase.v, tcase.typ, printValue(got), printValue(tcase.out))
+		}
+	}
+}
+
+func TestCompareNumeric(t *testing.T) {
+	tcases := []struct {
+		v1, v2 numeric
+		out    int
+	}{{
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Int64, ival: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Int64, ival: 2},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 1,
+	}, {
+		// Special case.
+		v1:  numeric{typ: Int64, ival: -1},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Int64, ival: 2},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Int64, ival: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Int64, ival: 2},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 1,
+	}, {
+		// Special case.
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Int64, ival: -1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Int64, ival: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 2},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 2},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Uint64, uval: 2},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Int64, ival: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 2},
+		v2:  numeric{typ: Int64, ival: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Uint64, uval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 2},
+		v2:  numeric{typ: Uint64, uval: 1},
+		out: 1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 0,
+	}, {
+		v1:  numeric{typ: Float64, fval: 1},
+		v2:  numeric{typ: Float64, fval: 2},
+		out: -1,
+	}, {
+		v1:  numeric{typ: Float64, fval: 2},
+		v2:  numeric{typ: Float64, fval: 1},
+		out: 1,
+	}}
+	for _, tcase := range tcases {
+		got := compareNumeric(tcase.v1, tcase.v2)
+		if got != tcase.out {
+			t.Errorf("equalNumeric(%v, %v): %v, want %v", tcase.v1, tcase.v2, got, tcase.out)
+		}
+	}
+}
+
+func makeInt(v int64) Value {
+	return MakeTrusted(Int64, strconv.AppendInt(nil, v, 10))
+}
+
+func makeUint(v uint64) Value {
+	return MakeTrusted(Uint64, strconv.AppendUint(nil, v, 10))
+}
+
+func makeFloat(v float64) Value {
+	return MakeTrusted(Float64, strconv.AppendFloat(nil, v, 'g', -1, 64))
+}
+
+func makeAny(typ querypb.Type, v string) Value {
+	return MakeTrusted(typ, []byte(v))
+}
+
+func printValue(v Value) string {
+	return fmt.Sprintf("%v:%q", v.typ, v.val)
+}
+
+// These benchmarks show that using existing ASCII representations
+// for numbers is about 6x slower than using native representations.
+// However, 229ns is still a negligible time compared to the cost of
+// other operations. The additional complexity of introducing native
+// types is currently not worth it. So, we'll stay with the existing
+// ASCII representation for now. Using interfaces is more expensive
+// than native representation of values. This is probably because
+// interfaces also allocate memory, and also perform type assertions.
+// Actual benchmark is based on NoNative. So, the numbers are similar.
+// Date: 6/4/17
+// Version: go1.8
+// BenchmarkAddActual-8            10000000               263 ns/op
+// BenchmarkAddNoNative-8          10000000               228 ns/op
+// BenchmarkAddNative-8            50000000                40.0 ns/op
+// BenchmarkAddGoInterface-8       30000000                52.4 ns/op
+// BenchmarkAddGoNonInterface-8    2000000000               1.00 ns/op
+// BenchmarkAddGo-8                2000000000               1.00 ns/op
+func BenchmarkAddActual(b *testing.B) {
+	v1 := MakeTrusted(Int64, []byte("1"))
+	v2 := MakeTrusted(Int64, []byte("12"))
+	for i := 0; i < b.N; i++ {
+		v1, _ = Add(v1, v2, Int64)
+	}
+}
+
+func BenchmarkAddNoNative(b *testing.B) {
+	v1 := MakeTrusted(Int64, []byte("1"))
+	v2 := MakeTrusted(Int64, []byte("12"))
+	for i := 0; i < b.N; i++ {
+		iv1, _ := v1.ParseInt64()
+		iv2, _ := v2.ParseInt64()
+		v1 = MakeTrusted(Int64, strconv.AppendInt(nil, iv1+iv2, 10))
+	}
+}
+
+func BenchmarkAddNative(b *testing.B) {
+	v1 := makeNativeInt64(1)
+	v2 := makeNativeInt64(12)
+	for i := 0; i < b.N; i++ {
+		iv1 := int64(binary.BigEndian.Uint64(v1.Raw()))
+		iv2 := int64(binary.BigEndian.Uint64(v2.Raw()))
+		v1 = makeNativeInt64(iv1 + iv2)
+	}
+}
+
+func makeNativeInt64(v int64) Value {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(v))
+	return MakeTrusted(Int64, buf)
+}
+
+func BenchmarkAddGoInterface(b *testing.B) {
+	var v1, v2 interface{}
+	v1 = int64(1)
+	v2 = int64(2)
+	for i := 0; i < b.N; i++ {
+		v1 = v1.(int64) + v2.(int64)
+	}
+}
+
+func BenchmarkAddGoNonInterface(b *testing.B) {
+	v1 := numeric{typ: Int64, ival: 1}
+	v2 := numeric{typ: Int64, ival: 12}
+	for i := 0; i < b.N; i++ {
+		if v1.typ != Int64 {
+			b.Error("type assertion failed")
+		}
+		if v2.typ != Int64 {
+			b.Error("type assertion failed")
+		}
+		v1 = numeric{typ: Int64, ival: v1.ival + v2.ival}
+	}
+}
+
+func BenchmarkAddGo(b *testing.B) {
+	v1 := int64(1)
+	v2 := int64(2)
+	for i := 0; i < b.N; i++ {
+		v1 += v2
+	}
+}

--- a/go/sqltypes/type.go
+++ b/go/sqltypes/type.go
@@ -74,6 +74,11 @@ func IsBinary(t querypb.Type) bool {
 	return int(t)&flagIsBinary == flagIsBinary
 }
 
+// isNumber returns true if the type is any type of number.
+func isNumber(t querypb.Type) bool {
+	return IsIntegral(t) || IsFloat(t) || t == Decimal
+}
+
 // Vitess data types. These are idiomatically
 // named synonyms for the querypb.Type values.
 const (

--- a/go/sqltypes/type_test.go
+++ b/go/sqltypes/type_test.go
@@ -119,6 +119,9 @@ func TestTypeValues(t *testing.T) {
 	}, {
 		defined:  TypeJSON,
 		expected: 30 | flagIsQuoted,
+	}, {
+		defined:  Expression,
+		expected: 31,
 	}}
 	for _, tcase := range testcases {
 		if int(tcase.defined) != tcase.expected {
@@ -169,6 +172,9 @@ func TestIsFunctions(t *testing.T) {
 	}
 	if !IsBinary(Binary) {
 		t.Error("Char: !IsBinary, must be true")
+	}
+	if !isNumber(Int64) {
+		t.Error("Int64: !isNumber, must be true")
 	}
 }
 


### PR DESCRIPTION
Issue #2897

This is the starting framework for performing arithmetic operations.
The benchmarks, included in this PR, show that using the ASCII
representation is not too expensive. So, we can avoid the complication
of introducing new native types. There is also the cost of eventually
converting the native types back to ASCII representation for
transmission.

Right now, we have Add and NullsafeCompare, which will be used for
aggregation and comparison operations.