### PR TITLE
messages: support for time_scheduled

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -207,7 +207,7 @@ func TestGenerateLoadMessagesQuery(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want := "select time_next, epoch, id, message from t1 where :#pk"
+	want := "select time_next, epoch, id, time_scheduled, message from t1 where :#pk"
 	if q.Query != want {
 		t.Errorf("GenerateLoadMessagesQuery: %s, want %s", q.Query, want)
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -41,6 +41,9 @@ var (
 		Name: "id",
 		Type: sqltypes.VarBinary,
 	}, {
+		Name: "time_scheduled",
+		Type: sqltypes.Int64,
+	}, {
 		Name: "message",
 		Type: sqltypes.VarBinary,
 	}}
@@ -315,9 +318,10 @@ func TestMessageManagerPoller(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, message from foo.*",
+		"select time_next, epoch, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
@@ -327,16 +331,19 @@ func TestMessageManagerPoller(t *testing.T) {
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("0")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("10")),
 				sqltypes.MakeString([]byte("01")),
 			}, {
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("2")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("0")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("2")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("20")),
 				sqltypes.MakeString([]byte("02")),
 			}, {
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("3")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("30")),
 				sqltypes.MakeString([]byte("11")),
 			}},
 		},
@@ -353,12 +360,15 @@ func TestMessageManagerPoller(t *testing.T) {
 	mm.pollerTicks.Trigger()
 	want := [][]sqltypes.Value{{
 		sqltypes.MakeTrusted(sqltypes.Int64, []byte("2")),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte("20")),
 		sqltypes.MakeString([]byte("02")),
 	}, {
 		sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte("10")),
 		sqltypes.MakeString([]byte("01")),
 	}, {
 		sqltypes.MakeTrusted(sqltypes.Int64, []byte("3")),
+		sqltypes.MakeTrusted(sqltypes.Int64, []byte("30")),
 		sqltypes.MakeString([]byte("11")),
 	}}
 	var got [][]sqltypes.Value
@@ -389,9 +399,10 @@ func TestMessagesPending1(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, message from foo.*",
+		"select time_next, epoch, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
@@ -401,6 +412,7 @@ func TestMessagesPending1(t *testing.T) {
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("0")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("a")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("10")),
 				sqltypes.MakeString([]byte("a")),
 			}},
 		},
@@ -454,9 +466,10 @@ func TestMessagesPending2(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, message from foo.*",
+		"select time_next, epoch, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
@@ -466,6 +479,7 @@ func TestMessagesPending2(t *testing.T) {
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("0")),
 				sqltypes.MakeTrusted(sqltypes.Int64, []byte("a")),
+				sqltypes.MakeTrusted(sqltypes.Int64, []byte("10")),
 				sqltypes.MakeString([]byte("a")),
 			}},
 		},

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -192,9 +192,10 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 	defer db.Close()
 	db.AddQueryPattern("insert into msg\\(time_scheduled, id, message, time_next, time_created, epoch\\) values \\(1, 2, 3, 1,.*", &sqltypes.Result{})
 	db.AddQuery(
-		"select time_next, epoch, id, message from msg where (time_scheduled = 1 and id = 2)",
+		"select time_next, epoch, id, time_scheduled, message from msg where (time_scheduled = 1 and id = 2)",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
@@ -205,6 +206,7 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 				sqltypes.MakeString([]byte("1")),
 				sqltypes.MakeString([]byte("0")),
 				sqltypes.MakeString([]byte("1")),
+				sqltypes.MakeString([]byte("10")),
 				sqltypes.MakeString([]byte("01")),
 			}},
 		},
@@ -238,6 +240,7 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 	wantqr := &sqltypes.Result{
 		Rows: [][]sqltypes.Value{{
 			sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+			sqltypes.MakeTrusted(sqltypes.Int64, []byte("10")),
 			sqltypes.MakeTrusted(sqltypes.Int64, []byte("01")),
 		}},
 	}

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -116,6 +116,9 @@ func TestLoadTableMessage(t *testing.T) {
 				Name: "id",
 				Type: sqltypes.Int64,
 			}, {
+				Name: "time_scheduled",
+				Type: sqltypes.Int64,
+			}, {
 				Name: "message",
 				Type: sqltypes.VarBinary,
 			}},

--- a/test/messaging.py
+++ b/test/messaging.py
@@ -183,13 +183,17 @@ class TestMessaging(unittest.TestCase):
         keyspace, name)
     self.assertEqual(
         fields,
-        [('id', query_pb2.INT64), ('message', query_pb2.VARCHAR)])
+        [
+          ('id', query_pb2.INT64),
+          ('time_scheduled', query_pb2.INT64),
+          ('message', query_pb2.VARCHAR),
+        ])
 
     # We should get both messages.
     result = {}
     for _ in xrange(2):
       row = it.next()
-      result[row[0]] = row[1]
+      result[row[0]] = row[2]
     self.assertEqual(result, {1: 'hello world 1', 4: 'hello world 4'})
 
     # After ack, we should get only one message.
@@ -198,7 +202,7 @@ class TestMessaging(unittest.TestCase):
     result = {}
     for _ in xrange(2):
       row = it.next()
-      result[row[0]] = row[1]
+      result[row[0]] = row[2]
     self.assertEqual(result, {1: 'hello world 1'})
     # Only one should be acked.
     count = vtgate_conn.message_ack(name, [1, 4])


### PR DESCRIPTION
time_scheduled is a useful field to return as part of the message
because the app could try to use it to differentiate messages
sent to the same entity

BUG=62266480