### PR TITLE
make grpc max message size options apply to the client as well

### DIFF
--- a/go/vt/servenv/grpcutils/options.go
+++ b/go/vt/servenv/grpcutils/options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcutils
+
+import (
+	"flag"
+)
+
+var (
+	defaultMaxMessageSize = 4 * 1024 * 1024
+	// MaxMessageSize is the maximum message size which the gRPC server will
+	// accept. Larger messages will be rejected.
+	MaxMessageSize = &defaultMaxMessageSize
+)
+
+// RegisterFlags registers the command line flags for common grpc options
+func RegisterFlags() {
+	// Note: We're using 4 MiB as default value because that's the default in the
+	// gRPC 1.0.0 Go server.
+	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -58,7 +58,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -77,6 +77,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if timeout > 0 {
 		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	}
+	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
 	cc, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err

--- a/test/environment.py
+++ b/test/environment.py
@@ -96,6 +96,9 @@ run_local_database = os.path.join(vtroot, 'py-vtdb', 'vttest',
 # url to hit to force the logs to flush.
 flush_logs_url = '/debug/flushlogs'
 
+# set the maximum size for grpc messages to be 5MB (larger than the default of
+# 4MB).
+grpc_max_message_size = 5 * 1024 * 1024
 
 def setup():
   try:

--- a/test/mysql_server_test.py
+++ b/test/mysql_server_test.py
@@ -156,10 +156,10 @@ class TestMySQL(unittest.TestCase):
     cursor.close()
 
     # verify that queries work end-to-end with large grpc messages
-    largeBlob = 'L' * ((4 * 1024 * 1024) + 1)
+    largeComment = 'L' * ((4 * 1024 * 1024) + 1)
     cursor = conn.cursor()
-    cursor.execute('insert into vt_insert_test (id, msg, keyspace_id, data) values(%s, %s, %s, %s)',
-        (1, 'large blob', 123, largeBlob))
+    cursor.execute('insert into vt_insert_test (id, msg, keyspace_id, data) values(%s, %s, %s, %s) /* %s */',
+        (1, 'large blob', 123, 'LLL', largeComment))
     cursor.close()
 
     cursor = conn.cursor()
@@ -168,8 +168,8 @@ class TestMySQL(unittest.TestCase):
         self.fail('expected 1 row got ' + str(cursor.rowcount))
 
     for (id, msg, keyspace_id, blob) in cursor:
-        if blob != largeBlob:
-            self.fail('blob did not match largeBlob')
+        if blob != 'LLL':
+            self.fail('blob did not match \'LLL\'')
 
     cursor.close()
 

--- a/test/tablet.py
+++ b/test/tablet.py
@@ -596,6 +596,7 @@ class Tablet(object):
       args.extend(['-service_map', ','.join(protocols_flavor().service_map())])
     if self.grpc_enabled():
       args.extend(['-grpc_port', str(self.grpc_port)])
+      args.extend(['-grpc_max_message_size', str(environment.grpc_max_message_size)])
     if lameduck_period:
       args.extend(environment.lameduck_flag(lameduck_period))
     if grace_period:

--- a/test/utils.py
+++ b/test/utils.py
@@ -586,6 +586,7 @@ class VtGate(object):
 
     if protocols_flavor().vtgate_protocol() == 'grpc':
       args.extend(['-grpc_port', str(self.grpc_port)])
+      args.extend(['-grpc_max_message_size', str(environment.grpc_max_message_size)])
     if protocols_flavor().service_map():
       args.extend(['-service_map', ','.join(protocols_flavor().service_map())])
     if topo_impl:


### PR DESCRIPTION
It turns out that grpc has a maximum message size options on the client-side as well as the server, and in order for large SQL queries to be able to flow end to end through both vtgate and vttablet, we need to set the max message call option as well as setting the option on the server.

To fix this:
* Move the max message size option into the `grpcutils` module.
* For both vttabletconn and vtgateconn, add options to the `grpc.Dial` call site to set the max message size option

TBD:
* I'd like to add an end-to-end test that ensures we can in fact do both an INSERT and a SELECT of a row that is larger than 4MB.
* Should we apply this to _all_ call sites of grpc.Dial for consistency?
