### PR TITLE
vttablet/tabletmanager: Set the ExternallyReparentedTimestamp to the current time if vttablet starts up as MASTER.

### DIFF
--- a/go/vt/proto/query/query.pb.go
+++ b/go/vt/proto/query/query.pb.go
@@ -2461,7 +2461,11 @@ type StreamHealthResponse struct {
 	// b) the last time an active reparent was executed through a vtctl command
 	//    (InitShardMaster, PlannedReparentShard, EmergencyReparentShard)
 	// OR
-	// c) 0 if it was never called.
+	// c) the last time vttablet was started and it initialized its tablet type
+	//    as MASTER because it was recorded as the shard's current master in the
+	//    topology (see go/vt/vttablet/tabletmanager/init_tablet.go)
+	// OR
+	// d) 0 if the vttablet was never a MASTER.
 	TabletExternallyReparentedTimestamp int64 `protobuf:"varint,3,opt,name=tablet_externally_reparented_timestamp,json=tabletExternallyReparentedTimestamp" json:"tablet_externally_reparented_timestamp,omitempty"`
 	// realtime_stats contains information about the tablet status
 	RealtimeStats *RealtimeStats `protobuf:"bytes,4,opt,name=realtime_stats,json=realtimeStats" json:"realtime_stats,omitempty"`

--- a/go/vt/vttablet/tabletmanager/init_tablet.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet.go
@@ -102,11 +102,17 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 			// There's no existing tablet record, so we can assume
 			// no one has left us a message to step down.
 			tabletType = topodatapb.TabletType_MASTER
+			// Update the TER timestamp (current value is 0) because we
+			// assume that we are actually the MASTER and in case of a tiebreak,
+			// vtgate should prefer us.
+			agent.setExternallyReparentedTime(time.Now())
 		case nil:
 			if oldTablet.Type == topodatapb.TabletType_MASTER {
 				// We're marked as master in the shard record,
 				// and our existing tablet record agrees.
 				tabletType = topodatapb.TabletType_MASTER
+				// Same comment as above. Update tiebreaking timestamp to now.
+				agent.setExternallyReparentedTime(time.Now())
 			}
 		default:
 			return fmt.Errorf("InitTablet failed to read existing tablet record: %v", err)

--- a/go/vt/vttablet/tabletmanager/init_tablet_test.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet_test.go
@@ -94,6 +94,9 @@ func TestInitTablet(t *testing.T) {
 	if ti.PortMap["grpc"] != gRPCPort {
 		t.Errorf("wrong gRPC port for tablet: %v", ti.PortMap["grpc"])
 	}
+	if got := agent._tabletExternallyReparentedTime; !got.IsZero() {
+		t.Fatalf("REPLICA tablet should not have an ExternallyReparentedTimestamp set: %v", got)
+	}
 
 	// 2. Update shard's master to our alias, then try to init again.
 	// (This simulates the case where the MasterAlias in the shard record says
@@ -117,6 +120,9 @@ func TestInitTablet(t *testing.T) {
 	if ti.Type != topodatapb.TabletType_REPLICA {
 		t.Errorf("wrong tablet type: %v", ti.Type)
 	}
+	if got := agent._tabletExternallyReparentedTime; !got.IsZero() {
+		t.Fatalf("REPLICA tablet should not have an ExternallyReparentedTimestamp set: %v", got)
+	}
 
 	// 3. Delete the tablet record. The shard record still says that we are the
 	// MASTER. Since it is the only source, we assume that its information is
@@ -133,6 +139,10 @@ func TestInitTablet(t *testing.T) {
 	}
 	if ti.Type != topodatapb.TabletType_MASTER {
 		t.Errorf("wrong tablet type: %v", ti.Type)
+	}
+	ter1 := agent._tabletExternallyReparentedTime
+	if ter1.IsZero() {
+		t.Fatalf("MASTER tablet should have an ExternallyReparentedTimestamp set")
 	}
 
 	// 4. Fix the tablet record to agree that we're master.
@@ -151,6 +161,10 @@ func TestInitTablet(t *testing.T) {
 	}
 	if ti.Type != topodatapb.TabletType_MASTER {
 		t.Errorf("wrong tablet type: %v", ti.Type)
+	}
+	ter2 := agent._tabletExternallyReparentedTime
+	if ter2.IsZero() || !ter2.After(ter1) {
+		t.Fatalf("After a restart, ExternallyReparentedTimestamp must be set to the current time. Previous timestamp: %v current timestamp: %v", ter1, ter2)
 	}
 
 	// 5. Subsequent inits will still start the vttablet as MASTER.
@@ -172,5 +186,9 @@ func TestInitTablet(t *testing.T) {
 	}
 	if len(ti.Tags) != 1 || ti.Tags["aaa"] != "bbb" {
 		t.Errorf("wrong tablet tags: %v", ti.Tags)
+	}
+	ter3 := agent._tabletExternallyReparentedTime
+	if ter3.IsZero() || !ter3.After(ter2) {
+		t.Fatalf("After a restart, ExternallyReparentedTimestamp must be set to the current time. Previous timestamp: %v current timestamp: %v", ter2, ter3)
 	}
 }

--- a/go/vt/vttablet/tabletmanager/init_tablet_test.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet_test.go
@@ -57,8 +57,8 @@ func TestInitTablet(t *testing.T) {
 		_healthy:        fmt.Errorf("healthcheck not run yet"),
 	}
 
-	// let's use a real tablet in a shard, that will create
-	// the keyspace and shard.
+	// 1. Initialize the tablet as REPLICA.
+	// This will create the respective topology records.
 	*tabletHostname = "localhost"
 	*initKeyspace = "test_keyspace"
 	*initShard = "-80"
@@ -95,7 +95,10 @@ func TestInitTablet(t *testing.T) {
 		t.Errorf("wrong gRPC port for tablet: %v", ti.PortMap["grpc"])
 	}
 
-	// update shard's master to our alias, then try to init again
+	// 2. Update shard's master to our alias, then try to init again.
+	// (This simulates the case where the MasterAlias in the shard record says
+	// that we are the master but the tablet record says otherwise. In that case,
+	// we assume we are not the MASTER.)
 	si, err = agent.TopoServer.UpdateShardFields(ctx, "test_keyspace", "-80", func(si *topo.ShardInfo) error {
 		si.MasterAlias = tabletAlias
 		return nil
@@ -115,7 +118,26 @@ func TestInitTablet(t *testing.T) {
 		t.Errorf("wrong tablet type: %v", ti.Type)
 	}
 
-	// Fix the tablet record to agree that we're master.
+	// 3. Delete the tablet record. The shard record still says that we are the
+	// MASTER. Since it is the only source, we assume that its information is
+	// correct and start as MASTER.
+	if err := ts.DeleteTablet(ctx, tabletAlias); err != nil {
+		t.Fatalf("DeleteTablet failed: %v", err)
+	}
+	if err := agent.InitTablet(port, gRPCPort); err != nil {
+		t.Fatalf("InitTablet(type, healthcheck) failed: %v", err)
+	}
+	ti, err = ts.GetTablet(ctx, tabletAlias)
+	if err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
+	if ti.Type != topodatapb.TabletType_MASTER {
+		t.Errorf("wrong tablet type: %v", ti.Type)
+	}
+
+	// 4. Fix the tablet record to agree that we're master.
+	// Shard and tablet record are in sync now and we assume that we are actually
+	// the MASTER.
 	ti.Type = topodatapb.TabletType_MASTER
 	if err := ts.UpdateTablet(ctx, ti); err != nil {
 		t.Fatalf("UpdateTablet failed: %v", err)
@@ -131,9 +153,8 @@ func TestInitTablet(t *testing.T) {
 		t.Errorf("wrong tablet type: %v", ti.Type)
 	}
 
-	// init again with the tablet_type set, using init_tablet_type
-	// (also check db name override and tags here)
-	*initTabletType = "replica"
+	// 5. Subsequent inits will still start the vttablet as MASTER.
+	// (Also check db name override and tags here.)
 	*initDbNameOverride = "DBNAME"
 	initTags.Set("aaa:bbb")
 	if err := agent.InitTablet(port, gRPCPort); err != nil {

--- a/proto/query.proto
+++ b/proto/query.proto
@@ -741,7 +741,11 @@ message StreamHealthResponse {
   // b) the last time an active reparent was executed through a vtctl command
   //    (InitShardMaster, PlannedReparentShard, EmergencyReparentShard)
   // OR
-  // c) 0 if it was never called.
+  // c) the last time vttablet was started and it initialized its tablet type
+  //    as MASTER because it was recorded as the shard's current master in the
+  //    topology (see go/vt/vttablet/tabletmanager/init_tablet.go)
+  // OR
+  // d) 0 if the vttablet was never a MASTER.
   int64 tablet_externally_reparented_timestamp = 3;
 
   // realtime_stats contains information about the tablet status


### PR DESCRIPTION
I've added an e2e test in tabletmanager.py to verify that it works.

Note that I've changed the line you said earlier and the related line above it for a similar case.

I also improved the coverage of the unit test and split that out into a separate commit.