### PR TITLE
messages: ACL and monitoring support

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -1073,6 +1073,27 @@
   "TableName": ""
 }
 
+# repair
+"repair a"
+{
+  "PlanID": "OTHER_ADMIN",
+  "TableName": ""
+}
+
+# optimize
+"optimize a"
+{
+  "PlanID": "OTHER_ADMIN",
+  "TableName": ""
+}
+
+# truncate
+"truncate a"
+{
+  "PlanID": "OTHER_ADMIN",
+  "TableName": ""
+}
+
 # table not found select
 "select * from aaaa"
 "table aaaa not found in schema"

--- a/go/vt/vttablet/endtoend/message_test.go
+++ b/go/vt/vttablet/endtoend/message_test.go
@@ -52,6 +52,13 @@ func TestMessage(t *testing.T) {
 	}
 	defer client.Execute("drop table vitess_message", nil)
 
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Acked"), 0; got != want {
+		t.Errorf("Messages/vitess_message.Acked: %d, want %d", got, want)
+	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Queued"), 0; got != want {
+		t.Errorf("Messages/vitess_message.Queued: %d, want %d", got, want)
+	}
+
 	// Start goroutine to consume message stream.
 	go func() {
 		if err := client.MessageStream("vitess_message", func(qr *sqltypes.Result) error {
@@ -111,6 +118,9 @@ func TestMessage(t *testing.T) {
 		t.Error(err)
 		return
 	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Queued"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Queued: %d, want %d", got, want)
+	}
 
 	// Consume first message.
 	start := time.Now().UnixNano()
@@ -151,6 +161,9 @@ func TestMessage(t *testing.T) {
 	default:
 		t.Errorf("epoch: %d, must be 0 or 1", epoch)
 	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Delayed"), 0; got != want {
+		t.Errorf("Messages/vitess_message.Delayed: %d, want %d", got, want)
+	}
 
 	// Consume the resend.
 	<-ch
@@ -172,6 +185,9 @@ func TestMessage(t *testing.T) {
 	default:
 		t.Errorf("epoch: %d, must be 1 or 2", epoch)
 	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Delayed"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Delayed: %d, want %d", got, want)
+	}
 
 	// Ack the message.
 	count, err := client.MessageAck("vitess_message", []string{"1"})
@@ -190,6 +206,9 @@ func TestMessage(t *testing.T) {
 	if !(end-1e9 < ack && ack < end) {
 		t.Errorf("ack: %d. must be within 1s of end: %d", ack/1e9, end/1e9)
 	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Acked"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Acked: %d, want %d", got, want)
+	}
 
 	// Within 3+1 seconds, the row should be deleted.
 	time.Sleep(4 * time.Second)
@@ -199,6 +218,20 @@ func TestMessage(t *testing.T) {
 	}
 	if qr.RowsAffected != 0 {
 		t.Error("The row has not been purged yet")
+	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Purged"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Purged: %d, want %d", got, want)
+	}
+
+	// Verify final counts.
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Queued"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Queued: %d, want %d", got, want)
+	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Acked"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Acked: %d, want %d", got, want)
+	}
+	if got, want := framework.FetchInt(framework.DebugVars(), "Messages/vitess_message.Delayed"), 1; got != want {
+		t.Errorf("Messages/vitess_message.Delayed: %d, want %d", got, want)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -158,6 +158,7 @@ func (me *Engine) UpdateCaches(newMessages map[string][]*MessageRow, changedMess
 		if mm == nil {
 			continue
 		}
+		MessageStats.Add([]string{name, "Queued"}, int64(len(mrs)))
 		for _, mr := range mrs {
 			if mr.TimeNext > now {
 				// We don't handle future messages yet.
@@ -232,7 +233,7 @@ func (me *Engine) schemaChanged(tables map[string]*schema.Table, created, altere
 			continue
 		}
 		if me.managers[name] != nil {
-			// TODO(sougou): Increment internal error counter.
+			tabletenv.InternalErrors.Add("Messages", 1)
 			log.Errorf("Newly created table alread exists in messages: %s", name)
 			continue
 		}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -44,41 +44,43 @@ const (
 	PlanPassSelect PlanType = iota
 	// PlanSelectLock is for a select that locks.
 	PlanSelectLock
-	// PlanNextval is for NEXTVAL
+	// PlanNextval is for NEXTVAL.
 	PlanNextval
 	// PlanPassDML is pass through update & delete statements. This is
 	// the default plan for update and delete statements.
 	PlanPassDML
 	// PlanDMLPK is an update or delete with an equality where clause(s)
-	// on primary key(s)
+	// on primary key(s).
 	PlanDMLPK
 	// PlanDMLSubquery is an update or delete with a subselect statement
 	PlanDMLSubquery
 	// PlanInsertPK is insert statement where the PK value is
-	// supplied with the query
+	// supplied with the query.
 	PlanInsertPK
-	// PlanInsertSubquery is same as PlanDMLSubquery but for inserts
+	// PlanInsertSubquery is same as PlanDMLSubquery but for inserts.
 	PlanInsertSubquery
-	// PlanUpsertPK is for insert ... on duplicate key constructs
+	// PlanUpsertPK is for insert ... on duplicate key constructs.
 	PlanUpsertPK
-	// PlanInsertMessage is for inserting into message tables
+	// PlanInsertMessage is for inserting into message tables.
 	PlanInsertMessage
-	// PlanSet is for SET statements
+	// PlanSet is for SET statements.
 	PlanSet
-	// PlanDDL is for DDL statements
+	// PlanDDL is for DDL statements.
 	PlanDDL
-	// PlanSelectStream is used for streaming queries
+	// PlanSelectStream is used for streaming queries.
 	PlanSelectStream
-	// PlanOtherRead is for SHOW, DESCRIBE & EXPLAIN statements
+	// PlanOtherRead is for SHOW, DESCRIBE & EXPLAIN statements.
 	PlanOtherRead
-	// PlanOtherAdmin is for REPAIR, OPTIMIZE and TRUNCATE statements
+	// PlanOtherAdmin is for REPAIR, OPTIMIZE and TRUNCATE statements.
 	PlanOtherAdmin
+	// PlanMessageStream is used for streaming messages.
+	PlanMessageStream
 	// NumPlans stores the total number of plans
 	NumPlans
 )
 
 // Must exactly match order of plan constants.
-var planName = []string{
+var planName = [NumPlans]string{
 	"PASS_SELECT",
 	"SELECT_LOCK",
 	"NEXTVAL",
@@ -94,6 +96,7 @@ var planName = []string{
 	"SELECT_STREAM",
 	"OTHER_READ",
 	"OTHER_ADMIN",
+	"MESSAGE_STREAM",
 }
 
 func (pt PlanType) String() string {
@@ -139,12 +142,14 @@ var tableACLRoles = map[PlanType]tableacl.Role{
 	PlanDMLSubquery:    tableacl.WRITER,
 	PlanInsertPK:       tableacl.WRITER,
 	PlanInsertSubquery: tableacl.WRITER,
+	PlanInsertMessage:  tableacl.WRITER,
 	PlanDDL:            tableacl.ADMIN,
 	PlanSelectStream:   tableacl.READER,
 	PlanOtherRead:      tableacl.READER,
 	PlanOtherAdmin:     tableacl.ADMIN,
 	PlanUpsertPK:       tableacl.WRITER,
 	PlanNextval:        tableacl.WRITER,
+	PlanMessageStream:  tableacl.WRITER,
 }
 
 //_______________________________________________
@@ -248,7 +253,7 @@ func (plan *Plan) setTable(tableName sqlparser.TableIdent, tables map[string]*sc
 }
 
 // Build builds a plan based on the schema.
-func Build(sql string, tables map[string]*schema.Table) (plan *Plan, err error) {
+func Build(sql string, tables map[string]*schema.Table) (*Plan, error) {
 	statement, err := sqlparser.Parse(sql)
 	if err != nil {
 		return nil, err
@@ -283,13 +288,13 @@ func Build(sql string, tables map[string]*schema.Table) (plan *Plan, err error) 
 }
 
 // BuildStreaming builds a streaming plan based on the schema.
-func BuildStreaming(sql string, tables map[string]*schema.Table) (plan *Plan, err error) {
+func BuildStreaming(sql string, tables map[string]*schema.Table) (*Plan, error) {
 	statement, err := sqlparser.Parse(sql)
 	if err != nil {
 		return nil, err
 	}
 
-	plan = &Plan{
+	plan := &Plan{
 		PlanID:    PlanSelectStream,
 		FullQuery: GenerateFullQuery(statement),
 	}
@@ -308,5 +313,20 @@ func BuildStreaming(sql string, tables map[string]*schema.Table) (plan *Plan, er
 		return nil, fmt.Errorf("'%v' not allowed for streaming", sqlparser.String(stmt))
 	}
 
+	return plan, nil
+}
+
+// BuildMessageStreaming builds a plan for message streaming.
+func BuildMessageStreaming(name string, tables map[string]*schema.Table) (*Plan, error) {
+	plan := &Plan{
+		PlanID: PlanMessageStream,
+		Table:  tables[name],
+	}
+	if plan.Table == nil {
+		return nil, fmt.Errorf("table %s not found in schema", name)
+	}
+	if plan.Table.Type != schema.Message {
+		return nil, fmt.Errorf("'%s' is not a message table", name)
+	}
 	return plan, nil
 }

--- a/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan_test.go
@@ -173,6 +173,39 @@ func TestDDLPlan(t *testing.T) {
 	}
 }
 
+func TestMessageStreamingPlan(t *testing.T) {
+	testSchema := loadSchema("schema_test.json")
+	plan, err := BuildMessageStreaming("msg", testSchema)
+	if err != nil {
+		t.Error(err)
+	}
+	bout, _ := toJSON(plan)
+	planJSON := string(bout)
+
+	wantPlan := &Plan{
+		PlanID: PlanMessageStream,
+		Table:  testSchema["msg"],
+	}
+	bout, _ = toJSON(wantPlan)
+	wantJSON := string(bout)
+
+	if planJSON != wantJSON {
+		t.Errorf("BuildMessageStreaming: \n%s, want\n%s", planJSON, wantJSON)
+	}
+
+	_, err = BuildMessageStreaming("absent", testSchema)
+	want := "table absent not found in schema"
+	if err == nil || err.Error() != want {
+		t.Errorf("BuildMessageStreaming(absent) error: %v, want %s", err, want)
+	}
+
+	_, err = BuildMessageStreaming("a", testSchema)
+	want = "'a' is not a message table"
+	if err == nil || err.Error() != want {
+		t.Errorf("BuildMessageStreaming(absent) error: %v, want %s", err, want)
+	}
+}
+
 func matchString(t *testing.T, line int, expected interface{}, actual string) {
 	if expected != nil {
 		if expected.(string) != actual {

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -21,8 +21,10 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -36,6 +38,7 @@ import (
 	"github.com/youtube/vitess/go/vt/tableacl/simpleacl"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/messager"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/rules"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -257,6 +260,42 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got: %v, want: %v", got, want)
+	}
+}
+
+func TestQueryExecutorInsertMessageACL(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int63())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group02",
+			TableNamesOrPrefixes: []string{"msg"},
+			Readers:              []string{"u2"},
+		}},
+	}
+	if err := tableacl.InitFromProto(config); err != nil {
+		t.Fatalf("unable to load tableacl config, error: %v", err)
+	}
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	query := "insert into msg(time_scheduled, id, message) values(1, 2, 3)"
+
+	callerID := &querypb.VTGateCallerID{
+		Username: "u2",
+	}
+	ctx := callerid.NewContext(context.Background(), nil, callerID)
+
+	tsv := newTestTabletServer(ctx, enableStrictTableACL, db)
+	qre := newTestQueryExecutor(ctx, tsv, query, 0)
+	defer tsv.StopService()
+
+	_, err := qre.Execute()
+	want := `table acl error: "u2" [] cannot run INSERT_MESSAGE on table "msg"`
+	if err == nil || err.Error() != want {
+		t.Errorf("qre.Execute(insert into msg) error: %v, want %s", err, want)
 	}
 }
 
@@ -1076,6 +1115,147 @@ func TestQueryExecutorPlanNextval(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("qre.Execute() =\n%#v, want:\n%#v", got, want)
+	}
+}
+
+func TestQueryExecutorMessageStream(t *testing.T) {
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+	ctx := context.Background()
+	tsv := newTestTabletServer(ctx, noFlags, db)
+	defer tsv.StopService()
+	logStats := tabletenv.NewLogStats(ctx, "TestQueryExecutor")
+
+	plan, err := tsv.qe.GetMessageStreamPlan("msg")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We can't call newTestQueryExecutor because there's no
+	// SQL syntax for message streaming yet.
+	qre := &QueryExecutor{
+		ctx:      ctx,
+		query:    "stream from msg",
+		plan:     plan,
+		logStats: logStats,
+		tsv:      tsv,
+	}
+	checkPlanID(t, planbuilder.PlanMessageStream, qre.plan.PlanID)
+
+	ch := make(chan *sqltypes.Result, 1)
+	done := make(chan struct{})
+	skippedField := false
+	go func() {
+		if err := qre.MessageStream(func(qr *sqltypes.Result) error {
+			// Skip first result (field info).
+			if !skippedField {
+				skippedField = true
+				return nil
+			}
+			ch <- qr
+			return io.EOF
+		}); err != nil {
+			t.Error(err)
+		}
+		close(done)
+	}()
+
+	newMessages := map[string][]*messager.MessageRow{
+		"msg": {
+			&messager.MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1")), sqltypes.NULL}},
+		},
+	}
+	// We hack-push a new message into the cache, which will cause
+	// the message manager to send it.
+	// We may have to iterate a few times before the stream kicks in.
+	for {
+		runtime.Gosched()
+		time.Sleep(10 * time.Millisecond)
+		unlock := tsv.messager.LockDB(newMessages, nil)
+		tsv.messager.UpdateCaches(newMessages, nil)
+		unlock()
+		want := &sqltypes.Result{
+			Rows: [][]sqltypes.Value{{
+				sqltypes.MakeString([]byte("1")),
+				sqltypes.NULL,
+			}},
+		}
+		select {
+		case got := <-ch:
+			if !want.Equal(got) {
+				t.Errorf("Stream:\n%v, want\n%v", got, want)
+			}
+		default:
+			continue
+		}
+		break
+	}
+	// This should not hang.
+	<-done
+}
+
+func TestQueryExecutorMessageStreamACL(t *testing.T) {
+	aclName := fmt.Sprintf("simpleacl-test-%d", rand.Int63())
+	tableacl.Register(aclName, &simpleacl.Factory{})
+	tableacl.SetDefaultACL(aclName)
+	config := &tableaclpb.Config{
+		TableGroups: []*tableaclpb.TableGroupSpec{{
+			Name:                 "group02",
+			TableNamesOrPrefixes: []string{"msg"},
+			Readers:              []string{"u2"},
+			Writers:              []string{"u1"},
+		}},
+	}
+	if err := tableacl.InitFromProto(config); err != nil {
+		t.Fatalf("unable to load tableacl config, error: %v", err)
+	}
+
+	db := setUpQueryExecutorTest(t)
+	defer db.Close()
+
+	tsv := newTestTabletServer(context.Background(), enableStrictTableACL, db)
+	defer tsv.StopService()
+
+	plan, err := tsv.qe.GetMessageStreamPlan("msg")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callerID := &querypb.VTGateCallerID{
+		Username: "u1",
+	}
+	ctx := callerid.NewContext(context.Background(), nil, callerID)
+	qre := &QueryExecutor{
+		ctx:      ctx,
+		query:    "stream from msg",
+		plan:     plan,
+		logStats: tabletenv.NewLogStats(ctx, "TestQueryExecutor"),
+		tsv:      tsv,
+	}
+
+	// Should not fail because u1 has permission.
+	err = qre.MessageStream(func(qr *sqltypes.Result) error {
+		return io.EOF
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callerID = &querypb.VTGateCallerID{
+		Username: "u2",
+	}
+	qre.ctx = callerid.NewContext(context.Background(), nil, callerID)
+	// Should fail because u2 does not have permission.
+	err = qre.MessageStream(func(qr *sqltypes.Result) error {
+		return io.EOF
+	})
+
+	want := `table acl error: "u2" [] cannot run MESSAGE_STREAM on table "msg"`
+	if err == nil || err.Error() != want {
+		t.Errorf("qre.MessageStream(msg) error: %v, want %s", err, want)
+	}
+	if code := vterrors.Code(err); code != vtrpcpb.Code_PERMISSION_DENIED {
+		t.Fatalf("qre.Execute: %v, want %v", code, vtrpcpb.Code_PERMISSION_DENIED)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1898,6 +1898,19 @@ func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
 				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 2, "id", false),
 			},
 		},
+		"select count(*), count(time_acked) from msg": {
+			Fields: []*querypb.Field{{
+				Name: "count(*)",
+				Type: sqltypes.Decimal,
+			}, {
+				Name: "count(time_acked)",
+				Type: sqltypes.Decimal,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
+			},
+		},
 		mysql.BaseShowTablesForTable("msg"): {
 			Fields:       mysql.BaseShowTablesFields,
 			RowsAffected: 1,

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1898,19 +1898,6 @@ func getQueryExecutorSupportedQueries() map[string]*sqltypes.Result {
 				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 2, "id", false),
 			},
 		},
-		"select count(*), count(time_acked) from msg": {
-			Fields: []*querypb.Field{{
-				Name: "count(*)",
-				Type: sqltypes.Decimal,
-			}, {
-				Name: "count(time_acked)",
-				Type: sqltypes.Decimal,
-			}},
-			RowsAffected: 1,
-			Rows: [][]sqltypes.Value{
-				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
-			},
-		},
 		mysql.BaseShowTablesForTable("msg"): {
 			Fields:       mysql.BaseShowTablesFields,
 			RowsAffected: 1,

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -270,8 +270,8 @@ func TestCreateOrUpdateTable(t *testing.T) {
 	se.RegisterNotifier("test", func(schema map[string]*Table, created, altered, dropped []string) {
 		switch i {
 		case 0:
-			if len(created) != 4 {
-				t.Errorf("callback 0: %v, want len of 4\n", created)
+			if len(created) != 5 {
+				t.Errorf("callback 0: %v, want len of 5\n", created)
 			}
 		case 1:
 			want := []string{"test_table_01"}

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -185,19 +185,6 @@ func Queries() map[string]*sqltypes.Result {
 				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 2, "id", false),
 			},
 		},
-		"select count(*), count(time_acked) from msg": {
-			Fields: []*querypb.Field{{
-				Name: "count(*)",
-				Type: sqltypes.Decimal,
-			}, {
-				Name: "count(time_acked)",
-				Type: sqltypes.Decimal,
-			}},
-			RowsAffected: 1,
-			Rows: [][]sqltypes.Value{
-				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
-			},
-		},
 		mysql.BaseShowTablesForTable("msg"): {
 			Fields:       mysql.BaseShowTablesFields,
 			RowsAffected: 1,

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -185,6 +185,19 @@ func Queries() map[string]*sqltypes.Result {
 				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 2, "id", false),
 			},
 		},
+		"select count(*), count(time_acked) from msg": {
+			Fields: []*querypb.Field{{
+				Name: "count(*)",
+				Type: sqltypes.Decimal,
+			}, {
+				Name: "count(time_acked)",
+				Type: sqltypes.Decimal,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
+			},
+		},
 		mysql.BaseShowTablesForTable("msg"): {
 			Fields:       mysql.BaseShowTablesFields,
 			RowsAffected: 1,

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -76,6 +76,7 @@ func Queries() map[string]*sqltypes.Result {
 				mysql.BaseShowTablesRow("test_table_01", false, ""),
 				mysql.BaseShowTablesRow("test_table_02", false, ""),
 				mysql.BaseShowTablesRow("test_table_03", false, ""),
+				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 			},
 		},
 		"select * from test_table_01 where 1 != 1": {
@@ -137,6 +138,58 @@ func Queries() map[string]*sqltypes.Result {
 			RowsAffected: 1,
 			Rows: [][]sqltypes.Value{
 				mysql.ShowIndexFromTableRow("test_table_03", true, "PRIMARY", 1, "pk", false),
+			},
+		},
+		"select * from msg where 1 != 1": {
+			Fields: []*querypb.Field{{
+				Name: "time_scheduled",
+				Type: sqltypes.Int32,
+			}, {
+				Name: "id",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "time_next",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "epoch",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "time_created",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "time_acked",
+				Type: sqltypes.Int64,
+			}, {
+				Name: "message",
+				Type: sqltypes.Int64,
+			}},
+		},
+		"describe msg": {
+			Fields:       mysql.DescribeTableFields,
+			RowsAffected: 7,
+			Rows: [][]sqltypes.Value{
+				mysql.DescribeTableRow("time_scheduled", "int(11)", false, "PRI", "0"),
+				mysql.DescribeTableRow("id", "bigint(20)", false, "PRI", "0"),
+				mysql.DescribeTableRow("time_next", "bigint(20)", false, "", "0"),
+				mysql.DescribeTableRow("epoch", "bigint(20)", false, "", "0"),
+				mysql.DescribeTableRow("time_created", "bigint(20)", false, "", "0"),
+				mysql.DescribeTableRow("time_acked", "bigint(20)", false, "", "0"),
+				mysql.DescribeTableRow("message", "bigint(20)", false, "", "0"),
+			},
+		},
+		"show index from msg": {
+			Fields:       mysql.ShowIndexFromTableFields,
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 1, "time_scheduled", false),
+				mysql.ShowIndexFromTableRow("msg", true, "PRIMARY", 2, "id", false),
+			},
+		},
+		mysql.BaseShowTablesForTable("msg"): {
+			Fields:       mysql.BaseShowTablesFields,
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				mysql.BaseShowTablesRow("test_table", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 			},
 		},
 		"begin":  {},

--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -27,8 +27,9 @@ import (
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/tb"
 	"github.com/youtube/vitess/go/vt/callerid"
-	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/sqlparser"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
 var (
@@ -64,7 +65,7 @@ var (
 		vtrpcpb.Code_DATA_LOSS.String(),
 	)
 	// InternalErrors shows number of errors from internal components.
-	InternalErrors = stats.NewCounters("InternalErrors", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail")
+	InternalErrors = stats.NewCounters("InternalErrors", "Task", "StrayTransactions", "Panic", "HungQuery", "Schema", "TwopcCommit", "TwopcResurrection", "WatchdogFail", "Messages")
 	// Warnings shows number of warnings
 	Warnings = stats.NewCounters("Warnings", "ResultsExceeded")
 	// Unresolved tracks unresolved items. For now it's just Prepares.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1100,9 +1100,14 @@ func (tsv *TabletServer) MessageAck(ctx context.Context, target *querypb.Target,
 		}
 		sids = append(sids, v.String())
 	}
-	return tsv.execDML(ctx, target, func() (string, map[string]*querypb.BindVariable, error) {
+	count, err = tsv.execDML(ctx, target, func() (string, map[string]*querypb.BindVariable, error) {
 		return tsv.messager.GenerateAckQuery(name, sids)
 	})
+	if err != nil {
+		return 0, err
+	}
+	messager.MessageStats.Add([]string{name, "Acked"}, count)
+	return count, nil
 }
 
 // PostponeMessages postpones the list of messages for a given message table.

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2485,19 +2485,6 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 			},
 		},
-		"select count(*), count(time_acked) from msg": {
-			Fields: []*querypb.Field{{
-				Name: "count(*)",
-				Type: sqltypes.Decimal,
-			}, {
-				Name: "count(time_acked)",
-				Type: sqltypes.Decimal,
-			}},
-			RowsAffected: 1,
-			Rows: [][]sqltypes.Value{
-				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
-			},
-		},
 		"begin":    {},
 		"commit":   {},
 		"rollback": {},

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"math/rand"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,7 +35,6 @@ import (
 	"github.com/youtube/vitess/go/mysql/fakesqldb"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/vterrors"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/messager"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -1814,59 +1812,26 @@ func TestMessageStream(t *testing.T) {
 	ctx := context.Background()
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 
-	wanterr := "message table nomsg not found"
-	if err := tsv.MessageStream(ctx, &target, "nomsg", func(qr *sqltypes.Result) error {
+	err := tsv.MessageStream(ctx, &target, "nomsg", func(qr *sqltypes.Result) error {
 		return nil
-	}); err == nil || err.Error() != wanterr {
-		t.Errorf("tsv.MessageStream: %v, want %s", err, wanterr)
+	})
+	wantErr := "table nomsg not found in schema"
+	if err == nil || err.Error() != wantErr {
+		t.Errorf("tsv.MessageStream: %v, want %s", err, wantErr)
 	}
-	ch := make(chan *sqltypes.Result, 1)
-	done := make(chan struct{})
-	skippedField := false
-	go func() {
-		if err := tsv.MessageStream(ctx, &target, "msg", func(qr *sqltypes.Result) error {
-			if !skippedField {
-				skippedField = true
-				return nil
-			}
-			ch <- qr
-			return io.EOF
-		}); err != nil {
-			t.Error(err)
-		}
-		close(done)
-	}()
-	// Skip first result (field info).
-	newMessages := map[string][]*messager.MessageRow{
-		"msg": {
-			&messager.MessageRow{Row: []sqltypes.Value{sqltypes.MakeString([]byte("1")), sqltypes.NULL}},
-		},
+
+	// Check that the streaming mechanism works.
+	called := false
+	err = tsv.MessageStream(ctx, &target, "msg", func(qr *sqltypes.Result) error {
+		called = true
+		return io.EOF
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
-	// We may have to iterate a few times before the stream kicks in.
-	for {
-		runtime.Gosched()
-		time.Sleep(10 * time.Millisecond)
-		unlock := tsv.messager.LockDB(newMessages, nil)
-		tsv.messager.UpdateCaches(newMessages, nil)
-		unlock()
-		want := &sqltypes.Result{
-			Rows: [][]sqltypes.Value{{
-				sqltypes.MakeString([]byte("1")),
-				sqltypes.NULL,
-			}},
-		}
-		select {
-		case got := <-ch:
-			if !want.Equal(got) {
-				t.Errorf("Stream:\n%v, want\n%v", got, want)
-			}
-		default:
-			continue
-		}
-		break
+	if !called {
+		t.Fatal("callback was not called for MessageStream")
 	}
-	// This should not hang.
-	<-done
 }
 
 func TestMessageAck(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2485,6 +2485,19 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				mysql.BaseShowTablesRow("msg", false, "vitess_message,vt_ack_wait=30,vt_purge_after=120,vt_batch_size=1,vt_cache_size=10,vt_poller_interval=30"),
 			},
 		},
+		"select count(*), count(time_acked) from msg": {
+			Fields: []*querypb.Field{{
+				Name: "count(*)",
+				Type: sqltypes.Decimal,
+			}, {
+				Name: "count(time_acked)",
+				Type: sqltypes.Decimal,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.MakeTrusted(sqltypes.Decimal, []byte("2")), sqltypes.MakeTrusted(sqltypes.Decimal, []byte("1"))},
+			},
+		},
 		"begin":    {},
 		"commit":   {},
 		"rollback": {},


### PR DESCRIPTION
BUG=38339731
BUG=38341338

This change enforces ACL for message tables. ACL was already
enforced for MessageAck, because it was converted into an update
statement which went through the regular Execute mechanism.

For inserts, the plan ID has now been added to the list of roles
at the WRITER level, and a test has been added to verify that
the mechanism works.

For MessageStream, the code has been changed to build a plan
with a plan ID of PlanMessageStream, which is also added to
the roles at the WRITER level. Even though MessageStream only
reads, the reader is required to call MessageAck. So, there's
not much point in giving it a READER level role.

I also added some missing tests in planbuilder for some
recently added plans.

The second commit adds monitoring support.