### PR TITLE
healthcheck: ensure Uid is non-zero before check

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -463,7 +463,7 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 		serving = false
 	}
 
-	if shr.TabletAlias != nil && *shr.TabletAlias != *oldTs.Tablet.Alias {
+	if shr.TabletAlias != nil && oldTs.Tablet.Alias.Uid != 0 && !proto.Equal(shr.TabletAlias, oldTs.Tablet.Alias) {
 		return fmt.Errorf("health stats mismatch, tablet %+v alias does not match response alias %v", oldTs.Tablet, shr.TabletAlias)
 	}
 


### PR DESCRIPTION
This was changed internally. Exporting this back in open source.

This was found on import. There are situations where the existing
alias Uid is 0, which causes the alias comparison to fail. I've
added a check for this.