### PR TITLE
vttablet: Hot Row Protection: Make the transaction concurrency for a hot row configurable.

### DIFF
--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -181,7 +181,9 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 
 	qe.consolidator = sync2.NewConsolidator()
 	qe.txSerializer = txserializer.New(config.EnableHotRowProtectionDryRun,
-		config.HotRowProtectionMaxQueueSize, config.HotRowProtectionMaxGlobalQueueSize)
+		config.HotRowProtectionMaxQueueSize,
+		config.HotRowProtectionMaxGlobalQueueSize,
+		config.HotRowProtectionConcurrentTransactions)
 	qe.streamQList = NewQueryList()
 
 	qe.autoCommit.Set(config.EnableAutoCommit)

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1475,6 +1475,7 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	config.EnableHotRowProtection = true
+	config.HotRowProtectionConcurrentTransactions = 1
 	// Reduce the txpool to 2 because we should never consume more than two slots.
 	config.TransactionCap = 2
 	tsv := NewTabletServerWithNilTopoServer(config)
@@ -1607,6 +1608,7 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.EnableHotRowProtection = true
 	config.HotRowProtectionMaxQueueSize = 1
+	config.HotRowProtectionConcurrentTransactions = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
@@ -1693,6 +1695,7 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	config.EnableHotRowProtection = true
+	config.HotRowProtectionConcurrentTransactions = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -1513,7 +1513,7 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	db.SetBeforeFunc("update test_table set name_string = 'tx1' where pk in (1) /* _stream test_table (pk ) (1 ); */",
 		func() {
 			close(tx1Started)
-			if err := waitForTxSerializationCount(tsv, "test_table where pk = 1 and name = 1", 2); err != nil {
+			if err := waitForTxSerializationPendingQueries(tsv, "test_table where pk = 1 and name = 1", 2); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1581,7 +1581,134 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	}
 }
 
-func waitForTxSerializationCount(tsv *TabletServer, key string, i int) error {
+func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
+	// This test runs three transaction in parallel:
+	// tx1 | tx2 | tx3
+	// Out of these three, two can run in parallel because we increased the
+	// ConcurrentTransactions limit to 2.
+	// One out of the three transaction will always get serialized though.
+	db := setUpTabletServerTest(t)
+	defer db.Close()
+	testUtils := newTestUtils()
+	config := testUtils.newQueryServiceConfig()
+	config.EnableHotRowProtection = true
+	config.HotRowProtectionConcurrentTransactions = 2
+	// Reduce the txpool to 2 because we should never consume more than two slots.
+	config.TransactionCap = 2
+	tsv := NewTabletServerWithNilTopoServer(config)
+	dbconfigs := testUtils.newDBConfigs(db)
+	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
+	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+		t.Fatalf("StartService failed: %v", err)
+	}
+	defer tsv.StopService()
+	countStart := tabletenv.WaitStats.Counts()["TxSerializer"]
+
+	// Fake data.
+	q1 := "update test_table set name_string = 'tx1' where pk = :pk and name = :name"
+	q2 := "update test_table set name_string = 'tx2' where pk = :pk and name = :name"
+	q3 := "update test_table set name_string = 'tx3' where pk = :pk and name = :name"
+	// Every request needs their own bind variables to avoid data races.
+	bvTx1 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(1),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+	bvTx2 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(1),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+	bvTx3 := map[string]*querypb.BindVariable{
+		"pk":   sqltypes.Int64BindVariable(1),
+		"name": sqltypes.Int64BindVariable(1),
+	}
+
+	tx1Started := make(chan struct{})
+	allQueriesPending := make(chan struct{})
+	db.SetBeforeFunc("update test_table set name_string = 'tx1' where pk in (1) /* _stream test_table (pk ) (1 ); */",
+		func() {
+			close(tx1Started)
+			<-allQueriesPending
+		})
+
+	// Run all three transactions.
+	ctx := context.Background()
+	wg := sync.WaitGroup{}
+
+	// tx1.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		_, tx1, err := tsv.BeginExecute(ctx, &target, q1, bvTx1, nil)
+		if err != nil {
+			t.Fatalf("failed to execute query: %s: %s", q1, err)
+		}
+
+		if err := tsv.Commit(ctx, &target, tx1); err != nil {
+			t.Fatalf("call TabletServer.Commit failed: %v", err)
+		}
+	}()
+
+	// tx2.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Wait for tx1 to avoid that this tx could pass tx1, without any contention.
+		// In that case, we would see less than 3 pending transactions.
+		<-tx1Started
+
+		_, tx2, err := tsv.BeginExecute(ctx, &target, q2, bvTx2, nil)
+		if err != nil {
+			t.Fatalf("failed to execute query: %s: %s", q2, err)
+		}
+
+		if err := tsv.Commit(ctx, &target, tx2); err != nil {
+			t.Fatalf("call TabletServer.Commit failed: %v", err)
+		}
+	}()
+
+	// tx3.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// Wait for tx1 to avoid that this tx could pass tx1, without any contention.
+		// In that case, we would see less than 3 pending transactions.
+		<-tx1Started
+
+		_, tx3, err := tsv.BeginExecute(ctx, &target, q3, bvTx3, nil)
+		if err != nil {
+			t.Fatalf("failed to execute query: %s: %s", q3, err)
+		}
+
+		if err := tsv.Commit(ctx, &target, tx3); err != nil {
+			t.Fatalf("call TabletServer.Commit failed: %v", err)
+		}
+	}()
+
+	// At this point, all three transactions should be blocked in BeginExecute()
+	// and therefore count as pending transaction by the Hot Row Protection.
+	//
+	// NOTE: We are not doing more sophisticated synchronizations between the
+	// transactions via db.SetBeforeFunc() for the same reason as mentioned
+	// in TestSerializeTransactionsSameRow: The MySQL C client does not seem
+	// to allow more than connection attempt at a time.
+	if err := waitForTxSerializationPendingQueries(tsv, "test_table where pk = 1 and name = 1", 3); err != nil {
+		t.Fatal(err)
+	}
+	close(allQueriesPending)
+
+	wg.Wait()
+
+	got, ok := tabletenv.WaitStats.Counts()["TxSerializer"]
+	want := countStart + 1
+	if !ok || got != want {
+		t.Fatalf("One out of the three transactions must have waited: ok? %v got: %v want: %v", ok, got, want)
+	}
+}
+
+func waitForTxSerializationPendingQueries(tsv *TabletServer, key string, i int) error {
 	start := time.Now()
 	for {
 		got, want := tsv.qe.txSerializer.Pending(key), i
@@ -1777,7 +1904,7 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 		defer wg.Done()
 
 		// Wait until tx1 and tx2 are pending to make the test deterministic.
-		if err := waitForTxSerializationCount(tsv, "test_table where pk = 1 and name = 1", 2); err != nil {
+		if err := waitForTxSerializationPendingQueries(tsv, "test_table where pk = 1 and name = 1", 2); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1792,7 +1919,7 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	}()
 
 	// Wait until tx1, 2 and 3 are pending.
-	if err := waitForTxSerializationCount(tsv, "test_table where pk = 1 and name = 1", 3); err != nil {
+	if err := waitForTxSerializationPendingQueries(tsv, "test_table where pk = 1 and name = 1", 3); err != nil {
 		t.Fatal(err)
 	}
 	// Now unblock tx2 and cancel it.

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -42,7 +42,7 @@ func resetVariables() {
 
 func TestTxSerializer(t *testing.T) {
 	resetVariables()
-	txs := New(false, 2, 3)
+	txs := New(false, 2, 3, 1)
 
 	// tx1.
 	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -108,6 +108,75 @@ func TestTxSerializer(t *testing.T) {
 	}
 }
 
+func TestTxSerializer_ConcurrentTransactions(t *testing.T) {
+	resetVariables()
+	// Allow up to 2 concurrent transactions per hot row.
+	txs := New(false, 3, 3, 2)
+
+	// tx1.
+	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+	if waited1 {
+		t.Fatalf("tx1 must never wait: %v", waited1)
+	}
+
+	// tx2.
+	done2, waited2, err2 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err2 != nil {
+		t.Fatal(err1)
+	}
+	if waited2 {
+		t.Fatalf("tx2 must not wait: %v", waited1)
+	}
+
+	// tx3 (gets queued and must wait).
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		done3, waited3, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
+		if err3 != nil {
+			t.Fatal(err3)
+		}
+		if !waited3 {
+			t.Fatalf("tx3 must wait: %v", waited2)
+		}
+		if got, want := waits.Counts()["t1"], int64(1); got != want {
+			t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+		}
+
+		done3()
+	}()
+
+	// Wait until tx3 is waiting before we finish tx2 and unblock tx3.
+	if err := waitForPending(txs, "t1 where1", 3); err != nil {
+		t.Fatal(err)
+	}
+	// Finish tx2 before tx1 to test that the "finish-order" does not matter.
+	// Unblocks tx3.
+	done2()
+	// Wait for tx3 to finish.
+	wg.Wait()
+	// Finish tx1 to delete the queue object.
+	done1()
+
+	if txs.queues["t1 where1"] != nil {
+		t.Fatal("queue object was not deleted after last transaction")
+	}
+
+	// 3 transactions were recorded.
+	if err := testHTTPHandler(txs, 3); err != nil {
+		t.Fatal(err)
+	}
+	// 1 of them had to wait.
+	if got, want := waits.Counts()["t1"], int64(1); got != want {
+		t.Fatalf("variable not incremented: got = %v, want = %v", got, want)
+	}
+}
+
 func waitForPending(txs *TxSerializer, key string, i int) error {
 	start := time.Now()
 	for {
@@ -144,13 +213,14 @@ func testHTTPHandler(txs *TxSerializer, count int) error {
 	return nil
 }
 
-// TestTxSerializerCancel runs 3 pending transactions. tx2 will get canceled
-// and tx3 will be unblocked once tx1 is done.
+// TestTxSerializerCancel runs 4 pending transactions.
+// tx1 and tx2 are allowed to run concurrently while tx3 and tx4 are queued.
+// tx3 will get canceled and tx4 will be unblocked once tx1 is done.
 func TestTxSerializerCancel(t *testing.T) {
 	resetVariables()
-	txs := New(false, 3, 3)
+	txs := New(false, 4, 4, 2)
 
-	// tx2 and tx3 will record their number once they're done waiting.
+	// tx3 and tx4 will record their number once they're done waiting.
 	txDone := make(chan int)
 
 	// tx1.
@@ -161,68 +231,77 @@ func TestTxSerializerCancel(t *testing.T) {
 	if waited1 {
 		t.Fatalf("tx1 must never wait: %v", waited1)
 	}
+	// tx2.
+	done2, waited2, err2 := txs.Wait(context.Background(), "t1 where1", "t1")
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if waited2 {
+		t.Fatalf("tx2 must not wait: %v", waited2)
+	}
 
-	// tx2 (gets queued and must wait).
-	ctx2, cancel2 := context.WithCancel(context.Background())
+	// tx3 (gets queued and must wait).
+	ctx3, cancel3 := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 
-		_, _, err2 := txs.Wait(ctx2, "t1 where1", "t1")
-		if err2 != context.Canceled {
-			t.Fatal(err2)
-		}
-
-		txDone <- 2
-	}()
-	// Wait until tx2 is waiting before we try tx3.
-	if err := waitForPending(txs, "t1 where1", 2); err != nil {
-		t.Fatal(err)
-	}
-
-	// tx3 (gets queued and must wait as well).
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		done3, waited3, err3 := txs.Wait(context.Background(), "t1 where1", "t1")
-		if err3 != nil {
+		_, _, err3 := txs.Wait(ctx3, "t1 where1", "t1")
+		if err3 != context.Canceled {
 			t.Fatal(err3)
-		}
-		if !waited3 {
-			t.Fatalf("tx3 must have waited: %v", waited3)
 		}
 
 		txDone <- 3
-
-		done3()
 	}()
-	// Wait until tx3 is waiting before we start to cancel tx2.
+	// Wait until tx3 is waiting before we try tx4.
 	if err := waitForPending(txs, "t1 where1", 3); err != nil {
 		t.Fatal(err)
 	}
 
-	// Cancel tx2.
-	cancel2()
-	if got := <-txDone; got != 2 {
-		t.Fatalf("tx2 should have been unblocked after the cancel: %v", got)
+	// tx4 (gets queued and must wait as well).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		done4, waited4, err4 := txs.Wait(context.Background(), "t1 where1", "t1")
+		if err4 != nil {
+			t.Fatal(err4)
+		}
+		if !waited4 {
+			t.Fatalf("tx4 must have waited: %v", waited4)
+		}
+
+		txDone <- 4
+
+		done4()
+	}()
+	// Wait until tx4 is waiting before we start to cancel tx3.
+	if err := waitForPending(txs, "t1 where1", 4); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cancel tx3.
+	cancel3()
+	if got := <-txDone; got != 3 {
+		t.Fatalf("tx3 should have been unblocked after the cancel: %v", got)
 	}
 	// Finish tx1.
 	done1()
-	// Wait for tx3.
-	if got := <-txDone; got != 3 {
+	// Wait for tx4.
+	if got := <-txDone; got != 4 {
 		t.Fatalf("wrong tx was unblocked after tx1: %v", got)
 	}
-
 	wg.Wait()
+	// Finish tx2 (the last transaction) which will delete the queue object.
+	done2()
 
 	if txs.queues["t1 where1"] != nil {
 		t.Fatal("queue object was not deleted after last transaction")
 	}
 
-	// 3 total transactions get recorded.
-	if err := testHTTPHandler(txs, 3); err != nil {
+	// 4 total transactions get recorded.
+	if err := testHTTPHandler(txs, 4); err != nil {
 		t.Fatal(err)
 	}
 	// 2 of them had to wait.
@@ -235,7 +314,7 @@ func TestTxSerializerCancel(t *testing.T) {
 // the two concurrent transactions for the same key.
 func TestTxSerializerDryRun(t *testing.T) {
 	resetVariables()
-	txs := New(true, 1, 2)
+	txs := New(true, 1, 2, 1)
 
 	// tx1.
 	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -300,7 +379,7 @@ func TestTxSerializerDryRun(t *testing.T) {
 // reject transactions although they may succeed within the txpool constraints
 // and RPC deadline.
 func TestTxSerializerGlobalQueueOverflow(t *testing.T) {
-	txs := New(false, 1, 1 /* maxGlobalQueueSize */)
+	txs := New(false, 1, 1 /* maxGlobalQueueSize */, 1)
 
 	// tx1.
 	done1, waited1, err1 := txs.Wait(context.Background(), "t1 where1", "t1")
@@ -337,7 +416,7 @@ func TestTxSerializerGlobalQueueOverflow(t *testing.T) {
 }
 
 func TestTxSerializerPending(t *testing.T) {
-	txs := New(false, 1, 1)
+	txs := New(false, 1, 1, 1)
 	if got, want := txs.Pending("t1 where1"), 0; got != want {
 		t.Fatalf("there should be no pending transaction: got = %v, want = %v", got, want)
 	}


### PR DESCRIPTION
By default, we will allow up to 5 transactions through to the tx pool to have a better pipelining effect and ensure that MySQL is always busy.

Sugu, I recommend to review this change one commit at a time. Some guidance:

* Commit 1 is the code which you already reviewed internally.
* Commit 2 adds an integration test (new).
* Commit 3 changes the channel semantics from pull to push as you suggested during the internal code review.
* Commit 4 defers the channel creation as an optimization.