### PR TITLE
mysql server timing metrics and logging improvements

### DIFF
--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -614,7 +614,7 @@ func (c *Conn) ID() int64 {
 }
 
 // Ident returns a useful identification string for error logging
-func (c *Conn) Ident() string {
+func (c *Conn) String() string {
 	return fmt.Sprintf("client %v (%s)", c.ConnectionID, c.RemoteAddr().String())
 }
 

--- a/go/mysql/conn.go
+++ b/go/mysql/conn.go
@@ -613,6 +613,11 @@ func (c *Conn) ID() int64 {
 	return int64(c.ConnectionID)
 }
 
+// Ident returns a useful identification string for error logging
+func (c *Conn) Ident() string {
+	return fmt.Sprintf("client %v (%s)", c.ConnectionID, c.RemoteAddr().String())
+}
+
 // Close closes the connection. It can be called from a different go
 // routine to interrupt the current connection.
 func (c *Conn) Close() {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -47,7 +47,7 @@ var (
 	connAccept = stats.NewInt("MysqlServerConnAccepted")
 	connSlow   = stats.NewInt("MysqlServerConnSlow")
 
-	// SlowConnectWarnThreshold, if non-nil, specifies an amount of time
+	// SlowConnectWarnThreshold if non-nil, specifies an amount of time
 	// beyond which a warning is logged to identify the slow connection
 	SlowConnectWarnThreshold *time.Duration
 )

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -35,9 +35,9 @@ const (
 	// Can be changed.
 	DefaultServerVersion = "5.5.10-Vitess"
 
-	// Timing metric keys
-	ConnectTiming = "Connect"
-	QueryTiming   = "Query"
+	// timing metric keys
+	connectTimingKey = "Connect"
+	queryTimingKey   = "Query"
 )
 
 var (
@@ -47,7 +47,8 @@ var (
 	connAccept = stats.NewInt("MysqlServerConnAccepted")
 	connSlow   = stats.NewInt("MysqlServerConnSlow")
 
-	// If non-nil, warn if it takes more than the given amount of time to connect
+	// SlowConnectWarnThreshold, if non-nil, specifies an amount of time
+	// beyond which a warning is logged to identify the slow connection
 	SlowConnectWarnThreshold *time.Duration
 )
 
@@ -283,7 +284,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 	}
 
 	// Record how long we took to establish the connection
-	timings.Record(ConnectTiming, acceptTime)
+	timings.Record(connectTimingKey, acceptTime)
 
 	// Log a warning if it took too long to connect
 	connectTime := time.Since(acceptTime)
@@ -374,7 +375,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 				}
 			}
 
-			timings.Record(QueryTiming, queryStart)
+			timings.Record(queryTimingKey, queryStart)
 
 		case ComPing:
 			// No payload to that one, just return OKPacket.

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -46,10 +46,6 @@ var (
 	connCount  = stats.NewInt("MysqlServerConnCount")
 	connAccept = stats.NewInt("MysqlServerConnAccepted")
 	connSlow   = stats.NewInt("MysqlServerConnSlow")
-
-	// SlowConnectWarnThreshold if non-nil, specifies an amount of time
-	// beyond which a warning is logged to identify the slow connection
-	SlowConnectWarnThreshold *time.Duration
 )
 
 // A Handler is an interface used by Listener to send queries.
@@ -109,6 +105,10 @@ type Listener struct {
 	// mysql_clear_password authentication method to be accepted
 	// by the server when TLS is not in use.
 	AllowClearTextWithoutTLS bool
+
+	// SlowConnectWarnThreshold if non-zero specifies an amount of time
+	// beyond which a warning is logged to identify the slow connection
+	SlowConnectWarnThreshold time.Duration
 
 	// The following parameters are changed by the Accept routine.
 
@@ -288,7 +288,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 
 	// Log a warning if it took too long to connect
 	connectTime := time.Since(acceptTime)
-	if SlowConnectWarnThreshold != nil && connectTime > *SlowConnectWarnThreshold {
+	if l.SlowConnectWarnThreshold != 0 && connectTime > l.SlowConnectWarnThreshold {
 		connSlow.Add(1)
 		log.Warningf("Slow connection from %s: %v", c.Ident(), connectTime)
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -232,8 +232,7 @@ func TestServer(t *testing.T) {
 	initialConnAccept := connAccept.Get()
 	initialConnSlow := connSlow.Get()
 
-	slowConnectThreshold := time.Duration(time.Nanosecond * 1)
-	SlowConnectWarnThreshold = &slowConnectThreshold
+	l.SlowConnectWarnThreshold = time.Duration(time.Nanosecond * 1)
 
 	// Run an 'error' command.
 	output, ok := runMysql(t, params, "error")
@@ -269,7 +268,7 @@ func TestServer(t *testing.T) {
 	}
 
 	// Set the slow connect threshold to something high that we don't expect to trigger
-	slowConnectThreshold = time.Duration(time.Second * 1)
+	l.SlowConnectWarnThreshold = time.Duration(time.Second * 1)
 
 	// Run a 'panic' command, other side should panic, recover and
 	// close the connection.

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -255,9 +255,9 @@ func TestServer(t *testing.T) {
 	}
 
 	expectedTimingDeltas := map[string]int64{
-		"All":         2,
-		ConnectTiming: 1,
-		QueryTiming:   1,
+		"All":            2,
+		connectTimingKey: 1,
+		queryTimingKey:   1,
 	}
 	gotTimingCounts := timings.Counts()
 	for key, got := range gotTimingCounts {

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -227,6 +227,9 @@ func TestServer(t *testing.T) {
 		Pass:  "password1",
 	}
 
+	initialTimingCounts := timings.Counts()
+	initialConnAccept := connAccept.Get()
+
 	// Run an 'error' command.
 	output, ok := runMysql(t, params, "error")
 	if ok {
@@ -235,6 +238,26 @@ func TestServer(t *testing.T) {
 	if !strings.Contains(output, "ERROR 1047 (08S01)") ||
 		!strings.Contains(output, "forced query handling error for") {
 		t.Errorf("Unexpected output for 'error'")
+	}
+	if connCount.Get() != 0 {
+		t.Errorf("Expected ConnCount=0, got %d", connCount.Get())
+	}
+	if connAccept.Get()-initialConnAccept != 1 {
+		t.Errorf("Expected ConnAccept delta=1, got %d", connAccept.Get()-initialConnAccept)
+	}
+
+	expectedTimingDeltas := map[string]int64{
+		"All":         2,
+		ConnectTiming: 1,
+		QueryTiming:   1,
+	}
+	gotTimingCounts := timings.Counts()
+	for key, got := range gotTimingCounts {
+		expected := expectedTimingDeltas[key]
+		delta := got - initialTimingCounts[key]
+		if delta != expected {
+			t.Errorf("Expected Timing count delta %s = %d, got %d", key, expected, delta)
+		}
 	}
 
 	// Run a 'panic' command, other side should panic, recover and
@@ -246,6 +269,12 @@ func TestServer(t *testing.T) {
 	if !strings.Contains(output, "ERROR 2013 (HY000)") ||
 		!strings.Contains(output, "Lost connection to MySQL server during query") {
 		t.Errorf("Unexpected output for 'panic'")
+	}
+	if connCount.Get() != 0 {
+		t.Errorf("Expected ConnCount=0, got %d", connCount.Get())
+	}
+	if connAccept.Get()-initialConnAccept != 2 {
+		t.Errorf("Expected ConnAccept=2, got %d", connAccept.Get()-initialConnAccept)
 	}
 
 	// Run a 'select rows' command with results.

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -129,12 +129,6 @@ func initMySQLProtocol() {
 		return
 	}
 
-	// Check for the connection threshold
-	if mysqlSlowConnectWarnThreshold.Nanoseconds() != 0 {
-		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
-		mysql.SlowConnectWarnThreshold = mysqlSlowConnectWarnThreshold
-	}
-
 	// Initialize registered AuthServer implementations (or other plugins)
 	for _, initFn := range pluginInitializers {
 		initFn()
@@ -156,6 +150,12 @@ func initMySQLProtocol() {
 		}
 	}
 	mysqlListener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
+
+	// Check for the connection threshold
+	if mysqlSlowConnectWarnThreshold.Nanoseconds() != 0 {
+		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
+		mysqlListener.SlowConnectWarnThreshold = *mysqlSlowConnectWarnThreshold
+	}
 
 	// And starts listening.
 	go func() {

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -42,6 +42,8 @@ var (
 	mysqlSslCert = flag.String("mysql_server_ssl_cert", "", "Path to the ssl cert for mysql server plugin SSL")
 	mysqlSslKey  = flag.String("mysql_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
 	mysqlSslCa   = flag.String("mysql_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
+
+	mysqlSlowConnectWarnThreshold = flag.Duration("mysql_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
 )
 
 // vtgateHandler implements the Listener interface.
@@ -125,6 +127,12 @@ func initMySQLProtocol() {
 	// If no VTGate was created, just return.
 	if rpcVTGate == nil {
 		return
+	}
+
+	// Check for the connection threshold
+	if mysqlSlowConnectWarnThreshold.Nanoseconds() != 0 {
+		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
+		mysql.SlowConnectWarnThreshold = mysqlSlowConnectWarnThreshold
 	}
 
 	// Initialize registered AuthServer implementations (or other plugins)

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -152,7 +152,7 @@ func initMySQLProtocol() {
 	mysqlListener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
 
 	// Check for the connection threshold
-	if mysqlSlowConnectWarnThreshold.Nanoseconds() != 0 {
+	if mysqlSlowConnectWarnThreshold != 0 {
 		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
 		mysqlListener.SlowConnectWarnThreshold = *mysqlSlowConnectWarnThreshold
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -152,7 +152,7 @@ func initMySQLProtocol() {
 	mysqlListener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
 
 	// Check for the connection threshold
-	if mysqlSlowConnectWarnThreshold != 0 {
+	if *mysqlSlowConnectWarnThreshold != 0 {
 		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
 		mysqlListener.SlowConnectWarnThreshold = *mysqlSlowConnectWarnThreshold
 	}


### PR DESCRIPTION
Three related changes to the mysql server implementation:

1. Add counters for the number of active mysql connections and the total accepted connections since the start of the process.
2. Include the remote IP/port as well as the ConnectionID when logging errors from mysql clients.
3. Add an option to set a connect time threshold such that connections that take too long to establish log a warning.
