### PR TITLE
Add vtctld health check

### DIFF
--- a/go/cmd/vtctld/main.go
+++ b/go/cmd/vtctld/main.go
@@ -50,6 +50,9 @@ func main() {
 	// Init the vtctld core
 	vtctld.InitVtctld(ts)
 
+	// Register http debug/health
+	vtctld.RegisterDebugHealthHandler(ts)
+
 	// Start schema manager service.
 	initSchema()
 

--- a/go/vt/vtctld/debug_health.go
+++ b/go/vt/vtctld/debug_health.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vtctld contains all the code to expose a vtctld server
+// based on the provided topo.Server.
+package vtctld
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/acl"
+	"github.com/youtube/vitess/go/vt/topo"
+)
+
+// RegisterDebugHealthHandler register a debug health http endpoint for a vtcld server
+func RegisterDebugHealthHandler(ts topo.Server) {
+	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
+		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {
+			acl.SendError(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		if err := isHealthy(ts); err != nil {
+			w.Write([]byte("not ok"))
+			return
+		}
+		w.Write([]byte("ok"))
+	})
+}
+
+func isHealthy(ts topo.Server) error {
+	_, err := ts.GetKeyspaces(context.Background())
+	return err
+}

--- a/test/vtctld_test.py
+++ b/test/vtctld_test.py
@@ -127,6 +127,14 @@ class TestVtctld(unittest.TestCase):
     self.assertIn('test_nj', result['Children'])
     self.assertIn('test_ny', result['Children'])
 
+  def test_health_check(self):
+    url = 'http://localhost:%d/debug/health' % utils.vtctld.port
+    f = urllib2.urlopen(url)
+    body = f.read()
+    f.close()
+    # test body response for health check is ok
+    self.assertEqual(body, 'ok')
+
   def _check_all_tablets(self, result):
     lines = result.splitlines()
     self.assertEqual(len(lines), len(tablets), 'got lines:\n%s' % lines)


### PR DESCRIPTION
### Description

* Proposal for a health check in vtcld to address  https://github.com/youtube/vitess/issues/2690. 
* It re-uses approach from [vtgate](https://github.com/youtube/vitess/blob/master/go/vt/vtgate/vtgate.go#L202) and [vttablet](https://github.com/youtube/vitess/blob/master/go/vt/vttablet/tabletserver/tabletserver.go#L1721).

### TODO
* Have a real `IsHealthy` function. Assuming that the main component here is the `topo.Server`, couple ideas that we can do:
  1.  Use an existent method from topology interface that is cheap to call and use it as a proxy for isHealthy()
  2.  Define a isHealthy function in topo interface and then implement what that means in each of the flavors (etcd, zk, consul) 
