### PR TITLE
Fix exempt ACL

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -89,6 +89,13 @@ func main() {
 		log.Warning(err)
 	}
 
+	if *tableACLConfig != "" {
+		// To override default simpleacl, other ACL plugins must set themselves to be default ACL factory
+		tableacl.Register("simpleacl", &simpleacl.Factory{})
+	} else if *enforceTableACLConfig {
+		log.Exit("table acl config has to be specified with table-acl-config flag because enforce-tableacl-config is set.")
+	}
+
 	// creates and registers the query service
 	ts := topo.Open()
 	qsc := tabletserver.NewServer(ts, *tabletAlias)
@@ -102,12 +109,6 @@ func main() {
 		qsc.StopService()
 	})
 
-	if *tableACLConfig != "" {
-		// To override default simpleacl, other ACL plugins must set themselves to be default ACL factory
-		tableacl.Register("simpleacl", &simpleacl.Factory{})
-	} else if *enforceTableACLConfig {
-		log.Exit("table acl config has to be specified with table-acl-config flag because enforce-tableacl-config is set.")
-	}
 	// tabletacl.Init loads ACL from file if *tableACLConfig is not empty
 	err = tableacl.Init(
 		*tableACLConfig,

--- a/go/vt/tableacl/tableacl.go
+++ b/go/vt/tableacl/tableacl.go
@@ -305,6 +305,9 @@ func SetDefaultACL(name string) {
 func GetCurrentAclFactory() (acl.Factory, error) {
 	mu.Lock()
 	defer mu.Unlock()
+	if len(acls) == 0 {
+		return nil, fmt.Errorf("no AclFactories registered")
+	}
 	if defaultACL == "" {
 		if len(acls) == 1 {
 			for _, aclFactory := range acls {


### PR DESCRIPTION
The exempt acl is initialized a few levels down in `tabletserver.NewServer`, but the `simpleacl` was not registered until after that NewServer call.  So exempt ACL was not working, instead printing an error: `there are more than one AclFactory registered but no default has been given`. This was not true, in fact there were no AclFactories registered.

This change moves the simpleacl registration to before NewServer. It also changes the error message when 0 factories are registered.