### PR TITLE
Ensure vtctlclient has a -server parameter and provide a clear message

### DIFF
--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"os"
 	"time"
@@ -44,6 +45,12 @@ func main() {
 	flag.Parse()
 
 	logger := logutil.NewConsoleLogger()
+
+	// We can't do much without a -server flag
+	if *server == "" {
+		log.Error(errors.New("Please specify -server <vtctld_host:vtctld_port> to specify the vtctld server to connect to"))
+		os.Exit(1)
+	}
 
 	err := vtctlclient.RunCommandAndWait(
 		context.Background(), *server, flag.Args(),


### PR DESCRIPTION
Currently if you do not provide a -server parameter vtctlclient tries to connect somewhere and may take some time to timeout (trying to send all the command line parameters).  The code now checks that at least the `-server` parameter is specified and gives a clearer warning if not.

```
[vitess@myhost ~/dev/src/github.com/youtube/vitess/go/cmd/vtctlclient]$ ./vtctlclient
E0901 06:16:06.558743   48376 main.go:51] Please specify -server <vtctld_host:vtctld_port> to specify the vtctld server to connect to
```