### PR TITLE
Treat non-binary encoded BINARY field as CHAR

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
@@ -122,6 +122,9 @@ public class FieldWithMetadata {
                 if (javaType == Types.VARBINARY && !isBinaryEncoded) {
                     this.javaType = Types.VARCHAR;
                 }
+                if (javaType == Types.BINARY && !isBinaryEncoded) {
+                    this.javaType = Types.CHAR;
+                }
             } else {
                 // Default encoding for number-types and date-types
                 // We keep the default javaType as passed from the server, and just set the encoding

--- a/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
@@ -113,10 +113,10 @@ public class FieldWithMetadata {
                 }
                 this.isSingleBit = this.javaType == Types.BIT && (field.getColumnLength() == 0 || field.getColumnLength() == 1);
 
-                // The server sends back a VARBINARY field whenever varchar/text data is stored on disk as binary, but
+                // The server sends back a BINARY/VARBINARY field whenever varchar/text data is stored on disk as binary, but
                 // that doesn't mean the data is actually binary. For instance, a field with collation ascii_bin
                 // gets stored on disk as bytes for case-sensitive comparison, but is still an ascii string.
-                // Re-map these VARBINARY types to VARCHAR when the data is not actually
+                // Re-map these BINARY/VARBINARY types to CHAR/VARCHAR when the data is not actually
                 // binary encoded
                 boolean isBinaryEncoded = isBinary() && collationIndex == CharsetMapping.MYSQL_COLLATION_INDEX_binary;
                 if (javaType == Types.VARBINARY && !isBinaryEncoded) {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
@@ -260,6 +260,28 @@ public class FieldWithMetadataTest extends BaseTest {
     }
 
     @Test
+    public void testBinaryToCharRemapping() throws SQLException {
+        VitessConnection conn = getVitessConnection();
+
+        Query.Field raw = Query.Field.newBuilder()
+            .setTable("foo")
+            .setColumnLength(3)
+            .setType(Query.Type.BINARY)
+            .setName("foo")
+            .setOrgName("foo")
+            .setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_binary)
+            .setFlags(Query.MySqlFlag.BINARY_FLAG_VALUE)
+            .build();
+
+        FieldWithMetadata fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals("no remapping - base case", Types.BINARY, fieldWithMetadata.getJavaType());
+
+        raw = raw.toBuilder().setCharset(CharsetMapping.MYSQL_COLLATION_INDEX_utf8).build();
+        fieldWithMetadata = new FieldWithMetadata(conn, raw);
+        Assert.assertEquals("remap to char due to non-binary encoding", Types.CHAR, fieldWithMetadata.getJavaType());
+    }
+
+    @Test
     public void testNumericAndDateTimeEncoding() throws SQLException{
         VitessConnection conn = getVitessConnection();
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
@@ -188,7 +188,7 @@ public class FieldWithMetadataTest extends BaseTest {
             .build();
 
         fieldWithMetadata = new FieldWithMetadata(conn, raw);
-        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(Types.CHAR, fieldWithMetadata.getJavaType());
         Assert.assertEquals("UTF-8", fieldWithMetadata.getEncoding());
         Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
 


### PR DESCRIPTION
This is a followon from https://github.com/youtube/vitess/pull/2847. Applying the same logic to BINARY types. This occurs when someone has a CHAR field in MySQL with `ascii_bin` collation.