### PR TITLE
change gofmt/goimports git hooks to use bash

### DIFF
--- a/misc/git/hooks/gofmt
+++ b/misc/git/hooks/gofmt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/misc/git/hooks/goimports
+++ b/misc/git/hooks/goimports
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2017 Google Inc.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
On my MacOS laptop, /bin/sh doesn't support echo -n, so update these
hooks to use /bin/bash.