### PR TITLE
support decoding JSON fields

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
@@ -163,6 +163,10 @@ public class FieldWithMetadata {
                 }
             }
         } else {
+            // MySQL always encodes JSON data with utf8mb4. Discard whatever else we've found, if the type is JSON
+            if (vitessType == Query.Type.JSON) {
+                this.encoding = "UTF-8";
+            }
             // Defaults to appease final variables when not including all fields
             this.isImplicitTempTable = false;
             this.isSingleBit = false;

--- a/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/FieldWithMetadata.java
@@ -349,7 +349,7 @@ public class FieldWithMetadata {
 
         // Detect CHAR(n) CHARACTER SET BINARY which is a synonym for fixed-length binary types
         if (this.collationIndex == CharsetMapping.MYSQL_COLLATION_INDEX_binary && isBinary()
-            && (this.javaType == Types.CHAR || this.javaType == Types.VARCHAR)) {
+            && (this.vitessType == Query.Type.CHAR || this.vitessType == Query.Type.VARCHAR)) {
             // Okay, queries resolved by temp tables also have this 'signature', check for that
             return !isImplicitTemporaryTable();
         }

--- a/java/jdbc/src/main/java/io/vitess/util/MysqlDefs.java
+++ b/java/jdbc/src/main/java/io/vitess/util/MysqlDefs.java
@@ -195,7 +195,7 @@ public final class MysqlDefs {
         vitesstoMySqlType.put(Query.Type.SET, Types.CHAR);
         vitesstoMySqlType.put(Query.Type.TUPLE, Types.OTHER);
         vitesstoMySqlType.put(Query.Type.GEOMETRY, Types.BINARY);
-        vitesstoMySqlType.put(Query.Type.JSON, Types.BINARY);
+        vitesstoMySqlType.put(Query.Type.JSON, Types.CHAR);
     }
 
     static {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/FieldWithMetadataTest.java
@@ -194,7 +194,7 @@ public class FieldWithMetadataTest extends BaseTest {
 
         conn.setIncludedFields(Query.ExecuteOptions.IncludedFields.TYPE_AND_NAME);
         fieldWithMetadata = new FieldWithMetadata(conn, raw);
-        Assert.assertEquals(Types.BINARY, fieldWithMetadata.getJavaType());
+        Assert.assertEquals(Types.CHAR, fieldWithMetadata.getJavaType());
         Assert.assertEquals(null, fieldWithMetadata.getEncoding());
         Assert.assertEquals(false, fieldWithMetadata.isSingleBit());
 


### PR DESCRIPTION
follow mysql-connector-j more strictly in deciding if a field isOpaqueBinary to support decoding JSON fields