### PR TITLE
add support for subqueries in DMLs for unsharded keyspaces

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -651,6 +651,21 @@
   }
 }
 
+# unsharded insert from union
+"insert into unsharded select 1 from dual union select 1 from dual"
+{
+  "Original": "insert into unsharded select 1 from dual union select 1 from dual",
+  "Instructions": {
+    "Opcode": "InsertUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "insert into unsharded select 1 from dual union select 1 from dual",
+    "Table": "unsharded"
+  }
+}
+
 # insert for non-vindex autoinc, invalid value
 "insert into user_extra(nonid, extra_id) values (2, 18446744073709551616)"
 "could not compute value for vindex or auto-inc column: strconv.ParseUint: parsing "18446744073709551616": value out of range"

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -34,6 +34,48 @@
   }
 }
 
+# subqueries in unsharded update
+"update unsharded set col = (select col from unsharded limit 1)"
+{
+  "Original": "update unsharded set col = (select col from unsharded limit 1)",
+  "Instructions": {
+    "Opcode": "UpdateUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "update unsharded set col = (select col from unsharded limit 1)"
+  }
+}
+
+# unsharded union in subquery of unsharded update
+"update unsharded set col = (select id from unsharded union select id from unsharded)"
+{
+  "Original": "update unsharded set col = (select id from unsharded union select id from unsharded)",
+  "Instructions": {
+    "Opcode": "UpdateUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "update unsharded set col = (select id from unsharded union select id from unsharded)"
+  }
+}
+
+# unsharded join in subquery of unsharded update
+"update unsharded set col = (select id from unsharded a join unsharded b on a.id = b.id)"
+{
+  "Original": "update unsharded set col = (select id from unsharded a join unsharded b on a.id = b.id)",
+  "Instructions": {
+    "Opcode": "UpdateUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "update unsharded set col = (select id from unsharded as a join unsharded as b on a.id = b.id)"
+  }
+}
+
 # delete unsharded
 "delete from unsharded"
 {
@@ -372,6 +414,22 @@
         null
       ]
     }
+  }
+}
+
+
+# unsharded insert subquery in insert value
+"insert into unsharded values((select 1 from dual), 1)"
+{
+  "Original": "insert into unsharded values((select 1 from dual), 1)",
+  "Instructions": {
+    "Opcode": "InsertUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "insert into unsharded values ((select 1 from dual), 1)",
+    "Table": "unsharded"
   }
 }
 

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -217,11 +217,31 @@
 
 # subqueries in update
 "update user set col = (select id from unsharded)"
-"unsupported: subqueries in DML"
+"unsupported: subqueries in sharded DML"
+
+# sharded subqueries in unsharded update
+"update unsharded set col = (select id from user)"
+"unsupported: sharded subqueries in DML"
+
+# sharded join unsharded subqueries in unsharded update
+"update unsharded set col = (select id from unsharded join user on unsharded.id = user.id)"
+"unsupported: sharded subqueries in DML"
 
 # subqueries in delete
 "delete from user where col = (select id from unsharded)"
-"unsupported: subqueries in DML"
+"unsupported: subqueries in sharded DML"
+
+# sharded subqueries in unsharded delete
+"delete from unsharded where col = (select id from user)"
+"unsupported: sharded subqueries in DML"
+
+# sharded subquery in unsharded subquery in unsharded delete
+"delete from unsharded where col = (select id from unsharded where id = (select id from user))"
+"unsupported: sharded subqueries in DML"
+
+# sharded join unsharded subqueries in unsharded delete
+"delete from unsharded where col = (select id from unsharded join user on unsharded.id = user.id)"
+"unsupported: sharded subqueries in DML"
 
 # update with no where clause
 "update user set val = 1"
@@ -285,7 +305,7 @@
 
 # cross-shard update tables
 "update (select id from user) as u set id = 4"
-"unsupported: subqueries in DML"
+"unsupported: subqueries in sharded DML"
 
 # join in update tables
 "update user join user_extra on user.id = user_extra.id set user.name = 'foo'"
@@ -311,9 +331,9 @@
 "insert into unsharded_auto select col from unsharded"
 "unsupported: auto-inc and select in insert"
 
-# unsharded inssert subquery in insert value
-"insert into unsharded values((select 1 from dual), 1)"
-"unsupported: subquery in insert values"
+# unsharded insert, with sharded subquery in insert value
+"insert into unsharded values((select 1 from user), 1)"
+"unsupported: sharded subquery in insert values"
 
 # unsharded insert, no col list with auto-inc
 "insert into unsharded_auto values(1,1)"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -315,17 +315,13 @@
 "update user as u, user_extra as ue set u.name = 'foo' where u.id = ue.id"
 "unsupported: multi-table update statement in sharded keyspace"
 
-# unsharded insert from union
-"insert into unsharded select 1 from dual union select 1 from dual"
-"unsupported: union in insert"
-
 # unsharded insert with cross-shard join"
 "insert into unsharded select u.col from user u join user u1"
-"unsupported: cross-shard join in insert"
+"unsupported: sharded subquery in insert values"
 
 # unsharded insert with mismatched keyspaces"
 "insert into unsharded select col from user where id=1"
-"unsupported: cross-keyspace select in insert"
+"unsupported: sharded subquery in insert values"
 
 # unsharded insert, unqualified names and auto-inc combined
 "insert into unsharded_auto select col from unsharded"

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -71,8 +71,8 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		return eRoute, nil
 	case sqlparser.Values:
 		rows = insertValues
-		if hasSubquery(rows) {
-			return nil, errors.New("unsupported: subquery in insert values")
+		if !validateSubquerySamePlan(rows, eRoute, vschema) {
+			return nil, errors.New("unsupported: sharded subquery in insert values")
 		}
 	default:
 		panic(fmt.Sprintf("BUG: unexpected construct in insert: %T", insertValues))


### PR DESCRIPTION
For the unsharded keyspace, subqueries are allowed in DMLs. We now validate that the subquery hits the same plan as the outer, recursively through walking the AST.
