### PR TITLE
v3: fixes for connector-j

### DIFF
--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -161,6 +161,38 @@
   }
 }
 
+# select from dual on unqualified keyspace
+"select @@session.auto_increment_increment from dual"
+{
+  "Original": "select @@session.auto_increment_increment from dual",
+  "Instructions": {
+    "Opcode": "SelectUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "select @@session.auto_increment_increment from dual",
+    "FieldQuery": "select @@session.auto_increment_increment from dual where 1 != 1"
+  }
+}
+
+# select from dual on sharded keyspace
+"select @@session.auto_increment_increment from user.dual"
+{
+  "Original": "select @@session.auto_increment_increment from user.dual",
+  "Instructions": {
+    "Opcode": "SelectEqualUnique",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select @@session.auto_increment_increment from dual",
+    "FieldQuery": "select @@session.auto_increment_increment from dual where 1 != 1",
+    "Vindex": "binary",
+    "Values": "\u0000"
+  }
+}
+
 # RHS route referenced
 "select user_extra.id from user join user_extra"
 {

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -314,6 +314,12 @@ func TestExtractSetValues(t *testing.T) {
 	}, {
 		sql: "set AUTOCOMMIT=1",
 		out: map[string]interface{}{"autocommit": int64(1)},
+	}, {
+		sql: "SET character_set_results = NULL",
+		out: map[string]interface{}{"character_set_results": nil},
+	}, {
+		sql: "SET foo = 0x1234",
+		err: "invalid value type: 0x1234",
 	}}
 	for _, tcase := range testcases {
 		out, err := ExtractSetValues(tcase.sql)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/sqlannotation"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/querytypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 var _ Primitive = (*Route)(nil)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -262,6 +262,11 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 				session.Options = &querypb.ExecuteOptions{}
 			}
 			session.Options.Workload = querypb.ExecuteOptions_Workload(out)
+		case "character_set_results":
+			// This is a statement that mysql-connector-j sends at the beginning. We return a canned response for it.
+			if v != nil {
+				return &sqltypes.Result{}, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "only NULL is allowed for character_set_results: %v", v)
+			}
 		default:
 			return &sqltypes.Result{}, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unsupported construct: %s", sql)
 		}

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -197,7 +197,9 @@ func createExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandboxconn
 	createSandbox(KsTestUnsharded)
 	sbclookup = hc.AddTestTablet(cell, "0", 1, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
 
-	bad := createSandbox("TestBadSharding")
+	// Ues the 'X' in the name to ensure it's not alphabetically first.
+	// Otherwise, it would become the default keyspace for the dual table.
+	bad := createSandbox("TestXBadSharding")
 	bad.VSchema = badVSchema
 
 	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -276,7 +276,7 @@ func TestShardFail(t *testing.T) {
 	getSandbox(KsTestUnsharded).SrvKeyspaceMustFail = 1
 
 	_, err := executorExec(executor, "select id from sharded_table where id = 1", nil)
-	want := "paramsAllShards: unsharded keyspace TestBadSharding has multiple shards: possible cause: sharded keyspace is marked as unsharded in vschema"
+	want := "paramsAllShards: unsharded keyspace TestXBadSharding has multiple shards: possible cause: sharded keyspace is marked as unsharded in vschema"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -419,6 +419,30 @@ func TestSelectEqual(t *testing.T) {
 	}}
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
+	}
+}
+
+func TestSelectDual(t *testing.T) {
+	executor, sbc1, _, lookup := createExecutorEnv()
+
+	_, err := executorExec(executor, "select @@aa.bb from dual", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries := []querytypes.BoundQuery{{
+		Sql:           "select @@aa.bb from dual",
+		BindVariables: map[string]interface{}{},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
+	}
+
+	_, err = executorExec(executor, "select @@aa.bb from TestUnsharded.dual", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(lookup.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
 	}
 }
 

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -161,6 +161,12 @@ func TestExecutorSet(t *testing.T) {
 		in:  "set autocommit=1+1",
 		err: "invalid syntax: 1 + 1",
 	}, {
+		in:  "set character_set_results=null",
+		out: &vtgatepb.Session{},
+	}, {
+		in:  "set character_set_results='abcd'",
+		err: "only NULL is allowed for character_set_results: abcd",
+	}, {
 		in:  "set foo=1",
 		err: "unsupported construct: set foo=1",
 	}}

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -253,10 +253,10 @@ func TestExecutorShow(t *testing.T) {
 		wantqr := &sqltypes.Result{
 			Fields: buildVarCharFields("Databases"),
 			Rows: [][]sqltypes.Value{
-				buildVarCharRow("TestBadSharding"),
 				buildVarCharRow("TestExecutor"),
 				buildVarCharRow(KsTestSharded),
 				buildVarCharRow(KsTestUnsharded),
+				buildVarCharRow("TestXBadSharding"),
 			},
 			RowsAffected: 4,
 		}
@@ -274,8 +274,8 @@ func TestExecutorShow(t *testing.T) {
 	wantqr := &sqltypes.Result{
 		Fields: buildVarCharFields("Shards"),
 		Rows: [][]sqltypes.Value{
-			buildVarCharRow("TestBadSharding/-20"),
-			buildVarCharRow(KsTestUnsharded + "/0"),
+			buildVarCharRow("TestExecutor/-20"),
+			buildVarCharRow("TestXBadSharding/e0-"),
 		},
 		RowsAffected: 25,
 	}
@@ -291,16 +291,17 @@ func TestExecutorShow(t *testing.T) {
 	wantqr = &sqltypes.Result{
 		Fields: buildVarCharFields("Tables"),
 		Rows: [][]sqltypes.Value{
+			buildVarCharRow("dual"),
 			buildVarCharRow("main1"),
 			buildVarCharRow("music_user_map"),
 			buildVarCharRow("name_user_map"),
 			buildVarCharRow("simple"),
 			buildVarCharRow("user_seq"),
 		},
-		RowsAffected: 5,
+		RowsAffected: 6,
 	}
 	if !reflect.DeepEqual(qr, wantqr) {
-		t.Errorf("show databases:\n%+v, want\n%+v", qr, wantqr)
+		t.Errorf("show vschema_tables:\n%+v, want\n%+v", qr, wantqr)
 	}
 
 	session = &vtgatepb.Session{}
@@ -548,7 +549,7 @@ func TestVSchemaStats(t *testing.T) {
 		t.Fatalf("error executing template: %v", err)
 	}
 	result := wr.String()
-	if !strings.Contains(result, "<td>TestBadSharding</td>") ||
+	if !strings.Contains(result, "<td>TestXBadSharding</td>") ||
 		!strings.Contains(result, "<td>TestUnsharded</td>") {
 		t.Errorf("invalid html result: %v", result)
 	}

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
@@ -270,7 +271,9 @@ func (st *symtab) searchResultColumn(col *sqlparser.ColName) (c *column, err err
 // is as described in Find.
 func (st *symtab) searchTables(col *sqlparser.ColName) (*column, error) {
 	var t *table
-	if col.Qualifier.IsEmpty() {
+	// @@ syntax is only allowed for dual tables, in which case there should be
+	// only one in the symtab. So, such expressions will be implicitly matched.
+	if col.Qualifier.IsEmpty() || strings.HasPrefix(col.Qualifier.Name.String(), "@@") {
 		// Search uniqueColumns first. If found, our job is done.
 		if c, ok := st.uniqueColumns[col.Name.Lowered()]; ok {
 			return c, nil

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -259,6 +259,10 @@ func addDual(vschema *VSchema) {
 		}
 		ks.Tables["dual"] = t
 		if first == "" || first > ksname {
+			// In case of a reference to dual that's not qualified
+			// by keyspace, we still want to resolve it to one of
+			// the keyspaces. For consistency, we'll always use the
+			// first keyspace by lexical ordering.
 			first = ksname
 			vschema.tables["dual"] = t
 		}

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -120,15 +120,21 @@ func TestUnshardedVSchema(t *testing.T) {
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: ks,
 	}
+	dual := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ks,
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"t1": t1,
+			"t1":   t1,
+			"dual": dual,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"unsharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
-					"t1": t1,
+					"t1":   t1,
+					"dual": dual,
 				},
 			},
 		},
@@ -209,15 +215,22 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		t1.ColumnVindexes[0],
 	}
 	t1.Owned = t1.ColumnVindexes[1:]
+	dual := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ks,
+		Pinned:   []byte{0},
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"t1": t1,
+			"t1":   t1,
+			"dual": dual,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"sharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
-					"t1": t1,
+					"t1":   t1,
+					"dual": dual,
 				},
 			},
 		},
@@ -292,15 +305,22 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		t1.ColumnVindexes[1],
 		t1.ColumnVindexes[0],
 	}
+	dual := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ks,
+		Pinned:   []byte{0},
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"t1": t1,
+			"t1":   t1,
+			"dual": dual,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"sharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
-					"t1": t1,
+					"t1":   t1,
+					"dual": dual,
 				},
 			},
 		},
@@ -429,21 +449,32 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 		Keyspace:   ksb,
 		IsSequence: true,
 	}
+	duala := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksa,
+	}
+	dualb := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksb,
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"t1": nil,
+			"t1":   nil,
+			"dual": duala,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
 				Tables: map[string]*Table{
-					"t1": t1a,
+					"t1":   t1a,
+					"dual": duala,
 				},
 			},
 			"ksb": {
 				Keyspace: ksb,
 				Tables: map[string]*Table{
-					"t1": t1b,
+					"t1":   t1b,
+					"dual": dualb,
 				},
 			},
 		},
@@ -485,21 +516,32 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: ksb,
 	}
+	duala := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksa,
+	}
+	dualb := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksb,
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"t1": nil,
+			"t1":   nil,
+			"dual": duala,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
 				Tables: map[string]*Table{
-					"t1": t1a,
+					"t1":   t1a,
+					"dual": duala,
 				},
 			},
 			"ksb": {
 				Keyspace: ksb,
 				Tables: map[string]*Table{
-					"t1": t1b,
+					"t1":   t1b,
+					"dual": dualb,
 				},
 			},
 		},
@@ -716,24 +758,36 @@ func TestSequence(t *testing.T) {
 	t2.Ordered = []*ColumnVindex{
 		t2.ColumnVindexes[0],
 	}
+	duala := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksu,
+	}
+	dualb := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: kss,
+		Pinned:   []byte{0},
+	}
 	want := &VSchema{
 		tables: map[string]*Table{
-			"seq": seq,
-			"t1":  t1,
-			"t2":  t2,
+			"seq":  seq,
+			"t1":   t1,
+			"t2":   t2,
+			"dual": dualb,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"unsharded": {
 				Keyspace: ksu,
 				Tables: map[string]*Table{
-					"seq": seq,
+					"seq":  seq,
+					"dual": duala,
 				},
 			},
 			"sharded": {
 				Keyspace: kss,
 				Tables: map[string]*Table{
-					"t1": t1,
-					"t2": t2,
+					"t1":   t1,
+					"t2":   t2,
+					"dual": dualb,
 				},
 			},
 		},


### PR DESCRIPTION
dual tables are now categorized as 'pinned' tables. For sharded
keyspaces, it means they'll always be in the first shard. So,
any query that uses dual will be sent to the first shard of
a sharded keyspace.

The default dual table always maps to the first shard using
alphabetical ordering.

This change essentially will find a route for any query that
uses dual as table.

Additionally, we add a canned response for `set character_set_results=null`, something
that connector-j sends at the beginning.