### PR TITLE
v3: bug fix: unsupport '*' and order by

### DIFF
--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -63,6 +63,10 @@
 "select id from (select user.id, user.col from user join user_extra) as t order by id"
 "unsupported: cannot order by on a cross-shard subquery"
 
+# scatter order by with * expression
+"select * from user order by id"
+"unsupported: scatter order by with a '*' in select expression"
+
 # filtering on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t where id=5"
 "unsupported: filtering on results of cross-shard subquery"

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -419,6 +419,10 @@ func (rb *route) PushOrderBy(order *sqlparser.Order) error {
 	default:
 		return fmt.Errorf("unsupported: in scatter query: complex order by expression: %v", sqlparser.String(expr))
 	}
+	// Ensure that it's not an anonymous column (* expression).
+	if rb.resultColumns[colnum].alias.IsEmpty() {
+		return errors.New("unsupported: scatter order by with a '*' in select expression")
+	}
 	rb.ERoute.OrderBy = append(rb.ERoute.OrderBy, engine.OrderbyParams{
 		Col:  colnum,
 		Desc: order.Direction == sqlparser.DescScr,


### PR DESCRIPTION
Issue #2897

If a '*' expression is used, the order by column auto-resolves
to that column number, which is incorrect. For now, I've added
a check for it. The more correct fix will come later where
such resolutions must fail for all use cases.

This is a critical bug. So, I'll push it through as soon as the
tests pass.