### PR TITLE
v3: merge-sort for streaming

### DIFF
--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file has the logic for performing merge-sorts of scatter queries.
+
+package engine
+
+import (
+	"container/heap"
+	"io"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// mergeSort performs a merge-sort of rows returned by a streaming scatter query.
+// Each shard of the scatter query is treated as a stream. One row from each stream
+// is added to the merge-sorter heap. Every time a value is pulled out of the heap,
+// a new value is added to it from the stream that was the source of the value that
+// was pulled out. Since the input streams are sorted the same way that the heap is
+// sorted, this guarantees that the merged stream will also be sorted the same way.
+func mergeSort(vcursor VCursor, query string, orderBy []OrderbyParams, params *scatterParams, callback func(*sqltypes.Result) error) error {
+	// We could consider exposing vcursor's context and
+	// using that here. Needs to be discussed.
+	ctx := context.TODO()
+
+	handles := make([]*streamHandle, len(params.shardVars))
+	id := 0
+	for shard, vars := range params.shardVars {
+		handles[id] = runOneStream(ctx, vcursor, query, params.ks, shard, vars)
+		id++
+	}
+	defer func() {
+		for _, handle := range handles {
+			handle.cancel()
+		}
+	}()
+
+	// Fetch field info from just one stream.
+	fields := <-handles[0].fields
+	// If fields is nil, it means there was an error.
+	if fields == nil {
+		return handles[0].err
+	}
+	if err := callback(&sqltypes.Result{Fields: fields}); err != nil {
+		return err
+	}
+
+	sh := &scatterHeap{
+		rows:    make([]streamRow, 0, len(handles)),
+		orderBy: orderBy,
+	}
+
+	// Prime the heap. One element must be pulled from
+	// each stream.
+	for i, handle := range handles {
+		select {
+		case row, ok := <-handle.row:
+			if !ok {
+				if handle.err != nil {
+					return handle.err
+				}
+				// It's possible that a stream returns no rows.
+				// If so, don't add anything to the heap.
+				continue
+			}
+			sh.rows = append(sh.rows, streamRow{row: row, id: i})
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	heap.Init(sh)
+	if sh.err != nil {
+		return sh.err
+	}
+
+	// Iterate one row at a time:
+	// Pop a row from the heap and send it out.
+	// Then pull the next row from the stream the popped
+	// row came from and push it into the heap.
+	for len(sh.rows) != 0 {
+		sr := heap.Pop(sh).(streamRow)
+		if sh.err != nil {
+			return sh.err
+		}
+		if err := callback(&sqltypes.Result{Rows: [][]sqltypes.Value{sr.row}}); err != nil {
+			return err
+		}
+
+		select {
+		case row, ok := <-handles[sr.id].row:
+			if !ok {
+				if handles[sr.id].err != nil {
+					return handles[sr.id].err
+				}
+				continue
+			}
+			sr.row = row
+			heap.Push(sh, sr)
+			if sh.err != nil {
+				return sh.err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// streamHandle is the rendez-vous point between each stream and the merge-sorter.
+// The fields channel is used by the stream to transmit the field info, which
+// is the first packet. Following this, the stream sends each row to the row
+// channel. At the end of the stream, fields and row are closed. If there
+// was an error, err is set before the channels are closed. The mergeSort
+// routine that pulls the rows out of each streamHandle can abort the stream
+// by calling cancel.
+type streamHandle struct {
+	fields chan []*querypb.Field
+	row    chan []sqltypes.Value
+	err    error
+	cancel context.CancelFunc
+}
+
+// runOnestream starts a streaming query on one shard, and returns a streamHandle for it.
+func runOneStream(ctx context.Context, vcursor VCursor, query, ks, shard string, vars map[string]interface{}) *streamHandle {
+	ctx, cancel := context.WithCancel(ctx)
+	handle := &streamHandle{
+		fields: make(chan []*querypb.Field, 1),
+		row:    make(chan []sqltypes.Value, 10),
+		cancel: cancel,
+	}
+
+	go func() {
+		defer close(handle.fields)
+		defer close(handle.row)
+
+		err := vcursor.StreamExecuteMulti(
+			query,
+			ks,
+			map[string]map[string]interface{}{shard: vars},
+			func(qr *sqltypes.Result) error {
+				if len(qr.Fields) != 0 {
+					select {
+					case handle.fields <- qr.Fields:
+					case <-ctx.Done():
+						return io.EOF
+					}
+				}
+
+				for _, row := range qr.Rows {
+					select {
+					case handle.row <- row:
+					case <-ctx.Done():
+						return io.EOF
+					}
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			handle.err = err
+		}
+	}()
+
+	return handle
+}
+
+// A streamRow represents a row identified by the stream
+// it came from. It is used as an element in scatterHeap.
+type streamRow struct {
+	row []sqltypes.Value
+	id  int
+}
+
+// scatterHeap is the heap that is used for merge-sorting.
+// You can push streamRow elements into it. Popping an
+// element will return the one with the lowest value
+// as defined by the orderBy criteria. If a comparison
+// yielded an error, err is set. This must be checked
+// after every heap operation.
+type scatterHeap struct {
+	rows    []streamRow
+	orderBy []OrderbyParams
+	err     error
+}
+
+func (sh *scatterHeap) Len() int {
+	return len(sh.rows)
+}
+
+func (sh *scatterHeap) Less(i, j int) bool {
+	for _, order := range sh.orderBy {
+		if sh.err != nil {
+			return true
+		}
+		cmp, err := sqltypes.NullsafeCompare(sh.rows[i].row[order.Col], sh.rows[j].row[order.Col])
+		if err != nil {
+			sh.err = err
+			return true
+		}
+		if cmp == 0 {
+			continue
+		}
+		if order.Desc {
+			cmp = -cmp
+		}
+		return cmp < 0
+	}
+	return true
+}
+
+func (sh *scatterHeap) Swap(i, j int) {
+	sh.rows[i], sh.rows[j] = sh.rows[j], sh.rows[i]
+}
+
+func (sh *scatterHeap) Push(x interface{}) {
+	sh.rows = append(sh.rows, x.(streamRow))
+}
+
+func (sh *scatterHeap) Pop() interface{} {
+	n := len(sh.rows)
+	x := sh.rows[n-1]
+	sh.rows = sh.rows[:n-1]
+	return x
+}

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/querytypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// TestMergeSortNormal tests the normal flow of a merge
+// sort where all shards return ordered rows with no errors.
+func TestMergeSortNormal(t *testing.T) {
+	vc := &testVCursor{
+		shardResults: map[string]*shardResult{
+			"0": {
+				results: []*sqltypes.Result{
+					fieldResult,
+					{
+						Rows: [][]sqltypes.Value{
+							makeRow("1", "a"),
+							makeRow("7", "g"),
+						},
+					},
+				},
+			},
+			"1": {
+				results: []*sqltypes.Result{
+					fieldResult,
+					{
+						Rows: [][]sqltypes.Value{
+							makeRow("2", "b"),
+						},
+					},
+					{
+						Rows: [][]sqltypes.Value{
+							makeRow("3", "c"),
+						},
+					},
+				},
+			},
+			"2": {
+				results: []*sqltypes.Result{
+					fieldResult,
+					{
+						Rows: [][]sqltypes.Value{
+							makeRow("4", "d"),
+							makeRow("6", "f"),
+						},
+					},
+				},
+			},
+			"3": {
+				results: []*sqltypes.Result{
+					fieldResult,
+					{
+						Rows: [][]sqltypes.Value{
+							makeRow("4", "d"),
+							makeRow("8", "h"),
+						},
+					},
+				},
+			},
+		},
+	}
+	orderBy := []OrderbyParams{{
+		Col: 0,
+	}}
+	params := &scatterParams{
+		shardVars: map[string]map[string]interface{}{
+			"0": nil,
+			"1": nil,
+			"2": nil,
+			"3": nil,
+		},
+	}
+
+	var results []*sqltypes.Result
+	err := mergeSort(vc, "", orderBy, params, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	wantResults := []*sqltypes.Result{
+		fieldResult,
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("1", "a"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("2", "b"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("3", "c"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("4", "d"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("4", "d"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("6", "f"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("7", "g"),
+			},
+		},
+		{
+			Rows: [][]sqltypes.Value{
+				makeRow("8", "h"),
+			},
+		},
+	}
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("merge-sort:\n%s, want\n%s", printResults(results), printResults(wantResults))
+	}
+}
+
+func printResults(results []*sqltypes.Result) string {
+	b := new(bytes.Buffer)
+	delim := ""
+	for _, r := range results {
+		fmt.Fprintf(b, "%s%v", delim, r)
+		delim = ", "
+	}
+	return b.String()
+}
+
+var fieldResult = &sqltypes.Result{
+	Fields: []*querypb.Field{
+		{Name: "id", Type: sqltypes.Int32},
+		{Name: "col", Type: sqltypes.VarChar},
+	},
+}
+
+func makeRow(id, col string) []sqltypes.Value {
+	return []sqltypes.Value{
+		sqltypes.MakeTrusted(sqltypes.Int32, []byte(id)),
+		sqltypes.MakeTrusted(sqltypes.Int32, []byte(col)),
+	}
+}
+
+type shardResult struct {
+	results []*sqltypes.Result
+	// sendErr is sent at the end of the stream if it's set.
+	sendErr error
+	// recvErr is set if a callback returned an error.
+	recvErr error
+}
+
+type testVCursor struct {
+	shardResults map[string]*shardResult
+}
+
+func (t *testVCursor) Execute(query string, bindvars map[string]interface{}, isDML bool) (*sqltypes.Result, error) {
+	panic("unimplemented")
+}
+
+func (t *testVCursor) ExecuteMultiShard(keyspace string, shardQueries map[string]querytypes.BoundQuery, isDML bool) (*sqltypes.Result, error) {
+	panic("unimplemented")
+}
+
+func (t *testVCursor) ExecuteStandalone(query string, bindvars map[string]interface{}, keyspace, shard string) (*sqltypes.Result, error) {
+	panic("unimplemented")
+}
+
+func (t *testVCursor) StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]interface{}, callback func(reply *sqltypes.Result) error) error {
+	var shard string
+	for k := range shardVars {
+		shard = k
+		break
+	}
+	for _, r := range t.shardResults[shard].results {
+		if err := callback(r); err != nil {
+			t.shardResults[shard].recvErr = err
+			return err
+		}
+	}
+	if t.shardResults[shard].sendErr != nil {
+		return t.shardResults[shard].sendErr
+	}
+	return nil
+}
+
+func (t *testVCursor) GetKeyspaceShards(vkeyspace *vindexes.Keyspace) (string, []*topodatapb.ShardReference, error) {
+	panic("unimplemented")
+}
+
+func (t *testVCursor) GetShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []byte) (string, error) {
+	panic("unimplemented")
+}


### PR DESCRIPTION
Issue #2897

This change implements the merge-sort for StreamExecute. All related
functions are in one merge_sort.go file for improved readability.