### PR TITLE
Add warning when there is an authentication failure

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -233,6 +233,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		// ValidateHash() method.
 		userData, err := l.authServer.ValidateHash(salt, user, authResponse)
 		if err != nil {
+			log.Warningf("Error authenticating user using MySQL native password: %v", err)
 			c.writeErrorPacketFromError(err)
 			return
 		}


### PR DESCRIPTION
### Description

* This is a very tiny change. It will be very useful for us to have a trailing audit in the logs when there is an authentication failure using the mysql client.  This pull requests adds that logging.

