### PR TITLE
Support for source host in mysql static configuration

### DIFF
--- a/examples/local/mysql_auth_server_static_creds.json
+++ b/examples/local/mysql_auth_server_static_creds.json
@@ -1,0 +1,19 @@
+{
+  "mysql_user": [
+    {
+      "Password": "mysql_password",
+      "UserData": "mysql_user"
+    }
+  ],
+  "vt_appdebug": [
+    {
+      "Password": "vtappdebug_password",
+      "UserData": "vt_appdebug"
+    },
+    {
+      "SourceHost": "localhost",
+      "Password": "",
+      "UserData": "vt_appdebug"
+    }
+  ]
+}

--- a/examples/local/vtgate-up.sh
+++ b/examples/local/vtgate-up.sh
@@ -22,6 +22,7 @@ cell='test'
 web_port=15001
 grpc_port=15991
 mysql_server_port=15306
+mysql_server_socket_path="/tmp/mysql.sock"
 
 script_root=`dirname "${BASH_SOURCE}"`
 source $script_root/env.sh
@@ -60,7 +61,8 @@ $VTROOT/bin/vtgate \
   -port $web_port \
   -grpc_port $grpc_port \
   -mysql_server_port $mysql_server_port \
-  -mysql_auth_server_static_string '{"mysql_user":{"Password":"mysql_password", "UserData":"mysql_user"}, "vt_appdebug": {"Password": "vtappdebug_password", "UserData": "vt_appdebug"}}' \
+  -mysql_server_socket_path $mysql_server_socket_path \
+  -mysql_auth_server_static_file "./mysql_auth_server_static_creds.json" \
   -cell $cell \
   -cells_to_watch $cell \
   -tablet_types_to_wait MASTER,REPLICA \

--- a/go/mysql/auth_server.go
+++ b/go/mysql/auth_server.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/sha1"
 	"fmt"
+	"net"
 
 	log "github.com/golang/glog"
 )
@@ -59,7 +60,7 @@ type AuthServer interface {
 
 	// ValidateHash validates the data sent by the client matches
 	// what the server computes.  It also returns the user data.
-	ValidateHash(salt []byte, user string, authResponse []byte) (Getter, error)
+	ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error)
 
 	// Negotiate is called if AuthMethod returns anything else
 	// than MysqlNativePassword. It is handed the connection after the
@@ -71,7 +72,7 @@ type AuthServer interface {
 	// - If the negotiation works, it should return the Getter,
 	// and no error. The framework is responsible for writing the
 	// OK packet.
-	Negotiate(c *Conn, user string) (Getter, error)
+	Negotiate(c *Conn, user string, remoteAddr net.Addr) (Getter, error)
 }
 
 // authServers is a registry of AuthServer implementations.

--- a/go/mysql/auth_server_none.go
+++ b/go/mysql/auth_server_none.go
@@ -17,6 +17,8 @@ limitations under the License.
 package mysql
 
 import (
+	"net"
+
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
@@ -39,13 +41,13 @@ func (a *AuthServerNone) Salt() ([]byte, error) {
 }
 
 // ValidateHash validates hash
-func (a *AuthServerNone) ValidateHash(salt []byte, user string, authResponse []byte) (Getter, error) {
+func (a *AuthServerNone) ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (Getter, error) {
 	return &NoneGetter{}, nil
 }
 
 // Negotiate is part of the AuthServer interface.
 // It will never be called.
-func (a *AuthServerNone) Negotiate(c *Conn, user string) (Getter, error) {
+func (a *AuthServerNone) Negotiate(c *Conn, user string, remotAddr net.Addr) (Getter, error) {
 	panic("Negotiate should not be called as AuthMethod returned mysql_native_password")
 }
 

--- a/go/mysql/auth_server_static_test.go
+++ b/go/mysql/auth_server_static_test.go
@@ -1,0 +1,72 @@
+/*
+copyright 2017 google inc.
+
+licensed under the apache license, version 2.0 (the "license");
+you may not use this file except in compliance with the license.
+you may obtain a copy of the license at
+
+    http://www.apache.org/licenses/license-2.0
+
+unless required by applicable law or agreedto in writing, software
+distributed under the license is distributed on an "as is" basis,
+without warranties or conditions of any kind, either express or implied.
+see the license for the specific language governing permissions and
+limitations under the license.
+*/
+
+package mysql
+
+import (
+	"net"
+	"testing"
+)
+
+func TestJsonConfigParser(t *testing.T) {
+	// works with legacy format
+	config := make(map[string][]*AuthServerStaticEntry)
+	jsonConfig := "{\"mysql_user\":{\"Password\":\"123\", \"UserData\":\"dummy\"}, \"mysql_user_2\": {\"Password\": \"123\", \"UserData\": \"mysql_user_2\"}}"
+	err := parseConfig([]byte(jsonConfig), &config)
+	if err != nil {
+		t.Fatalf("should not get an error, but got: %v", err)
+	}
+	if len(config["mysql_user"]) != 1 {
+		t.Fatalf("mysql_user config size should be equal to 1")
+	}
+
+	if len(config["mysql_user_2"]) != 1 {
+		t.Fatalf("mysql_user config size should be equal to 1")
+	}
+	// works with new format
+	jsonConfig = "{\"mysql_user\":[{\"Password\":\"123\", \"UserData\":\"dummy\", \"SourceHost\": \"localhost\"}, {\"Password\": \"123\", \"UserData\": \"mysql_user_all\"}]}"
+	err = parseConfig([]byte(jsonConfig), &config)
+	if err != nil {
+		t.Fatalf("should not get an error, but got: %v", err)
+	}
+	if len(config["mysql_user"]) != 2 {
+		t.Fatalf("mysql_user config size should be equal to 2")
+	}
+
+	if config["mysql_user"][0].SourceHost != "localhost" {
+		t.Fatalf("SourceHost should be equal localhost")
+	}
+}
+
+func TestHostMatcher(t *testing.T) {
+	ip := net.ParseIP("192.168.0.1")
+	addr := &net.TCPAddr{IP: ip, Port: 9999}
+	match := matchSourceHost(net.Addr(addr), "")
+	if !match {
+		t.Fatalf("Should match any addres when target is empty")
+	}
+
+	match = matchSourceHost(net.Addr(addr), "localhost")
+	if match {
+		t.Fatalf("Should not match address when target is localhost")
+	}
+
+	socket := &net.UnixAddr{Name: "unixSocket", Net: "1"}
+	match = matchSourceHost(net.Addr(socket), "localhost")
+	if !match {
+		t.Fatalf("Should match socket when target is localhost")
+	}
+}

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -38,8 +38,8 @@ func TestClearTextClientAuth(t *testing.T) {
 
 	authServer := NewAuthServerStatic()
 	authServer.Method = MysqlClearPassword
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
-		Password: "password1",
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{
+		&AuthServerStaticEntry{Password: "password1"},
 	}
 
 	// Create the listener.
@@ -96,8 +96,8 @@ func TestSSLConnection(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
-		Password: "password1",
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{
+		&AuthServerStaticEntry{Password: "password1"},
 	}
 
 	// Create the listener, so we can get its host.

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"sync"
 	"time"
 
@@ -94,12 +95,12 @@ func (asl *AuthServerLdap) Salt() ([]byte, error) {
 }
 
 // ValidateHash is unimplemented for AuthServerLdap.
-func (asl *AuthServerLdap) ValidateHash(salt []byte, user string, authResponse []byte) (mysql.Getter, error) {
+func (asl *AuthServerLdap) ValidateHash(salt []byte, user string, authResponse []byte, remoteAddr net.Addr) (mysql.Getter, error) {
 	panic("unimplemented")
 }
 
 // Negotiate is part of the AuthServer interface.
-func (asl *AuthServerLdap) Negotiate(c *mysql.Conn, user string) (mysql.Getter, error) {
+func (asl *AuthServerLdap) Negotiate(c *mysql.Conn, user string, remoteAddr net.Addr) (mysql.Getter, error) {
 	// Finish the negotiation.
 	password, err := mysql.AuthServerNegotiateClearOrDialog(c, asl.Method)
 	if err != nil {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -231,7 +231,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		// Both server and client want to use MysqlNativePassword:
 		// the negotiation can be completed right away, using the
 		// ValidateHash() method.
-		userData, err := l.authServer.ValidateHash(salt, user, authResponse)
+		userData, err := l.authServer.ValidateHash(salt, user, authResponse, conn.RemoteAddr())
 		if err != nil {
 			log.Warningf("Error authenticating user using MySQL native password: %v", err)
 			c.writeErrorPacketFromError(err)
@@ -269,7 +269,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 
 		// Then hand over the rest of the negotiation to the
 		// auth server.
-		userData, err := l.authServer.Negotiate(c, user)
+		userData, err := l.authServer.Negotiate(c, user, conn.RemoteAddr())
 		if err != nil {
 			c.writeErrorPacketFromError(err)
 			return

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -145,14 +145,127 @@ func (th *testHandler) ComQuery(c *Conn, q []byte, callback func(*sqltypes.Resul
 	return nil
 }
 
+func TestConnectionWithoutSourceHost(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic()
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
+		Password: "password1",
+		UserData: "userData1",
+	}}
+	l, err := NewListener("tcp", ":0", authServer, th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		l.Accept()
+	}()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	c, err := Connect(context.Background(), params)
+	if err != nil {
+		t.Errorf("Should be able to connect to server but found error: %v", err)
+	}
+	c.Close()
+}
+
+func TestConnectionWithSourceHost(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic()
+
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{
+		&AuthServerStaticEntry{
+			Password:   "password1",
+			UserData:   "userData1",
+			SourceHost: "localhost",
+		},
+	}
+
+	l, err := NewListener("tcp", ":0", authServer, th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		l.Accept()
+	}()
+
+	host := l.Addr().(*net.TCPAddr).IP.String()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		Host:  host,
+		Port:  port,
+		Uname: "user1",
+		Pass:  "password1",
+	}
+
+	_, err = Connect(context.Background(), params)
+	// target is localhost, should not work from tcp connection
+	if err == nil {
+		t.Errorf("Should be able to connect to server but found error: %v", err)
+	}
+}
+
+func TestConnectionUnixSocket(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := NewAuthServerStatic()
+
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{
+		&AuthServerStaticEntry{
+			Password:   "password1",
+			UserData:   "userData1",
+			SourceHost: "localhost",
+		},
+	}
+
+	unixSocket := "/tmp/mysql_vitess_test.sock"
+
+	l, err := NewListener("unix", unixSocket, authServer, th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		l.Accept()
+	}()
+
+	// Setup the right parameters.
+	params := &ConnParams{
+		UnixSocket: unixSocket,
+		Uname:      "user1",
+		Pass:       "password1",
+	}
+
+	c, err := Connect(context.Background(), params)
+	if err != nil {
+		t.Errorf("Should be able to connect to server but found error: %v", err)
+	}
+	c.Close()
+}
+
 func TestClientFoundRows(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
 		Password: "password1",
 		UserData: "userData1",
-	}
+	}}
 	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
@@ -204,10 +317,10 @@ func TestServer(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
 		Password: "password1",
 		UserData: "userData1",
-	}
+	}}
 	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
 		t.Fatalf("NewListener failed: %v", err)
@@ -394,10 +507,10 @@ func TestClearTextServer(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
 		Password: "password1",
 		UserData: "userData1",
-	}
+	}}
 	authServer.Method = MysqlClearPassword
 	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
@@ -482,10 +595,10 @@ func TestDialogServer(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
 		Password: "password1",
 		UserData: "userData1",
-	}
+	}}
 	authServer.Method = MysqlDialog
 	l, err := NewListener("tcp", ":0", authServer, th)
 	if err != nil {
@@ -529,9 +642,9 @@ func TestTLSServer(t *testing.T) {
 	th := &testHandler{}
 
 	authServer := NewAuthServerStatic()
-	authServer.Entries["user1"] = &AuthServerStaticEntry{
+	authServer.Entries["user1"] = []*AuthServerStaticEntry{&AuthServerStaticEntry{
 		Password: "password1",
-	}
+	}}
 
 	// Create the listener, so we can get its host.
 	// Below, we are enabling --ssl-verify-server-cert, which adds

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -37,6 +37,7 @@ import (
 var (
 	mysqlServerPort               = flag.Int("mysql_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
 	mysqlServerBindAddress        = flag.String("mysql_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
+	mysqlServerSocketPath         = flag.String("mysql_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
 	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "static", "Which auth server implementation to use.")
 	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
 
@@ -117,6 +118,7 @@ func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query []byte, callback func(*sq
 }
 
 var mysqlListener *mysql.Listener
+var mysqlUnixListener *mysql.Listener
 
 // initiMySQLProtocol starts the mysql protocol.
 // It should be called only once in a process.
@@ -158,11 +160,21 @@ func initMySQLProtocol() {
 		log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
 		mysqlListener.SlowConnectWarnThreshold = *mysqlSlowConnectWarnThreshold
 	}
-
-	// And starts listening.
+	// Start listening for tcp
 	go func() {
 		mysqlListener.Accept()
 	}()
+
+	if mysqlServerSocketPath != nil {
+		mysqlUnixListener, err = mysql.NewListener("unix", *mysqlServerSocketPath, authServer, vh)
+		if err != nil {
+			log.Fatalf("mysql.NewListener failed: %v", err)
+		}
+		// Listen for unix socket
+		go func() {
+			mysqlUnixListener.Accept()
+		}()
+	}
 }
 
 func init() {
@@ -172,6 +184,10 @@ func init() {
 		if mysqlListener != nil {
 			mysqlListener.Close()
 			mysqlListener = nil
+		}
+		if mysqlUnixListener != nil {
+			mysqlUnixListener.Close()
+			mysqlUnixListener = nil
 		}
 	})
 }


### PR DESCRIPTION
### Description 
* MySQL supports accounts per host name: `CREATE USER 'david'@'localhost'`
  This will enforce that this account only works when connecting from
  localhost.

* The following PR adds a starting point for this feature in Vitess. The main
  changes are:
    - Added new config format to support multiple user credentials
      depending on the `SourceHost` when using mysql static auth.
    - Backwards compatibility for config.
    - Updated `auth_server_static` to match both user and source host when
      performing authentication. At the moment, only `""` or `localhost`
      are supported. Empty string means it could connect from everywhere.
    - Added support to start a listener in a unix socket. When a config entry has
      `SourceHost` equal to localhost, it will only be allowed to connect via this 
      socket.
* This initial approach is not a complete port of MySQL feature, as it doesn't 
   add support for full wildcards, host match and network masks as the source 
   hosts.  If we see need, in the future we could match the MySQL 
   implementation.

### Usage

* When starting a vtgate you can pass this new flag: `-mysql_server_socket_path`. When present, it will listen for connections in that unix socket path. 
* In addition, when specifying an static config entry, you can provide `SourceHost` with `localhost`. This entry will only work when connecting via the unix socket (same behavior as you would have with MySQL).
* From a mysql client this will work: 
  ```
  $ mysql -h localhost -uuname -p  # Yei! 
  ```

### Tests

* So far I have tested these changes in a local cluster and our development environment. 