### PR TITLE
Adding parameter to bind mysql port socket to.

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -36,6 +36,7 @@ import (
 
 var (
 	mysqlServerPort               = flag.Int("mysql_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
+	mysqlServerBindAddress        = flag.String("mysql_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
 	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "static", "Which auth server implementation to use.")
 	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
 
@@ -136,7 +137,7 @@ func initMySQLProtocol() {
 	// Create a Listener.
 	var err error
 	vh := newVtgateHandler(rpcVTGate)
-	mysqlListener, err = mysql.NewListener("tcp", net.JoinHostPort("", fmt.Sprintf("%v", *mysqlServerPort)), authServer, vh)
+	mysqlListener, err = mysql.NewListener("tcp", net.JoinHostPort(*mysqlServerBindAddress, fmt.Sprintf("%v", *mysqlServerPort)), authServer, vh)
 	if err != nil {
 		log.Fatalf("mysql.NewListener failed: %v", err)
 	}

--- a/py/vttest/vt_processes.py
+++ b/py/vttest/vt_processes.py
@@ -1,11 +1,11 @@
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -171,7 +171,8 @@ class VtcomboProcess(VtProcess):
     self.vtcombo_mysql_port = environment.get_port('vtcombo_mysql_port')
     self.extraparams.extend(
         ['-mysql_auth_server_impl', 'none',
-         '-mysql_server_port', str(self.vtcombo_mysql_port)])
+         '-mysql_server_port', str(self.vtcombo_mysql_port),
+         '-mysql_server_bind_address', 'localhost'])
 
 
 vtcombo_process = None


### PR DESCRIPTION
And using it in vtcombo local usages, so unit tests only bind to
'localhost', and don't provide an open MySQL port with no user/password
required.

BUG=63407520