### PR TITLE
Upsert passthrough with one unique key

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -296,25 +296,36 @@
   "PKValues": [1, 2]
 }
 
-# on dup
+# on dup multiple unique index
+"insert into a (eid, id) values (1, 2) on duplicate key update name = func(a)"
+{
+  "PlanID": "UPSERT_PK",
+  "TableName": "a",
+  "FullQuery": "insert into a(eid, id) values (1, 2) on duplicate key update name = func(a)",
+  "OuterQuery": "insert into a(eid, id) values (1, 2)",
+  "UpsertQuery": "update a set name = func(a) where :#pk",
+  "PKValues": [1, 2]
+}
+
+# on dup single unique index
 "insert into b (eid, id) values (1, 2) on duplicate key update name = func(a)"
 {
   "PlanID": "UPSERT_PK",
+  "Reason": "UPSERT_SINGLE_INDEX",
   "TableName": "b",
   "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update name = func(a)",
-  "OuterQuery": "insert into b(eid, id) values (1, 2)",
-  "UpsertQuery": "update b set name = func(a) where :#pk",
+  "OuterQuery": "insert into b(eid, id) values (1, 2) on duplicate key update name = func(a)",
   "PKValues": [1, 2]
 }
 
 # on dup pk change
-"insert into b (eid, id) values (1, 2) on duplicate key update eid = 2"
+"insert into a (eid, id) values (1, 2) on duplicate key update eid = 2"
 {
   "PlanID": "UPSERT_PK",
-  "TableName": "b",
-  "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update eid = 2",
-  "OuterQuery": "insert into b(eid, id) values (1, 2)",
-  "UpsertQuery": "update b set eid = 2 where :#pk",
+  "TableName": "a",
+  "FullQuery": "insert into a(eid, id) values (1, 2) on duplicate key update eid = 2",
+  "OuterQuery": "insert into a(eid, id) values (1, 2)",
+  "UpsertQuery": "update a set eid = 2 where :#pk",
   "PKValues": [1, 2],
   "SecondaryPKValues": [2, null]
 }
@@ -396,13 +407,13 @@
 }
 
 # on dup pk change, with values() func
-"insert into b (eid, id) values (1, 2) on duplicate key update eid = values(eid), id = values(id)"
+"insert into a (eid, id) values (1, 2) on duplicate key update eid = values(eid), id = values(id)"
 {
   "PlanID": "UPSERT_PK",
-  "TableName": "b",
-  "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update eid = values(eid), id = values(id)",
-  "OuterQuery": "insert into b(eid, id) values (1, 2)",
-  "UpsertQuery": "update b set eid = 1, id = 2 where :#pk",
+  "TableName": "a",
+  "FullQuery": "insert into a(eid, id) values (1, 2) on duplicate key update eid = values(eid), id = values(id)",
+  "OuterQuery": "insert into a(eid, id) values (1, 2)",
+  "UpsertQuery": "update a set eid = 1, id = 2 where :#pk",
   "PKValues": [1, 2],
   "SecondaryPKValues": [1, 2]
 }
@@ -420,22 +431,33 @@
 }
 
 # on dup complex pk change
-"insert into b (id, eid) values (1, 2) on duplicate key update eid = func(a)"
+"insert into a (id, eid) values (1, 2) on duplicate key update eid = func(a)"
 {
   "PlanID": "PASS_DML",
   "Reason": "PK_CHANGE",
-  "TableName": "b",
-  "FullQuery": "insert into b(id, eid) values (1, 2) on duplicate key update eid = func(a)",
+  "TableName": "a",
+  "FullQuery": "insert into a(id, eid) values (1, 2) on duplicate key update eid = func(a)",
   "PKValues": [2, 1]
 }
 
-# on dup multi-row
-"insert into b (id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)"
+# on dup multi-row with multiple unique indexes
+"insert into a (id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)"
 {
   "PlanID": "PASS_DML",
-  "Reason": "UPSERT",
+  "Reason": "UPSERT_MULTI_ROW",
+  "TableName": "a",
+  "FullQuery": "insert into a(id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)",
+  "PKValues": [[2,3],[1,2]]
+}
+
+# on dup multi-row with 0-1 unique indexes
+"insert into b (id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)"
+{
+  "PlanID": "UPSERT_PK",
+  "Reason": "UPSERT_SINGLE_INDEX",
   "TableName": "b",
   "FullQuery": "insert into b(id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)",
+  "OuterQuery": "insert into b(id, eid) values (1, 2), (2, 3) on duplicate key update name = func(a)",
   "PKValues": [[2,3],[1,2]]
 }
 
@@ -443,7 +465,7 @@
 "insert into b (id, eid) select * from a on duplicate key update name = func(a)"
 {
   "PlanID": "PASS_DML",
-  "Reason": "UPSERT",
+  "Reason": "UPSERT_SUBQUERY",
   "TableName": "b",
   "FullQuery": "insert into b(id, eid) select * from a on duplicate key update name = func(a)"
 }

--- a/data/test/tabletserver/schema_test.json
+++ b/data/test/tabletserver/schema_test.json
@@ -26,6 +26,7 @@
     "Indexes": [
       {
         "Name": "PRIMARY",
+        "Unique": true,
         "Columns": [
           "eid",
           "id"
@@ -43,6 +44,7 @@
       },
       {
         "Name": "a_name",
+        "Unique": true,
         "Columns": [
           "eid",
           "name"
@@ -107,66 +109,7 @@
     "Indexes": [
       {
         "Name": "PRIMARY",
-        "Columns": [
-          "eid",
-          "id"
-        ],
-        "Cardinality": [
-          1,
-          1
-        ],
-        "DataColumns": [
-          "eid",
-          "id",
-          "name",
-          "foo"
-        ]
-      },
-      {
-        "Name": "a_name",
-        "Columns": [
-          "eid",
-          "name"
-        ],
-        "Cardinality": [
-          1,
-          1
-        ],
-        "DataColumns": [
-          "eid",
-          "name",
-          "id"
-        ]
-      },
-      {
-        "Name": "b_name",
-        "Columns": [
-          "name"
-        ],
-        "Cardinality": [
-          3
-        ],
-        "DataColumns": [
-          "name",
-          "eid",
-          "id"
-        ]
-      },
-      {
-        "Name": "c_name",
-        "Columns": [
-          "name"
-        ],
-        "Cardinality": [
-          2
-        ],
-        "DataColumns": [
-          "eid",
-          "id"
-        ]
-      },
-      {
-        "Name": "PRIMARY",
+        "Unique": true,
         "Columns": [
           "eid",
           "id"
@@ -226,6 +169,7 @@
     "Indexes": [
       {
         "Name": "PRIMARY",
+        "Unique": true,
         "Columns": [
           "name"
         ],
@@ -287,6 +231,7 @@
     "Indexes": [
       {
         "Name": "PRIMARY",
+        "Unique": true,
         "Columns": [
           "id"
         ],
@@ -330,6 +275,7 @@
     "Indexes": [
       {
         "Name": "PRIMARY",
+        "Unique": true,
         "Columns": [
           "time_scheduled",
           "id"

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -255,6 +255,21 @@
   }
 }
 
+# simple upsert unsharded
+"insert into unsharded values(1, 2) on duplicate key update x = 3"
+{
+  "Original": "insert into unsharded values(1, 2) on duplicate key update x = 3",
+  "Instructions": {
+    "Opcode": "InsertUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "insert into unsharded values (1, 2) on duplicate key update x = 3",
+    "Table": "unsharded"
+  }
+}
+
 # insert unsharded with select
 "insert into unsharded select id from unsharded_auto"
 {

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -389,6 +389,70 @@ func TestInsertSharded(t *testing.T) {
 	}
 }
 
+func TestUpsertSharded(t *testing.T) {
+	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
+
+	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname') on duplicate key update v = values(v) + 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries := []querytypes.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) on duplicate key update v = values(v) + 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{
+			"_Id0":   int64(1),
+			"_name0": []byte("myname"),
+			"__seq0": int64(1),
+		},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
+	}
+	if sbc2.Queries != nil {
+		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
+	}
+	wantQueries = []querytypes.BoundQuery{{
+		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		BindVariables: map[string]interface{}{
+			"name0":    []byte("myname"),
+			"user_id0": int64(1),
+		},
+	}}
+	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
+		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
+	}
+
+	sbc1.Queries = nil
+	sbclookup.Queries = nil
+	_, err = executorExec(executor, "insert into user(id, v, name) values (3, 2, 'myname2') on duplicate key update v = values(v) + 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries = []querytypes.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) on duplicate key update v = values(v) + 1 /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]interface{}{
+			"_Id0":   int64(3),
+			"__seq0": int64(3),
+			"_name0": []byte("myname2"),
+		},
+	}}
+	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
+		t.Errorf("sbc2.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
+	}
+	if sbc1.Queries != nil {
+		t.Errorf("sbc1.Queries: %+v, want nil\n", sbc1.Queries)
+	}
+	wantQueries = []querytypes.BoundQuery{{
+		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		BindVariables: map[string]interface{}{
+			"name0":    []byte("myname2"),
+			"user_id0": int64(3),
+		},
+	}}
+	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
+		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
+	}
+}
+
 func TestInsertComments(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 
@@ -924,6 +988,96 @@ func TestMultiInsertSharded(t *testing.T) {
 			"user_id0": uint64(1),
 			"name1":    []byte("myname2"),
 			"user_id1": uint64(2),
+		},
+	}}
+	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
+		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v\n", sbclookup.Queries, wantQueries)
+	}
+}
+
+func TestMultiUpsertSharded(t *testing.T) {
+	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
+
+	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 1, 'myname1'),(3, 3, 'myname3') on duplicate key update v = values(v) + 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries1 := []querytypes.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id0, 1, :_name0) on duplicate key update v = values(v) + 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]interface{}{
+			"_Id0":   int64(1),
+			"_name0": []byte("myname1"),
+			"__seq0": int64(1),
+			"_Id1":   int64(3),
+			"_name1": []byte("myname3"),
+			"__seq1": int64(3),
+		},
+	}}
+
+	wantQueries2 := []querytypes.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id1, 3, :_name1) on duplicate key update v = values(v) + 1 /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]interface{}{
+			"_Id0":   int64(1),
+			"_name0": []byte("myname1"),
+			"__seq0": int64(1),
+			"_Id1":   int64(3),
+			"_name1": []byte("myname3"),
+			"__seq1": int64(3),
+		},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries1) {
+		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries1)
+	}
+
+	if !reflect.DeepEqual(sbc2.Queries, wantQueries2) {
+		t.Errorf("sbc2.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries2)
+	}
+
+	wantQueries1 = []querytypes.BoundQuery{{
+		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		BindVariables: map[string]interface{}{
+			"name0":    []byte("myname1"),
+			"user_id0": int64(1),
+			"name1":    []byte("myname3"),
+			"user_id1": int64(3),
+		},
+	}}
+	if !reflect.DeepEqual(sbclookup.Queries, wantQueries1) {
+		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries1)
+	}
+
+	sbc1.Queries = nil
+	sbclookup.Queries = nil
+	sbc2.Queries = nil
+	_, err = executorExec(executor, "insert into user(id, v, name) values (1, 1, 'myname1'),(2, 2, 'myname2') on duplicate key update v = values(v) + 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries := []querytypes.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id0, 1, :_name0),(:_Id1, 2, :_name1) on duplicate key update v = values(v) + 1 /* vtgate:: keyspace_id:166b40b44aba4bd6,06e7ea22ce92708f */",
+		BindVariables: map[string]interface{}{
+			"_Id0":   int64(1),
+			"__seq0": int64(1),
+			"_name0": []byte("myname1"),
+			"_Id1":   int64(2),
+			"__seq1": int64(2),
+			"_name1": []byte("myname2"),
+		},
+	}}
+
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
+	}
+	if sbc2.Queries != nil {
+		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
+	}
+	wantQueries = []querytypes.BoundQuery{{
+		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0), (:name1, :user_id1)",
+		BindVariables: map[string]interface{}{
+			"name0":    []byte("myname1"),
+			"user_id0": int64(1),
+			"name1":    []byte("myname2"),
+			"user_id1": int64(2),
 		},
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {

--- a/go/vt/vttablet/tabletserver/codex_test.go
+++ b/go/vt/vttablet/tabletserver/codex_test.go
@@ -487,7 +487,7 @@ func setPK(ta *schema.Table, colnames []string) error {
 	if len(ta.Indexes) != 0 {
 		panic("setPK must be called before adding other indexes")
 	}
-	pkIndex := ta.AddIndex("PRIMARY")
+	pkIndex := ta.AddIndex("PRIMARY", true)
 	for _, colname := range colnames {
 		pkIndex.AddColumn(colname, 1)
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -158,8 +158,10 @@ const (
 	ReasonTableNoIndex
 	ReasonPKChange
 	ReasonComplexExpr
-	ReasonUpsert
+	ReasonUpsertSubquery
+	ReasonUpsertSafePassthrough
 	ReasonUpsertColMismatch
+	ReasonUpsertMultiRow
 	ReasonReplace
 	ReasonMultiTable
 )
@@ -171,8 +173,10 @@ var reasonName = []string{
 	"TABLE_NOINDEX",
 	"PK_CHANGE",
 	"COMPLEX_EXPR",
-	"UPSERT",
+	"UPSERT_SUBQUERY",
+	"UPSERT_SAFE_PASSTHROUGH",
 	"UPSERT_COL_MISMATCH",
+	"UPSERT_MULTI_ROW",
 	"REPLACE",
 	"MULTI_TABLE",
 }

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -536,6 +536,11 @@ func (qre *QueryExecutor) execUpsertPK(conn *TxConnection) (*sqltypes.Result, er
 		return qre.txFetch(conn, qre.plan.FullQuery, qre.bindVars, nil, false, true)
 	}
 
+	// For tables that don't have multiple unique keys, upserts are safe to pass through
+	if qre.plan.Reason == planbuilder.ReasonUpsertSafePassthrough {
+		return qre.execInsertPK(conn)
+	}
+
 	// For statement or mixed mode, we have to split into two ops.
 	pkRows, err := buildValueList(qre.plan.Table, qre.plan.PKValues, qre.bindVars)
 	if err != nil {

--- a/go/vt/vttablet/tabletserver/schema/load_table.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table.go
@@ -90,7 +90,11 @@ func fetchIndexes(ta *Table, conn *connpool.DBConn, sqlTableName string) error {
 	for _, row := range indexes.Rows {
 		indexName := row[2].String()
 		if currentName != indexName {
-			currentIndex = ta.AddIndex(indexName)
+			nonUnique, err := row[1].ParseUint64()
+			if err != nil {
+				log.Errorf("Table: %s, index Non_unique column is not integral type", ta.Name)
+			}
+			currentIndex = ta.AddIndex(indexName, nonUnique == 0)
 			currentName = indexName
 		}
 		var cardinality uint64

--- a/go/vt/vttablet/tabletserver/schema/load_table_test.go
+++ b/go/vt/vttablet/tabletserver/schema/load_table_test.go
@@ -49,6 +49,12 @@ func TestLoadTable(t *testing.T) {
 	if len(table.PKColumns) != 1 {
 		t.Fatalf("table should have one PK column although the cardinality is invalid")
 	}
+	if len(table.Indexes) != 3 {
+		t.Fatalf("table should have three indexes")
+	}
+	if count := table.UniqueIndexes(); count != 2 {
+		t.Errorf("table.UniqueIndexes(): %d expected 2", count)
+	}
 	if idx := table.Indexes[0].FindColumn(sqlparser.NewColIdent("pk")); idx != 0 {
 		t.Errorf("table.Indexes[0].FindColumn(pk): %d, want 0", idx)
 	}
@@ -57,6 +63,27 @@ func TestLoadTable(t *testing.T) {
 	}
 	if name := table.GetPKColumn(0).Name.String(); name != "pk" {
 		t.Errorf("table.GetPKColumn(0): %s, want pk", name)
+	}
+	if unique := table.Indexes[0].Unique; unique != true {
+		t.Errorf("table.Indexes[0].Unique: expected true")
+	}
+	if idx := table.Indexes[1].FindColumn(sqlparser.NewColIdent("pk")); idx != 0 {
+		t.Errorf("table.Indexes[1].FindColumn(pk): %d, want 0", idx)
+	}
+	if idx := table.Indexes[1].FindColumn(sqlparser.NewColIdent("name")); idx != 1 {
+		t.Errorf("table.Indexes[1].FindColumn(name): %d, want 1", idx)
+	}
+	if idx := table.Indexes[1].FindColumn(sqlparser.NewColIdent("addr")); idx != -1 {
+		t.Errorf("table.Indexes[1].FindColumn(pk): %d, want -1", idx)
+	}
+	if unique := table.Indexes[1].Unique; unique != true {
+		t.Errorf("table.Indexes[1].Unique: expected true")
+	}
+	if idx := table.Indexes[2].FindColumn(sqlparser.NewColIdent("addr")); idx != 0 {
+		t.Errorf("table.Indexes[1].FindColumn(addr): %d, want 0", idx)
+	}
+	if unique := table.Indexes[2].Unique; unique != false {
+		t.Errorf("table.Indexes[2].Unique: expected false")
 	}
 }
 
@@ -219,6 +246,7 @@ func getTestLoadTableQueries() map[string]*sqltypes.Result {
 				mysql.ShowIndexFromTableRow("test_table", true, "PRIMARY", 1, "pk", false),
 				mysql.ShowIndexFromTableRow("test_table", true, "index", 1, "pk", false),
 				mysql.ShowIndexFromTableRow("test_table", true, "index", 2, "name", false),
+				mysql.ShowIndexFromTableRow("test_table", false, "index2", 1, "addr", false),
 			},
 		},
 	}

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -205,7 +205,7 @@ func (ta *Table) HasPrimary() bool {
 func (ta *Table) UniqueIndexes() int {
 	unique := 0
 	for _, idx := range ta.Indexes {
-		if (idx.Unique) {
+		if idx.Unique {
 			unique++
 		}
 	}
@@ -214,7 +214,7 @@ func (ta *Table) UniqueIndexes() int {
 
 // Index contains info about a table index.
 type Index struct {
-	Name sqlparser.ColIdent
+	Name   sqlparser.ColIdent
 	Unique bool
 	// Columns are the columns comprising the index.
 	Columns []sqlparser.ColIdent

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -176,8 +176,8 @@ func (ta *Table) GetPKColumn(index int) *TableColumn {
 }
 
 // AddIndex adds an index to the table.
-func (ta *Table) AddIndex(name string) (index *Index) {
-	index = NewIndex(name)
+func (ta *Table) AddIndex(name string, unique bool) (index *Index) {
+	index = NewIndex(name, unique)
 	ta.Indexes = append(ta.Indexes, index)
 	return index
 }
@@ -201,9 +201,21 @@ func (ta *Table) HasPrimary() bool {
 	return len(ta.Indexes) != 0 && ta.Indexes[0].Name.EqualString("primary")
 }
 
+// UniqueIndexes returns the number of unique indexes on the table
+func (ta *Table) UniqueIndexes() int {
+	unique := 0
+	for _, idx := range ta.Indexes {
+		if (idx.Unique) {
+			unique++
+		}
+	}
+	return unique
+}
+
 // Index contains info about a table index.
 type Index struct {
 	Name sqlparser.ColIdent
+	Unique bool
 	// Columns are the columns comprising the index.
 	Columns []sqlparser.ColIdent
 	// Cardinality[i] is the number of distinct values of Columns[i] in the
@@ -212,8 +224,8 @@ type Index struct {
 }
 
 // NewIndex creates a new Index.
-func NewIndex(name string) *Index {
-	return &Index{Name: sqlparser.NewColIdent(name)}
+func NewIndex(name string, unique bool) *Index {
+	return &Index{Name: sqlparser.NewColIdent(name), Unique: unique}
 }
 
 // AddColumn adds a column to the index.

--- a/go/vt/vttablet/tabletserver/schema/schemaz_test.go
+++ b/go/vt/vttablet/tabletserver/schema/schemaz_test.go
@@ -36,11 +36,11 @@ func TestSchamazHandler(t *testing.T) {
 	tableD := NewTable("c")
 
 	tableA.AddColumn("column1", sqltypes.Int64, sqltypes.MakeTrusted(sqltypes.Int32, []byte("0")), "auto_increment")
-	tableA.AddIndex("index1").AddColumn("index_column", 1000)
+	tableA.AddIndex("index1", true).AddColumn("index_column", 1000)
 	tableA.Type = NoType
 
 	tableB.AddColumn("column2", sqltypes.VarChar, sqltypes.MakeString([]byte("NULL")), "")
-	tableB.AddIndex("index2").AddColumn("index_column2", 200)
+	tableB.AddIndex("index2", true).AddColumn("index_column2", 200)
 	tableB.Type = Sequence
 
 	tableC.Type = Message


### PR DESCRIPTION
As discussed in #2951 the current handling of upsert queries doesn't accept multiple rows in a single query in SBR mode because it is trying to split into separate INSERT and UPDATE statements.

Since it is safe to pass through the queries even in SBR mode if the table only has one unique key, modify the query executor to track the number of unique indexes on each table and pass through any upsert query, including those with multiple rows, on tables where there is only one unique index.
