### PR TITLE
adds two new flags: default_tablet_type and allowed_tablet_types, all…

### DIFF
--- a/go/vt/topo/topoproto/flag.go
+++ b/go/vt/topo/topoproto/flag.go
@@ -1,0 +1,51 @@
+package topoproto
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+// TabletTypeListVar defines a []TabletType flag with the specified name and usage
+// string. The argument 'p' points to a []TabletType in which to store the value of the flag.
+func TabletTypeListVar(p *[]topodata.TabletType, name string, usage string) {
+	flag.Var((*TabletTypeListValue)(p), name, usage)
+}
+
+// TabletTypeVar defines a TabletType flag with the specified name, default value and usage
+// string. The argument 'p' points to a tabletType in which to store the value of the flag.
+func TabletTypeVar(p *topodata.TabletType, name string, defaultValue topodata.TabletType, usage string) {
+	*p = defaultValue
+	flag.Var((*TabletTypeFlag)(p), name, usage)
+}
+
+// TabletTypeListValue implements the flag.Value interface, for parsing a command-line comma-separated
+// list of value into a slice of TabletTypes.
+type TabletTypeListValue []topodata.TabletType
+
+// String is part of the flag.Value interface.
+func (ttlv *TabletTypeListValue) String() string {
+	return strings.Join(MakeStringTypeList(*ttlv), ",")
+}
+
+// Set is part of the flag.Value interface.
+func (ttlv *TabletTypeListValue) Set(v string) (err error) {
+	*ttlv, err = ParseTabletTypes(v)
+	return err
+}
+
+// TabletTypeFlag implements the flag.Value interface, for parsing a command-line value into a TabletType.
+type TabletTypeFlag topodata.TabletType
+
+// String is part of the flag.Value interface.
+func (ttf *TabletTypeFlag) String() string {
+	return topodata.TabletType(*ttf).String()
+}
+
+// Set is part of the flag.Value interface.
+func (ttf *TabletTypeFlag) Set(v string) error {
+	t, err := ParseTabletType(v)
+	*ttf = TabletTypeFlag(t)
+	return err
+}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -49,7 +49,14 @@ import (
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
-var errNoKeyspace = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspace in database name specified. Supported database name format: keyspace[:shard][@type]")
+var (
+	errNoKeyspace     = vterrors.Errorf(vtrpcpb.Code_FAILED_PRECONDITION, "no keyspace in database name specified. Supported database name format: keyspace[:shard][@type]")
+	defaultTabletType topodatapb.TabletType
+)
+
+func init() {
+	topoproto.TabletTypeVar(&defaultTabletType, "default_tablet_type", topodatapb.TabletType_MASTER, "The default tablet type to set for queries, when one is not explicitly selected")
+}
 
 // Executor is the engine that executes queries by utilizing
 // the abilities of the underlying vttablets.
@@ -636,7 +643,7 @@ func (e *Executor) VSchema() *vindexes.VSchema {
 func (e *Executor) ParseTarget(targetString string) querypb.Target {
 	// Default tablet type is master.
 	target := querypb.Target{
-		TabletType: topodatapb.TabletType_MASTER,
+		TabletType: defaultTabletType,
 	}
 	last := strings.LastIndexAny(targetString, "@")
 	if last != -1 {


### PR DESCRIPTION
…owing you to choose the default tablet type for a vtgate and enforce what tablet types a vtgate can talk to

This addresses #3054 

Going to add some tests shortly.