### PR TITLE
Fix mysql server test

### DIFF
--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -542,7 +542,13 @@ func TestTLSServer(t *testing.T) {
 		t.Fatalf("NewListener failed: %v", err)
 	}
 	defer l.Close()
-	host := l.Addr().(*net.TCPAddr).IP.String()
+
+	// Make sure hostname is added as an entry to /etc/hosts, otherwise ssl handshake will fail
+	host, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("Failed to get os Hostname: %v", err)
+	}
+
 	port := l.Addr().(*net.TCPAddr).Port
 
 	// Create the certs.


### PR DESCRIPTION
Using the host fetched from the listener ip is not working consistently. It could return an empty value, which results in a SSL handshake validation failure  when connecting to the mysql server (the SSL certificate generated by the test has an empty host). The following is an example of the failure:

```bash
$ source dev.env
$ make site_test
...
E0803 03:38:43.076735    3910 server.go:366] Error in the middle of a stream to client 4 ([::1]:33844): forced query handling error for: error after send (errno 1047) (sqlstate 08S01)
E0803 03:38:44.448673    3910 server.go:208] Cannot read post-SSL client handshake response from client 1 ([::1]:44604): EOF
--- FAIL: TestTLSServer (1.21s)
        server_test.go:587: mysql failed: mysql: [Warning] Using a password on the command line interface can be insecure.
                ERROR 2026 (HY000): SSL connection error: SSL certificate validation failure
                WARNING: --ssl is deprecated and will be removed in a future version. Use --ssl-mode instead.
                WARNING: --ssl-verify-server-cert is deprecated and will be removed in a future version. Use --ssl-mode=VERIFY_IDENTITY instead.
...
```

Is there something special that we could set in our environment to avoid this problem? 

One approach that works is to use `os.Hostname()` to get host information. Any thoughts on using this approach? 