### PR TITLE
Adding a check for actionMutex in tabletmanager.

### DIFF
--- a/go/vt/vttablet/tabletmanager/restore.go
+++ b/go/vt/vttablet/tabletmanager/restore.go
@@ -44,8 +44,10 @@ var (
 // an error in case of a non-recoverable error.
 // It takes the action lock so no RPC interferes.
 func (agent *ActionAgent) RestoreData(ctx context.Context, logger logutil.Logger, deleteBeforeRestore bool) error {
-	agent.actionMutex.Lock()
-	defer agent.actionMutex.Unlock()
+	if err := agent.lock(ctx); err != nil {
+		return err
+	}
+	defer agent.unlock()
 	return agent.restoreDataLocked(ctx, logger, deleteBeforeRestore)
 }
 

--- a/go/vt/vttablet/tabletmanager/state_change.go
+++ b/go/vt/vttablet/tabletmanager/state_change.go
@@ -125,6 +125,7 @@ func (agent *ActionAgent) broadcastHealth() {
 // refreshTablet needs to be run after an action may have changed the current
 // state of the tablet.
 func (agent *ActionAgent) refreshTablet(ctx context.Context, reason string) error {
+	agent.checkLock()
 	log.Infof("Executing post-action state refresh: %v", reason)
 
 	span := trace.NewSpanFromContext(ctx)
@@ -186,6 +187,8 @@ func (agent *ActionAgent) updateState(ctx context.Context, newTablet *topodatapb
 //
 // It owns reading the TabletControl for the current tablet, and storing it.
 func (agent *ActionAgent) changeCallback(ctx context.Context, oldTablet, newTablet *topodatapb.Tablet) {
+	agent.checkLock()
+
 	span := trace.NewSpanFromContext(ctx)
 	span.StartLocal("ActionAgent.changeCallback")
 	defer span.Finish()


### PR DESCRIPTION
That way the methods that need to have the actionLock taken can check
for it.

@michael-berlin that is what we talked about.