### PR TITLE
Treat unsigned long like mysql-connector-j -- as a BigInteger. UnsignedLong…

### DIFF
--- a/java/client/src/main/java/io/vitess/client/cursor/Row.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/Row.java
@@ -18,15 +18,9 @@ package io.vitess.client.cursor;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.primitives.UnsignedLong;
-import com.google.protobuf.ByteString;
-import io.vitess.mysql.DateTime;
-import io.vitess.proto.Query;
-import io.vitess.proto.Query.Field;
-import io.vitess.proto.Query.Type;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Date;
 import java.sql.SQLDataException;
 import java.sql.SQLException;
@@ -36,7 +30,17 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+
 import javax.annotation.concurrent.NotThreadSafe;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.primitives.UnsignedLong;
+import com.google.protobuf.ByteString;
+
+import io.vitess.mysql.DateTime;
+import io.vitess.proto.Query;
+import io.vitess.proto.Query.Field;
+import io.vitess.proto.Query.Type;
 
 /**
  * Type-converting wrapper around raw {@link io.vitess.proto.Query.Row} proto.
@@ -244,7 +248,8 @@ public class Row {
    * @param columnIndex 1-based column number (0 is invalid)
    */
   public UnsignedLong getULong(int columnIndex) throws SQLException {
-    return getObject(columnIndex, UnsignedLong.class);
+    BigInteger l = getObject(columnIndex, BigInteger.class);
+    return l == null ? null : UnsignedLong.fromLongBits(l.longValue());
   }
 
   /**
@@ -648,7 +653,7 @@ public class Row {
       case INT64:
         return Long.valueOf(value.toStringUtf8());
       case UINT64:
-        return UnsignedLong.valueOf(value.toStringUtf8());
+        return new BigInteger(value.toStringUtf8());
       case FLOAT32:
         return Float.valueOf(value.toStringUtf8());
       case FLOAT64:

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessResultSetTest.java
@@ -16,13 +16,6 @@
 
 package io.vitess.jdbc;
 
-import com.google.protobuf.ByteString;
-import io.vitess.client.cursor.Cursor;
-import io.vitess.client.cursor.SimpleCursor;
-import io.vitess.proto.Query;
-import io.vitess.util.MysqlDefs;
-import io.vitess.util.StringUtils;
-import io.vitess.util.charset.CharsetMapping;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -32,6 +25,7 @@ import java.sql.Clob;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +34,15 @@ import org.mockito.internal.verification.VerificationModeFactory;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.protobuf.ByteString;
+
+import io.vitess.client.cursor.Cursor;
+import io.vitess.client.cursor.SimpleCursor;
+import io.vitess.proto.Query;
+import io.vitess.util.MysqlDefs;
+import io.vitess.util.StringUtils;
+import io.vitess.util.charset.CharsetMapping;
 
 /**
  * Created by harshit.gangal on 19/01/16.
@@ -251,6 +254,14 @@ public class VitessResultSetTest extends BaseTest {
         Assert.assertEquals("0", vitessResultSet.getString(25));
         Assert.assertEquals("val123", vitessResultSet.getString(26));
         Assert.assertEquals(null, vitessResultSet.getString(27));
+    }
+
+    @Test public void getObjectUint64AsBigInteger() throws SQLException {
+        Cursor cursor = getCursorWithRowsAsNull();
+        VitessResultSet vitessResultSet = new VitessResultSet(cursor, getVitessStatement());
+        vitessResultSet.next();
+
+        Assert.assertEquals(new BigInteger("1000"), vitessResultSet.getObject(10));
     }
 
     @Test public void testgetBoolean() throws SQLException {


### PR DESCRIPTION
… causes interface incompatibilities for consumers of the vitess jdbc who expect it to work like mysql-connector-j

@harshit-gangal this has caused a number of issues for us.  Various downstream libraries, such as jackson (for json serialization), JDBI, etc, handle UnsignedLong differently than BigInteger (or not at all).  The `mysql-connector-j` treats BIGINT as a BigInteger when unsigned. I think that maps well to our UINT64.

See https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-reference-type-conversions.html