### PR TITLE
bug: fail early on invalid connection parameters

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -114,7 +114,10 @@ func main() {
 	if err != nil {
 		log.Warning(err)
 	}
-	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	mysqld, err := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	if err != nil {
+		log.Exit(err)
+	}
 	servenv.OnClose(mysqld.Close)
 
 	// tablets configuration and init

--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -125,7 +125,10 @@ func main() {
 	// Create mysqld and register the health reporter (needs to be done
 	// before initializing the agent, so the initial health check
 	// done by the agent has the right reporter)
-	mysqld := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	mysqld, err := mysqlctl.NewMysqld(mycnf, dbcfgs, dbconfigFlags)
+	if err != nil {
+		log.Exit(err)
+	}
 	servenv.OnClose(mysqld.Close)
 
 	// Depends on both query and updateStream.

--- a/go/mysql/conn_params.go
+++ b/go/mysql/conn_params.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package mysql
 
+import "errors"
+
 // ConnParams contains all the parameters to use to connect to mysql.
 type ConnParams struct {
 	Host       string `json:"host"`
@@ -48,4 +50,15 @@ func (cp *ConnParams) SslEnabled() bool {
 // EnableClientFoundRows sets the flag for CLIENT_FOUND_ROWS.
 func (cp *ConnParams) EnableClientFoundRows() {
 	cp.Flags |= CapabilityClientFoundRows
+}
+
+// Validate returns an error if ConnParams has invalid fields.
+func (cp *ConnParams) Validate() error {
+	if cp == nil {
+		return errors.New("mysql connection parameters are empty")
+	}
+	if cp.Port == 0 && cp.UnixSocket == "" {
+		return errors.New("either a unix socket or port must be specified for the mysql connection")
+	}
+	return nil
 }

--- a/go/mysql/conn_test.go
+++ b/go/mysql/conn_test.go
@@ -260,3 +260,20 @@ func TestBasicPackets(t *testing.T) {
 		t.Fatalf("cConn.ReadPacket - EOFPacket failed: %v %v", data, err)
 	}
 }
+
+func TestConnParamsValidate(t *testing.T) {
+	var c *ConnParams
+	want := "mysql connection parameters are empty"
+	if err := c.Validate(); err == nil || err.Error() != want {
+		t.Errorf("Validate(%v): %v, want %s", c, err, want)
+	}
+	c = &ConnParams{}
+	want = "either a unix socket or port must be specified for the mysql connection"
+	if err := c.Validate(); err == nil || err.Error() != want {
+		t.Errorf("Validate(%v): %v, want %s", c, err, want)
+	}
+	c = &ConnParams{Port: 1}
+	if err := c.Validate(); err != nil {
+		t.Error(err)
+	}
+}

--- a/go/vt/mysqlctl/cmd.go
+++ b/go/vt/mysqlctl/cmd.go
@@ -52,7 +52,7 @@ func CreateMysqld(tabletUID uint32, mysqlSocket string, mysqlPort int32, dbconfi
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, dbcfgs, dbconfigFlags), nil
+	return NewMysqld(mycnf, dbcfgs, dbconfigFlags)
 }
 
 // OpenMysqld returns a Mysqld object to use for working with a MySQL
@@ -70,5 +70,5 @@ func OpenMysqld(tabletUID uint32, dbconfigFlags dbconfigs.DBConfigFlag) (*Mysqld
 		return nil, fmt.Errorf("couldn't Init dbconfigs: %v", err)
 	}
 
-	return NewMysqld(mycnf, dbcfgs, dbconfigFlags), nil
+	return NewMysqld(mycnf, dbcfgs, dbconfigFlags)
 }

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -85,7 +85,7 @@ type Mysqld struct {
 
 // NewMysqld creates a Mysqld object based on the provided configuration
 // and connection parameters.
-func NewMysqld(config *Mycnf, dbcfgs *dbconfigs.DBConfigs, dbconfigsFlags dbconfigs.DBConfigFlag) *Mysqld {
+func NewMysqld(config *Mycnf, dbcfgs *dbconfigs.DBConfigs, dbconfigsFlags dbconfigs.DBConfigFlag) (*Mysqld, error) {
 	result := &Mysqld{
 		config:    config,
 		dbcfgs:    dbcfgs,
@@ -94,17 +94,23 @@ func NewMysqld(config *Mycnf, dbcfgs *dbconfigs.DBConfigs, dbconfigsFlags dbconf
 
 	// Create and open the connection pool for dba access.
 	if dbconfigs.DbaConfig&dbconfigsFlags != 0 {
+		if err := dbcfgs.Dba.Validate(); err != nil {
+			return nil, fmt.Errorf("DBA connection: %v", err)
+		}
 		result.dbaPool = dbconnpool.NewConnectionPool("DbaConnPool", *dbaPoolSize, *dbaIdleTimeout)
 		result.dbaPool.Open(dbconnpool.DBConnectionCreator(&dbcfgs.Dba, dbaMysqlStats))
 	}
 
 	// Create and open the connection pool for app access.
 	if dbconfigs.AppConfig&dbconfigsFlags != 0 {
+		if err := dbcfgs.App.Validate(); err != nil {
+			return nil, fmt.Errorf("App connection: %v", err)
+		}
 		result.appPool = dbconnpool.NewConnectionPool("AppConnPool", *appPoolSize, *appIdleTimeout)
 		result.appPool.Open(dbconnpool.DBConnectionCreator(&dbcfgs.App, appMysqlStats))
 	}
 
-	return result
+	return result, nil
 }
 
 // Cnf returns the mysql config for the daemon

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -65,11 +65,14 @@ func StartServer(connParams mysql.ConnParams) error {
 		SidecarDBName: "_vt",
 	}
 
-	mysqld := mysqlctl.NewMysqld(
+	mysqld, err := mysqlctl.NewMysqld(
 		&mysqlctl.Mycnf{},
 		&dbcfgs,
 		dbconfigs.AppConfig,
 	)
+	if err != nil {
+		return err
+	}
 
 	config := tabletenv.DefaultQsConfig
 	config.EnableAutoCommit = true
@@ -86,7 +89,7 @@ func StartServer(connParams mysql.ConnParams) error {
 
 	Server = tabletserver.NewTabletServerWithNilTopoServer(config)
 	Server.Register()
-	err := Server.StartService(Target, dbcfgs, mysqld)
+	err = Server.StartService(Target, dbcfgs, mysqld)
 	if err != nil {
 		return fmt.Errorf("could not start service: %v", err)
 	}

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -55,11 +55,15 @@ func (util *testUtils) newMysqld(dbcfgs *dbconfigs.DBConfigs) mysqlctl.MysqlDaem
 	// Assigning ServerID to be different from tablet UID to make sure that there are no
 	// assumptions in the code that those IDs are the same.
 	cnf.ServerID = 22222
-	return mysqlctl.NewMysqld(
+	mysqld, err := mysqlctl.NewMysqld(
 		cnf,
 		dbcfgs,
 		dbconfigs.AppConfig, // These tests only use the app pool.
 	)
+	if err != nil {
+		panic(err)
+	}
+	return mysqld
 }
 
 func (util *testUtils) newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {


### PR DESCRIPTION
If mysql connection parameters are incorrect, the failure happens
late, and it's hard to troubleshoot. This change causes such cases
to fail early with explicit error messages.