### PR TITLE
makes the various timeouts configurable on the connection -- connect,…

### DIFF
--- a/java/client/src/main/java/io/vitess/client/cursor/FieldMap.java
+++ b/java/client/src/main/java/io/vitess/client/cursor/FieldMap.java
@@ -19,12 +19,16 @@ package io.vitess.client.cursor;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.collect.ImmutableList;
-import io.vitess.proto.Query.Field;
 import java.util.List;
 import java.util.Map;
+
 import javax.annotation.Nullable;
+
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+
+import com.google.common.collect.ImmutableList;
+
+import io.vitess.proto.Query.Field;
 
 /**
  * A wrapper for {@code List<Field>} that also facilitates lookup by field name.

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -16,11 +16,6 @@
 
 package io.vitess.jdbc;
 
-import io.vitess.proto.Query;
-import io.vitess.proto.Topodata;
-import io.vitess.util.Constants;
-import io.vitess.util.StringUtils;
-
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.sql.DriverPropertyInfo;
@@ -29,6 +24,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+
+import io.vitess.proto.Query;
+import io.vitess.proto.Topodata;
+import io.vitess.util.Constants;
+import io.vitess.util.StringUtils;
 
 public class ConnectionProperties {
 
@@ -206,6 +206,24 @@ public class ConnectionProperties {
         "treatUtilDateAsTimestamp",
         "Should the driver treat java.util.Date as a TIMESTAMP for the purposes of PreparedStatement.setObject()",
         true);
+
+    private LongConnectionProperty queryTimeoutMillis = new LongConnectionProperty(
+        "queryTimeoutMillis",
+        "The default query timeout, in millis, to use for queries which do not explicitly setQueryTimeout",
+        Constants.DEFAULT_TIMEOUT
+    );
+
+    private LongConnectionProperty connectionTimeoutMillis = new LongConnectionProperty(
+        "connectionTimeoutMillis",
+        "The timeout, in millis, to use when creating new gRPC connections",
+        Constants.CONNECTION_TIMEOUT
+    );
+
+    private LongConnectionProperty transactionTimeoutMillis = new LongConnectionProperty(
+        "transactionTimeoutMillis",
+        "The timeout, in millis, to use when committing or rolling back transactions",
+        Constants.DEFAULT_TIMEOUT
+    );
 
     // Caching of some hot properties to avoid casting over and over
     private Topodata.TabletType tabletTypeCache;
@@ -460,6 +478,30 @@ public class ConnectionProperties {
 
     public void setTreatUtilDateAsTimestamp(boolean treatUtilDateAsTimestamp) {
         this.treatUtilDateAsTimestamp.setValue(treatUtilDateAsTimestamp);
+    }
+
+    public long getQueryTimeoutMillis() {
+        return queryTimeoutMillis.getValueAsLong();
+    }
+
+    public void setQueryTimeoutMillis(long queryTimeoutMillis) {
+        this.queryTimeoutMillis.setValue(queryTimeoutMillis);
+    }
+
+    public long getConnectionTimeoutMillis() {
+        return connectionTimeoutMillis.getValueAsLong();
+    }
+
+    public void setConnectionTimeoutMillis(long connectionTimeoutMillis) {
+        this.connectionTimeoutMillis.setValue(connectionTimeoutMillis);
+    }
+
+    public long getTransactionTimeoutMillis() {
+        return transactionTimeoutMillis.getValueAsLong();
+    }
+
+    public void setTransactionTimeoutMillis(long transactionTimeoutMillis) {
+        this.transactionTimeoutMillis.setValue(transactionTimeoutMillis);
     }
 
     public String getTarget() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -207,20 +207,20 @@ public class ConnectionProperties {
         "Should the driver treat java.util.Date as a TIMESTAMP for the purposes of PreparedStatement.setObject()",
         true);
 
-    private LongConnectionProperty queryTimeoutMillis = new LongConnectionProperty(
-        "queryTimeoutMillis",
+    private LongConnectionProperty queryTimeout = new LongConnectionProperty(
+        "queryTimeout",
         "The default query timeout, in millis, to use for queries which do not explicitly setQueryTimeout",
         Constants.DEFAULT_TIMEOUT
     );
 
-    private LongConnectionProperty connectionTimeoutMillis = new LongConnectionProperty(
-        "connectionTimeoutMillis",
+    private LongConnectionProperty connectionTimeout = new LongConnectionProperty(
+        "connectionTimeout",
         "The timeout, in millis, to use when creating new gRPC connections",
         Constants.CONNECTION_TIMEOUT
     );
 
-    private LongConnectionProperty transactionTimeoutMillis = new LongConnectionProperty(
-        "transactionTimeoutMillis",
+    private LongConnectionProperty transactionTimeout = new LongConnectionProperty(
+        "transactionTimeout",
         "The timeout, in millis, to use when committing or rolling back transactions",
         Constants.DEFAULT_TIMEOUT
     );
@@ -480,28 +480,28 @@ public class ConnectionProperties {
         this.treatUtilDateAsTimestamp.setValue(treatUtilDateAsTimestamp);
     }
 
-    public long getQueryTimeoutMillis() {
-        return queryTimeoutMillis.getValueAsLong();
+    public long getQueryTimeout() {
+        return queryTimeout.getValueAsLong();
     }
 
-    public void setQueryTimeoutMillis(long queryTimeoutMillis) {
-        this.queryTimeoutMillis.setValue(queryTimeoutMillis);
+    public void setQueryTimeout(long queryTimeout) {
+        this.queryTimeout.setValue(queryTimeout);
     }
 
-    public long getConnectionTimeoutMillis() {
-        return connectionTimeoutMillis.getValueAsLong();
+    public long getConnectionTimeout() {
+        return connectionTimeout.getValueAsLong();
     }
 
-    public void setConnectionTimeoutMillis(long connectionTimeoutMillis) {
-        this.connectionTimeoutMillis.setValue(connectionTimeoutMillis);
+    public void setConnectionTimeout(long connectionTimeout) {
+        this.connectionTimeout.setValue(connectionTimeout);
     }
 
-    public long getTransactionTimeoutMillis() {
-        return transactionTimeoutMillis.getValueAsLong();
+    public long getTransactionTimeout() {
+        return transactionTimeout.getValueAsLong();
     }
 
-    public void setTransactionTimeoutMillis(long transactionTimeoutMillis) {
-        this.transactionTimeoutMillis.setValue(transactionTimeoutMillis);
+    public void setTransactionTimeout(long transactionTimeout) {
+        this.transactionTimeout.setValue(transactionTimeout);
     }
 
     public String getTarget() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -207,21 +207,9 @@ public class ConnectionProperties {
         "Should the driver treat java.util.Date as a TIMESTAMP for the purposes of PreparedStatement.setObject()",
         true);
 
-    private LongConnectionProperty queryTimeout = new LongConnectionProperty(
-        "queryTimeout",
-        "The default query timeout, in millis, to use for queries which do not explicitly setQueryTimeout",
-        Constants.DEFAULT_TIMEOUT
-    );
-
-    private LongConnectionProperty connectionTimeout = new LongConnectionProperty(
-        "connectionTimeout",
-        "The timeout, in millis, to use when creating new gRPC connections",
-        Constants.CONNECTION_TIMEOUT
-    );
-
-    private LongConnectionProperty transactionTimeout = new LongConnectionProperty(
-        "transactionTimeout",
-        "The timeout, in millis, to use when committing or rolling back transactions",
+    private LongConnectionProperty timeout = new LongConnectionProperty(
+        "timeout",
+        "The default timeout, in millis, to use for queries, connections, and transaction commit/rollback. Query timeout can be overridden by explicitly calling setQueryTimeout",
         Constants.DEFAULT_TIMEOUT
     );
 
@@ -480,28 +468,12 @@ public class ConnectionProperties {
         this.treatUtilDateAsTimestamp.setValue(treatUtilDateAsTimestamp);
     }
 
-    public long getQueryTimeout() {
-        return queryTimeout.getValueAsLong();
+    public long getTimeout() {
+        return timeout.getValueAsLong();
     }
 
-    public void setQueryTimeout(long queryTimeout) {
-        this.queryTimeout.setValue(queryTimeout);
-    }
-
-    public long getConnectionTimeout() {
-        return connectionTimeout.getValueAsLong();
-    }
-
-    public void setConnectionTimeout(long connectionTimeout) {
-        this.connectionTimeout.setValue(connectionTimeout);
-    }
-
-    public long getTransactionTimeout() {
-        return transactionTimeout.getValueAsLong();
-    }
-
-    public void setTransactionTimeout(long transactionTimeout) {
-        this.transactionTimeout.setValue(transactionTimeout);
+    public void setTimeout(long timeout) {
+        this.timeout.setValue(timeout);
     }
 
     public String getTarget() {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
@@ -172,7 +172,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.COMMIT_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(getTransactionTimeoutMillis());
+                Context context = createContext(getTransactionTimeout());
                 this.vtGateTx.commit(context, getTwopcEnabled()).checkedGet();
             }
         } finally {
@@ -191,7 +191,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.ROLLBACK_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(getTransactionTimeoutMillis());
+                Context context = createContext(getTransactionTimeout());
                 this.vtGateTx.rollback(context).checkedGet();
             }
         } finally {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
@@ -172,7 +172,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.COMMIT_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(getTransactionTimeout());
+                Context context = createContext(getTimeout());
                 this.vtGateTx.commit(context, getTwopcEnabled()).checkedGet();
             }
         } finally {
@@ -191,7 +191,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.ROLLBACK_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(getTransactionTimeout());
+                Context context = createContext(getTimeout());
                 this.vtGateTx.rollback(context).checkedGet();
             }
         } finally {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessConnection.java
@@ -16,13 +16,6 @@
 
 package io.vitess.jdbc;
 
-import io.vitess.client.Context;
-import io.vitess.client.VTGateConn;
-import io.vitess.client.VTGateTx;
-import io.vitess.util.CommonUtils;
-import io.vitess.util.Constants;
-import io.vitess.util.MysqlDefs;
-
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
@@ -49,6 +42,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.logging.Logger;
+
+import io.vitess.client.Context;
+import io.vitess.client.VTGateConn;
+import io.vitess.client.VTGateTx;
+import io.vitess.util.CommonUtils;
+import io.vitess.util.Constants;
+import io.vitess.util.MysqlDefs;
 
 /**
  * Created by harshit.gangal on 23/01/16.
@@ -172,7 +172,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.COMMIT_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(Constants.CONNECTION_TIMEOUT);
+                Context context = createContext(getTransactionTimeoutMillis());
                 this.vtGateTx.commit(context, getTwopcEnabled()).checkedGet();
             }
         } finally {
@@ -191,7 +191,7 @@ public class VitessConnection extends ConnectionProperties implements Connection
         checkAutoCommit(Constants.SQLExceptionMessages.ROLLBACK_WHEN_AUTO_COMMIT_TRUE);
         try {
             if (isInTransaction()) {
-                Context context = createContext(Constants.CONNECTION_TIMEOUT);
+                Context context = createContext(getTransactionTimeoutMillis());
                 this.vtGateTx.rollback(context).checkedGet();
             }
         } finally {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -78,7 +78,7 @@ public class VitessStatement implements Statement {
     public VitessStatement(VitessConnection vitessConnection, int resultSetType,
         int resultSetConcurrency) {
         this.vitessConnection = vitessConnection;
-        this.queryTimeoutInMillis = vitessConnection.getQueryTimeoutMillis();
+        this.queryTimeoutInMillis = vitessConnection.getQueryTimeout();
         this.vitessResultSet = null;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
@@ -268,7 +268,7 @@ public class VitessStatement implements Statement {
                 Constants.SQLExceptionMessages.ILLEGAL_VALUE_FOR + "query timeout");
         }
         this.queryTimeoutInMillis =
-            (0 == seconds) ? vitessConnection.getQueryTimeoutMillis() : (long) seconds * 1000;
+            (0 == seconds) ? vitessConnection.getQueryTimeout() : (long) seconds * 1000;
     }
 
     /**

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -78,7 +78,7 @@ public class VitessStatement implements Statement {
     public VitessStatement(VitessConnection vitessConnection, int resultSetType,
         int resultSetConcurrency) {
         this.vitessConnection = vitessConnection;
-        this.queryTimeoutInMillis = vitessConnection.getQueryTimeout();
+        this.queryTimeoutInMillis = vitessConnection.getTimeout();
         this.vitessResultSet = null;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
@@ -268,7 +268,7 @@ public class VitessStatement implements Statement {
                 Constants.SQLExceptionMessages.ILLEGAL_VALUE_FOR + "query timeout");
         }
         this.queryTimeoutInMillis =
-            (0 == seconds) ? vitessConnection.getQueryTimeout() : (long) seconds * 1000;
+            (0 == seconds) ? vitessConnection.getTimeout() : (long) seconds * 1000;
     }
 
     /**

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessStatement.java
@@ -57,7 +57,7 @@ public class VitessStatement implements Statement {
     protected VitessConnection vitessConnection;
     protected boolean closed;
     protected long resultCount;
-    protected long queryTimeoutInMillis = Constants.DEFAULT_TIMEOUT;
+    protected long queryTimeoutInMillis;
     protected int maxFieldSize = Constants.MAX_BUFFER_SIZE;
     protected int maxRows = 0;
     protected int fetchSize = 0;
@@ -78,6 +78,7 @@ public class VitessStatement implements Statement {
     public VitessStatement(VitessConnection vitessConnection, int resultSetType,
         int resultSetConcurrency) {
         this.vitessConnection = vitessConnection;
+        this.queryTimeoutInMillis = vitessConnection.getQueryTimeoutMillis();
         this.vitessResultSet = null;
         this.resultSetType = resultSetType;
         this.resultSetConcurrency = resultSetConcurrency;
@@ -267,7 +268,7 @@ public class VitessStatement implements Statement {
                 Constants.SQLExceptionMessages.ILLEGAL_VALUE_FOR + "query timeout");
         }
         this.queryTimeoutInMillis =
-            (0 == seconds) ? Constants.DEFAULT_TIMEOUT : (long) seconds * 1000;
+            (0 == seconds) ? vitessConnection.getQueryTimeoutMillis() : (long) seconds * 1000;
     }
 
     /**

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -16,6 +16,13 @@
 
 package io.vitess.jdbc;
 
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+
 import io.vitess.client.Context;
 import io.vitess.client.RpcClient;
 import io.vitess.client.VTGateConn;
@@ -24,12 +31,6 @@ import io.vitess.client.grpc.RetryingInterceptorConfig;
 import io.vitess.client.grpc.tls.TlsOptions;
 import io.vitess.util.CommonUtils;
 import io.vitess.util.Constants;
-import java.io.IOException;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by naveen.nahata on 24/02/16.
@@ -107,7 +108,7 @@ public class VitessVTGateManager {
     private static VTGateConn getVtGateConn(VitessJDBCUrl.HostInfo hostInfo, VitessConnection connection) {
         final String username = connection.getUsername();
         final String keyspace = connection.getKeyspace();
-        final Context context = CommonUtils.createContext(username, Constants.CONNECTION_TIMEOUT);
+        final Context context = CommonUtils.createContext(username,connection.getConnectionTimeoutMillis());
         RetryingInterceptorConfig retryingConfig = getRetryingInterceptorConfig(connection);
         RpcClient client;
         if (connection.getUseSSL()) {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -108,7 +108,7 @@ public class VitessVTGateManager {
     private static VTGateConn getVtGateConn(VitessJDBCUrl.HostInfo hostInfo, VitessConnection connection) {
         final String username = connection.getUsername();
         final String keyspace = connection.getKeyspace();
-        final Context context = CommonUtils.createContext(username,connection.getConnectionTimeout());
+        final Context context = CommonUtils.createContext(username,connection.getTimeout());
         RetryingInterceptorConfig retryingConfig = getRetryingInterceptorConfig(connection);
         RpcClient client;
         if (connection.getUseSSL()) {

--- a/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/VitessVTGateManager.java
@@ -108,7 +108,7 @@ public class VitessVTGateManager {
     private static VTGateConn getVtGateConn(VitessJDBCUrl.HostInfo hostInfo, VitessConnection connection) {
         final String username = connection.getUsername();
         final String keyspace = connection.getKeyspace();
-        final Context context = CommonUtils.createContext(username,connection.getConnectionTimeoutMillis());
+        final Context context = CommonUtils.createContext(username,connection.getConnectionTimeout());
         RetryingInterceptorConfig retryingConfig = getRetryingInterceptorConfig(connection);
         RpcClient client;
         if (connection.getUseSSL()) {

--- a/java/jdbc/src/main/java/io/vitess/util/CommonUtils.java
+++ b/java/jdbc/src/main/java/io/vitess/util/CommonUtils.java
@@ -30,10 +30,10 @@ public class CommonUtils {
      * Create context used to create grpc client and executing query.
      *
      * @param username
-     * @param connectionTimeout
+     * @param timeout
      * @return
      */
-    public static Context createContext(String username, long connectionTimeout) {
+    public static Context createContext(String username, long timeout) {
         Context context = Context.getDefault();
         Vtrpc.CallerID callerID = null;
         if (null != username) {
@@ -43,8 +43,8 @@ public class CommonUtils {
         if (null != callerID) {
             context = context.withCallerId(callerID);
         }
-        if (connectionTimeout > 0) {
-            context = context.withDeadlineAfter(Duration.millis(connectionTimeout));
+        if (timeout > 0) {
+            context = context.withDeadlineAfter(Duration.millis(timeout));
         }
 
         return context;

--- a/java/jdbc/src/main/java/io/vitess/util/CommonUtils.java
+++ b/java/jdbc/src/main/java/io/vitess/util/CommonUtils.java
@@ -16,9 +16,10 @@
 
 package io.vitess.util;
 
+import org.joda.time.Duration;
+
 import io.vitess.client.Context;
 import io.vitess.proto.Vtrpc;
-import org.joda.time.Duration;
 
 /**
  * Created by naveen.nahata on 24/02/16.
@@ -33,19 +34,20 @@ public class CommonUtils {
      * @return
      */
     public static Context createContext(String username, long connectionTimeout) {
-        Context context;
+        Context context = Context.getDefault();
         Vtrpc.CallerID callerID = null;
         if (null != username) {
             callerID = Vtrpc.CallerID.newBuilder().setPrincipal(username).build();
         }
+
         if (null != callerID) {
-            context = Context.getDefault().withDeadlineAfter(Duration.millis(connectionTimeout))
-                .withCallerId(callerID);
-        } else {
-            context = Context.getDefault().withDeadlineAfter(Duration.millis(connectionTimeout));
+            context = context.withCallerId(callerID);
         }
+        if (connectionTimeout > 0) {
+            context = context.withDeadlineAfter(Duration.millis(connectionTimeout));
+        }
+
         return context;
     }
-
 }
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -31,7 +31,7 @@ import io.vitess.util.Constants;
 
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 34;
+    private static final int NUM_PROPS = 32;
 
     @Test
     public void testReflection() throws Exception {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -16,21 +16,22 @@
 
 package io.vitess.jdbc;
 
-import io.vitess.proto.Query;
-import io.vitess.proto.Topodata;
-import io.vitess.util.Constants;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Properties;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.vitess.proto.Query;
+import io.vitess.proto.Topodata;
+import io.vitess.util.Constants;
+
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 31;
+    private static final int NUM_PROPS = 34;
 
     @Test
     public void testReflection() throws Exception {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
@@ -530,7 +530,7 @@ import io.vitess.util.Constants;
 
     @Test public void testGetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
+        Mockito.when(mockConn.getTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
         Assert.assertEquals(30, statement.getQueryTimeout());
@@ -538,7 +538,7 @@ import io.vitess.util.Constants;
 
     @Test public void testGetQueryTimeoutZeroDefault() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeout()).thenReturn(0L);
+        Mockito.when(mockConn.getTimeout()).thenReturn(0L);
 
         VitessStatement statement = new VitessStatement(mockConn);
         Assert.assertEquals(0, statement.getQueryTimeout());
@@ -546,7 +546,7 @@ import io.vitess.util.Constants;
 
     @Test public void testSetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
+        Mockito.when(mockConn.getTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
@@ -530,7 +530,7 @@ import io.vitess.util.Constants;
 
     @Test public void testGetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
+        Mockito.when(mockConn.getQueryTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
         Assert.assertEquals(30, statement.getQueryTimeout());
@@ -538,7 +538,7 @@ import io.vitess.util.Constants;
 
     @Test public void testGetQueryTimeoutZeroDefault() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn(0L);
+        Mockito.when(mockConn.getQueryTimeout()).thenReturn(0L);
 
         VitessStatement statement = new VitessStatement(mockConn);
         Assert.assertEquals(0, statement.getQueryTimeout());
@@ -546,7 +546,7 @@ import io.vitess.util.Constants;
 
     @Test public void testSetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
-        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
+        Mockito.when(mockConn.getQueryTimeout()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
 

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessStatementTest.java
@@ -530,13 +530,23 @@ import io.vitess.util.Constants;
 
     @Test public void testGetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
+        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
         Assert.assertEquals(30, statement.getQueryTimeout());
     }
 
+    @Test public void testGetQueryTimeoutZeroDefault() throws SQLException {
+        VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
+        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn(0L);
+
+        VitessStatement statement = new VitessStatement(mockConn);
+        Assert.assertEquals(0, statement.getQueryTimeout());
+    }
+
     @Test public void testSetQueryTimeout() throws SQLException {
         VitessConnection mockConn = PowerMockito.mock(VitessConnection.class);
+        Mockito.when(mockConn.getQueryTimeoutMillis()).thenReturn((long)Constants.DEFAULT_TIMEOUT);
 
         VitessStatement statement = new VitessStatement(mockConn);
 
@@ -550,6 +560,9 @@ import io.vitess.util.Constants;
         } catch (SQLException ex) {
             Assert.assertEquals("Illegal value for query timeout", ex.getMessage());
         }
+
+        statement.setQueryTimeout(0);
+        Assert.assertEquals(30, statement.getQueryTimeout());
     }
 
     @Test public void testGetWarnings() throws SQLException {


### PR DESCRIPTION
… query, transaction

We have a need to configure these settings. Also, we have a need to disable the timeouts in some cases -- such as database migrations which may take a long time. Therefore, if the configured timeout is set to 0 it is ignored `createContext`