### PR TITLE
two minor logging changes

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -51,6 +51,7 @@ import (
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
+	"github.com/youtube/vitess/go/vt/topotools"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletconn"
 	"golang.org/x/net/context"
@@ -477,7 +478,8 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 	// initial message), we want to log it, and maybe advertise it too.
 	if hcc.tabletStats.Target.TabletType != topodatapb.TabletType_UNKNOWN && hcc.tabletStats.Target.TabletType != shr.Target.TabletType {
 		// Log and maybe notify
-		log.Infof("HealthCheckUpdate(Type Change): %v, tablet: %v/%+v, target %+v => %+v, reparent time: %v", oldTs.Name, oldTs.Tablet.Alias.Cell, oldTs.Tablet, oldTs.Target, shr.Target, shr.TabletExternallyReparentedTimestamp)
+		log.Infof("HealthCheckUpdate(Type Change): %v, tablet: %s, target %+v => %+v, reparent time: %v",
+			oldTs.Name, topotools.TabletIdent(oldTs.Tablet), topotools.TargetIdent(oldTs.Target), topotools.TargetIdent(shr.Target), shr.TabletExternallyReparentedTimestamp)
 		if hc.listener != nil && hc.sendDownEvents {
 			oldTs.Up = false
 			hc.listener.StatsUpdate(&oldTs)

--- a/go/vt/discovery/tablet_stats_cache.go
+++ b/go/vt/discovery/tablet_stats_cache.go
@@ -196,12 +196,12 @@ func (tc *TabletStatsCache) StatsUpdate(ts *TabletStats) {
 			// We already have one up server, see if we
 			// need to replace it.
 			if ts.TabletExternallyReparentedTimestamp < e.healthy[0].TabletExternallyReparentedTimestamp {
-				log.Warningf("not marking healthy master as Up because its externally reparented timestamp is smaller than the highest known timestamp from previous MASTERs: %d < %d ",
-					ts.TabletExternallyReparentedTimestamp,
-					e.healthy[0].TabletExternallyReparentedTimestamp,
-					topoproto.KeyspaceShardString(ts.Target.Keyspace, ts.Target.Shard),
+				log.Warningf("not marking healthy master %s as Up for %s because its externally reparented timestamp is smaller than the highest known timestamp from previous MASTERs %s: %d < %d ",
 					topoproto.TabletAliasString(ts.Tablet.Alias),
-					topoproto.TabletAliasString(e.healthy[0].Tablet.Alias))
+					topoproto.KeyspaceShardString(ts.Target.Keyspace, ts.Target.Shard),
+					topoproto.TabletAliasString(e.healthy[0].Tablet.Alias),
+					ts.TabletExternallyReparentedTimestamp,
+					e.healthy[0].TabletExternallyReparentedTimestamp)
 				return
 			}
 

--- a/go/vt/topotools/tablet.go
+++ b/go/vt/topotools/tablet.go
@@ -44,6 +44,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
@@ -112,4 +113,9 @@ func TabletIdent(tablet *topodatapb.Tablet) string {
 	}
 
 	return fmt.Sprintf("%s-%d (%s%s)", tablet.Alias.Cell, tablet.Alias.Uid, tablet.Hostname, tagStr)
+}
+
+// TargetIdent returns a concise string representation of a query target
+func TargetIdent(target *querypb.Target) string {
+	return fmt.Sprintf("%s/%s (%s)", target.Keyspace, target.Shard, target.TabletType)
 }


### PR DESCRIPTION
Make the logging in `HealthCheckUpdate` more concise by leveraging the previously added `TabletIdent` string representation and adding an analogous function for concisely identifying a shard `Target`.

Along the way I happened to notice that the warning log added in #3084 didn't reference all the arguments in the format string, so I reworked the string so all the arguments are properly included.
