### PR TITLE
v3: fix second regression in aggregates

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -187,6 +187,38 @@
   }
 }
 
+# group by a unique vindex should revert to simple route
+"select id, count(*) from user group by id"
+{
+  "Original": "select id, count(*) from user group by id",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id, count(*) from user group by id",
+    "FieldQuery": "select id, count(*) from user where 1 != 1 group by id"
+  }
+}
+
+# group by a unique vindex should revert to simple route, and having clause should find the correct symbols.
+"select id, count(*) c from user group by id having id=1 and c=10"
+{
+  "Original": "select id, count(*) c from user group by id having id=1 and c=10",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id, count(*) as c from user group by id having id = 1 and c = 10",
+    "FieldQuery": "select id, count(*) as c from user where 1 != 1 group by id",
+    "Vindex": "user_index",
+    "Values": 1
+  }
+}
+
 # scatter aggregate in a subquery
 "select a from (select count(*) as a from user) t"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -143,13 +143,9 @@
 "select id from user group by col"
 "unsupported: in scatter query: group by column must reference column in SELECT list"
 
-# scatter aggregate invalid order by number
-"select id from user group by id order by 2"
-"in order by: column number out of range: 2"
-
 # scatter aggregate order by (number) references aggregate function.
 "select id, count(*) from user group by id order by 2"
-"unsupported: in scatter query: order by expression cannot reference an aggregate function: 2"
+"unsupported: scatter and order by"
 
 # scatter aggregate symtab lookup error
 "select id, b as id, count(*) from user order by id"
@@ -157,7 +153,7 @@
 
 # scatter aggregate complex order by
 "select id from user group by id order by id+1"
-"unsupported: in scatter query: complex order by expression: id + 1"
+"unsupported: scatter and order by"
 
 # scatter aggregate order by does not reference group by
 "select a, b, count(*) from user group by a order by b"

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -386,9 +386,9 @@ func (rb *route) MakeDistinct() error {
 }
 
 // SetGroupBy sets the GROUP BY clause for the route.
-func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) error {
+func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) (builder, error) {
 	rb.Select.(*sqlparser.Select).GroupBy = groupBy
-	return nil
+	return rb, nil
 }
 
 // PushOrderBy sets the order by for the route.

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -58,7 +58,7 @@ func processSelect(sel *sqlparser.Select, vschema VSchema, outer builder) (build
 	if err != nil {
 		return nil, err
 	}
-	err = pushSelectExprs(sel, bldr)
+	bldr, err = pushSelectExprs(sel, bldr)
 	if err != nil {
 		return nil, err
 	}
@@ -120,18 +120,18 @@ func reorderBySubquery(filters []sqlparser.Expr) {
 
 // pushSelectExprs identifies the target route for the
 // select expressions and pushes them down.
-func pushSelectExprs(sel *sqlparser.Select, bldr builder) error {
+func pushSelectExprs(sel *sqlparser.Select, bldr builder) (builder, error) {
 	resultColumns, err := pushSelectRoutes(sel.SelectExprs, bldr)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	bldr.Symtab().ResultColumns = resultColumns
 
-	err = pushGroupBy(sel, bldr)
+	bldr, err = pushGroupBy(sel, bldr)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return bldr, nil
 }
 
 // pusheSelectRoutes is a convenience function that pushes all the select


### PR DESCRIPTION
This will also need to be pushed through quickly.

This is for the use case where a group by clause references
a unique vindex: 'select ... group by id'. Such statements
can be pushed through as simple scatter routes without the
need to perform post-processing.

This regression fix is more involved because of the catch-22:
group by clause cannot be analyzed until selects are analyzed,
but the decision to create an orderedAggregate primitive has to
be made before selects are analyzed.

After much consideration, I decided to go with the approach of
creating the primitive before the select analysis, and then
making the orderedAggregate defunct if we later found that the
group by clause does reference a unique vindex.