### PR TITLE
Fix replication error that occurs when following kubernetes tutorial

### DIFF
--- a/examples/kubernetes/vttablet-pod-template.yaml
+++ b/examples/kubernetes/vttablet-pod-template.yaml
@@ -48,6 +48,7 @@ spec:
           chown -R vitess /vt
 
           su -p -s /bin/bash -c "/vt/bin/vttablet
+          -binlog_use_v3_resharding_mode
           -topo_implementation etcd
           -etcd_global_addrs http://etcd-global:4001
           -log_dir $VTDATAROOT/tmp


### PR DESCRIPTION
When currently running the Kubernetes tutorial, you get:
 ```Error received from Stream rpc error: code = 2 desc = newKeyspaceIDResolverFactory failed: ShardingColumnName needs to be set for a v2 sharding key for keyspace test_keyspace```.  This fix make the example use v3 resharding, by default, so that it works with the tutorial instruction vschema.