### PR TITLE
Expose build info & add CLI version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build:
 ifndef NOBANNER
 	echo $$(date): Building source tree
 endif
-	go install $(VT_GO_PARALLEL) -ldflags "$(tools/build_version_flags.sh)" ./go/...
+	go install $(VT_GO_PARALLEL) -ldflags "$(shell tools/build_version_flags.sh)" ./go/...
 
 parser:
 	make -C go/vt/sqlparser

--- a/go/cmd/automation_server/automation_server.go
+++ b/go/cmd/automation_server/automation_server.go
@@ -34,8 +34,16 @@ func init() {
 }
 
 func main() {
+
 	flag.Parse()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	fmt.Println("Automation Server, listening on:", *servenv.Port)
+
 	if *servenv.Port == 0 {
 		fmt.Println("No port specified using --port.")
 		os.Exit(1)

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -57,6 +58,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
 
 	ts := topo.Open()
 	defer ts.Close()

--- a/go/cmd/mysqlctld/mysqlctld.go
+++ b/go/cmd/mysqlctld/mysqlctld.go
@@ -60,6 +60,11 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	flag.Parse()
 
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	// We'll register this OnTerm handler before mysqld starts, so we get notified
 	// if mysqld dies on its own without us (or our RPC client) telling it to.
 	mysqldTerminated := make(chan struct{})

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"flag"
+	"os"
 	"strings"
 	"time"
 
@@ -66,6 +67,12 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	mysqlctl.RegisterFlags()
 	flag.Parse()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	if len(flag.Args()) > 0 {
 		flag.Usage()
 		log.Errorf("vtcombo doesn't take any positional arguments")

--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -70,10 +70,17 @@ func main() {
 
 	flag.Parse()
 	args := flag.Args()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	if len(args) == 0 {
 		flag.Usage()
 		exit.Return(1)
 	}
+
 	action := args[0]
 
 	startMsg := fmt.Sprintf("USER=%v SUDO_USER=%v %v", os.Getenv("USER"), os.Getenv("SUDO_USER"), strings.Join(os.Args, " "))

--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -37,6 +38,11 @@ func main() {
 	flag.Parse()
 	servenv.Init()
 	defer servenv.Close()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
 
 	ts = topo.Open()
 	defer ts.Close()

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -60,6 +61,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
 
 	if initFakeZK != nil {
 		initFakeZK()

--- a/go/cmd/vtgateclienttest/main.go
+++ b/go/cmd/vtgateclienttest/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/youtube/vitess/go/cmd/vtgateclienttest/services"
 	"github.com/youtube/vitess/go/exit"
@@ -37,6 +38,11 @@ func main() {
 
 	flag.Parse()
 	servenv.Init()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
 
 	// The implementation chain.
 	servenv.OnRun(func() {

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -52,6 +53,12 @@ func main() {
 	dbconfigs.RegisterFlags(dbconfigFlags)
 	mysqlctl.RegisterFlags()
 	flag.Parse()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	if len(flag.Args()) > 0 {
 		flag.Usage()
 		log.Exit("vttablet doesn't take any positional arguments")

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -70,6 +70,11 @@ func main() {
 	servenv.Init()
 	defer servenv.Close()
 
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
 	ts := topo.Open()
 	defer ts.Close()
 

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -31,7 +31,7 @@ var (
 	buildTime   = ""
 	buildGitRev = ""
 
-	// Command line flag to expose build info.
+	// Version registers the command line flag to expose build info.
 	Version = flag.Bool("version", false, "print binary version")
 )
 

--- a/go/vt/servenv/buildinfo.go
+++ b/go/vt/servenv/buildinfo.go
@@ -30,9 +30,12 @@ var (
 	buildUser   = ""
 	buildTime   = ""
 	buildGitRev = ""
-	Version     = flag.Bool("version", false, "print binary version")
+
+	// Command line flag to expose build info.
+	Version = flag.Bool("version", false, "print binary version")
 )
 
+// AppVersion is the struct to store build info.
 var AppVersion versionInfo
 
 type versionInfo struct {


### PR DESCRIPTION
This PR expose some build info like git hash, build time, go version/OS/architecture etc. via the stats API and the new `version` CLI flag.

```
$ ./vtctl -version
Version: a78c18da1fbb913a6f630667028d4c9ab713e66a built on Tue Jun 13 05:41:49 PDT 2017 by jenkins@build-slave using go1.8.3 linux/amd64
```