### PR TITLE
Fixing mastership termination after election.

### DIFF
--- a/go/vt/etcdtopo/election.go
+++ b/go/vt/etcdtopo/election.go
@@ -63,6 +63,13 @@ type etcdMasterParticipation struct {
 
 // WaitForMastership is part of the topo.MasterParticipation interface.
 func (mp *etcdMasterParticipation) WaitForMastership() (context.Context, error) {
+	// If Stop was already called, mp.done is closed, so we are interrupted.
+	select {
+	case <-mp.done:
+		return nil, topo.ErrInterrupted
+	default:
+	}
+
 	electionPath := path.Join(electionDirPath, mp.name)
 
 	for {

--- a/go/vt/topo/consultopo/election.go
+++ b/go/vt/topo/consultopo/election.go
@@ -74,6 +74,13 @@ type consulMasterParticipation struct {
 
 // WaitForMastership is part of the topo.MasterParticipation interface.
 func (mp *consulMasterParticipation) WaitForMastership() (context.Context, error) {
+	// If Stop was already called, mp.done is closed, so we are interrupted.
+	select {
+	case <-mp.done:
+		return nil, topo.ErrInterrupted
+	default:
+	}
+
 	// Try to lock until mp.stop is closed.
 	lost, err := mp.lock.Lock(mp.stop)
 	if err != nil {

--- a/go/vt/topo/etcd2topo/election.go
+++ b/go/vt/topo/etcd2topo/election.go
@@ -61,6 +61,13 @@ type etcdMasterParticipation struct {
 
 // WaitForMastership is part of the topo.MasterParticipation interface.
 func (mp *etcdMasterParticipation) WaitForMastership() (context.Context, error) {
+	// If Stop was already called, mp.done is closed, so we are interrupted.
+	select {
+	case <-mp.done:
+		return nil, topo.ErrInterrupted
+	default:
+	}
+
 	electionPath := path.Join(mp.s.global.root, electionsPath, mp.name)
 	lockPath := ""
 

--- a/go/vt/topo/memorytopo/election.go
+++ b/go/vt/topo/memorytopo/election.go
@@ -69,6 +69,13 @@ type mtMasterParticipation struct {
 
 // WaitForMastership is part of the topo.MasterParticipation interface.
 func (mp *mtMasterParticipation) WaitForMastership() (context.Context, error) {
+	// If Stop was already called, mp.done is closed, so we are interrupted.
+	select {
+	case <-mp.done:
+		return nil, topo.ErrInterrupted
+	default:
+	}
+
 	electionPath := path.Join(electionsPath, mp.name)
 	lockPath := ""
 

--- a/go/vt/topo/zk2topo/election.go
+++ b/go/vt/topo/zk2topo/election.go
@@ -87,8 +87,14 @@ type zkMasterParticipation struct {
 
 // WaitForMastership is part of the topo.MasterParticipation interface.
 func (mp *zkMasterParticipation) WaitForMastership() (context.Context, error) {
-	ctx := context.TODO()
+	// If Stop was already called, mp.done is closed, so we are interrupted.
+	select {
+	case <-mp.done:
+		return nil, topo.ErrInterrupted
+	default:
+	}
 
+	ctx := context.TODO()
 	conn, root, err := mp.zs.connForCell(ctx, topo.GlobalCell)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
After Stop() has been called, a master election object WaitForMastership
call needs to return topo.ErrInterrupted. Adding a unit test case, and
fixing all implementations.

This should fix https://github.com/youtube/vitess/issues/2955
