### PR TITLE
Enable Travis CI to run in all forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ sudo: false
 language: go
 go:
   - 1.8
+go_import_path: github.com/youtube/vitess
 addons:
   apt:
     sources:


### PR DESCRIPTION
Existent Travis CI setup won't work with forks of the project. An example of these failures can be found [here](https://travis-ci.org/tinyspeck/vitess/jobs/260007925). 

This is mostly due to some assumptions that are made in the [dev.env](https://github.com/rafael/vitess/blob/master/dev.env#L24) script and also because of the way imports work in golang. 

This PR uses  [go_import_path](https://docs.travis-ci.com/user/languages/go/) feature from Travis to solve the problem.  With this change existent and futures forks of Vitess will benefit from CI. 
