### PR TITLE
Two healthcheck small changes.

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -676,6 +676,11 @@ func (agent *ActionAgent) checkTabletMysqlPort(ctx context.Context, tablet *topo
 		return nil
 	}
 
+	// Update the port in the topology. Use a shorter timeout, so if
+	// the topo server is busy / throttling us, we don't hang forever here.
+	// The healthcheck go routine will try again next time.
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	if !agent.waitingForMysql {
 		log.Warningf("MySQL port has changed from %v to %v, updating it in tablet record", topoproto.MysqlPort(tablet), mport)
 	}

--- a/go/vt/vttablet/tabletmanager/state_change.go
+++ b/go/vt/vttablet/tabletmanager/state_change.go
@@ -141,6 +141,11 @@ func (agent *ActionAgent) refreshTablet(ctx context.Context, reason string) erro
 	}
 	tablet := ti.Tablet
 
+	// Also refresh the MySQL port, to be sure it's correct.
+	// Note if this run doesn't succeed, the healthcheck go routine
+	// will try again.
+	agent.gotMysqlPort = false
+	agent.waitingForMysql = false
 	if updatedTablet := agent.checkTabletMysqlPort(ctx, tablet); updatedTablet != nil {
 		tablet = updatedTablet
 	}


### PR DESCRIPTION
1. Add a timeout for topo operation to update the tablet record when
MySQL port has changed. That way if we're throttled by topo server,
we don't hang forever (updating the topo record is not required for
serving).

2. when RefreshState is called, re-asking for MySQL port all the time.

BUG=62771732