### PR TITLE
don't pick up python2 from PYTHONPATH during selenium install

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -268,7 +268,7 @@ selenium_dist=$VTROOT/dist/selenium
 mkdir -p $selenium_dist
 $VIRTUALENV $selenium_dist
 PIP=$selenium_dist/bin/pip
-$PIP install selenium
+PYTHONPATH= $PIP install selenium
 mkdir -p $VTROOT/dist/chromedriver
 curl -sL http://chromedriver.storage.googleapis.com/2.25/chromedriver_linux64.zip > chromedriver_linux64.zip
 unzip -o -q chromedriver_linux64.zip -d $VTROOT/dist/chromedriver

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -268,6 +268,8 @@ selenium_dist=$VTROOT/dist/selenium
 mkdir -p $selenium_dist
 $VIRTUALENV $selenium_dist
 PIP=$selenium_dist/bin/pip
+# PYTHONPATH is removed for `pip install` because otherwise it can pick up go/dist/grpc/usr/local/lib/python2.7/site-packages
+# instead of go/dist/selenium/lib/python3.5/site-packages and then can't find module 'pip._vendor.requests'
 PYTHONPATH= $PIP install selenium
 mkdir -p $VTROOT/dist/chromedriver
 curl -sL http://chromedriver.storage.googleapis.com/2.25/chromedriver_linux64.zip > chromedriver_linux64.zip


### PR DESCRIPTION
$ ./bootstrap.sh
...
Installing setuptools, pip, wheel...done.
Traceback (most recent call last):
  File "/home/whatever/go/dist/selenium/bin/pip", line 7, in <module>
    from pip import main
  File "/home/whatever/go/dist/grpc/usr/local/lib/python2.7/site-packages/pip/__init__.py", line 21, in <module>
    from pip._vendor.requests.packages.urllib3.exceptions import DependencyWarning
ImportError: No module named 'pip._vendor.requests'

Turned out to be because PYTHONPATH had go/dist/grpc/usr/local/lib/python2.7/site-packages before go/dist/selenium/lib/python3.5/site-packages (3.5 has the missing module).

Setting PYTHONPATH= for that pip install worked for me.
Slightly worried because Alex Charis made some commits about this in February ( f14c0586fc391c8677 , 3a5949bb9ca1440c3e ), so maybe I'm just undoing that.