### PR TITLE
Check NewName in tableacl and Admin statement type

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -1061,21 +1061,21 @@
 # show
 "show a"
 {
-  "PlanID": "OTHER",
+  "PlanID": "OTHER_READ",
   "TableName": ""
 }
 
 # describe
 "describe a"
 {
-  "PlanID": "OTHER",
+  "PlanID": "OTHER_READ",
   "TableName": ""
 }
 
 # explain
 "explain a"
 {
-  "PlanID": "OTHER",
+  "PlanID": "OTHER_READ",
   "TableName": ""
 }
 

--- a/data/test/tabletserver/stream_cases.txt
+++ b/data/test/tabletserver/stream_cases.txt
@@ -39,7 +39,7 @@
 {
   "PlanID": "SELECT_STREAM",
   "TableName": "",
-  "FullQuery": "other"
+  "FullQuery": "otherread"
 }
 
 # dml

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -25,7 +25,7 @@
 
 # DBA statements
 "explain select * from user"
-"unsupported construct: other"
+"unsupported construct: other read"
 
 # union operations in subqueries (FROM)
 "select * from (select * from user union all select * from user_extra) as t"

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -113,16 +113,17 @@ type Statement interface {
 	SQLNode
 }
 
-func (*Union) iStatement()  {}
-func (*Select) iStatement() {}
-func (*Insert) iStatement() {}
-func (*Update) iStatement() {}
-func (*Delete) iStatement() {}
-func (*Set) iStatement()    {}
-func (*DDL) iStatement()    {}
-func (*Show) iStatement()   {}
-func (*Use) iStatement()    {}
-func (*Other) iStatement()  {}
+func (*Union) iStatement()      {}
+func (*Select) iStatement()     {}
+func (*Insert) iStatement()     {}
+func (*Update) iStatement()     {}
+func (*Delete) iStatement()     {}
+func (*Set) iStatement()        {}
+func (*DDL) iStatement()        {}
+func (*Show) iStatement()       {}
+func (*Use) iStatement()        {}
+func (*OtherRead) iStatement()  {}
+func (*OtherAdmin) iStatement() {}
 
 // ParenSelect can actually not be a top level statement,
 // but we have to allow it because it's a requirement
@@ -571,18 +572,34 @@ func (node *Use) WalkSubtree(visit Visit) error {
 	return Walk(visit, node.DBName)
 }
 
-// Other represents a DESCRIBE, or EXPLAIN statement.
+// OtherRead represents a DESCRIBE, or EXPLAIN statement.
 // It should be used only as an indicator. It does not contain
 // the full AST for the statement.
-type Other struct{}
+type OtherRead struct{}
 
 // Format formats the node.
-func (node *Other) Format(buf *TrackedBuffer) {
-	buf.WriteString("other")
+func (node *OtherRead) Format(buf *TrackedBuffer) {
+	buf.WriteString("otherread")
 }
 
 // WalkSubtree walks the nodes of the subtree.
-func (node *Other) WalkSubtree(visit Visit) error {
+func (node *OtherRead) WalkSubtree(visit Visit) error {
+	return nil
+}
+
+// OtherAdmin represents a misc statement that relies on ADMIN privileges,
+// such as REPAIR, OPTIMIZE, or TRUNCATE statement.
+// It should be used only as an indicator. It does not contain
+// the full AST for the statement.
+type OtherAdmin struct{}
+
+// Format formats the node.
+func (node *OtherAdmin) Format(buf *TrackedBuffer) {
+	buf.WriteString("otheradmin")
+}
+
+// WalkSubtree walks the nodes of the subtree.
+func (node *OtherAdmin) WalkSubtree(visit Visit) error {
 	return nil
 }
 

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -754,16 +754,22 @@ func TestValid(t *testing.T) {
 		output: "use `ks:-80@master`",
 	}, {
 		input:  "describe foobar",
-		output: "other",
+		output: "otherread",
 	}, {
 		input:  "desc foobar",
-		output: "other",
+		output: "otherread",
 	}, {
 		input:  "explain foobar",
-		output: "other",
+		output: "otherread",
 	}, {
 		input:  "truncate foo",
-		output: "other",
+		output: "otheradmin",
+	}, {
+		input:  "repair foo",
+		output: "otheradmin",
+	}, {
+		input:  "optimize foo",
+		output: "otheradmin",
 	}, {
 		input: "select /* EQ true */ 1 from t where a = true",
 	}, {

--- a/go/vt/sqlparser/sql.go
+++ b/go/vt/sqlparser/sql.go
@@ -1,9 +1,9 @@
-//line ./go/vt/sqlparser/sql.y:18
+//line sql.y:18
 package sqlparser
 
 import __yyfmt__ "fmt"
 
-//line ./go/vt/sqlparser/sql.y:18
+//line sql.y:18
 func setParseTree(yylex interface{}, stmt Statement) {
 	yylex.(*Tokenizer).ParseTree = stmt
 }
@@ -28,7 +28,7 @@ func forceEOF(yylex interface{}) {
 	yylex.(*Tokenizer).ForceEOF = true
 }
 
-//line ./go/vt/sqlparser/sql.y:46
+//line sql.y:46
 type yySymType struct {
 	yys              int
 	empty            struct{}
@@ -1526,29 +1526,29 @@ yydefault:
 
 	case 1:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:216
+		//line sql.y:216
 		{
 			setParseTree(yylex, yyDollar[1].statement)
 		}
 	case 2:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:221
+		//line sql.y:221
 		{
 		}
 	case 3:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:222
+		//line sql.y:222
 		{
 		}
 	case 4:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:226
+		//line sql.y:226
 		{
 			yyVAL.statement = yyDollar[1].selStmt
 		}
 	case 17:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:244
+		//line sql.y:244
 		{
 			sel := yyDollar[1].selStmt.(*Select)
 			sel.OrderBy = yyDollar[2].orderBy
@@ -1558,49 +1558,49 @@ yydefault:
 		}
 	case 18:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:252
+		//line sql.y:252
 		{
 			yyVAL.selStmt = &Union{Type: yyDollar[2].str, Left: yyDollar[1].selStmt, Right: yyDollar[3].selStmt, OrderBy: yyDollar[4].orderBy, Limit: yyDollar[5].limit, Lock: yyDollar[6].str}
 		}
 	case 19:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:256
+		//line sql.y:256
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, SelectExprs: SelectExprs{Nextval{Expr: yyDollar[5].expr}}, From: TableExprs{&AliasedTableExpr{Expr: yyDollar[7].tableName}}}
 		}
 	case 20:
 		yyDollar = yyS[yypt-10 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:263
+		//line sql.y:263
 		{
 			yyVAL.selStmt = &Select{Comments: Comments(yyDollar[2].bytes2), Cache: yyDollar[3].str, Distinct: yyDollar[4].str, Hints: yyDollar[5].str, SelectExprs: yyDollar[6].selectExprs, From: yyDollar[7].tableExprs, Where: NewWhere(WhereStr, yyDollar[8].expr), GroupBy: GroupBy(yyDollar[9].exprs), Having: NewWhere(HavingStr, yyDollar[10].expr)}
 		}
 	case 21:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:269
+		//line sql.y:269
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 22:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:273
+		//line sql.y:273
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:279
+		//line sql.y:279
 		{
 			yyVAL.selStmt = yyDollar[1].selStmt
 		}
 	case 24:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:283
+		//line sql.y:283
 		{
 			yyVAL.selStmt = &ParenSelect{Select: yyDollar[2].selStmt}
 		}
 	case 25:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:290
+		//line sql.y:290
 		{
 			// insert_data returns a *Insert pre-filled with Columns & Values
 			ins := yyDollar[5].ins
@@ -1613,7 +1613,7 @@ yydefault:
 		}
 	case 26:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:301
+		//line sql.y:301
 		{
 			cols := make(Columns, 0, len(yyDollar[6].updateExprs))
 			vals := make(ValTuple, 0, len(yyDollar[7].updateExprs))
@@ -1625,122 +1625,122 @@ yydefault:
 		}
 	case 27:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:313
+		//line sql.y:313
 		{
 			yyVAL.str = InsertStr
 		}
 	case 28:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:317
+		//line sql.y:317
 		{
 			yyVAL.str = ReplaceStr
 		}
 	case 29:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:323
+		//line sql.y:323
 		{
 			yyVAL.statement = &Update{Comments: Comments(yyDollar[2].bytes2), TableExprs: yyDollar[3].tableExprs, Exprs: yyDollar[5].updateExprs, Where: NewWhere(WhereStr, yyDollar[6].expr), OrderBy: yyDollar[7].orderBy, Limit: yyDollar[8].limit}
 		}
 	case 30:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:329
+		//line sql.y:329
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), TableExprs: TableExprs{&AliasedTableExpr{Expr: yyDollar[4].tableName}}, Where: NewWhere(WhereStr, yyDollar[5].expr), OrderBy: yyDollar[6].orderBy, Limit: yyDollar[7].limit}
 		}
 	case 31:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:333
+		//line sql.y:333
 		{
 			yyVAL.statement = &Delete{Comments: Comments(yyDollar[2].bytes2), Targets: yyDollar[3].tableNames, TableExprs: yyDollar[5].tableExprs, Where: NewWhere(WhereStr, yyDollar[6].expr)}
 		}
 	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:338
+		//line sql.y:338
 		{
 		}
 	case 33:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:339
+		//line sql.y:339
 		{
 		}
 	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:343
+		//line sql.y:343
 		{
 			yyVAL.tableNames = TableNames{yyDollar[1].tableName}
 		}
 	case 35:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:347
+		//line sql.y:347
 		{
 			yyVAL.tableNames = append(yyVAL.tableNames, yyDollar[3].tableName)
 		}
 	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:353
+		//line sql.y:353
 		{
 			yyVAL.statement = &Set{Comments: Comments(yyDollar[2].bytes2), Exprs: yyDollar[3].updateExprs}
 		}
 	case 37:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:359
+		//line sql.y:359
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, NewName: yyDollar[4].tableName}
 		}
 	case 38:
 		yyDollar = yyS[yypt-8 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:363
+		//line sql.y:363
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[7].tableName, NewName: yyDollar[7].tableName}
 		}
 	case 39:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:368
+		//line sql.y:368
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, NewName: yyDollar[3].tableName.ToViewName()}
 		}
 	case 40:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:372
+		//line sql.y:372
 		{
 			yyVAL.statement = &DDL{Action: CreateStr, NewName: yyDollar[5].tableName.ToViewName()}
 		}
 	case 41:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:378
+		//line sql.y:378
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 42:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:382
+		//line sql.y:382
 		{
 			// Change this to a rename statement
 			yyVAL.statement = &DDL{Action: RenameStr, Table: yyDollar[4].tableName, NewName: yyDollar[7].tableName}
 		}
 	case 43:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:387
+		//line sql.y:387
 		{
 			// Rename an index can just be an alter
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[4].tableName, NewName: yyDollar[4].tableName}
 		}
 	case 44:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:392
+		//line sql.y:392
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[3].tableName.ToViewName(), NewName: yyDollar[3].tableName.ToViewName()}
 		}
 	case 45:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:398
+		//line sql.y:398
 		{
 			yyVAL.statement = &DDL{Action: RenameStr, Table: yyDollar[3].tableName, NewName: yyDollar[5].tableName}
 		}
 	case 46:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:404
+		//line sql.y:404
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -1750,14 +1750,14 @@ yydefault:
 		}
 	case 47:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:412
+		//line sql.y:412
 		{
 			// Change this to an alter statement
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[5].tableName, NewName: yyDollar[5].tableName}
 		}
 	case 48:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:417
+		//line sql.y:417
 		{
 			var exists bool
 			if yyDollar[3].byt != 0 {
@@ -1767,19 +1767,19 @@ yydefault:
 		}
 	case 49:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:427
+		//line sql.y:427
 		{
 			yyVAL.statement = &DDL{Action: AlterStr, Table: yyDollar[3].tableName, NewName: yyDollar[3].tableName}
 		}
 	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:433
+		//line sql.y:433
 		{
 			yyVAL.str = ShowUnsupportedStr
 		}
 	case 51:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:437
+		//line sql.y:437
 		{
 			switch v := string(yyDollar[1].bytes); v {
 			case ShowDatabasesStr, ShowTablesStr, ShowKeyspacesStr, ShowShardsStr, ShowVSchemaTablesStr:
@@ -1790,380 +1790,380 @@ yydefault:
 		}
 	case 52:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:446
+		//line sql.y:446
 		{
 			yyVAL.str = ShowUnsupportedStr
 		}
 	case 53:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:452
+		//line sql.y:452
 		{
 			yyVAL.statement = &Show{Type: yyDollar[2].str}
 		}
 	case 54:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:458
+		//line sql.y:458
 		{
 			yyVAL.statement = &Use{DBName: yyDollar[2].tableIdent}
 		}
 	case 55:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:464
+		//line sql.y:464
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherRead{}
 		}
 	case 56:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:468
+		//line sql.y:468
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherRead{}
 		}
 	case 57:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:472
+		//line sql.y:472
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherRead{}
 		}
 	case 58:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:476
+		//line sql.y:476
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherAdmin{}
 		}
 	case 59:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:480
+		//line sql.y:480
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherAdmin{}
 		}
 	case 60:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:484
+		//line sql.y:484
 		{
-			yyVAL.statement = &Other{}
+			yyVAL.statement = &OtherAdmin{}
 		}
 	case 61:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:489
+		//line sql.y:489
 		{
 			setAllowComments(yylex, true)
 		}
 	case 62:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:493
+		//line sql.y:493
 		{
 			yyVAL.bytes2 = yyDollar[2].bytes2
 			setAllowComments(yylex, false)
 		}
 	case 63:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:499
+		//line sql.y:499
 		{
 			yyVAL.bytes2 = nil
 		}
 	case 64:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:503
+		//line sql.y:503
 		{
 			yyVAL.bytes2 = append(yyDollar[1].bytes2, yyDollar[2].bytes)
 		}
 	case 65:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:509
+		//line sql.y:509
 		{
 			yyVAL.str = UnionStr
 		}
 	case 66:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:513
+		//line sql.y:513
 		{
 			yyVAL.str = UnionAllStr
 		}
 	case 67:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:517
+		//line sql.y:517
 		{
 			yyVAL.str = UnionDistinctStr
 		}
 	case 68:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:522
+		//line sql.y:522
 		{
 			yyVAL.str = ""
 		}
 	case 69:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:526
+		//line sql.y:526
 		{
 			yyVAL.str = SQLNoCacheStr
 		}
 	case 70:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:530
+		//line sql.y:530
 		{
 			yyVAL.str = SQLCacheStr
 		}
 	case 71:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:535
+		//line sql.y:535
 		{
 			yyVAL.str = ""
 		}
 	case 72:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:539
+		//line sql.y:539
 		{
 			yyVAL.str = DistinctStr
 		}
 	case 73:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:544
+		//line sql.y:544
 		{
 			yyVAL.str = ""
 		}
 	case 74:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:548
+		//line sql.y:548
 		{
 			yyVAL.str = StraightJoinHint
 		}
 	case 75:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:553
+		//line sql.y:553
 		{
 			yyVAL.selectExprs = nil
 		}
 	case 76:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:557
+		//line sql.y:557
 		{
 			yyVAL.selectExprs = yyDollar[1].selectExprs
 		}
 	case 77:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:563
+		//line sql.y:563
 		{
 			yyVAL.selectExprs = SelectExprs{yyDollar[1].selectExpr}
 		}
 	case 78:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:567
+		//line sql.y:567
 		{
 			yyVAL.selectExprs = append(yyVAL.selectExprs, yyDollar[3].selectExpr)
 		}
 	case 79:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:573
+		//line sql.y:573
 		{
 			yyVAL.selectExpr = &StarExpr{}
 		}
 	case 80:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:577
+		//line sql.y:577
 		{
 			yyVAL.selectExpr = &AliasedExpr{Expr: yyDollar[1].expr, As: yyDollar[2].colIdent}
 		}
 	case 81:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:581
+		//line sql.y:581
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Name: yyDollar[1].tableIdent}}
 		}
 	case 82:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:585
+		//line sql.y:585
 		{
 			yyVAL.selectExpr = &StarExpr{TableName: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}}
 		}
 	case 83:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:590
+		//line sql.y:590
 		{
 			yyVAL.colIdent = ColIdent{}
 		}
 	case 84:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:594
+		//line sql.y:594
 		{
 			yyVAL.colIdent = yyDollar[1].colIdent
 		}
 	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:598
+		//line sql.y:598
 		{
 			yyVAL.colIdent = yyDollar[2].colIdent
 		}
 	case 87:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:605
+		//line sql.y:605
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 88:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:610
+		//line sql.y:610
 		{
 			yyVAL.tableExprs = TableExprs{&AliasedTableExpr{Expr: TableName{Name: NewTableIdent("dual")}}}
 		}
 	case 89:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:614
+		//line sql.y:614
 		{
 			yyVAL.tableExprs = yyDollar[2].tableExprs
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:620
+		//line sql.y:620
 		{
 			yyVAL.tableExprs = TableExprs{yyDollar[1].tableExpr}
 		}
 	case 91:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:624
+		//line sql.y:624
 		{
 			yyVAL.tableExprs = append(yyVAL.tableExprs, yyDollar[3].tableExpr)
 		}
 	case 94:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:634
+		//line sql.y:634
 		{
 			yyVAL.tableExpr = yyDollar[1].aliasedTableName
 		}
 	case 95:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:638
+		//line sql.y:638
 		{
 			yyVAL.tableExpr = &AliasedTableExpr{Expr: yyDollar[1].subquery, As: yyDollar[3].tableIdent}
 		}
 	case 96:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:642
+		//line sql.y:642
 		{
 			yyVAL.tableExpr = &ParenTableExpr{Exprs: yyDollar[2].tableExprs}
 		}
 	case 97:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:648
+		//line sql.y:648
 		{
 			yyVAL.aliasedTableName = &AliasedTableExpr{Expr: yyDollar[1].tableName, As: yyDollar[2].tableIdent, Hints: yyDollar[3].indexHints}
 		}
 	case 98:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:661
+		//line sql.y:661
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 99:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:665
+		//line sql.y:665
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, On: yyDollar[5].expr}
 		}
 	case 100:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:669
+		//line sql.y:669
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr, On: yyDollar[5].expr}
 		}
 	case 101:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:673
+		//line sql.y:673
 		{
 			yyVAL.tableExpr = &JoinTableExpr{LeftExpr: yyDollar[1].tableExpr, Join: yyDollar[2].str, RightExpr: yyDollar[3].tableExpr}
 		}
 	case 102:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:678
+		//line sql.y:678
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 103:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:680
+		//line sql.y:680
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 104:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:683
+		//line sql.y:683
 		{
 			yyVAL.tableIdent = NewTableIdent("")
 		}
 	case 105:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:687
+		//line sql.y:687
 		{
 			yyVAL.tableIdent = yyDollar[1].tableIdent
 		}
 	case 106:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:691
+		//line sql.y:691
 		{
 			yyVAL.tableIdent = yyDollar[2].tableIdent
 		}
 	case 108:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:698
+		//line sql.y:698
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 109:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:704
+		//line sql.y:704
 		{
 			yyVAL.str = JoinStr
 		}
 	case 110:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:708
+		//line sql.y:708
 		{
 			yyVAL.str = JoinStr
 		}
 	case 111:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:712
+		//line sql.y:712
 		{
 			yyVAL.str = JoinStr
 		}
 	case 112:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:716
+		//line sql.y:716
 		{
 			yyVAL.str = StraightJoinStr
 		}
 	case 113:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:722
+		//line sql.y:722
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 114:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:726
+		//line sql.y:726
 		{
 			yyVAL.str = LeftJoinStr
 		}
 	case 115:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:730
+		//line sql.y:730
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 116:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:734
+		//line sql.y:734
 		{
 			yyVAL.str = RightJoinStr
 		}
 	case 117:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:740
+		//line sql.y:740
 		{
 			yyVAL.str = NaturalJoinStr
 		}
 	case 118:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:744
+		//line sql.y:744
 		{
 			if yyDollar[2].str == LeftJoinStr {
 				yyVAL.str = NaturalLeftJoinStr
@@ -2173,469 +2173,469 @@ yydefault:
 		}
 	case 119:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:754
+		//line sql.y:754
 		{
 			yyVAL.tableName = yyDollar[2].tableName
 		}
 	case 120:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:758
+		//line sql.y:758
 		{
 			yyVAL.tableName = yyDollar[1].tableName
 		}
 	case 121:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:764
+		//line sql.y:764
 		{
 			yyVAL.tableName = TableName{Name: yyDollar[1].tableIdent}
 		}
 	case 122:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:768
+		//line sql.y:768
 		{
 			yyVAL.tableName = TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}
 		}
 	case 123:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:773
+		//line sql.y:773
 		{
 			yyVAL.indexHints = nil
 		}
 	case 124:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:777
+		//line sql.y:777
 		{
 			yyVAL.indexHints = &IndexHints{Type: UseStr, Indexes: yyDollar[4].colIdents}
 		}
 	case 125:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:781
+		//line sql.y:781
 		{
 			yyVAL.indexHints = &IndexHints{Type: IgnoreStr, Indexes: yyDollar[4].colIdents}
 		}
 	case 126:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:785
+		//line sql.y:785
 		{
 			yyVAL.indexHints = &IndexHints{Type: ForceStr, Indexes: yyDollar[4].colIdents}
 		}
 	case 127:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:791
+		//line sql.y:791
 		{
 			yyVAL.colIdents = []ColIdent{yyDollar[1].colIdent}
 		}
 	case 128:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:795
+		//line sql.y:795
 		{
 			yyVAL.colIdents = append(yyDollar[1].colIdents, yyDollar[3].colIdent)
 		}
 	case 129:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:800
+		//line sql.y:800
 		{
 			yyVAL.expr = nil
 		}
 	case 130:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:804
+		//line sql.y:804
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 131:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:810
+		//line sql.y:810
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 132:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:814
+		//line sql.y:814
 		{
 			yyVAL.expr = &AndExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 133:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:818
+		//line sql.y:818
 		{
 			yyVAL.expr = &OrExpr{Left: yyDollar[1].expr, Right: yyDollar[3].expr}
 		}
 	case 134:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:822
+		//line sql.y:822
 		{
 			yyVAL.expr = &NotExpr{Expr: yyDollar[2].expr}
 		}
 	case 135:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:826
+		//line sql.y:826
 		{
 			yyVAL.expr = &IsExpr{Operator: yyDollar[3].str, Expr: yyDollar[1].expr}
 		}
 	case 136:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:830
+		//line sql.y:830
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 137:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:836
+		//line sql.y:836
 		{
 			yyVAL.boolVal = BoolVal(true)
 		}
 	case 138:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:840
+		//line sql.y:840
 		{
 			yyVAL.boolVal = BoolVal(false)
 		}
 	case 139:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:846
+		//line sql.y:846
 		{
 			yyVAL.expr = yyDollar[1].boolVal
 		}
 	case 140:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:850
+		//line sql.y:850
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: yyDollar[2].str, Right: yyDollar[3].boolVal}
 		}
 	case 141:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:854
+		//line sql.y:854
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: yyDollar[2].str, Right: yyDollar[3].expr}
 		}
 	case 142:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:858
+		//line sql.y:858
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: InStr, Right: yyDollar[3].colTuple}
 		}
 	case 143:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:862
+		//line sql.y:862
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotInStr, Right: yyDollar[4].colTuple}
 		}
 	case 144:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:866
+		//line sql.y:866
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: LikeStr, Right: yyDollar[3].expr, Escape: yyDollar[4].expr}
 		}
 	case 145:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:870
+		//line sql.y:870
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotLikeStr, Right: yyDollar[4].expr, Escape: yyDollar[5].expr}
 		}
 	case 146:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:874
+		//line sql.y:874
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: RegexpStr, Right: yyDollar[3].expr}
 		}
 	case 147:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:878
+		//line sql.y:878
 		{
 			yyVAL.expr = &ComparisonExpr{Left: yyDollar[1].expr, Operator: NotRegexpStr, Right: yyDollar[4].expr}
 		}
 	case 148:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:882
+		//line sql.y:882
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: BetweenStr, From: yyDollar[3].expr, To: yyDollar[5].expr}
 		}
 	case 149:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:886
+		//line sql.y:886
 		{
 			yyVAL.expr = &RangeCond{Left: yyDollar[1].expr, Operator: NotBetweenStr, From: yyDollar[4].expr, To: yyDollar[6].expr}
 		}
 	case 150:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:890
+		//line sql.y:890
 		{
 			yyVAL.expr = &ExistsExpr{Subquery: yyDollar[2].subquery}
 		}
 	case 151:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:896
+		//line sql.y:896
 		{
 			yyVAL.str = IsNullStr
 		}
 	case 152:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:900
+		//line sql.y:900
 		{
 			yyVAL.str = IsNotNullStr
 		}
 	case 153:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:904
+		//line sql.y:904
 		{
 			yyVAL.str = IsTrueStr
 		}
 	case 154:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:908
+		//line sql.y:908
 		{
 			yyVAL.str = IsNotTrueStr
 		}
 	case 155:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:912
+		//line sql.y:912
 		{
 			yyVAL.str = IsFalseStr
 		}
 	case 156:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:916
+		//line sql.y:916
 		{
 			yyVAL.str = IsNotFalseStr
 		}
 	case 157:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:922
+		//line sql.y:922
 		{
 			yyVAL.str = EqualStr
 		}
 	case 158:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:926
+		//line sql.y:926
 		{
 			yyVAL.str = LessThanStr
 		}
 	case 159:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:930
+		//line sql.y:930
 		{
 			yyVAL.str = GreaterThanStr
 		}
 	case 160:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:934
+		//line sql.y:934
 		{
 			yyVAL.str = LessEqualStr
 		}
 	case 161:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:938
+		//line sql.y:938
 		{
 			yyVAL.str = GreaterEqualStr
 		}
 	case 162:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:942
+		//line sql.y:942
 		{
 			yyVAL.str = NotEqualStr
 		}
 	case 163:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:946
+		//line sql.y:946
 		{
 			yyVAL.str = NullSafeEqualStr
 		}
 	case 164:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:951
+		//line sql.y:951
 		{
 			yyVAL.expr = nil
 		}
 	case 165:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:955
+		//line sql.y:955
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 166:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:961
+		//line sql.y:961
 		{
 			yyVAL.colTuple = yyDollar[1].valTuple
 		}
 	case 167:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:965
+		//line sql.y:965
 		{
 			yyVAL.colTuple = yyDollar[1].subquery
 		}
 	case 168:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:969
+		//line sql.y:969
 		{
 			yyVAL.colTuple = ListArg(yyDollar[1].bytes)
 		}
 	case 169:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:975
+		//line sql.y:975
 		{
 			yyVAL.subquery = &Subquery{yyDollar[2].selStmt}
 		}
 	case 170:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:981
+		//line sql.y:981
 		{
 			yyVAL.exprs = Exprs{yyDollar[1].expr}
 		}
 	case 171:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:985
+		//line sql.y:985
 		{
 			yyVAL.exprs = append(yyDollar[1].exprs, yyDollar[3].expr)
 		}
 	case 172:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:991
+		//line sql.y:991
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 173:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:995
+		//line sql.y:995
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 174:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:999
+		//line sql.y:999
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 175:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1003
+		//line sql.y:1003
 		{
 			yyVAL.str = string(yyDollar[1].bytes)
 		}
 	case 176:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1009
+		//line sql.y:1009
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 177:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1013
+		//line sql.y:1013
 		{
 			yyVAL.expr = yyDollar[1].colName
 		}
 	case 178:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1017
+		//line sql.y:1017
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 179:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1021
+		//line sql.y:1021
 		{
 			yyVAL.expr = yyDollar[1].subquery
 		}
 	case 180:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1025
+		//line sql.y:1025
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitAndStr, Right: yyDollar[3].expr}
 		}
 	case 181:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1029
+		//line sql.y:1029
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitOrStr, Right: yyDollar[3].expr}
 		}
 	case 182:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1033
+		//line sql.y:1033
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: BitXorStr, Right: yyDollar[3].expr}
 		}
 	case 183:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1037
+		//line sql.y:1037
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: PlusStr, Right: yyDollar[3].expr}
 		}
 	case 184:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1041
+		//line sql.y:1041
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MinusStr, Right: yyDollar[3].expr}
 		}
 	case 185:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1045
+		//line sql.y:1045
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: MultStr, Right: yyDollar[3].expr}
 		}
 	case 186:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1049
+		//line sql.y:1049
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: DivStr, Right: yyDollar[3].expr}
 		}
 	case 187:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1053
+		//line sql.y:1053
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: IntDivStr, Right: yyDollar[3].expr}
 		}
 	case 188:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1057
+		//line sql.y:1057
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 189:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1061
+		//line sql.y:1061
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ModStr, Right: yyDollar[3].expr}
 		}
 	case 190:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1065
+		//line sql.y:1065
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftLeftStr, Right: yyDollar[3].expr}
 		}
 	case 191:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1069
+		//line sql.y:1069
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].expr, Operator: ShiftRightStr, Right: yyDollar[3].expr}
 		}
 	case 192:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1073
+		//line sql.y:1073
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONExtractOp, Right: yyDollar[3].expr}
 		}
 	case 193:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1077
+		//line sql.y:1077
 		{
 			yyVAL.expr = &BinaryExpr{Left: yyDollar[1].colName, Operator: JSONUnquoteExtractOp, Right: yyDollar[3].expr}
 		}
 	case 194:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1081
+		//line sql.y:1081
 		{
 			yyVAL.expr = &CollateExpr{Expr: yyDollar[1].expr, Charset: yyDollar[3].str}
 		}
 	case 195:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1085
+		//line sql.y:1085
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BinaryStr, Expr: yyDollar[2].expr}
 		}
 	case 196:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1089
+		//line sql.y:1089
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				yyVAL.expr = num
@@ -2645,7 +2645,7 @@ yydefault:
 		}
 	case 197:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1097
+		//line sql.y:1097
 		{
 			if num, ok := yyDollar[2].expr.(*SQLVal); ok && num.Type == IntVal {
 				// Handle double negative
@@ -2661,19 +2661,19 @@ yydefault:
 		}
 	case 198:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1111
+		//line sql.y:1111
 		{
 			yyVAL.expr = &UnaryExpr{Operator: TildaStr, Expr: yyDollar[2].expr}
 		}
 	case 199:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1115
+		//line sql.y:1115
 		{
 			yyVAL.expr = &UnaryExpr{Operator: BangStr, Expr: yyDollar[2].expr}
 		}
 	case 200:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1119
+		//line sql.y:1119
 		{
 			// This rule prevents the usage of INTERVAL
 			// as a function. If support is needed for that,
@@ -2683,343 +2683,343 @@ yydefault:
 		}
 	case 205:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1137
+		//line sql.y:1137
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Exprs: yyDollar[3].selectExprs}
 		}
 	case 206:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1141
+		//line sql.y:1141
 		{
 			yyVAL.expr = &FuncExpr{Name: yyDollar[1].colIdent, Distinct: true, Exprs: yyDollar[4].selectExprs}
 		}
 	case 207:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1145
+		//line sql.y:1145
 		{
 			yyVAL.expr = &FuncExpr{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].colIdent, Exprs: yyDollar[5].selectExprs}
 		}
 	case 208:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1155
+		//line sql.y:1155
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("left"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 209:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1159
+		//line sql.y:1159
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("right"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 210:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1163
+		//line sql.y:1163
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 211:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1167
+		//line sql.y:1167
 		{
 			yyVAL.expr = &ConvertExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].convertType}
 		}
 	case 212:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1171
+		//line sql.y:1171
 		{
 			yyVAL.expr = &ConvertUsingExpr{Expr: yyDollar[3].expr, Type: yyDollar[5].str}
 		}
 	case 213:
 		yyDollar = yyS[yypt-9 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1175
+		//line sql.y:1175
 		{
 			yyVAL.expr = &MatchExpr{Columns: yyDollar[3].selectExprs, Expr: yyDollar[7].expr, Option: yyDollar[8].str}
 		}
 	case 214:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1179
+		//line sql.y:1179
 		{
 			yyVAL.expr = &GroupConcatExpr{Distinct: yyDollar[3].str, Exprs: yyDollar[4].selectExprs, OrderBy: yyDollar[5].orderBy, Separator: yyDollar[6].str}
 		}
 	case 215:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1183
+		//line sql.y:1183
 		{
 			yyVAL.expr = &CaseExpr{Expr: yyDollar[2].expr, Whens: yyDollar[3].whens, Else: yyDollar[4].expr}
 		}
 	case 216:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1187
+		//line sql.y:1187
 		{
 			yyVAL.expr = &ValuesFuncExpr{Name: yyDollar[3].colIdent}
 		}
 	case 217:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1197
+		//line sql.y:1197
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_timestamp")}
 		}
 	case 218:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1201
+		//line sql.y:1201
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_timestamp")}
 		}
 	case 219:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1205
+		//line sql.y:1205
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_time")}
 		}
 	case 220:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1209
+		//line sql.y:1209
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("utc_date")}
 		}
 	case 221:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1214
+		//line sql.y:1214
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtime")}
 		}
 	case 222:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1219
+		//line sql.y:1219
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("localtimestamp")}
 		}
 	case 223:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1224
+		//line sql.y:1224
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_date")}
 		}
 	case 224:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1229
+		//line sql.y:1229
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("current_time")}
 		}
 	case 227:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1243
+		//line sql.y:1243
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("if"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 228:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1247
+		//line sql.y:1247
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("database"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 229:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1251
+		//line sql.y:1251
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("mod"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 230:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1255
+		//line sql.y:1255
 		{
 			yyVAL.expr = &FuncExpr{Name: NewColIdent("replace"), Exprs: yyDollar[3].selectExprs}
 		}
 	case 231:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1261
+		//line sql.y:1261
 		{
 			yyVAL.str = ""
 		}
 	case 232:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1265
+		//line sql.y:1265
 		{
 			yyVAL.str = BooleanModeStr
 		}
 	case 233:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1269
+		//line sql.y:1269
 		{
 			yyVAL.str = NaturalLanguageModeStr
 		}
 	case 234:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1273
+		//line sql.y:1273
 		{
 			yyVAL.str = NaturalLanguageModeWithQueryExpansionStr
 		}
 	case 235:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1277
+		//line sql.y:1277
 		{
 			yyVAL.str = QueryExpansionStr
 		}
 	case 236:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1284
+		//line sql.y:1284
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str}
 		}
 	case 237:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1288
+		//line sql.y:1288
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str}
 		}
 	case 238:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1292
+		//line sql.y:1292
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Length: NewIntVal(yyDollar[3].bytes)}
 		}
 	case 239:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1296
+		//line sql.y:1296
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Length: NewIntVal(yyDollar[3].bytes), Charset: yyDollar[5].str}
 		}
 	case 240:
 		yyDollar = yyS[yypt-7 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1300
+		//line sql.y:1300
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Length: NewIntVal(yyDollar[3].bytes), Charset: yyDollar[7].str, Operator: CharacterSetStr}
 		}
 	case 241:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1304
+		//line sql.y:1304
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Charset: yyDollar[2].str}
 		}
 	case 242:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1308
+		//line sql.y:1308
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Charset: yyDollar[4].str, Operator: CharacterSetStr}
 		}
 	case 243:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1312
+		//line sql.y:1312
 		{
 			yyVAL.convertType = &ConvertType{Type: yyDollar[1].str, Length: NewIntVal(yyDollar[3].bytes), Scale: NewIntVal(yyDollar[5].bytes)}
 		}
 	case 244:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1317
+		//line sql.y:1317
 		{
 			yyVAL.expr = nil
 		}
 	case 245:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1321
+		//line sql.y:1321
 		{
 			yyVAL.expr = yyDollar[1].expr
 		}
 	case 246:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1326
+		//line sql.y:1326
 		{
 			yyVAL.str = string("")
 		}
 	case 247:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1330
+		//line sql.y:1330
 		{
 			yyVAL.str = " separator '" + string(yyDollar[2].bytes) + "'"
 		}
 	case 248:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1336
+		//line sql.y:1336
 		{
 			yyVAL.whens = []*When{yyDollar[1].when}
 		}
 	case 249:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1340
+		//line sql.y:1340
 		{
 			yyVAL.whens = append(yyDollar[1].whens, yyDollar[2].when)
 		}
 	case 250:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1346
+		//line sql.y:1346
 		{
 			yyVAL.when = &When{Cond: yyDollar[2].expr, Val: yyDollar[4].expr}
 		}
 	case 251:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1351
+		//line sql.y:1351
 		{
 			yyVAL.expr = nil
 		}
 	case 252:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1355
+		//line sql.y:1355
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 253:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1361
+		//line sql.y:1361
 		{
 			yyVAL.colName = &ColName{Name: yyDollar[1].colIdent}
 		}
 	case 254:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1365
+		//line sql.y:1365
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Name: yyDollar[1].tableIdent}, Name: yyDollar[3].colIdent}
 		}
 	case 255:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1369
+		//line sql.y:1369
 		{
 			yyVAL.colName = &ColName{Qualifier: TableName{Qualifier: yyDollar[1].tableIdent, Name: yyDollar[3].tableIdent}, Name: yyDollar[5].colIdent}
 		}
 	case 256:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1375
+		//line sql.y:1375
 		{
 			yyVAL.expr = NewStrVal(yyDollar[1].bytes)
 		}
 	case 257:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1379
+		//line sql.y:1379
 		{
 			yyVAL.expr = NewHexVal(yyDollar[1].bytes)
 		}
 	case 258:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1383
+		//line sql.y:1383
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 259:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1387
+		//line sql.y:1387
 		{
 			yyVAL.expr = NewFloatVal(yyDollar[1].bytes)
 		}
 	case 260:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1391
+		//line sql.y:1391
 		{
 			yyVAL.expr = NewHexNum(yyDollar[1].bytes)
 		}
 	case 261:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1395
+		//line sql.y:1395
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 262:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1399
+		//line sql.y:1399
 		{
 			yyVAL.expr = &NullVal{}
 		}
 	case 263:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1405
+		//line sql.y:1405
 		{
 			// TODO(sougou): Deprecate this construct.
 			if yyDollar[1].colIdent.Lowered() != "value" {
@@ -3030,237 +3030,237 @@ yydefault:
 		}
 	case 264:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1414
+		//line sql.y:1414
 		{
 			yyVAL.expr = NewIntVal(yyDollar[1].bytes)
 		}
 	case 265:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1418
+		//line sql.y:1418
 		{
 			yyVAL.expr = NewValArg(yyDollar[1].bytes)
 		}
 	case 266:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1423
+		//line sql.y:1423
 		{
 			yyVAL.exprs = nil
 		}
 	case 267:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1427
+		//line sql.y:1427
 		{
 			yyVAL.exprs = yyDollar[3].exprs
 		}
 	case 268:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1432
+		//line sql.y:1432
 		{
 			yyVAL.expr = nil
 		}
 	case 269:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1436
+		//line sql.y:1436
 		{
 			yyVAL.expr = yyDollar[2].expr
 		}
 	case 270:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1441
+		//line sql.y:1441
 		{
 			yyVAL.orderBy = nil
 		}
 	case 271:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1445
+		//line sql.y:1445
 		{
 			yyVAL.orderBy = yyDollar[3].orderBy
 		}
 	case 272:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1451
+		//line sql.y:1451
 		{
 			yyVAL.orderBy = OrderBy{yyDollar[1].order}
 		}
 	case 273:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1455
+		//line sql.y:1455
 		{
 			yyVAL.orderBy = append(yyDollar[1].orderBy, yyDollar[3].order)
 		}
 	case 274:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1461
+		//line sql.y:1461
 		{
 			yyVAL.order = &Order{Expr: yyDollar[1].expr, Direction: yyDollar[2].str}
 		}
 	case 275:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1466
+		//line sql.y:1466
 		{
 			yyVAL.str = AscScr
 		}
 	case 276:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1470
+		//line sql.y:1470
 		{
 			yyVAL.str = AscScr
 		}
 	case 277:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1474
+		//line sql.y:1474
 		{
 			yyVAL.str = DescScr
 		}
 	case 278:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1479
+		//line sql.y:1479
 		{
 			yyVAL.limit = nil
 		}
 	case 279:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1483
+		//line sql.y:1483
 		{
 			yyVAL.limit = &Limit{Rowcount: yyDollar[2].expr}
 		}
 	case 280:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1487
+		//line sql.y:1487
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[2].expr, Rowcount: yyDollar[4].expr}
 		}
 	case 281:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1491
+		//line sql.y:1491
 		{
 			yyVAL.limit = &Limit{Offset: yyDollar[4].expr, Rowcount: yyDollar[2].expr}
 		}
 	case 282:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1496
+		//line sql.y:1496
 		{
 			yyVAL.str = ""
 		}
 	case 283:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1500
+		//line sql.y:1500
 		{
 			yyVAL.str = ForUpdateStr
 		}
 	case 284:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1504
+		//line sql.y:1504
 		{
 			yyVAL.str = ShareModeStr
 		}
 	case 285:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1517
+		//line sql.y:1517
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[2].values}
 		}
 	case 286:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1521
+		//line sql.y:1521
 		{
 			yyVAL.ins = &Insert{Rows: yyDollar[1].selStmt}
 		}
 	case 287:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1525
+		//line sql.y:1525
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Rows: yyDollar[2].selStmt}
 		}
 	case 288:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1530
+		//line sql.y:1530
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].values}
 		}
 	case 289:
 		yyDollar = yyS[yypt-4 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1534
+		//line sql.y:1534
 		{
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[4].selStmt}
 		}
 	case 290:
 		yyDollar = yyS[yypt-6 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1538
+		//line sql.y:1538
 		{
 			// Drop the redundant parenthesis.
 			yyVAL.ins = &Insert{Columns: yyDollar[2].columns, Rows: yyDollar[5].selStmt}
 		}
 	case 291:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1545
+		//line sql.y:1545
 		{
 			yyVAL.columns = Columns{yyDollar[1].colIdent}
 		}
 	case 292:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1549
+		//line sql.y:1549
 		{
 			yyVAL.columns = Columns{yyDollar[3].colIdent}
 		}
 	case 293:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1553
+		//line sql.y:1553
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[3].colIdent)
 		}
 	case 294:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1557
+		//line sql.y:1557
 		{
 			yyVAL.columns = append(yyVAL.columns, yyDollar[5].colIdent)
 		}
 	case 295:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1562
+		//line sql.y:1562
 		{
 			yyVAL.updateExprs = nil
 		}
 	case 296:
 		yyDollar = yyS[yypt-5 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1566
+		//line sql.y:1566
 		{
 			yyVAL.updateExprs = yyDollar[5].updateExprs
 		}
 	case 297:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1572
+		//line sql.y:1572
 		{
 			yyVAL.values = Values{yyDollar[1].valTuple}
 		}
 	case 298:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1576
+		//line sql.y:1576
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].valTuple)
 		}
 	case 299:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1582
+		//line sql.y:1582
 		{
 			yyVAL.valTuple = yyDollar[1].valTuple
 		}
 	case 300:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1586
+		//line sql.y:1586
 		{
 			yyVAL.valTuple = ValTuple{}
 		}
 	case 301:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1592
+		//line sql.y:1592
 		{
 			yyVAL.valTuple = ValTuple(yyDollar[2].exprs)
 		}
 	case 302:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1598
+		//line sql.y:1598
 		{
 			if len(yyDollar[1].valTuple) == 1 {
 				yyVAL.expr = &ParenExpr{yyDollar[1].valTuple[0]}
@@ -3270,199 +3270,199 @@ yydefault:
 		}
 	case 303:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1608
+		//line sql.y:1608
 		{
 			yyVAL.updateExprs = UpdateExprs{yyDollar[1].updateExpr}
 		}
 	case 304:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1612
+		//line sql.y:1612
 		{
 			yyVAL.updateExprs = append(yyDollar[1].updateExprs, yyDollar[3].updateExpr)
 		}
 	case 305:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1618
+		//line sql.y:1618
 		{
 			yyVAL.updateExpr = &UpdateExpr{Name: yyDollar[1].colName, Expr: yyDollar[3].expr}
 		}
 	case 308:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1627
+		//line sql.y:1627
 		{
 			yyVAL.byt = 0
 		}
 	case 309:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1629
+		//line sql.y:1629
 		{
 			yyVAL.byt = 1
 		}
 	case 310:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1632
+		//line sql.y:1632
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 311:
 		yyDollar = yyS[yypt-3 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1634
+		//line sql.y:1634
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 312:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1637
+		//line sql.y:1637
 		{
 			yyVAL.str = ""
 		}
 	case 313:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1639
+		//line sql.y:1639
 		{
 			yyVAL.str = IgnoreStr
 		}
 	case 314:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1643
+		//line sql.y:1643
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 315:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1645
+		//line sql.y:1645
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 316:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1647
+		//line sql.y:1647
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 317:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1649
+		//line sql.y:1649
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 318:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1651
+		//line sql.y:1651
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 319:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1653
+		//line sql.y:1653
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 320:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1655
+		//line sql.y:1655
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 321:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1658
+		//line sql.y:1658
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 322:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1660
+		//line sql.y:1660
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 323:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1662
+		//line sql.y:1662
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 324:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1666
+		//line sql.y:1666
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 325:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1668
+		//line sql.y:1668
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 326:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1671
+		//line sql.y:1671
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 327:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1673
+		//line sql.y:1673
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 328:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1675
+		//line sql.y:1675
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 329:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1678
+		//line sql.y:1678
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 330:
 		yyDollar = yyS[yypt-2 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1680
+		//line sql.y:1680
 		{
 			yyVAL.empty = struct{}{}
 		}
 	case 331:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1684
+		//line sql.y:1684
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 332:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1688
+		//line sql.y:1688
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 334:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1695
+		//line sql.y:1695
 		{
 			yyVAL.colIdent = NewColIdent(string(yyDollar[1].bytes))
 		}
 	case 335:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1701
+		//line sql.y:1701
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 336:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1705
+		//line sql.y:1705
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 338:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1712
+		//line sql.y:1712
 		{
 			yyVAL.tableIdent = NewTableIdent(string(yyDollar[1].bytes))
 		}
 	case 445:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1843
+		//line sql.y:1843
 		{
 			if incNesting(yylex) {
 				yylex.Error("max nesting level reached")
@@ -3471,31 +3471,31 @@ yydefault:
 		}
 	case 446:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1852
+		//line sql.y:1852
 		{
 			decNesting(yylex)
 		}
 	case 447:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1857
+		//line sql.y:1857
 		{
 			forceEOF(yylex)
 		}
 	case 448:
 		yyDollar = yyS[yypt-0 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1862
+		//line sql.y:1862
 		{
 			forceEOF(yylex)
 		}
 	case 449:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1866
+		//line sql.y:1866
 		{
 			forceEOF(yylex)
 		}
 	case 450:
 		yyDollar = yyS[yypt-1 : yypt+1]
-		//line ./go/vt/sqlparser/sql.y:1870
+		//line sql.y:1870
 		{
 			forceEOF(yylex)
 		}

--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -462,27 +462,27 @@ use_statement:
 other_statement:
   DESC force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherRead{}
   }
 | DESCRIBE force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherRead{}
   }
 | EXPLAIN force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherRead{}
   }
 | REPAIR force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherAdmin{}
   }
 | OPTIMIZE force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherAdmin{}
   }
 | TRUNCATE force_eof
   {
-    $$ = &Other{}
+    $$ = &OtherAdmin{}
   }
 
 comment_opt:

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -148,8 +148,10 @@ func BuildFromStmt(query string, stmt sqlparser.Statement, vschema VSchema) (*en
 		return nil, errors.New("unsupported construct: show")
 	case *sqlparser.DDL:
 		return nil, errors.New("unsupported construct: ddl")
-	case *sqlparser.Other:
-		return nil, errors.New("unsupported construct: other")
+	case *sqlparser.OtherRead:
+		return nil, errors.New("unsupported construct: other read")
+	case *sqlparser.OtherAdmin:
+		return nil, errors.New("unsupported construct: other admin")
 	default:
 		panic(fmt.Sprintf("BUG: unexpected statement type: %T", stmt))
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/ddl.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/ddl.go
@@ -48,7 +48,8 @@ func DDLParse(sql string) (plan *DDLPlan) {
 func analyzeDDL(ddl *sqlparser.DDL, tables map[string]*schema.Table) *Plan {
 	// TODO(sougou): Add support for sequences.
 	return &Plan{
-		PlanID: PlanDDL,
-		Table:  tables[ddl.Table.Name.String()],
+		PlanID:  PlanDDL,
+		Table:   tables[ddl.Table.Name.String()],
+		NewName: ddl.NewName.Name,
 	}
 }

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -788,7 +788,7 @@ func TestQueryExecutorPlanOtherWithinATransaction(t *testing.T) {
 	qre := newTestQueryExecutor(ctx, tsv, query, txid)
 	defer tsv.StopService()
 	defer testCommitHelper(t, tsv, qre)
-	checkPlanID(t, planbuilder.PlanOther, qre.plan.PlanID)
+	checkPlanID(t, planbuilder.PlanOtherRead, qre.plan.PlanID)
 	got, err := qre.Execute()
 	if err != nil {
 		t.Fatalf("qre.Execute() = %v, want nil", err)
@@ -938,7 +938,7 @@ func TestQueryExecutorPlanOther(t *testing.T) {
 	tsv := newTestTabletServer(ctx, noFlags, db)
 	qre := newTestQueryExecutor(ctx, tsv, query, 0)
 	defer tsv.StopService()
-	checkPlanID(t, planbuilder.PlanOther, qre.plan.PlanID)
+	checkPlanID(t, planbuilder.PlanOtherRead, qre.plan.PlanID)
 	got, err := qre.Execute()
 	if err != nil {
 		t.Fatalf("got: %v, want nil", err)

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -59,7 +59,7 @@ func TestQueryzHandler(t *testing.T) {
 	plan3 := &TabletPlan{
 		Plan: &planbuilder.Plan{
 			Table:  &schema.Table{Name: sqlparser.NewTableIdent("")},
-			PlanID: planbuilder.PlanOther,
+			PlanID: planbuilder.PlanOtherRead,
 			Reason: planbuilder.ReasonDefault,
 		},
 	}
@@ -70,7 +70,7 @@ func TestQueryzHandler(t *testing.T) {
 	plan4 := &TabletPlan{
 		Plan: &planbuilder.Plan{
 			Table:  &schema.Table{Name: sqlparser.NewTableIdent("")},
-			PlanID: planbuilder.PlanOther,
+			PlanID: planbuilder.PlanOtherRead,
 			Reason: planbuilder.ReasonDefault,
 		},
 	}
@@ -122,7 +122,7 @@ func TestQueryzHandler(t *testing.T) {
 		`<tr class="medium">`,
 		`<td>show tables</td>`,
 		`<td></td>`,
-		`<td>OTHER</td>`,
+		`<td>OTHER_READ</td>`,
 		`<td>DEFAULT</td>`,
 		`<td>1</td>`,
 		`<td>0.075000</td>`,
@@ -139,7 +139,7 @@ func TestQueryzHandler(t *testing.T) {
 		`<tr class="low">`,
 		`<td>insert into test_table values .* \[TRUNCATED\][^<]*</td>`,
 		`<td></td>`,
-		`<td>OTHER</td>`,
+		`<td>OTHER_READ</td>`,
 		`<td>DEFAULT</td>`,
 		`<td>1</td>`,
 		`<td>0.001000</td>`,


### PR DESCRIPTION
This PR has two related changes:

I noticed that unprivileged users can create tables that they shouldn't be allowed to create. This is because the CREATE statement sets NewName instead of Table. One change is to pipe the NewName through and run the tableacl check on it in the query executor.

After I had fixed that, I noticed that an unprivileged user was no longer allowed to execute SHOW statements. The second change allows users with read privileges access to SHOW, DESCRIBE, and EXPLAIN statements. To keep REPAIR, OPTIMIZE and TRUNCATE restricted to users with ADMIN privileges, I made a new statement type (and plan type).

Questions I have:
 - Does my change to planbuilder.Plan necessitate a protobuf change? I don't think it does, but wanted to check to be sure.
 - I'm open to other naming suggestions if people don't like sqlparser.Admin and PlanAdmin.
 - I commented on query_executor.go L301 because I don't think we can be nil there. I know there was some discussion here on panic vs. error. Where did we land there? What do we want here?
 - My other comment was in query_executor.go L297. I didn't think it was a big deal, but I'm happy to develop a way to get NewName into the audit log and stats. Is this desired?