### PR TITLE
v3: limit for scatter queries

### DIFF
--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -402,7 +402,8 @@
   }
 }
 
-# limit for joins
+# limit for joins. Can't push down the limit because result
+# counts get multiplied by join operations.
 "select user.col from user join user_extra limit 1"
 {
   "Original": "select user.col from user join user_extra limit 1",

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -401,3 +401,76 @@
     "Values": 1
   }
 }
+
+# limit for joins
+"select user.col from user join user_extra limit 1"
+{
+  "Original": "select user.col from user join user_extra limit 1",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 1,
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select user.col from user",
+        "FieldQuery": "select user.col from user where 1 != 1"
+      },
+      "Right": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select 1 from user_extra",
+        "FieldQuery": "select 1 from user_extra where 1 != 1"
+      },
+      "Cols": [
+        -1
+      ]
+    }
+  }
+}
+
+# limit for scatter
+"select col from user limit 1"
+{
+  "Original": "select col from user limit 1",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 1,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user limit 1",
+      "FieldQuery": "select col from user where 1 != 1"
+    }
+  }
+}
+
+# cross-shard expression in parenthesis with limit
+"select * from user where (id = 4 AND name ='abc') limit 5"
+{
+  "Original": "select * from user where (id = 4 AND name ='abc') limit 5",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 5,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select * from user where (id = 4 and name = 'abc') limit 5",
+      "FieldQuery": "select * from user where 1 != 1"
+    }
+  }
+}
+

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -207,14 +207,6 @@
 "select id from unsharded order by (select id from unsharded)"
 "unsupported: order by has subquery"
 
-# limit for joins
-"select user.col from user join user_extra limit 1"
-"unsupported: limits with cross-shard query"
-
-# limit for scatter
-"select col from user limit 1"
-"unsupported: limits with scatter"
-
 # sequence in subquery
 "select col from unsharded where id in (select next value from seq)"
 "unsupported: use of sequence in subquery"
@@ -303,10 +295,6 @@
 "insert into unsharded select 1 from dual union select 1 from dual"
 "unsupported: union in insert"
 
-# unsharded insert with cross-shard select
-"insert into unsharded select col from user limit 1"
-"unsupported: limits with scatter"
-
 # unsharded insert with cross-shard join"
 "insert into unsharded select u.col from user u join user u1"
 "unsupported: cross-shard join in insert"
@@ -374,10 +362,6 @@
 # replace with multiple rows
 "replace into user(id) values (1), (2)"
 "unsupported: REPLACE INTO with sharded schema"
-
-# cross-shard expression in parenthesis with limit not supported yet
-"select * from user where (id = 4 AND name ='abc') limit 5"
-"unsupported: limits with scatter"
 
 # union of information_schema with normal table
 "select * from information_schema.a union select * from unsharded"

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+var _ Primitive = (*Limit)(nil)
+
+// Limit is a primitive that performs the LIMIT operation.
+// For now, it only supports count without offset.
+type Limit struct {
+	Count interface{}
+	Input Primitive
+}
+
+// MarshalJSON serializes the Limit into a JSON representation.
+// It's used for testing and diagnostics.
+func (l *Limit) MarshalJSON() ([]byte, error) {
+	marshalLimit := struct {
+		Opcode string
+		Count  interface{}
+		Input  Primitive
+	}{
+		Opcode: "Limit",
+		Count:  prettyValue(l.Count),
+		Input:  l.Input,
+	}
+	return json.Marshal(marshalLimit)
+}
+
+// Execute is a Primitive function.
+func (l *Limit) Execute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	count, err := l.fetchCount(bindVars, joinVars)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := l.Input.Execute(vcursor, bindVars, joinVars, wantfields)
+	if err != nil {
+		return nil, err
+	}
+
+	if count < len(result.Rows) {
+		result.Rows = result.Rows[:count]
+		result.RowsAffected = uint64(count)
+	}
+	return result, nil
+}
+
+// StreamExecute is a Primitive function.
+func (l *Limit) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool, callback func(*sqltypes.Result) error) error {
+	count, err := l.fetchCount(bindVars, joinVars)
+	if err != nil {
+		return err
+	}
+
+	err = l.Input.StreamExecute(vcursor, bindVars, joinVars, wantfields, func(qr *sqltypes.Result) error {
+		if len(qr.Fields) != 0 {
+			if err := callback(&sqltypes.Result{Fields: qr.Fields}); err != nil {
+				return err
+			}
+		}
+
+		// reduce count till 0.
+		result := &sqltypes.Result{Rows: qr.Rows}
+		if count > len(result.Rows) {
+			count -= len(result.Rows)
+			return callback(result)
+		}
+		result.Rows = result.Rows[:count]
+		count = 0
+		if err := callback(result); err != nil {
+			return err
+		}
+		return io.EOF
+	})
+
+	// We may get back the EOF we returned in the callback.
+	// If so, suppress it.
+	if err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+// GetFields is a Primitive function.
+func (l *Limit) GetFields(vcursor VCursor, bindVars, joinVars map[string]interface{}) (*sqltypes.Result, error) {
+	return l.Input.GetFields(vcursor, bindVars, joinVars)
+}
+
+func (l *Limit) fetchCount(bindVars, joinVars map[string]interface{}) (int, error) {
+	// TODO(sougou): to avoid duplication, check if this can be done
+	// by the supplier of joinVars instead.
+	bindVars = combineVars(bindVars, joinVars)
+
+	resolved, err := resolveBindvar(l.Count, bindVars)
+	if err != nil {
+		return 0, err
+	}
+	num, err := sqltypes.ConvertToUint64(resolved)
+	if err != nil {
+		return 0, err
+	}
+	count := int(num)
+	if count < 0 {
+		return 0, fmt.Errorf("requested limit is out of range: %v", num)
+	}
+	return count, nil
+}
+
+// resolveBindvar may have a value or bind var name. If it's
+// a bind var name, it returns the resolved value.
+// TODO(sougou): move this to a more reusable location.
+func resolveBindvar(val interface{}, bindVars map[string]interface{}) (interface{}, error) {
+	// If it's a bindvar, it will be a string.
+	if v, ok := val.(string); ok {
+		val, ok = bindVars[v[1:]]
+		if !ok {
+			return nil, fmt.Errorf("could not find bind var %s", v)
+		}
+	}
+	return val, nil
+}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -931,6 +931,9 @@ func TestSelectScatterOrderBy(t *testing.T) {
 			InsertID:     0,
 			Rows: [][]sqltypes.Value{{
 				sqltypes.MakeTrusted(sqltypes.Int32, []byte("1")),
+				// i%4 ensures that there are duplicates across shards.
+				// This will allow us to test that cross-shard ordering
+				// still works correctly.
 				sqltypes.MakeTrusted(sqltypes.Int32, []byte(strconv.Itoa(i%4))),
 			}},
 		}})

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -73,6 +73,11 @@ type builder interface {
 	// just on optimization hint.
 	PushOrderByNull()
 
+	// SetUpperLimit is an optimization hint that tells that primitive
+	// that it need not return more than the specified number of rows.
+	// A primitive that cannot perform this can ignore the request.
+	SetUpperLimit(count interface{})
+
 	// PushMisc pushes miscelleaneous constructs to all the primitives.
 	PushMisc(sel *sqlparser.Select)
 

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -74,8 +74,10 @@ type builder interface {
 	PushOrderByNull()
 
 	// SetUpperLimit is an optimization hint that tells that primitive
-	// that it need not return more than the specified number of rows.
+	// that it it does not need to return more than the specified number of rows.
 	// A primitive that cannot perform this can ignore the request.
+	// The count is similar to a plan Value. In this case, it can be
+	// a string (bindvar name), or an int64.
 	SetUpperLimit(count interface{})
 
 	// PushMisc pushes miscelleaneous constructs to all the primitives.

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -198,6 +198,9 @@ func (jb *join) PushOrderByNull() {
 }
 
 // SetUpperLimit satisfies the builder interface.
+// The call is ignored because results get multiplied
+// as they join with others. So, it's hard to reliably
+// predict if a limit push down will work correctly.
 func (jb *join) SetUpperLimit(_ interface{}) {
 }
 

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -197,6 +197,10 @@ func (jb *join) PushOrderByNull() {
 	jb.Right.PushOrderByNull()
 }
 
+// SetUpperLimit satisfies the builder interface.
+func (jb *join) SetUpperLimit(_ interface{}) {
+}
+
 // PushMisc satisfies the builder interface.
 func (jb *join) PushMisc(sel *sqlparser.Select) {
 	jb.Left.PushMisc(sel)

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+)
+
+// limit is the builder for engine.Limit.
+// This gets built if a limit needs to be applied
+// after rows are returned from an underlying
+// operation. Since a limit is the final operation
+// of a SELECT, most pushes are not applicable.
+type limit struct {
+	symtab        *symtab
+	maxOrder      int
+	resultColumns []*resultColumn
+	input         builder
+	elimit        *engine.Limit
+}
+
+// newLimit builds a new limit.
+func newLimit(bldr builder) *limit {
+	return &limit{
+		symtab:        bldr.Symtab(),
+		maxOrder:      bldr.MaxOrder(),
+		resultColumns: bldr.ResultColumns(),
+		input:         bldr,
+		elimit:        &engine.Limit{},
+	}
+}
+
+// Symtab satisfies the builder interface.
+func (l *limit) Symtab() *symtab {
+	return l.symtab
+}
+
+// MaxOrder satisfies the builder interface.
+func (l *limit) MaxOrder() int {
+	return l.maxOrder
+}
+
+// SetOrder satisfies the builder interface.
+func (l *limit) SetOrder(order int) {
+	panic("BUG: reordering can only happen within the FROM clause")
+}
+
+// Primitive satisfies the builder interface.
+func (l *limit) Primitive() engine.Primitive {
+	l.elimit.Input = l.input.Primitive()
+	return l.elimit
+}
+
+// Leftmost satisfies the builder interface.
+func (l *limit) Leftmost() columnOriginator {
+	return l.input.Leftmost()
+}
+
+// ResultColumns satisfies the builder interface.
+func (l *limit) ResultColumns() []*resultColumn {
+	return l.resultColumns
+}
+
+// PushFilter satisfies the builder interface.
+func (l *limit) PushFilter(_ sqlparser.Expr, whereType string, _ columnOriginator) error {
+	return errors.New("unsupported: filtering on results of aggregates")
+}
+
+// PushSelect satisfies the builder interface.
+func (l *limit) PushSelect(expr *sqlparser.AliasedExpr, origin columnOriginator) (rc *resultColumn, colnum int, err error) {
+	panic("BUG: unreachable")
+}
+
+// MakeDistinct satisfies the builder interface.
+func (l *limit) MakeDistinct() error {
+	panic("BUG: unreachable")
+}
+
+// SetGroupBy satisfies the builder interface.
+func (l *limit) SetGroupBy(groupBy sqlparser.GroupBy) (builder, error) {
+	panic("BUG: unreachable")
+}
+
+// PushOrderByNull satisfies the builder interface.
+func (l *limit) PushOrderByNull() {
+	panic("BUG: unreachable")
+}
+
+// SetLimit sets the limit for the primitive. It calls the underlying
+// primitive's SetUpperLimit, which is an optimization hint that informs
+// the underlying primitive that it doesn't need to return more rows than
+// specified.
+func (l *limit) SetLimit(limit *sqlparser.Limit) error {
+	if limit.Offset != nil {
+		return errors.New("unsupported: offset limit for cross-shard queries")
+	}
+	sqlVal, ok := limit.Rowcount.(*sqlparser.SQLVal)
+	if !ok {
+		return fmt.Errorf("unexpected expression in LIMIT: %v", sqlparser.String(limit))
+	}
+	var count interface{}
+	switch sqlVal.Type {
+	case sqlparser.ValArg:
+		count = string(sqlVal.Val)
+	case sqlparser.IntVal:
+		var err error
+		count, err = strconv.ParseInt(string(sqlVal.Val), 10, 64)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unexpected expression in LIMIT: %v", sqlparser.String(limit))
+	}
+	l.SetUpperLimit(count)
+	return nil
+}
+
+// SetUpperLimit satisfies the builder interface.
+func (l *limit) SetUpperLimit(count interface{}) {
+	l.elimit.Count = count
+	l.input.SetUpperLimit(count)
+}
+
+// PushMisc satisfies the builder interface.
+func (l *limit) PushMisc(sel *sqlparser.Select) {
+	l.input.PushMisc(sel)
+}
+
+// Wireup satisfies the builder interface.
+func (l *limit) Wireup(bldr builder, jt *jointab) error {
+	return l.input.Wireup(bldr, jt)
+}
+
+// SupplyVar satisfies the builder interface.
+func (l *limit) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	l.input.SupplyVar(from, to, col, varname)
+}
+
+// SupplyCol satisfies the builder interface.
+func (l *limit) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	panic("BUG: nothing should depend on LIMIT")
+}

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -381,6 +381,11 @@ func (oa *orderedAggregate) PushOrderByNull() {
 	panic("BUG: unreachable")
 }
 
+// SetUpperLimit satisfies the builder interface.
+func (oa *orderedAggregate) SetUpperLimit(count interface{}) {
+	oa.input.SetUpperLimit(count)
+}
+
 // PushMisc satisfies the builder interface.
 func (oa *orderedAggregate) PushMisc(sel *sqlparser.Select) {
 	oa.input.PushMisc(sel)

--- a/go/vt/vtgate/planbuilder/postprocess.go
+++ b/go/vt/vtgate/planbuilder/postprocess.go
@@ -136,9 +136,9 @@ func pushLimit(limit *sqlparser.Limit, bldr builder) (builder, error) {
 		rb.SetLimit(limit)
 		return bldr, nil
 	}
-	l := newLimit(bldr)
-	if err := l.SetLimit(limit); err != nil {
+	lb := newLimit(bldr)
+	if err := lb.SetLimit(limit); err != nil {
 		return nil, err
 	}
-	return l, nil
+	return lb, nil
 }

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -72,7 +72,7 @@ func processSelect(sel *sqlparser.Select, vschema VSchema, outer builder) (build
 	if err != nil {
 		return nil, err
 	}
-	err = pushLimit(sel.Limit, bldr)
+	bldr, err = pushLimit(sel.Limit, bldr)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -141,6 +141,10 @@ func (sq *subquery) PushOrderByNull() {
 }
 
 // SetUpperLimit satisfies the builder interface.
+// For now, the call is ignored because the
+// repercussions of pushing this limit down
+// into a subquery have not been studied yet.
+// We can consider doing it in the future.
 // TODO(sougou): this could be improved.
 func (sq *subquery) SetUpperLimit(_ interface{}) {
 }

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -140,6 +140,11 @@ func (sq *subquery) PushSelect(expr *sqlparser.AliasedExpr, _ columnOriginator) 
 func (sq *subquery) PushOrderByNull() {
 }
 
+// SetUpperLimit satisfies the builder interface.
+// TODO(sougou): this could be improved.
+func (sq *subquery) SetUpperLimit(_ interface{}) {
+}
+
 // PushMisc satisfies the builder interface.
 func (sq *subquery) PushMisc(sel *sqlparser.Select) {
 }

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -58,7 +58,7 @@ func processUnion(union *sqlparser.Union, vschema VSchema, outer builder) (build
 	if err != nil {
 		return nil, err
 	}
-	err = pushLimit(union.Limit, bldr)
+	bldr, err = pushLimit(union.Limit, bldr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #2897

Create the Limit primitve that implements the LIMIT clause.
The initial support is only for counts without offset.

There just enough tests to make sure the feature works.
The next PR will have tests that cover all recent features.
The tests are getting bloated. I may consider a refactor.