### PR TITLE
fix more flakyness due to slow travis

### DIFF
--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -305,11 +305,11 @@ func TestConsolidation(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		framework.NewClient().Execute("select sleep(0.25) from dual", nil)
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
 		wg.Done()
 	}()
 	go func() {
-		framework.NewClient().Execute("select sleep(0.25) from dual", nil)
+		framework.NewClient().Execute("select sleep(0.5) from dual", nil)
 		wg.Done()
 	}()
 	wg.Wait()

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -90,7 +90,7 @@ func newTestReceiver(size int) *testReceiver {
 		tr.count.Add(1)
 		select {
 		case tr.ch <- qr:
-		case <-time.After(10 * time.Second):
+		case <-time.After(20 * time.Second):
 			panic("test may be hung")
 		}
 		return nil


### PR DESCRIPTION
* Make the sleep longer for consolidations. Sometimes the queries
  end up not consolidating.
* Increase the grace period for hung test detection in messages.

BUG=37363173