### PR TITLE
types: use PlanValue in vtgate

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -28,7 +28,7 @@
     "Query": "select count(*), col from user where id = 1",
     "FieldQuery": "select count(*), col from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -285,7 +285,7 @@
     "Query": "select id, count(*) as c from user group by id having id = 1 and c = 10",
     "FieldQuery": "select id, count(*) as c from user where 1 != 1 group by id",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -823,6 +823,6 @@
       "Query":"select user.col1 as a from user where user.id = 5 group by a collate utf8_general_ci",
       "FieldQuery":"select user.col1 as a from user where 1 != 1 group by a collate utf8_general_ci",
       "Vindex":"user_index",
-      "Values":5
+      "Values":[5]
    }
 }

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -60,7 +60,7 @@
     },
     "Query": "update user set val = 1 where id = 1",
     "Vindex": "user_index",
-    "Values": 1,
+    "Values": [1],
     "Table": "user"
   }
 }
@@ -77,7 +77,7 @@
     },
     "Query": "update user set val = 1 where id = id2 and id = 1",
     "Vindex": "user_index",
-    "Values": 1,
+    "Values": [1],
     "Table": "user"
   }
 }
@@ -94,7 +94,7 @@
     },
     "Query": "update user set val = 1 where id = 18446744073709551616 and id = 1",
     "Vindex": "user_index",
-    "Values": 1,
+    "Values": [1],
     "Table": "user"
   }
 }
@@ -111,7 +111,7 @@
     },
     "Query": "delete from user where id = 1",
     "Vindex": "user_index",
-    "Values": 1,
+    "Values": [1],
     "Table": "user",
     "Subquery": "select Name, Costly from user where id = 1 for update"
   }
@@ -157,7 +157,7 @@
     },
     "Query": "update music set val = 1 where id = 1",
     "Vindex": "music_user_map",
-    "Values": 1,
+    "Values": [1],
     "Table": "music"
   }
 }
@@ -202,7 +202,7 @@
     },
     "Query": "delete from music where id = 1",
     "Vindex": "music_user_map",
-    "Values": 1,
+    "Values": [1],
     "Table": "music",
     "Subquery": "select id from music where id = 1 for update"
   }
@@ -220,7 +220,7 @@
     },
     "Query": "delete from music_extra where user_id = 1",
     "Vindex": "user_index",
-    "Values": 1,
+    "Values": [1],
     "Table": "music_extra"
   }
 }
@@ -272,7 +272,7 @@
 
 # insert unsharded, invalid value for auto-inc
 "insert into unsharded_auto(id, val) values(18446744073709551616, 'aa')"
-"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"could not compute value for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert unsharded, column present
 "insert into unsharded_auto(id, val) values(1, 'aa')"
@@ -414,6 +414,40 @@
     },
     "Prefix": "insert into user(id, Name, Costly) values ",
     "Mid":["(:_Id0, :_Name0, :_Costly0)"]
+  }
+}
+
+# insert with one vindex and bind var
+"insert into user(id) values (:aa)"
+{
+  "Original": "insert into user(id) values (:aa)",
+  "Instructions": {
+    "Opcode": "InsertSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "insert into user(id, Name, Costly) values (:_Id0, :_Name0, :_Costly0)",
+    "Values": [
+      [":__seq0"],
+      [null],
+      [null]
+    ],
+    "Table": "user",
+    "Generate": {
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select next :n values from seq",
+      "Values": [
+        ":aa"
+      ]
+    },
+    "Prefix": "insert into user(id, Name, Costly) values ",
+    "Mid": [
+      "(:_Id0, :_Name0, :_Costly0)"
+    ]
   }
 }
 
@@ -561,15 +595,15 @@
 
 # insert for non-vindex autoinc, invalid value
 "insert into user_extra(nonid, extra_id) values (2, 18446744073709551616)"
-"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"could not compute value for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert invalid index value
 "insert into music_extra(music_id, user_id) values(1, 18446744073709551616)"
-"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"could not compute value for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert invalid index value
 "insert into music_extra(music_id, user_id) values(1, id)"
-"unsupported: complex expression 'id' for vindex or auto-inc column: id is not a value"
+"could not compute value for vindex or auto-inc column: expression is too complex 'id'"
 
 # insert invalid table
 "insert into noexist(music_id, user_id) values(1, 18446744073709551616)"
@@ -646,7 +680,7 @@
 
 # replace unsharded, invalid value for auto-inc
 "replace into unsharded_auto(id, val) values(18446744073709551616, 'aa')"
-"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"could not compute value for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # replace unsharded, column present
 "replace into unsharded_auto(id, val) values(1, 'aa')"

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -272,7 +272,7 @@
 
 # insert unsharded, invalid value for auto-inc
 "insert into unsharded_auto(id, val) values(18446744073709551616, 'aa')"
-"could not convert val: 18446744073709551616, pos: 0: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert unsharded, column present
 "insert into unsharded_auto(id, val) values(1, 'aa')"
@@ -398,11 +398,11 @@
       "Sharded": true
     },
     "Query": "insert into user(id, Name, Costly) values (:_Id0, :_Name0, :_Costly0)",
-    "Values": [[
-      ":__seq0",
-      null,
-      null
-    ]],
+    "Values": [
+      [":__seq0"],
+      [null],
+      [null]
+    ],
     "Table": "user",
     "Generate": {
       "Keyspace": {
@@ -427,12 +427,12 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "insert into user(nonid, Id, Name, Costly) values (2, :_Id0, :_Name0, :_Costly0)",
-    "Values": [[
-      ":__seq0",
-      null,
-      null
-    ]],
+    "Query": "insert into user(nonid, id, Name, Costly) values (2, :_Id0, :_Name0, :_Costly0)",
+    "Values": [
+      [":__seq0"],
+      [null],
+      [null]
+    ],
     "Table": "user",
     "Generate": {
       "Keyspace": {
@@ -442,7 +442,7 @@
       "Query": "select next :n values from seq",
       "Values": [null]
     },
-    "Prefix": "insert into user(nonid, Id, Name, Costly) values ",
+    "Prefix": "insert into user(nonid, id, Name, Costly) values ",
     "Mid": ["(2, :_Id0, :_Name0, :_Costly0)"]
   }
 }
@@ -457,12 +457,12 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "insert into user(nonid, Id, Name, Costly) values (true, :_Id0, :_Name0, :_Costly0)",
-    "Values": [[
-      ":__seq0",
-      null,
-      null
-    ]],
+    "Query": "insert into user(nonid, id, Name, Costly) values (true, :_Id0, :_Name0, :_Costly0)",
+    "Values": [
+      [":__seq0"],
+      [null],
+      [null]
+    ],
     "Table": "user",
     "Generate": {
       "Keyspace": {
@@ -472,7 +472,7 @@
       "Query": "select next :n values from seq",
       "Values": [null]
     },
-    "Prefix": "insert into user(nonid, Id, Name, Costly) values ",
+    "Prefix": "insert into user(nonid, id, Name, Costly) values ",
     "Mid": ["(true, :_Id0, :_Name0, :_Costly0)"]
   }
 }
@@ -488,11 +488,11 @@
       "Sharded": true
     },
     "Query": "insert into user(nonid, name, id, Costly) values (2, :_Name0, :_Id0, :_Costly0)",
-    "Values": [[
-      ":__seq0",
-      "foo",
-      null
-    ]],
+    "Values": [
+      [":__seq0"],
+      ["foo"],
+      [null]
+    ],
     "Table": "user",
     "Generate": {
       "Keyspace": {
@@ -517,7 +517,7 @@
       "Name": "user",
       "Sharded": true
     },
-    "Query": "insert into user_extra(nonid, user_id, extra_id) values (2, :_user_id0, :__seq0)",
+    "Query": "insert into user_extra(nonid, extra_id, user_id) values (2, :__seq0, :_user_id0)",
     "Values": [[
       null
     ]],
@@ -530,8 +530,8 @@
       "Query": "select next :n values from seq",
       "Values": [null]
     },
-    "Prefix": "insert into user_extra(nonid, user_id, extra_id) values ",
-    "Mid": ["(2, :_user_id0, :__seq0)"]
+    "Prefix": "insert into user_extra(nonid, extra_id, user_id) values ",
+    "Mid": ["(2, :__seq0, :_user_id0)"]
   }
 }
 
@@ -561,15 +561,15 @@
 
 # insert for non-vindex autoinc, invalid value
 "insert into user_extra(nonid, extra_id) values (2, 18446744073709551616)"
-"could not convert val: 18446744073709551616, pos: 1: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert invalid index value
 "insert into music_extra(music_id, user_id) values(1, 18446744073709551616)"
-"could not convert val: 18446744073709551616, pos: 1: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # insert invalid index value
 "insert into music_extra(music_id, user_id) values(1, id)"
-"could not convert val: id, pos: 1: id is not a value"
+"unsupported: complex expression 'id' for vindex or auto-inc column: id is not a value"
 
 # insert invalid table
 "insert into noexist(music_id, user_id) values(1, 18446744073709551616)"
@@ -589,11 +589,13 @@
     "Values": [
       [
         ":__seq0",
+        ":__seq1"
+      ],
+      [
         null,
         null
       ],
       [
-        ":__seq1",
         null,
         null
       ]
@@ -644,7 +646,7 @@
 
 # replace unsharded, invalid value for auto-inc
 "replace into unsharded_auto(id, val) values(18446744073709551616, 'aa')"
-"could not convert val: 18446744073709551616, pos: 0: strconv.ParseUint: parsing "18446744073709551616": value out of range"
+"unsupported: complex expression '18446744073709551616' for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"
 
 # replace unsharded, column present
 "replace into unsharded_auto(id, val) values(1, 'aa')"

--- a/data/test/vtgate/filter_cases.txt
+++ b/data/test/vtgate/filter_cases.txt
@@ -26,7 +26,7 @@
     "Query": "select id from user where user.id = 5",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -58,7 +58,7 @@
     "Query": "select id from music where id = 5 and user_id = 4",
     "FieldQuery": "select id from music where 1 != 1",
     "Vindex": "user_index",
-    "Values": 4
+    "Values": [4]
   }
 }
 
@@ -75,7 +75,7 @@
     "Query": "select id from user where costly = 'aa' and name = 'bb'",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": "bb"
+    "Values": ["bb"]
   }
 }
 
@@ -93,8 +93,7 @@
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
     "Values": [
-      "aa",
-      "bb"
+      ["aa", "bb"]
     ]
   }
 }
@@ -127,7 +126,7 @@
     "Query": "select id from user where name = :a",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": ":a"
+    "Values": [":a"]
   }
 }
 
@@ -144,7 +143,7 @@
     "Query": "select id from user where name = 18446744073709551615",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": 18446744073709551615
+    "Values": [18446744073709551615]
   }
 }
 
@@ -161,7 +160,7 @@
     "Query": "select id from user where name in ::__vals",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": "::list"
+    "Values": ["::list"]
   }
 }
 
@@ -178,7 +177,7 @@
     "Query": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where user.id = 5",
     "FieldQuery": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -195,7 +194,7 @@
     "Query": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where user_extra.user_id = 5",
     "FieldQuery": "select user_extra.id from user join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -212,7 +211,7 @@
     "Query": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where user.id = 5",
     "FieldQuery": "select user_extra.id from user left join user_extra on user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -246,7 +245,7 @@
       "Query": "select user.col from user where user.id = 5",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Right": {
       "Opcode": "SelectScatter",
@@ -284,7 +283,7 @@
       "Query": "select user.col from user where user.id = 5",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Right": {
       "Opcode": "SelectEqualUnique",
@@ -295,7 +294,7 @@
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = 5",
       "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5,
+      "Values": [5],
       "JoinVars": {
         "user_col": {}
       }
@@ -333,7 +332,7 @@
       "Query": "select user_extra.id from user_extra where user_extra.col = :user_col and user_extra.user_id = :user_col",
       "FieldQuery": "select user_extra.id from user_extra where 1 != 1",
       "Vindex": "user_index",
-      "Values": ":user_col",
+      "Values": [":user_col"],
       "JoinVars": {
         "user_col": {}
       }
@@ -397,8 +396,7 @@
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
-      1,
-      2
+      [1, 2]
     ]
   }
 }
@@ -417,8 +415,7 @@
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
     "Values": [
-      1,
-      2
+      [1, 2]
     ]
   }
 }
@@ -436,7 +433,7 @@
     "Query": "select (id or col) as val from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa'",
     "FieldQuery": "select (id or col) as val from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": "aa"
+    "Values": ["aa"]
   }
 }
 
@@ -453,7 +450,7 @@
     "Query": "select id from user where user.col = false and user.id in (1, 2) and user.name = 'aa'",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "name_user_map",
-    "Values": "aa"
+    "Values": ["aa"]
   }
 }
 
@@ -470,7 +467,7 @@
     "Query": "select id from user where user.col = 5 and user.id in (1, 2) and user.name = 'aa' and user.id = 1",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -487,7 +484,7 @@
     "Query": "select id from user where user.id = 1 and user.name = 'aa' and user.id in (1, 2) and user.col = 5",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -582,8 +579,7 @@
       "FieldQuery": "select u.m from user as u where 1 != 1",
       "Vindex": "user_index",
       "Values": [
-        ":user_extra_col",
-        1
+        [":user_extra_col", 1]
       ],
       "JoinVars": {
         "user_extra_col": {}
@@ -622,7 +618,7 @@
       "Query": "select u.m from user as u where u.id = 5 and u.id in (select m2 from user where user.id = 5)",
       "FieldQuery": "select u.m from user as u where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Cols": [
       1
@@ -655,8 +651,7 @@
       "FieldQuery": "select u.m from user as u where 1 != 1",
       "Vindex": "user_index",
       "Values": [
-        ":user_extra_col",
-        1
+        [":user_extra_col", 1]
       ],
       "JoinVars": {
         "user_extra_col": {}
@@ -699,7 +694,7 @@
     "Query": "select id from user where id = 5 and user.col in (select user_extra.col from user_extra where user_extra.user_id = 5)",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -716,7 +711,7 @@
     "Query": "select id from user where id = 'aa' and user.col in (select user_extra.col from user_extra where user_extra.user_id = 'aa')",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": "aa"
+    "Values": ["aa"]
   }
 }
 
@@ -733,7 +728,7 @@
     "Query": "select id from user where id = :a and user.col in (select user_extra.col from user_extra where user_extra.user_id = :a)",
     "FieldQuery": "select id from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": ":a"
+    "Values": [":a"]
   }
 }
 
@@ -769,7 +764,7 @@
     "Query": "select user_extra.Id from user join user_extra on user.iD = user_extra.User_Id where user.Id = 5",
     "FieldQuery": "select user_extra.Id from user join user_extra on user.iD = user_extra.User_Id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -561,7 +561,7 @@
     "Query": "select user.col from user join user_extra on user.id = 5 and user.id = user_extra.user_id",
     "FieldQuery": "select user.col from user join user_extra on user.id = 5 and user.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -616,7 +616,7 @@
       "Query": "select user.col from user where user.id = 5",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Right": {
       "Opcode": "SelectScatter",
@@ -648,7 +648,7 @@
       "Query": "select user.col from user where user.id = 5",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Right": {
       "Opcode": "SelectScatter",
@@ -725,7 +725,7 @@
       "Query": "select user.col from user where user.name = :user_extra_user_id",
       "FieldQuery": "select user.col from user where 1 != 1",
       "Vindex": "name_user_map",
-      "Values": ":user_extra_user_id",
+      "Values": [":user_extra_user_id"],
       "JoinVars": {
         "user_extra_user_id": {}
       }
@@ -752,7 +752,7 @@
     "Query": "select id from (select id, col from user where id = 5) as t",
     "FieldQuery": "select id from (select id, col from user where 1 != 1) as t where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -769,7 +769,7 @@
     "Query": "select t.id from (select id from user where id = 5) as t join user_extra on t.id = user_extra.user_id",
     "FieldQuery": "select t.id from (select id from user where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -786,7 +786,7 @@
     "Query": "select t.id from (select user.id from user where user.id = 5) as t join user_extra on t.id = user_extra.user_id",
     "FieldQuery": "select t.id from (select user.id from user where 1 != 1) as t join user_extra on t.id = user_extra.user_id where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -824,7 +824,7 @@
       "Query": "select t.id from (select id from user where id = 5) as t",
       "FieldQuery": "select t.id from (select id from user where 1 != 1) as t where 1 != 1",
       "Vindex": "user_index",
-      "Values": 5
+      "Values": [5]
     },
     "Right": {
       "Opcode": "SelectScatter",
@@ -860,7 +860,7 @@
     "Query": "select u.col, e.col from (select col from user where id = 5) as u join (select col from user_extra where user_id = 5) as e",
     "FieldQuery": "select u.col, e.col from (select col from user where 1 != 1) as u join (select col from user_extra where 1 != 1) as e where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -93,7 +93,7 @@
     "Query": "select col from user where id = 5 order by aa asc",
     "FieldQuery": "select col from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -110,7 +110,7 @@
     "Query": "select col from user where id = 1 order by 1 asc",
     "FieldQuery": "select col from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -169,7 +169,7 @@
       "Query": "select user.col1 as a, user.col2, user.id from user where user.id = 1 order by null",
       "FieldQuery": "select user.col1 as a, user.col2, user.id from user where 1 != 1",
       "Vindex": "user_index",
-      "Values": 1
+      "Values": [1]
     },
     "Right": {
       "Opcode": "SelectEqualUnique",
@@ -180,7 +180,7 @@
       "Query": "select music.col3 from music where music.id = :user_id order by null",
       "FieldQuery": "select music.col3 from music where 1 != 1",
       "Vindex": "music_user_map",
-      "Values": ":user_id",
+      "Values": [":user_id"],
       "JoinVars": {
         "user_id": {}
       }
@@ -209,7 +209,7 @@
     "Query": "select * from user where id = 5 order by col asc",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -226,7 +226,7 @@
     "Query": "select user.* from user where id = 5 order by user.col asc",
     "FieldQuery": "select user.* from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -243,7 +243,7 @@
     "Query": "select * from user where id = 5 order by user.col asc",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -313,7 +313,7 @@
     "Query": "select * from user where id = 5 order by user.col collate utf8_general_ci asc",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -330,7 +330,7 @@
       "Query":"select * from user where id = 5 order by -col1 asc",
       "FieldQuery":"select * from user where 1 != 1",
       "Vindex":"user_index",
-      "Values":5
+      "Values":[5]
    }
 }
 
@@ -347,7 +347,7 @@
       "Query":"select * from user where id = 5 order by concat(col, col1) collate utf8_general_ci desc",
       "FieldQuery":"select * from user where 1 != 1",
       "Vindex":"user_index",
-      "Values":5
+      "Values":[5]
    }
 }
 
@@ -364,7 +364,7 @@
       "Query":"select * from user where id = 5 order by id + col collate utf8_general_ci desc",
       "FieldQuery":"select * from user where 1 != 1",
       "Vindex":"user_index",
-      "Values":5
+      "Values":[5]
    }
 }
 
@@ -381,7 +381,7 @@
       "Query":"select * from user as u join (select user_id from user_extra where user_id = 5) as eu on u.id = eu.user_id where u.id = 5 order by eu.user_id asc",
       "FieldQuery":"select * from user as u join (select user_id from user_extra where 1 != 1) as eu on u.id = eu.user_id where 1 != 1",
       "Vindex":"user_index",
-      "Values":5
+      "Values":[5]
    }
 }
 
@@ -398,7 +398,7 @@
     "Query": "select col1 from user where id = 1 limit 1",
     "FieldQuery": "select col1 from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -497,7 +497,3 @@
 # invalid limit expression
 "select id from user limit 1+1"
 "unexpected expression in LIMIT:  limit 1 + 1"
-
-# invalid value in limit
-"select id from user limit 'a'"
-"unexpected expression in LIMIT:  limit 'a'"

--- a/data/test/vtgate/select_cases.txt
+++ b/data/test/vtgate/select_cases.txt
@@ -189,7 +189,7 @@
     "Query": "select @@session.auto_increment_increment from dual",
     "FieldQuery": "select @@session.auto_increment_increment from dual where 1 != 1",
     "Vindex": "binary",
-    "Values": "\u0000"
+    "Values": ["\u0000"]
   }
 }
 
@@ -477,7 +477,7 @@
     "Query": "select * from user where name = 'abc' and (id = 4) limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 4
+    "Values": [4]
   }
 }
 
@@ -494,7 +494,7 @@
     "Query": "select * from user where (id = 4) and (name = 'abc') limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 4
+    "Values": [4]
   }
 }
 
@@ -511,7 +511,7 @@
     "Query": "select user0_.col as col0_ from user as user0_ where id = 1 order by user0_.col desc limit 2",
     "FieldQuery": "select user0_.col as col0_ from user as user0_ where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -528,7 +528,7 @@
     "Query": "select user0_.col as col0_ from user as user0_ where id = 1 order by col0_ desc limit 3",
     "FieldQuery": "select user0_.col as col0_ from user as user0_ where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -545,7 +545,7 @@
     "Query": "select * from user where (id = 1) and name = true limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -562,7 +562,7 @@
     "Query": "select * from user where (id = 1) and name limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 
@@ -579,7 +579,7 @@
     "Query": "select * from user where (id = 5) and name = true limit 5",
     "FieldQuery": "select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 5
+    "Values": [5]
   }
 }
 
@@ -615,7 +615,7 @@
     "Query": "select * from music where user_id = 1 union select * from user where id = 1",
     "FieldQuery": "select * from music where 1 != 1 union select * from user where 1 != 1",
     "Vindex": "user_index",
-    "Values": 1
+    "Values": [1]
   }
 }
 

--- a/data/test/vtgate/wireup_cases.txt
+++ b/data/test/vtgate/wireup_cases.txt
@@ -285,7 +285,7 @@
         "Query": "select 1 from user as u3 where u3.id = :u1_col",
         "FieldQuery": "select 1 from user as u3 where 1 != 1",
         "Vindex": "user_index",
-        "Values": ":u1_col",
+        "Values": [":u1_col"],
         "JoinVars": {
           "u1_col": {}
         }
@@ -345,7 +345,7 @@
         "Query": "select 1 from user as u2 where u2.id = :u1_col",
         "FieldQuery": "select 1 from user as u2 where 1 != 1",
         "Vindex": "user_index",
-        "Values": ":u1_col",
+        "Values": [":u1_col"],
         "JoinVars": {
           "u1_col": {}
         }
@@ -359,7 +359,7 @@
         "Query": "select 1 from user as u3 where u3.id = :u1_col",
         "FieldQuery": "select 1 from user as u3 where 1 != 1",
         "Vindex": "user_index",
-        "Values": ":u1_col",
+        "Values": [":u1_col"],
         "JoinVars": {
           "u1_col": {}
         }

--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -225,7 +225,7 @@ func ConvertToUint64(v interface{}) (uint64, error) {
 		}
 		num, err = newIntegralNumeric(sv)
 	default:
-		return 0, fmt.Errorf("getNumber: unexpected type for %v: %T", v, v)
+		return 0, fmt.Errorf("ConvertToUint64: unexpected type for %v: %T", v, v)
 	}
 	if err != nil {
 		return 0, err
@@ -234,7 +234,7 @@ func ConvertToUint64(v interface{}) (uint64, error) {
 	switch num.typ {
 	case Int64:
 		if num.ival < 0 {
-			return 0, fmt.Errorf("getNumber: negative number cannot be converted to unsigned: %d", num.ival)
+			return 0, fmt.Errorf("ConvertToUint64: negative number cannot be converted to unsigned: %d", num.ival)
 		}
 		return uint64(num.ival), nil
 	case Uint64:
@@ -245,7 +245,7 @@ func ConvertToUint64(v interface{}) (uint64, error) {
 
 func int64ToUint64(n int64) (uint64, error) {
 	if n < 0 {
-		return 0, fmt.Errorf("getNumber: negative number cannot be converted to unsigned: %d", n)
+		return 0, fmt.Errorf("ConvertToUint64: negative number cannot be converted to unsigned: %d", n)
 	}
 	return uint64(n), nil
 }

--- a/go/sqltypes/arithmetic_test.go
+++ b/go/sqltypes/arithmetic_test.go
@@ -284,7 +284,7 @@ func TestConvertToUint64(t *testing.T) {
 		out: 1,
 	}, {
 		v:   int64(-1),
-		err: "getNumber: negative number cannot be converted to unsigned: -1",
+		err: "ConvertToUint64: negative number cannot be converted to unsigned: -1",
 	}, {
 		v:   uint(1),
 		out: 1,
@@ -317,13 +317,13 @@ func TestConvertToUint64(t *testing.T) {
 		err: "cannot convert a TUPLE bind var into a value",
 	}, {
 		v:   nil,
-		err: "getNumber: unexpected type for <nil>: <nil>",
+		err: "ConvertToUint64: unexpected type for <nil>: <nil>",
 	}, {
 		v:   makeAny(VarChar, "abcd"),
 		err: "could not parse value: abcd",
 	}, {
 		v:   makeInt(-1),
-		err: "getNumber: negative number cannot be converted to unsigned: -1",
+		err: "ConvertToUint64: negative number cannot be converted to unsigned: -1",
 	}, {
 		v:   makeUint(1),
 		out: 1,

--- a/go/sqltypes/plan_value.go
+++ b/go/sqltypes/plan_value.go
@@ -68,6 +68,11 @@ func (pv PlanValue) IsNull() bool {
 	return pv.Key == "" && pv.Value.IsNull() && pv.ListKey == "" && pv.Values == nil
 }
 
+// IsList returns true if the PlanValue is a list.
+func (pv PlanValue) IsList() bool {
+	return pv.ListKey != "" || pv.Values != nil
+}
+
 // ResolveValue resolves a PlanValue as a single value based on the supplied bindvars.
 func (pv PlanValue) ResolveValue(bindVars map[string]*querypb.BindVariable) (Value, error) {
 	switch {
@@ -149,7 +154,7 @@ func (pv PlanValue) MarshalJSON() ([]byte, error) {
 		}
 		return json.Marshal(pv.Value.String())
 	case pv.ListKey != "":
-		return json.Marshal("::" + pv.Key)
+		return json.Marshal("::" + pv.ListKey)
 	case pv.Values != nil:
 		return json.Marshal(pv.Values)
 	}

--- a/go/sqltypes/plan_value_test.go
+++ b/go/sqltypes/plan_value_test.go
@@ -52,6 +52,34 @@ func TestPlanValueIsNull(t *testing.T) {
 	}
 }
 
+func TestPlanValueIsList(t *testing.T) {
+	tcases := []struct {
+		in  PlanValue
+		out bool
+	}{{
+		in:  PlanValue{},
+		out: false,
+	}, {
+		in:  PlanValue{Key: "aa"},
+		out: false,
+	}, {
+		in:  PlanValue{Value: MakeString([]byte("aa"))},
+		out: false,
+	}, {
+		in:  PlanValue{ListKey: "aa"},
+		out: true,
+	}, {
+		in:  PlanValue{Values: []PlanValue{}},
+		out: true,
+	}}
+	for _, tc := range tcases {
+		got := tc.in.IsList()
+		if got != tc.out {
+			t.Errorf("IsList(%v): %v, want %v", tc.in, got, tc.out)
+		}
+	}
+}
+
 func TestResolveRows(t *testing.T) {
 	testBindVars := map[string]*querypb.BindVariable{
 		"int":    Int64BindVariable(10),

--- a/go/vt/binlog/keyspace_id_resolver.go
+++ b/go/vt/binlog/keyspace_id_resolver.go
@@ -168,7 +168,7 @@ type keyspaceIDResolverFactoryV3 struct {
 }
 
 func (r *keyspaceIDResolverFactoryV3) keyspaceID(v sqltypes.Value) ([]byte, error) {
-	ids := []interface{}{v}
+	ids := []sqltypes.Value{v}
 	ksids, err := r.vindex.Map(nil, ids)
 	if err != nil {
 		return nil, err

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sqlparser
 
 import (
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -357,58 +356,6 @@ func TestNewPlanValue(t *testing.T) {
 	}
 }
 
-func TestAsInterface(t *testing.T) {
-	testcases := []struct {
-		in  Expr
-		out interface{}
-	}{{
-		in:  ValTuple{newStrVal("aa")},
-		out: []interface{}{sqltypes.MakeString([]byte("aa"))},
-	}, {
-		in:  ValTuple{&ColName{}},
-		out: errors.New("expression is too complex ''"),
-	}, {
-		in:  newValArg(":aa"),
-		out: ":aa",
-	}, {
-		in:  ListArg("::aa"),
-		out: "::aa",
-	}, {
-		in:  newStrVal("aa"),
-		out: sqltypes.MakeString([]byte("aa")),
-	}, {
-		in:  newHexVal("3131"),
-		out: sqltypes.MakeString([]byte("11")),
-	}, {
-		in:  newHexVal("313"),
-		out: errors.New("encoding/hex: odd length hex string"),
-	}, {
-		in:  newIntVal("313"),
-		out: sqltypes.MakeTrusted(sqltypes.Int64, []byte("313")),
-	}, {
-		in:  newIntVal("18446744073709551616"),
-		out: errors.New("type mismatch: strconv.ParseUint: parsing \"18446744073709551616\": value out of range"),
-	}, {
-		in:  newFloatVal("1.2"),
-		out: errors.New("expression is too complex '1.2'"),
-	}, {
-		in:  &NullVal{},
-		out: nil,
-	}, {
-		in:  &ColName{},
-		out: errors.New("expression is too complex ''"),
-	}}
-	for _, tc := range testcases {
-		out, err := AsInterface(tc.in)
-		if err != nil {
-			out = err
-		}
-		if !reflect.DeepEqual(out, tc.out) {
-			t.Errorf("AsInterface(%#v): %#v, want %#v", tc.in, out, tc.out)
-		}
-	}
-}
-
 func TestStringIn(t *testing.T) {
 	testcases := []struct {
 		in1 string
@@ -484,10 +431,6 @@ func newStrVal(in string) *SQLVal {
 
 func newIntVal(in string) *SQLVal {
 	return NewIntVal([]byte(in))
-}
-
-func newFloatVal(in string) *SQLVal {
-	return NewFloatVal([]byte(in))
 }
 
 func newHexVal(in string) *SQLVal {

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -153,24 +153,42 @@ func TestIsValue(t *testing.T) {
 		in  Expr
 		out bool
 	}{{
-		in:  newStrVal(""),
+		in:  newStrVal("aa"),
 		out: true,
 	}, {
-		in:  newHexVal(""),
+		in:  newHexVal("3131"),
 		out: true,
 	}, {
-		in:  newIntVal(""),
+		in:  newIntVal("1"),
 		out: true,
 	}, {
-		in:  newValArg(""),
+		in:  newValArg(":a"),
 		out: true,
 	}, {
-		in: &NullVal{},
+		in: &ValuesFuncExpr{
+			Name:     NewColIdent("foo"),
+			Resolved: newStrVal(""),
+		},
+		out: true,
+	}, {
+		in: &ValuesFuncExpr{
+			Name: NewColIdent("foo"),
+		},
+		out: false,
+	}, {
+		in:  &NullVal{},
+		out: false,
 	}}
 	for _, tc := range testcases {
 		out := IsValue(tc.in)
 		if out != tc.out {
 			t.Errorf("IsValue(%T): %v, want %v", tc.in, out, tc.out)
+		}
+		if tc.out {
+			// NewPlanValue should not fail for valid values.
+			if _, err := NewPlanValue(tc.in); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }
@@ -198,12 +216,12 @@ func TestIsSimpleTuple(t *testing.T) {
 		in  Expr
 		out bool
 	}{{
-		in:  ValTuple{newStrVal("")},
+		in:  ValTuple{newStrVal("aa")},
 		out: true,
 	}, {
 		in: ValTuple{&ColName{}},
 	}, {
-		in:  ListArg(""),
+		in:  ListArg("::a"),
 		out: true,
 	}, {
 		in: &ColName{},
@@ -212,6 +230,12 @@ func TestIsSimpleTuple(t *testing.T) {
 		out := IsSimpleTuple(tc.in)
 		if out != tc.out {
 			t.Errorf("IsSimpleTuple(%T): %v, want %v", tc.in, out, tc.out)
+		}
+		if tc.out {
+			// NewPlanValue should not fail for valid tuples.
+			if _, err := NewPlanValue(tc.in); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 }

--- a/go/vt/vtgate/engine/limit_test.go
+++ b/go/vt/vtgate/engine/limit_test.go
@@ -19,6 +19,7 @@ package engine
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
@@ -41,7 +42,7 @@ func TestLimitExecute(t *testing.T) {
 	}
 
 	l := &Limit{
-		Count: 2,
+		Count: int64PlanValue(2),
 		Input: tp,
 	}
 
@@ -61,7 +62,7 @@ func TestLimitExecute(t *testing.T) {
 
 	// Test with limit equal to input.
 	tp.rewind()
-	l.Count = 3
+	l.Count = int64PlanValue(3)
 	result, err = l.Execute(nil, nil, nil, false)
 	if err != nil {
 		t.Error(err)
@@ -72,7 +73,7 @@ func TestLimitExecute(t *testing.T) {
 
 	// Test with limit higher than input.
 	tp.rewind()
-	l.Count = 4
+	l.Count = int64PlanValue(4)
 	result, err = l.Execute(nil, nil, nil, false)
 	if err != nil {
 		t.Error(err)
@@ -83,7 +84,7 @@ func TestLimitExecute(t *testing.T) {
 
 	// Test with bind vars.
 	tp.rewind()
-	l.Count = ":l"
+	l.Count = sqltypes.PlanValue{Key: "l"}
 	result, err = l.Execute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, nil, false)
 	if err != nil {
 		t.Error(err)
@@ -109,7 +110,7 @@ func TestLimitStreamExecute(t *testing.T) {
 	}
 
 	l := &Limit{
-		Count: 2,
+		Count: int64PlanValue(2),
 		Input: tp,
 	}
 
@@ -133,7 +134,7 @@ func TestLimitStreamExecute(t *testing.T) {
 
 	// Test with bind vars.
 	tp.rewind()
-	l.Count = ":l"
+	l.Count = sqltypes.PlanValue{Key: "l"}
 	results = nil
 	err = l.StreamExecute(nil, map[string]*querypb.BindVariable{"l": sqltypes.Int64BindVariable(2)}, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
@@ -148,7 +149,7 @@ func TestLimitStreamExecute(t *testing.T) {
 
 	// Test with limit equal to input
 	tp.rewind()
-	l.Count = 3
+	l.Count = int64PlanValue(3)
 	results = nil
 	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
@@ -170,7 +171,7 @@ func TestLimitStreamExecute(t *testing.T) {
 
 	// Test with limit higher than input.
 	tp.rewind()
-	l.Count = 4
+	l.Count = int64PlanValue(4)
 	results = nil
 	err = l.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
 		results = append(results, qr)
@@ -208,7 +209,7 @@ func TestLimitGetFields(t *testing.T) {
 func TestLimitInputFail(t *testing.T) {
 	tp := &fakePrimitive{sendErr: errors.New("input fail")}
 
-	l := &Limit{Count: 1, Input: tp}
+	l := &Limit{Count: int64PlanValue(1), Input: tp}
 
 	want := "input fail"
 	if _, err := l.Execute(nil, nil, nil, false); err == nil || err.Error() != want {
@@ -229,22 +230,22 @@ func TestLimitInputFail(t *testing.T) {
 
 func TestLimitInvalidCount(t *testing.T) {
 	l := &Limit{
-		Count: "l",
+		Count: sqltypes.PlanValue{Key: "l"},
 	}
 	_, err := l.fetchCount(nil, nil)
-	want := "could not find bind var l"
+	want := "missing bind var l"
 	if err == nil || err.Error() != want {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
-	l.Count = 1.2
+	l.Count = sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.Float64, []byte("1.2"))}
 	_, err = l.fetchCount(nil, nil)
-	want = "getNumber: unexpected type for 1.2: float64"
+	want = "could not parse value: 1.2"
 	if err == nil || err.Error() != want {
 		t.Errorf("fetchCount: %v, want %s", err, want)
 	}
 
-	l.Count = uint64(18446744073709551615)
+	l.Count = sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.Uint64, []byte("18446744073709551615"))}
 	_, err = l.fetchCount(nil, nil)
 	want = "requested limit is out of range: 18446744073709551615"
 	if err == nil || err.Error() != want {
@@ -261,4 +262,8 @@ func TestLimitInvalidCount(t *testing.T) {
 	if err == nil || err.Error() != want {
 		t.Errorf("l.Execute: %v, want %s", err, want)
 	}
+}
+
+func int64PlanValue(v int64) sqltypes.PlanValue {
+	return sqltypes.PlanValue{Value: sqltypes.MakeTrusted(sqltypes.Int64, strconv.AppendInt(nil, v, 10))}
 }

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -599,14 +599,14 @@ func (route *Route) getInsertShardedRoute(vcursor VCursor, bindVars map[string]*
 	}
 
 	inputs := route.Values.([]interface{})
-	allKeys := make([][]interface{}, len(inputs[0].([]interface{})))
-	for _, input := range inputs {
+	allKeys := make([][]interface{}, len(inputs))
+	for colNum, input := range inputs {
 		keys, err := route.resolveKeys(input.([]interface{}), bindVars)
 		if err != nil {
 			return "", nil, fmt.Errorf("getInsertShardedRoute: %v", err)
 		}
-		for colNum := 0; colNum < len(keys); colNum++ {
-			allKeys[colNum] = append(allKeys[colNum], keys[colNum])
+		for _, key := range keys {
+			allKeys[colNum] = append(allKeys[colNum], key)
 		}
 	}
 

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -470,15 +470,12 @@ func (e *Executor) MessageAck(ctx context.Context, keyspace, name string, ids []
 		// We always use the (unique) primary vindex. The ID must be the
 		// primary vindex for message tables.
 		mapper := table.ColumnVindexes[0].Vindex.(vindexes.Unique)
-		// convert []*querypb.Value to []interface{} for calling Map.
-		asInterface := make([]interface{}, 0, len(ids))
+		// convert []*querypb.Value to []sqltypes.Value for calling Map.
+		values := make([]sqltypes.Value, 0, len(ids))
 		for _, id := range ids {
-			asInterface = append(asInterface, &querypb.BindVariable{
-				Type:  id.Type,
-				Value: id.Value,
-			})
+			values = append(values, sqltypes.MakeTrusted(id.Type, id.Value))
 		}
-		ksids, err := mapper.Map(vcursor, asInterface)
+		ksids, err := mapper.Map(vcursor, values)
 		if err != nil {
 			return 0, err
 		}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -436,7 +436,7 @@ func TestInsertGeneratorSharded(t *testing.T) {
 		t.Error(err)
 	}
 	wantQueries := []*querypb.BoundQuery{{
-		Sql: "insert into user(v, name, Id) values (2, :_name0, :_Id0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		Sql: "insert into user(v, name, id) values (2, :_name0, :_Id0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
 		BindVariables: map[string]*querypb.BindVariable{
 			"_Id0":   sqltypes.Int64BindVariable(1),
 			"__seq0": sqltypes.Int64BindVariable(1),

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -114,7 +114,7 @@ func TestUpdateEqualFail(t *testing.T) {
 	s := getSandbox("TestExecutor")
 
 	_, err := executorExec(executor, "update user set a=2 where id = :aa", nil)
-	want := "execUpdateEqual: could not find bind var :aa"
+	want := "execUpdateEqual: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -291,7 +291,7 @@ func TestDeleteEqualFail(t *testing.T) {
 	s := getSandbox("TestExecutor")
 
 	_, err := executorExec(executor, "delete from user where id = :aa", nil)
-	want := "execDeleteEqual: could not find bind var :aa"
+	want := "execDeleteEqual: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -687,13 +687,13 @@ func TestInsertFail(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
 
 	_, err := executorExec(executor, "insert into user(id, v, name) values (:aa, 2, 'myname')", nil)
-	want := "execInsertSharded: handleGenerate: could not find bind var :aa"
+	want := "execInsertSharded: handleGenerate: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
 
 	_, err = executorExec(executor, "insert into main1(id, v, name) values (:aa, 2, 'myname')", nil)
-	want = "execInsertUnsharded: handleGenerate: could not find bind var :aa"
+	want = "execInsertUnsharded: handleGenerate: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -534,7 +534,7 @@ func TestSelectEqualFail(t *testing.T) {
 	}
 
 	_, err = executorExec(executor, "select id from user where id = :aa", nil)
-	want = "paramsSelectEqual: could not find bind var :aa"
+	want = "paramsSelectEqual: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -736,13 +736,13 @@ func TestSelectINFail(t *testing.T) {
 	executor, _, _, _ := createExecutorEnv()
 
 	_, err := executorExec(executor, "select id from user where id in (:aa)", nil)
-	want := "paramsSelectIN: could not find bind var :aa"
+	want := "paramsSelectIN: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
 
 	_, err = executorExec(executor, "select id from user where id in ::aa", nil)
-	want = "paramsSelectIN: could not find bind var ::aa"
+	want = "paramsSelectIN: missing bind var aa"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -750,7 +750,7 @@ func TestSelectINFail(t *testing.T) {
 	_, err = executorExec(executor, "select id from user where id in ::aa", map[string]*querypb.BindVariable{
 		"aa": sqltypes.Int64BindVariable(1),
 	})
-	want = `paramsSelectIN: expecting list for bind var ::aa: type:INT64 value:"1" `
+	want = `paramsSelectIN: single value was supplied for TUPLE bind var aa`
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec:\n%v, want\n%v", err, want)
 	}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -74,11 +74,9 @@ type builder interface {
 	PushOrderByNull()
 
 	// SetUpperLimit is an optimization hint that tells that primitive
-	// that it it does not need to return more than the specified number of rows.
+	// that it does not need to return more than the specified number of rows.
 	// A primitive that cannot perform this can ignore the request.
-	// The count is similar to a plan Value. In this case, it can be
-	// a string (bindvar name), or an int64.
-	SetUpperLimit(count interface{})
+	SetUpperLimit(count *sqlparser.SQLVal)
 
 	// PushMisc pushes miscelleaneous constructs to all the primitives.
 	PushMisc(sel *sqlparser.Select)

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
 )
@@ -190,33 +189,4 @@ func hexEqual(a, b *sqlparser.SQLVal) bool {
 		return bytes.Equal(v, v2)
 	}
 	return false
-}
-
-// valConvert converts an AST value to the Value field in the route.
-func valConvert(node sqlparser.Expr) (interface{}, error) {
-	switch node := node.(type) {
-	case *sqlparser.SQLVal:
-		switch node.Type {
-		case sqlparser.ValArg:
-			return string(node.Val), nil
-		case sqlparser.StrVal:
-			return []byte(node.Val), nil
-		case sqlparser.HexVal:
-			return node.HexDecode()
-		case sqlparser.IntVal:
-			val := string(node.Val)
-			signed, err := strconv.ParseInt(val, 0, 64)
-			if err == nil {
-				return signed, nil
-			}
-			unsigned, err := strconv.ParseUint(val, 0, 64)
-			if err == nil {
-				return unsigned, nil
-			}
-			return nil, err
-		}
-	case *sqlparser.NullVal:
-		return nil, nil
-	}
-	return nil, fmt.Errorf("%v is not a value", sqlparser.String(node))
 }

--- a/go/vt/vtgate/planbuilder/expr_test.go
+++ b/go/vt/vtgate/planbuilder/expr_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package planbuilder
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
@@ -100,43 +99,6 @@ func TestValEqual(t *testing.T) {
 		out := valEqual(tc.in1, tc.in2)
 		if out != tc.out {
 			t.Errorf("valEqual(%#v, %#v): %v, want %v", tc.in1, tc.in2, out, tc.out)
-		}
-	}
-}
-
-func TestValConvert(t *testing.T) {
-	testcases := []struct {
-		in  sqlparser.Expr
-		out interface{}
-	}{{
-		in:  newValArg(":aa"),
-		out: ":aa",
-	}, {
-		in:  newStrVal("aa"),
-		out: []byte("aa"),
-	}, {
-		in:  newHexVal("3131"),
-		out: []byte("11"),
-	}, {
-		in:  newIntVal("3131"),
-		out: int64(3131),
-	}, {
-		in:  newIntVal("18446744073709551615"),
-		out: uint64(18446744073709551615),
-	}, {
-		in:  newIntVal("aa"),
-		out: "strconv.ParseUint: parsing \"aa\": invalid syntax",
-	}, {
-		in:  sqlparser.ListArg("::aa"),
-		out: "::aa is not a value",
-	}}
-	for _, tc := range testcases {
-		out, err := valConvert(tc.in)
-		if err != nil {
-			out = err.Error()
-		}
-		if !reflect.DeepEqual(out, tc.out) {
-			t.Errorf("ValConvert(%#v): %#v, want %#v", tc.in, out, tc.out)
 		}
 	}
 }

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -47,12 +47,12 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		Table:    table,
 		Keyspace: table.Keyspace,
 	}
-	var values sqlparser.Values
-	switch rows := ins.Rows.(type) {
+	var rows sqlparser.Values
+	switch insertValues := ins.Rows.(type) {
 	case *sqlparser.Union:
 		return nil, errors.New("unsupported: union in insert")
 	case *sqlparser.Select:
-		bldr, err := processSelect(rows, vschema, nil)
+		bldr, err := processSelect(insertValues, vschema, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -69,39 +69,29 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		eRoute.Query = generateQuery(ins)
 		return eRoute, nil
 	case sqlparser.Values:
-		values = rows
-		if hasSubquery(values) {
+		rows = insertValues
+		if hasSubquery(rows) {
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", rows))
+		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", insertValues))
 	}
 	if eRoute.Table.AutoIncrement == nil {
 		eRoute.Query = generateQuery(ins)
 		return eRoute, nil
 	}
+
+	// Table has auto-inc and has a VALUES clause.
 	if len(ins.Columns) == 0 {
 		return nil, errors.New("column list required for tables with auto-inc columns")
 	}
-	for _, value := range values {
-		if len(ins.Columns) != len(value) {
+	for _, row := range rows {
+		if len(ins.Columns) != len(row) {
 			return nil, errors.New("column list doesn't match values")
 		}
 	}
-	autoIncValues := make([]interface{}, 0, len(values))
-	for rowNum := range values {
-		autoIncVal, err := handleAutoinc(ins, eRoute.Table.AutoIncrement, rowNum)
-		if err != nil {
-			return nil, err
-		}
-		autoIncValues = append(autoIncValues, autoIncVal)
-	}
-	if eRoute.Table.AutoIncrement != nil {
-		eRoute.Generate = &engine.Generate{
-			Keyspace: eRoute.Table.AutoIncrement.Sequence.Keyspace,
-			Query:    fmt.Sprintf("select next :n values from %s", sqlparser.String(eRoute.Table.AutoIncrement.Sequence.Name)),
-			Values:   autoIncValues,
-		}
+	if err := modifyForAutoinc(ins, eRoute); err != nil {
+		return nil, err
 	}
 	eRoute.Query = generateQuery(ins)
 	return eRoute, nil
@@ -116,57 +106,43 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 	if len(ins.Columns) == 0 {
 		return nil, errors.New("no column list")
 	}
-	var values sqlparser.Values
-	switch rows := ins.Rows.(type) {
+	var rows sqlparser.Values
+	switch insertValues := ins.Rows.(type) {
 	case *sqlparser.Select, *sqlparser.Union:
 		return nil, errors.New("unsupported: insert into select")
 	case sqlparser.Values:
-		values = rows
-		if hasSubquery(values) {
+		rows = insertValues
+		if hasSubquery(rows) {
 			return nil, errors.New("unsupported: subquery in insert values")
 		}
 	default:
-		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", rows))
+		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", insertValues))
 	}
-	for _, value := range values {
+	for _, value := range rows {
 		if len(ins.Columns) != len(value) {
 			return nil, errors.New("column list doesn't match values")
 		}
 	}
 
-	colVindexes := eRoute.Table.ColumnVindexes
-	routeValues := make([]interface{}, 0, len(values))
-	autoIncValues := make([]interface{}, 0, len(values))
-	for rowNum := range values {
-		rowValue := make([]interface{}, 0, len(colVindexes))
-		for _, index := range colVindexes {
-			row, pos := findOrInsertPos(ins, index.Column, rowNum)
-			value, err := handleVindexCol(index, rowNum, row, pos)
-			if err != nil {
-				return nil, err
-			}
-			rowValue = append(rowValue, value)
-		}
-		if eRoute.Table.AutoIncrement != nil {
-			autoIncVal, value, err := handleShardedAutoinc(ins, eRoute.Table.AutoIncrement, rowValue, rowNum)
-			if err != nil {
-				return nil, err
-			}
-			rowValue = value
-			autoIncValues = append(autoIncValues, autoIncVal)
-		}
-		routeValues = append(routeValues, rowValue)
-	}
 	if eRoute.Table.AutoIncrement != nil {
-		eRoute.Generate = &engine.Generate{
-			Keyspace: eRoute.Table.AutoIncrement.Sequence.Keyspace,
-			Query:    fmt.Sprintf("select next :n values from %s", sqlparser.String(eRoute.Table.AutoIncrement.Sequence.Name)),
-			Values:   autoIncValues,
+		if err := modifyForAutoinc(ins, eRoute); err != nil {
+			return nil, err
 		}
+	}
+
+	routeValues := make([]interface{}, 0, len(rows))
+	for _, colVindex := range eRoute.Table.ColumnVindexes {
+		pos := findOrAddColumn(ins, colVindex.Column)
+		swappedValues, err := swapBindVariables(rows, pos, ":_"+colVindex.Column.CompliantName())
+		if err != nil {
+			return nil, err
+		}
+		routeValues = append(routeValues, swappedValues)
 	}
 	eRoute.Values = routeValues
+
 	eRoute.Query = generateQuery(ins)
-	generateInsertShardedQuery(ins, eRoute, values)
+	generateInsertShardedQuery(ins, eRoute, rows)
 	return eRoute, nil
 }
 
@@ -188,59 +164,51 @@ func generateInsertShardedQuery(node *sqlparser.Insert, eRoute *engine.Route, va
 	eRoute.Suffix = suffixBuf.String()
 }
 
-// handleVindexCol substitutes the insert value with a bind var name and returns
-// the converted value, which will be used at the time of insert to validate the vindex value.
-func handleVindexCol(colVindex *vindexes.ColumnVindex, rowNum int, row sqlparser.ValTuple, pos int) (interface{}, error) {
-	val, err := valConvert(row[pos])
+// modifyForAutoinc modfies the AST and the plan to generate
+// necessary autoinc values. It must be called only if eRoute.Table.AutoIncrement
+// is set.
+func modifyForAutoinc(ins *sqlparser.Insert, eRoute *engine.Route) error {
+	pos := findOrAddColumn(ins, eRoute.Table.AutoIncrement.Column)
+	autoIncValues, err := swapBindVariables(ins.Rows.(sqlparser.Values), pos, ":"+engine.SeqVarName)
 	if err != nil {
-		return val, fmt.Errorf("could not convert val: %s, pos: %d: %v", sqlparser.String(row[pos]), pos, err)
+		return err
 	}
-	row[pos] = sqlparser.NewValArg([]byte(":_" + colVindex.Column.CompliantName() + strconv.Itoa(rowNum)))
-	return val, nil
+	eRoute.Generate = &engine.Generate{
+		Keyspace: eRoute.Table.AutoIncrement.Sequence.Keyspace,
+		Query:    fmt.Sprintf("select next :n values from %s", sqlparser.String(eRoute.Table.AutoIncrement.Sequence.Name)),
+		Values:   autoIncValues,
+	}
+	return nil
 }
 
-// handleShardedAutoinc substitutes the insert value with a bind var and returns
-// the converted value, which will be used at the time of decide if a new value should be generated.
-// This is for a sharded keyspace which also needs to take care of an additional redirect.
-func handleShardedAutoinc(ins *sqlparser.Insert, autoinc *vindexes.AutoIncrement, rowValue []interface{}, rowNum int) (interface{}, []interface{}, error) {
-	// If it's also a colvindex, we have to add a redirect from route.Values.
-	// Otherwise, we have to redirect from row[pos].
-	if autoinc.ColumnVindexNum >= 0 {
-		val := rowValue[autoinc.ColumnVindexNum]
-		rowValue[autoinc.ColumnVindexNum] = ":" + engine.SeqVarName + strconv.Itoa(rowNum)
-		return val, rowValue, nil
+// swapBindVariables swaps in bind variable names at the the specified
+// column position in the AST values and returns the converted values back.
+// Bind variable names are generated using baseName.
+func swapBindVariables(rows sqlparser.Values, colNum int, baseName string) ([]interface{}, error) {
+	vals := make([]interface{}, len(rows))
+	for rowNum, row := range rows {
+		val, err := valConvert(row[colNum])
+		if err != nil {
+			return nil, fmt.Errorf("unsupported: complex expression '%s' for vindex or auto-inc column: %v", sqlparser.String(row[colNum]), err)
+		}
+		vals[rowNum] = val
+		row[colNum] = sqlparser.NewValArg([]byte(baseName + strconv.Itoa(rowNum)))
 	}
-	val, err := handleAutoinc(ins, autoinc, rowNum)
-	return val, rowValue, err
+	return vals, nil
 }
 
-// handleAutoinc substitutes the insert value with a bind var and returns
-// the converted value, which will be used at the time of decide if a new value should be generated.
-// This works for columns with no vindexes.
-func handleAutoinc(ins *sqlparser.Insert, autoinc *vindexes.AutoIncrement, rowNum int) (interface{}, error) {
-	row, pos := findOrInsertPos(ins, autoinc.Column, rowNum)
-	val, err := valConvert(row[pos])
-	if err != nil {
-		return nil, fmt.Errorf("could not convert val: %s, pos: %d: %v", sqlparser.String(row[pos]), pos, err)
-	}
-	row[pos] = sqlparser.NewValArg([]byte(":" + engine.SeqVarName + strconv.Itoa(rowNum)))
-	return val, nil
-}
-
-func findOrInsertPos(ins *sqlparser.Insert, col sqlparser.ColIdent, rowNum int) (row sqlparser.ValTuple, pos int) {
-	pos = -1
+// findOrAddColumn finds the position of a column in the insert. If it's
+// absent it appends it to the with NULL values and returns that position.
+func findOrAddColumn(ins *sqlparser.Insert, col sqlparser.ColIdent) int {
 	for i, column := range ins.Columns {
 		if col.Equal(column) {
-			pos = i
-			break
+			return i
 		}
 	}
-	if pos == -1 {
-		pos = len(ins.Columns)
-		ins.Columns = append(ins.Columns, col)
+	ins.Columns = append(ins.Columns, col)
+	rows := ins.Rows.(sqlparser.Values)
+	for i := range rows {
+		rows[i] = append(rows[i], &sqlparser.NullVal{})
 	}
-	if pos >= len(ins.Rows.(sqlparser.Values)[rowNum]) {
-		ins.Rows.(sqlparser.Values)[rowNum] = append(ins.Rows.(sqlparser.Values)[rowNum], &sqlparser.NullVal{})
-	}
-	return ins.Rows.(sqlparser.Values)[rowNum], pos
+	return len(ins.Columns) - 1
 }

--- a/go/vt/vtgate/planbuilder/join.go
+++ b/go/vt/vtgate/planbuilder/join.go
@@ -201,7 +201,7 @@ func (jb *join) PushOrderByNull() {
 // The call is ignored because results get multiplied
 // as they join with others. So, it's hard to reliably
 // predict if a limit push down will work correctly.
-func (jb *join) SetUpperLimit(_ interface{}) {
+func (jb *join) SetUpperLimit(_ *sqlparser.SQLVal) {
 }
 
 // PushMisc satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -382,7 +382,7 @@ func (oa *orderedAggregate) PushOrderByNull() {
 }
 
 // SetUpperLimit satisfies the builder interface.
-func (oa *orderedAggregate) SetUpperLimit(count interface{}) {
+func (oa *orderedAggregate) SetUpperLimit(count *sqlparser.SQLVal) {
 	oa.input.SetUpperLimit(count)
 }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/testfiles"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
@@ -37,12 +38,12 @@ type hashIndex struct{ name string }
 
 func (v *hashIndex) String() string { return v.name }
 func (*hashIndex) Cost() int        { return 1 }
-func (*hashIndex) Verify(vindexes.VCursor, []interface{}, [][]byte) (bool, error) {
+func (*hashIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) (bool, error) {
 	return false, nil
 }
-func (*hashIndex) Map(vindexes.VCursor, []interface{}) ([][]byte, error) { return nil, nil }
-func (*hashIndex) Create(vindexes.VCursor, []interface{}) error          { return nil }
-func (*hashIndex) Delete(vindexes.VCursor, []interface{}, []byte) error  { return nil }
+func (*hashIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][]byte, error) { return nil, nil }
+func (*hashIndex) Create(vindexes.VCursor, []sqltypes.Value) error          { return nil }
+func (*hashIndex) Delete(vindexes.VCursor, []sqltypes.Value, []byte) error  { return nil }
 
 func newHashIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &hashIndex{name: name}, nil
@@ -53,12 +54,12 @@ type lookupIndex struct{ name string }
 
 func (v *lookupIndex) String() string { return v.name }
 func (*lookupIndex) Cost() int        { return 2 }
-func (*lookupIndex) Verify(vindexes.VCursor, []interface{}, [][]byte) (bool, error) {
+func (*lookupIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) (bool, error) {
 	return false, nil
 }
-func (*lookupIndex) Map(vindexes.VCursor, []interface{}) ([][]byte, error)  { return nil, nil }
-func (*lookupIndex) Create(vindexes.VCursor, []interface{}, [][]byte) error { return nil }
-func (*lookupIndex) Delete(vindexes.VCursor, []interface{}, []byte) error   { return nil }
+func (*lookupIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][]byte, error)  { return nil, nil }
+func (*lookupIndex) Create(vindexes.VCursor, []sqltypes.Value, [][]byte) error { return nil }
+func (*lookupIndex) Delete(vindexes.VCursor, []sqltypes.Value, []byte) error   { return nil }
 
 func newLookupIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &lookupIndex{name: name}, nil
@@ -69,12 +70,12 @@ type multiIndex struct{ name string }
 
 func (v *multiIndex) String() string { return v.name }
 func (*multiIndex) Cost() int        { return 3 }
-func (*multiIndex) Verify(vindexes.VCursor, []interface{}, [][]byte) (bool, error) {
+func (*multiIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) (bool, error) {
 	return false, nil
 }
-func (*multiIndex) Map(vindexes.VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
-func (*multiIndex) Create(vindexes.VCursor, []interface{}, [][]byte) error  { return nil }
-func (*multiIndex) Delete(vindexes.VCursor, []interface{}, []byte) error    { return nil }
+func (*multiIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error) { return nil, nil }
+func (*multiIndex) Create(vindexes.VCursor, []sqltypes.Value, [][]byte) error  { return nil }
+func (*multiIndex) Delete(vindexes.VCursor, []sqltypes.Value, []byte) error    { return nil }
 
 func newMultiIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &multiIndex{name: name}, nil
@@ -85,12 +86,12 @@ type costlyIndex struct{ name string }
 
 func (v *costlyIndex) String() string { return v.name }
 func (*costlyIndex) Cost() int        { return 10 }
-func (*costlyIndex) Verify(vindexes.VCursor, []interface{}, [][]byte) (bool, error) {
+func (*costlyIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) (bool, error) {
 	return false, nil
 }
-func (*costlyIndex) Map(vindexes.VCursor, []interface{}) ([][][]byte, error) { return nil, nil }
-func (*costlyIndex) Create(vindexes.VCursor, []interface{}, [][]byte) error  { return nil }
-func (*costlyIndex) Delete(vindexes.VCursor, []interface{}, []byte) error    { return nil }
+func (*costlyIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error) { return nil, nil }
+func (*costlyIndex) Create(vindexes.VCursor, []sqltypes.Value, [][]byte) error  { return nil }
+func (*costlyIndex) Delete(vindexes.VCursor, []sqltypes.Value, []byte) error    { return nil }
 
 func newCostlyIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &costlyIndex{name: name}, nil

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -146,7 +146,7 @@ func (sq *subquery) PushOrderByNull() {
 // into a subquery have not been studied yet.
 // We can consider doing it in the future.
 // TODO(sougou): this could be improved.
-func (sq *subquery) SetUpperLimit(_ interface{}) {
+func (sq *subquery) SetUpperLimit(_ *sqlparser.SQLVal) {
 }
 
 // PushMisc satisfies the builder interface.

--- a/go/vt/vtgate/planbuilder/union.go
+++ b/go/vt/vtgate/planbuilder/union.go
@@ -99,6 +99,7 @@ func unionRouteMerge(union *sqlparser.Union, left, right builder, vschema VSchem
 	rb := newRoute(
 		&sqlparser.Union{Type: union.Type, Left: union.Left, Right: union.Right, Lock: union.Lock},
 		lroute.ERoute,
+		lroute.condition,
 		vschema,
 	)
 	lroute.Redirect = rb

--- a/go/vt/vtgate/vindexes/binary.go
+++ b/go/vt/vtgate/vindexes/binary.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // Binary is a vindex that converts binary bits to a keyspace id.
@@ -45,16 +44,12 @@ func (vind *Binary) Cost() int {
 }
 
 // Verify returns true if ids maps to ksids.
-func (vind *Binary) Verify(_ VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vind *Binary) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	if len(ids) != len(ksids) {
 		return false, fmt.Errorf("Binary.Verify: length of ids %v doesn't match length of ksids %v", len(ids), len(ksids))
 	}
-	for rowNum := range ids {
-		data, err := getBytes(ids[rowNum])
-		if err != nil {
-			return false, fmt.Errorf("Binary.Verify: %v", err)
-		}
-		if bytes.Compare(data, ksids[rowNum]) != 0 {
+	for i := range ids {
+		if bytes.Compare(ids[i].Bytes(), ksids[i]) != 0 {
 			return false, nil
 		}
 	}
@@ -62,45 +57,26 @@ func (vind *Binary) Verify(_ VCursor, ids []interface{}, ksids [][]byte) (bool, 
 }
 
 // Map returns the corresponding keyspace id values for the given ids.
-func (vind *Binary) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *Binary) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
-		data, err := getBytes(id)
-		if err != nil {
-			return nil, fmt.Errorf("Binary.Map :%v", err)
-		}
-		out = append(out, data)
+		out = append(out, id.Bytes())
 	}
 	return out, nil
 }
 
 // ReverseMap returns the associated ids for the ksids.
-func (*Binary) ReverseMap(_ VCursor, ksids [][]byte) ([]interface{}, error) {
-	var reverseIds = make([]interface{}, len(ksids))
+func (*Binary) ReverseMap(_ VCursor, ksids [][]byte) ([]sqltypes.Value, error) {
+	var reverseIds = make([]sqltypes.Value, len(ksids))
 	for rownum, keyspaceID := range ksids {
 		if keyspaceID == nil {
 			return nil, fmt.Errorf("Binary.ReverseMap: keyspaceId is nil")
 		}
-		reverseIds[rownum] = []byte(keyspaceID)
+		reverseIds[rownum] = sqltypes.MakeTrusted(sqltypes.VarBinary, keyspaceID)
 	}
 	return reverseIds, nil
 }
 
 func init() {
 	Register("binary", NewBinary)
-}
-
-// getBytes returns the raw bytes for a value.
-func getBytes(key interface{}) ([]byte, error) {
-	switch v := key.(type) {
-	case string:
-		return []byte(v), nil
-	case []byte:
-		return v, nil
-	case sqltypes.Value:
-		return v.Bytes(), nil
-	case *querypb.BindVariable:
-		return v.Value, nil
-	}
-	return nil, fmt.Errorf("unexpected data type for getBytes: %T", key)
 }

--- a/go/vt/vtgate/vindexes/binary_test.go
+++ b/go/vt/vtgate/vindexes/binary_test.go
@@ -18,11 +18,11 @@ package vindexes
 
 import (
 	"bytes"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 var binOnlyVindex Vindex
@@ -45,27 +45,25 @@ func TestBinaryString(t *testing.T) {
 
 func TestBinary(t *testing.T) {
 	tcases := []struct {
-		in, out []byte
+		in  sqltypes.Value
+		out []byte
 	}{{
-		in:  []byte("test"),
-		out: []byte("test"),
+		in:  testVal("test1"),
+		out: []byte("test1"),
 	}, {
-		in:  []byte("test2"),
+		in:  testVal("test2"),
 		out: []byte("test2"),
-	}, {
-		in:  []byte("test3"),
-		out: []byte("test3"),
 	}}
 	for _, tcase := range tcases {
-		got, err := binOnlyVindex.(Unique).Map(nil, []interface{}{tcase.in})
+		got, err := binOnlyVindex.(Unique).Map(nil, []sqltypes.Value{tcase.in})
 		if err != nil {
 			t.Error(err)
 		}
 		out := []byte(got[0])
-		if bytes.Compare(tcase.in, out) != 0 {
+		if bytes.Compare(tcase.out, out) != 0 {
 			t.Errorf("Map(%#v): %#v, want %#v", tcase.in, out, tcase.out)
 		}
-		ok, err := binOnlyVindex.Verify(nil, []interface{}{tcase.in}, [][]byte{tcase.out})
+		ok, err := binOnlyVindex.Verify(nil, []sqltypes.Value{tcase.in}, [][]byte{tcase.out})
 		if err != nil {
 			t.Error(err)
 		}
@@ -73,34 +71,21 @@ func TestBinary(t *testing.T) {
 			t.Errorf("Verify(%#v): false, want true", tcase.in)
 		}
 	}
-
-	//Negative Test Case
-	_, err := binOnlyVindex.(Unique).Map(nil, []interface{}{1})
-	want := "Binary.Map :unexpected data type for getBytes: int"
-	if err.Error() != want {
-		t.Error(err)
-	}
 }
 
 func TestBinaryVerifyNeg(t *testing.T) {
-	_, err := binOnlyVindex.Verify(nil, []interface{}{[]byte("test1"), []byte("test2")}, [][]byte{[]byte("test1")})
+	_, err := binOnlyVindex.Verify(nil, []sqltypes.Value{testVal("test1"), testVal("test2")}, [][]byte{[]byte("test1")})
 	want := "Binary.Verify: length of ids 2 doesn't match length of ksids 1"
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	ok, err := binOnlyVindex.Verify(nil, []interface{}{[]byte("test2")}, [][]byte{[]byte("test1")})
+	ok, err := binOnlyVindex.Verify(nil, []sqltypes.Value{testVal("test2")}, [][]byte{[]byte("test1")})
 	if err != nil {
 		t.Error(err)
 	}
 	if ok {
-		t.Errorf("Verify(%#v): true, want false", []byte("test2"))
-	}
-
-	_, err = binOnlyVindex.Verify(nil, []interface{}{1}, [][]byte{[]byte("test1")})
-	want = "Binary.Verify: unexpected data type for getBytes: int"
-	if err.Error() != want {
-		t.Error(err)
+		t.Errorf("Verify(%v): true, want false", []byte("test2"))
 	}
 }
 
@@ -109,48 +94,15 @@ func TestBinaryReverseMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if bytes.Compare(got[0].([]byte), []byte("\x00\x00\x00\x00\x00\x00\x00\x01")) != 0 {
-		t.Errorf("ReverseMap(): %+v, want %+v", got, []byte("\x00\x00\x00\x00\x00\x00\x00\x01"))
+	want := []sqltypes.Value{testVal([]byte("\x00\x00\x00\x00\x00\x00\x00\x01"))}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReverseMap(): %+v, want %+v", got, want)
 	}
 
-	//Negative Test
+	// Negative Test
 	_, err = binOnlyVindex.(Reversible).ReverseMap(nil, [][]byte{[]byte(nil)})
-	want := "Binary.ReverseMap: keyspaceId is nil"
-	if err.Error() != want {
-		t.Error(err)
-	}
-}
-
-func TestGetBytes(t *testing.T) {
-	tcases := []struct {
-		in  interface{}
-		out string
-	}{{
-		in:  []byte{'1', '2', '3'},
-		out: "123",
-	}, {
-		in:  "1234",
-		out: "1234",
-	}, {
-		in:  sqltypes.MakeTrusted(querypb.Type_UINT64, []byte{'1', '2', '3'}),
-		out: "123",
-	}, {
-		in:  sqltypes.BytesBindVariable([]byte{'1', '2', '3'}),
-		out: "123",
-	}, {
-		in:  65,
-		out: "unexpected data type for getBytes: int",
-	}}
-	for _, tcase := range tcases {
-		b, err := getBytes(tcase.in)
-		got := ""
-		if err != nil {
-			got = err.Error()
-		} else {
-			got = string(b)
-		}
-		if got != tcase.out {
-			t.Errorf("getBytes(%v) got %v %v expected %v", tcase.in, b, err, tcase.out)
-		}
+	wantErr := "Binary.ReverseMap: keyspaceId is nil"
+	if err == nil || err.Error() != wantErr {
+		t.Errorf("ReverseMap(): %v, want %s", err, wantErr)
 	}
 }

--- a/go/vt/vtgate/vindexes/binarymd5_test.go
+++ b/go/vt/vtgate/vindexes/binarymd5_test.go
@@ -56,7 +56,7 @@ func TestBinaryMD5(t *testing.T) {
 		out: "\f\xbcf\x11\xf5T\vЀ\x9a8\x8d\xc9Za[",
 	}}
 	for _, tcase := range tcases {
-		got, err := binVindex.(Unique).Map(nil, []interface{}{[]byte(tcase.in)})
+		got, err := binVindex.(Unique).Map(nil, []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.VarBinary, []byte(tcase.in))})
 		if err != nil {
 			t.Error(err)
 		}
@@ -64,7 +64,7 @@ func TestBinaryMD5(t *testing.T) {
 		if out != tcase.out {
 			t.Errorf("Map(%#v): %#v, want %#v", tcase.in, out, tcase.out)
 		}
-		ok, err := binVindex.Verify(nil, []interface{}{[]byte(tcase.in)}, [][]byte{[]byte(tcase.out)})
+		ok, err := binVindex.Verify(nil, []sqltypes.Value{sqltypes.MakeTrusted(sqltypes.VarBinary, []byte(tcase.in))}, [][]byte{[]byte(tcase.out)})
 		if err != nil {
 			t.Error(err)
 		}
@@ -72,40 +72,27 @@ func TestBinaryMD5(t *testing.T) {
 			t.Errorf("Verify(%#v): false, want true", tcase.in)
 		}
 	}
-
-	//Negative Test Case
-	_, err := binVindex.(Unique).Map(nil, []interface{}{1})
-	want := "BinaryMd5.Map :unexpected data type for getBytes: int"
-	if err.Error() != want {
-		t.Error(err)
-	}
 }
 
 func TestBinaryMD5VerifyNeg(t *testing.T) {
-	_, err := binVindex.Verify(nil, []interface{}{[]byte("test1"), []byte("test2")}, [][]byte{[]byte("test1")})
+	_, err := binVindex.Verify(nil, []sqltypes.Value{testVal("test1"), testVal("test2")}, [][]byte{[]byte("test1")})
 	want := "BinaryMD5_hash.Verify: length of ids 2 doesn't match length of ksids 1"
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	ok, err := binVindex.Verify(nil, []interface{}{[]byte("test2")}, [][]byte{[]byte("test1")})
+	ok, err := binVindex.Verify(nil, []sqltypes.Value{testVal("test2")}, [][]byte{[]byte("test1")})
 	if err != nil {
 		t.Error(err)
 	}
 	if ok {
 		t.Errorf("Verify(%#v): true, want false", []byte("test2"))
 	}
-
-	_, err = binVindex.Verify(nil, []interface{}{1}, [][]byte{[]byte("test1")})
-	want = "BinaryMD5_hash.Verify: unexpected data type for getBytes: int"
-	if err.Error() != want {
-		t.Error(err)
-	}
 }
 
 func TestSQLValue(t *testing.T) {
 	val := sqltypes.MakeTrusted(sqltypes.VarBinary, []byte("Test"))
-	got, err := binVindex.(Unique).Map(nil, []interface{}{val})
+	got, err := binVindex.(Unique).Map(nil, []sqltypes.Value{val})
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/hash_test.go
+++ b/go/vt/vtgate/vindexes/hash_test.go
@@ -63,7 +63,7 @@ func TestHashMap(t *testing.T) {
 
 	//Negative Test Case
 	_, err = hash.(Unique).Map(nil, []interface{}{1.2})
-	wanterr := "hash.Map: getNumber: unexpected type for 1.2: float64"
+	wanterr := "hash.Map: ConvertToUint64: unexpected type for 1.2: float64"
 	if err.Error() != wanterr {
 		t.Error(err)
 	}
@@ -87,7 +87,7 @@ func TestHashVerifyNeg(t *testing.T) {
 	}
 
 	_, err = hash.Verify(nil, []interface{}{1.2}, [][]byte{[]byte("test1")})
-	want = "hash.Verify: getNumber: unexpected type for 1.2: float64"
+	want = "hash.Verify: ConvertToUint64: unexpected type for 1.2: float64"
 	if err.Error() != want {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -18,6 +18,8 @@ package vindexes
 
 import (
 	"encoding/json"
+
+	"github.com/youtube/vitess/go/sqltypes"
 )
 
 func init() {
@@ -50,22 +52,22 @@ func (vindex *LookupNonUnique) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vindex *LookupNonUnique) Map(vcursor VCursor, ids []interface{}) ([][][]byte, error) {
+func (vindex *LookupNonUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, error) {
 	return vindex.lkp.MapNonUniqueLookup(vcursor, ids)
 }
 
 // Verify returns true if ids maps to ksids.
-func (vindex *LookupNonUnique) Verify(vcursor VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vindex *LookupNonUnique) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	return vindex.lkp.Verify(vcursor, ids, ksids)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vindex *LookupNonUnique) Create(vcursor VCursor, id []interface{}, ksids [][]byte) error {
+func (vindex *LookupNonUnique) Create(vcursor VCursor, id []sqltypes.Value, ksids [][]byte) error {
 	return vindex.lkp.Create(vcursor, id, ksids)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vindex *LookupNonUnique) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
+func (vindex *LookupNonUnique) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []byte) error {
 	return vindex.lkp.Delete(vcursor, ids, ksid)
 }
 
@@ -100,22 +102,22 @@ func (vindex *LookupUnique) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vindex *LookupUnique) Map(vcursor VCursor, ids []interface{}) ([][]byte, error) {
+func (vindex *LookupUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	return vindex.lkp.MapUniqueLookup(vcursor, ids)
 }
 
 // Verify returns true if ids maps to ksids.
-func (vindex *LookupUnique) Verify(vcursor VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vindex *LookupUnique) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	return vindex.lkp.Verify(vcursor, ids, ksids)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vindex *LookupUnique) Create(vcursor VCursor, id []interface{}, ksids [][]byte) error {
+func (vindex *LookupUnique) Create(vcursor VCursor, id []sqltypes.Value, ksids [][]byte) error {
 	return vindex.lkp.Create(vcursor, id, ksids)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vindex *LookupUnique) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
+func (vindex *LookupUnique) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []byte) error {
 	return vindex.lkp.Delete(vcursor, ids, ksid)
 }
 

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -18,6 +18,8 @@ package vindexes
 
 import (
 	"encoding/json"
+
+	"github.com/youtube/vitess/go/sqltypes"
 )
 
 func init() {
@@ -53,22 +55,22 @@ func (vind *LookupHash) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vind *LookupHash) Map(vcursor VCursor, ids []interface{}) ([][][]byte, error) {
+func (vind *LookupHash) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, error) {
 	return vind.lkp.MapNonUniqueLookup(vcursor, ids)
 }
 
 // Verify returns true if ids maps to ksids.
-func (vind *LookupHash) Verify(vcursor VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vind *LookupHash) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	return vind.lkp.Verify(vcursor, ids, ksids)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vind *LookupHash) Create(vcursor VCursor, id []interface{}, ksids [][]byte) error {
+func (vind *LookupHash) Create(vcursor VCursor, id []sqltypes.Value, ksids [][]byte) error {
 	return vind.lkp.Create(vcursor, id, ksids)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vind *LookupHash) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
+func (vind *LookupHash) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []byte) error {
 	return vind.lkp.Delete(vcursor, ids, ksid)
 }
 
@@ -105,22 +107,22 @@ func (vind *LookupHashUnique) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (vind *LookupHashUnique) Map(vcursor VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *LookupHashUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	return vind.lkp.MapUniqueLookup(vcursor, ids)
 }
 
 // Verify returns true if ids maps to ksids.
-func (vind *LookupHashUnique) Verify(vcursor VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vind *LookupHashUnique) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	return vind.lkp.Verify(vcursor, ids, ksids)
 }
 
 // Create reserves the id by inserting it into the vindex table.
-func (vind *LookupHashUnique) Create(vcursor VCursor, id []interface{}, ksids [][]byte) error {
+func (vind *LookupHashUnique) Create(vcursor VCursor, id []sqltypes.Value, ksids [][]byte) error {
 	return vind.lkp.Create(vcursor, id, ksids)
 }
 
 // Delete deletes the entry from the vindex table.
-func (vind *LookupHashUnique) Delete(vcursor VCursor, ids []interface{}, ksid []byte) error {
+func (vind *LookupHashUnique) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []byte) error {
 	return vind.lkp.Delete(vcursor, ids, ksid)
 }
 

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -104,7 +104,7 @@ func TestLookupHashString(t *testing.T) {
 
 func TestLookupHashMap(t *testing.T) {
 	vc := &vcursor{numRows: 2}
-	got, err := lookuphash.(NonUnique).Map(vc, []interface{}{1, int64(2)})
+	got, err := lookuphash.(NonUnique).Map(vc, []sqltypes.Value{testVal(1), testVal(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -122,7 +122,7 @@ func TestLookupHashMap(t *testing.T) {
 
 func TestLookupHashVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	success, err := lookuphash.Verify(vc, []interface{}{1}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	success, err := lookuphash.Verify(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -133,7 +133,7 @@ func TestLookupHashVerify(t *testing.T) {
 
 func TestLookupHashCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lookuphash.(Lookup).Create(vc, []interface{}{1}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	err := lookuphash.(Lookup).Create(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -158,7 +158,7 @@ func TestLookupHashReverse(t *testing.T) {
 
 func TestLookupHashDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lookuphash.(Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lookuphash.(Lookup).Delete(vc, []sqltypes.Value{testVal(1)}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -43,7 +43,7 @@ func TestLookupHashUniqueCost(t *testing.T) {
 
 func TestLookupHashUniqueMap(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	got, err := lhu.(Unique).Map(vc, []interface{}{1, int64(2)})
+	got, err := lhu.(Unique).Map(vc, []sqltypes.Value{testVal(1), testVal(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -58,7 +58,7 @@ func TestLookupHashUniqueMap(t *testing.T) {
 
 func TestLookupHashUniqueVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	success, err := lhu.Verify(vc, []interface{}{1}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	success, err := lhu.Verify(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -69,7 +69,7 @@ func TestLookupHashUniqueVerify(t *testing.T) {
 
 func TestLookupHashUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lhu.(Lookup).Create(vc, []interface{}{1}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	err := lhu.(Lookup).Create(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -94,7 +94,7 @@ func TestLookupHashUniqueReverse(t *testing.T) {
 
 func TestLookupHashUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lhu.(Lookup).Delete(vc, []interface{}{1}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lhu.(Lookup).Delete(vc, []sqltypes.Value{testVal(1)}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -70,7 +70,7 @@ func TestLookupNonUniqueString(t *testing.T) {
 
 func TestLookupUniqueVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	_, err := lookupUnique.Verify(vc, []interface{}{1}, [][]byte{[]byte("test")})
+	_, err := lookupUnique.Verify(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test")})
 	wantQuery := &querypb.BoundQuery{
 		Sql: "select fromc from t where ((fromc=:fromc0 and toc=:toc0))",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -87,12 +87,12 @@ func TestLookupUniqueVerify(t *testing.T) {
 
 	//Negative test
 	want := "lookup.Verify:length of ids 2 doesn't match length of ksids 1"
-	_, err = lookupUnique.Verify(vc, []interface{}{1, 2}, [][]byte{[]byte("test")})
+	_, err = lookupUnique.Verify(vc, []sqltypes.Value{testVal(1), testVal(2)}, [][]byte{[]byte("test")})
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	_, err = lookuphashunique.Verify(nil, []interface{}{1}, [][]byte{[]byte("test1test23")})
+	_, err = lookuphashunique.Verify(nil, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test1test23")})
 	want = "lookup.Verify: invalid keyspace id: 7465737431746573743233"
 	if err.Error() != want {
 		t.Error(err)
@@ -101,7 +101,7 @@ func TestLookupUniqueVerify(t *testing.T) {
 
 func TestLookupUniqueMap(t *testing.T) {
 	vc := &vcursor{}
-	_, err := lookupUnique.(Unique).Map(vc, []interface{}{2})
+	_, err := lookupUnique.(Unique).Map(vc, []sqltypes.Value{testVal(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -118,7 +118,7 @@ func TestLookupUniqueMap(t *testing.T) {
 
 func TestLookupUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupUnique.(Lookup).Create(vc, []interface{}{1}, [][]byte{[]byte("test")})
+	err := lookupUnique.(Lookup).Create(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -135,12 +135,12 @@ func TestLookupUniqueCreate(t *testing.T) {
 
 	//Negative test
 	want := "lookup.Create:length of ids 2 doesn't match length of ksids 1"
-	err = lookupUnique.(Lookup).Create(vc, []interface{}{1, 2}, [][]byte{[]byte("test")})
+	err = lookupUnique.(Lookup).Create(vc, []sqltypes.Value{testVal(1), testVal(2)}, [][]byte{[]byte("test")})
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	err = lookuphashunique.(Lookup).Create(nil, []interface{}{1}, [][]byte{[]byte("test1test23")})
+	err = lookuphashunique.(Lookup).Create(nil, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test1test23")})
 	want = "lookup.Create: invalid keyspace id: 7465737431746573743233"
 	if err.Error() != want {
 		t.Error(err)
@@ -156,7 +156,7 @@ func TestLookupUniqueReverse(t *testing.T) {
 
 func TestLookupUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupUnique.(Lookup).Delete(vc, []interface{}{1}, []byte("test"))
+	err := lookupUnique.(Lookup).Delete(vc, []sqltypes.Value{testVal(1)}, []byte("test"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -172,7 +172,7 @@ func TestLookupUniqueDelete(t *testing.T) {
 	}
 
 	//Negative Test
-	err = lookuphashunique.(Lookup).Delete(vc, []interface{}{1}, []byte("test1test23"))
+	err = lookuphashunique.(Lookup).Delete(vc, []sqltypes.Value{testVal(1)}, []byte("test1test23"))
 	want := "lookup.Delete: invalid keyspace id: 7465737431746573743233"
 	if err.Error() != want {
 		t.Error(err)
@@ -181,7 +181,7 @@ func TestLookupUniqueDelete(t *testing.T) {
 
 func TestLookupNonUniqueVerify(t *testing.T) {
 	vc := &vcursor{numRows: 1}
-	_, err := lookupNonUnique.Verify(vc, []interface{}{1}, [][]byte{[]byte("test")})
+	_, err := lookupNonUnique.Verify(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test")})
 	wantQuery := &querypb.BoundQuery{
 		Sql: "select fromc from t where ((fromc=:fromc0 and toc=:toc0))",
 		BindVariables: map[string]*querypb.BindVariable{
@@ -199,7 +199,7 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 
 func TestLookupNonUniqueMap(t *testing.T) {
 	vc := &vcursor{}
-	_, err := lookupNonUnique.(NonUnique).Map(vc, []interface{}{2})
+	_, err := lookupNonUnique.(NonUnique).Map(vc, []sqltypes.Value{testVal(2)})
 	if err != nil {
 		t.Error(err)
 	}
@@ -216,7 +216,7 @@ func TestLookupNonUniqueMap(t *testing.T) {
 
 func TestLookupNonUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupNonUnique.(Lookup).Create(vc, []interface{}{1}, [][]byte{[]byte("test")})
+	err := lookupNonUnique.(Lookup).Create(vc, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("test")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -241,7 +241,7 @@ func TestLookupNonUniqueReverse(t *testing.T) {
 
 func TestLookupNonUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupNonUnique.(Lookup).Delete(vc, []interface{}{1}, []byte("test"))
+	err := lookupNonUnique.(Lookup).Delete(vc, []sqltypes.Value{testVal(1)}, []byte("test"))
 	if err != nil {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -71,7 +71,7 @@ func (*NumericStaticMap) Cost() int {
 }
 
 // Verify returns true if ids and ksids match.
-func (vind *NumericStaticMap) Verify(_ VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vind *NumericStaticMap) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	if len(ids) != len(ksids) {
 		return false, fmt.Errorf("NumericStaticMap.Verify: length of ids %v doesn't match length of ksids %v", len(ids), len(ksids))
 	}
@@ -94,7 +94,7 @@ func (vind *NumericStaticMap) Verify(_ VCursor, ids []interface{}, ksids [][]byt
 }
 
 // Map returns the associated keyspace ids for the given ids.
-func (vind *NumericStaticMap) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *NumericStaticMap) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
 		num, err := sqltypes.ConvertToUint64(id)

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -63,16 +63,15 @@ func TestNumericStaticMapMap(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)
 	}
-	sqlVal, _ := sqltypes.BuildIntegral("8")
-	got, err := numericStaticMap.(Unique).Map(nil, []interface{}{
-		1,
-		int32(2),
-		int64(3),
-		uint(4),
-		uint32(5),
-		uint64(6),
-		[]byte("7"),
-		sqlVal,
+	got, err := numericStaticMap.(Unique).Map(nil, []sqltypes.Value{
+		testVal(1),
+		testVal(2),
+		testVal(3),
+		testVal(4),
+		testVal(5),
+		testVal(6),
+		testVal(7),
+		testVal(8),
 	})
 	if err != nil {
 		t.Error(err)
@@ -100,8 +99,8 @@ func TestNumericStaticMapMapBadData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)
 	}
-	_, err = numericStaticMap.(Unique).Map(nil, []interface{}{1.1})
-	want := `NumericStaticMap.Map: ConvertToUint64: unexpected type for 1.1: float64`
+	_, err = numericStaticMap.(Unique).Map(nil, []sqltypes.Value{testVal(1.1)})
+	want := `NumericStaticMap.Map: could not parse value: 1.1`
 	if err == nil || err.Error() != want {
 		t.Errorf("NumericStaticMap.Map: %v, want %v", err, want)
 	}
@@ -112,7 +111,7 @@ func TestNumericStaticMapVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)
 	}
-	success, err := numericStaticMap.Verify(nil, []interface{}{1}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
+	success, err := numericStaticMap.Verify(nil, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -126,24 +125,23 @@ func TestNumericStaticMapVerifyNeg(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create vindex: %v", err)
 	}
-	_, err = numericStaticMap.Verify(nil, []interface{}{1, 2}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	_, err = numericStaticMap.Verify(nil, []sqltypes.Value{testVal(1), testVal(2)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	want := "NumericStaticMap.Verify: length of ids 2 doesn't match length of ksids 1"
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	_, err = numericStaticMap.Verify(nil, []interface{}{1.1}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	want = `NumericStaticMap.Verify: ConvertToUint64: unexpected type for 1.1: float64`
+	_, err = numericStaticMap.Verify(nil, []sqltypes.Value{testVal(1.1)}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
+	want = `NumericStaticMap.Verify: could not parse value: 1.1`
 	if err == nil || err.Error() != want {
 		t.Errorf("numericStaticMap.Map: %v, want %v", err, want)
 	}
 
-	success, err := numericStaticMap.Verify(nil, []interface{}{1}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x02")})
+	success, err := numericStaticMap.Verify(nil, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x02")})
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 	if success {
 		t.Errorf("Numeric.Verify(): %+v, want false", success)
 	}
-
 }

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -101,7 +101,7 @@ func TestNumericStaticMapMapBadData(t *testing.T) {
 		t.Fatalf("failed to create vindex: %v", err)
 	}
 	_, err = numericStaticMap.(Unique).Map(nil, []interface{}{1.1})
-	want := `NumericStaticMap.Map: getNumber: unexpected type for 1.1: float64`
+	want := `NumericStaticMap.Map: ConvertToUint64: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("NumericStaticMap.Map: %v, want %v", err, want)
 	}
@@ -133,7 +133,7 @@ func TestNumericStaticMapVerifyNeg(t *testing.T) {
 	}
 
 	_, err = numericStaticMap.Verify(nil, []interface{}{1.1}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
-	want = `NumericStaticMap.Verify: getNumber: unexpected type for 1.1: float64`
+	want = `NumericStaticMap.Verify: ConvertToUint64: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numericStaticMap.Map: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -75,7 +75,7 @@ func TestNumericMap(t *testing.T) {
 
 func TestNumericMapBadData(t *testing.T) {
 	_, err := numeric.(Unique).Map(nil, []interface{}{1.1})
-	want := `Numeric.Map: getNumber: unexpected type for 1.1: float64`
+	want := `Numeric.Map: ConvertToUint64: unexpected type for 1.1: float64`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)
 	}
@@ -99,7 +99,7 @@ func TestNumericVerifyNeg(t *testing.T) {
 	}
 
 	_, err = numeric.Verify(nil, []interface{}{1.1}, [][]byte{[]byte("test1")})
-	want = "Numeric.Verify: getNumber: unexpected type for 1.1: float64"
+	want = "Numeric.Verify: ConvertToUint64: unexpected type for 1.1: float64"
 	if err.Error() != want {
 		t.Error(err)
 	}

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -44,16 +44,15 @@ func TestNumericString(t *testing.T) {
 }
 
 func TestNumericMap(t *testing.T) {
-	sqlVal, _ := sqltypes.BuildIntegral("8")
-	got, err := numeric.(Unique).Map(nil, []interface{}{
-		1,
-		int32(2),
-		int64(3),
-		uint(4),
-		uint32(5),
-		uint64(6),
-		[]byte("7"),
-		sqlVal,
+	got, err := numeric.(Unique).Map(nil, []sqltypes.Value{
+		testVal(1),
+		testVal(2),
+		testVal(3),
+		testVal(4),
+		testVal(5),
+		testVal(6),
+		testVal(7),
+		testVal(8),
 	})
 	if err != nil {
 		t.Error(err)
@@ -74,15 +73,15 @@ func TestNumericMap(t *testing.T) {
 }
 
 func TestNumericMapBadData(t *testing.T) {
-	_, err := numeric.(Unique).Map(nil, []interface{}{1.1})
-	want := `Numeric.Map: ConvertToUint64: unexpected type for 1.1: float64`
+	_, err := numeric.(Unique).Map(nil, []sqltypes.Value{testVal(1.1)})
+	want := `Numeric.Map: could not parse value: 1.1`
 	if err == nil || err.Error() != want {
 		t.Errorf("numeric.Map: %v, want %v", err, want)
 	}
 }
 
 func TestNumericVerify(t *testing.T) {
-	success, err := numeric.Verify(nil, []interface{}{1}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
+	success, err := numeric.Verify(nil, []sqltypes.Value{testVal(1)}, [][]byte{[]byte("\x00\x00\x00\x00\x00\x00\x00\x01")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -92,19 +91,19 @@ func TestNumericVerify(t *testing.T) {
 }
 
 func TestNumericVerifyNeg(t *testing.T) {
-	_, err := numeric.Verify(nil, []interface{}{1, 2}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
+	_, err := numeric.Verify(nil, []sqltypes.Value{testVal(1), testVal(2)}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")})
 	want := "Numeric.Verify: length of ids 2 doesn't match length of ksids 1"
 	if err.Error() != want {
 		t.Error(err.Error())
 	}
 
-	_, err = numeric.Verify(nil, []interface{}{1.1}, [][]byte{[]byte("test1")})
-	want = "Numeric.Verify: ConvertToUint64: unexpected type for 1.1: float64"
+	_, err = numeric.Verify(nil, []sqltypes.Value{testVal(1.1)}, [][]byte{[]byte("test1")})
+	want = "Numeric.Verify: could not parse value: 1.1"
 	if err.Error() != want {
 		t.Error(err)
 	}
 
-	success, err := numeric.Verify(nil, []interface{}{uint(4)}, [][]byte{[]byte("\x06\xe7\xea\"Βp\x8f")})
+	success, err := numeric.Verify(nil, []sqltypes.Value{testVal(4)}, [][]byte{[]byte("\x06\xe7\xea\"Βp\x8f")})
 	if err != nil {
 		t.Error(err)
 	}
@@ -118,8 +117,9 @@ func TestNumericReverseMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if got[0].(uint64) != 1 {
-		t.Errorf("ReverseMap(): %+v, want 1", got)
+	want := []sqltypes.Value{testVal(uint64(1))}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ReverseMap(): %v, want %v", got, want)
 	}
 }
 

--- a/go/vt/vtgate/vindexes/unicodeloosemd5.go
+++ b/go/vt/vtgate/vindexes/unicodeloosemd5.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"unicode/utf8"
 
+	"github.com/youtube/vitess/go/sqltypes"
+
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 )
@@ -51,7 +53,7 @@ func (vind *UnicodeLooseMD5) Cost() int {
 }
 
 // Verify returns true if ids maps to ksids.
-func (vind *UnicodeLooseMD5) Verify(_ VCursor, ids []interface{}, ksids [][]byte) (bool, error) {
+func (vind *UnicodeLooseMD5) Verify(_ VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error) {
 	if len(ids) != len(ksids) {
 		return false, fmt.Errorf("UnicodeLooseMD5.Verify: length of ids %v doesn't match length of ksids %v", len(ids), len(ksids))
 	}
@@ -68,7 +70,7 @@ func (vind *UnicodeLooseMD5) Verify(_ VCursor, ids []interface{}, ksids [][]byte
 }
 
 // Map returns the corresponding keyspace id values for the given ids.
-func (vind *UnicodeLooseMD5) Map(_ VCursor, ids []interface{}) ([][]byte, error) {
+func (vind *UnicodeLooseMD5) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	out := make([][]byte, 0, len(ids))
 	for _, id := range ids {
 		data, err := unicodeHash(id)
@@ -80,16 +82,11 @@ func (vind *UnicodeLooseMD5) Map(_ VCursor, ids []interface{}) ([][]byte, error)
 	return out, nil
 }
 
-func unicodeHash(key interface{}) ([]byte, error) {
-	source, err := getBytes(key)
-	if err != nil {
-		return nil, err
-	}
-
+func unicodeHash(key sqltypes.Value) ([]byte, error) {
 	collator := collatorPool.Get().(pooledCollator)
 	defer collatorPool.Put(collator)
 
-	norm, err := normalize(collator.col, collator.buf, source)
+	norm, err := normalize(collator.col, collator.buf, key.Bytes())
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -52,20 +52,20 @@ type Vindex interface {
 
 	// Verify must be implented by all vindexes. It should return
 	// true if the ids can be mapped to the keyspace ids.
-	Verify(cursor VCursor, ids []interface{}, ksids [][]byte) (bool, error)
+	Verify(cursor VCursor, ids []sqltypes.Value, ksids [][]byte) (bool, error)
 }
 
 // Unique defines the interface for a unique vindex.
 // For a vindex to be unique, an id has to map to at most
 // one keyspace id.
 type Unique interface {
-	Map(cursor VCursor, ids []interface{}) ([][]byte, error)
+	Map(cursor VCursor, ids []sqltypes.Value) ([][]byte, error)
 }
 
 // NonUnique defines the interface for a non-unique vindex.
 // This means that an id can map to multiple keyspace ids.
 type NonUnique interface {
-	Map(cursor VCursor, ids []interface{}) ([][][]byte, error)
+	Map(cursor VCursor, ids []sqltypes.Value) ([][][]byte, error)
 }
 
 // IsUnique returns true if the Vindex is Unique.
@@ -79,7 +79,7 @@ func IsUnique(v Vindex) bool {
 // is optional. If present, VTGate can use it to
 // fill column values based on the target keyspace id.
 type Reversible interface {
-	ReverseMap(cursor VCursor, ks [][]byte) ([]interface{}, error)
+	ReverseMap(cursor VCursor, ks [][]byte) ([]sqltypes.Value, error)
 }
 
 // A Functional vindex is an index that can compute
@@ -100,8 +100,8 @@ type Functional interface {
 // keyspace_id, which must be supplied, can be used
 // to determine the target shard for an insert operation.
 type Lookup interface {
-	Create(VCursor, []interface{}, [][]byte) error
-	Delete(VCursor, []interface{}, []byte) error
+	Create(VCursor, []sqltypes.Value, [][]byte) error
+	Delete(VCursor, []sqltypes.Value, []byte) error
 }
 
 // A NewVindexFunc is a function that creates a Vindex based on the

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 
 	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
@@ -35,10 +36,10 @@ type stFU struct {
 	Params map[string]string
 }
 
-func (v *stFU) String() string                                      { return v.name }
-func (*stFU) Cost() int                                             { return 1 }
-func (*stFU) Verify(VCursor, []interface{}, [][]byte) (bool, error) { return false, nil }
-func (*stFU) Map(VCursor, []interface{}) ([][]byte, error)          { return nil, nil }
+func (v *stFU) String() string                                         { return v.name }
+func (*stFU) Cost() int                                                { return 1 }
+func (*stFU) Verify(VCursor, []sqltypes.Value, [][]byte) (bool, error) { return false, nil }
+func (*stFU) Map(VCursor, []sqltypes.Value) ([][]byte, error)          { return nil, nil }
 
 func NewSTFU(name string, params map[string]string) (Vindex, error) {
 	return &stFU{name: name, Params: params}, nil
@@ -50,9 +51,9 @@ type stF struct {
 	Params map[string]string
 }
 
-func (v *stF) String() string                                      { return v.name }
-func (*stF) Cost() int                                             { return 0 }
-func (*stF) Verify(VCursor, []interface{}, [][]byte) (bool, error) { return false, nil }
+func (v *stF) String() string                                         { return v.name }
+func (*stF) Cost() int                                                { return 0 }
+func (*stF) Verify(VCursor, []sqltypes.Value, [][]byte) (bool, error) { return false, nil }
 
 func NewSTF(name string, params map[string]string) (Vindex, error) {
 	return &stF{name: name, Params: params}, nil
@@ -64,12 +65,12 @@ type stLN struct {
 	Params map[string]string
 }
 
-func (v *stLN) String() string                                      { return v.name }
-func (*stLN) Cost() int                                             { return 0 }
-func (*stLN) Verify(VCursor, []interface{}, [][]byte) (bool, error) { return false, nil }
-func (*stLN) Map(VCursor, []interface{}) ([][][]byte, error)        { return nil, nil }
-func (*stLN) Create(VCursor, []interface{}, [][]byte) error         { return nil }
-func (*stLN) Delete(VCursor, []interface{}, []byte) error           { return nil }
+func (v *stLN) String() string                                         { return v.name }
+func (*stLN) Cost() int                                                { return 0 }
+func (*stLN) Verify(VCursor, []sqltypes.Value, [][]byte) (bool, error) { return false, nil }
+func (*stLN) Map(VCursor, []sqltypes.Value) ([][][]byte, error)        { return nil, nil }
+func (*stLN) Create(VCursor, []sqltypes.Value, [][]byte) error         { return nil }
+func (*stLN) Delete(VCursor, []sqltypes.Value, []byte) error           { return nil }
 
 func NewSTLN(name string, params map[string]string) (Vindex, error) {
 	return &stLN{name: name, Params: params}, nil
@@ -81,12 +82,12 @@ type stLU struct {
 	Params map[string]string
 }
 
-func (v *stLU) String() string                                      { return v.name }
-func (*stLU) Cost() int                                             { return 2 }
-func (*stLU) Verify(VCursor, []interface{}, [][]byte) (bool, error) { return false, nil }
-func (*stLU) Map(VCursor, []interface{}) ([][]byte, error)          { return nil, nil }
-func (*stLU) Create(VCursor, []interface{}, [][]byte) error         { return nil }
-func (*stLU) Delete(VCursor, []interface{}, []byte) error           { return nil }
+func (v *stLU) String() string                                         { return v.name }
+func (*stLU) Cost() int                                                { return 2 }
+func (*stLU) Verify(VCursor, []sqltypes.Value, [][]byte) (bool, error) { return false, nil }
+func (*stLU) Map(VCursor, []sqltypes.Value) ([][]byte, error)          { return nil, nil }
+func (*stLU) Create(VCursor, []sqltypes.Value, [][]byte) error         { return nil }
+func (*stLU) Delete(VCursor, []sqltypes.Value, []byte) error           { return nil }
 
 func NewSTLU(name string, params map[string]string) (Vindex, error) {
 	return &stLU{name: name, Params: params}, nil

--- a/go/vt/worker/key_resolver.go
+++ b/go/vt/worker/key_resolver.go
@@ -172,7 +172,7 @@ func newV3ResolverFromColumnList(keyspaceSchema *vindexes.KeyspaceSchema, name s
 // keyspaceID implements the keyspaceIDResolver interface.
 func (r *v3Resolver) keyspaceID(row []sqltypes.Value) ([]byte, error) {
 	v := row[r.shardingColumnIndex]
-	ids := []interface{}{v}
+	ids := []sqltypes.Value{v}
 	ksids, err := r.vindex.Map(nil, ids)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
VTGate was slightly trickier than tabletserver, which resulted in three commits:
* The Values for the insert plan were stored row-wise. The new PlanValue rule requires them to be column-wise. The first commit makes that switch first.
* vtgate is changed to use PlanValue. This affected the various primitives in engine. Additionally, the route builder was cheating: It was temporarily storing AST elements in those values and later replacing them into actual values during the wire-up phase. The route builder now has its own `condition` field where it stores the routing condition, and later resolves it into the `Values` into the engine's route.
* Vindexes are also converted to use sqltypes.Value.

With these changes, more functions in sqltypes.Value should be obsolete. The next phase of changes will be the cleanup and tightening of sqltypes.