### PR TITLE
Fix usage of last_insert_id with updates

### DIFF
--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -118,6 +118,14 @@ insert into vitess_b(eid, id) values(1, 1), (1, 2);
 insert into vitess_c(eid, name, foo) values(10, 'abcd', '20'), (11, 'bcde', '30');
 create table vitess_mixed_case(Col1 int default 0, COL2 int default null, primary key(col1));
 
+CREATE TABLE vitess_autoinc_seq (
+  id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  name varchar(255) NOT NULL,
+  sequence bigint(20) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (id),
+  UNIQUE KEY name (name)
+);
+
 create table vitess_big(id int default 0, string1 varchar(128) default null, string2 varchar(100) default null, string3 char(1) default null, string4 varchar(50) default null, string5 varchar(50) default null, string6 varchar(16) default null, string7 varchar(120) default null, bigint1 bigint(20) default null, bigint2 bigint(20) default null, integer1 int default null, tinyint1 tinyint(4) default null, primary key(id));
 
 create table vitess_ints(tiny tinyint default 0, tinyu tinyint unsigned default null, small smallint default null, smallu smallint unsigned default null, medium mediumint default null, mediumu mediumint unsigned default null, normal int default null, normalu int unsigned default null, big bigint default null, bigu bigint unsigned default null, y year default null, primary key(tiny));
@@ -170,7 +178,7 @@ var tableACLConfig = `{
     },
     {
       "name": "vitess",
-      "table_names_or_prefixes": ["vitess_a", "vitess_b", "vitess_c", "dual", "vitess_d", "vitess_temp", "vitess_e", "vitess_f", "vitess_mixed_case", "upsert_test", "vitess_strings", "vitess_fracts", "vitess_ints", "vitess_misc", "vitess_big", "vitess_view", "vitess_json", "vitess_bool"],
+      "table_names_or_prefixes": ["vitess_a", "vitess_b", "vitess_c", "dual", "vitess_d", "vitess_temp", "vitess_e", "vitess_f", "vitess_mixed_case", "upsert_test", "vitess_strings", "vitess_fracts", "vitess_ints", "vitess_misc", "vitess_big", "vitess_view", "vitess_json", "vitess_bool", "vitess_autoinc_seq"],
       "readers": ["dev"],
       "writers": ["dev"],
       "admins": ["dev"]

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -678,7 +678,12 @@ func (qre *QueryExecutor) execDMLPKRows(conn *TxConnection, query *sqlparser.Par
 		if err != nil {
 			return nil, err
 		}
-		// DMLs should only return RowsAffected.
+
+		// UPDATEs can return InsertID when LAST_INSERT_ID(expr) is used. In
+		// this case it should be the same for all rows.
+		result.InsertID = r.InsertID
+
+		// DMLs should all return RowsAffected.
 		result.RowsAffected += r.RowsAffected
 	}
 	if qre.plan.Table.Type == schema.Message {


### PR DESCRIPTION
@sougou we have a use case that uses a table as a sequence generator. This should work per https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_last-insert-id.

When the app is run against direct mysql it would return the sequence value generated. But against vitess it would always return 0. This is because we were not filling in the InsertId in execDMLPK.

I added a test case and added the 1 line fix.  Let me know if you can think of any other tests or issues