### PR TITLE
mysql: make ComQuery streamable

### DIFF
--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -408,13 +408,26 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		if got != query {
 			t.Errorf("server got query '%v' but expected '%v'", got, query)
 		}
-		if err := sConn.writeResult(result); err != nil {
+		if err := writeResult(sConn, result); err != nil {
 			t.Errorf("Error writing result to client: %v", err)
 		}
 		sConn.sequence = 0
 	}
 
 	wg.Wait()
+}
+
+func writeResult(conn *Conn, result *sqltypes.Result) error {
+	if err := conn.writeFields(result); err != nil {
+		return err
+	}
+	if len(result.Fields) == 0 {
+		return nil
+	}
+	if err := conn.writeRows(result); err != nil {
+		return err
+	}
+	return conn.writeEndResult()
 }
 
 func RowString(row []sqltypes.Value) string {


### PR DESCRIPTION
ComQuery signature has been changed to use a callback, which
can be used for streaming results.

The function the handles ComQuery became slightly complex for
two reasons:
1. If there's no field info (DMLs), no further packs must be sent.
2. There is no way to send an error mid-stream (I tested it). All
   we can do is abort, which closes the connection.