### PR TITLE
v3: tests for the new features

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -694,6 +694,50 @@
   }
 }
 
+# Scatter order by is complex
+"select col, count(*) from user group by col order by col+1"
+"unsupported: in scatter query: complex order by expression: col + 1"
+
+# invalid order by column numner for scatter
+"select col, count(*) from user group by col order by 5 limit 10"
+"invalid order by: column number out of range: 5"
+
+# aggregate with limit
+"select col, count(*) from user group by col limit 10"
+{
+  "Original": "select col, count(*) from user group by col limit 10",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 10,
+    "Input": {
+      "Aggregates": [
+        {
+          "Opcode": "count",
+          "Col": 1
+        }
+      ],
+      "Keys": [
+        0
+      ],
+      "Input": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select col, count(*) from user group by col order by col asc limit 10",
+        "FieldQuery": "select col, count(*) from user where 1 != 1 group by col",
+        "OrderBy": [
+          {
+            "Col": 0,
+            "Desc": false
+          }
+        ]
+      }
+    }
+  }
+}
+
 # Group by with collate operator
 "select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci"
 {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -456,6 +456,25 @@
   }
 }
 
+# limit for scatter with bind var
+"select col from user limit :a"
+{
+  "Original": "select col from user limit :a",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": ":a",
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col from user limit :a",
+      "FieldQuery": "select col from user where 1 != 1"
+    }
+  }
+}
+
 # cross-shard expression in parenthesis with limit
 "select * from user where (id = 4 AND name ='abc') limit 5"
 {
@@ -475,3 +494,10 @@
   }
 }
 
+# invalid limit expression
+"select id from user limit 1+1"
+"unexpected expression in LIMIT:  limit 1 + 1"
+
+# invalid value in limit
+"select id from user limit 'a'"
+"unexpected expression in LIMIT:  limit 'a'"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -199,13 +199,17 @@
 "select user.col1 as a from user order by 1 collate utf8_general_ci"
 "unsupported: in scatter query: complex order by expression: 1 collate utf8_general_ci"
 
-#Order by for join, but order by is cross-shard
+# Order by for join, but order by is cross-shard
 "select user.col1 as a, user_extra.col2 as b from user join user_extra on user_extra.user_id = 5 where user.id = 5 order by a+b"
 "unsupported: order by spans across shards"
 
 # Order by has subqueries
 "select id from unsharded order by (select id from unsharded)"
 "unsupported: order by has subquery"
+
+# limit with offset for scatter query
+"select id from user limit 10, 20"
+"unsupported: offset limit for cross-shard queries"
 
 # sequence in subquery
 "select col from unsharded where id in (select next value from seq)"

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -447,6 +447,47 @@
   }
 }
 
+# wire-up with limit primitive
+"select u.id, e.id from user u join user_extra e where e.id = u.col limit 10"
+{
+  "Original": "select u.id, e.id from user u join user_extra e where e.id = u.col limit 10",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 10,
+    "Input": {
+      "Opcode": "Join",
+      "Left": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select u.id, u.col from user as u",
+        "FieldQuery": "select u.id, u.col from user as u where 1 != 1"
+      },
+      "Right": {
+        "Opcode": "SelectScatter",
+        "Keyspace": {
+          "Name": "user",
+          "Sharded": true
+        },
+        "Query": "select e.id from user_extra as e where e.id = :u_col",
+        "FieldQuery": "select e.id from user_extra as e where 1 != 1",
+        "JoinVars": {
+          "u_col": {}
+        }
+      },
+      "Cols": [
+        -1,
+        1
+      ],
+      "Vars": {
+        "u_col": 1
+      }
+    }
+  }
+}
+
 # Invalid value in IN clause
 "select id from user where id in (18446744073709551616, 1)"
 "strconv.ParseUint: parsing "18446744073709551616": value out of range"

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -69,21 +69,10 @@ func (result *Result) Copy() *Result {
 		out.Fields = fieldsp
 	}
 	if result.Rows != nil {
-		rows := make([][]Value, len(result.Rows))
-		for i, r := range result.Rows {
-			rows[i] = make([]Value, len(r))
-			totalLen := 0
-			for _, c := range r {
-				totalLen += len(c.val)
-			}
-			arena := make([]byte, 0, totalLen)
-			for j, c := range r {
-				start := len(arena)
-				arena = append(arena, c.val...)
-				rows[i][j] = MakeTrusted(c.typ, arena[start:start+len(c.val)])
-			}
+		out.Rows = make([][]Value, 0, len(result.Rows))
+		for _, r := range result.Rows {
+			out.Rows = append(out.Rows, CopyRow(r))
 		}
-		out.Rows = rows
 	}
 	if result.Extras != nil {
 		out.Extras = &querypb.ResultExtras{
@@ -97,6 +86,15 @@ func (result *Result) Copy() *Result {
 			}
 		}
 	}
+	return out
+}
+
+// CopyRow makes a copy of the row.
+func CopyRow(r []Value) []Value {
+	// The raw bytes of the values are supposed to be treated as read-only.
+	// So, there's no need to copy them.
+	out := make([]Value, len(r))
+	copy(out, r)
 	return out
 }
 

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -70,34 +70,9 @@ func TestCopy(t *testing.T) {
 			Fresher: true,
 		},
 	}
-	want := &Result{
-		Fields: []*querypb.Field{{
-			Type: Int64,
-		}, {
-			Type: VarChar,
-		}},
-		InsertID:     1,
-		RowsAffected: 2,
-		Rows: [][]Value{
-			{testVal(Int64, "1"), MakeTrusted(Null, nil)},
-			{testVal(Int64, "2"), testVal(VarChar, "")},
-			{testVal(Int64, "3"), testVal(VarChar, "")},
-		},
-		Extras: &querypb.ResultExtras{
-			EventToken: &querypb.EventToken{
-				Timestamp: 123,
-				Shard:     "sh",
-				Position:  "po",
-			},
-			Fresher: true,
-		},
-	}
 	out := in.Copy()
-	// Change in so we're sure out got actually copied
-	in.Fields[0].Type = VarChar
-	in.Rows[0][0] = testVal(VarChar, "aa")
-	if !reflect.DeepEqual(out, want) {
-		t.Errorf("Copy:\n%#v, want\n%#v", out, want)
+	if !reflect.DeepEqual(out, in) {
+		t.Errorf("Copy:\n%v, want\n%v", out, in)
 	}
 }
 

--- a/go/sqltypes/testing.go
+++ b/go/sqltypes/testing.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// Functions in this file should only be used for testing.
+// This is an experiment to see if test code bloat can be
+// reduced and readability improved.
+
+// MakeTestFields builds a []*querypb.Field for testing.
+//   fields := sqltypes.MakeTestFields(
+//     "a|b",
+//     "int64|varchar",
+//   )
+// The field types are as defined in querypb and are case
+// insensitive. Delimiters must be used only to sepearate
+// strings and not at the beginning or the end.
+func MakeTestFields(names, types string) []*querypb.Field {
+	n := split(names)
+	t := split(types)
+	var fields []*querypb.Field
+	for i := range n {
+		fields = append(fields, &querypb.Field{
+			Name: n[i],
+			Type: querypb.Type(querypb.Type_value[strings.ToUpper(t[i])]),
+		})
+	}
+	return fields
+}
+
+// MakeTestResult builds a *sqltypes.Result object for testing.
+//   result := sqltypes.MakeTestResult(
+//     fields,
+//     " 1|a",
+//     "10|abcd",
+//   )
+// The field type values are set as the types for the rows built.
+// Spaces are trimmed from row values.
+func MakeTestResult(fields []*querypb.Field, rows ...string) *Result {
+	result := &Result{
+		Fields: fields,
+		Rows:   make([][]Value, len(rows)),
+	}
+	for i, row := range rows {
+		result.Rows[i] = make([]Value, len(fields))
+		for j, col := range split(row) {
+			result.Rows[i][j] = MakeTrusted(fields[j].Type, []byte(col))
+		}
+	}
+	result.RowsAffected = uint64(len(result.Rows))
+	return result
+}
+
+// MakeTestStreamingResults builds a list or results for streaming.
+//   results := sqltypes.MakeStreamingResults(
+//     fields,
+//		 "1|a",
+//     "2|b",
+//     "---",
+//     "c|c",
+//   )
+// The first result contains only the fields. Subsequent results
+// are built using the field types. Every input that starts with a "-"
+// is treated as delimiter for one result. A final delimiter must
+// not be supplied.
+func MakeTestStreamingResults(fields []*querypb.Field, rows ...string) []*Result {
+	var results []*Result
+	results = append(results, &Result{Fields: fields})
+	start := 0
+	cur := 0
+	// Add a final delimiter to simplify the loop below.
+	rows = append(rows, "-")
+	for cur < len(rows) {
+		if rows[cur][0] != '-' {
+			cur++
+			continue
+		}
+		result := MakeTestResult(fields, rows[start:cur]...)
+		result.Fields = nil
+		result.RowsAffected = 0
+		results = append(results, result)
+		start = cur + 1
+		cur = start
+	}
+	return results
+}
+
+// PrintResults prints []*Results into a string.
+// This function should only be used for testing.
+func PrintResults(results []*Result) string {
+	b := new(bytes.Buffer)
+	delim := ""
+	for _, r := range results {
+		fmt.Fprintf(b, "%s%v", delim, r)
+		delim = ", "
+	}
+	return b.String()
+}
+
+func split(str string) []string {
+	splits := strings.Split(str, "|")
+	for i, v := range splits {
+		splits[i] = strings.TrimSpace(v)
+	}
+	return splits
+}

--- a/go/sqltypes/testing.go
+++ b/go/sqltypes/testing.go
@@ -34,7 +34,7 @@ import (
 //     "int64|varchar",
 //   )
 // The field types are as defined in querypb and are case
-// insensitive. Delimiters must be used only to sepearate
+// insensitive. Column delimiters must be used only to sepearate
 // strings and not at the beginning or the end.
 func MakeTestFields(names, types string) []*querypb.Field {
 	n := split(names)
@@ -72,7 +72,7 @@ func MakeTestResult(fields []*querypb.Field, rows ...string) *Result {
 	return result
 }
 
-// MakeTestStreamingResults builds a list or results for streaming.
+// MakeTestStreamingResults builds a list of results for streaming.
 //   results := sqltypes.MakeStreamingResults(
 //     fields,
 //		 "1|a",
@@ -82,14 +82,14 @@ func MakeTestResult(fields []*querypb.Field, rows ...string) *Result {
 //   )
 // The first result contains only the fields. Subsequent results
 // are built using the field types. Every input that starts with a "-"
-// is treated as delimiter for one result. A final delimiter must
-// not be supplied.
+// is treated as streaming delimiter for one result. A final
+// delimiter must not be supplied.
 func MakeTestStreamingResults(fields []*querypb.Field, rows ...string) []*Result {
 	var results []*Result
 	results = append(results, &Result{Fields: fields})
 	start := 0
 	cur := 0
-	// Add a final delimiter to simplify the loop below.
+	// Add a final streaming delimiter to simplify the loop below.
 	rows = append(rows, "-")
 	for cur < len(rows) {
 		if rows[cur][0] != '-' {
@@ -110,10 +110,12 @@ func MakeTestStreamingResults(fields []*querypb.Field, rows ...string) []*Result
 // This function should only be used for testing.
 func PrintResults(results []*Result) string {
 	b := new(bytes.Buffer)
-	delim := ""
-	for _, r := range results {
-		fmt.Fprintf(b, "%s%v", delim, r)
-		delim = ", "
+	for i, r := range results {
+		if i == 0 {
+			fmt.Fprintf(b, "%v", r)
+			continue
+		}
+		fmt.Fprintf(b, ", %v", r)
 	}
 	return b.String()
 }

--- a/go/sqltypes/value.go
+++ b/go/sqltypes/value.go
@@ -206,6 +206,15 @@ func (v Value) Raw() []byte {
 	return v.val
 }
 
+// Bytes returns a copy of the raw data. All types are currently implemented as []byte.
+// Use this function instead of Raw if you can't be sure about maintaining the read-only
+// requirements of the bytes.
+func (v Value) Bytes() []byte {
+	out := make([]byte, len(v.val))
+	copy(out, v.val)
+	return out
+}
+
 // Len returns the length.
 func (v Value) Len() int {
 	return len(v.val)

--- a/go/sqltypes/value_test.go
+++ b/go/sqltypes/value_test.go
@@ -419,6 +419,18 @@ func TestAccessors(t *testing.T) {
 	}
 }
 
+func TestBytes(t *testing.T) {
+	for _, v := range []Value{
+		NULL,
+		testVal(Int64, "1"),
+		testVal(Int64, "12"),
+	} {
+		if b := v.Bytes(); bytes.Compare(b, v.Raw()) != 0 {
+			t.Errorf("v1.Bytes: %s, want %s", b, v.Raw())
+		}
+	}
+}
+
 func TestToNative(t *testing.T) {
 	testcases := []struct {
 		in  Value

--- a/go/vt/vtgate/engine/fake_primitive_test.go
+++ b/go/vt/vtgate/engine/fake_primitive_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import "github.com/youtube/vitess/go/sqltypes"
+
+// fakePrimitive fakes a primitive. For every call, it sends the
+// next result from the results. If the next result is nil, it
+// returns sendErr. For streaming calls, it sends the field info
+// first and two rows at a time till all rows are sent.
+type fakePrimitive struct {
+	results   []*sqltypes.Result
+	curResult int
+	// sendErr is sent at the end of the stream if it's set.
+	sendErr error
+}
+
+func (tp *fakePrimitive) rewind() {
+	tp.curResult = 0
+}
+
+func (tp *fakePrimitive) Execute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	if tp.results == nil {
+		return nil, tp.sendErr
+	}
+
+	r := tp.results[tp.curResult]
+	tp.curResult++
+	if r == nil {
+		return nil, tp.sendErr
+	}
+	return r, nil
+}
+
+func (tp *fakePrimitive) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantields bool, callback func(*sqltypes.Result) error) error {
+	if tp.results == nil {
+		return tp.sendErr
+	}
+
+	r := tp.results[tp.curResult]
+	tp.curResult++
+	if r == nil {
+		return tp.sendErr
+	}
+	if err := callback(&sqltypes.Result{Fields: r.Fields}); err != nil {
+		return err
+	}
+	result := &sqltypes.Result{}
+	for i := 0; i < len(r.Rows); i++ {
+		result.Rows = append(result.Rows, r.Rows[i])
+		// Send only two rows at a time.
+		if i%2 == 1 {
+			if err := callback(result); err != nil {
+				return err
+			}
+			result = &sqltypes.Result{}
+		}
+	}
+	if len(result.Rows) != 0 {
+		if err := callback(result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tp *fakePrimitive) GetFields(vcursor VCursor, bindVars, joinVars map[string]interface{}) (*sqltypes.Result, error) {
+	return tp.Execute(vcursor, bindVars, joinVars, false /* wantfields */)
+}

--- a/go/vt/vtgate/engine/limit.go
+++ b/go/vt/vtgate/engine/limit.go
@@ -80,6 +80,14 @@ func (l *Limit) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]int
 				return err
 			}
 		}
+		if len(qr.Rows) == 0 {
+			return nil
+		}
+
+		if count == 0 {
+			// Unreachable: this is just a failsafe.
+			return io.EOF
+		}
 
 		// reduce count till 0.
 		result := &sqltypes.Result{Rows: qr.Rows}

--- a/go/vt/vtgate/engine/limit_test.go
+++ b/go/vt/vtgate/engine/limit_test.go
@@ -144,13 +144,10 @@ func TestLimitStreamExecute(t *testing.T) {
 	if !reflect.DeepEqual(results, wantResults) {
 		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
 	}
-	if !reflect.DeepEqual(results, wantResults) {
-		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
-	}
 
 	// Test with limit equal to input
 	tp.rewind()
-	l.Count = 4
+	l.Count = 3
 	results = nil
 	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
@@ -187,7 +184,7 @@ func TestLimitStreamExecute(t *testing.T) {
 	}
 }
 
-func TestOrderedAggregateGetFields(t *testing.T) {
+func TestLimitGetFields(t *testing.T) {
 	result := sqltypes.MakeTestResult(
 		sqltypes.MakeTestFields(
 			"col1|col2",
@@ -218,7 +215,8 @@ func TestLimitInputFail(t *testing.T) {
 	}
 
 	tp.rewind()
-	if err := l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+	err := l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil })
+	if err == nil || err.Error() != want {
 		t.Errorf("l.StreamExecute(): %v, want %s", err, want)
 	}
 
@@ -252,7 +250,7 @@ func TestLimitInvalidCount(t *testing.T) {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
-	// Test the API.
+	// When going through the API, it should return the same error.
 	_, err = l.Execute(nil, nil, nil, false)
 	if err == nil || err.Error() != want {
 		t.Errorf("l.Execute: %v, want %s", err, want)

--- a/go/vt/vtgate/engine/limit_test.go
+++ b/go/vt/vtgate/engine/limit_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestLimitExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col1|col2",
+		"int64|varchar",
+	)
+	inputResult := sqltypes.MakeTestResult(
+		fields,
+		"a|1",
+		"b|2",
+		"c|3",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{inputResult},
+	}
+
+	l := &Limit{
+		Count: 2,
+		Input: tp,
+	}
+
+	// Test with limit smaller than input.
+	result, err := l.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Error(err)
+	}
+	wantResult := sqltypes.MakeTestResult(
+		fields,
+		"a|1",
+		"b|2",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("l.Execute:\n%v, want\n%v", result, wantResult)
+	}
+
+	// Test with limit equal to input.
+	tp.rewind()
+	l.Count = 3
+	result, err = l.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(result, inputResult) {
+		t.Errorf("l.Execute:\n%v, want\n%v", result, inputResult)
+	}
+
+	// Test with limit higher than input.
+	tp.rewind()
+	l.Count = 4
+	result, err = l.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(result, inputResult) {
+		t.Errorf("l.Execute:\n%v, want\n%v", result, inputResult)
+	}
+
+	// Test with bind vars.
+	tp.rewind()
+	l.Count = ":l"
+	result, err = l.Execute(nil, map[string]interface{}{"l": 2}, nil, false)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("l.Execute:\n%v, want\n%v", result, wantResult)
+	}
+}
+
+func TestLimitStreamExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col1|col2",
+		"int64|varchar",
+	)
+	inputResult := sqltypes.MakeTestResult(
+		fields,
+		"a|1",
+		"b|2",
+		"c|3",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{inputResult},
+	}
+
+	l := &Limit{
+		Count: 2,
+		Input: tp,
+	}
+
+	// Test with limit smaller than input.
+	var results []*sqltypes.Result
+	err := l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	wantResults := sqltypes.MakeTestStreamingResults(
+		fields,
+		"a|1",
+		"b|2",
+	)
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+
+	// Test with bind vars.
+	tp.rewind()
+	l.Count = ":l"
+	results = nil
+	err = l.StreamExecute(nil, map[string]interface{}{"l": 2}, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+
+	// Test with limit equal to input
+	tp.rewind()
+	l.Count = 4
+	results = nil
+	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	wantResults = sqltypes.MakeTestStreamingResults(
+		fields,
+		"a|1",
+		"b|2",
+		"---",
+		"c|3",
+	)
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+
+	// Test with limit higher than input.
+	tp.rewind()
+	l.Count = 4
+	results = nil
+	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	// wantResults is same as before.
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("l.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+}
+
+func TestOrderedAggregateGetFields(t *testing.T) {
+	result := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col1|col2",
+			"int64|varchar",
+		),
+	)
+	tp := &fakePrimitive{results: []*sqltypes.Result{result}}
+
+	l := &Limit{Input: tp}
+
+	got, err := l.GetFields(nil, nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(got, result) {
+		t.Errorf("l.GetFields:\n%v, want\n%v", got, result)
+	}
+}
+
+func TestLimitInputFail(t *testing.T) {
+	tp := &fakePrimitive{sendErr: errors.New("input fail")}
+
+	l := &Limit{Count: 1, Input: tp}
+
+	want := "input fail"
+	if _, err := l.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+		t.Errorf("l.Execute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if err := l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+		t.Errorf("l.StreamExecute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if _, err := l.GetFields(nil, nil, nil); err == nil || err.Error() != want {
+		t.Errorf("l.GetFields(): %v, want %s", err, want)
+	}
+}
+
+func TestLimitInvalidCount(t *testing.T) {
+	l := &Limit{
+		Count: "l",
+	}
+	_, err := l.fetchCount(nil, nil)
+	want := "could not find bind var l"
+	if err == nil || err.Error() != want {
+		t.Errorf("fetchCount: %v, want %s", err, want)
+	}
+
+	l.Count = 1.2
+	_, err = l.fetchCount(nil, nil)
+	want = "getNumber: unexpected type for 1.2: float64"
+	if err == nil || err.Error() != want {
+		t.Errorf("fetchCount: %v, want %s", err, want)
+	}
+
+	l.Count = uint64(18446744073709551615)
+	_, err = l.fetchCount(nil, nil)
+	want = "requested limit is out of range: 18446744073709551615"
+	if err == nil || err.Error() != want {
+		t.Errorf("fetchCount: %v, want %s", err, want)
+	}
+
+	// Test the API.
+	_, err = l.Execute(nil, nil, nil, false)
+	if err == nil || err.Error() != want {
+		t.Errorf("l.Execute: %v, want %s", err, want)
+	}
+
+	err = l.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil })
+	if err == nil || err.Error() != want {
+		t.Errorf("l.Execute: %v, want %s", err, want)
+	}
+}

--- a/go/vt/vtgate/engine/merge_sort.go
+++ b/go/vt/vtgate/engine/merge_sort.go
@@ -91,6 +91,7 @@ func mergeSort(vcursor VCursor, query string, orderBy []OrderbyParams, params *s
 	for len(sh.rows) != 0 {
 		sr := heap.Pop(sh).(streamRow)
 		if sh.err != nil {
+			// Unreachable: This should never fail.
 			return sh.err
 		}
 		if err := callback(&sqltypes.Result{Rows: [][]sqltypes.Value{sr.row}}); err != nil {
@@ -141,7 +142,7 @@ func runOneStream(ctx context.Context, vcursor VCursor, query, ks, shard string,
 		defer close(handle.fields)
 		defer close(handle.row)
 
-		err := vcursor.StreamExecuteMulti(
+		handle.err = vcursor.StreamExecuteMulti(
 			query,
 			ks,
 			map[string]map[string]interface{}{shard: vars},
@@ -164,9 +165,6 @@ func runOneStream(ctx context.Context, vcursor VCursor, query, ks, shard string,
 				return nil
 			},
 		)
-		if err != nil {
-			handle.err = err
-		}
 	}()
 
 	return handle

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/querytypes"
@@ -187,6 +189,10 @@ type shardResult struct {
 
 type testVCursor struct {
 	shardResults map[string]*shardResult
+}
+
+func (t *testVCursor) Context() context.Context {
+	return context.Background()
 }
 
 func (t *testVCursor) Execute(query string, bindvars map[string]interface{}, isDML bool) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestOrderedAggregateExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col|count(*)",
+		"varbinary|decimal",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"a|1",
+			"b|2",
+			"c|3",
+			"c|4",
+		)},
+	}
+
+	oa := &OrderedAggregate{
+		Aggregates: []AggregateParams{{
+			Opcode: AggregateCount,
+			Col:    1,
+		}},
+		Keys:  []int{0},
+		Input: tp,
+	}
+
+	result, err := oa.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantResult := sqltypes.MakeTestResult(
+		fields,
+		"a|2",
+		"b|2",
+		"c|7",
+	)
+	if !reflect.DeepEqual(result, wantResult) {
+		t.Errorf("oa.Execute:\n%v, want\n%v", result, wantResult)
+	}
+}
+
+func TestOrderedAggregateStreamExecute(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col|count(*)",
+		"varbinary|decimal",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"a|1",
+			"b|2",
+			"c|3",
+			"c|4",
+		)},
+	}
+
+	oa := &OrderedAggregate{
+		Aggregates: []AggregateParams{{
+			Opcode: AggregateCount,
+			Col:    1,
+		}},
+		Keys:  []int{0},
+		Input: tp,
+	}
+
+	var results []*sqltypes.Result
+	err := oa.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+		results = append(results, qr)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantResults := sqltypes.MakeTestStreamingResults(
+		fields,
+		"a|2",
+		"---",
+		"b|2",
+		"---",
+		"c|7",
+	)
+	if !reflect.DeepEqual(results, wantResults) {
+		t.Errorf("oa.StreamExecute:\n%s, want\n%s", sqltypes.PrintResults(results), sqltypes.PrintResults(wantResults))
+	}
+}
+
+func TestLimitGetFields(t *testing.T) {
+	result := sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields(
+			"col|count(*)",
+			"varbinary|decimal",
+		),
+	)
+	tp := &fakePrimitive{results: []*sqltypes.Result{result}}
+
+	oa := &OrderedAggregate{Input: tp}
+
+	got, err := oa.GetFields(nil, nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(got, result) {
+		t.Errorf("oa.GetFields:\n%v, want\n%v", got, result)
+	}
+}
+
+func TestOrderedAggregateInputFail(t *testing.T) {
+	tp := &fakePrimitive{sendErr: errors.New("input fail")}
+
+	oa := &OrderedAggregate{Input: tp}
+
+	want := "input fail"
+	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+		t.Errorf("oa.Execute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if _, err := oa.GetFields(nil, nil, nil); err == nil || err.Error() != want {
+		t.Errorf("oa.GetFields(): %v, want %s", err, want)
+	}
+}
+
+func TestOrderedAggregateKeysFail(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col|count(*)",
+		"varchar|decimal",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"a|1",
+		)},
+	}
+
+	oa := &OrderedAggregate{
+		Aggregates: []AggregateParams{{
+			Opcode: AggregateCount,
+			Col:    1,
+		}},
+		Keys:  []int{0},
+		Input: tp,
+	}
+
+	want := "text fields cannot be compared"
+	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+		t.Errorf("oa.Execute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
+	}
+}
+
+func TestOrderedAggregateMergeFail(t *testing.T) {
+	fields := sqltypes.MakeTestFields(
+		"col|count(*)",
+		"varbinary|decimal",
+	)
+	tp := &fakePrimitive{
+		results: []*sqltypes.Result{sqltypes.MakeTestResult(
+			fields,
+			"a|1",
+			"a|b",
+		)},
+	}
+
+	oa := &OrderedAggregate{
+		Aggregates: []AggregateParams{{
+			Opcode: AggregateCount,
+			Col:    1,
+		}},
+		Keys:  []int{0},
+		Input: tp,
+	}
+
+	want := "could not parse value: b"
+	if _, err := oa.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
+		t.Errorf("oa.Execute(): %v, want %s", err, want)
+	}
+
+	tp.rewind()
+	if err := oa.StreamExecute(nil, nil, nil, false, func(_ *sqltypes.Result) error { return nil }); err == nil || err.Error() != want {
+		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
+	}
+}
+
+// fakePrimitive fakes a primitive. For every call, it sends the
+// next result from the results. If the next result is nil, it
+// returns sendErr. For streaming calls, it sends the field info
+// first and two rows at a time till all rows are sent.
+type fakePrimitive struct {
+	results   []*sqltypes.Result
+	curResult int
+	// sendErr is sent at the end of the stream if it's set.
+	sendErr error
+}
+
+func (tp *fakePrimitive) rewind() {
+	tp.curResult = 0
+}
+
+func (tp *fakePrimitive) Execute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantfields bool) (*sqltypes.Result, error) {
+	if tp.results == nil {
+		return nil, tp.sendErr
+	}
+
+	r := tp.results[tp.curResult]
+	tp.curResult++
+	if r == nil {
+		return nil, tp.sendErr
+	}
+	return r, nil
+}
+
+func (tp *fakePrimitive) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]interface{}, wantields bool, callback func(*sqltypes.Result) error) error {
+	if tp.results == nil {
+		return tp.sendErr
+	}
+
+	r := tp.results[tp.curResult]
+	tp.curResult++
+	if r == nil {
+		return tp.sendErr
+	}
+	if err := callback(&sqltypes.Result{Fields: r.Fields}); err != nil {
+		return err
+	}
+	result := &sqltypes.Result{}
+	for i := 0; i < len(r.Rows); i++ {
+		result.Rows = append(result.Rows, r.Rows[i])
+		if i%2 == 1 {
+			if err := callback(result); err != nil {
+				return err
+			}
+			result = &sqltypes.Result{}
+		}
+	}
+	if len(result.Rows) != 0 {
+		if err := callback(result); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (tp *fakePrimitive) GetFields(vcursor VCursor, bindVars, joinVars map[string]interface{}) (*sqltypes.Result, error) {
+	return tp.Execute(vcursor, bindVars, joinVars, false /* wantfields */)
+}

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -17,10 +17,13 @@ limitations under the License.
 package engine
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/sqltypes"
-	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/querytypes"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 // SeqVarName is a reserved bind var name for sequence values.
@@ -34,6 +37,7 @@ const ListVarName = "__vals"
 // VCursor defines the interface the engine will use
 // to execute routes.
 type VCursor interface {
+	Context() context.Context
 	Execute(query string, bindvars map[string]interface{}, isDML bool) (*sqltypes.Result, error)
 	ExecuteMultiShard(keyspace string, shardQueries map[string]querytypes.BoundQuery, isDML bool) (*sqltypes.Result, error)
 	ExecuteStandalone(query string, bindvars map[string]interface{}, keyspace, shard string) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -37,6 +37,7 @@ const ListVarName = "__vals"
 // VCursor defines the interface the engine will use
 // to execute routes.
 type VCursor interface {
+	// Context returns the context of the current request.
 	Context() context.Context
 	Execute(query string, bindvars map[string]interface{}, isDML bool) (*sqltypes.Result, error)
 	ExecuteMultiShard(keyspace string, shardQueries map[string]querytypes.BoundQuery, isDML bool) (*sqltypes.Result, error)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -350,10 +350,7 @@ func (route *Route) Execute(vcursor VCursor, bindVars, joinVars map[string]inter
 		return result, nil
 	}
 
-	if err := route.sort(result); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return route.sort(result)
 }
 
 // StreamExecute performs a streaming exec.
@@ -461,9 +458,19 @@ func (route *Route) execAnyShard(vcursor VCursor, bindVars map[string]interface{
 	return vcursor.ExecuteStandalone(route.Query, bindVars, ks, shard)
 }
 
-func (route *Route) sort(result *sqltypes.Result) error {
+func (route *Route) sort(in *sqltypes.Result) (*sqltypes.Result, error) {
 	var err error
-	sort.Slice(result.Rows, func(i, j int) bool {
+	// Since Result is immutable, we make a copy.
+	// The copy can be shallow because we won't be changing
+	// the contents of any row.
+	out := &sqltypes.Result{
+		Fields:       in.Fields,
+		Rows:         in.Rows,
+		RowsAffected: in.RowsAffected,
+		InsertID:     in.InsertID,
+	}
+
+	sort.Slice(out.Rows, func(i, j int) bool {
 		// If there are any errors below, the function sets
 		// the external err and returns true. Once err is set,
 		// all subsequent calls return true. This will make
@@ -474,7 +481,7 @@ func (route *Route) sort(result *sqltypes.Result) error {
 				return true
 			}
 			var cmp int
-			cmp, err = sqltypes.NullsafeCompare(result.Rows[i][order.Col], result.Rows[j][order.Col])
+			cmp, err = sqltypes.NullsafeCompare(out.Rows[i][order.Col], out.Rows[j][order.Col])
 			if err != nil {
 				return true
 			}
@@ -488,7 +495,8 @@ func (route *Route) sort(result *sqltypes.Result) error {
 		}
 		return true
 	})
-	return err
+
+	return out, err
 }
 
 func (route *Route) execUpdateEqual(vcursor VCursor, bindVars map[string]interface{}) (*sqltypes.Result, error) {

--- a/go/vt/vtgate/planbuilder/limit.go
+++ b/go/vt/vtgate/planbuilder/limit.go
@@ -82,7 +82,7 @@ func (l *limit) ResultColumns() []*resultColumn {
 
 // PushFilter satisfies the builder interface.
 func (l *limit) PushFilter(_ sqlparser.Expr, whereType string, _ columnOriginator) error {
-	return errors.New("unsupported: filtering on results of aggregates")
+	panic("BUG: unreachable")
 }
 
 // PushSelect satisfies the builder interface.

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -59,6 +59,11 @@ func newVCursorImpl(ctx context.Context, session *vtgatepb.Session, target query
 	}
 }
 
+// Context returns the current Context.
+func (vc *vcursorImpl) Context() context.Context {
+	return vc.ctx
+}
+
 // Find finds the specified table. If the keyspace what specified in the input, it gets used as qualifier.
 // Otherwise, the keyspace from the request is used, if one was provided.
 func (vc *vcursorImpl) Find(name sqlparser.TableName) (table *vindexes.Table, err error) {

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -98,7 +98,7 @@ func getBytes(key interface{}) ([]byte, error) {
 	case []byte:
 		return v, nil
 	case sqltypes.Value:
-		return v.Raw(), nil
+		return v.Bytes(), nil
 	case *querypb.BindVariable:
 		return v.Value, nil
 	}

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -73,7 +73,7 @@ func (lkp *lookup) MapUniqueLookup(vcursor VCursor, ids []interface{}) ([][]byte
 			}
 			out = append(out, vhash(num))
 		} else {
-			out = append(out, result.Rows[0][0].Raw())
+			out = append(out, result.Rows[0][0].Bytes())
 		}
 	}
 	return out, nil
@@ -100,7 +100,7 @@ func (lkp *lookup) MapNonUniqueLookup(vcursor VCursor, ids []interface{}) ([][][
 			}
 		} else {
 			for _, row := range result.Rows {
-				ksids = append(ksids, row[0].Raw())
+				ksids = append(ksids, row[0].Bytes())
 			}
 		}
 		out = append(out, ksids)

--- a/go/vt/vttablet/tabletserver/schema/schema.go
+++ b/go/vt/vttablet/tabletserver/schema/schema.go
@@ -156,7 +156,7 @@ func (ta *Table) AddColumn(name string, columnType querypb.Type, defval sqltypes
 		return
 	}
 	// Schema values are trusted.
-	ta.Columns[index].Default = sqltypes.MakeTrusted(ta.Columns[index].Type, defval.Raw())
+	ta.Columns[index].Default = sqltypes.MakeTrusted(ta.Columns[index].Type, defval.Bytes())
 }
 
 // FindColumn finds a column in the table. It returns the index if found.


### PR DESCRIPTION
These are comprehensive tests for the engine side of the recent changes: Route's merge-sort, OrderedAggregate and Limit.

I've introduced an experimental framework to avoid code bloat in tests: convenience functions for building results.

Additional tweaks:
* Since sqltypes.Value is to be treated as immutable, I've changed the copy functions to just point at them.
* For some places where code was pulling Raw out of the Values, I've changed them to use Bytes. These are situations where one cannot be sure that callers will honor the immutability of the data.
* Since sqltypes.Result is also immutable, I've changed some places where the code was mutating it to copy before mutating.
* I'm changing my testing strategy for engine. The code was previously tested from vtgate's Executor. I'm instead testing them using traditional unit tests within the package. If this approach is good, I'll migrate the rest of the tests to this framework.
* Unrelated fix: export VCursor's context for engine to avoid context.TODOs.