### PR TITLE
vtexplain groundwork

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -747,6 +747,13 @@ func (e *Executor) ServeHTTP(response http.ResponseWriter, request *http.Request
 	}
 }
 
+// Plans returns the LRU plan cache
+func (e *Executor) Plans() *cache.LRUCache {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.plans
+}
+
 // VSchemaStats returns the loaded vschema stats.
 func (e *Executor) VSchemaStats() *VSchemaStats {
 	e.mu.Lock()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -58,6 +58,20 @@ type QueryExecutor struct {
 	tsv              *TabletServer
 }
 
+// NewQueryExecutor creates a new executor.
+func NewQueryExecutor(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, plan *TabletPlan, logStats *tabletenv.LogStats, tsv *TabletServer) *QueryExecutor {
+	return &QueryExecutor{
+		query:         query,
+		bindVars:      bindVars,
+		transactionID: transactionID,
+		options:       options,
+		plan:          plan,
+		ctx:           ctx,
+		logStats:      logStats,
+		tsv:           tsv,
+	}
+}
+
 var sequenceFields = []*querypb.Field{
 	{
 		Name: "nextval",

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1714,6 +1714,11 @@ func (tsv *TabletServer) endRequest(isTx bool) {
 	}
 }
 
+// GetPlan is only used from vtexplain
+func (tsv *TabletServer) GetPlan(ctx context.Context, logStats *tabletenv.LogStats, sql string) (*TabletPlan, error) {
+	return tsv.qe.GetPlan(ctx, logStats, sql)
+}
+
 func (tsv *TabletServer) registerDebugHealthHandler() {
 	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {


### PR DESCRIPTION
Minor changes needed to support vtexplain:

* Add an optional QueryLogger to the fakesqldb that calls a registered callback whenever 
* Add an accessor to expose the vtgate executor's plan cache outside of the package
* Expose a constructor to create a vttablet QueryExecutor and to get the tablet execution plan 