### PR TITLE
perf: improve parser performance

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -215,7 +215,9 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	db.t.Logf("NewConnection(%v): client %v", db.name, c.ConnectionID)
+	if db.t != nil {
+		db.t.Logf("NewConnection(%v): client %v", db.name, c.ConnectionID)
+	}
 
 	if db.isConnFail {
 		panic(fmt.Errorf("simulating a connection failure"))
@@ -232,7 +234,9 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	db.t.Logf("ConnectionClosed(%v): client %v", db.name, c.ConnectionID)
+	if db.t != nil {
+		db.t.Logf("ConnectionClosed(%v): client %v", db.name, c.ConnectionID)
+	}
 
 	if _, ok := db.connections[c.ConnectionID]; !ok {
 		db.t.Fatalf("BUG: Cannot delete connection from list of open connections because it is not registered. ID: %v Conn: %v", c.ConnectionID, c)
@@ -243,7 +247,9 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 // ComQuery is part of the mysql.Handler interface.
 func (db *DB) ComQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
 	query := string(q)
-	db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
+	if db.t != nil {
+		db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
+	}
 
 	key := strings.ToLower(query)
 	db.mu.Lock()

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -260,7 +261,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		c.sequence = 0
 		data, err := c.readEphemeralPacket()
 		if err != nil {
-			log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
+			// Don't log EOF errors. They cause too much spam.
+			if !strings.HasSuffix(err.Error(), "EOF") {
+				log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
+			}
 			return
 		}
 

--- a/go/vt/binlog/event_streamer.go
+++ b/go/vt/binlog/event_streamer.go
@@ -200,7 +200,7 @@ func parsePkNames(tokenizer *sqlparser.Tokenizer) ([]*querypb.Field, error) {
 				Name: string(val),
 			})
 		default:
-			return nil, fmt.Errorf("syntax error at position: %d", tokenizer.Position)
+			return nil, fmt.Errorf("syntax error at position: %d", tokenizer.Position())
 		}
 	}
 	return columns, nil
@@ -305,7 +305,7 @@ func parsePkTuple(tokenizer *sqlparser.Tokenizer, insertid int64, fields []*quer
 			result.Lengths = append(result.Lengths, int64(numDecoded))
 			result.Values = append(result.Values, decoded[:numDecoded]...)
 		default:
-			return nil, insertid, fmt.Errorf("syntax error at position: %d", tokenizer.Position)
+			return nil, insertid, fmt.Errorf("syntax error at position: %d", tokenizer.Position())
 		}
 		index++
 	}

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -295,7 +295,7 @@ func TestExtractSetValues(t *testing.T) {
 		err string
 	}{{
 		sql: "invalid",
-		err: "syntax error at position 8 near 'invalid'",
+		err: "syntax error at position 7 near 'invalid'",
 	}, {
 		sql: "select * from t",
 		err: "ast did not yield *sqlparser.Set: *sqlparser.Select",

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"strings"
 
 	"github.com/youtube/vitess/go/sqltypes"
@@ -43,7 +42,7 @@ import (
 func Parse(sql string) (Statement, error) {
 	tokenizer := NewStringTokenizer(sql)
 	if yyParse(tokenizer) != 0 {
-		return nil, errors.New(tokenizer.LastError)
+		return nil, tokenizer.LastError
 	}
 	return tokenizer.ParseTree, nil
 }
@@ -1364,10 +1363,8 @@ func (node *SQLVal) Format(buf *TrackedBuffer) {
 	case StrVal:
 		s := sqltypes.MakeString([]byte(node.Val))
 		s.EncodeSQL(buf)
-	case IntVal, FloatVal, HexNum:
+	case IntVal, FloatVal, HexNum, HexVal:
 		buf.Myprintf("%s", []byte(node.Val))
-	case HexVal:
-		buf.Myprintf("X'%s'", []byte(node.Val))
 	case ValArg:
 		buf.WriteArg(string(node.Val))
 	default:

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
+
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -43,23 +43,35 @@ func Normalize(stmt Statement, bindVars map[string]interface{}, prefix string) {
 				// If unsuccessful continue.
 				return true, nil
 			}
-			// Check if there's a bindvar for that value already.
-			var key string
-			if bval.Type == sqltypes.VarBinary {
-				// Prefixing strings with "'" ensures that a string
-				// and number that have the same representation don't
-				// collide.
-				key = "'" + string(node.Val)
+
+			// Only reuse bindvars for small values.
+			// Otherwise their keys get too big.
+			// Do not create implicit variables in this block.
+			var bvname string
+			if len(node.Val) <= 1024 {
+				// Check if there's a bindvar for that value already.
+				var key string
+				if bval.Type == sqltypes.VarBinary {
+					// Prefixing strings with "'" ensures that a string
+					// and number that have the same representation don't
+					// collide.
+					key = "'" + string(node.Val)
+				} else {
+					key = string(node.Val)
+				}
+				var ok bool
+				bvname, ok = vals[key]
+				if !ok {
+					// If there's no such bindvar, make a new one.
+					bvname, counter = newName(prefix, counter, reserved)
+					vals[key] = bvname
+					bindVars[bvname] = bval
+				}
 			} else {
-				key = string(node.Val)
-			}
-			bvname, ok := vals[key]
-			if !ok {
-				// If there's no such bindvar, make a new one.
 				bvname, counter = newName(prefix, counter, reserved)
-				vals[key] = bvname
 				bindVars[bvname] = bval
 			}
+
 			// Modify the AST node to a bindvar.
 			node.Type = ValArg
 			node.Val = append([]byte(":"), bvname...)

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1260,6 +1260,10 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+// Benchmark run on 6/23/17, prior to improvements:
+// BenchmarkParse1-4         100000             16334 ns/op
+// BenchmarkParse2-4          30000             44121 ns/op
+
 func BenchmarkParse1(b *testing.B) {
 	sql := "select 'abcd', 20, 30.0, eid from a where 1=eid and name='3'"
 	for i := 0; i < b.N; i++ {

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package sqlparser
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestValid(t *testing.T) {
 	validSQL := []struct {
@@ -457,7 +459,7 @@ func TestValid(t *testing.T) {
 		input: "select /* octal */ 010 from t",
 	}, {
 		input:  "select /* hex */ x'f0A1' from t",
-		output: "select /* hex */ X'f0A1' from t",
+		output: "select /* hex */ x'f0A1' from t",
 	}, {
 		input: "select /* hex caps */ X'F0a1' from t",
 	}, {
@@ -1154,16 +1156,13 @@ func TestErrors(t *testing.T) {
 		output: "syntax error at position 10 near '0x'",
 	}, {
 		input:  "select x'78 from t",
-		output: "syntax error at position 12 near '78'",
-	}, {
-		input:  "select x'777' from t",
-		output: "syntax error at position 14 near '777'",
+		output: "syntax error at position 12 near 'x'78'",
 	}, {
 		input:  "select 'aa\\",
-		output: "syntax error at position 12 near 'aa'",
+		output: "syntax error at position 11 near 'aa'",
 	}, {
 		input:  "select 'aa",
-		output: "syntax error at position 12 near 'aa'",
+		output: "syntax error at position 10 near 'a'",
 	}, {
 		input:  "select * from t where :1 = 2",
 		output: "syntax error at position 24 near ':'",
@@ -1188,7 +1187,7 @@ func TestErrors(t *testing.T) {
 			"(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(" +
 			"F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F" +
 			"(F(F(F(F(F(F(F(F(F(F(F(F(",
-		output: "max nesting level reached at position 406",
+		output: "max nesting level reached at position 405",
 	}, {
 		input: "select(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F" +
 			"(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(" +
@@ -1198,17 +1197,17 @@ func TestErrors(t *testing.T) {
 			"(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(" +
 			"F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F" +
 			"(F(F(F(F(F(F(F(F(F(F(F(",
-		output: "syntax error at position 405",
+		output: "syntax error at position 403",
 	}, {
 		input:  "select /* aa",
-		output: "syntax error at position 13 near '/* aa'",
+		output: "syntax error at position 12 near '/* aa'",
 	}, {
 		// This construct is considered invalid due to a grammar conflict.
 		input:  "insert into a select * from b join c on duplicate key update d=e",
 		output: "syntax error at position 54 near 'key'",
 	}, {
 		input:  "select * from a left join b",
-		output: "syntax error at position 29",
+		output: "syntax error at position 27",
 	}, {
 		input:  "select * from a natural join b on c = d",
 		output: "syntax error at position 34 near 'on'",
@@ -1223,7 +1222,7 @@ func TestErrors(t *testing.T) {
 		output: "syntax error at position 29 near 'select'",
 	}, {
 		input:  "select database",
-		output: "syntax error at position 17",
+		output: "syntax error at position 15",
 	}, {
 		input:  "select mod from t",
 		output: "syntax error at position 16 near 'from'",
@@ -1232,7 +1231,7 @@ func TestErrors(t *testing.T) {
 		output: "syntax error at position 26 near 'div'",
 	}, {
 		input:  "select 1 from t where binary",
-		output: "syntax error at position 30",
+		output: "syntax error at position 28",
 	}, {
 		input:  "select match(a1, a2) against ('foo' in boolean mode with query expansion) from t",
 		output: "syntax error at position 57 near 'with'",
@@ -1244,7 +1243,7 @@ func TestErrors(t *testing.T) {
 		output: "syntax error at position 81 near 'escape'",
 	}, {
 		input:  "(select /* parenthesized select */ * from t)",
-		output: "syntax error at position 46",
+		output: "syntax error at position 44",
 	}, {
 		input:  "select * from t where id = ((select a from t1 union select b from t2) order by a limit 1)",
 		output: "syntax error at position 76 near 'order'",

--- a/go/vt/vtgate/bench_test.go
+++ b/go/vt/vtgate/bench_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+)
+
+// Benchmark run on 6/23/17, prior to improvements:
+// BenchmarkWithNormalizer-4            100          10927765 ns/op
+// BenchmarkWithoutNormalizer-4      200000              8845 ns/op
+
+var benchQuery string
+
+func init() {
+	// benchQuerySize is the approximate size of the query.
+	benchQuerySize := 1000000
+
+	// Size of value is 1/10 size of query. Then we add
+	// 10 such values to the where clause.
+	baseval := &bytes.Buffer{}
+	for i := 0; i < benchQuerySize/100; i++ {
+		// Add an escape character: This will force the upcoming
+		// tokenizer improvement to still create a copy of the string.
+		// Then we can see if avoiding the copy will be worth it.
+		baseval.WriteString("\\'123456789")
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteString("select a from t1 where v = 1")
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(buf, " and v%d = '%d%s'", i, i, baseval.String())
+	}
+	benchQuery = buf.String()
+	// fmt.Printf("len: %d\n", len(benchQuery))
+}
+
+func BenchmarkWithNormalizer(b *testing.B) {
+	createSandbox(KsTestUnsharded)
+	hcVTGateTest.Reset()
+	_ = hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1001, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
+	saved := rpcVTGate.executor.normalize
+	rpcVTGate.executor.normalize = true
+	defer func() { rpcVTGate.executor.normalize = saved }()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := rpcVTGate.Execute(
+			context.Background(),
+			&vtgatepb.Session{
+				TargetString: "@master",
+				Options:      executeOptions,
+			},
+			benchQuery,
+			nil,
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkWithoutNormalizer(b *testing.B) {
+	createSandbox(KsTestUnsharded)
+	hcVTGateTest.Reset()
+	_ = hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1001, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
+	saved := rpcVTGate.executor.normalize
+	rpcVTGate.executor.normalize = false
+	defer func() { rpcVTGate.executor.normalize = saved }()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := rpcVTGate.Execute(
+			context.Background(),
+			&vtgatepb.Session{
+				TargetString: "@master",
+				Options:      executeOptions,
+			},
+			benchQuery,
+			nil,
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/go/vt/vtgate/bench_test.go
+++ b/go/vt/vtgate/bench_test.go
@@ -27,6 +27,10 @@ import (
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 )
 
+// Benchmark run on 6/23/17, parser improved to directly reference []byte:
+// BenchmarkWithNormalizer-4            300           5236269 ns/op
+// BenchmarkWithoutNormalizer-4      200000              8936 ns/op
+
 // Benchmark run on 6/23/17, prior to improvements:
 // BenchmarkWithNormalizer-4            100          10927765 ns/op
 // BenchmarkWithoutNormalizer-4      200000              8845 ns/op

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -311,7 +311,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	qr, err = executor.Execute(context.Background(), session, "show 10", nil)
-	want = "syntax error at position 8 near '10'"
+	want = "syntax error at position 7 near '10'"
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}
@@ -348,7 +348,7 @@ func TestExecutorUse(t *testing.T) {
 	}
 
 	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "use 1", nil)
-	wantErr := "syntax error at position 6 near '1'"
+	wantErr := "syntax error at position 5 near '1'"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("use 1: %v, want %v", err, wantErr)
 	}
@@ -665,7 +665,7 @@ func TestGetPlanNormalized(t *testing.T) {
 
 	// Errors
 	_, err = r.getPlan(emptyvc, "syntax", map[string]interface{}{})
-	wantErr := "syntax error at position 7 near 'syntax'"
+	wantErr := "syntax error at position 6 near 'syntax'"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("getPlan(syntax): %v, want %s", err, wantErr)
 	}

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// Benchmark run on 6/23/17, prior to improvements:
+// BenchmarkExecuteVarBinary-4           20          55313818 ns/op
+// BenchmarkExecuteExpression-4          50          32585437 ns/op
+
+var benchQuery = "select a from test_table where v = :vtg1 and v0 = :vtg2 and v1 = :vtg3 and v2 = :vtg4 and v3 = :vtg5 and v4 = :vtg6 and v5 = :vtg7 and v6 = :vtg8 and v7 = :vtg9 and v8 = :vtg10 and v9 = :vtg11"
+var benchVarValue []byte
+
+func init() {
+	// benchQuerySize is the approximate size of the query.
+	// This code is in sync with bench_test.go in vtgate.
+	benchQuerySize := 1000000
+
+	// Size of value is 1/10 size of query. Then we add
+	// 10 such values to the where clause.
+	baseval := &bytes.Buffer{}
+	for i := 0; i < benchQuerySize/100; i++ {
+		baseval.WriteString("\\'123456789")
+	}
+	benchVarValue = baseval.Bytes()
+}
+
+func BenchmarkExecuteVarBinary(b *testing.B) {
+	db := setUpTabletServerTest(nil)
+	defer db.Close()
+	testUtils := newTestUtils()
+	// sql that will be executed in this test
+	bv := map[string]interface{}{
+		"vtg1": sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+	}
+	for i := 2; i <= 11; i++ {
+		bv[fmt.Sprintf("vtg%d", i)] = sqltypes.MakeTrusted(sqltypes.VarBinary, benchVarValue)
+	}
+	db.AddQuery("select a from test_table where 1 != 1", &sqltypes.Result{})
+	db.AddQueryPattern("select a from test_table.*", &sqltypes.Result{})
+
+	config := testUtils.newQueryServiceConfig()
+	tsv := NewTabletServerWithNilTopoServer(config)
+	dbconfigs := testUtils.newDBConfigs(db)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	if err != nil {
+		panic(err)
+	}
+	defer tsv.StopService()
+
+	for i := 0; i < b.N; i++ {
+		_, err = tsv.Execute(context.Background(), &target, benchQuery, bv, 0, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkExecuteExpression(b *testing.B) {
+	db := setUpTabletServerTest(nil)
+	defer db.Close()
+	testUtils := newTestUtils()
+	// sql that will be executed in this test
+	bv := map[string]interface{}{
+		"vtg1": sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+	}
+	for i := 2; i <= 11; i++ {
+		bv[fmt.Sprintf("vtg%d", i)] = sqltypes.MakeTrusted(sqltypes.Expression, benchVarValue)
+	}
+	db.AddQuery("select a from test_table where 1 != 1", &sqltypes.Result{})
+	db.AddQueryPattern("select a from test_table.*", &sqltypes.Result{})
+
+	config := testUtils.newQueryServiceConfig()
+	tsv := NewTabletServerWithNilTopoServer(config)
+	dbconfigs := testUtils.newDBConfigs(db)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	if err != nil {
+		panic(err)
+	}
+	defer tsv.StopService()
+
+	for i := 0; i < b.N; i++ {
+		_, err = tsv.Execute(context.Background(), &target, benchQuery, bv, 0, nil)
+		if err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
Issue #2849

This change makes the parser generate tokens by pointing directly
to the input. A copy is made only when there's divergence. For
example, in the case of excaped strings.

This change offers substantial improvements in VTGate performance:
New:
BenchmarkWithNormalizer-4            300           5215343 ns/op
Old:
BenchmarkWithNormalizer-4            100          10927765 ns/op
 
The VTTablet benchmarks were unaffected.

The Parser API still accepts a string, which it copies into a
[]byte. This extra copy can be avoided in some flows because
the query itself comes in as a []byte.

This improvement does not yet address large blobs, which will
almost always be copied because they'll contain escape characters
that will be unescaped by the parser. We'll work on improving
this in upcoming changes.