### PR TITLE
vtgate/buffer: Reset value in test to the same value as the default value.

### DIFF
--- a/go/vt/vtgate/buffer/flags.go
+++ b/go/vt/vtgate/buffer/flags.go
@@ -48,7 +48,7 @@ func resetFlagsForTesting() {
 	flag.Set("buffer_window", "10s")
 	flag.Set("buffer_keyspace_shards", "")
 	flag.Set("buffer_max_failover_duration", "20s")
-	flag.Set("buffer_min_time_between_failovers", "5m")
+	flag.Set("buffer_min_time_between_failovers", "1m")
 }
 
 func verifyFlags() error {


### PR DESCRIPTION
This became out of sync.