### PR TITLE
perf: optimize byte operations

### DIFF
--- a/go/bytes2/buffer.go
+++ b/go/bytes2/buffer.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytes2
+
+// Buffer implements a subset of the write portion of
+// bytes.Buffer, but more efficiently. This is meant to
+// be used in very high QPS operations, especially for
+// WriteByte, and without abstracting it as a Writer.
+// Function signatures contain errors for compatibility,
+// but they do not return errors.
+type Buffer struct {
+	bytes []byte
+}
+
+// NewBuffer is equivalent to bytes.NewBuffer.
+func NewBuffer(b []byte) *Buffer {
+	return &Buffer{bytes: b}
+}
+
+// Write is equivalent to bytes.Buffer.Write.
+func (buf *Buffer) Write(b []byte) (int, error) {
+	buf.bytes = append(buf.bytes, b...)
+	return len(b), nil
+}
+
+// WriteString is equivalent to bytes.Buffer.WriteString.
+func (buf *Buffer) WriteString(s string) (int, error) {
+	buf.bytes = append(buf.bytes, s...)
+	return len(s), nil
+}
+
+// WriteByte is equivalent to bytes.Buffer.WriteByte.
+func (buf *Buffer) WriteByte(b byte) error {
+	buf.bytes = append(buf.bytes, b)
+	return nil
+}
+
+// Bytes is equivalent to bytes.Buffer.Bytes.
+func (buf *Buffer) Bytes() []byte {
+	return buf.bytes
+}
+
+// Strings is equivalent to bytes.Buffer.Strings.
+func (buf *Buffer) String() string {
+	return string(buf.bytes)
+}
+
+// Len is equivalent to bytes.Buffer.Len.
+func (buf *Buffer) Len() int {
+	return len(buf.bytes)
+}

--- a/go/bytes2/buffer_test.go
+++ b/go/bytes2/buffer_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytes2
+
+import "testing"
+
+func TestBuffer(t *testing.T) {
+	b := NewBuffer(nil)
+	b.Write([]byte("ab"))
+	b.WriteString("cd")
+	b.WriteByte('e')
+	want := "abcde"
+	if got := string(b.Bytes()); got != want {
+		t.Errorf("b.Bytes(): %s, want %s", got, want)
+	}
+	if got := b.String(); got != want {
+		t.Errorf("b.String(): %s, want %s", got, want)
+	}
+	if got := b.Len(); got != 5 {
+		t.Errorf("b.Len(): %d, want 5", got)
+	}
+}

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -250,6 +250,9 @@ func (c *Conn) readEphemeralPacket() ([]byte, error) {
 
 	var header [4]byte
 	if _, err := io.ReadFull(c.reader, header[:]); err != nil {
+		if err == io.EOF {
+			return nil, err
+		}
 		return nil, fmt.Errorf("io.ReadFull(header size) failed: %v", err)
 	}
 

--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -68,6 +68,9 @@ type DB struct {
 	// processing the next query. This will trigger a MySQL client error with
 	// errno 2013 ("server lost").
 	shouldClose bool
+	// AllowAll: if set to true, ComQuery returns an empty result
+	// for all queries. This flag is used for benchmarking.
+	AllowAll bool
 	// data maps tolower(query) to a result.
 	data map[string]*ExpectedResult
 	// rejectedData maps tolower(query) to an error.
@@ -215,7 +218,9 @@ func (db *DB) NewConnection(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	db.t.Logf("NewConnection(%v): client %v", db.name, c.ConnectionID)
+	if db.t != nil {
+		db.t.Logf("NewConnection(%v): client %v", db.name, c.ConnectionID)
+	}
 
 	if db.isConnFail {
 		panic(fmt.Errorf("simulating a connection failure"))
@@ -232,7 +237,9 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	db.t.Logf("ConnectionClosed(%v): client %v", db.name, c.ConnectionID)
+	if db.t != nil {
+		db.t.Logf("ConnectionClosed(%v): client %v", db.name, c.ConnectionID)
+	}
 
 	if _, ok := db.connections[c.ConnectionID]; !ok {
 		db.t.Fatalf("BUG: Cannot delete connection from list of open connections because it is not registered. ID: %v Conn: %v", c.ConnectionID, c)
@@ -242,8 +249,14 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 
 // ComQuery is part of the mysql.Handler interface.
 func (db *DB) ComQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
+	if db.AllowAll {
+		return callback(&sqltypes.Result{})
+	}
+
 	query := string(q)
-	db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
+	if db.t != nil {
+		db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
+	}
 
 	key := strings.ToLower(query)
 	db.mu.Lock()

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -260,7 +261,10 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		c.sequence = 0
 		data, err := c.readEphemeralPacket()
 		if err != nil {
-			log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
+			// Don't log EOF errors. They cause too much spam.
+			if !strings.HasSuffix(err.Error(), "EOF") {
+				log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
+			}
 			return
 		}
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -262,7 +261,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32) {
 		data, err := c.readEphemeralPacket()
 		if err != nil {
 			// Don't log EOF errors. They cause too much spam.
-			if !strings.HasSuffix(err.Error(), "EOF") {
+			if err != io.EOF {
 				log.Errorf("Error reading packet from client %v: %v", c.ConnectionID, err)
 			}
 			return

--- a/go/vt/sqlparser/normalizer.go
+++ b/go/vt/sqlparser/normalizer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
+
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1260,6 +1260,10 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+// Benchmark run on 6/23/17, prior to improvements:
+// BenchmarkParse1-4         100000             16334 ns/op
+// BenchmarkParse2-4          30000             44121 ns/op
+
 func BenchmarkParse1(b *testing.B) {
 	sql := "select 'abcd', 20, 30.0, eid from a where 1=eid and name='3'"
 	for i := 0; i < b.N; i++ {

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/youtube/vitess/go/bytes2"
 	"github.com/youtube/vitess/go/sqltypes"
 )
 
@@ -330,7 +331,7 @@ func (tkn *Tokenizer) Lex(lval *yySymType) int {
 
 // Error is called by go yacc if there's a parsing error.
 func (tkn *Tokenizer) Error(err string) {
-	buf := &bytes.Buffer{}
+	buf := &bytes2.Buffer{}
 	if tkn.lastToken != nil {
 		fmt.Fprintf(buf, "%s at position %v near '%s'", err, tkn.Position, tkn.lastToken)
 	} else {
@@ -385,7 +386,7 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 			return int(ch), nil
 		case '?':
 			tkn.posVarIndex++
-			buf := new(bytes.Buffer)
+			buf := new(bytes2.Buffer)
 			fmt.Fprintf(buf, ":v%d", tkn.posVarIndex)
 			return VALUE_ARG, buf.Bytes()
 		case '.':
@@ -477,7 +478,7 @@ func (tkn *Tokenizer) skipBlank() {
 }
 
 func (tkn *Tokenizer) scanIdentifier(firstByte byte) (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	buffer.WriteByte(firstByte)
 	for isLetter(tkn.lastChar) || isDigit(tkn.lastChar) {
 		buffer.WriteByte(byte(tkn.lastChar))
@@ -496,7 +497,7 @@ func (tkn *Tokenizer) scanIdentifier(firstByte byte) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanHex() (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	tkn.scanMantissa(16, buffer)
 	if tkn.lastChar != '\'' {
 		return LEX_ERROR, buffer.Bytes()
@@ -509,7 +510,7 @@ func (tkn *Tokenizer) scanHex() (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanLiteralIdentifier() (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	backTickSeen := false
 	for {
 		if backTickSeen {
@@ -540,7 +541,7 @@ func (tkn *Tokenizer) scanLiteralIdentifier() (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanBindVar() (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	buffer.WriteByte(byte(tkn.lastChar))
 	token := VALUE_ARG
 	tkn.next()
@@ -559,7 +560,7 @@ func (tkn *Tokenizer) scanBindVar() (int, []byte) {
 	return token, buffer.Bytes()
 }
 
-func (tkn *Tokenizer) scanMantissa(base int, buffer *bytes.Buffer) {
+func (tkn *Tokenizer) scanMantissa(base int, buffer *bytes2.Buffer) {
 	for digitVal(tkn.lastChar) < base {
 		tkn.consumeNext(buffer)
 	}
@@ -567,7 +568,7 @@ func (tkn *Tokenizer) scanMantissa(base int, buffer *bytes.Buffer) {
 
 func (tkn *Tokenizer) scanNumber(seenDecimalPoint bool) (int, []byte) {
 	token := INTEGRAL
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	if seenDecimalPoint {
 		token = FLOAT
 		buffer.WriteByte('.')
@@ -614,7 +615,7 @@ exit:
 }
 
 func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	for {
 		ch := tkn.lastChar
 		tkn.next()
@@ -644,7 +645,7 @@ func (tkn *Tokenizer) scanString(delim uint16, typ int) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanCommentType1(prefix string) (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	buffer.WriteString(prefix)
 	for tkn.lastChar != eofChar {
 		if tkn.lastChar == '\n' {
@@ -657,7 +658,7 @@ func (tkn *Tokenizer) scanCommentType1(prefix string) (int, []byte) {
 }
 
 func (tkn *Tokenizer) scanCommentType2() (int, []byte) {
-	buffer := &bytes.Buffer{}
+	buffer := &bytes2.Buffer{}
 	buffer.WriteString("/*")
 	for {
 		if tkn.lastChar == '*' {
@@ -676,7 +677,7 @@ func (tkn *Tokenizer) scanCommentType2() (int, []byte) {
 	return COMMENT, buffer.Bytes()
 }
 
-func (tkn *Tokenizer) consumeNext(buffer *bytes.Buffer) {
+func (tkn *Tokenizer) consumeNext(buffer *bytes2.Buffer) {
 	if tkn.lastChar == eofChar {
 		// This should never happen.
 		panic("unexpected EOF")

--- a/go/vt/vtgate/bench_test.go
+++ b/go/vt/vtgate/bench_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+)
+
+// Benchmark run on 6/25/17, prior to improvements:
+// BenchmarkWithNormalizer-4            100          10629161 ns/op
+// BenchmarkWithoutNormalizer-4      200000              8584 ns/op
+
+var benchQuery string
+
+func init() {
+	// benchQuerySize is the approximate size of the query.
+	benchQuerySize := 1000000
+
+	// Size of value is 1/10 size of query. Then we add
+	// 10 such values to the where clause.
+	baseval := &bytes.Buffer{}
+	for i := 0; i < benchQuerySize/100; i++ {
+		// Add an escape character: This will force the upcoming
+		// tokenizer improvement to still create a copy of the string.
+		// Then we can see if avoiding the copy will be worth it.
+		baseval.WriteString("\\'123456789")
+	}
+
+	buf := &bytes.Buffer{}
+	buf.WriteString("select a from t1 where v = 1")
+	for i := 0; i < 10; i++ {
+		fmt.Fprintf(buf, " and v%d = '%d%s'", i, i, baseval.String())
+	}
+	benchQuery = buf.String()
+	// fmt.Printf("len: %d\n", len(benchQuery))
+}
+
+func BenchmarkWithNormalizer(b *testing.B) {
+	createSandbox(KsTestUnsharded)
+	hcVTGateTest.Reset()
+	_ = hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1001, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
+	saved := rpcVTGate.executor.normalize
+	rpcVTGate.executor.normalize = true
+	defer func() { rpcVTGate.executor.normalize = saved }()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := rpcVTGate.Execute(
+			context.Background(),
+			&vtgatepb.Session{
+				TargetString: "@master",
+				Options:      executeOptions,
+			},
+			benchQuery,
+			nil,
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkWithoutNormalizer(b *testing.B) {
+	createSandbox(KsTestUnsharded)
+	hcVTGateTest.Reset()
+	_ = hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1001, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
+	saved := rpcVTGate.executor.normalize
+	rpcVTGate.executor.normalize = false
+	defer func() { rpcVTGate.executor.normalize = saved }()
+
+	for i := 0; i < b.N; i++ {
+		_, _, err := rpcVTGate.Execute(
+			context.Background(),
+			&vtgatepb.Session{
+				TargetString: "@master",
+				Options:      executeOptions,
+			},
+			benchQuery,
+			nil,
+		)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/go/vt/vtgate/bench_test.go
+++ b/go/vt/vtgate/bench_test.go
@@ -27,6 +27,10 @@ import (
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 )
 
+// Benchmark run on 6/27/17, with optimized byte-level operations
+// using bytes2.Buffer:
+// BenchmarkWithNormalizer-4            300           5694660 ns/op
+
 // Benchmark run on 6/25/17, prior to improvements:
 // BenchmarkWithNormalizer-4            100          10629161 ns/op
 // BenchmarkWithoutNormalizer-4      200000              8584 ns/op

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -29,6 +29,10 @@ import (
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
+// Benchmark run on 6/27/17, with optimized byte-level operations
+// using bytes2.Buffer:
+// BenchmarkExecuteVarBinary-4          300           4751125 ns/op
+
 // Benchmark run on 6/25/17, prior to improvements:
 // BenchmarkExecuteVarBinary-4          100          14610045 ns/op
 // BenchmarkExecuteExpression-4        1000           1047798 ns/op

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletserver
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// Benchmark run on 6/25/17, prior to improvements:
+// BenchmarkExecuteVarBinary-4          100          14610045 ns/op
+// BenchmarkExecuteExpression-4        1000           1047798 ns/op
+
+var benchQuery = "select a from test_table where v = :vtg1 and v0 = :vtg2 and v1 = :vtg3 and v2 = :vtg4 and v3 = :vtg5 and v4 = :vtg6 and v5 = :vtg7 and v6 = :vtg8 and v7 = :vtg9 and v8 = :vtg10 and v9 = :vtg11"
+var benchVarValue []byte
+
+func init() {
+	// benchQuerySize is the approximate size of the query.
+	// This code is in sync with bench_test.go in vtgate.
+	benchQuerySize := 1000000
+
+	// Size of value is 1/10 size of query. Then we add
+	// 10 such values to the where clause.
+	baseval := &bytes.Buffer{}
+	for i := 0; i < benchQuerySize/100; i++ {
+		baseval.WriteString("\\'123456789")
+	}
+	benchVarValue = baseval.Bytes()
+}
+
+func BenchmarkExecuteVarBinary(b *testing.B) {
+	db := setUpTabletServerTest(nil)
+	defer db.Close()
+	testUtils := newTestUtils()
+	// sql that will be executed in this test
+	bv := map[string]interface{}{
+		"vtg1": sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+	}
+	for i := 2; i <= 11; i++ {
+		bv[fmt.Sprintf("vtg%d", i)] = sqltypes.MakeTrusted(sqltypes.VarBinary, benchVarValue)
+	}
+
+	config := testUtils.newQueryServiceConfig()
+	tsv := NewTabletServerWithNilTopoServer(config)
+	dbconfigs := testUtils.newDBConfigs(db)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+		panic(err)
+	}
+	defer tsv.StopService()
+
+	db.AllowAll = true
+	for i := 0; i < b.N; i++ {
+		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, nil); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkExecuteExpression(b *testing.B) {
+	db := setUpTabletServerTest(nil)
+	defer db.Close()
+	testUtils := newTestUtils()
+	// sql that will be executed in this test
+	bv := map[string]interface{}{
+		"vtg1": sqltypes.MakeTrusted(sqltypes.Int64, []byte("1")),
+	}
+	for i := 2; i <= 11; i++ {
+		bv[fmt.Sprintf("vtg%d", i)] = sqltypes.MakeTrusted(sqltypes.Expression, benchVarValue)
+	}
+
+	config := testUtils.newQueryServiceConfig()
+	tsv := NewTabletServerWithNilTopoServer(config)
+	dbconfigs := testUtils.newDBConfigs(db)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+		panic(err)
+	}
+	defer tsv.StopService()
+
+	db.AllowAll = true
+	for i := 0; i < b.N; i++ {
+		if _, err := tsv.Execute(context.Background(), &target, benchQuery, bv, 0, nil); err != nil {
+			panic(err)
+		}
+	}
+}


### PR DESCRIPTION
Issue #2849

It turns out that the lion's share of the time was consumed
by byte-by-byte operations. There were two factors:
1. Calling panic in a function somehow makes it more expensive.
2. Calling a function through an interface also adds up.

This PR makes spot improvements to address two cases:
1. The tokenizer was calling bytes.Buffer.WriteByte for every byte
   of the input query.
2. The EncodeSQL function in sqltypes.Value was calling
   a wrapper (that had a panic), which in turn called
   buffer.WriteByte.

I've now written a bytes2.Buffer package that implements a subset
of bytes.Buffer, but more efficiently.

Resulting improvements:
```
VTGate New:
BenchmarkWithNormalizer-4            300           5694660 ns/op
VTGate Old:
BenchmarkWithNormalizer-4            100          10927765 ns/op

VTTablet New:
BenchmarkExecuteVarBinary-4          300           4751125 ns/op
VTTablet Old:
BenchmarkExecuteVarBinary-4          100          14888528 ns/op
```
These numbers can further be improved as mentioned in the issue.
But the work to get to the next level is more involved.
