### PR TITLE
ensure GOPATH is set in the pre-commit hook

### DIFF
--- a/misc/git/pre-commit
+++ b/misc/git/pre-commit
@@ -8,6 +8,13 @@ if [ -z "$GIT_DIR" ]; then
   DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
   GIT_DIR="${DIR}/.."
 fi
+
+# This is necessary because the Atom packages don't set GOPATH
+if [ -z "$GOPATH" ]; then
+  GOPATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../../../../.." && pwd )
+  export GOPATH
+fi
+
 for hook in $GIT_DIR/../misc/git/hooks/*; do
   $hook
 done


### PR DESCRIPTION
Atom's new Github integration doesn't pull GOPATH from the environment
(on Mac at least), so make sure it's set in the pre-commit hook.