### PR TITLE
vttablet/tabletmanager: Update the tablet_externally_reparented_timestamp every time the TabletExternallyReparented RPC is called.

### DIFF
--- a/go/vt/vtgate/buffer/buffer_test.go
+++ b/go/vt/vtgate/buffer/buffer_test.go
@@ -56,6 +56,21 @@ var (
 
 	statsKeyJoinedLastReparentTooRecent = statsKeyJoined + "." + string(skippedLastReparentTooRecent)
 	statsKeyJoinedLastFailoverTooRecent = statsKeyJoined + "." + string(skippedLastFailoverTooRecent)
+
+	oldMaster = &topodatapb.Tablet{
+		Alias:    &topodatapb.TabletAlias{Cell: "cell1", Uid: 100},
+		Keyspace: keyspace,
+		Shard:    shard,
+		Type:     topodatapb.TabletType_MASTER,
+		PortMap:  map[string]int32{"vt": int32(100)},
+	}
+	newMaster = &topodatapb.Tablet{
+		Alias:    &topodatapb.TabletAlias{Cell: "cell1", Uid: 101},
+		Keyspace: keyspace,
+		Shard:    shard,
+		Type:     topodatapb.TabletType_MASTER,
+		PortMap:  map[string]int32{"vt": int32(101)},
+	}
 )
 
 func TestBuffer(t *testing.T) {
@@ -70,7 +85,19 @@ func TestBuffer(t *testing.T) {
 	defer resetFlagsForTesting()
 
 	// Create the buffer.
-	b := New()
+	now := time.Now()
+	b := newWithNow(func() time.Time { return now })
+
+	// Simulate that the current master reports its ExternallyReparentedTimestamp.
+	// vtgate sees this at startup. Additional periodic updates will be sent out
+	// after this. If the TabletExternallyReparented RPC is called regularly by
+	// an external failover tool, the timestamp will be increased (even though
+	// the master did not change.)
+	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: oldMaster,
+		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		TabletExternallyReparentedTimestamp: now.Unix(),
+	})
 
 	// First request with failover error starts buffering.
 	stopped := issueRequest(context.Background(), t, b, failoverErr)
@@ -95,9 +122,11 @@ func TestBuffer(t *testing.T) {
 	}
 
 	// Mimic the failover end.
+	now = now.Add(1 * time.Second)
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
-		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
+		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
 	// Check that the drain is successful.
@@ -140,8 +169,8 @@ func TestBuffer(t *testing.T) {
 		t.Fatalf("skipped request was not tracked: got = %v, want = %v", got, want)
 	}
 
-	// Second failover is buffered if we reduce the limit.
-	flag.Set("buffer_min_time_between_failovers", "0s")
+	// Second failover is buffered if enough time has passed.
+	now = now.Add(*minTimeBetweenFailovers)
 	stopped4 := issueRequest(context.Background(), t, b, failoverErr)
 	if err := waitForRequestsInFlight(b, 1); err != nil {
 		t.Fatal(err)
@@ -156,8 +185,9 @@ func TestBuffer(t *testing.T) {
 	}
 	// Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: oldMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
-		TabletExternallyReparentedTimestamp: 2, // Must be >1.
+		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 	if err := <-stopped4; err != nil {
 		t.Fatalf("request should have been buffered and not returned an error: %v", err)
@@ -292,6 +322,7 @@ func TestDryRun(t *testing.T) {
 
 	// End of failover is tracked as well.
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
@@ -326,30 +357,35 @@ func TestPassthrough(t *testing.T) {
 	}
 }
 
-// TestPassThroughLastReparentTooRecent tests that buffering is skipped if
-// we see the failover end faster than the beginning.
-func TestPassThroughLastReparentTooRecent(t *testing.T) {
+// TestLastReparentTooRecent_BufferingSkipped tests that buffering is skipped if
+// we see the reparent (end) *before* any request failures due to it.
+// We must not start buffering because we already observed the trigger for
+// stopping buffering (the reparent) and may not see it again.
+func TestLastReparentTooRecent_BufferingSkipped(t *testing.T) {
 	resetVariables()
 
 	flag.Set("enable_buffer", "true")
 	// Enable the buffer (no explicit whitelist i.e. it applies to everything).
 	defer resetFlagsForTesting()
-	b := New()
+	now := time.Now()
+	b := newWithNow(func() time.Time { return now })
 
 	// Simulate that the old master notified us about its reparented timestamp
 	// very recently (time.Now()).
 	// vtgate should see this immediately after the start.
-	nowSeconds := time.Now().Unix()
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: oldMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
-		TabletExternallyReparentedTimestamp: nowSeconds,
+		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
 	// Failover to new master. Its end is detected faster than the beginning.
 	// Do not start buffering.
+	now = now.Add(1 * time.Second)
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
-		TabletExternallyReparentedTimestamp: nowSeconds + 1,
+		TabletExternallyReparentedTimestamp: now.Unix(),
 	})
 
 	if retryDone, err := b.WaitForFailoverEnd(context.Background(), keyspace, shard, failoverErr); err != nil || retryDone != nil {
@@ -363,6 +399,68 @@ func TestPassThroughLastReparentTooRecent(t *testing.T) {
 	}
 	if got, want := requestsBuffered.Counts()[statsKeyJoined], int64(0); got != want {
 		t.Fatalf("no request should have been tracked as buffered: got = %v, want = %v", got, want)
+	}
+}
+
+// TestLastReparentTooRecent_Buffering explicitly tests that the "too recent"
+// skipping of the buffering does NOT get triggered because enough time has
+// elapsed since the last seen reparent.
+func TestLastReparentTooRecent_Buffering(t *testing.T) {
+	resetVariables()
+
+	flag.Set("enable_buffer", "true")
+	// Enable the buffer (no explicit whitelist i.e. it applies to everything).
+	defer resetFlagsForTesting()
+	now := time.Now()
+	b := newWithNow(func() time.Time { return now })
+
+	// Simulate that the old master notified us about its reparented timestamp
+	// very recently (time.Now()).
+	// vtgate should see this immediately after the start.
+	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: oldMaster,
+		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		TabletExternallyReparentedTimestamp: now.Unix(),
+	})
+
+	// Failover to new master. Do not issue any requests before or after i.e.
+	// there was 0 QPS traffic and no buffering was started.
+	now = now.Add(1 * time.Second)
+	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
+		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		TabletExternallyReparentedTimestamp: now.Unix(),
+	})
+
+	// After we're past the --buffer_min_time_between_failovers threshold, go
+	// through a failover with non-zero QPS.
+	now = now.Add(*minTimeBetweenFailovers)
+	// We're seeing errors first.
+	stopped := issueRequest(context.Background(), t, b, failoverErr)
+	if err := waitForRequestsInFlight(b, 1); err != nil {
+		t.Fatal(err)
+	}
+	// And then the failover end.
+	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
+		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
+		TabletExternallyReparentedTimestamp: now.Unix(),
+	})
+
+	// Check that the drain is successful.
+	if err := <-stopped; err != nil {
+		t.Fatalf("request should have been buffered and not returned an error: %v", err)
+	}
+	// Drain will reset the state to "idle" eventually.
+	if err := waitForState(b, stateIdle); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := requestsSkipped.Counts()[statsKeyJoinedLastReparentTooRecent], int64(0); got != want {
+		t.Fatalf("request should not have been skipped: got = %v, want = %v", got, want)
+	}
+	if got, want := requestsBuffered.Counts()[statsKeyJoined], int64(1); got != want {
+		t.Fatalf("request should have been tracked as buffered: got = %v, want = %v", got, want)
 	}
 }
 
@@ -383,6 +481,7 @@ func TestPassthroughDuringDrain(t *testing.T) {
 
 	// Stop buffering and trigger drain.
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
@@ -497,6 +596,7 @@ func testRequestCanceled(t *testing.T, explicitEnd bool) {
 
 	if explicitEnd {
 		b.StatsUpdate(&discovery.TabletStats{
+			Tablet: newMaster,
 			Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 			TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 		})
@@ -515,6 +615,7 @@ func testRequestCanceled(t *testing.T, explicitEnd bool) {
 	// shortly after. In that case, the buffer should ignore it.
 	if !explicitEnd {
 		b.StatsUpdate(&discovery.TabletStats{
+			Tablet: newMaster,
 			Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 			TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 		})
@@ -560,6 +661,7 @@ func TestEviction(t *testing.T) {
 
 	// End of failover. Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})
@@ -642,6 +744,7 @@ func TestEvictionNotPossible(t *testing.T) {
 
 	// End of failover. Stop buffering.
 	b.StatsUpdate(&discovery.TabletStats{
+		Tablet: newMaster,
 		Target: &querypb.Target{Keyspace: keyspace, Shard: shard, TabletType: topodatapb.TabletType_MASTER},
 		TabletExternallyReparentedTimestamp: 1, // Use any value > 0.
 	})

--- a/go/vt/vttablet/tabletmanager/rpc_external_reparent_test.go
+++ b/go/vt/vttablet/tabletmanager/rpc_external_reparent_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tabletmanager
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTabletExternallyReparentedAlwaysUpdatesTimestamp(t *testing.T) {
+	ctx := context.Background()
+	agent, _ := createTestAgent(ctx, t, nil)
+
+	// Initial call sets the timestamp.
+	if err := agent.TabletExternallyReparented(ctx, "unused_id"); err != nil {
+		t.Fatal(err)
+	}
+	if agent._tabletExternallyReparentedTime.IsZero() {
+		t.Fatalf("externally_reparented_time should have been updated")
+	}
+
+	// Run RPC again and verify that the timestamp was updated.
+	ter1 := agent._tabletExternallyReparentedTime
+	if err := agent.TabletExternallyReparented(ctx, "unused_id"); err != nil {
+		t.Fatal(err)
+	}
+	ter2 := agent._tabletExternallyReparentedTime
+	if ter1 == ter2 {
+		t.Fatalf("subsequent TER call did not update the timestamp: %v = %v", ter1, ter2)
+	}
+}

--- a/go/vt/vttablet/tabletmanager/rpc_replication.go
+++ b/go/vt/vttablet/tabletmanager/rpc_replication.go
@@ -194,7 +194,7 @@ func (agent *ActionAgent) InitMaster(ctx context.Context) (string, error) {
 	if err := agent.MysqlDaemon.SetReadOnly(false); err != nil {
 		return "", err
 	}
-	agent.setLastReparentedTime(startTime)
+	agent.setExternallyReparentedTime(startTime)
 
 	// Change our type to master if not already
 	if _, err := agent.TopoServer.UpdateTabletFields(ctx, agent.TabletAlias, func(tablet *topodatapb.Tablet) error {
@@ -351,7 +351,7 @@ func (agent *ActionAgent) PromoteSlaveWhenCaughtUp(ctx context.Context, position
 	if err := agent.MysqlDaemon.SetReadOnly(false); err != nil {
 		return "", err
 	}
-	agent.setLastReparentedTime(startTime)
+	agent.setExternallyReparentedTime(startTime)
 
 	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_MASTER); err != nil {
 		return "", err
@@ -538,7 +538,7 @@ func (agent *ActionAgent) PromoteSlave(ctx context.Context) (string, error) {
 	if err := agent.MysqlDaemon.SetReadOnly(false); err != nil {
 		return "", err
 	}
-	agent.setLastReparentedTime(startTime)
+	agent.setExternallyReparentedTime(startTime)
 
 	if _, err := topotools.ChangeType(ctx, agent.TopoServer, agent.TabletAlias, topodatapb.TabletType_MASTER); err != nil {
 		return "", err

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -723,11 +723,25 @@ message StreamHealthResponse {
   // or if a replica should not be used because the keyspace is being resharded.
   bool serving = 2;
 
-  // tablet_externally_reparented_timestamp contains the last time
-  // tabletmanager.TabletExternallyReparented was called on this tablet,
-  // or 0 if it was never called. This is meant to differentiate two tablets
-  // that report a target.TabletType of MASTER, only the one with the latest
-  // timestamp should be trusted.
+  // tablet_externally_reparented_timestamp can be interpreted as the last time
+  // we knew that this tablet was the MASTER of this shard.
+  //
+  // It is used by vtgate when determining the current MASTER of a shard.
+  // If vtgate sees more than one MASTER tablet, this timestamp is used
+  // as tiebreaker where the MASTER with the highest timestamp wins.
+  // Another usage of this timestamp is in go/vt/vtgate/buffer to detect the end
+  // of a reparent (failover) and stop buffering.
+  //
+  // In practice, this field is set to:
+  // a) the last time the RPC tabletmanager.TabletExternallyReparented was
+  //    called on this tablet (usually done by an external failover tool e.g.
+  //    Orchestrator). The failover tool can call this as long as we are the
+  //    master i.e. even ages after the last reparent occurred.
+  // OR
+  // b) the last time an active reparent was executed through a vtctl command
+  //    (InitShardMaster, PlannedReparentShard, EmergencyReparentShard)
+  // OR
+  // c) 0 if it was never called.
   int64 tablet_externally_reparented_timestamp = 3;
 
   // realtime_stats contains information about the tablet status


### PR DESCRIPTION
This was always the original intention, but until now we skipped setting the timestamp if the tablet is already the MASTER. See the change in rpc_external_reparent.go.

I've wrote a minimal unit test to verify the new behavior.

Additionally, I had to change the vtgate buffer code because it was dependent on the old behavior to detect a corner case when it should not start to buffer. That's when it saw the end of a reparent *before* an error due to the same reparent. In order to better test the new code, I had to change the unit tests to use a fake of time.Now().