### PR TITLE
v3: postprocessing for scatter: done (for now)

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -93,7 +93,7 @@
   }
 }
 
-# simple aggregate
+# count aggregate
 "select count(*) from user"
 {
   "Original": "select count(*) from user",
@@ -113,6 +113,78 @@
       },
       "Query": "select count(*) from user",
       "FieldQuery": "select count(*) from user where 1 != 1"
+    }
+  }
+}
+
+# sum aggregate
+"select sum(col) from user"
+{
+  "Original": "select sum(col) from user",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "sum",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select sum(col) from user",
+      "FieldQuery": "select sum(col) from user where 1 != 1"
+    }
+  }
+}
+
+# min aggregate
+"select min(col) from user"
+{
+  "Original": "select min(col) from user",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "min",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select min(col) from user",
+      "FieldQuery": "select min(col) from user where 1 != 1"
+    }
+  }
+}
+
+# max aggregate
+"select max(col) from user"
+{
+  "Original": "select max(col) from user",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "max",
+        "Col": 0
+      }
+    ],
+    "Keys": null,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select max(col) from user",
+      "FieldQuery": "select max(col) from user where 1 != 1"
     }
   }
 }

--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -126,8 +126,10 @@ func minmax(v1, v2 Value, min bool) (Value, error) {
 	if err != nil {
 		return NULL, err
 	}
-	// XNOR: see tests.
-	if min == (n < 0) {
+
+	// XNOR construct. See tests.
+	v1isSmaller := n < 0
+	if min == v1isSmaller {
 		return v1, nil
 	}
 	return v2, nil

--- a/go/vt/vtgate/engine/ordered_aggregate_test.go
+++ b/go/vt/vtgate/engine/ordered_aggregate_test.go
@@ -218,3 +218,47 @@ func TestOrderedAggregateMergeFail(t *testing.T) {
 		t.Errorf("oa.StreamExecute(): %v, want %s", err, want)
 	}
 }
+
+func TestMerge(t *testing.T) {
+	oa := &OrderedAggregate{
+		Aggregates: []AggregateParams{{
+			Opcode: AggregateCount,
+			Col:    1,
+		}, {
+			Opcode: AggregateSum,
+			Col:    2,
+		}, {
+			Opcode: AggregateMin,
+			Col:    3,
+		}, {
+			Opcode: AggregateMax,
+			Col:    4,
+		}},
+	}
+	fields := sqltypes.MakeTestFields(
+		"a|b|c|d|e",
+		"int64|int64|decimal|in32|varbinary",
+	)
+	r := sqltypes.MakeTestResult(fields,
+		"1|2|3.2|3|ab",
+		"1|3|2.8|2|bc",
+	)
+
+	merged, err := oa.merge(fields, r.Rows[0], r.Rows[1])
+	if err != nil {
+		t.Error(err)
+	}
+	want := sqltypes.MakeTestResult(fields, "1|5|6|2|bc").Rows[0]
+	if !reflect.DeepEqual(merged, want) {
+		t.Errorf("oa.merge(row1, row2): %v, want %v", merged, want)
+	}
+
+	// swap and retry
+	merged, err = oa.merge(fields, r.Rows[1], r.Rows[0])
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(merged, want) {
+		t.Errorf("oa.merge(row1, row2): %v, want %v", merged, want)
+	}
+}


### PR DESCRIPTION
This last phase adjusts Add functionality to match mysql
behavior. The function has been renamed to NullsafeAdd.

I've added Min and Max to also match MySQL behavior.

This temporarily concludes v3 work for scatter postprocessing.
Things that are still not supported, but not too hard to do:
* limits with offset
* AVG
* VarChar columns

I'll come back to these at a later time.

Other more complex constructs like ordering by aggregate expression,
etc. are more involved. We can consider them if showstopper use
cases come up.