### PR TITLE
Fix small typo in Hook.findHook() error text

### DIFF
--- a/go/vt/hook/hook.go
+++ b/go/vt/hook/hook.go
@@ -89,7 +89,7 @@ func NewSimpleHook(name string) *Hook {
 func (hook *Hook) findHook() (*exec.Cmd, int, error) {
 	// Check the hook path.
 	if strings.Contains(hook.Name, "/") {
-		return nil, HOOK_INVALID_NAME, fmt.Errorf("hooks cannot contains '/'")
+		return nil, HOOK_INVALID_NAME, fmt.Errorf("hook cannot contain '/'")
 	}
 
 	// Find our root.


### PR DESCRIPTION
Minor typo in text that seemed worth fixing.