### PR TITLE
Allow for MySQL 8.0 in a few places

### DIFF
--- a/go/vt/mysqlctl/mysql_flavor_mysql56.go
+++ b/go/vt/mysqlctl/mysql_flavor_mysql56.go
@@ -35,7 +35,9 @@ const mysql56FlavorID = "MySQL56"
 
 // VersionMatch implements MysqlFlavor.VersionMatch().
 func (*mysql56) VersionMatch(version string) bool {
-	return strings.HasPrefix(version, "5.6") || strings.HasPrefix(version, "5.7")
+	return strings.HasPrefix(version, "5.6") ||
+		strings.HasPrefix(version, "5.7") ||
+		strings.HasPrefix(version, "8.0")
 }
 
 // MasterPosition implements MysqlFlavor.MasterPosition().

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -526,6 +526,13 @@ func (mysqld *Mysqld) Init(ctx context.Context, initDBSQLFile string) error {
 	return nil
 }
 
+// MySQL 5.7 GA and up have deprecated mysql_install_db.
+// Instead, initialization is built into mysqld.
+func useMysqldInitialize(version string) bool {
+	return strings.Contains(version, "Ver 5.7.") ||
+		strings.Contains(version, "Ver 8.0.")
+}
+
 func (mysqld *Mysqld) installDataDir() error {
 	mysqlRoot, err := vtenv.VtMysqlRoot()
 	if err != nil {
@@ -542,9 +549,7 @@ func (mysqld *Mysqld) installDataDir() error {
 		return err
 	}
 
-	if strings.Contains(version, "Ver 5.7.") {
-		// MySQL 5.7 GA and up have deprecated mysql_install_db.
-		// Instead, initialization is built into mysqld.
+	if useMysqldInitialize(version) {
 		log.Infof("Installing data dir with mysqld --initialize-insecure")
 
 		args := []string{


### PR DESCRIPTION
Oracle MySQL now have a dev version of 8.0. It seems useful to be able to at least recognise the version in the code etc. So there are 2 patches here which allow for that.

On a side note it seems to me that the `MYSQL_FLAVOR=MySQL56` definition which has been used is a little outdated and thus confusing given it also applies to MySQL 5.7 and 8.0. Perhaps a more appropriate value might be OracleMySQL or similar?  Adapting the code to use a different name might be better (as this is currently a configuration option) though an improvement would be to recognise the appropriate version where this is needed and automatically adjust behaviour accordingly.

In any case this small patch at least makes Vitess minimally aware of MySQL 8.0 and ensures it should do the right thing.