### PR TITLE
bug: hot row protection should strip comments

### DIFF
--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -77,6 +77,7 @@ func StartServer(connParams mysql.ConnParams) error {
 	config.TwoPCEnable = true
 	config.TwoPCAbandonAge = 1
 	config.TwoPCCoordinatorAddress = "fake"
+	config.EnableHotRowProtection = true
 
 	Target = querypb.Target{
 		Keyspace:   "vttest",

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1025,6 +1025,8 @@ func (tsv *TabletServer) beginWaitForSameRangeTransactions(ctx context.Context, 
 // It returns an empty string as key if the row (range) cannot be parsed from
 // the query and bind variables or the table name is empty.
 func (tsv *TabletServer) computeTxSerializerKey(ctx context.Context, logStats *tabletenv.LogStats, sql string, bindVariables map[string]*querypb.BindVariable) (string, string) {
+	// Strip trailing comments so we don't pollute the query cache.
+	sql, _ = sqlparser.SplitTrailingComments(sql)
 	plan, err := tsv.qe.GetPlan(ctx, logStats, sql)
 	if err != nil {
 		logComputeRowSerializerKey.Errorf("failed to get plan for query: %v err: %v", sql, err)


### PR DESCRIPTION
BUG=38246346

Comments should be stripped before calling GetPlan. Otherwise, the
query cache gets polluted with queries that have trailing comments.