### PR TITLE
v3: SQL support for vindex functions

### DIFF
--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -29,6 +29,10 @@
         "costly_map": {
           "type": "costly",
           "owner": "user"
+        },
+        "hash_dup": {
+          "type": "hash_test",
+          "owner": "user"
         }
       },
       "tables": {
@@ -116,6 +120,17 @@
             }
           ]
         }
+      }
+    },
+    "second_user": {
+      "sharded": true,
+      "vindexes": {
+        "hash_dup": {
+          "type": "hash_test",
+          "owner": "user"
+        }
+      },
+      "tables": {
       }
     },
     "main": {

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -444,3 +444,27 @@
 
 "select 'b','c' from user union (select user.id, user.name from user join user_extra where user_extra.extra = 'asdf')"
 "unsupported construct: SELECT of UNION is non-trivial"
+
+"select keyspace_id from user_index where id = 1 and id = 2"
+"unsupported: where clause for vindex function must be of the form id = <val> (multiple filters)"
+
+"select keyspace_id from user_index where func(id)"
+"unsupported: where clause for vindex function must be of the form id = <val> (not a comparison)"
+
+"select keyspace_id from user_index where id > 1"
+"unsupported: where clause for vindex function must be of the form id = <val> (not equality)"
+
+"select keyspace_id from user_index where 1 = id"
+"unsupported: where clause for vindex function must be of the form id = <val> (lhs is not a column)"
+
+"select keyspace_id from user_index where none = 1"
+"unsupported: where clause for vindex function must be of the form id = <val> (lhs is not id)"
+
+"select keyspace_id from user_index where id = a"
+"unsupported: where clause for vindex function must be of the form id = <val> (rhs is not a value)"
+
+"select keyspace_id from user_index"
+"unsupported: where clause for vindex function must be of the form id = <val> (where clause missing)"
+
+"select func(keyspace_id) from user_index where id = :id"
+"unsupported: expression on results of a vindex function"

--- a/data/test/vtgate/vindex_func_cases.txt
+++ b/data/test/vtgate/vindex_func_cases.txt
@@ -24,6 +24,41 @@
   }
 }
 
+# ambiguous vindex reference
+"select id, keyspace_id, id from hash_dup where id = :id"
+"ambiguous vindex reference: hash_dup"
+
+# disambiguated vindex reference
+"select id, keyspace_id, id from second_user.hash_dup where id = :id"
+{
+  "Original": "select id, keyspace_id, id from second_user.hash_dup where id = :id",
+  "Instructions": {
+    "Opcode": "VindexMap",
+    "Fields": [
+      {
+        "name": "id",
+        "type": 10262
+      },
+      {
+        "name": "keyspace_id",
+        "type": 10262
+      },
+      {
+        "name": "id",
+        "type": 10262
+      }
+    ],
+    "Cols": [
+      0,
+      1,
+      0
+    ],
+    "Vindex": "hash_dup",
+    "Value": ":id"
+  }
+}
+
+
 # You can even join with a vindexFunc primitive
 "select user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id"
 {

--- a/data/test/vtgate/vindex_func_cases.txt
+++ b/data/test/vtgate/vindex_func_cases.txt
@@ -1,0 +1,261 @@
+# vindex func read
+"select id, keyspace_id, id from user_index where id = :id"
+{
+  "Original": "select id, keyspace_id, id from user_index where id = :id",
+  "Instructions": {
+    "Opcode": "VindexMap",
+    "Fields": [
+      {
+        "name": "id",
+        "type": 10262
+      },
+      {
+        "name": "keyspace_id",
+        "type": 10262
+      },
+      {
+        "name": "id",
+        "type": 10262
+      }
+    ],
+    "Cols": [0, 1, 0],
+    "Vindex": "user_index",
+    "Value": ":id"
+  }
+}
+
+# You can even join with a vindexFunc primitive
+"select user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id"
+{
+  "Original": "select user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        }
+      ],
+      "Cols": [1],
+      "Vindex": "user_index",
+      "Value": ":id"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.id from unsharded",
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
+    },
+    "Cols": [-1, 1]
+  }
+}
+
+# Join vindexFunc on RHS
+"select user_index.keyspace_id, unsharded.id from unsharded join user_index where user_index.id = :id"
+{
+  "Original": "select user_index.keyspace_id, unsharded.id from unsharded join user_index where user_index.id = :id",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.id from unsharded",
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        1
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    },
+    "Cols": [
+      1,
+      -1
+    ]
+  }
+}
+
+# Join with vindexFunc on a column of it, already present in select list
+"select user_index.id, user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id and unsharded.id = user_index.id"
+{
+  "Original": "select user_index.id, user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id and unsharded.id = user_index.id",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "id",
+          "type": 10262
+        },
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        0,
+        1
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id",
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+      "JoinVars": {
+        "user_index_id": {}
+      }
+    },
+    "Cols": [
+      -1,
+      -2,
+      1
+    ],
+    "Vars": {
+      "user_index_id": 0
+    }
+  }
+}
+
+# Join with vindexFunc on a column of it, not present in select list
+"select user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id and unsharded.id = user_index.id"
+{
+  "Original": "select user_index.keyspace_id, unsharded.id from user_index join unsharded where user_index.id = :id and unsharded.id = user_index.id",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        },
+        {
+          "name": "id",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        1,
+        0
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.id from unsharded where unsharded.id = :user_index_id",
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+      "JoinVars": {
+        "user_index_id": {}
+      }
+    },
+    "Cols": [
+      -1,
+      1
+    ],
+    "Vars": {
+      "user_index_id": 1
+    }
+  }
+}
+
+# Join with aliased table name
+"select ui.keyspace_id, unsharded.id from user_index ui join unsharded where ui.id = :id and unsharded.id = ui.id"
+{
+  "Original": "select ui.keyspace_id, unsharded.id from user_index ui join unsharded where ui.id = :id and unsharded.id = ui.id",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        },
+        {
+          "name": "id",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        1,
+        0
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select unsharded.id from unsharded where unsharded.id = :ui_id",
+      "FieldQuery": "select unsharded.id from unsharded where 1 != 1",
+      "JoinVars": {
+        "ui_id": {}
+      }
+    },
+    "Cols": [
+      -1,
+      1
+    ],
+    "Vars": {
+      "ui_id": 1
+    }
+  }
+}
+
+# limit and order by null clauses
+"select keyspace_id from user_index where id = :id order by null limit 1"
+{
+  "Original": "select keyspace_id from user_index where id = :id order by null limit 1",
+  "Instructions": {
+    "Opcode": "Limit",
+    "Count": 1,
+    "Input": {
+      "Opcode": "VindexMap",
+      "Fields": [
+        {
+          "name": "keyspace_id",
+          "type": 10262
+        }
+      ],
+      "Cols": [
+        1
+      ],
+      "Vindex": "user_index",
+      "Value": ":id"
+    }
+  }
+}
+
+"select none from user_index where id = :id"
+"unrecognized column none for vindex: user_index"

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -17,9 +17,9 @@ limitations under the License.
 package engine
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
-
 	"strconv"
 	"strings"
 
@@ -233,36 +233,27 @@ const (
 	NumCodes
 )
 
-// routeName must exactly match order of opcode constants.
-var routeName = [NumCodes]string{
-	"Error",
-	"SelectUnsharded",
-	"SelectEqualUnique",
-	"SelectEqual",
-	"SelectIN",
-	"SelectScatter",
-	"SelectNext",
-	"ExecDBA",
-	"UpdateUnsharded",
-	"UpdateEqual",
-	"DeleteUnsharded",
-	"DeleteEqual",
-	"InsertUnsharded",
-	"InsertSharded",
-	"InsertShardedIgnore",
-}
-
-func (code RouteOpcode) String() string {
-	if code < 0 || code >= NumCodes {
-		return ""
-	}
-	return routeName[code]
+var routeName = map[RouteOpcode]string{
+	SelectUnsharded:     "SelectUnsharded",
+	SelectEqualUnique:   "SelectEqualUnique",
+	SelectEqual:         "SelectEqual",
+	SelectIN:            "SelectIN",
+	SelectScatter:       "SelectScatter",
+	SelectNext:          "SelectNext",
+	ExecDBA:             "ExecDBA",
+	UpdateUnsharded:     "UpdateUnsharded",
+	UpdateEqual:         "UpdateEqual",
+	DeleteUnsharded:     "DeleteUnsharded",
+	DeleteEqual:         "DeleteEqual",
+	InsertUnsharded:     "InsertUnsharded",
+	InsertSharded:       "InsertSharded",
+	InsertShardedIgnore: "InsertShardedIgnore",
 }
 
 // MarshalJSON serializes the RouteOpcode as a JSON string.
 // It's used for testing and diagnostics.
 func (code RouteOpcode) MarshalJSON() ([]byte, error) {
-	return ([]byte)(fmt.Sprintf("\"%s\"", code.String())), nil
+	return json.Marshal(routeName[code])
 }
 
 type scatterParams struct {

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"encoding/json"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+var _ Primitive = (*VindexFunc)(nil)
+
+// VindexFunc is a primitive that performs vindex functions.
+type VindexFunc struct {
+	Opcode VindexOpcode
+	Vindex vindexes.Vindex
+	Value  sqltypes.PlanValue
+}
+
+// MarshalJSON serializes the VindexFunc into a JSON representation.
+// It's used for testing and diagnostics.
+func (vf *VindexFunc) MarshalJSON() ([]byte, error) {
+	v := struct {
+		Opcode VindexOpcode
+		Vindex string
+		Value  sqltypes.PlanValue
+	}{
+		Opcode: vf.Opcode,
+		Vindex: vf.Vindex.String(),
+		Value:  vf.Value,
+	}
+	return json.Marshal(v)
+}
+
+// VindexOpcode is the opcode for a VindexFunc.
+type VindexOpcode int
+
+// These are opcode values for VindexFunc.
+const (
+	VindexMap = VindexOpcode(iota)
+	NumVindexCodes
+)
+
+var vindexOpcodeName = map[VindexOpcode]string{
+	VindexMap: "VindexMap",
+}
+
+// MarshalJSON serializes the VindexOpcode into a JSON representation.
+// It's used for testing and diagnostics.
+func (code VindexOpcode) MarshalJSON() ([]byte, error) {
+	return json.Marshal(vindexOpcodeName[code])
+}
+
+// Execute performs a non-streaming exec.
+func (vf *VindexFunc) Execute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool) (*sqltypes.Result, error) {
+	return vf.mapVindex(vcursor, bindVars, joinVars)
+}
+
+// StreamExecute performs a streaming exec.
+func (vf *VindexFunc) StreamExecute(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable, wantfields bool, callback func(*sqltypes.Result) error) error {
+	r, err := vf.mapVindex(vcursor, bindVars, joinVars)
+	if err != nil {
+		return err
+	}
+	if err := callback(&sqltypes.Result{Fields: r.Fields}); err != nil {
+		return err
+	}
+	return callback(&sqltypes.Result{Rows: r.Rows})
+}
+
+// GetFields fetches the field info.
+func (vf *VindexFunc) GetFields(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	r, err := vf.mapVindex(vcursor, bindVars, joinVars)
+	if err != nil {
+		return nil, err
+	}
+	return &sqltypes.Result{Fields: r.Fields}, nil
+}
+
+func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars, joinVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	bindVars = combineVars(bindVars, joinVars)
+	key, err := vf.Value.ResolveValue(bindVars)
+	if err != nil {
+		return nil, err
+	}
+	result := &sqltypes.Result{
+		Fields: []*querypb.Field{{
+			Name: "id",
+			Type: key.Type(),
+		}, {
+			Name: "keyspace_id",
+			Type: querypb.Type_VARBINARY,
+		}},
+	}
+
+	switch mapper := vf.Vindex.(type) {
+	case vindexes.Unique:
+		ksids, err := mapper.Map(vcursor, []sqltypes.Value{key})
+		if err != nil {
+			return nil, err
+		}
+		// TODO(sougou): change this to nil check after upsert code is
+		// merged to master.
+		if len(ksids[0]) != 0 {
+			result.Rows = [][]sqltypes.Value{{
+				key, sqltypes.MakeTrusted(sqltypes.VarBinary, ksids[0]),
+			}}
+			result.RowsAffected = 1
+		}
+	case vindexes.NonUnique:
+		ksidss, err := mapper.Map(vcursor, []sqltypes.Value{key})
+		if err != nil {
+			return nil, err
+		}
+		for _, ksid := range ksidss[0] {
+			result.Rows = append(result.Rows, []sqltypes.Value{key, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid)})
+		}
+		result.RowsAffected = uint64(len(ksidss[0]))
+	default:
+		panic("unexpected")
+	}
+	return result, nil
+}

--- a/go/vt/vtgate/engine/vindex_func.go
+++ b/go/vt/vtgate/engine/vindex_func.go
@@ -119,9 +119,7 @@ func (vf *VindexFunc) mapVindex(vcursor VCursor, bindVars, joinVars map[string]*
 		if err != nil {
 			return nil, err
 		}
-		// TODO(sougou): change this to nil check after upsert code is
-		// merged to master.
-		if len(ksids[0]) != 0 {
+		if ksids[0] != nil {
 			result.Rows = [][]sqltypes.Value{
 				vf.buildRow(vkey, ksids[0]),
 			}

--- a/go/vt/vtgate/engine/vindex_func_test.go
+++ b/go/vt/vtgate/engine/vindex_func_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package engine
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+)
+
+// uvindex is Unique.
+type uvindex struct{ match bool }
+
+func (*uvindex) String() string { return "uvindex" }
+func (*uvindex) Cost() int      { return 1 }
+func (*uvindex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
+	return []bool{}, nil
+}
+func (v *uvindex) Map(vindexes.VCursor, []sqltypes.Value) ([][]byte, error) {
+	if v.match {
+		return [][]byte{
+			[]byte("foo"),
+		}, nil
+	}
+	return [][]byte{nil}, nil
+}
+
+// nvindex is NonUnique.
+type nvindex struct{ match bool }
+
+func (*nvindex) String() string { return "nvindex" }
+func (*nvindex) Cost() int      { return 1 }
+func (*nvindex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
+	return []bool{}, nil
+}
+func (v *nvindex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error) {
+	if v.match {
+		return [][][]byte{{
+			[]byte("foo"), []byte("bar"),
+		}}, nil
+	}
+	return [][][]byte{nil}, nil
+}
+
+func TestVindexFuncMap(t *testing.T) {
+	// Unique Vindex returning 0 rows.
+	vf := &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &uvindex{},
+		Value:  int64PlanValue(1),
+	}
+	got, err := vf.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &sqltypes.Result{
+		Fields: sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
+	}
+
+	// Unique Vindex returning 1 row.
+	vf = &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &uvindex{match: true},
+		Value:  int64PlanValue(1),
+	}
+	got, err = vf.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+		"1|foo",
+	)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
+	}
+
+	// NonUnique Vindex returning 0 rows.
+	vf = &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &nvindex{},
+		Value:  int64PlanValue(1),
+	}
+	got, err = vf.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = &sqltypes.Result{
+		Fields: sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
+	}
+
+	// NonUnique Vindex returning 2 rows.
+	vf = &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &nvindex{match: true},
+		Value:  int64PlanValue(1),
+	}
+	got, err = vf.Execute(nil, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = sqltypes.MakeTestResult(
+		sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+		"1|foo",
+		"1|bar",
+	)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
+	}
+}
+
+func TestVindexFuncStreamExecute(t *testing.T) {
+	vf := &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &nvindex{match: true},
+		Value:  int64PlanValue(1),
+	}
+	want := []*sqltypes.Result{{
+		Fields: sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+	}, {
+		Rows: [][]sqltypes.Value{{
+			sqltypes.NewInt64(1), sqltypes.NewVarBinary("foo"),
+		}, {
+			sqltypes.NewInt64(1), sqltypes.NewVarBinary("bar"),
+		}},
+	}}
+	i := 0
+	err := vf.StreamExecute(nil, nil, nil, false, func(qr *sqltypes.Result) error {
+		if !reflect.DeepEqual(qr, want[i]) {
+			t.Errorf("callback(%d):\n%v, want\n%v", i, qr, want[i])
+		}
+		i++
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestVindexFuncGetFields(t *testing.T) {
+	vf := &VindexFunc{
+		Opcode: VindexMap,
+		Vindex: &uvindex{match: true},
+		Value:  int64PlanValue(1),
+	}
+	got, err := vf.GetFields(nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &sqltypes.Result{
+		Fields: sqltypes.MakeTestFields("id|keyspace_id", "int64|varbinary"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Execute(Map, uvindex(none)):\n%v, want\n%v", got, want)
+	}
+}

--- a/go/vt/vtgate/engine/vindex_func_test.go
+++ b/go/vt/vtgate/engine/vindex_func_test.go
@@ -30,8 +30,9 @@ type uvindex struct{ match bool }
 func (*uvindex) String() string { return "uvindex" }
 func (*uvindex) Cost() int      { return 1 }
 func (*uvindex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
-	return []bool{}, nil
+	panic("unimplemented")
 }
+
 func (v *uvindex) Map(vindexes.VCursor, []sqltypes.Value) ([][]byte, error) {
 	if v.match {
 		return [][]byte{
@@ -47,8 +48,9 @@ type nvindex struct{ match bool }
 func (*nvindex) String() string { return "nvindex" }
 func (*nvindex) Cost() int      { return 1 }
 func (*nvindex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
-	return []bool{}, nil
+	panic("unimplemented")
 }
+
 func (v *nvindex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error) {
 	if v.match {
 		return [][][]byte{{

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -544,7 +544,7 @@ func (e *Executor) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 
 // MessageAck acks messages.
 func (e *Executor) MessageAck(ctx context.Context, keyspace, name string, ids []*querypb.Value) (int64, error) {
-	table, err := e.VSchema().Find(keyspace, name)
+	table, err := e.VSchema().FindTable(keyspace, name)
 	if err != nil {
 		return 0, err
 	}

--- a/go/vt/vtgate/planbuilder/builder.go
+++ b/go/vt/vtgate/planbuilder/builder.go
@@ -113,7 +113,8 @@ type columnOriginator interface {
 // VSchema defines the interface for this package to fetch
 // info about tables.
 type VSchema interface {
-	Find(tablename sqlparser.TableName) (table *vindexes.Table, err error)
+	FindTable(tablename sqlparser.TableName) (*vindexes.Table, error)
+	FindTableOrVindex(tablename sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, error)
 	DefaultKeyspace() (*vindexes.Keyspace, error)
 }
 

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -74,7 +74,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 	for t := range rb.Symtab().tables {
 		tableName = t
 	}
-	er.Table, err = vschema.Find(tableName)
+	er.Table, err = vschema.FindTable(tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, err
 	for t := range rb.Symtab().tables {
 		tableName = t
 	}
-	er.Table, err = vschema.Find(tableName)
+	er.Table, err = vschema.FindTable(tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -29,7 +29,7 @@ import (
 
 // buildInsertPlan builds the route for an INSERT statement.
 func buildInsertPlan(ins *sqlparser.Insert, vschema VSchema) (*engine.Route, error) {
-	table, err := vschema.Find(ins.Table)
+	table, err := vschema.FindTable(ins.Table)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -83,7 +83,12 @@ func checkAggregates(sel *sqlparser.Select, bldr builder) (builder, error) {
 	if !hasAggregates {
 		return bldr, nil
 	}
-	if hasAggregates && !isRoute {
+
+	// The query has aggregates. We can proceed only
+	// if the underlying primitive is a route because
+	// we need the ability to push down group by and
+	// order by clauses.
+	if !isRoute {
 		return bldr, errors.New("unsupported: cross-shard query with aggregates")
 	}
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -118,6 +118,7 @@ func TestPlan(t *testing.T) {
 	testFile(t, "postprocess_cases.txt", vschema)
 	testFile(t, "wireup_cases.txt", vschema)
 	testFile(t, "dml_cases.txt", vschema)
+	testFile(t, "vindex_func_cases.txt", vschema)
 	testFile(t, "unsupported_cases.txt", vschema)
 }
 
@@ -142,8 +143,12 @@ type vschemaWrapper struct {
 	v *vindexes.VSchema
 }
 
-func (vw *vschemaWrapper) Find(tab sqlparser.TableName) (*vindexes.Table, error) {
+func (vw *vschemaWrapper) FindTable(tab sqlparser.TableName) (*vindexes.Table, error) {
 	return vw.v.FindTable(tab.Qualifier.String(), tab.Name.String())
+}
+
+func (vw *vschemaWrapper) FindTableOrVindex(tab sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, error) {
+	return vw.v.FindTableOrVindex(tab.Qualifier.String(), tab.Name.String())
 }
 
 func (vw *vschemaWrapper) DefaultKeyspace() (*vindexes.Keyspace, error) {

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -143,7 +143,7 @@ type vschemaWrapper struct {
 }
 
 func (vw *vschemaWrapper) Find(tab sqlparser.TableName) (*vindexes.Table, error) {
-	return vw.v.Find(tab.Qualifier.String(), tab.Name.String())
+	return vw.v.FindTable(tab.Qualifier.String(), tab.Name.String())
 }
 
 func (vw *vschemaWrapper) DefaultKeyspace() (*vindexes.Keyspace, error) {

--- a/go/vt/vtgate/planbuilder/subquery.go
+++ b/go/vt/vtgate/planbuilder/subquery.go
@@ -175,9 +175,6 @@ func (sq *subquery) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum 
 	// columns that reference subqueries will have their colnum set.
 	// Let's use it here.
 	sq.esubquery.Cols = append(sq.esubquery.Cols, c.colnum)
-	sq.resultColumns = append(sq.resultColumns, &resultColumn{
-		alias:  col.Name,
-		column: c,
-	})
+	sq.resultColumns = append(sq.resultColumns, &resultColumn{column: c})
 	return rc, len(sq.resultColumns) - 1
 }

--- a/go/vt/vtgate/planbuilder/symtab.go
+++ b/go/vt/vtgate/planbuilder/symtab.go
@@ -439,7 +439,8 @@ type column struct {
 	name   sqlparser.ColIdent
 	table  *table
 
-	// colnum is set only if it originates from a subquery.
+	// colnum is set only for primitives that can return a
+	// subset of their internal result like subquery or vindexFunc.
 	colnum int
 }
 

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+var _ builder = (*vindexFunc)(nil)
+var _ columnOriginator = (*vindexFunc)(nil)
+
+// vindexFunc is used to build a VindexFunc primitive.
+type vindexFunc struct {
+	order  int
+	symtab *symtab
+
+	// resultColumns represent the columns returned by this route.
+	resultColumns []*resultColumn
+
+	// eVindexFunc is the primitive being built.
+	eVindexFunc *engine.VindexFunc
+}
+
+func newVindexFunc(alias sqlparser.TableName, vindex vindexes.Vindex, vschema VSchema) *vindexFunc {
+	vf := &vindexFunc{
+		symtab: newSymtab(vschema),
+		order:  1,
+		eVindexFunc: &engine.VindexFunc{
+			Vindex: vindex,
+		},
+	}
+
+	// Create a 'table' that represents the vindex.
+	t := &table{
+		alias:  alias,
+		origin: vf,
+	}
+
+	// Column names are hard-coded to id, keyspace_id
+	t.columns = map[string]*column{
+		"id": {
+			origin: vf,
+			name:   sqlparser.NewColIdent("id"),
+			table:  t,
+			colnum: 0,
+		},
+		"keyspace_id": {
+			origin: vf,
+			name:   sqlparser.NewColIdent("keyspace_id"),
+			table:  t,
+			colnum: 1,
+		},
+	}
+
+	// AddTable will not fail because symtab is empty.
+	_ = vf.symtab.AddTable(t)
+	return vf
+}
+
+// Symtab satisfies the builder interface.
+func (vf *vindexFunc) Symtab() *symtab {
+	return vf.symtab.Resolve()
+}
+
+// Order returns the order of the subquery.
+func (vf *vindexFunc) Order() int {
+	return vf.order
+}
+
+// MaxOrder satisfies the builder interface.
+func (vf *vindexFunc) MaxOrder() int {
+	return vf.order
+}
+
+// SetOrder satisfies the builder interface.
+func (vf *vindexFunc) SetOrder(order int) {
+	vf.order = order + 1
+}
+
+// Primitive satisfies the builder interface.
+func (vf *vindexFunc) Primitive() engine.Primitive {
+	return vf.eVindexFunc
+}
+
+// Leftmost satisfies the builder interface.
+func (vf *vindexFunc) Leftmost() columnOriginator {
+	return vf
+}
+
+// ResultColumns satisfies the builder interface.
+func (vf *vindexFunc) ResultColumns() []*resultColumn {
+	return vf.resultColumns
+}
+
+// PushFilter satisfies the builder interface.
+// Only some where clauses are allowed.
+func (vf *vindexFunc) PushFilter(filter sqlparser.Expr, whereType string, _ columnOriginator) error {
+	if vf.eVindexFunc.Opcode != engine.VindexNone {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (multiple filters)")
+	}
+
+	// Check LHS.
+	comparison, ok := filter.(*sqlparser.ComparisonExpr)
+	if !ok {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (not a comparison)")
+	}
+	if comparison.Operator != sqlparser.EqualStr {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (not equality)")
+	}
+	colname, ok := comparison.Left.(*sqlparser.ColName)
+	if !ok {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (lhs is not a column)")
+	}
+	if !colname.Name.EqualString("id") {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (lhs is not id)")
+	}
+
+	// Check RHS.
+	// We have to check before calling NewPlanValue because NewPlanValue allows lists also.
+	if !sqlparser.IsValue(comparison.Right) {
+		return errors.New("unsupported: where clause for vindex function must be of the form id = <val> (rhs is not a value)")
+	}
+	var err error
+	vf.eVindexFunc.Value, err = sqlparser.NewPlanValue(comparison.Right)
+	if err != nil {
+		return fmt.Errorf("unsupported: where clause for vindex function must be of the form id = <val>: %v", err)
+	}
+	vf.eVindexFunc.Opcode = engine.VindexMap
+	return nil
+}
+
+// PushSelect satisfies the builder interface.
+func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ columnOriginator) (rc *resultColumn, colnum int, err error) {
+	// Catch the case where no where clause was specified. If so, the opcode
+	// won't be set.
+	if vf.eVindexFunc.Opcode == engine.VindexNone {
+		return nil, 0, errors.New("unsupported: where clause for vindex function must be of the form id = <val> (where clause missing)")
+	}
+	col, ok := expr.Expr.(*sqlparser.ColName)
+	if !ok {
+		return nil, 0, errors.New("unsupported: expression on results of a vindex function")
+	}
+	rc = vf.symtab.NewResultColumn(expr, vf)
+	vf.resultColumns = append(vf.resultColumns, rc)
+	vf.eVindexFunc.Fields = append(vf.eVindexFunc.Fields, &querypb.Field{
+		Name: rc.alias.String(),
+		Type: querypb.Type_VARBINARY,
+	})
+	switch {
+	case col.Name.EqualString("id"):
+		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 0)
+	case col.Name.EqualString("keyspace_id"):
+		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 1)
+	default:
+		return nil, 0, fmt.Errorf("unrecognized column %s for vindex: %s", col.Name, vf.eVindexFunc.Vindex)
+	}
+	return rc, len(vf.resultColumns) - 1, nil
+}
+
+// PushOrderByNull satisfies the builder interface.
+func (vf *vindexFunc) PushOrderByNull() {
+}
+
+// SetUpperLimit satisfies the builder interface.
+func (vf *vindexFunc) SetUpperLimit(_ *sqlparser.SQLVal) {
+}
+
+// PushMisc satisfies the builder interface.
+func (vf *vindexFunc) PushMisc(sel *sqlparser.Select) {
+}
+
+// Wireup satisfies the builder interface.
+func (vf *vindexFunc) Wireup(bldr builder, jt *jointab) error {
+	return nil
+}
+
+// SupplyVar satisfies the builder interface.
+func (vf *vindexFunc) SupplyVar(from, to int, col *sqlparser.ColName, varname string) {
+	// vindexFunc is an atomic primitive. So, SupplyVar cannot be
+	// called on it.
+	panic("BUG: route is an atomic node.")
+}
+
+// SupplyCol satisfies the builder interface.
+func (vf *vindexFunc) SupplyCol(col *sqlparser.ColName) (rc *resultColumn, colnum int) {
+	c := col.Metadata.(*column)
+	for i, rc := range vf.resultColumns {
+		if rc.column == c {
+			return rc, i
+		}
+	}
+
+	vf.resultColumns = append(vf.resultColumns, &resultColumn{column: c})
+	vf.eVindexFunc.Fields = append(vf.eVindexFunc.Fields, &querypb.Field{
+		Name: col.Name.String(),
+		Type: querypb.Type_VARBINARY,
+	})
+
+	// columns that reference vindexFunc will have their colnum set.
+	// Let's use it here.
+	vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, c.colnum)
+	return rc, len(vf.resultColumns) - 1
+}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -70,7 +70,7 @@ func (vc *vcursorImpl) Find(name sqlparser.TableName) (table *vindexes.Table, er
 	if ks == "" {
 		ks = vc.target.Keyspace
 	}
-	return vc.executor.VSchema().Find(ks, name.Name.String())
+	return vc.executor.VSchema().FindTable(ks, name.Name.String())
 }
 
 // DefaultKeyspace returns the default keyspace of the current request

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -63,14 +63,23 @@ func (vc *vcursorImpl) Context() context.Context {
 	return vc.ctx
 }
 
-// Find finds the specified table. If the keyspace what specified in the input, it gets used as qualifier.
+// FindTable finds the specified table. If the keyspace what specified in the input, it gets used as qualifier.
 // Otherwise, the keyspace from the request is used, if one was provided.
-func (vc *vcursorImpl) Find(name sqlparser.TableName) (table *vindexes.Table, err error) {
+func (vc *vcursorImpl) FindTable(name sqlparser.TableName) (*vindexes.Table, error) {
 	ks := name.Qualifier.String()
 	if ks == "" {
 		ks = vc.target.Keyspace
 	}
 	return vc.executor.VSchema().FindTable(ks, name.Name.String())
+}
+
+// FindTableOrVindex finds the specified table or vindex.
+func (vc *vcursorImpl) FindTableOrVindex(name sqlparser.TableName) (*vindexes.Table, vindexes.Vindex, error) {
+	ks := name.Qualifier.String()
+	if ks == "" {
+		ks = vc.target.Keyspace
+	}
+	return vc.executor.VSchema().FindTableOrVindex(ks, name.Name.String())
 }
 
 // DefaultKeyspace returns the default keyspace of the current request

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 
 	"github.com/youtube/vitess/go/json2"
-	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
 	"github.com/youtube/vitess/go/vt/sqlparser"
+
+	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
 )
 
 // VSchema represents the denormalized version of SrvVSchema,

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -33,6 +33,7 @@ import (
 // used for building routing plans.
 type VSchema struct {
 	tables    map[string]*Table
+	vindexes  map[string]Vindex
 	Keyspaces map[string]*KeyspaceSchema `json:"keyspaces"`
 }
 
@@ -67,16 +68,19 @@ type ColumnVindex struct {
 type KeyspaceSchema struct {
 	Keyspace *Keyspace
 	Tables   map[string]*Table
+	Vindexes map[string]Vindex
 }
 
 // MarshalJSON returns a JSON representation of KeyspaceSchema.
 func (ks *KeyspaceSchema) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Sharded bool              `json:"sharded,omitempty"`
-		Tables  map[string]*Table `json:"tables,omitempty"`
+		Sharded  bool              `json:"sharded,omitempty"`
+		Tables   map[string]*Table `json:"tables,omitempty"`
+		Vindexes map[string]Vindex `json:"vindexes,omitempty"`
 	}{
-		Sharded: ks.Keyspace.Sharded,
-		Tables:  ks.Tables,
+		Sharded:  ks.Keyspace.Sharded,
+		Tables:   ks.Tables,
+		Vindexes: ks.Vindexes,
 	})
 }
 
@@ -93,6 +97,7 @@ type AutoIncrement struct {
 func BuildVSchema(source *vschemapb.SrvVSchema) (vschema *VSchema, err error) {
 	vschema = &VSchema{
 		tables:    make(map[string]*Table),
+		vindexes:  make(map[string]Vindex),
 		Keyspaces: make(map[string]*KeyspaceSchema),
 	}
 	buildKeyspaces(source, vschema)
@@ -122,6 +127,7 @@ func BuildKeyspaceSchema(input *vschemapb.Keyspace, keyspace string) (*KeyspaceS
 	}
 	vschema := &VSchema{
 		tables:    make(map[string]*Table),
+		vindexes:  make(map[string]Vindex),
 		Keyspaces: make(map[string]*KeyspaceSchema),
 	}
 	buildKeyspaces(formal, vschema)
@@ -146,7 +152,8 @@ func buildKeyspaces(source *vschemapb.SrvVSchema, vschema *VSchema) {
 				Name:    ksname,
 				Sharded: ks.Sharded,
 			},
-			Tables: make(map[string]*Table),
+			Tables:   make(map[string]*Table),
+			Vindexes: make(map[string]Vindex),
 		}
 	}
 }
@@ -154,7 +161,6 @@ func buildKeyspaces(source *vschemapb.SrvVSchema, vschema *VSchema) {
 func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 	for ksname, ks := range source.Keyspaces {
 		keyspace := vschema.Keyspaces[ksname].Keyspace
-		vindexes := make(map[string]Vindex)
 		for vname, vindexInfo := range ks.Vindexes {
 			vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params)
 			if err != nil {
@@ -166,7 +172,12 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 			default:
 				return fmt.Errorf("vindex %q needs to be Unique or NonUnique", vname)
 			}
-			vindexes[vname] = vindex
+			if _, ok := vschema.vindexes[vname]; ok {
+				vschema.vindexes[vname] = nil
+			} else {
+				vschema.vindexes[vname] = vindex
+			}
+			vschema.Keyspaces[ksname].Vindexes[vname] = vindex
 		}
 		for tname, table := range ks.Tables {
 			t := &Table{
@@ -190,7 +201,7 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 				if !ok {
 					return fmt.Errorf("vindex %s not found for table %s", ind.Name, tname)
 				}
-				vindex := vindexes[ind.Name]
+				vindex := vschema.Keyspaces[ksname].Vindexes[ind.Name]
 				owned := false
 				if _, ok := vindex.(Lookup); ok && vindexInfo.Owner == tname {
 					owned = true
@@ -276,21 +287,33 @@ func (vschema *VSchema) findQualified(name string) (*Table, error) {
 	splits := strings.Split(name, ".")
 	switch len(splits) {
 	case 1:
-		return vschema.Find("", splits[0])
+		return vschema.FindTable("", splits[0])
 	case 2:
-		return vschema.Find(splits[0], splits[1])
+		return vschema.FindTable(splits[0], splits[1])
 	}
 	return nil, fmt.Errorf("table %s not found", name)
 }
 
-// Find returns a pointer to the Table. If a keyspace is specified, only tables
+// FindTable returns a pointer to the Table. If a keyspace is specified, only tables
 // from that keyspace are searched. If the specified keyspace is unsharded
-// and no tables matched, it's considered valid: Find will construct a table
+// and no tables matched, it's considered valid: FindTable will construct a table
 // of that name and return it. If no kesypace is specified, then a table is returned
 // only if its name is unique across all keyspaces. If there is only one
 // keyspace in the vschema, and it's unsharded, then all table requests are considered
 // valid and belonging to that keyspace.
-func (vschema *VSchema) Find(keyspace, tablename string) (table *Table, err error) {
+func (vschema *VSchema) FindTable(keyspace, tablename string) (*Table, error) {
+	t, err := vschema.findTable(keyspace, tablename)
+	if err != nil {
+		return nil, err
+	}
+	if t == nil {
+		return nil, fmt.Errorf("table %s not found", tablename)
+	}
+	return t, nil
+}
+
+// findTable is like FindTable, but does not return an error if a table is not found.
+func (vschema *VSchema) findTable(keyspace, tablename string) (*Table, error) {
 	if keyspace == "" {
 		table, ok := vschema.tables[tablename]
 		if table == nil {
@@ -298,12 +321,12 @@ func (vschema *VSchema) Find(keyspace, tablename string) (table *Table, err erro
 				return nil, fmt.Errorf("ambiguous table reference: %s", tablename)
 			}
 			if len(vschema.Keyspaces) != 1 {
-				return nil, fmt.Errorf("table %s not found", tablename)
+				return nil, nil
 			}
 			// Loop happens only once.
 			for _, ks := range vschema.Keyspaces {
 				if ks.Keyspace.Sharded {
-					return nil, fmt.Errorf("table %s not found", tablename)
+					return nil, nil
 				}
 				return &Table{Name: sqlparser.NewTableIdent(tablename), Keyspace: ks.Keyspace}, nil
 			}
@@ -314,14 +337,52 @@ func (vschema *VSchema) Find(keyspace, tablename string) (table *Table, err erro
 	if !ok {
 		return nil, fmt.Errorf("keyspace %s not found in vschema", keyspace)
 	}
-	table = ks.Tables[tablename]
+	table := ks.Tables[tablename]
 	if table == nil {
 		if ks.Keyspace.Sharded {
-			return nil, fmt.Errorf("table %s not found", tablename)
+			return nil, nil
 		}
 		return &Table{Name: sqlparser.NewTableIdent(tablename), Keyspace: ks.Keyspace}, nil
 	}
 	return table, nil
+}
+
+// FindTableOrVindex finds a table or a Vindex by name using Find and FindVindex.
+func (vschema *VSchema) FindTableOrVindex(keyspace, name string) (*Table, Vindex, error) {
+	t, err := vschema.findTable(keyspace, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if t != nil {
+		return t, nil, nil
+	}
+	v, err := vschema.FindVindex(keyspace, name)
+	if err != nil {
+		return nil, nil, err
+	}
+	if v == nil {
+		return nil, nil, fmt.Errorf("table %s not found", name)
+	}
+	return nil, v, nil
+}
+
+// FindVindex finds a vindex by name. If a keyspace is specified, only vindexes
+// from that keyspace are searched. If no kesypace is specified, then a vindex
+// is returned only if its name is unique across all keyspaces. The function
+// returns an error only if the vindex name is ambiguous.
+func (vschema *VSchema) FindVindex(keyspace, name string) (Vindex, error) {
+	if keyspace == "" {
+		vindex, ok := vschema.vindexes[name]
+		if vindex == nil && ok {
+			return nil, fmt.Errorf("ambiguous vindex reference: %s", name)
+		}
+		return vindex, nil
+	}
+	ks, ok := vschema.Keyspaces[keyspace]
+	if !ok {
+		return nil, fmt.Errorf("keyspace %s not found in vschema", keyspace)
+	}
+	return ks.Vindexes[name], nil
 }
 
 // ByCost provides the interface needed for ColumnVindexes to

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -126,11 +126,11 @@ func TestUnshardedVSchema(t *testing.T) {
 		Keyspace: ks,
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   t1,
 			"dual": dual,
 		},
-		vindexes: map[string]Vindex{},
+		uniqueVindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"unsharded": {
 				Keyspace: ks,
@@ -226,11 +226,11 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		Pinned:   []byte{0},
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   t1,
 			"dual": dual,
 		},
-		vindexes: map[string]Vindex{
+		uniqueVindexes: map[string]Vindex{
 			"stfu1": vindex1,
 			"stln1": vindex2,
 		},
@@ -326,11 +326,11 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		Pinned:   []byte{0},
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   t1,
 			"dual": dual,
 		},
-		vindexes: map[string]Vindex{
+		uniqueVindexes: map[string]Vindex{
 			"stlu1": vindex1,
 			"stfu1": vindex2,
 		},
@@ -483,11 +483,11 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 		Keyspace: ksb,
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   nil,
 			"dual": duala,
 		},
-		vindexes: map[string]Vindex{},
+		uniqueVindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
@@ -553,11 +553,11 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 		Keyspace: ksb,
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   nil,
 			"dual": duala,
 		},
-		vindexes: map[string]Vindex{},
+		uniqueVindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
@@ -683,11 +683,11 @@ func TestBuildVSchemaDupVindex(t *testing.T) {
 		Pinned:   []byte{0},
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"t1":   nil,
 			"dual": duala,
 		},
-		vindexes: map[string]Vindex{
+		uniqueVindexes: map[string]Vindex{
 			"stlu1": nil,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{
@@ -931,13 +931,13 @@ func TestSequence(t *testing.T) {
 		Pinned:   []byte{0},
 	}
 	want := &VSchema{
-		tables: map[string]*Table{
+		uniqueTables: map[string]*Table{
 			"seq":  seq,
 			"t1":   t1,
 			"t2":   t2,
 			"dual": dualb,
 		},
-		vindexes: map[string]Vindex{
+		uniqueVindexes: map[string]Vindex{
 			"stfu1": vindex1,
 		},
 		Keyspaces: map[string]*KeyspaceSchema{

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -130,6 +130,7 @@ func TestUnshardedVSchema(t *testing.T) {
 			"t1":   t1,
 			"dual": dual,
 		},
+		vindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"unsharded": {
 				Keyspace: ks,
@@ -137,11 +138,12 @@ func TestUnshardedVSchema(t *testing.T) {
 					"t1":   t1,
 					"dual": dual,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("BuildVSchema:s\n%v, want\n%v", got, want)
+		t.Errorf("BuildVSchema:\n%v, want\n%v", got, want)
 	}
 }
 
@@ -187,6 +189,13 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		Name:    "sharded",
 		Sharded: true,
 	}
+	vindex1 := &stFU{
+		name: "stfu1",
+		Params: map[string]string{
+			"stfu1": "1",
+		},
+	}
+	vindex2 := &stLN{name: "stln1"}
 	t1 := &Table{
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: ks,
@@ -195,19 +204,14 @@ func TestShardedVSchemaOwned(t *testing.T) {
 				Column: sqlparser.NewColIdent("c1"),
 				Type:   "stfu",
 				Name:   "stfu1",
-				Vindex: &stFU{
-					name: "stfu1",
-					Params: map[string]string{
-						"stfu1": "1",
-					},
-				},
+				Vindex: vindex1,
 			},
 			{
 				Column: sqlparser.NewColIdent("c2"),
 				Type:   "stln",
 				Name:   "stln1",
 				Owned:  true,
-				Vindex: &stLN{name: "stln1"},
+				Vindex: vindex2,
 			},
 		},
 	}
@@ -226,6 +230,10 @@ func TestShardedVSchemaOwned(t *testing.T) {
 			"t1":   t1,
 			"dual": dual,
 		},
+		vindexes: map[string]Vindex{
+			"stfu1": vindex1,
+			"stln1": vindex2,
+		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"sharded": {
 				Keyspace: ks,
@@ -233,13 +241,17 @@ func TestShardedVSchemaOwned(t *testing.T) {
 					"t1":   t1,
 					"dual": dual,
 				},
+				Vindexes: map[string]Vindex{
+					"stfu1": vindex1,
+					"stln1": vindex2,
+				},
 			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		gotjson, _ := json.Marshal(got)
 		wantjson, _ := json.Marshal(want)
-		t.Errorf("BuildVSchema:s\n%s, want\n%s", gotjson, wantjson)
+		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
 	}
 }
 
@@ -282,6 +294,8 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		Name:    "sharded",
 		Sharded: true,
 	}
+	vindex1 := &stLU{name: "stlu1"}
+	vindex2 := &stFU{name: "stfu1"}
 	t1 := &Table{
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: ks,
@@ -291,14 +305,14 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 				Type:   "stlu",
 				Name:   "stlu1",
 				Owned:  false,
-				Vindex: &stLU{name: "stlu1"},
+				Vindex: vindex1,
 			},
 			{
 				Column: sqlparser.NewColIdent("c2"),
 				Type:   "stfu",
 				Name:   "stfu1",
 				Owned:  false,
-				Vindex: &stFU{name: "stfu1"},
+				Vindex: vindex2,
 			},
 		},
 	}
@@ -316,12 +330,20 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 			"t1":   t1,
 			"dual": dual,
 		},
+		vindexes: map[string]Vindex{
+			"stlu1": vindex1,
+			"stfu1": vindex2,
+		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"sharded": {
 				Keyspace: ks,
 				Tables: map[string]*Table{
 					"t1":   t1,
 					"dual": dual,
+				},
+				Vindexes: map[string]Vindex{
+					"stlu1": vindex1,
+					"stfu1": vindex2,
 				},
 			},
 		},
@@ -465,6 +487,7 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 			"t1":   nil,
 			"dual": duala,
 		},
+		vindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
@@ -472,6 +495,7 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 					"t1":   t1a,
 					"dual": duala,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 			"ksb": {
 				Keyspace: ksb,
@@ -479,13 +503,14 @@ func TestBuildVSchemaDupSeq(t *testing.T) {
 					"t1":   t1b,
 					"dual": dualb,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		gotjson, _ := json.Marshal(got)
 		wantjson, _ := json.Marshal(want)
-		t.Errorf("BuildVSchema:s\n%s, want\n%s", gotjson, wantjson)
+		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
 	}
 }
 
@@ -532,6 +557,7 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 			"t1":   nil,
 			"dual": duala,
 		},
+		vindexes: map[string]Vindex{},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"ksa": {
 				Keyspace: ksa,
@@ -539,6 +565,7 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 					"t1":   t1a,
 					"dual": duala,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 			"ksb": {
 				Keyspace: ksb,
@@ -546,13 +573,150 @@ func TestBuildVSchemaDupTable(t *testing.T) {
 					"t1":   t1b,
 					"dual": dualb,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		gotjson, _ := json.Marshal(got)
 		wantjson, _ := json.Marshal(want)
-		t.Errorf("BuildVSchema:s\n%s, want\n%s", gotjson, wantjson)
+		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
+	}
+}
+
+func TestBuildVSchemaDupVindex(t *testing.T) {
+	good := vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ksa": {
+				Sharded: true,
+				Vindexes: map[string]*vschemapb.Vindex{
+					"stlu1": {
+						Type:  "stlu",
+						Owner: "",
+					},
+				},
+				Tables: map[string]*vschemapb.Table{
+					"t1": {
+						ColumnVindexes: []*vschemapb.ColumnVindex{
+							{
+								Column: "c1",
+								Name:   "stlu1",
+							},
+						},
+					},
+				},
+			},
+			"ksb": {
+				Sharded: true,
+				Vindexes: map[string]*vschemapb.Vindex{
+					"stlu1": {
+						Type:  "stlu",
+						Owner: "",
+					},
+				},
+				Tables: map[string]*vschemapb.Table{
+					"t1": {
+						ColumnVindexes: []*vschemapb.ColumnVindex{
+							{
+								Column: "c1",
+								Name:   "stlu1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got, err := BuildVSchema(&good)
+	if err != nil {
+		t.Error(err)
+	}
+	ksa := &Keyspace{
+		Name:    "ksa",
+		Sharded: true,
+	}
+	ksb := &Keyspace{
+		Name:    "ksb",
+		Sharded: true,
+	}
+	vindex1 := &stLU{name: "stlu1"}
+	t1 := &Table{
+		Name:     sqlparser.NewTableIdent("t1"),
+		Keyspace: ksa,
+		ColumnVindexes: []*ColumnVindex{
+			{
+				Column: sqlparser.NewColIdent("c1"),
+				Type:   "stlu",
+				Name:   "stlu1",
+				Owned:  false,
+				Vindex: vindex1,
+			},
+		},
+	}
+	t1.Ordered = []*ColumnVindex{
+		t1.ColumnVindexes[0],
+	}
+	t2 := &Table{
+		Name:     sqlparser.NewTableIdent("t1"),
+		Keyspace: ksb,
+		ColumnVindexes: []*ColumnVindex{
+			{
+				Column: sqlparser.NewColIdent("c1"),
+				Type:   "stlu",
+				Name:   "stlu1",
+				Owned:  false,
+				Vindex: vindex1,
+			},
+		},
+	}
+	t2.Ordered = []*ColumnVindex{
+		t2.ColumnVindexes[0],
+	}
+	duala := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksa,
+		Pinned:   []byte{0},
+	}
+	dualb := &Table{
+		Name:     sqlparser.NewTableIdent("dual"),
+		Keyspace: ksb,
+		Pinned:   []byte{0},
+	}
+	want := &VSchema{
+		tables: map[string]*Table{
+			"t1":   nil,
+			"dual": duala,
+		},
+		vindexes: map[string]Vindex{
+			"stlu1": nil,
+		},
+		Keyspaces: map[string]*KeyspaceSchema{
+			"ksa": {
+				Keyspace: ksa,
+				Tables: map[string]*Table{
+					"t1":   t1,
+					"dual": duala,
+				},
+				Vindexes: map[string]Vindex{
+					"stlu1": vindex1,
+				},
+			},
+			"ksb": {
+				Keyspace: ksb,
+				Tables: map[string]*Table{
+					"t1":   t2,
+					"dual": dualb,
+				},
+				Vindexes: map[string]Vindex{
+					"stlu1": vindex1,
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		gotjson, _ := json.Marshal(got)
+		wantjson, _ := json.Marshal(want)
+		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
 	}
 }
 
@@ -712,6 +876,12 @@ func TestSequence(t *testing.T) {
 		Keyspace:   ksu,
 		IsSequence: true,
 	}
+	vindex1 := &stFU{
+		name: "stfu1",
+		Params: map[string]string{
+			"stfu1": "1",
+		},
+	}
 	t1 := &Table{
 		Name:     sqlparser.NewTableIdent("t1"),
 		Keyspace: kss,
@@ -720,12 +890,7 @@ func TestSequence(t *testing.T) {
 				Column: sqlparser.NewColIdent("c1"),
 				Type:   "stfu",
 				Name:   "stfu1",
-				Vindex: &stFU{
-					name: "stfu1",
-					Params: map[string]string{
-						"stfu1": "1",
-					},
-				},
+				Vindex: vindex1,
 			},
 		},
 		AutoIncrement: &AutoIncrement{
@@ -744,12 +909,7 @@ func TestSequence(t *testing.T) {
 				Column: sqlparser.NewColIdent("c1"),
 				Type:   "stfu",
 				Name:   "stfu1",
-				Vindex: &stFU{
-					name: "stfu1",
-					Params: map[string]string{
-						"stfu1": "1",
-					},
-				},
+				Vindex: vindex1,
 			},
 		},
 		AutoIncrement: &AutoIncrement{
@@ -777,6 +937,9 @@ func TestSequence(t *testing.T) {
 			"t2":   t2,
 			"dual": dualb,
 		},
+		vindexes: map[string]Vindex{
+			"stfu1": vindex1,
+		},
 		Keyspaces: map[string]*KeyspaceSchema{
 			"unsharded": {
 				Keyspace: ksu,
@@ -784,6 +947,7 @@ func TestSequence(t *testing.T) {
 					"seq":  seq,
 					"dual": duala,
 				},
+				Vindexes: map[string]Vindex{},
 			},
 			"sharded": {
 				Keyspace: kss,
@@ -792,13 +956,16 @@ func TestSequence(t *testing.T) {
 					"t2":   t2,
 					"dual": dualb,
 				},
+				Vindexes: map[string]Vindex{
+					"stfu1": vindex1,
+				},
 			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
 		gotjson, _ := json.Marshal(got)
 		wantjson, _ := json.Marshal(want)
-		t.Errorf("BuildVSchema:s\n%s, want\n%s", gotjson, wantjson)
+		t.Errorf("BuildVSchema:\n%s, want\n%s", gotjson, wantjson)
 	}
 }
 
@@ -870,7 +1037,7 @@ func TestBadSequenceName(t *testing.T) {
 	}
 }
 
-func TestFind(t *testing.T) {
+func TestFindTable(t *testing.T) {
 	input := vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
 			"ksa": {
@@ -911,17 +1078,17 @@ func TestFind(t *testing.T) {
 		},
 	}
 	vschema, _ := BuildVSchema(&input)
-	_, err := vschema.Find("", "t1")
+	_, err := vschema.FindTable("", "t1")
 	wantErr := "ambiguous table reference: t1"
 	if err == nil || err.Error() != wantErr {
-		t.Errorf("Find(\"\"): %v, want %s", err, wantErr)
+		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
 	}
-	_, err = vschema.Find("", "none")
+	_, err = vschema.FindTable("", "none")
 	wantErr = "table none not found"
 	if err == nil || err.Error() != wantErr {
-		t.Errorf("Find(\"\"): %v, want %s", err, wantErr)
+		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
 	}
-	got, err := vschema.Find("", "ta")
+	got, err := vschema.FindTable("", "ta")
 	if err != nil {
 		t.Error(err)
 		return
@@ -933,11 +1100,11 @@ func TestFind(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(got, ta) {
-		t.Errorf("Find(\"t1a\"): %+v, want %+v", got, ta)
+		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, ta)
 	}
-	got, err = vschema.Find("ksa", "ta")
+	got, err = vschema.FindTable("ksa", "ta")
 	if !reflect.DeepEqual(got, ta) {
-		t.Errorf("Find(\"t1a\"): %+v, want %+v", got, ta)
+		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, ta)
 	}
 	none := &Table{
 		Name: sqlparser.NewTableIdent("none"),
@@ -945,19 +1112,120 @@ func TestFind(t *testing.T) {
 			Name: "ksa",
 		},
 	}
-	got, err = vschema.Find("ksa", "none")
+	got, err = vschema.FindTable("ksa", "none")
 	if !reflect.DeepEqual(got, none) {
-		t.Errorf("Find(\"t1a\"): %+v, want %+v", got, none)
+		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, none)
 	}
-	_, err = vschema.Find("ksb", "none")
+	_, err = vschema.FindTable("ksb", "none")
 	wantErr = "table none not found"
 	if err == nil || err.Error() != wantErr {
-		t.Errorf("Find(\"\"): %v, want %s", err, wantErr)
+		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
 	}
-	_, err = vschema.Find("none", "aa")
+	_, err = vschema.FindTable("none", "aa")
 	wantErr = "keyspace none not found in vschema"
 	if err == nil || err.Error() != wantErr {
-		t.Errorf("Find(\"\"): %v, want %s", err, wantErr)
+		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
+	}
+}
+
+func TestFindTableOrVindex(t *testing.T) {
+	input := vschemapb.SrvVSchema{
+		Keyspaces: map[string]*vschemapb.Keyspace{
+			"ksa": {
+				Tables: map[string]*vschemapb.Table{
+					"ta": {},
+					"t1": {},
+				},
+			},
+			"ksb": {
+				Sharded: true,
+				Vindexes: map[string]*vschemapb.Vindex{
+					"stfu1": {
+						Type: "stfu",
+					},
+					"dup": {
+						Type: "stfu",
+					},
+				},
+				Tables: map[string]*vschemapb.Table{
+					"t1": {
+						ColumnVindexes: []*vschemapb.ColumnVindex{
+							{
+								Column: "c1",
+								Name:   "stfu1",
+							},
+						},
+					},
+				},
+			},
+			"ksc": {
+				Sharded: true,
+				Vindexes: map[string]*vschemapb.Vindex{
+					"dup": {
+						Type: "stfu",
+					},
+					"ta": {
+						Type: "stfu",
+					},
+				},
+				Tables: map[string]*vschemapb.Table{},
+			},
+		},
+	}
+	vschema, _ := BuildVSchema(&input)
+
+	_, _, err := vschema.FindTableOrVindex("", "t1")
+	wantErr := "ambiguous table reference: t1"
+	if err == nil || err.Error() != wantErr {
+		t.Errorf("FindTableOrVindex(\"\"): %v, want %s", err, wantErr)
+	}
+
+	_, _, err = vschema.FindTableOrVindex("", "none")
+	wantErr = "table none not found"
+	if err == nil || err.Error() != wantErr {
+		t.Errorf("FindTableOrVindex(\"\"): %v, want %s", err, wantErr)
+	}
+
+	got, _, err := vschema.FindTableOrVindex("", "ta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ta := &Table{
+		Name: sqlparser.NewTableIdent("ta"),
+		Keyspace: &Keyspace{
+			Name: "ksa",
+		},
+	}
+	if !reflect.DeepEqual(got, ta) {
+		t.Errorf("FindTableOrVindex(\"t1a\"): %+v, want %+v", got, ta)
+	}
+
+	_, vindex, err := vschema.FindTableOrVindex("", "stfu1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantVindex := &stFU{
+		name: "stfu1",
+	}
+	if !reflect.DeepEqual(vindex, wantVindex) {
+		t.Errorf("FindTableOrVindex(\"stfu1\"): %+v, want %+v", vindex, wantVindex)
+	}
+
+	_, vindex, err = vschema.FindTableOrVindex("ksc", "ta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantVindex = &stFU{
+		name: "ta",
+	}
+	if !reflect.DeepEqual(vindex, wantVindex) {
+		t.Errorf("FindTableOrVindex(\"stfu1\"): %+v, want %+v", vindex, wantVindex)
+	}
+
+	_, _, err = vschema.FindTableOrVindex("", "dup")
+	wantErr = "ambiguous vindex reference: dup"
+	if err == nil || err.Error() != wantErr {
+		t.Errorf("FindTableOrVindex(\"\"): %v, want %s", err, wantErr)
 	}
 }
 
@@ -994,6 +1262,7 @@ func TestBuildKeyspaceSchema(t *testing.T) {
 			"t1": t1,
 			"t2": t2,
 		},
+		Vindexes: map[string]Vindex{},
 	}
 	if !reflect.DeepEqual(got, want) {
 		gs, _ := json.Marshal(got)
@@ -1192,9 +1461,9 @@ func TestFindSingleKeyspace(t *testing.T) {
 			Name: "ksa",
 		},
 	}
-	got, _ := vschema.Find("", "none")
+	got, _ := vschema.FindTable("", "none")
 	if !reflect.DeepEqual(got, none) {
-		t.Errorf("Find(\"t1a\"): %+v, want %+v", got, none)
+		t.Errorf("FindTable(\"t1a\"): %+v, want %+v", got, none)
 	}
 	input = vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
@@ -1227,9 +1496,9 @@ func TestFindSingleKeyspace(t *testing.T) {
 		},
 	}
 	vschema, _ = BuildVSchema(&input)
-	_, err := vschema.Find("", "none")
+	_, err := vschema.FindTable("", "none")
 	wantErr := "table none not found"
 	if err == nil || err.Error() != wantErr {
-		t.Errorf("Find(\"\"): %v, want %s", err, wantErr)
+		t.Errorf("FindTable(\"\"): %v, want %s", err, wantErr)
 	}
 }

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -494,6 +494,7 @@ class TestVTGateFunctions(unittest.TestCase):
 
   int_type = 265
   string_type = 6165
+  varbinary_type = 10262
 
   def setUp(self):
     self.master_tablet = shard_1_master
@@ -1408,6 +1409,20 @@ class TestVTGateFunctions(unittest.TestCase):
             {'email': 'test 10'})
     finally:
       vtgate_conn.rollback()
+
+  def test_vindex_func(self):
+    vtgate_conn = get_connection()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'select id, keyspace_id from user_index where id = :id',
+        {'id': 1})
+    self.assertEqual(
+        result,
+        ([('1', '\x16k@\xb4J\xbaK\xd6')],
+         1,
+         0,
+         [('id', self.varbinary_type),
+          ('keyspace_id', self.varbinary_type)]))
 
   def test_transaction_modes(self):
     vtgate_conn = get_connection()


### PR DESCRIPTION
Issues #3076, #2918 
Design doc: https://github.com/youtube/vitess/blob/master/doc/VindexAsTable.md

The PR mostly follows what the doc says. The one serendipitous exception is that the primitive does orthogonally combine with other primitives without writing any special code. The tests demonstrate some of those combos.