### PR TITLE
Do not clear Target after a stream error

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -429,10 +429,14 @@ func (hcc *healthCheckConn) stream(ctx context.Context, hc *HealthCheckImpl, cal
 		hcc.mu.Lock()
 		hcc.conn.Close(ctx)
 		hcc.conn = nil
-		hcc.tabletStats.Target = &querypb.Target{}
 		hcc.tabletStats.Serving = false
 		hcc.tabletStats.LastError = err
+		ts := hcc.tabletStats
 		hcc.mu.Unlock()
+		// notify downstream for serving status change
+		if hc.listener != nil {
+			hc.listener.StatsUpdate(&ts)
+		}
 		return
 	}
 	return

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -584,10 +584,13 @@ func discoveryDialer(tablet *topodatapb.Tablet, timeout time.Duration) (queryser
 
 type fakeConn struct {
 	queryservice.QueryService
-	tablet  *topodatapb.Tablet
-	hcChan  chan *querypb.StreamHealthResponse // next health response from the tablet
-	errCh   chan error                         // next stream error to return
-	cbErrCh chan error                         // records errors returned from the callback
+	tablet *topodatapb.Tablet
+	// hcChan should be an unbuffered channel which holds the tablet's next health response.
+	hcChan chan *querypb.StreamHealthResponse
+	// errCh is either an unbuffered channel which holds the stream error to return, or nil.
+	errCh chan error
+	// cbErrCh is a channel which receives errors returned from the supplied callback.
+	cbErrCh chan error
 
 	mu       sync.Mutex
 	canceled bool

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -585,9 +585,9 @@ func discoveryDialer(tablet *topodatapb.Tablet, timeout time.Duration) (queryser
 type fakeConn struct {
 	queryservice.QueryService
 	tablet  *topodatapb.Tablet
-	hcChan  chan *querypb.StreamHealthResponse
-	errCh   chan error
-	cbErrCh chan error
+	hcChan  chan *querypb.StreamHealthResponse // next health response from the tablet
+	errCh   chan error                         // next stream error to return
+	cbErrCh chan error                         // records errors returned from the callback
 
 	mu       sync.Mutex
 	canceled bool


### PR DESCRIPTION
Some listeners need keyspace and shard to route tablet down notification properly.

Also send a notification after a stream error. This may change behavior for transient errors, because previously the stream was silently reconnected.

BUG=64377995