### PR TITLE
Adding VT_MYSQL_BASEDIR environment variable

### DIFF
--- a/go/vt/env/env.go
+++ b/go/vt/env/env.go
@@ -74,3 +74,19 @@ func VtMysqlRoot() (string, error) {
 	}
 	return root, nil
 }
+
+// VtMysqlBaseDir returns the Mysql base directory, which
+// contains the fill_help_tables.sql script for instance
+func VtMysqlBaseDir() (string, error) {
+	// if the environment variable is set, use that
+	if root := os.Getenv("VT_MYSQL_BASEDIR"); root != "" {
+		return root, nil
+	}
+
+	// otherwise let's use VtMysqlRoot
+	root, err := VtMysqlRoot()
+	if err != nil {
+		return "", errors.New("VT_MYSQL_BASEDIR is not set. Please set $VT_MYSQL_BASEDIR.")
+	}
+	return root, nil
+}

--- a/go/vt/mysqlctl/mysqld.go
+++ b/go/vt/mysqlctl/mysqld.go
@@ -543,6 +543,11 @@ func (mysqld *Mysqld) installDataDir() error {
 		return err
 	}
 
+	mysqlBaseDir, err := vtenv.VtMysqlBaseDir()
+	if err != nil {
+		return err
+	}
+
 	// Check mysqld version.
 	_, version, err := execCmd(mysqldPath, []string{"--version"}, nil, mysqlRoot, nil)
 	if err != nil {
@@ -554,7 +559,7 @@ func (mysqld *Mysqld) installDataDir() error {
 
 		args := []string{
 			"--defaults-file=" + mysqld.config.path,
-			"--basedir=" + mysqlRoot,
+			"--basedir=" + mysqlBaseDir,
 			"--initialize-insecure", // Use empty 'root'@'localhost' password.
 		}
 		if _, _, err = execCmd(mysqldPath, args, nil, mysqlRoot, nil); err != nil {
@@ -567,7 +572,7 @@ func (mysqld *Mysqld) installDataDir() error {
 	log.Infof("Installing data dir with mysql_install_db")
 	args := []string{
 		"--defaults-file=" + mysqld.config.path,
-		"--basedir=" + mysqlRoot,
+		"--basedir=" + mysqlBaseDir,
 	}
 	cmdPath, err := binaryPath(mysqlRoot, "mysql_install_db")
 	if err != nil {


### PR DESCRIPTION
Issue #2866 
Adding a new environment variable (VT_MYSQL_BASEDIR) which can take custom mysql base directory. 
If this environment variable is not set the default VtMysqlRoot will be used. Hence keeping the original flow intact.
Example: export VT_MYSQL_BASEDIR=/usr

