### PR TITLE
set autocommit to true by default for mysql server sessions

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -94,6 +94,7 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query []byte, callback func(*sq
 			Options: &querypb.ExecuteOptions{
 				IncludedFields: querypb.ExecuteOptions_ALL,
 			},
+			Autocommit: true,
 		}
 		if c.Capabilities&mysql.CapabilityClientFoundRows != 0 {
 			session.Options.ClientFoundRows = true


### PR DESCRIPTION
As discussed, this sets the session Autocommit flag to true by default for all mysql server connections.
