### PR TITLE
types: new PlanValue type and tabletserver changes

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -193,7 +193,7 @@
   "TableName": "a",
   "FullQuery": "insert into a(eid, id) values (1, :a)",
   "OuterQuery": "insert into a(eid, id) values (1, :a)",
-  "PKValues": [1, ":a"]
+  "PKValues": [[1], [":a"]]
 }
 
 # default number
@@ -203,7 +203,7 @@
   "TableName": "a",
   "FullQuery": "insert into a(id) values (1)",
   "OuterQuery": "insert into a(id) values (1)",
-  "PKValues": [0, 1]
+  "PKValues": [0, [1]]
 }
 
 # default string
@@ -237,7 +237,7 @@
   "TableName": "a",
   "FullQuery": "insert into a(eid, id) values (-1, 2)",
   "OuterQuery": "insert into a(eid, id) values (-1, 2)",
-  "PKValues": [-1, 2]
+  "PKValues": [[-1], [2]]
 }
 
 # positive number
@@ -247,7 +247,7 @@
   "TableName": "a",
   "FullQuery": "insert into a(eid, id) values (1, 2)",
   "OuterQuery": "insert into a(eid, id) values (1, 2)",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # non-trivial unary
@@ -293,7 +293,7 @@
   "TableName": "a",
   "FullQuery": "insert into a values (1, 2)",
   "OuterQuery": "insert into a values (1, 2)",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup
@@ -304,7 +304,7 @@
   "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update name = func(a)",
   "OuterQuery": "insert into b(eid, id) values (1, 2)",
   "UpsertQuery": "update b set name = func(a) where :#pk",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup pk change
@@ -315,7 +315,7 @@
   "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update eid = 2",
   "OuterQuery": "insert into b(eid, id) values (1, 2)",
   "UpsertQuery": "update b set eid = 2 where :#pk",
-  "PKValues": [1, 2],
+  "PKValues": [[1], [2]],
   "SecondaryPKValues": [2, null]
 }
 
@@ -327,7 +327,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, 2, 'foo') on duplicate key update name = values(name)",
   "OuterQuery": "insert into a(eid, id, name) values (1, 2, 'foo')",
   "UpsertQuery": "update a set name = 'foo' where :#pk",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup, with values() inside another func
@@ -338,7 +338,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, 2, 'foo') on duplicate key update name = concat(values(name), 'foo')",
   "OuterQuery": "insert into a(eid, id, name) values (1, 2, 'foo')",
   "UpsertQuery": "update a set name = concat('foo', 'foo') where :#pk",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup, with values() and simple expression
@@ -349,7 +349,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, 2, 3) on duplicate key update name = values(name) + 5",
   "OuterQuery": "insert into a(eid, id, name) values (1, 2, 3)",
   "UpsertQuery": "update a set name = 3 + 5 where :#pk",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup, with values() and case expression
@@ -360,7 +360,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, 2, 3) on duplicate key update name = case when values(eid) \u003c values(id) then values(name) + 5 else 3 end",
   "OuterQuery": "insert into a(eid, id, name) values (1, 2, 3)",
   "UpsertQuery": "update a set name = case when 1 \u003c 2 then 3 + 5 else 3 end where :#pk",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup, with bindvars in values()
@@ -371,7 +371,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, :id, :name) on duplicate key update name = values(name), id = values(id)",
   "OuterQuery": "insert into a(eid, id, name) values (1, :id, :name)",
   "UpsertQuery": "update a set name = :name, id = :id where :#pk",
-  "PKValues": [1, ":id"],
+  "PKValues": [[1], [":id"]],
   "SecondaryPKValues": [null, ":id"]
 }
 
@@ -392,7 +392,7 @@
   "Reason": "UPSERT_COL_MISMATCH",
   "TableName": "a",
   "FullQuery": "insert into a(eid, id) values (1, 2) on duplicate key update eid = values(eid), name = values(name)",
-  "PKValues": [1, 2]
+  "PKValues": [[1], [2]]
 }
 
 # on dup pk change, with values() func
@@ -403,7 +403,7 @@
   "FullQuery": "insert into b(eid, id) values (1, 2) on duplicate key update eid = values(eid), id = values(id)",
   "OuterQuery": "insert into b(eid, id) values (1, 2)",
   "UpsertQuery": "update b set eid = 1, id = 2 where :#pk",
-  "PKValues": [1, 2],
+  "PKValues": [[1], [2]],
   "SecondaryPKValues": [1, 2]
 }
 
@@ -415,7 +415,7 @@
   "FullQuery": "insert into a(eid, id, name) values (1, 2, 'foo') on duplicate key update eid = 2, id = values(id), name = func()",
   "OuterQuery": "insert into a(eid, id, name) values (1, 2, 'foo')",
   "UpsertQuery": "update a set eid = 2, id = 2, name = func() where :#pk",
-  "PKValues": [1, 2],
+  "PKValues": [[1], [2]],
   "SecondaryPKValues": [2, 2]
 }
 
@@ -426,7 +426,7 @@
   "Reason": "PK_CHANGE",
   "TableName": "b",
   "FullQuery": "insert into b(id, eid) values (1, 2) on duplicate key update eid = func(a)",
-  "PKValues": [2, 1]
+  "PKValues": [[2], [1]]
 }
 
 # on dup multi-row
@@ -489,10 +489,7 @@
   "TableName": "msg",
   "FullQuery": "insert into msg(time_scheduled, id, message) values (1, 2, 'aa')",
   "OuterQuery": "insert into msg(time_scheduled, id, message, time_next, time_created, epoch) values (1, 2, 'aa', 1, :#time_now, 0)",
-  "PKValues": [
-    1,
-    2
-  ]
+  "PKValues": [[1], [2]]
 }
 
 # message insert with no time_schedule
@@ -502,10 +499,7 @@
   "TableName": "msg",
   "FullQuery": "insert into msg(id, message) values (2, 'aa')",
   "OuterQuery": "insert into msg(id, message, time_scheduled, time_next, time_created, epoch) values (2, 'aa', :#time_now, :#time_now, :#time_now, 0)",
-  "PKValues": [
-    ":#time_now",
-    2
-  ]
+  "PKValues": [[":#time_now"], [2]]
 }
 
 # message multi-value insert
@@ -640,7 +634,7 @@
 
 # type mismatch
 "update b set eid=18446744073709551616"
-"type mismatch: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # complex pk change
 "update b set eid=foo()"

--- a/go/sqltypes/plan_value.go
+++ b/go/sqltypes/plan_value.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"errors"
+	"fmt"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// PlanValue represents a value or a list of values for
+// a column that will later be resolved using bind vars and used
+// to perform plan actions like generating the final query or
+// deciding on a route.
+//
+// Plan values are typically used as a slice ([]planValue)
+// where each entry is for one column. For situations where
+// the required output is a list of rows (like in the case
+// of multi-value inserts), the representation is pivoted.
+// For example, a statement like this:
+// 	INSERT INTO t VALUES (1, 2), (3, 4)
+// will be represented as follows:
+// 	[]PlanValue{
+// 		Values: {1, 3},
+// 		Values: {2, 4},
+// 	}
+//
+// For WHERE clause items that contain a combination of
+// equality expressions and IN clauses like this:
+//   WHERE pk1 = 1 AND pk2 IN (2, 3, 4)
+// The plan values will be represented as follows:
+// 	[]PlanValue{
+// 		Value: 1,
+// 		Values: {2, 3, 4},
+// 	}
+// When converted into rows, columns with single values
+// are replicated as the same for all rows:
+// 	[][]Value{
+// 		{1, 2},
+// 		{1, 3},
+// 		{1, 4},
+// 	}
+type PlanValue struct {
+	Key     string
+	Value   Value
+	ListKey string
+	Values  []PlanValue
+}
+
+// IsNull returns true if the PlanValue is NULL.
+func (pv PlanValue) IsNull() bool {
+	return pv.Key == "" && pv.Value.IsNull() && pv.ListKey == "" && pv.Values == nil
+}
+
+// ResolveValue resolves a PlanValue as a single value based on the supplied bindvars.
+func (pv PlanValue) ResolveValue(bindVars map[string]*querypb.BindVariable) (Value, error) {
+	switch {
+	case pv.Key != "":
+		bv, err := pv.lookupValue(bindVars)
+		if err != nil {
+			return NULL, err
+		}
+		return MakeTrusted(bv.Type, bv.Value), nil
+	case !pv.Value.IsNull():
+		return pv.Value, nil
+	case pv.ListKey != "" || pv.Values != nil:
+		// This code is unreachable because the parser does not allow
+		// multi-value constructs where a single value is expected.
+		return NULL, errors.New("a list was supplied where a single value was expected")
+	}
+	return NULL, nil
+}
+
+func (pv PlanValue) lookupValue(bindVars map[string]*querypb.BindVariable) (*querypb.BindVariable, error) {
+	bv, ok := bindVars[pv.Key]
+	if !ok {
+		return nil, fmt.Errorf("missing bind var %s", pv.ListKey)
+	}
+	if bv.Type == querypb.Type_TUPLE {
+		return nil, fmt.Errorf("TUPLE was supplied for single value bind var %s", pv.ListKey)
+	}
+	return bv, nil
+}
+
+// ResolveList resolves a PlanValue as a list of values based on the supplied bindvars.
+func (pv PlanValue) ResolveList(bindVars map[string]*querypb.BindVariable) ([]Value, error) {
+	switch {
+	case pv.ListKey != "":
+		bv, err := pv.lookupList(bindVars)
+		if err != nil {
+			return nil, err
+		}
+		values := make([]Value, 0, len(bv.Values))
+		for _, val := range bv.Values {
+			values = append(values, MakeTrusted(val.Type, val.Value))
+		}
+		return values, nil
+	case pv.Values != nil:
+		values := make([]Value, 0, len(pv.Values))
+		for _, val := range pv.Values {
+			values = append(values, val.Value)
+		}
+		return values, nil
+	}
+	// This code is unreachable because the parser does not allow
+	// single value constructs where multiple values are expected.
+	return nil, errors.New("a single value was supplied where a list was expected")
+}
+
+func (pv PlanValue) lookupList(bindVars map[string]*querypb.BindVariable) (*querypb.BindVariable, error) {
+	bv, ok := bindVars[pv.ListKey]
+	if !ok {
+		return nil, fmt.Errorf("missing bind var %s", pv.ListKey)
+	}
+	if bv.Type != querypb.Type_TUPLE {
+		return nil, fmt.Errorf("single value was supplied for TUPLE bind var %s", pv.ListKey)
+	}
+	return bv, nil
+}
+
+func rowCount(pvs []PlanValue, bindVars map[string]*querypb.BindVariable) (int, error) {
+	count := -1
+	setCount := func(l int) error {
+		switch count {
+		case -1:
+			count = l
+			return nil
+		case l:
+			return nil
+		default:
+			return errors.New("mismatch in number of column values")
+		}
+	}
+
+	for _, pv := range pvs {
+		switch {
+		case pv.Key != "" || !pv.Value.IsNull():
+			continue
+		case pv.Values != nil:
+			if err := setCount(len(pv.Values)); err != nil {
+				return 0, err
+			}
+		case pv.ListKey != "":
+			bv, err := pv.lookupList(bindVars)
+			if err != nil {
+				return 0, err
+			}
+			if err := setCount(len(bv.Values)); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	if count == -1 {
+		// If there were no lists inside, it was a single row.
+		// Note that count can never be 0 because there is enough
+		// protection at the top level: list bind vars must have
+		// at least one value (enforced by vtgate), and AST lists
+		// must have at least one value (enforced by the parser).
+		// Also lists created internally after vtgate validation
+		// ensure at least one value.
+		// TODO(sougou): verify and change API to enforce this.
+		return 1, nil
+	}
+	return count, nil
+}
+
+// ResolveRows resolves a []PlanValue as rows based on the supplied bindvars.
+func ResolveRows(pvs []PlanValue, bindVars map[string]*querypb.BindVariable) ([][]Value, error) {
+	count, err := rowCount(pvs, bindVars)
+	if err != nil {
+		return nil, err
+	}
+
+	// Allocate the rows.
+	rows := make([][]Value, count)
+	for i := range rows {
+		rows[i] = make([]Value, len(pvs))
+	}
+
+	// Using j becasue we're resolving by columns.
+	for j, pv := range pvs {
+		switch {
+		case pv.Key != "":
+			bv, err := pv.lookupValue(bindVars)
+			if err != nil {
+				return nil, err
+			}
+			for i := range rows {
+				rows[i][j] = MakeTrusted(bv.Type, bv.Value)
+			}
+		case !pv.Value.IsNull():
+			for i := range rows {
+				rows[i][j] = pv.Value
+			}
+		case pv.ListKey != "":
+			bv, err := pv.lookupList(bindVars)
+			if err != nil {
+				// This code is unreachable because pvRowCount already checks this.
+				return nil, err
+			}
+			for i := range rows {
+				rows[i][j] = MakeTrusted(bv.Values[i].Type, bv.Values[i].Value)
+			}
+		case pv.Values != nil:
+			for i := range rows {
+				rows[i][j] = pv.Values[i].Value
+			}
+			// default case is a NULL value, which the row values are already initialized to.
+		}
+	}
+	return rows, nil
+}

--- a/go/sqltypes/plan_value_test.go
+++ b/go/sqltypes/plan_value_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestPlanValueIsNull(t *testing.T) {
+	tcases := []struct {
+		in  PlanValue
+		out bool
+	}{{
+		in:  PlanValue{},
+		out: true,
+	}, {
+		in:  PlanValue{Key: "aa"},
+		out: false,
+	}, {
+		in:  PlanValue{Value: MakeString([]byte("aa"))},
+		out: false,
+	}, {
+		in:  PlanValue{ListKey: "aa"},
+		out: false,
+	}, {
+		in:  PlanValue{Values: []PlanValue{}},
+		out: false,
+	}}
+	for _, tc := range tcases {
+		got := tc.in.IsNull()
+		if got != tc.out {
+			t.Errorf("IsNull(%v): %v, want %v", tc.in, got, tc.out)
+		}
+	}
+}
+
+func TestResolveRows(t *testing.T) {
+	testBindVars := map[string]*querypb.BindVariable{
+		"int":    Int64BindVariable(10),
+		"intstr": MakeTestBindVar([]interface{}{10, "aa"}),
+	}
+	intValue := MakeTrusted(Int64, []byte("10"))
+	strValue := MakeTrusted(VarChar, []byte("aa"))
+	tcases := []struct {
+		in  []PlanValue
+		out [][]Value
+		err string
+	}{{
+		// Simple cases.
+		in: []PlanValue{
+			{Key: "int"},
+		},
+		out: [][]Value{
+			{intValue},
+		},
+	}, {
+		in: []PlanValue{
+			{Value: intValue},
+		},
+		out: [][]Value{
+			{intValue},
+		},
+	}, {
+		in: []PlanValue{
+			{ListKey: "intstr"},
+		},
+		out: [][]Value{
+			{intValue},
+			{strValue},
+		},
+	}, {
+		in: []PlanValue{
+			{Values: []PlanValue{{Value: intValue}, {Value: strValue}}},
+		},
+		out: [][]Value{
+			{intValue},
+			{strValue},
+		},
+	}, {
+		in: []PlanValue{{}},
+		out: [][]Value{
+			{NULL},
+		},
+	}, {
+		// Cases with varying rowcounts.
+		// All types of input..
+		in: []PlanValue{
+			{Key: "int"},
+			{Value: strValue},
+			{ListKey: "intstr"},
+			{Values: []PlanValue{{Value: strValue}, {Value: intValue}}},
+		},
+		out: [][]Value{
+			{intValue, strValue, intValue, strValue},
+			{intValue, strValue, strValue, intValue},
+		},
+	}, {
+		// list, val, list.
+		in: []PlanValue{
+			{Value: strValue},
+			{Key: "int"},
+			{Values: []PlanValue{{Value: strValue}, {Value: intValue}}},
+		},
+		out: [][]Value{
+			{strValue, intValue, strValue},
+			{strValue, intValue, intValue},
+		},
+	}, {
+		// list, list
+		in: []PlanValue{
+			{ListKey: "intstr"},
+			{Values: []PlanValue{{Value: strValue}, {Value: intValue}}},
+		},
+		out: [][]Value{
+			{intValue, strValue},
+			{strValue, intValue},
+		},
+	}, {
+		// Error cases
+		in: []PlanValue{
+			{ListKey: "intstr"},
+			{Values: []PlanValue{{Value: strValue}}},
+		},
+		err: "mismatch in number of column values",
+	}, {
+		// This is a different code path for a similar validation.
+		in: []PlanValue{
+			{Values: []PlanValue{{Value: strValue}}},
+			{ListKey: "intstr"},
+		},
+		err: "mismatch in number of column values",
+	}, {
+		in: []PlanValue{
+			{Key: "absent"},
+		},
+		err: "missing bind var",
+	}, {
+		in: []PlanValue{
+			{ListKey: "absent"},
+		},
+		err: "missing bind var",
+	}}
+
+	for _, tc := range tcases {
+		got, err := ResolveRows(tc.in, testBindVars)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("ResolveRows(%v) error: %v, want '%s'", tc.in, err, tc.err)
+			}
+			continue
+		}
+		if tc.err != "" {
+			t.Errorf("ResolveRows(%v) error: nil, want '%s'", tc.in, tc.err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.out) {
+			t.Errorf("ResolveRows(%v): %v, want %v", tc.in, got, tc.out)
+		}
+	}
+}
+
+func TestResolveList(t *testing.T) {
+	testBindVars := map[string]*querypb.BindVariable{
+		"int":    Int64BindVariable(10),
+		"intstr": MakeTestBindVar([]interface{}{10, "aa"}),
+	}
+	intValue := MakeTrusted(Int64, []byte("10"))
+	strValue := MakeTrusted(VarChar, []byte("aa"))
+	tcases := []struct {
+		in  PlanValue
+		out []Value
+		err string
+	}{{
+		in:  PlanValue{ListKey: "intstr"},
+		out: []Value{intValue, strValue},
+	}, {
+		in:  PlanValue{Values: []PlanValue{{Value: intValue}, {Value: strValue}}},
+		out: []Value{intValue, strValue},
+	}, {
+		in:  PlanValue{ListKey: "absent"},
+		err: "missing bind var",
+	}, {
+		in:  PlanValue{ListKey: "int"},
+		err: "single value was supplied for TUPLE bind var",
+	}, {
+		in:  PlanValue{Key: "int"},
+		err: "a single value was supplied where a list was expected",
+	}}
+
+	for _, tc := range tcases {
+		got, err := tc.in.ResolveList(testBindVars)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("ResolveList(%v) error: %v, want '%s'", tc.in, err, tc.err)
+			}
+			continue
+		}
+		if tc.err != "" {
+			t.Errorf("ResolveList(%v) error: nil, want '%s'", tc.in, tc.err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.out) {
+			t.Errorf("ResolveList(%v): %v, want %v", tc.in, got, tc.out)
+		}
+	}
+}
+
+func TestResolveValue(t *testing.T) {
+	testBindVars := map[string]*querypb.BindVariable{
+		"int":    Int64BindVariable(10),
+		"intstr": MakeTestBindVar([]interface{}{10, "aa"}),
+	}
+	intValue := MakeTrusted(Int64, []byte("10"))
+	tcases := []struct {
+		in  PlanValue
+		out Value
+		err string
+	}{{
+		in:  PlanValue{Key: "int"},
+		out: intValue,
+	}, {
+		in:  PlanValue{Value: intValue},
+		out: intValue,
+	}, {
+		in:  PlanValue{},
+		out: NULL,
+	}, {
+		in:  PlanValue{Key: "absent"},
+		err: "missing bind var",
+	}, {
+		in:  PlanValue{Key: "intstr"},
+		err: "TUPLE was supplied for single value bind var",
+	}, {
+		in:  PlanValue{ListKey: "intstr"},
+		err: "a list was supplied where a single value was expected",
+	}}
+
+	for _, tc := range tcases {
+		got, err := tc.in.ResolveValue(testBindVars)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.err) {
+				t.Errorf("ResolveValue(%v) error: %v, want '%s'", tc.in, err, tc.err)
+			}
+			continue
+		}
+		if tc.err != "" {
+			t.Errorf("ResolveValue(%v) error: nil, want '%s'", tc.in, tc.err)
+			continue
+		}
+		if !reflect.DeepEqual(got, tc.out) {
+			t.Errorf("ResolveValue(%v): %v, want %v", tc.in, got, tc.out)
+		}
+	}
+}

--- a/go/sqltypes/plan_value_test.go
+++ b/go/sqltypes/plan_value_test.go
@@ -95,6 +95,14 @@ func TestResolveRows(t *testing.T) {
 			{strValue},
 		},
 	}, {
+		in: []PlanValue{
+			{Values: []PlanValue{{Key: "int"}, {Value: strValue}}},
+		},
+		out: [][]Value{
+			{intValue},
+			{strValue},
+		},
+	}, {
 		in: []PlanValue{{}},
 		out: [][]Value{
 			{NULL},
@@ -157,6 +165,11 @@ func TestResolveRows(t *testing.T) {
 			{ListKey: "absent"},
 		},
 		err: "missing bind var",
+	}, {
+		in: []PlanValue{
+			{Values: []PlanValue{{Key: "absent"}}},
+		},
+		err: "missing bind var",
 	}}
 
 	for _, tc := range tcases {
@@ -195,7 +208,13 @@ func TestResolveList(t *testing.T) {
 		in:  PlanValue{Values: []PlanValue{{Value: intValue}, {Value: strValue}}},
 		out: []Value{intValue, strValue},
 	}, {
+		in:  PlanValue{Values: []PlanValue{{Key: "int"}, {Value: strValue}}},
+		out: []Value{intValue, strValue},
+	}, {
 		in:  PlanValue{ListKey: "absent"},
+		err: "missing bind var",
+	}, {
+		in:  PlanValue{Values: []PlanValue{{Key: "absent"}, {Value: strValue}}},
 		err: "missing bind var",
 	}, {
 		in:  PlanValue{ListKey: "int"},

--- a/go/vt/vttablet/endtoend/compatibility_test.go
+++ b/go/vt/vttablet/endtoend/compatibility_test.go
@@ -704,15 +704,7 @@ func TestTypeLimits(t *testing.T) {
 	}, {
 		query: "insert into vitess_ints(tiny) values(:fl)",
 		bv:    map[string]*querypb.BindVariable{"fl": sqltypes.Float64BindVariable(1.2)},
-		out:   "type mismatch",
-	}, {
-		query: "insert into vitess_strings(vb) values(1)",
-		bv:    nil,
-		out:   "type mismatch",
-	}, {
-		query: "insert into vitess_strings(vb) values(:id)",
-		bv:    map[string]*querypb.BindVariable{"id": sqltypes.Int64BindVariable(1)},
-		out:   "type mismatch",
+		out:   "invalid syntax",
 	}, {
 		query: "insert into vitess_strings(vb) select tiny from vitess_ints",
 		bv:    nil,
@@ -728,7 +720,7 @@ func TestTypeLimits(t *testing.T) {
 	}}
 	for _, tcase := range mismatchCases {
 		_, err := client.Execute(tcase.query, tcase.bv)
-		if err == nil || !strings.HasPrefix(err.Error(), tcase.out) {
+		if err == nil || !strings.Contains(err.Error(), tcase.out) {
 			t.Errorf("Error(%s): %v, want %s", tcase.query, err, tcase.out)
 		}
 	}

--- a/go/vt/vttablet/tabletserver/codex.go
+++ b/go/vt/vttablet/tabletserver/codex.go
@@ -29,149 +29,55 @@ import (
 // buildValueList builds the set of PK reference rows used to drive the next query.
 // It uses the PK values supplied in the original query and bind variables.
 // The generated reference rows are validated for type match against the PK of the table.
-func buildValueList(table *schema.Table, pkValues []interface{}, bindVars map[string]*querypb.BindVariable) ([][]sqltypes.Value, error) {
-	resolved, length, err := resolvePKValues(table, pkValues, bindVars)
+func buildValueList(table *schema.Table, pkValues []sqltypes.PlanValue, bindVars map[string]*querypb.BindVariable) ([][]sqltypes.Value, error) {
+	rows, err := sqltypes.ResolveRows(pkValues, bindVars)
 	if err != nil {
 		return nil, err
 	}
-	valueList := make([][]sqltypes.Value, length)
-	for i := 0; i < length; i++ {
-		valueList[i] = make([]sqltypes.Value, len(resolved))
-		for j, val := range resolved {
-			if list, ok := val.([]sqltypes.Value); ok {
-				valueList[i][j] = list[i]
-			} else {
-				valueList[i][j] = val.(sqltypes.Value)
-			}
-		}
-	}
-	return valueList, nil
-}
-
-func resolvePKValues(table *schema.Table, pkValues []interface{}, bindVars map[string]*querypb.BindVariable) (resolved []interface{}, length int, err error) {
-	length = -1
-	setLengthFunc := func(list []sqltypes.Value) error {
-		if length == -1 {
-			length = len(list)
-		} else if len(list) != length {
-			return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "mismatched lengths for values %v", pkValues)
-		}
-		return nil
-	}
-	resolved = make([]interface{}, len(pkValues))
-	for i, val := range pkValues {
-		switch val := val.(type) {
-		case string:
-			if val[1] != ':' {
-				resolved[i], err = resolveValue(table.GetPKColumn(i), val, bindVars)
-				if err != nil {
-					return nil, 0, err
-				}
-			} else {
-				list, err := resolveListArg(table.GetPKColumn(i), val, bindVars)
-				if err != nil {
-					return nil, 0, err
-				}
-				if err := setLengthFunc(list); err != nil {
-					return nil, 0, err
-				}
-				resolved[i] = list
-			}
-		case []interface{}:
-			list := make([]sqltypes.Value, len(val))
-			for j, listVal := range val {
-				list[j], err = resolveValue(table.GetPKColumn(i), listVal, bindVars)
-				if err != nil {
-					return nil, 0, err
-				}
-			}
-			if err := setLengthFunc(list); err != nil {
-				return nil, 0, err
-			}
-			resolved[i] = list
-		default:
-			resolved[i], err = resolveValue(table.GetPKColumn(i), val, nil)
+	// Iterate by columns.
+	for j := range pkValues {
+		typ := table.GetPKColumn(j).Type
+		for i := range rows {
+			rows[i][j], err = sqltypes.Cast(rows[i][j], typ)
 			if err != nil {
-				return nil, 0, err
+				return nil, err
 			}
 		}
 	}
-	if length == -1 {
-		length = 1
-	}
-	return resolved, length, nil
-}
-
-func resolveListArg(col *schema.TableColumn, key string, bindVars map[string]*querypb.BindVariable) ([]sqltypes.Value, error) {
-	list, _, err := sqlparser.FetchBindVar(key, bindVars)
-	if err != nil {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
-	}
-	if list.Type != querypb.Type_TUPLE {
-		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "expecting list for bind var %s: %v", key, list)
-	}
-
-	resolved := make([]sqltypes.Value, len(list.Values))
-	for i, v := range list.Values {
-		// We can use MakeTrusted as BuildConverted will check the value.
-		sqlval := sqltypes.MakeTrusted(col.Type, v.Value)
-		if err = validateValue(col, sqlval); err != nil {
-			return nil, err
-		}
-		resolved[i] = sqlval
-	}
-	return resolved, nil
+	return rows, nil
 }
 
 // buildSecondaryList is used for handling ON DUPLICATE DMLs, or those that change the PK.
-func buildSecondaryList(table *schema.Table, pkList [][]sqltypes.Value, secondaryList []interface{}, bindVars map[string]*querypb.BindVariable) ([][]sqltypes.Value, error) {
+func buildSecondaryList(table *schema.Table, pkList [][]sqltypes.Value, secondaryList []sqltypes.PlanValue, bindVars map[string]*querypb.BindVariable) ([][]sqltypes.Value, error) {
 	if secondaryList == nil {
 		return nil, nil
 	}
-	valueList := make([][]sqltypes.Value, len(pkList))
+	secondaryRows, err := sqltypes.ResolveRows(secondaryList, bindVars)
+	if err != nil {
+		return nil, err
+	}
+	// We only expect one row because ON DUPLICATE KEY SET
+	// statements can set only one value. Only pk columns
+	// whose values are changing will be set. The rest will
+	// be NULL.
+	changedValues := secondaryRows[0]
+	rows := make([][]sqltypes.Value, len(pkList))
 	for i, row := range pkList {
-		valueList[i] = make([]sqltypes.Value, len(row))
-		for j, cell := range row {
-			if secondaryList[j] == nil {
-				valueList[i][j] = cell
+		rows[i] = make([]sqltypes.Value, len(row))
+		for j, value := range row {
+			if changedValues[j].IsNull() {
+				rows[i][j] = value
 			} else {
-				var err error
-				if valueList[i][j], err = resolveValue(table.GetPKColumn(j), secondaryList[j], bindVars); err != nil {
-					return valueList, err
-				}
+				rows[i][j] = changedValues[j]
 			}
 		}
 	}
-	return valueList, nil
-}
-
-func resolveValue(col *schema.TableColumn, value interface{}, bindVars map[string]*querypb.BindVariable) (result sqltypes.Value, err error) {
-	if v, ok := value.(string); ok {
-		value, _, err = sqlparser.FetchBindVar(v, bindVars)
-		if err != nil {
-			return result, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
-		}
-	}
-	result, err = sqltypes.BuildConverted(col.Type, value)
-	if err != nil {
-		return result, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
-	}
-	if err = validateValue(col, result); err != nil {
-		return result, err
-	}
-	return result, nil
+	return rows, nil
 }
 
 // resolveNumber extracts a number from a bind variable or sql value.
-func resolveNumber(value interface{}, bindVars map[string]*querypb.BindVariable) (int64, error) {
-	var err error
-	if v, ok := value.(string); ok {
-		value, _, err = sqlparser.FetchBindVar(v, bindVars)
-		if err != nil {
-			return 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
-		}
-	}
-	v, err := sqltypes.BuildValue(value)
+func resolveNumber(pv sqltypes.PlanValue, bindVars map[string]*querypb.BindVariable) (int64, error) {
+	v, err := pv.ResolveValue(bindVars)
 	if err != nil {
 		return 0, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v", err)
 	}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -189,16 +190,6 @@ func (rt ReasonType) MarshalJSON() ([]byte, error) {
 
 //_______________________________________________
 
-// MessageRowValues is used to store the values
-// of a message row in a plan.
-type MessageRowValues struct {
-	TimeNext interface{}
-	ID       interface{}
-	Message  interface{}
-}
-
-//_______________________________________________
-
 // Plan is built for selects and DMLs.
 type Plan struct {
 	PlanID  PlanType
@@ -227,10 +218,10 @@ type Plan struct {
 	// PlanDMLPK: where clause values.
 	// PlanInsertPK: values clause.
 	// PlanNextVal: increment.
-	PKValues []interface{}
+	PKValues []sqltypes.PlanValue
 
 	// For update: set clause if pk is changing.
-	SecondaryPKValues []interface{}
+	SecondaryPKValues []sqltypes.PlanValue
 
 	// WhereClause is set for DMLs. It is used by the hot row protection
 	// to serialize e.g. UPDATEs going to the same row.

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/testfiles"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -50,8 +51,8 @@ func toJSON(p *Plan) ([]byte, error) {
 		Subquery          *sqlparser.ParsedQuery `json:",omitempty"`
 		UpsertQuery       *sqlparser.ParsedQuery `json:",omitempty"`
 		ColumnNumbers     []int                  `json:",omitempty"`
-		PKValues          []interface{}          `json:",omitempty"`
-		SecondaryPKValues []interface{}          `json:",omitempty"`
+		PKValues          []sqltypes.PlanValue   `json:",omitempty"`
+		SecondaryPKValues []sqltypes.PlanValue   `json:",omitempty"`
 		WhereClause       *sqlparser.ParsedQuery `json:",omitempty"`
 		SubqueryPKColumns []int                  `json:",omitempty"`
 	}{


### PR DESCRIPTION
Issue #2919

Implement the new PlanValue type that will be used to populate values for plans built by vtgate as well as vttablet.

This type unifies the functionality needed by both planbuilders. Additionally, we move away from the interface{} duck-typing that was unreadable and hard to verify correctness for.

The new PlanValue is more strict and clear about its rules and they are enforced as encapsulated functionality.

Also implemented the Cast function in arithmetic.go. This is required to convert resolved values to the target column type. This deprecates much of the functionality in codex.go.

The subsequent PR makes use of this PlanValue in tabletserver. Additional notes:
* The old scheme used to special-case single-row inserts and stored single values in such cases, whereas multi-row inserts stored lists. The new scheme always stores lists. This simplifies the code a bit.
* Fixed a bug in PlanValue where bindvars were getting ignored in lists. Added more tests.
* codex.go has become tiny. We could get rid of the file by finding better homes for the left-over functions.
