### PR TITLE
Fix base_environment for test to use 'hostname' instead of 'ip'.

### DIFF
--- a/test/cluster/base_environment.py
+++ b/test/cluster/base_environment.py
@@ -398,7 +398,10 @@ class BaseEnvironment(object):
     """
     tablet_info = json.loads(self.vtctl_helper.execute_vtctl_command(
         ['GetTablet', tablet_name]))
-    return '%s:%s' % (tablet_info['ip'], tablet_info['port_map']['vt'])
+    host = tablet_info['hostname']
+    if ':' in host:
+      host = '[%s]' % host
+    return '%s:%s' % (host, tablet_info['port_map']['vt'])
 
   def get_tablet_types_for_shard(self, keyspace, shard_name):
     """Get the types for all tablets in a shard.


### PR DESCRIPTION
Since https://github.com/youtube/vitess/pull/2892 topodata.Tablet message
doesn't have the ip field anymore, the field hostname should be used instead.

While at it I'm also fixing get_tablet_ip_port() method to work properly if the
hostname contains IPv6 address.

BUG=62421941