### PR TITLE
vttablet: add a tableacl health reporter

### DIFF
--- a/go/vt/health/health.go
+++ b/go/vt/health/health.go
@@ -134,8 +134,7 @@ func (ag *Aggregator) Report(isSlaveType, shouldQueryServiceBeRunning bool) (tim
 	return result, err
 }
 
-// Register registers rep with ag. Only keys specified in keys will be
-// aggregated from this particular Reporter.
+// Register registers rep with ag.
 func (ag *Aggregator) Register(name string, rep Reporter) {
 	ag.mu.Lock()
 	defer ag.mu.Unlock()
@@ -143,7 +142,11 @@ func (ag *Aggregator) Register(name string, rep Reporter) {
 		panic("reporter named " + name + " is already registered")
 	}
 	ag.reporters[name] = rep
+}
 
+// RegisterSimpleCheck registers a simple health check function.
+func (ag *Aggregator) RegisterSimpleCheck(name string, check func() error) {
+	ag.Register(name, simpleReporter{html: template.HTML(name), check: check})
 }
 
 // HTMLName returns an aggregate name for all the reporters
@@ -156,4 +159,17 @@ func (ag *Aggregator) HTMLName() template.HTML {
 	}
 	sort.Strings(result)
 	return template.HTML(strings.Join(result, "&nbsp; + &nbsp;"))
+}
+
+type simpleReporter struct {
+	html  template.HTML
+	check func() error
+}
+
+func (s simpleReporter) HTMLName() template.HTML {
+	return s.html
+}
+
+func (s simpleReporter) Report(bool, bool) (time.Duration, error) {
+	return 0, s.check()
 }

--- a/go/vt/health/health_test.go
+++ b/go/vt/health/health_test.go
@@ -18,51 +18,42 @@ package health
 
 import (
 	"errors"
+	"html/template"
 	"testing"
 	"time"
 )
 
 func TestReporters(t *testing.T) {
-
-	// two aggregators returning valid numbers
-	ag := NewAggregator()
-	ag.Register("a", FunctionReporter(func(bool, bool) (time.Duration, error) {
-		return 10 * time.Second, nil
-	}))
-	ag.Register("b", FunctionReporter(func(bool, bool) (time.Duration, error) {
-		return 5 * time.Second, nil
-	}))
-	delay, err := ag.Report(true, true)
-	if err != nil {
-		t.Error(err)
+	tests := []struct {
+		isSlaveType                 bool
+		shouldQueryServiceBeRunning bool
+		delay1                      time.Duration
+		delay2                      time.Duration
+		err                         error
+		wantDelay                   time.Duration
+		strict                      bool
+	}{
+		{true, true, 10 * time.Second, 5 * time.Second, nil, 10 * time.Second, false},
+		{true, false, 10 * time.Second, 5 * time.Second, errors.New("oops"), 0, false},
+		{true, false, 10 * time.Second, 5 * time.Second, ErrSlaveNotRunning, 10 * time.Second, true},
 	}
-	if delay != 10*time.Second {
-		t.Errorf("delay=%v, want 10s", delay)
-	}
-
-	// three aggregators, third one returning an error
-	cReturns := errors.New("e error")
-	ag.Register("c", FunctionReporter(func(bool, bool) (time.Duration, error) {
-		return 0, cReturns
-	}))
-	if _, err := ag.Report(true, false); err == nil {
-		t.Errorf("ag.Run: expected error")
-	} else {
-		want := "c: e error"
-		if got := err.Error(); got != want {
-			t.Errorf("got wrong error: got '%v' expected '%v'", got, want)
+	for _, test := range tests {
+		ag := NewAggregator()
+		ag.Register("1", FunctionReporter(func(bool, bool) (time.Duration, error) {
+			return test.delay1, nil
+		}))
+		ag.Register("2", FunctionReporter(func(bool, bool) (time.Duration, error) {
+			return test.delay2, nil
+		}))
+		ag.RegisterSimpleCheck("simplecheck", func() error { return test.err })
+		delay, err := ag.Report(test.isSlaveType, test.shouldQueryServiceBeRunning)
+		if delay != test.wantDelay || test.strict && err != test.err || (err == nil) != (test.err == nil) {
+			t.Errorf("ag.Report(%v, %v) = (%v, %v), want (%v, %v)",
+				test.isSlaveType, test.shouldQueryServiceBeRunning, delay, err, test.wantDelay, test.err)
 		}
-	}
-
-	// three aggregators, third one returning ErrSlaveNotRunning
-	cReturns = ErrSlaveNotRunning
-	if _, err := ag.Report(true, false); err != ErrSlaveNotRunning {
-		t.Errorf("ag.Run: expected error: %v", err)
-	}
-
-	// check name is good
-	name := ag.HTMLName()
-	if string(name) != "FunctionReporter&nbsp; + &nbsp;FunctionReporter&nbsp; + &nbsp;FunctionReporter" {
-		t.Errorf("ag.HTMLName() returned: %v", name)
+		wantHTML := template.HTML("FunctionReporter&nbsp; + &nbsp;FunctionReporter&nbsp; + &nbsp;simplecheck")
+		if got, want := ag.HTMLName(), wantHTML; got != want {
+			t.Errorf("ag.HTMLName() = %v, want %v", got, want)
+		}
 	}
 }

--- a/go/vt/tableacl/tableacl_test.go
+++ b/go/vt/tableacl/tableacl_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package tableacl
 
 import (
-	"fmt"
+	"errors"
+	"io"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"reflect"
 	"testing"
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	"github.com/youtube/vitess/go/vt/health"
 	"github.com/youtube/vitess/go/vt/tableacl/acl"
 	"github.com/youtube/vitess/go/vt/tableacl/simpleacl"
 
@@ -37,12 +38,12 @@ import (
 type fakeACLFactory struct{}
 
 func (factory *fakeACLFactory) New(entries []string) (acl.ACL, error) {
-	return nil, fmt.Errorf("unable to create a new ACL")
+	return nil, errors.New("unable to create a new ACL")
 }
 
 func TestInitWithInvalidFilePath(t *testing.T) {
-	setUpTableACL(&simpleacl.Factory{})
-	if err := Init("/invalid_file_path", func() {}); err == nil {
+	tacl := tableACL{factory: &simpleacl.Factory{}}
+	if err := tacl.init("/invalid_file_path", func() {}); err == nil {
 		t.Fatalf("init should fail for an invalid config file path")
 	}
 }
@@ -59,33 +60,26 @@ var aclJSON = `{
 }`
 
 func TestInitWithValidConfig(t *testing.T) {
-	setUpTableACL(&simpleacl.Factory{})
+	tacl := tableACL{factory: &simpleacl.Factory{}}
 	f, err := ioutil.TempFile("", "tableacl")
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 	defer os.Remove(f.Name())
-	n, err := f.WriteString(aclJSON)
-	if err != nil {
-		t.Error(err)
-		return
+	if _, err := io.WriteString(f, aclJSON); err != nil {
+		t.Fatal(err)
 	}
-	if n != len(aclJSON) {
-		t.Error("short write")
-		return
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
-	err = f.Close()
-	if err != nil {
-		t.Error(err)
-		return
+	if err := tacl.init(f.Name(), func() {}); err != nil {
+		t.Fatal(err)
 	}
-	Init(f.Name(), func() {})
 }
 
 func TestInitFromProto(t *testing.T) {
-	setUpTableACL(&simpleacl.Factory{})
-	readerACL := Authorized("my_test_table", READER)
+	tacl := tableACL{factory: &simpleacl.Factory{}}
+	readerACL := tacl.Authorized("my_test_table", READER)
 	want := &ACLResult{ACL: acl.DenyAllACL{}, GroupName: ""}
 	if !reflect.DeepEqual(readerACL, want) {
 		t.Fatalf("tableacl has not been initialized, got: %v, want: %v", readerACL, want)
@@ -97,20 +91,17 @@ func TestInitFromProto(t *testing.T) {
 			Readers:              []string{"vt"},
 		}},
 	}
-	if err := InitFromProto(config); err != nil {
+	if err := tacl.Set(config); err != nil {
 		t.Fatalf("tableacl init should succeed, but got error: %v", err)
 	}
-
-	if !proto.Equal(GetCurrentConfig(), config) {
-		t.Fatalf("GetCurrentConfig() = %v, want: %v", GetCurrentConfig(), config)
+	if got := tacl.Config(); !proto.Equal(got, config) {
+		t.Fatalf("GetCurrentConfig() = %v, want: %v", got, config)
 	}
-
-	readerACL = Authorized("unknown_table", READER)
+	readerACL = tacl.Authorized("unknown_table", READER)
 	if !reflect.DeepEqual(readerACL, want) {
 		t.Fatalf("there is no config for unknown_table, should deny by default")
 	}
-
-	readerACL = Authorized("test_table", READER)
+	readerACL = tacl.Authorized("test_table", READER)
 	if !readerACL.IsMember(&querypb.VTGateCallerID{Username: "vt"}) {
 		t.Fatalf("user: vt should have reader permission to table: test_table")
 	}
@@ -151,7 +142,7 @@ func TestTableACLValidateConfig(t *testing.T) {
 }
 
 func TestTableACLAuthorize(t *testing.T) {
-	setUpTableACL(&simpleacl.Factory{})
+	tacl := tableACL{factory: &simpleacl.Factory{}}
 	config := &tableaclpb.Config{
 		TableGroups: []*tableaclpb.TableGroupSpec{
 			{
@@ -184,11 +175,11 @@ func TestTableACLAuthorize(t *testing.T) {
 			},
 		},
 	}
-	if err := InitFromProto(config); err != nil {
+	if err := tacl.Set(config); err != nil {
 		t.Fatalf("InitFromProto(<data>) = %v, want: nil", err)
 	}
 
-	readerACL := Authorized("test_data_any", READER)
+	readerACL := tacl.Authorized("test_data_any", READER)
 	if !readerACL.IsMember(&querypb.VTGateCallerID{Username: "u1"}) {
 		t.Fatalf("user u1 should have reader permission to table test_data_any")
 	}
@@ -198,7 +189,7 @@ func TestTableACLAuthorize(t *testing.T) {
 }
 
 func TestFailedToCreateACL(t *testing.T) {
-	setUpTableACL(&fakeACLFactory{})
+	tacl := tableACL{factory: &fakeACLFactory{}}
 	config := &tableaclpb.Config{
 		TableGroups: []*tableaclpb.TableGroupSpec{{
 			Name:                 "group01",
@@ -207,14 +198,13 @@ func TestFailedToCreateACL(t *testing.T) {
 			Writers:              []string{"vt"},
 		}},
 	}
-	if err := InitFromProto(config); err == nil {
+	if err := tacl.Set(config); err == nil {
 		t.Fatalf("tableacl init should fail because fake ACL returns an error")
 	}
 }
 
 func TestDoubleRegisterTheSameKey(t *testing.T) {
-	acls = make(map[string]acl.Factory)
-	name := fmt.Sprintf("tableacl-name-%d", rand.Int63())
+	name := "tableacl-name-TestDoubleRegisterTheSameKey"
 	Register(name, &simpleacl.Factory{})
 	defer func() {
 		err := recover()
@@ -225,12 +215,12 @@ func TestDoubleRegisterTheSameKey(t *testing.T) {
 	Register(name, &simpleacl.Factory{})
 }
 
-func TestGetAclFactory(t *testing.T) {
+func TestGetCurrentAclFactory(t *testing.T) {
 	acls = make(map[string]acl.Factory)
 	defaultACL = ""
-	name := fmt.Sprintf("tableacl-name-%d", rand.Int63())
+	name := "tableacl-name-TestGetCurrentAclFactory"
 	aclFactory := &simpleacl.Factory{}
-	Register(name, aclFactory)
+	Register(name+"-1", aclFactory)
 	f, err := GetCurrentAclFactory()
 	if err != nil {
 		t.Errorf("Fail to get current ACL Factory: %v", err)
@@ -238,20 +228,20 @@ func TestGetAclFactory(t *testing.T) {
 	if !reflect.DeepEqual(aclFactory, f) {
 		t.Fatalf("should return registered acl factory even if default acl is not set.")
 	}
-	Register(name+"2", aclFactory)
+	Register(name+"-2", aclFactory)
 	_, err = GetCurrentAclFactory()
 	if err == nil {
 		t.Fatalf("there are more than one acl factories, but the default is not set")
 	}
 }
 
-func TestGetAclFactoryWithWrongDefault(t *testing.T) {
+func TestGetCurrentAclFactoryWithWrongDefault(t *testing.T) {
 	acls = make(map[string]acl.Factory)
 	defaultACL = ""
-	name := fmt.Sprintf("tableacl-name-%d", rand.Int63())
+	name := "tableacl-name-TestGetCurrentAclFactoryWithWrongDefault"
 	aclFactory := &simpleacl.Factory{}
-	Register(name, aclFactory)
-	Register(name+"2", aclFactory)
+	Register(name+"-1", aclFactory)
+	Register(name+"-2", aclFactory)
 	SetDefaultACL("wrong_name")
 	_, err := GetCurrentAclFactory()
 	if err == nil {
@@ -259,12 +249,47 @@ func TestGetAclFactoryWithWrongDefault(t *testing.T) {
 	}
 }
 
-func setUpTableACL(factory acl.Factory) {
-	name := fmt.Sprintf("tableacl-name-%d", rand.Int63())
-	Register(name, factory)
-	SetDefaultACL(name)
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
+func TestHealthWithACL(t *testing.T) {
+	tacl := tableACL{factory: &simpleacl.Factory{}}
+	ha := health.NewAggregator()
+	tests := []struct {
+		config *tableaclpb.Config
+		wantOK bool
+	}{
+		{
+			config: nil,
+			wantOK: false,
+		},
+		{
+			config: &tableaclpb.Config{
+				TableGroups: []*tableaclpb.TableGroupSpec{{
+					Name:                 "group01",
+					TableNamesOrPrefixes: []string{"test_table"},
+					Readers:              []string{"vt"},
+					Writers:              []string{"vt"},
+				}}},
+			wantOK: true,
+		},
+		{
+			config: &tableaclpb.Config{},
+			wantOK: true,
+		},
+	}
+	ha.RegisterSimpleCheck("tableacl", func() error { return checkHealth(&tacl) })
+	for _, test := range tests {
+		if test.config != nil {
+			if err := tacl.Set(test.config); err != nil {
+				t.Fatalf("tacl.Set(%#v) = %v, want %v", test.config, err, nil)
+			}
+		}
+		delay, err := ha.Report(true, true)
+		wantErr := error(nil)
+		if !test.wantOK {
+			wantErr = errors.New("<not nil>")
+		}
+		wantDelay := time.Duration(0)
+		if delay != wantDelay || (err == nil) != test.wantOK {
+			t.Errorf("ha.Report(true, true) == (%v, %v), want (%v, %v)", delay, err, wantDelay, wantErr)
+		}
+	}
 }


### PR DESCRIPTION
Currently if tableacls are not loaded or are empty for whatever reason, vttablet will reject all requests that check tableacl for access, but the health may be reported as perfectly fine. Add a health check so that we won't report good health until a tableacl is loaded successfully.

Also refactored for cleaner testing and added a test.