### PR TITLE
set the grpc max message size for both sending and receiving

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -95,14 +95,16 @@ func createGRPCServer() {
 		creds := credentials.NewTLS(config)
 		opts = []grpc.ServerOption{grpc.Creds(creds)}
 	}
-	// Override the default max message size (which is 4 MiB in gRPC 1.0.0).
-	// Large messages can occur when users try to insert very big rows. If they
-	// hit the limit, they'll see the following error:
+	// Override the default max message size for both send and receive
+	// (which is 4 MiB in gRPC 1.0.0).
+	// Large messages can occur when users try to insert or fetch very big
+	// rows. If they hit the limit, they'll see the following error:
 	// grpc: received message length XXXXXXX exceeding the max size 4194304
 	// Note: For gRPC 1.0.0 it's sufficient to set the limit on the server only
 	// because it's not enforced on the client side.
 	if GRPCMaxMessageSize != nil {
-		opts = append(opts, grpc.MaxMsgSize(*GRPCMaxMessageSize))
+		opts = append(opts, grpc.MaxRecvMsgSize(*GRPCMaxMessageSize))
+		opts = append(opts, grpc.MaxSendMsgSize(*GRPCMaxMessageSize))
 	}
 
 	GRPCServer = grpc.NewServer(opts...)


### PR DESCRIPTION
In our test systems, I noticed occasional errors like the folllowing:
`grpc: trying to send message larger than max (13767312 vs. 4194304)`

This is in spite of the fact that we run all vitess components with `-grpc_max_message_size 31457280`

Digging into this a bit more, it appears that there are separate limits for the send and receive size, and that the deprecated option `grpc.MaxMsgSize` is an alias for _just_ the receive part:
https://github.com/grpc/grpc-go/blob/57ff3285cf4df537f41daa0a5fa283bdb5944e60/server.go#L179


