### PR TITLE
Fix backwards compatibility issue

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -248,7 +248,7 @@ func (cp *Pool) IdleTimeout() time.Duration {
 
 func (cp *Pool) isCallerIDAppDebug(ctx context.Context) bool {
 	callerID := callerid.ImmediateCallerIDFromContext(ctx)
-	if cp.appDebugParams == nil {
+	if cp.appDebugParams.Uname == "" {
 		return false
 	}
 	return callerID != nil && callerID.Username == cp.appDebugParams.Uname


### PR DESCRIPTION
### Description 

* When appdebug config is not set it will match an empty callerID. You could get an empty callerID if vtgate mysql static config is setup without `UserData`.

* This change fixes this issue and makes sure that we stay backwards compatible.