### PR TITLE
fix index out of bounds on empty query after stripping leading commen…

### DIFF
--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -114,28 +114,26 @@ func StripLeadingComments(sql string) string {
 	sql = strings.TrimFunc(sql, unicode.IsSpace)
 
 	for hasCommentPrefix(sql) {
-		// Multi line comment
-		if sql[0] == '/' {
+		switch sql[0] {
+		case '/':
+			// Multi line comment
 			index := strings.Index(sql, "*/")
-			if index != -1 {
-				sql = sql[index+2:]
-			} else {
-				break
+			if index <= 1 {
+				return sql
 			}
-		}
-
-		// Single line comment
-		if sql[0] == '-' {
+			sql = sql[index+2:]
+		case '-':
+			// Single line comment
 			index := strings.Index(sql, "\n")
-			if index != -1 {
-				sql = sql[index+1:]
-			} else {
-				break
+			if index == -1 {
+				return sql
 			}
+			sql = sql[index+1:]
 		}
 
 		sql = strings.TrimFunc(sql, unicode.IsSpace)
 	}
+
 	return sql
 }
 


### PR DESCRIPTION
…ts.  add tests

@sougou we've seen panics when Preview tries to strip leading comments from a query that is left empty. For example:

```sql
/* foo */;
```
This caused an index out of bounds because the existing code first stripped multi-line then tried to strip single-line before checking if it even should.

I refactored the code to use a switch so taht we can properly strip and test the resulting sql of each loop before trying to index into it.  I also added a bunch of tests.