### PR TITLE
Allow VTDATAROOT to be configurable

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -29,7 +29,7 @@ fi
 export GOTOP=$VTTOP/go
 export PYTOP=$VTTOP/py
 
-export VTDATAROOT="$VTROOT/vtdataroot"
+export VTDATAROOT="${VTDATAROOT:-${VTROOT}/vtdataroot}"
 mkdir -p $VTDATAROOT
 
 export VTPORTSTART=15000


### PR DESCRIPTION
* This will allow users to provide a VTDATAROOT env variable and make this
  directory configurable.
* Main motivation for this change is that we are using [Vagrant](https://www.vagrantup.com/) for  our development environment and having `VTDATAROOT` outside of the shared folder between the VM and the host makes the tests run in a more reliable way. 