### PR TITLE
go/vitessdriver: Implement time.Time native conversion

### DIFF
--- a/go/sqltypes/arithmetic.go
+++ b/go/sqltypes/arithmetic.go
@@ -223,6 +223,13 @@ func ToFloat64(v Value) (float64, error) {
 // ToNative converts Value to a native go type.
 // Decimal is returned as []byte.
 func ToNative(v Value) (interface{}, error) {
+	return ToNativeEx(v, DefaultNativeOptions)
+}
+
+// ToNativeEx converts Value to a native go type with the
+// given conversion options.
+// Decimal is returned as []byte.
+func ToNativeEx(v Value, opts *NativeOptions) (interface{}, error) {
 	var out interface{}
 	var err error
 	switch {
@@ -234,6 +241,10 @@ func ToNative(v Value) (interface{}, error) {
 		return ToUint64(v)
 	case v.IsFloat():
 		return ToFloat64(v)
+	case opts.ConvertDatetime && v.Type() == Date:
+		return DateToNative(v, opts.DefaultLocation)
+	case opts.ConvertDatetime && v.Type() == Datetime:
+		return DatetimeToNative(v, opts.DefaultLocation)
 	case v.IsQuoted() || v.Type() == Decimal:
 		out = v.val
 	case v.Type() == Expression:

--- a/go/sqltypes/bind_variables.go
+++ b/go/sqltypes/bind_variables.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 
@@ -81,6 +82,11 @@ func BytesBindVariable(v []byte) *querypb.BindVariable {
 	return &querypb.BindVariable{Type: VarBinary, Value: v}
 }
 
+// DatetimeBindVariable converts a time.Time to a bind var.
+func DatetimeBindVariable(t time.Time) *querypb.BindVariable {
+	return ValueBindVariable(NewDatetime(t))
+}
+
 // ValueBindVariable converts a Value to a bind var.
 func ValueBindVariable(v Value) *querypb.BindVariable {
 	return &querypb.BindVariable{Type: v.typ, Value: v.val}
@@ -106,6 +112,8 @@ func BuildBindVariable(v interface{}) (*querypb.BindVariable, error) {
 		return Float64BindVariable(v), nil
 	case nil:
 		return NullBindVariable, nil
+	case time.Time:
+		return DatetimeBindVariable(v), nil
 	case Value:
 		return ValueBindVariable(v), nil
 	case *querypb.BindVariable:

--- a/go/sqltypes/bind_variables_test.go
+++ b/go/sqltypes/bind_variables_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 
@@ -227,6 +228,12 @@ func TestBuildBindVariable(t *testing.T) {
 	}, {
 		in:  []interface{}{1, byte(1)},
 		err: "type uint8 not supported as bind var: 1",
+	}, {
+		in: time.Date(1999, 5, 1, 19, 30, 0, 0, time.UTC),
+		out: &querypb.BindVariable{
+			Type:  querypb.Type_DATETIME,
+			Value: []byte("1999-05-01 19:30:00"),
+		},
 	}}
 	for _, tcase := range tcases {
 		bv, err := BuildBindVariable(tcase.in)

--- a/go/sqltypes/time.go
+++ b/go/sqltypes/time.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrInvalidTime is returned when we fail to parse a datetime
+// string from MySQL. This should never happen unless things are
+// seriously messed up.
+var ErrInvalidTime = errors.New("invalid MySQL time string")
+
+var isoTimeFormat = "2006-01-02 15:04:05.999999"
+var isoNullTime = "0000-00-00 00:00:00.000000"
+var isoTimeLength = len(isoTimeFormat)
+
+// parseISOTime pases a time string in MySQL's textual datetime format.
+// This is very similar to ISO8601, with some differences:
+//
+// - There is no T separator between the date and time sections;
+//   a space is used instead.
+// - There is never a timezone section in the string, as these datetimes
+//   are not timezone-aware. There isn't a Z value for UTC times for
+//   the same reason.
+//
+// Note that this function can handle both DATE (which should _always_ have
+// a length of 10) and DATETIME strings (which have a variable length, 18+
+// depending on the number of decimal sub-second places).
+//
+// Also note that this function handles the case where MySQL returns a NULL
+// time (with a string where all sections are zeroes) by returning a zeroed
+// out time.Time object. NULL time strings are not considered a parsing error.
+//
+// See: isoTimeFormat
+func parseISOTime(tstr string, loc *time.Location, minLen, maxLen int) (t time.Time, err error) {
+	tlen := len(tstr)
+	if tlen < minLen || tlen > maxLen {
+		err = ErrInvalidTime
+		return
+	}
+
+	if tstr == isoNullTime[:tlen] {
+		// This is what MySQL would send when the date is NULL,
+		// so return an empty time.Time instead.
+		// This is not a parsing error
+		return
+	}
+
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	// Since the time format returned from MySQL never has a Timezone
+	// section, ParseInLocation will initialize the time.Time struct
+	// with the default `loc` we're passing here.
+	return time.ParseInLocation(isoTimeFormat[:tlen], tstr, loc)
+}
+
+func checkTimeFormat(t string) (err error) {
+	// Valid format string offsets for any ISO time from MySQL:
+	//  |DATETIME |10      |19+
+	//  |---------|--------|
+	// "2006-01-02 15:04:05.999999"
+	_, err = parseISOTime(t, time.UTC, 10, isoTimeLength)
+	return
+}
+
+// DatetimeToNative converts a Datetime Value into a time.Time
+func DatetimeToNative(v Value, loc *time.Location) (time.Time, error) {
+	// Valid format string offsets for a DATETIME
+	//  |DATETIME          |19+
+	//  |------------------|------|
+	// "2006-01-02 15:04:05.999999"
+	return parseISOTime(v.ToString(), loc, 19, isoTimeLength)
+}
+
+// DateToNative converts a Date Value into a time.Time.
+// Note that there's no specific type in the Go stdlib to represent
+// dates without time components, so the returned Time will have
+// their hours/mins/seconds zeroed out.
+func DateToNative(v Value, loc *time.Location) (time.Time, error) {
+	// Valid format string offsets for a DATE
+	//  |DATE     |10
+	//  |---------|
+	// "2006-01-02 15:04:05.999999"
+	return parseISOTime(v.ToString(), loc, 10, 10)
+}
+
+// NewDatetime builds a Datetime Value
+func NewDatetime(t time.Time) Value {
+	return MakeTrusted(Datetime, []byte(t.Format(isoTimeFormat)))
+}

--- a/go/sqltypes/time_test.go
+++ b/go/sqltypes/time_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqltypes
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+var randomLocation = time.FixedZone("Nowhere", 3*60*60)
+
+func TestDatetimeToNative(t *testing.T) {
+
+	tcases := []struct {
+		val Value
+		loc *time.Location
+		out time.Time
+		err bool
+	}{{
+		val: TestValue(Datetime, "1899-08-24 17:20:00"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: TestValue(Datetime, "1952-03-11 01:02:03"),
+		loc: time.Local,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, time.Local),
+	}, {
+		val: TestValue(Datetime, "1952-03-11 01:02:03"),
+		loc: randomLocation,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, randomLocation),
+	}, {
+		val: TestValue(Datetime, "1952-03-11 01:02:03"),
+		loc: time.UTC,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, time.UTC),
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.000000"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.000001"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(1*time.Microsecond), time.UTC),
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.123456"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(123456*time.Microsecond), time.UTC),
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.222"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(222*time.Millisecond), time.UTC),
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.1234567"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00.1"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(100*time.Millisecond), time.UTC),
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00"),
+		out: time.Time{},
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00.0"),
+		out: time.Time{},
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00.000"),
+		out: time.Time{},
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00.000000"),
+		out: time.Time{},
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00.0000000"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24T17:20:00.000000"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-02-31 17:20:00.000000"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00."),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00.000001"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00 +02:00"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "This is not a valid timestamp"),
+		err: true,
+	}}
+
+	for _, tcase := range tcases {
+		got, err := DatetimeToNative(tcase.val, tcase.loc)
+		if tcase.err && err == nil {
+			t.Errorf("DatetimeToNative(%v, %#v) succeeded; expected error", printValue(tcase.val), tcase.loc)
+		}
+		if !tcase.err && err != nil {
+			t.Errorf("DatetimeToNative(%v, %#v) failed: %v", printValue(tcase.val), tcase.loc, err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("DatetimeToNative(%v, %#v): %v, want %v", printValue(tcase.val), tcase.loc, got, tcase.out)
+		}
+	}
+}
+
+func TestDateToNative(t *testing.T) {
+	tcases := []struct {
+		val Value
+		loc *time.Location
+		out time.Time
+		err bool
+	}{{
+		val: TestValue(Datetime, "1899-08-24"),
+		out: time.Date(1899, 8, 24, 0, 0, 0, 0, time.UTC),
+	}, {
+		val: TestValue(Datetime, "1952-03-11"),
+		loc: time.Local,
+		out: time.Date(1952, 3, 11, 0, 0, 0, 0, time.Local),
+	}, {
+		val: TestValue(Datetime, "1952-03-11"),
+		loc: randomLocation,
+		out: time.Date(1952, 3, 11, 0, 0, 0, 0, randomLocation),
+	}, {
+		val: TestValue(Datetime, "0000-00-00"),
+		out: time.Time{},
+	}, {
+		val: TestValue(Datetime, "1899-02-31"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "1899-08-24 17:20:00"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "0000-00-00 00:00:00"),
+		err: true,
+	}, {
+		val: TestValue(Datetime, "This is not a valid timestamp"),
+		err: true,
+	}}
+
+	for _, tcase := range tcases {
+		got, err := DateToNative(tcase.val, tcase.loc)
+		if tcase.err && err == nil {
+			t.Errorf("DateToNative(%v, %#v) succeeded; expected error", printValue(tcase.val), tcase.loc)
+		}
+		if !tcase.err && err != nil {
+			t.Errorf("DateToNative(%v, %#v) failed: %v", printValue(tcase.val), tcase.loc, err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("DateToNative(%v, %#v): %v, want %v", printValue(tcase.val), tcase.loc, got, tcase.out)
+		}
+	}
+}

--- a/go/vt/vitessdriver/driver_go18.go
+++ b/go/vt/vitessdriver/driver_go18.go
@@ -80,14 +80,14 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		if err != nil {
 			return nil, err
 		}
-		return newStreamingRows(stream, nil), nil
+		return newStreamingRows(stream, nil, c.native), nil
 	}
 
 	qr, err := c.session.Execute(ctx, query, bv)
 	if err != nil {
 		return nil, err
 	}
-	return newRows(qr), nil
+	return newRows(qr, c.native), nil
 }
 
 func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -27,6 +27,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 )
 
@@ -58,6 +59,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpen(t *testing.T) {
+	locationPST, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+
 	var testcases = []struct {
 		desc    string
 		connStr string
@@ -71,6 +77,9 @@ func TestOpen(t *testing.T) {
 					Target:  "@replica",
 					Timeout: 30 * time.Second,
 				},
+				native: &sqltypes.NativeOptions{
+					DefaultLocation: time.UTC,
+				},
 			},
 		},
 		{
@@ -79,6 +88,9 @@ func TestOpen(t *testing.T) {
 			conn: &conn{
 				Configuration: Configuration{
 					Timeout: 30 * time.Second,
+				},
+				native: &sqltypes.NativeOptions{
+					DefaultLocation: time.UTC,
 				},
 			},
 		},
@@ -90,6 +102,40 @@ func TestOpen(t *testing.T) {
 					Protocol: "grpc",
 					Target:   "ks:0@replica",
 					Timeout:  30 * time.Second,
+				},
+				native: &sqltypes.NativeOptions{
+					DefaultLocation: time.UTC,
+				},
+			},
+		},
+		{
+			desc:    "Open() with native conversion options",
+			connStr: fmt.Sprintf(`{"address": "%s", "timeout": %d, "convertdatetime": true}`, testAddress, int64(30*time.Second)),
+			conn: &conn{
+				Configuration: Configuration{
+					Timeout:         30 * time.Second,
+					ConvertDatetime: true,
+				},
+				native: &sqltypes.NativeOptions{
+					ConvertDatetime: true,
+					DefaultLocation: time.UTC,
+				},
+			},
+		},
+		{
+			desc: "Open() with custom timezone",
+			connStr: fmt.Sprintf(
+				`{"address": "%s", "timeout": %d, "convertdatetime": true, "defaultlocation": "America/Los_Angeles"}`,
+				testAddress, int64(30*time.Second)),
+			conn: &conn{
+				Configuration: Configuration{
+					Timeout:         30 * time.Second,
+					ConvertDatetime: true,
+					DefaultLocation: "America/Los_Angeles",
+				},
+				native: &sqltypes.NativeOptions{
+					ConvertDatetime: true,
+					DefaultLocation: locationPST,
 				},
 			},
 		},
@@ -173,12 +219,14 @@ func TestExec(t *testing.T) {
 
 func TestConfigurationToJSON(t *testing.T) {
 	config := Configuration{
-		Protocol:  "some-invalid-protocol",
-		Target:    "ks2",
-		Streaming: true,
-		Timeout:   1 * time.Second,
+		Protocol:        "some-invalid-protocol",
+		Target:          "ks2",
+		Streaming:       true,
+		Timeout:         1 * time.Second,
+		ConvertDatetime: true,
+		DefaultLocation: "Local",
 	}
-	want := `{"Protocol":"some-invalid-protocol","Address":"","Target":"ks2","Streaming":true,"Timeout":1000000000}`
+	want := `{"Protocol":"some-invalid-protocol","Address":"","Target":"ks2","Streaming":true,"Timeout":1000000000,"ConvertDatetime":true,"DefaultLocation":"Local"}`
 
 	json, err := config.toJSON()
 	if err != nil {
@@ -308,6 +356,169 @@ func TestQuery(t *testing.T) {
 		}
 		if err == nil || !strings.Contains(err.Error(), want) {
 			t.Errorf("%v: err: %v, does not contain %s", tc.desc, err, want)
+		}
+	}
+}
+
+func TestDatetimeQuery(t *testing.T) {
+	var testcases = []struct {
+		desc        string
+		config      Configuration
+		requestName string
+	}{
+		{
+			desc: "datetime & date, vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				ConvertDatetime: true,
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date (local timezone), vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				ConvertDatetime: true,
+				DefaultLocation: "Local",
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date (no conversion), vtgate",
+			config: Configuration{
+				Protocol: "grpc",
+				Address:  testAddress,
+				Target:   "@rdonly",
+				Timeout:  30 * time.Second,
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date, streaming, vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				Streaming:       true,
+				ConvertDatetime: true,
+			},
+			requestName: "requestDates",
+		},
+	}
+
+	for _, tc := range testcases {
+		db, err := OpenWithConfiguration(tc.config)
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer db.Close()
+
+		s, err := db.Prepare(tc.requestName)
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer s.Close()
+
+		r, err := s.Query(time.Time{})
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer r.Close()
+
+		cols, err := r.Columns()
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		wantCols := []string{
+			"fieldDatetime",
+			"fieldDate",
+		}
+		if !reflect.DeepEqual(cols, wantCols) {
+			t.Errorf("%v: cols: %v, want %v", tc.desc, cols, wantCols)
+		}
+
+		location := time.UTC
+		if tc.config.DefaultLocation != "" {
+			location, err = time.LoadLocation(tc.config.DefaultLocation)
+			if err != nil {
+				t.Errorf("%v: %v", tc.desc, err)
+			}
+		}
+
+		count := 0
+		wantValues := []struct {
+			fieldDatetime time.Time
+			fieldDate     time.Time
+		}{{
+			time.Date(2009, 3, 29, 17, 22, 11, 0, location),
+			time.Date(2006, 7, 2, 0, 0, 0, 0, location),
+		}, {
+			time.Time{},
+			time.Time{},
+		}}
+
+		rawValues := []struct {
+			fieldDatetime string
+			fieldDate     string
+		}{{
+			"2009-03-29 17:22:11",
+			"2006-07-02",
+		}, {
+			"0000-00-00 00:00:00",
+			"0000-00-00",
+		}}
+
+		if tc.config.ConvertDatetime {
+			for r.Next() {
+				var fieldDatetime time.Time
+				var fieldDate time.Time
+				err := r.Scan(&fieldDatetime, &fieldDate)
+				if err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+				if want := wantValues[count].fieldDatetime; fieldDatetime != want {
+					t.Errorf("%v: wrong value for fieldDatetime: got: %v want: %v", tc.desc, fieldDatetime, want)
+				}
+				if want := wantValues[count].fieldDate; fieldDate != want {
+					t.Errorf("%v: wrong value for fieldDate: got: %v want: %v", tc.desc, fieldDate, want)
+				}
+				count++
+			}
+		} else {
+			for r.Next() {
+				var t1, t2 time.Time
+				var fieldDatetime []byte
+				var fieldDate []byte
+
+				err := r.Scan(&t1, &t2)
+				if err == nil {
+					t.Errorf("%v: storing driver.Value into time.Time should be unsupported", tc.desc)
+				}
+
+				err = r.Scan(&fieldDatetime, &fieldDate)
+				if err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+				if want := rawValues[count].fieldDatetime; string(fieldDatetime) != want {
+					t.Errorf("%v: wrong value for fieldDatetime: got: %v want: %v", tc.desc, fieldDatetime, want)
+				}
+				if want := rawValues[count].fieldDate; string(fieldDate) != want {
+					t.Errorf("%v: wrong value for fieldDate: got: %v want: %v", tc.desc, fieldDate, want)
+				}
+
+				count++
+			}
+		}
+
+		if count != len(wantValues) {
+			t.Errorf("%v: count: %d, want %d", tc.desc, count, len(wantValues))
 		}
 	}
 }

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
@@ -271,6 +272,19 @@ var execMap = map[string]struct {
 		result:  &result1,
 		session: nil,
 	},
+	"requestDates": {
+		execQuery: &queryExecute{
+			SQL: "requestDates",
+			BindVariables: map[string]*querypb.BindVariable{
+				"v1": sqltypes.DatetimeBindVariable(time.Time{}),
+			},
+			Session: &vtgatepb.Session{
+				TargetString: "@rdonly",
+			},
+		},
+		result:  &result2,
+		session: nil,
+	},
 	"txRequest": {
 		execQuery: &queryExecute{
 			SQL: "txRequest",
@@ -335,6 +349,31 @@ var result1 = sqltypes.Result{
 		{
 			sqltypes.NewVarBinary("2"),
 			sqltypes.NewVarBinary("value2"),
+		},
+	},
+}
+
+var result2 = sqltypes.Result{
+	Fields: []*querypb.Field{
+		{
+			Name: "fieldDatetime",
+			Type: sqltypes.Datetime,
+		},
+		{
+			Name: "fieldDate",
+			Type: sqltypes.Date,
+		},
+	},
+	RowsAffected: 42,
+	InsertID:     73,
+	Rows: [][]sqltypes.Value{
+		{
+			sqltypes.NewVarBinary("2009-03-29 17:22:11"),
+			sqltypes.NewVarBinary("2006-07-02"),
+		},
+		{
+			sqltypes.NewVarBinary("0000-00-00 00:00:00"),
+			sqltypes.NewVarBinary("0000-00-00"),
 		},
 	},
 }

--- a/go/vt/vitessdriver/rows_test.go
+++ b/go/vt/vitessdriver/rows_test.go
@@ -84,7 +84,7 @@ func logMismatchedTypes(t *testing.T, gotRow, wantRow []driver.Value) {
 }
 
 func TestRows(t *testing.T) {
-	ri := newRows(&rowsResult1)
+	ri := newRows(&rowsResult1, sqltypes.DefaultNativeOptions)
 	wantCols := []string{
 		"field1",
 		"field2",

--- a/go/vt/vitessdriver/streaming_rows.go
+++ b/go/vt/vitessdriver/streaming_rows.go
@@ -35,13 +35,15 @@ type streamingRows struct {
 	qr     *sqltypes.Result
 	index  int
 	cancel context.CancelFunc
+	native *sqltypes.NativeOptions
 }
 
 // newStreamingRows creates a new streamingRows from stream.
-func newStreamingRows(stream sqltypes.ResultStream, cancel context.CancelFunc) driver.Rows {
+func newStreamingRows(stream sqltypes.ResultStream, cancel context.CancelFunc, opts *sqltypes.NativeOptions) driver.Rows {
 	return &streamingRows{
 		stream: stream,
 		cancel: cancel,
+		native: opts,
 	}
 }
 
@@ -84,7 +86,7 @@ func (ri *streamingRows) Next(dest []driver.Value) error {
 		ri.qr = qr
 		ri.index = 0
 	}
-	populateRow(dest, ri.qr.Rows[ri.index])
+	populateRow(dest, ri.qr.Rows[ri.index], ri.native)
 	ri.index++
 	return nil
 }

--- a/go/vt/vitessdriver/streaming_rows_test.go
+++ b/go/vt/vitessdriver/streaming_rows_test.go
@@ -84,7 +84,7 @@ func TestStreamingRows(t *testing.T) {
 	c <- &packet2
 	c <- &packet3
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil, sqltypes.DefaultNativeOptions)
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -136,7 +136,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 	c <- &packet2
 	c <- &packet3
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil, sqltypes.DefaultNativeOptions)
 	defer ri.Close()
 
 	wantRow := []driver.Value{
@@ -169,7 +169,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 func TestStreamingRowsError(t *testing.T) {
 	c := make(chan *sqltypes.Result)
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: errors.New("error before fields")}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: errors.New("error before fields")}, nil, sqltypes.DefaultNativeOptions)
 
 	gotCols := ri.Columns()
 	if gotCols != nil {
@@ -186,7 +186,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c = make(chan *sqltypes.Result, 1)
 	c <- &packet1
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after fields")}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after fields")}, nil, sqltypes.DefaultNativeOptions)
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -213,7 +213,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c <- &packet1
 	c <- &packet2
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after rows")}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after rows")}, nil, sqltypes.DefaultNativeOptions)
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	if err != nil {
@@ -229,7 +229,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c = make(chan *sqltypes.Result, 1)
 	c <- &packet2
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: io.EOF}, nil, sqltypes.DefaultNativeOptions)
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	wantErr = "first packet did not return fields"


### PR DESCRIPTION
Hey everyone!

So I got this awful legacy app going (let's call it "G-I Thub") where pretty much every MySQL table has a `DATETIME` column. We're trying to sprinkle some Vitess on it (starting with the Golang services that connect to the main MySQL clusters), but the lack of `time.Time` support in the Vitess driver is making A/B testing very difficult!

This PR implements `time.Time` support in a very similar way to what the mainstream `go-sql-driver/mysql` driver does: the functionality is hidden behind a feature flag and disabled by default, as to ensure there are no backwards compatibility issues.

Full details in the commit message, inlined below:

````
This commit adds native time.Time support for the Vitess Golang driver.

It allows users of the driver to use `time.Time` values as bind
variables in queries and prepared statements, and (optionally) to Scan
MySQL DATETIME and DATE columns into `time.Time` objects.

The implementation follows a very similar interface as the mainstream
"plain MySQL" Go driver, `go-sql-driver/mysql`, wherein scanning
date/time values into `time.Time` is _not_ enabled by default, and needs
a specific flag in the configuration for the driver to enable this
feature. (The MySQL driver adds this flag as part of the DSN -- here it
is implemented as part of the Configuration struct).

This approach should result in a 100% functionally identical driver
behavior as before when the flag is not set. The tests for the driver
have been modified accordingly to attempt to verify this.

Besides the flag to toggle this new behavior, another config option has
been added to Configuration to let the user choose the default timezone
for the time.Time values which the driver generates. Although inelegant,
this is pretty much a hard requirement as DATETIME and DATE columns in
MySQL are not timezone aware. This also follows the design of the
mainstream MySQL driver.

The meat of the implementation happens in the `sqltypes` package, where
a new `time.go` file has been added to contain all the time-related
functionality. The previously mentioned conversion settings have been
implemented in the `sqltypes.NativeOptions` struct, with the hopeful
goal it could also be used in the future to further tune some of the
conversion options for other MySQL data (such as Decimal).

Special care has been taken not to break any of the public interfaces in
the `sqltypes` package.
````

That's pretty much it. I'd very much like to hear if you think this approach is acceptable, or if you'd consider merging a different implementation.

Cheerios!