### PR TITLE
doubly escape periods in counter names so we dont create invalid json

### DIFF
--- a/go/stats/counters.go
+++ b/go/stats/counters.go
@@ -225,7 +225,7 @@ func NewMultiCountersFunc(name string, labels []string, f CountersFunc) *MultiCo
 	return t
 }
 
-var escaper = strings.NewReplacer(".", "\\.", "\\", "\\\\")
+var escaper = strings.NewReplacer(".", "\\\\.", "\\", "\\\\\\")
 
 func mapKey(ss []string) string {
 	esc := make([]string, len(ss))


### PR DESCRIPTION
This fixes an issue created by https://github.com/youtube/vitess/pull/2992. This broke our automation and monitoring which relies on the json response of /debug/vars being proper json.

cc @nerdatmath @sougou 