### PR TITLE
use streaming if fetchSize is specified

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessPreparedStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessPreparedStatement.java
@@ -16,15 +16,6 @@
 
 package io.vitess.jdbc;
 
-import io.vitess.client.Context;
-import io.vitess.client.VTGateConn;
-import io.vitess.client.VTGateTx;
-import io.vitess.client.cursor.Cursor;
-import io.vitess.client.cursor.CursorWithError;
-import io.vitess.mysql.DateTime;
-import io.vitess.proto.Topodata;
-import io.vitess.util.Constants;
-import io.vitess.util.StringUtils;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
@@ -58,6 +49,16 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import io.vitess.client.Context;
+import io.vitess.client.VTGateConn;
+import io.vitess.client.VTGateTx;
+import io.vitess.client.cursor.Cursor;
+import io.vitess.client.cursor.CursorWithError;
+import io.vitess.mysql.DateTime;
+import io.vitess.proto.Topodata;
+import io.vitess.util.Constants;
+import io.vitess.util.StringUtils;
 
 /**
  * Created by harshit.gangal on 25/01/16.
@@ -127,7 +128,7 @@ public class VitessPreparedStatement extends VitessStatement implements Prepared
                     .getAutoCommit()) {
                     Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                    if (vitessConnection.isSimpleExecute()) {
+                    if (vitessConnection.isSimpleExecute() && this.fetchSize == 0) {
                         cursor =
                             vtGateConn.execute(context, this.sql, this.bindVariables, tabletType, vitessConnection.getIncludedFields())
                                 .checkedGet();

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -16,6 +16,17 @@
 
 package io.vitess.jdbc;
 
+import java.sql.BatchUpdateException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
 import io.vitess.client.Context;
 import io.vitess.client.Proto;
 import io.vitess.client.VTGateConn;
@@ -27,16 +38,6 @@ import io.vitess.proto.Topodata;
 import io.vitess.proto.Vtrpc;
 import io.vitess.util.Constants;
 import io.vitess.util.StringUtils;
-import java.sql.BatchUpdateException;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
-import java.sql.SQLRecoverableException;
-import java.sql.SQLWarning;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * Created by harshit.gangal on 19/01/16.
@@ -118,7 +119,7 @@ public class VitessStatement implements Statement {
                     .getAutoCommit()) {
                 Context context =
                         this.vitessConnection.createContext(this.queryTimeoutInMillis);
-                if (vitessConnection.isSimpleExecute()) {
+                if (vitessConnection.isSimpleExecute() && this.fetchSize == 0) {
                     cursor = vtGateConn.execute(context, sql, null, tabletType, vitessConnection.getIncludedFields()).checkedGet();
                 } else {
                     cursor = vtGateConn.streamExecute(context, sql, null, tabletType, vitessConnection.getIncludedFields());


### PR DESCRIPTION
@harshit-gangal 

This is related to your comment [here](https://github.com/youtube/vitess/issues/2933#issuecomment-309191466). Currently the JDBC driver does nothing with the fetchSize parameter. This PR causes StreamExecute to be used when fetchSize is non-zero.

In the future perhaps we can pass the value down to vttablet in ExecuteOptions to inform the batching, but for now I think just using it to enable streaming is a plus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/youtube/vitess/2949)
<!-- Reviewable:end -->
