### PR TITLE
v3: ordering and aggregations

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -98,9 +98,6 @@
 {
   "Original": "select count(*) from user",
   "Instructions": {
-    "Results": [
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -125,24 +122,11 @@
 {
   "Original": "select distinct col1, col2 from user group by col1",
   "Instructions": {
-    "Results": [
-      0,
-      1
-    ],
     "Aggregates": null,
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      0,
+      1,
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -151,7 +135,21 @@
         "Sharded": true
       },
       "Query": "select distinct col1, col2 from user group by col1 order by col1 asc, col2 asc, col1 asc",
-      "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1"
+      "FieldQuery": "select col1, col2 from user where 1 != 1 group by col1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -228,9 +226,6 @@
       0
     ],
     "Subquery": {
-      "Results": [
-        -1
-      ],
       "Aggregates": [
         {
           "Opcode": "count",
@@ -256,10 +251,6 @@
 {
   "Original": "select id, count(*) from user",
   "Instructions": {
-    "Results": [
-      0,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -284,15 +275,9 @@
 {
   "Original": "select distinct col from user",
   "Instructions": {
-    "Results": [
-      0
-    ],
     "Aggregates": null,
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -301,7 +286,13 @@
         "Sharded": true
       },
       "Query": "select distinct col from user order by col asc",
-      "FieldQuery": "select col from user where 1 != 1"
+      "FieldQuery": "select col from user where 1 != 1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -311,15 +302,9 @@
 {
   "Original": "select col from user group by col",
   "Instructions": {
-    "Results": [
-      0
-    ],
     "Aggregates": null,
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -328,7 +313,13 @@
         "Sharded": true
       },
       "Query": "select col from user group by col order by col asc",
-      "FieldQuery": "select col from user where 1 != 1 group by col"
+      "FieldQuery": "select col from user where 1 != 1 group by col",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -342,11 +333,6 @@
 {
   "Original": "select a, b, count(*) from user group by b, a",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -354,14 +340,8 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      1,
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -370,7 +350,17 @@
         "Sharded": true
       },
       "Query": "select a, b, count(*) from user group by b, a order by b asc, a asc",
-      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by b, a"
+      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by b, a",
+      "OrderBy": [
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -380,11 +370,6 @@
 {
   "Original": "select a, b, count(*) from user group by 2, 1",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -392,14 +377,8 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      1,
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -408,7 +387,17 @@
         "Sharded": true
       },
       "Query": "select a, b, count(*) from user group by 2, 1 order by b asc, a asc",
-      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by 2, 1"
+      "FieldQuery": "select a, b, count(*) from user where 1 != 1 group by 2, 1",
+      "OrderBy": [
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -418,15 +407,9 @@
 {
   "Original": "select col from user group by 1",
   "Instructions": {
-    "Results": [
-      0
-    ],
     "Aggregates": null,
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      }
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -435,7 +418,13 @@
         "Sharded": true
       },
       "Query": "select col from user group by 1 order by col asc",
-      "FieldQuery": "select col from user where 1 != 1 group by 1"
+      "FieldQuery": "select col from user where 1 != 1 group by 1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -458,9 +447,6 @@
 {
   "Original": "select count(*) from user order by null",
   "Instructions": {
-    "Results": [
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -493,13 +479,6 @@
 {
   "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1, 2, 3",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      2,
-      3,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -507,18 +486,9 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 2,
-        "Desc": false
-      }
+      0,
+      1,
+      2
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -527,7 +497,21 @@
         "Sharded": true
       },
       "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by 1 asc, 2 asc, 3 asc",
-      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3"
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 2,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -537,13 +521,6 @@
 {
   "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by a, b, c",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      2,
-      3,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -551,18 +528,9 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": false
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 2,
-        "Desc": false
-      }
+      0,
+      1,
+      2
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -571,7 +539,21 @@
         "Sharded": true
       },
       "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3 order by a asc, b asc, c asc",
-      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3"
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 2,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -581,13 +563,6 @@
 {
   "Original": "select a, b, c, d, count(*) from user group by 1, 2, 3, 4 order by d, b, a, c",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      2,
-      3,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -595,22 +570,10 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 3,
-        "Desc": false
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 0,
-        "Desc": false
-      },
-      {
-        "Col": 2,
-        "Desc": false
-      }
+      0,
+      1,
+      2,
+      3
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -619,7 +582,25 @@
         "Sharded": true
       },
       "Query": "select a, b, c, d, count(*) from user group by 1, 2, 3, 4 order by d asc, b asc, a asc, c asc",
-      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3, 4"
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 1, 2, 3, 4",
+      "OrderBy": [
+        {
+          "Col": 3,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 2,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -629,13 +610,6 @@
 {
   "Original": "select a, b, c, d, count(*) from user group by 3, 2, 1, 4 order by d, b, a, c",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      2,
-      3,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -643,22 +617,10 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 3,
-        "Desc": false
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      },
-      {
-        "Col": 0,
-        "Desc": false
-      },
-      {
-        "Col": 2,
-        "Desc": false
-      }
+      2,
+      1,
+      0,
+      3
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -667,7 +629,25 @@
         "Sharded": true
       },
       "Query": "select a, b, c, d, count(*) from user group by 3, 2, 1, 4 order by d asc, b asc, a asc, c asc",
-      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 3, 2, 1, 4"
+      "FieldQuery": "select a, b, c, d, count(*) from user where 1 != 1 group by 3, 2, 1, 4",
+      "OrderBy": [
+        {
+          "Col": 3,
+          "Desc": false
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 0,
+          "Desc": false
+        },
+        {
+          "Col": 2,
+          "Desc": false
+        }
+      ]
     }
   }
 }
@@ -677,12 +657,6 @@
 {
   "Original": "select a, b, c, count(*) from user group by 3, 2, 1 order by 1 desc, 3 desc, b",
   "Instructions": {
-    "Results": [
-      0,
-      1,
-      2,
-      -1
-    ],
     "Aggregates": [
       {
         "Opcode": "count",
@@ -690,18 +664,9 @@
       }
     ],
     "Keys": [
-      {
-        "Col": 0,
-        "Desc": true
-      },
-      {
-        "Col": 2,
-        "Desc": true
-      },
-      {
-        "Col": 1,
-        "Desc": false
-      }
+      2,
+      1,
+      0
     ],
     "Input": {
       "Opcode": "SelectScatter",
@@ -710,7 +675,21 @@
         "Sharded": true
       },
       "Query": "select a, b, c, count(*) from user group by 3, 2, 1 order by 1 desc, 3 desc, b asc",
-      "FieldQuery": "select a, b, c, count(*) from user where 1 != 1 group by 3, 2, 1"
+      "FieldQuery": "select a, b, c, count(*) from user where 1 != 1 group by 3, 2, 1",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": true
+        },
+        {
+          "Col": 2,
+          "Desc": true
+        },
+        {
+          "Col": 1,
+          "Desc": false
+        }
+      ]
     }
   }
 }

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -114,6 +114,31 @@
   }
 }
 
+# ORDER BY on scatter
+"select col from user order by col"
+{
+  "Original": "select col from user order by col",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select col from user order by col asc",
+    "FieldQuery": "select col from user where 1 != 1",
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      }
+    ]
+  }
+}
+
+# ORDER BY invalid col number on scatter
+"select col from user order by 2"
+"column number out of range: 2"
+
 # ORDER BY NULL
 "select col from user order by null"
 {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -143,17 +143,13 @@
 "select id from user group by col"
 "unsupported: in scatter query: group by column must reference column in SELECT list"
 
-# scatter aggregate order by (number) references aggregate function.
-"select id, count(*) from user group by id order by 2"
-"unsupported: scatter and order by"
-
 # scatter aggregate symtab lookup error
 "select id, b as id, count(*) from user order by id"
 "in order by: ambiguous symbol reference: id"
 
 # scatter aggregate complex order by
 "select id from user group by id order by id+1"
-"unsupported: scatter and order by"
+"unsupported: in scatter query: complex order by expression: id + 1"
 
 # scatter aggregate order by does not reference group by
 "select a, b, count(*) from user group by a order by b"
@@ -185,15 +181,11 @@
 
 # Order by uses cross-shard expression
 "select id from user order by id+1"
-"unsupported: scatter and order by"
+"unsupported: in scatter query: complex order by expression: id + 1"
 
 # Order by for join, but sequence is too cross-shard
 "select user.col1 as a, user.col2, music.col3 from user join music on user.id = music.id where user.id = 1 order by 1 asc, 3 desc, 2 asc"
 "unsupported: order by spans across shards"
-
-# Order by for scatter routes
-"select col from user order by col"
-"unsupported: scatter and order by"
 
 # Order by and left join
 "select user.col1 as a, user_extra.col2 as b from user left join user_extra on user_extra.user_id = 5 where user.id = 5 order by 1, 2"
@@ -201,7 +193,7 @@
 
 # Order by column number with collate
 "select user.col1 as a from user order by 1 collate utf8_general_ci"
-"unsupported: scatter and order by"
+"unsupported: in scatter query: complex order by expression: 1 collate utf8_general_ci"
 
 #Order by for join, but order by is cross-shard
 "select user.col1 as a, user_extra.col2 as b from user join user_extra on user_extra.user_id = 5 where user.id = 5 order by a+b"
@@ -382,10 +374,6 @@
 # cross-shard expression in parenthesis with limit not supported yet
 "select * from user where (id = 4 AND name ='abc') limit 5"
 "unsupported: limits with scatter"
-
-# cross-shard expression in parenthesis with order by not supported yet
-"select * from user where (id = 4 AND name ='abc') order by id"
-"unsupported: scatter and order by"
 
 # union of information_schema with normal table
 "select * from information_schema.a union select * from unsharded"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -145,7 +145,7 @@
 
 # scatter aggregate symtab lookup error
 "select id, b as id, count(*) from user order by id"
-"in order by: ambiguous symbol reference: id"
+"invalid order by: ambiguous symbol reference: id"
 
 # scatter aggregate complex order by
 "select id from user group by id order by id+1"

--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -168,6 +168,12 @@ def main():
 
 
 def decimal_default(obj):
+  """Provide json-encodable conversion for decimal.Decimal type.
+
+  json encoding fails on decimal.Decimal. This
+  function converts the decimal into a float object
+  which json knows how to encode.
+  """
   if isinstance(obj, decimal.Decimal):
     return float(obj)
   raise TypeError

--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,6 +17,7 @@
 """This module allows you to bring up and tear down keyspaces."""
 
 import cgi
+import decimal
 import json
 import subprocess
 import threading
@@ -63,6 +64,8 @@ def exec_query(conn, title, query, response, keyspace=None, kr=None):  # pylint:
         "title": title,
         "error": str(e),
         }
+    cursor.rollback()
+    cursor.close()
 
 
 def capture_log(port, queries):  # pylint: disable=missing-docstring
@@ -159,9 +162,15 @@ def main():
         conn, "name_user_idx", "select * from name_user_idx", response,
         keyspace="lookup", kr="-")
 
-    print json.dumps(response)
+    print json.dumps(response, default=decimal_default)
   except Exception as e:  # pylint: disable=broad-except
     print json.dumps({"error": str(e)})
+
+
+def decimal_default(obj):
+  if isinstance(obj, decimal.Decimal):
+    return float(obj)
+  raise TypeError
 
 
 if __name__ == "__main__":

--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -200,22 +200,22 @@ func floatPlusAny(v1 float64, v2 numeric) numeric {
 }
 
 func castFromNumeric(v numeric, resultType querypb.Type) (Value, error) {
-	switch resultType {
-	case Int64:
+	switch {
+	case IsSigned(resultType):
 		switch v.typ {
 		case Int64:
 			return MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10)), nil
 		case Uint64, Float64:
 			return NULL, fmt.Errorf("unexpected type conversion: %v to %v", v.typ, resultType)
 		}
-	case Uint64:
+	case IsUnsigned(resultType):
 		switch v.typ {
 		case Uint64:
 			return MakeTrusted(resultType, strconv.AppendUint(nil, v.uval, 10)), nil
 		case Int64, Float64:
 			return NULL, fmt.Errorf("unexpected type conversion: %v to %v", v.typ, resultType)
 		}
-	case Float64, Decimal:
+	case IsFloat(resultType) || resultType == Decimal:
 		switch v.typ {
 		case Int64:
 			return MakeTrusted(resultType, strconv.AppendInt(nil, v.ival, 10)), nil

--- a/go/vt/vtgate/engine/ordered_aggregate.go
+++ b/go/vt/vtgate/engine/ordered_aggregate.go
@@ -138,10 +138,12 @@ func (oa *OrderedAggregate) aggregate(fields []*querypb.Field, nextRow func() []
 			emit(current)
 			return nil
 		}
+
 		equal, err := oa.keysEqual(current, next)
 		if err != nil {
 			return err
 		}
+
 		if equal {
 			if err := oa.merge(fields, current, next); err != nil {
 				return err

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -50,7 +50,7 @@ type Route struct {
 	// FieldQuery specifies the query to be executed for a GetFieldInfo request.
 	FieldQuery string
 
-	// Vindex and values specify how routing must be computed
+	// Vindex and Values specify how routing must be computed
 	Vindex vindexes.Vindex
 	Values interface{}
 
@@ -70,7 +70,7 @@ type Route struct {
 
 	// Subquery is only set for deletes. A select of the rows to be
 	// deleted is performed to figure out which lookup vindex entries must
-	// be deleteed.
+	// be deleted.
 	Subquery string
 
 	// Generate is only set for inserts where a sequence must be generated.
@@ -82,7 +82,7 @@ type Route struct {
 	Suffix string
 }
 
-// OrderbyParams specifies the parameters for ordering,
+// OrderbyParams specifies the parameters for ordering.
 // This is used for merge-sorting scatter queries.
 type OrderbyParams struct {
 	Col  int
@@ -464,6 +464,11 @@ func (route *Route) execAnyShard(vcursor VCursor, bindVars map[string]interface{
 func (route *Route) sort(result *sqltypes.Result) error {
 	var err error
 	sort.Slice(result.Rows, func(i, j int) bool {
+		// If there are any errors below, the function sets
+		// the external err and returns true. Once err is set,
+		// all subsequent calls return true. This will make
+		// Slice think that all elements are in the correct
+		// order and return more quickly.
 		for _, order := range route.OrderBy {
 			if err != nil {
 				return true

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -840,6 +841,170 @@ func TestSelectScatterFail(t *testing.T) {
 	want := "paramsAllShards: keyspace TestExecutor fetch error: topo error GetSrvKeyspace"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
+	}
+}
+
+func TestSelectScatterOrderBy(t *testing.T) {
+	// Special setup: Don't use createExecutorEnv.
+	cell := "aa"
+	hc := discovery.NewFakeHealthCheck()
+	s := createSandbox("TestExecutor")
+	s.VSchema = executorVSchema
+	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
+	serv := new(sandboxTopo)
+	resolver := newTestResolver(hc, serv, cell)
+	shards := []string{"-20", "20-40", "40-60", "60-80", "80-a0", "a0-c0", "c0-e0", "e0-"}
+	var conns []*sandboxconn.SandboxConn
+	for i, shard := range shards {
+		sbc := hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_MASTER, true, 1, nil)
+		sbc.SetResults([]*sqltypes.Result{{
+			Fields: []*querypb.Field{
+				{Name: "id", Type: sqltypes.Int32},
+				{Name: "col", Type: sqltypes.Int32},
+			},
+			RowsAffected: 1,
+			InsertID:     0,
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeTrusted(sqltypes.Int32, []byte("1")),
+				sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i%4))),
+			}},
+		}})
+		conns = append(conns, sbc)
+	}
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false)
+
+	query := "select id, col from user order by col desc"
+	gotResult, err := executorExec(executor, query, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantQueries := []querytypes.BoundQuery{{
+		Sql:           query,
+		BindVariables: map[string]interface{}{},
+	}}
+	for _, conn := range conns {
+		if !reflect.DeepEqual(conn.Queries, wantQueries) {
+			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
+		}
+	}
+
+	wantResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "id", Type: sqltypes.Int32},
+			{Name: "col", Type: sqltypes.Int32},
+		},
+		RowsAffected: 8,
+		InsertID:     0,
+	}
+	for i := 0; i < 4; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(sqltypes.Int32, []byte("1")),
+			sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(3-i))),
+		}
+		wantResult.Rows = append(wantResult.Rows, row, row)
+	}
+	if !reflect.DeepEqual(gotResult, wantResult) {
+		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
+	}
+}
+
+func TestSelectScatterOrderByFail(t *testing.T) {
+	// Special setup: Don't use createExecutorEnv.
+	cell := "aa"
+	hc := discovery.NewFakeHealthCheck()
+	s := createSandbox("TestExecutor")
+	s.VSchema = executorVSchema
+	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
+	serv := new(sandboxTopo)
+	resolver := newTestResolver(hc, serv, cell)
+	shards := []string{"-20", "20-40", "40-60", "60-80", "80-a0", "a0-c0", "c0-e0", "e0-"}
+	for _, shard := range shards {
+		sbc := hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_MASTER, true, 1, nil)
+		sbc.SetResults([]*sqltypes.Result{{
+			Fields: []*querypb.Field{
+				{Name: "id", Type: sqltypes.Int32},
+				{Name: "col", Type: sqltypes.Int32},
+			},
+			RowsAffected: 1,
+			InsertID:     0,
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeTrusted(sqltypes.Int32, []byte("1")),
+				sqltypes.MakeTrusted(sqltypes.VarChar, []byte("aaa")),
+			}},
+		}})
+	}
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false)
+
+	_, err := executorExec(executor, "select id, col from user order by col asc", nil)
+	want := "text fields cannot be compared"
+	if err == nil || err.Error() != want {
+		t.Errorf("scatter order by error: %v, want %s", err, want)
+	}
+}
+
+func TestSelectScatterAggregate(t *testing.T) {
+	// Special setup: Don't use createExecutorEnv.
+	cell := "aa"
+	hc := discovery.NewFakeHealthCheck()
+	s := createSandbox("TestExecutor")
+	s.VSchema = executorVSchema
+	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
+	serv := new(sandboxTopo)
+	resolver := newTestResolver(hc, serv, cell)
+	shards := []string{"-20", "20-40", "40-60", "60-80", "80-a0", "a0-c0", "c0-e0", "e0-"}
+	var conns []*sandboxconn.SandboxConn
+	for i, shard := range shards {
+		sbc := hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_MASTER, true, 1, nil)
+		sbc.SetResults([]*sqltypes.Result{{
+			Fields: []*querypb.Field{
+				{Name: "col", Type: sqltypes.Int32},
+				{Name: "sum(foo)", Type: sqltypes.Int32},
+			},
+			RowsAffected: 1,
+			InsertID:     0,
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i%4))),
+				sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i))),
+			}},
+		}})
+		conns = append(conns, sbc)
+	}
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false)
+
+	query := "select col, sum(foo) from user group by col"
+	gotResult, err := executorExec(executor, query, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantQueries := []querytypes.BoundQuery{{
+		Sql:           query + " order by col asc",
+		BindVariables: map[string]interface{}{},
+	}}
+	for _, conn := range conns {
+		if !reflect.DeepEqual(conn.Queries, wantQueries) {
+			t.Errorf("conn.Queries = %#v, want %#v", conn.Queries, wantQueries)
+		}
+	}
+
+	wantResult := &sqltypes.Result{
+		Fields: []*querypb.Field{
+			{Name: "col", Type: sqltypes.Int32},
+			{Name: "sum(foo)", Type: sqltypes.Int32},
+		},
+		RowsAffected: 4,
+		InsertID:     0,
+	}
+	for i := 0; i < 4; i++ {
+		row := []sqltypes.Value{
+			sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i))),
+			sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i*2+4))),
+		}
+		wantResult.Rows = append(wantResult.Rows, row)
+	}
+	if !reflect.DeepEqual(gotResult, wantResult) {
+		t.Errorf("scatter order by:\n%v, want\n%v", gotResult, wantResult)
 	}
 }
 

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -393,32 +393,37 @@ func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) (builder, error) {
 
 // PushOrderBy sets the order by for the route.
 func (rb *route) PushOrderBy(order *sqlparser.Order) error {
-	if !rb.IsSingle() {
-		var colnum int
-		switch expr := order.Expr.(type) {
-		case *sqlparser.SQLVal:
-			var err error
-			if colnum, err = ResultFromNumber(rb.resultColumns, expr); err != nil {
-				return fmt.Errorf("in order by: %v", err)
-			}
-		case *sqlparser.ColName:
-			c := expr.Metadata.(*column)
-			// The column is guaranteed to be found because this function is called
-			// only after a successful symbol resolution that points to this route.
-			for i, rc := range rb.resultColumns {
-				if rc.column == c {
-					colnum = i
-					break
-				}
-			}
-		default:
-			return fmt.Errorf("unsupported: in scatter query: complex order by expression: %v", sqlparser.String(expr))
-		}
-		rb.ERoute.OrderBy = append(rb.ERoute.OrderBy, engine.OrderbyParams{
-			Col:  colnum,
-			Desc: order.Direction == sqlparser.DescScr,
-		})
+	if rb.IsSingle() {
+		rb.Select.AddOrder(order)
+		return nil
 	}
+
+	// If it's a scatter, we have to populate the OrderBy field.
+	var colnum int
+	switch expr := order.Expr.(type) {
+	case *sqlparser.SQLVal:
+		var err error
+		if colnum, err = ResultFromNumber(rb.resultColumns, expr); err != nil {
+			return fmt.Errorf("invalid order by: %v", err)
+		}
+	case *sqlparser.ColName:
+		c := expr.Metadata.(*column)
+		// The column is guaranteed to be found because this function is called
+		// only after a successful symbol resolution that points to this route.
+		for i, rc := range rb.resultColumns {
+			if rc.column == c {
+				colnum = i
+				break
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported: in scatter query: complex order by expression: %v", sqlparser.String(expr))
+	}
+	rb.ERoute.OrderBy = append(rb.ERoute.OrderBy, engine.OrderbyParams{
+		Col:  colnum,
+		Desc: order.Direction == sqlparser.DescScr,
+	})
+
 	rb.Select.AddOrder(order)
 	return nil
 }

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -343,7 +343,7 @@ func (st *symtab) NewResultColumn(expr *sqlparser.AliasedExpr, origin columnOrig
 
 // ResultFromNumber returns the result column index based on the column
 // order expression.
-func (st *symtab) ResultFromNumber(val *sqlparser.SQLVal) (int, error) {
+func ResultFromNumber(resultColumns []*resultColumn, val *sqlparser.SQLVal) (int, error) {
 	if val.Type != sqlparser.IntVal {
 		return 0, errors.New("column number is not an int")
 	}
@@ -351,7 +351,7 @@ func (st *symtab) ResultFromNumber(val *sqlparser.SQLVal) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error parsing column number: %s", sqlparser.String(val))
 	}
-	if num < 1 || num > int64(len(st.ResultColumns)) {
+	if num < 1 || num > int64(len(resultColumns)) {
 		return 0, fmt.Errorf("column number out of range: %d", num)
 	}
 	return int(num - 1), nil


### PR DESCRIPTION
Issue #2897

This change implements ordering and aggregation for scatter
queries. The previous strategy was to perform the ordering
in orderedAggregator. However, that plan was flawed because
ordering needs to perform a merge-sort underneath the route.

In this new change, the ordering responsibility is assigned
to the route. This will allow the route to sort the results
before sending them up to the aggregator. With this change,
we also get non-aggregate ordering for free.

The aggregator receives a single ordered stream of the results
on which it performs the aggregation.

Right now, only the non-streaming part is implemented. For
simplicity, the route does not perform a merge-sort. Instead,
it just puts all the results together and performs the sort
provided by go's framework.

The streaming implementation will, however, perform a merge-sort.