### PR TITLE
v3: fix regression in aggregate handling

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -272,6 +272,51 @@
   }
 }
 
+# group by a unique vindex should revert to simple route, even if aggr is complex
+"select id, 1+count(*) from user group by id"
+{
+  "Original": "select id, 1+count(*) from user group by id",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id, 1 + count(*) from user group by id",
+    "FieldQuery": "select id, 1 + count(*) from user where 1 != 1 group by id"
+  }
+}
+
+# group by a unique vindex where expression is qualified (alias should be ignored)
+"select val as id, 1+count(*) from user group by user.id"
+{
+  "Original": "select val as id, 1+count(*) from user group by user.id",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select val as id, 1 + count(*) from user group by user.id",
+    "FieldQuery": "select val as id, 1 + count(*) from user where 1 != 1 group by user.id"
+  }
+}
+
+# group by a unique vindex where it should skip non-aliasex expressions.
+"select *, id, 1+count(*) from user group by id"
+{
+  "Original": "select *, id, 1+count(*) from user group by id",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select *, id, 1 + count(*) from user group by id",
+    "FieldQuery": "select *, id, 1 + count(*) from user where 1 != 1 group by id"
+  }
+}
+
 # group by a unique vindex should revert to simple route, and having clause should find the correct symbols.
 "select id, count(*) c from user group by id having id=1 and c=10"
 {
@@ -826,3 +871,11 @@
       "Values":[5]
    }
 }
+
+# Group by invalid column number (code is duplicated from symab).
+"select id from user group by 1.1"
+"column number is not an int"
+
+# Group by out of range column number (code is duplicated from symab).
+"select id from user group by 2"
+"column number out of range: 2"

--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -257,7 +257,7 @@
   }
 }
 
-# group by a unique vindex should revert to simple route
+# group by a unique vindex should use a simple route
 "select id, count(*) from user group by id"
 {
   "Original": "select id, count(*) from user group by id",
@@ -272,7 +272,86 @@
   }
 }
 
-# group by a unique vindex should revert to simple route, even if aggr is complex
+# group by a unique vindex and other column should use a simple route
+"select id, col, count(*) from user group by id, col"
+{
+  "Original": "select id, col, count(*) from user group by id, col",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id, col, count(*) from user group by id, col",
+    "FieldQuery": "select id, col, count(*) from user where 1 != 1 group by id, col"
+  }
+}
+
+# group by a non-vindex column should use an OrderdAggregate primitive
+"select col, count(*) from user group by col"
+{
+  "Original": "select col, count(*) from user group by col",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 1
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select col, count(*) from user group by col order by col asc",
+      "FieldQuery": "select col, count(*) from user where 1 != 1 group by col",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# group by a non-unique vindex column should use an OrderdAggregate primitive
+"select name, count(*) from user group by name"
+{
+  "Original": "select name, count(*) from user group by name",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 1
+      }
+    ],
+    "Keys": [
+      0
+    ],
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select name, count(*) from user group by name order by name asc",
+      "FieldQuery": "select name, count(*) from user where 1 != 1 group by name",
+      "OrderBy": [
+        {
+          "Col": 0,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
+# group by a unique vindex should use a simple route, even if aggr is complex
 "select id, 1+count(*) from user group by id"
 {
   "Original": "select id, 1+count(*) from user group by id",
@@ -284,6 +363,21 @@
     },
     "Query": "select id, 1 + count(*) from user group by id",
     "FieldQuery": "select id, 1 + count(*) from user where 1 != 1 group by id"
+  }
+}
+
+# group by a unique vindex where alias from select list is used
+"select id as val, 1+count(*) from user group by val"
+{
+  "Original": "select id as val, 1+count(*) from user group by val",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select id as val, 1 + count(*) from user group by val",
+    "FieldQuery": "select id as val, 1 + count(*) from user where 1 != 1 group by val"
   }
 }
 
@@ -302,7 +396,7 @@
   }
 }
 
-# group by a unique vindex where it should skip non-aliasex expressions.
+# group by a unique vindex where it should skip non-aliased expressions.
 "select *, id, 1+count(*) from user group by id"
 {
   "Original": "select *, id, 1+count(*) from user group by id",

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -123,6 +123,10 @@
 "select * from user join user_extra"
 "unsupported: '*' expression in cross-shard query"
 
+# Group by column number, used with non-aliased expression (duplicated code)
+"select * from user group by 1"
+"unsupported: '*' expression in cross-shard query"
+
 # Filtering on scatter aggregates
 "select count(*) a from user having a >10"
 "unsupported: filtering on results of aggregates"

--- a/go/vt/vtgate/planbuilder/ordered_aggregate.go
+++ b/go/vt/vtgate/planbuilder/ordered_aggregate.go
@@ -149,7 +149,7 @@ func nodeHasAggregates(node sqlparser.SQLNode) bool {
 	return hasAggregates
 }
 
-// groupbyHaUniqueVindex looks ahead at the group by expression to see if
+// groupbyHasUniqueVindex looks ahead at the group by expression to see if
 // it references a unique vindex.
 //
 // The vitess group by rules are different from MySQL because it's not possible

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -392,9 +392,9 @@ func (rb *route) MakeDistinct() error {
 }
 
 // SetGroupBy sets the GROUP BY clause for the route.
-func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) (builder, error) {
+func (rb *route) SetGroupBy(groupBy sqlparser.GroupBy) error {
 	rb.Select.(*sqlparser.Select).GroupBy = groupBy
-	return rb, nil
+	return nil
 }
 
 // PushOrderBy sets the order by for the route.

--- a/go/vt/vtgate/planbuilder/select.go
+++ b/go/vt/vtgate/planbuilder/select.go
@@ -127,8 +127,7 @@ func pushSelectExprs(sel *sqlparser.Select, bldr builder) (builder, error) {
 	}
 	bldr.Symtab().ResultColumns = resultColumns
 
-	bldr, err = pushGroupBy(sel, bldr)
-	if err != nil {
+	if err := pushGroupBy(sel, bldr); err != nil {
 		return nil, err
 	}
 	return bldr, nil


### PR DESCRIPTION
@rnavarro @demmer @bbeaudreault @mberlin-bot This needs urgent review because it's blocking StitchLabs rollout. Using a private test, I've verified that the previously failing query from StitchLabs passes.

The recent v3 scatter aggregates feature introduced a regression:
If there is a complex aggregate expression, but the group by
references a unique vindex, then it fails the query as unsupported.

The fix was tricky because the newer code creates the OrderedAggregate
primitive upfront, and then it gets dissolved later if a group
by was found referencing a unique vindex. But this was possible
only for non-complex expressions where the OA primitive could
represent them.

The newer code instead looks ahead into the group by first.
If a unique vindex is found, then no OA is created. So, complex
expressions can be freely pushed down into the route. This complicates
the look-ahead code because it has to do it without disturbing
the symbol table. But it also simplifies the OA code a bit because
there's no need to dissolve it in the future. The execution tree
is essentially fixed upfront.