### PR TITLE
go/vitessdriver: Allow custom conversion settings

### DIFF
--- a/go/vt/vitessdriver/convert.go
+++ b/go/vt/vitessdriver/convert.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessdriver
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+type converter struct {
+	datetime bool
+	location *time.Location
+}
+
+func (cv *converter) ToNative(v sqltypes.Value) (interface{}, error) {
+	if cv.datetime {
+		switch v.Type() {
+		case sqltypes.Datetime:
+			return DatetimeToNative(v, cv.location)
+		case sqltypes.Date:
+			return DateToNative(v, cv.location)
+		}
+	}
+	return sqltypes.ToNative(v)
+}
+
+func (cv *converter) BuildBindVariable(v interface{}) (*querypb.BindVariable, error) {
+	if cv.datetime {
+		if t, ok := v.(time.Time); ok {
+			return sqltypes.ValueBindVariable(NewDatetime(t, cv.location)), nil
+		}
+	}
+	return sqltypes.BuildBindVariable(v)
+}
+
+// populateRow populates a row of data using the table's field descriptions.
+// The returned types for "dest" include the list from the interface
+// specification at https://golang.org/pkg/database/sql/driver/#Value
+// and in addition the type "uint64" for unsigned BIGINT MySQL records.
+func (cv *converter) populateRow(dest []driver.Value, row []sqltypes.Value) (err error) {
+	for i := range dest {
+		dest[i], err = cv.ToNative(row[i])
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (cv *converter) buildBindVars(args []driver.Value) (map[string]*querypb.BindVariable, error) {
+	bindVars := make(map[string]*querypb.BindVariable, len(args))
+	for i, v := range args {
+		bv, err := cv.BuildBindVariable(v)
+		if err != nil {
+			return nil, err
+		}
+		bindVars[fmt.Sprintf("v%d", i+1)] = bv
+	}
+	return bindVars, nil
+}
+
+func (cv *converter) bindVarsFromNamedValues(args []driver.NamedValue) (map[string]*querypb.BindVariable, error) {
+	bindVars := make(map[string]*querypb.BindVariable, len(args))
+	nameUsed := false
+	for i, v := range args {
+		bv, err := cv.BuildBindVariable(v.Value)
+		if err != nil {
+			return nil, err
+		}
+		if i == 0 {
+			// Determine if args are based on names or ordinals.
+			if v.Name != "" {
+				nameUsed = true
+			}
+		} else {
+			// Verify that there's no intermixing.
+			if nameUsed && v.Name == "" {
+				return nil, errNoIntermixing
+			}
+			if !nameUsed && v.Name != "" {
+				return nil, errNoIntermixing
+			}
+		}
+		if v.Name == "" {
+			bindVars[fmt.Sprintf("v%d", i+1)] = bv
+		} else {
+			if v.Name[0] == ':' || v.Name[0] == '@' {
+				bindVars[v.Name[1:]] = bv
+			} else {
+				bindVars[v.Name] = bv
+			}
+		}
+	}
+	return bindVars, nil
+}
+
+func newConverter(cfg *Configuration) (c *converter, err error) {
+	c = &converter{
+		datetime: cfg.ConvertDatetime,
+		location: time.UTC,
+	}
+	if cfg.DefaultLocation != "" {
+		c.location, err = time.LoadLocation(cfg.DefaultLocation)
+	}
+	return
+}

--- a/go/vt/vitessdriver/convert.go
+++ b/go/vt/vitessdriver/convert.go
@@ -26,27 +26,22 @@ import (
 )
 
 type converter struct {
-	datetime bool
 	location *time.Location
 }
 
 func (cv *converter) ToNative(v sqltypes.Value) (interface{}, error) {
-	if cv.datetime {
-		switch v.Type() {
-		case sqltypes.Datetime:
-			return DatetimeToNative(v, cv.location)
-		case sqltypes.Date:
-			return DateToNative(v, cv.location)
-		}
+	switch v.Type() {
+	case sqltypes.Datetime:
+		return DatetimeToNative(v, cv.location)
+	case sqltypes.Date:
+		return DateToNative(v, cv.location)
 	}
 	return sqltypes.ToNative(v)
 }
 
 func (cv *converter) BuildBindVariable(v interface{}) (*querypb.BindVariable, error) {
-	if cv.datetime {
-		if t, ok := v.(time.Time); ok {
-			return sqltypes.ValueBindVariable(NewDatetime(t, cv.location)), nil
-		}
+	if t, ok := v.(time.Time); ok {
+		return sqltypes.ValueBindVariable(NewDatetime(t, cv.location)), nil
 	}
 	return sqltypes.BuildBindVariable(v)
 }
@@ -114,7 +109,6 @@ func (cv *converter) bindVarsFromNamedValues(args []driver.NamedValue) (map[stri
 
 func newConverter(cfg *Configuration) (c *converter, err error) {
 	c = &converter{
-		datetime: cfg.ConvertDatetime,
 		location: time.UTC,
 	}
 	if cfg.DefaultLocation != "" {

--- a/go/vt/vitessdriver/convert_test.go
+++ b/go/vt/vitessdriver/convert_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessdriver
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+func TestToNative(t *testing.T) {
+	convertTime := &converter{
+		datetime: true,
+	}
+
+	convertTimeLocal := &converter{
+		datetime: true,
+		location: time.Local,
+	}
+
+	testcases := []struct {
+		convert *converter
+		in      sqltypes.Value
+		out     interface{}
+	}{{
+		convert: convertTime,
+		in:      sqltypes.TestValue(sqltypes.Int32, "1"),
+		out:     int64(1),
+	}, {
+		convert: convertTime,
+		in:      sqltypes.TestValue(sqltypes.Timestamp, "2012-02-24 23:19:43"),
+		out:     []byte("2012-02-24 23:19:43"), // TIMESTAMP is not handled
+	}, {
+		convert: convertTime,
+		in:      sqltypes.TestValue(sqltypes.Time, "23:19:43"),
+		out:     []byte("23:19:43"), // TIME is not handled
+	}, {
+		convert: convertTime,
+		in:      sqltypes.TestValue(sqltypes.Date, "2012-02-24"),
+		out:     time.Date(2012, 02, 24, 0, 0, 0, 0, time.UTC),
+	}, {
+		convert: convertTime,
+		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),
+		out:     time.Date(2012, 02, 24, 23, 19, 43, 0, time.UTC),
+	}, {
+		convert: &converter{},
+		in:      sqltypes.TestValue(sqltypes.Date, "2012-02-24"),
+		out:     []byte("2012-02-24"),
+	}, {
+		convert: &converter{},
+		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),
+		out:     []byte("2012-02-24 23:19:43"),
+	}, {
+		convert: convertTimeLocal,
+		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),
+		out:     time.Date(2012, 02, 24, 23, 19, 43, 0, time.Local),
+	}, {
+		convert: convertTimeLocal,
+		in:      sqltypes.TestValue(sqltypes.Date, "2012-02-24"),
+		out:     time.Date(2012, 02, 24, 0, 0, 0, 0, time.Local),
+	}}
+
+	for _, tcase := range testcases {
+		v, err := tcase.convert.ToNative(tcase.in)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(v, tcase.out) {
+			t.Errorf("%v.ToNativeEx = %#v, want %#v", tcase.in, v, tcase.out)
+		}
+	}
+}

--- a/go/vt/vitessdriver/convert_test.go
+++ b/go/vt/vitessdriver/convert_test.go
@@ -25,12 +25,7 @@ import (
 )
 
 func TestToNative(t *testing.T) {
-	convertTime := &converter{
-		datetime: true,
-	}
-
 	convertTimeLocal := &converter{
-		datetime: true,
 		location: time.Local,
 	}
 
@@ -39,33 +34,25 @@ func TestToNative(t *testing.T) {
 		in      sqltypes.Value
 		out     interface{}
 	}{{
-		convert: convertTime,
+		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Int32, "1"),
 		out:     int64(1),
 	}, {
-		convert: convertTime,
+		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Timestamp, "2012-02-24 23:19:43"),
 		out:     []byte("2012-02-24 23:19:43"), // TIMESTAMP is not handled
 	}, {
-		convert: convertTime,
+		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Time, "23:19:43"),
 		out:     []byte("23:19:43"), // TIME is not handled
 	}, {
-		convert: convertTime,
+		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Date, "2012-02-24"),
 		out:     time.Date(2012, 02, 24, 0, 0, 0, 0, time.UTC),
 	}, {
-		convert: convertTime,
+		convert: &converter{},
 		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),
 		out:     time.Date(2012, 02, 24, 23, 19, 43, 0, time.UTC),
-	}, {
-		convert: &converter{},
-		in:      sqltypes.TestValue(sqltypes.Date, "2012-02-24"),
-		out:     []byte("2012-02-24"),
-	}, {
-		convert: &converter{},
-		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),
-		out:     []byte("2012-02-24 23:19:43"),
 	}, {
 		convert: convertTimeLocal,
 		in:      sqltypes.TestValue(sqltypes.Datetime, "2012-02-24 23:19:43"),

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -132,12 +132,6 @@ type Configuration struct {
 	// TODO(sougou): deprecate once we switch to go1.8.
 	Timeout time.Duration
 
-	// ConvertDatetime must be set to enable native conversion
-	// between MySQL DATETIME and DATE data into Go's time.Time
-	// structs. If not set, these column types will be scanned
-	// as their raw []byte representation
-	ConvertDatetime bool
-
 	// DefaultLocation is the timezone string that will be used
 	// when converting DATETIME and DATE into time.Time.
 	// This setting has no effect if ConvertDatetime is not set.

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -21,13 +21,10 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"time"
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/sqltypes"
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 )
 
@@ -99,6 +96,9 @@ func (d drv) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	if c.convert, err = newConverter(&c.Configuration); err != nil {
+		return nil, err
+	}
 	if err = c.dial(); err != nil {
 		return nil, err
 	}
@@ -131,6 +131,18 @@ type Configuration struct {
 	// Timeout after which a pending query will be aborted.
 	// TODO(sougou): deprecate once we switch to go1.8.
 	Timeout time.Duration
+
+	// ConvertDatetime must be set to enable native conversion
+	// between MySQL DATETIME and DATE data into Go's time.Time
+	// structs. If not set, these column types will be scanned
+	// as their raw []byte representation
+	ConvertDatetime bool
+
+	// DefaultLocation is the timezone string that will be used
+	// when converting DATETIME and DATE into time.Time.
+	// This setting has no effect if ConvertDatetime is not set.
+	// Default: UTC
+	DefaultLocation string
 }
 
 // toJSON converts Configuration to the JSON string which is required by the
@@ -153,6 +165,7 @@ func (c *Configuration) setDefaults() {
 
 type conn struct {
 	Configuration
+	convert *converter
 	conn    *vtgateconn.VTGateConn
 	session *vtgateconn.VTGateSession
 }
@@ -208,7 +221,7 @@ func (c *conn) Exec(query string, args []driver.Value) (driver.Result, error) {
 	if c.Streaming {
 		return nil, errors.New("Exec not allowed for streaming connections")
 	}
-	bindVars, err := buildBindVars(args)
+	bindVars, err := c.convert.buildBindVars(args)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +235,7 @@ func (c *conn) Exec(query string, args []driver.Value) (driver.Result, error) {
 
 func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
-	bindVars, err := buildBindVars(args)
+	bindVars, err := c.convert.buildBindVars(args)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +246,7 @@ func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 			cancel()
 			return nil, err
 		}
-		return newStreamingRows(stream, cancel), nil
+		return newStreamingRows(stream, cancel, c.convert), nil
 	}
 	// Do not cancel in case of a streaming query.
 	// It will be called when streamingRows is closed later.
@@ -243,7 +256,7 @@ func (c *conn) Query(query string, args []driver.Value) (driver.Rows, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newRows(qr), nil
+	return newRows(qr, c.convert), nil
 }
 
 type stmt struct {
@@ -266,18 +279,6 @@ func (s *stmt) Exec(args []driver.Value) (driver.Result, error) {
 
 func (s *stmt) Query(args []driver.Value) (driver.Rows, error) {
 	return s.c.Query(s.query, args)
-}
-
-func buildBindVars(args []driver.Value) (map[string]*querypb.BindVariable, error) {
-	bindVars := make(map[string]*querypb.BindVariable, len(args))
-	for i, v := range args {
-		bv, err := sqltypes.BuildBindVariable(v)
-		if err != nil {
-			return nil, err
-		}
-		bindVars[fmt.Sprintf("v%d", i+1)] = bv
-	}
-	return bindVars, nil
 }
 
 type result struct {

--- a/go/vt/vitessdriver/driver_go18_test.go
+++ b/go/vt/vitessdriver/driver_go18_test.go
@@ -112,8 +112,11 @@ func TestBindVars(t *testing.T) {
 		}},
 		outErr: errNoIntermixing.Error(),
 	}}
+
+	converter := &converter{}
+
 	for _, tc := range testcases {
-		bv, err := bindVarsFromNamedValues(tc.in)
+		bv, err := converter.bindVarsFromNamedValues(tc.in)
 		if bv != nil {
 			if !reflect.DeepEqual(bv, tc.out) {
 				t.Errorf("%s: %v, want %v", tc.desc, bv, tc.out)

--- a/go/vt/vitessdriver/driver_test.go
+++ b/go/vt/vitessdriver/driver_test.go
@@ -58,6 +58,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestOpen(t *testing.T) {
+	locationPST, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+
 	var testcases = []struct {
 		desc    string
 		connStr string
@@ -71,6 +76,9 @@ func TestOpen(t *testing.T) {
 					Target:  "@replica",
 					Timeout: 30 * time.Second,
 				},
+				convert: &converter{
+					location: time.UTC,
+				},
 			},
 		},
 		{
@@ -79,6 +87,9 @@ func TestOpen(t *testing.T) {
 			conn: &conn{
 				Configuration: Configuration{
 					Timeout: 30 * time.Second,
+				},
+				convert: &converter{
+					location: time.UTC,
 				},
 			},
 		},
@@ -90,6 +101,40 @@ func TestOpen(t *testing.T) {
 					Protocol: "grpc",
 					Target:   "ks:0@replica",
 					Timeout:  30 * time.Second,
+				},
+				convert: &converter{
+					location: time.UTC,
+				},
+			},
+		},
+		{
+			desc:    "Open() with native conversion options",
+			connStr: fmt.Sprintf(`{"address": "%s", "timeout": %d, "convertdatetime": true}`, testAddress, int64(30*time.Second)),
+			conn: &conn{
+				Configuration: Configuration{
+					Timeout:         30 * time.Second,
+					ConvertDatetime: true,
+				},
+				convert: &converter{
+					datetime: true,
+					location: time.UTC,
+				},
+			},
+		},
+		{
+			desc: "Open() with custom timezone",
+			connStr: fmt.Sprintf(
+				`{"address": "%s", "timeout": %d, "convertdatetime": true, "defaultlocation": "America/Los_Angeles"}`,
+				testAddress, int64(30*time.Second)),
+			conn: &conn{
+				Configuration: Configuration{
+					Timeout:         30 * time.Second,
+					ConvertDatetime: true,
+					DefaultLocation: "America/Los_Angeles",
+				},
+				convert: &converter{
+					datetime: true,
+					location: locationPST,
 				},
 			},
 		},
@@ -173,12 +218,14 @@ func TestExec(t *testing.T) {
 
 func TestConfigurationToJSON(t *testing.T) {
 	config := Configuration{
-		Protocol:  "some-invalid-protocol",
-		Target:    "ks2",
-		Streaming: true,
-		Timeout:   1 * time.Second,
+		Protocol:        "some-invalid-protocol",
+		Target:          "ks2",
+		Streaming:       true,
+		Timeout:         1 * time.Second,
+		ConvertDatetime: true,
+		DefaultLocation: "Local",
 	}
-	want := `{"Protocol":"some-invalid-protocol","Address":"","Target":"ks2","Streaming":true,"Timeout":1000000000}`
+	want := `{"Protocol":"some-invalid-protocol","Address":"","Target":"ks2","Streaming":true,"Timeout":1000000000,"ConvertDatetime":true,"DefaultLocation":"Local"}`
 
 	json, err := config.toJSON()
 	if err != nil {
@@ -308,6 +355,169 @@ func TestQuery(t *testing.T) {
 		}
 		if err == nil || !strings.Contains(err.Error(), want) {
 			t.Errorf("%v: err: %v, does not contain %s", tc.desc, err, want)
+		}
+	}
+}
+
+func TestDatetimeQuery(t *testing.T) {
+	var testcases = []struct {
+		desc        string
+		config      Configuration
+		requestName string
+	}{
+		{
+			desc: "datetime & date, vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				ConvertDatetime: true,
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date (local timezone), vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				ConvertDatetime: true,
+				DefaultLocation: "Local",
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date, streaming, vtgate",
+			config: Configuration{
+				Protocol:        "grpc",
+				Address:         testAddress,
+				Target:          "@rdonly",
+				Timeout:         30 * time.Second,
+				Streaming:       true,
+				ConvertDatetime: true,
+			},
+			requestName: "requestDates",
+		},
+		{
+			desc: "datetime & date (no conversion), vtgate",
+			config: Configuration{
+				Protocol: "grpc",
+				Address:  testAddress,
+				Target:   "@rdonly",
+				Timeout:  30 * time.Second,
+			},
+			requestName: "requestDates",
+		},
+	}
+
+	for _, tc := range testcases {
+		db, err := OpenWithConfiguration(tc.config)
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer db.Close()
+
+		s, err := db.Prepare(tc.requestName)
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer s.Close()
+
+		r, err := s.Query(0)
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		defer r.Close()
+
+		cols, err := r.Columns()
+		if err != nil {
+			t.Errorf("%v: %v", tc.desc, err)
+		}
+		wantCols := []string{
+			"fieldDatetime",
+			"fieldDate",
+		}
+		if !reflect.DeepEqual(cols, wantCols) {
+			t.Errorf("%v: cols: %v, want %v", tc.desc, cols, wantCols)
+		}
+
+		location := time.UTC
+		if tc.config.DefaultLocation != "" {
+			location, err = time.LoadLocation(tc.config.DefaultLocation)
+			if err != nil {
+				t.Errorf("%v: %v", tc.desc, err)
+			}
+		}
+
+		count := 0
+		wantValues := []struct {
+			fieldDatetime time.Time
+			fieldDate     time.Time
+		}{{
+			time.Date(2009, 3, 29, 17, 22, 11, 0, location),
+			time.Date(2006, 7, 2, 0, 0, 0, 0, location),
+		}, {
+			time.Time{},
+			time.Time{},
+		}}
+
+		rawValues := []struct {
+			fieldDatetime string
+			fieldDate     string
+		}{{
+			"2009-03-29 17:22:11",
+			"2006-07-02",
+		}, {
+			"0000-00-00 00:00:00",
+			"0000-00-00",
+		}}
+
+		if tc.config.ConvertDatetime {
+			for r.Next() {
+				var fieldDatetime time.Time
+				var fieldDate time.Time
+				err := r.Scan(&fieldDatetime, &fieldDate)
+				if err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+				if want := wantValues[count].fieldDatetime; fieldDatetime != want {
+					t.Errorf("%v: wrong value for fieldDatetime: got: %v want: %v", tc.desc, fieldDatetime, want)
+				}
+				if want := wantValues[count].fieldDate; fieldDate != want {
+					t.Errorf("%v: wrong value for fieldDate: got: %v want: %v", tc.desc, fieldDate, want)
+				}
+				count++
+			}
+		} else {
+			for r.Next() {
+				var t1, t2 time.Time
+				var fieldDatetime []byte
+				var fieldDate []byte
+
+				err := r.Scan(&t1, &t2)
+				if err == nil {
+					t.Errorf("%v: storing driver.Value into time.Time should be unsupported", tc.desc)
+				}
+
+				err = r.Scan(&fieldDatetime, &fieldDate)
+				if err != nil {
+					t.Errorf("%v: %v", tc.desc, err)
+				}
+				if want := rawValues[count].fieldDatetime; string(fieldDatetime) != want {
+					t.Errorf("%v: wrong value for fieldDatetime: got: %v want: %v", tc.desc, fieldDatetime, want)
+				}
+				if want := rawValues[count].fieldDate; string(fieldDate) != want {
+					t.Errorf("%v: wrong value for fieldDate: got: %v want: %v", tc.desc, fieldDate, want)
+				}
+
+				count++
+			}
+		}
+
+		if count != len(wantValues) {
+			t.Errorf("%v: count: %d, want %d", tc.desc, count, len(wantValues))
 		}
 	}
 }

--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -271,6 +271,19 @@ var execMap = map[string]struct {
 		result:  &result1,
 		session: nil,
 	},
+	"requestDates": {
+		execQuery: &queryExecute{
+			SQL: "requestDates",
+			BindVariables: map[string]*querypb.BindVariable{
+				"v1": sqltypes.Int64BindVariable(0),
+			},
+			Session: &vtgatepb.Session{
+				TargetString: "@rdonly",
+			},
+		},
+		result:  &result2,
+		session: nil,
+	},
 	"txRequest": {
 		execQuery: &queryExecute{
 			SQL: "txRequest",
@@ -335,6 +348,31 @@ var result1 = sqltypes.Result{
 		{
 			sqltypes.NewVarBinary("2"),
 			sqltypes.NewVarBinary("value2"),
+		},
+	},
+}
+
+var result2 = sqltypes.Result{
+	Fields: []*querypb.Field{
+		{
+			Name: "fieldDatetime",
+			Type: sqltypes.Datetime,
+		},
+		{
+			Name: "fieldDate",
+			Type: sqltypes.Date,
+		},
+	},
+	RowsAffected: 42,
+	InsertID:     73,
+	Rows: [][]sqltypes.Value{
+		{
+			sqltypes.NewVarBinary("2009-03-29 17:22:11"),
+			sqltypes.NewVarBinary("2006-07-02"),
+		},
+		{
+			sqltypes.NewVarBinary("0000-00-00 00:00:00"),
+			sqltypes.NewVarBinary("0000-00-00"),
 		},
 	},
 }

--- a/go/vt/vitessdriver/rows.go
+++ b/go/vt/vitessdriver/rows.go
@@ -26,13 +26,14 @@ import (
 // rows creates a database/sql/driver compliant Row iterator
 // for a non-streaming QueryResult.
 type rows struct {
-	qr    *sqltypes.Result
-	index int
+	convert *converter
+	qr      *sqltypes.Result
+	index   int
 }
 
 // newRows creates a new rows from qr.
-func newRows(qr *sqltypes.Result) driver.Rows {
-	return &rows{qr: qr}
+func newRows(qr *sqltypes.Result, c *converter) driver.Rows {
+	return &rows{qr: qr, convert: c}
 }
 
 func (ri *rows) Columns() []string {
@@ -51,17 +52,9 @@ func (ri *rows) Next(dest []driver.Value) error {
 	if ri.index == len(ri.qr.Rows) {
 		return io.EOF
 	}
-	populateRow(dest, ri.qr.Rows[ri.index])
+	if err := ri.convert.populateRow(dest, ri.qr.Rows[ri.index]); err != nil {
+		return err
+	}
 	ri.index++
 	return nil
-}
-
-// populateRow populates a row of data using the table's field descriptions.
-// The returned types for "dest" include the list from the interface
-// specification at https://golang.org/pkg/database/sql/driver/#Value
-// and in addition the type "uint64" for unsigned BIGINT MySQL records.
-func populateRow(dest []driver.Value, row []sqltypes.Value) {
-	for i := range dest {
-		dest[i], _ = sqltypes.ToNative(row[i])
-	}
 }

--- a/go/vt/vitessdriver/rows_test.go
+++ b/go/vt/vitessdriver/rows_test.go
@@ -84,7 +84,7 @@ func logMismatchedTypes(t *testing.T, gotRow, wantRow []driver.Value) {
 }
 
 func TestRows(t *testing.T) {
-	ri := newRows(&rowsResult1)
+	ri := newRows(&rowsResult1, &converter{})
 	wantCols := []string{
 		"field1",
 		"field2",

--- a/go/vt/vitessdriver/streaming_rows_test.go
+++ b/go/vt/vitessdriver/streaming_rows_test.go
@@ -84,7 +84,7 @@ func TestStreamingRows(t *testing.T) {
 	c <- &packet2
 	c <- &packet3
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil, &converter{})
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -136,7 +136,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 	c <- &packet2
 	c <- &packet3
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: io.EOF}, nil, &converter{})
 	defer ri.Close()
 
 	wantRow := []driver.Value{
@@ -169,7 +169,7 @@ func TestStreamingRowsReversed(t *testing.T) {
 func TestStreamingRowsError(t *testing.T) {
 	c := make(chan *sqltypes.Result)
 	close(c)
-	ri := newStreamingRows(&adapter{c: c, err: errors.New("error before fields")}, nil)
+	ri := newStreamingRows(&adapter{c: c, err: errors.New("error before fields")}, nil, &converter{})
 
 	gotCols := ri.Columns()
 	if gotCols != nil {
@@ -186,7 +186,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c = make(chan *sqltypes.Result, 1)
 	c <- &packet1
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after fields")}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after fields")}, nil, &converter{})
 	wantCols := []string{
 		"field1",
 		"field2",
@@ -213,7 +213,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c <- &packet1
 	c <- &packet2
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after rows")}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: errors.New("error after rows")}, nil, &converter{})
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	if err != nil {
@@ -229,7 +229,7 @@ func TestStreamingRowsError(t *testing.T) {
 	c = make(chan *sqltypes.Result, 1)
 	c <- &packet2
 	close(c)
-	ri = newStreamingRows(&adapter{c: c, err: io.EOF}, nil)
+	ri = newStreamingRows(&adapter{c: c, err: io.EOF}, nil, &converter{})
 	gotRow = make([]driver.Value, 3)
 	err = ri.Next(gotRow)
 	wantErr = "first packet did not return fields"

--- a/go/vt/vitessdriver/time.go
+++ b/go/vt/vitessdriver/time.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessdriver
+
+import (
+	"errors"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+// ErrInvalidTime is returned when we fail to parse a datetime
+// string from MySQL. This should never happen unless things are
+// seriously messed up.
+var ErrInvalidTime = errors.New("invalid MySQL time string")
+
+var isoTimeFormat = "2006-01-02 15:04:05.999999"
+var isoNullTime = "0000-00-00 00:00:00.000000"
+var isoTimeLength = len(isoTimeFormat)
+
+// parseISOTime pases a time string in MySQL's textual datetime format.
+// This is very similar to ISO8601, with some differences:
+//
+// - There is no T separator between the date and time sections;
+//   a space is used instead.
+// - There is never a timezone section in the string, as these datetimes
+//   are not timezone-aware. There isn't a Z value for UTC times for
+//   the same reason.
+//
+// Note that this function can handle both DATE (which should _always_ have
+// a length of 10) and DATETIME strings (which have a variable length, 18+
+// depending on the number of decimal sub-second places).
+//
+// Also note that this function handles the case where MySQL returns a NULL
+// time (with a string where all sections are zeroes) by returning a zeroed
+// out time.Time object. NULL time strings are not considered a parsing error.
+//
+// See: isoTimeFormat
+func parseISOTime(tstr string, loc *time.Location, minLen, maxLen int) (t time.Time, err error) {
+	tlen := len(tstr)
+	if tlen < minLen || tlen > maxLen {
+		err = ErrInvalidTime
+		return
+	}
+
+	if tstr == isoNullTime[:tlen] {
+		// This is what MySQL would send when the date is NULL,
+		// so return an empty time.Time instead.
+		// This is not a parsing error
+		return
+	}
+
+	if loc == nil {
+		loc = time.UTC
+	}
+
+	// Since the time format returned from MySQL never has a Timezone
+	// section, ParseInLocation will initialize the time.Time struct
+	// with the default `loc` we're passing here.
+	return time.ParseInLocation(isoTimeFormat[:tlen], tstr, loc)
+}
+
+func checkTimeFormat(t string) (err error) {
+	// Valid format string offsets for any ISO time from MySQL:
+	//  |DATETIME |10      |19+
+	//  |---------|--------|
+	// "2006-01-02 15:04:05.999999"
+	_, err = parseISOTime(t, time.UTC, 10, isoTimeLength)
+	return
+}
+
+// DatetimeToNative converts a Datetime Value into a time.Time
+func DatetimeToNative(v sqltypes.Value, loc *time.Location) (time.Time, error) {
+	// Valid format string offsets for a DATETIME
+	//  |DATETIME          |19+
+	//  |------------------|------|
+	// "2006-01-02 15:04:05.999999"
+	return parseISOTime(v.ToString(), loc, 19, isoTimeLength)
+}
+
+// DateToNative converts a Date Value into a time.Time.
+// Note that there's no specific type in the Go stdlib to represent
+// dates without time components, so the returned Time will have
+// their hours/mins/seconds zeroed out.
+func DateToNative(v sqltypes.Value, loc *time.Location) (time.Time, error) {
+	// Valid format string offsets for a DATE
+	//  |DATE     |10
+	//  |---------|
+	// "2006-01-02 00:00:00.000000"
+	return parseISOTime(v.ToString(), loc, 10, 10)
+}
+
+// NewDatetime builds a Datetime Value
+func NewDatetime(t time.Time, defaultLoc *time.Location) sqltypes.Value {
+	if t.Location() != defaultLoc {
+		t = t.In(defaultLoc)
+	}
+	return sqltypes.MakeTrusted(sqltypes.Datetime, []byte(t.Format(isoTimeFormat)))
+}

--- a/go/vt/vitessdriver/time_test.go
+++ b/go/vt/vitessdriver/time_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vitessdriver
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+var randomLocation = time.FixedZone("Nowhere", 3*60*60)
+
+func DatetimeValue(str string) sqltypes.Value {
+	return sqltypes.TestValue(sqltypes.Datetime, str)
+}
+
+func DateValue(str string) sqltypes.Value {
+	return sqltypes.TestValue(sqltypes.Date, str)
+}
+
+func TestDatetimeToNative(t *testing.T) {
+
+	tcases := []struct {
+		val sqltypes.Value
+		loc *time.Location
+		out time.Time
+		err bool
+	}{{
+		val: DatetimeValue("1899-08-24 17:20:00"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: DatetimeValue("1952-03-11 01:02:03"),
+		loc: time.Local,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, time.Local),
+	}, {
+		val: DatetimeValue("1952-03-11 01:02:03"),
+		loc: randomLocation,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, randomLocation),
+	}, {
+		val: DatetimeValue("1952-03-11 01:02:03"),
+		loc: time.UTC,
+		out: time.Date(1952, 3, 11, 1, 2, 3, 0, time.UTC),
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.000000"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.000001"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(1*time.Microsecond), time.UTC),
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.123456"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(123456*time.Microsecond), time.UTC),
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.222"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(222*time.Millisecond), time.UTC),
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.1234567"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00.1"),
+		out: time.Date(1899, 8, 24, 17, 20, 0, int(100*time.Millisecond), time.UTC),
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00"),
+		out: time.Time{},
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00.0"),
+		out: time.Time{},
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00.000"),
+		out: time.Time{},
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00.000000"),
+		out: time.Time{},
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00.0000000"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-08-24T17:20:00.000000"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-02-31 17:20:00.000000"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00."),
+		out: time.Date(1899, 8, 24, 17, 20, 0, 0, time.UTC),
+	}, {
+		val: DatetimeValue("0000-00-00 00:00:00.000001"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-08-24 17:20:00 +02:00"),
+		err: true,
+	}, {
+		val: DatetimeValue("1899-08-24"),
+		err: true,
+	}, {
+		val: DatetimeValue("This is not a valid timestamp"),
+		err: true,
+	}}
+
+	for _, tcase := range tcases {
+		got, err := DatetimeToNative(tcase.val, tcase.loc)
+		if tcase.err && err == nil {
+			t.Errorf("DatetimeToNative(%v, %#v) succeeded; expected error", tcase.val, tcase.loc)
+		}
+		if !tcase.err && err != nil {
+			t.Errorf("DatetimeToNative(%v, %#v) failed: %v", tcase.val, tcase.loc, err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("DatetimeToNative(%v, %#v): %v, want %v", tcase.val, tcase.loc, got, tcase.out)
+		}
+	}
+}
+
+func TestDateToNative(t *testing.T) {
+	tcases := []struct {
+		val sqltypes.Value
+		loc *time.Location
+		out time.Time
+		err bool
+	}{{
+		val: DateValue("1899-08-24"),
+		out: time.Date(1899, 8, 24, 0, 0, 0, 0, time.UTC),
+	}, {
+		val: DateValue("1952-03-11"),
+		loc: time.Local,
+		out: time.Date(1952, 3, 11, 0, 0, 0, 0, time.Local),
+	}, {
+		val: DateValue("1952-03-11"),
+		loc: randomLocation,
+		out: time.Date(1952, 3, 11, 0, 0, 0, 0, randomLocation),
+	}, {
+		val: DateValue("0000-00-00"),
+		out: time.Time{},
+	}, {
+		val: DateValue("1899-02-31"),
+		err: true,
+	}, {
+		val: DateValue("1899-08-24 17:20:00"),
+		err: true,
+	}, {
+		val: DateValue("0000-00-00 00:00:00"),
+		err: true,
+	}, {
+		val: DateValue("This is not a valid timestamp"),
+		err: true,
+	}}
+
+	for _, tcase := range tcases {
+		got, err := DateToNative(tcase.val, tcase.loc)
+		if tcase.err && err == nil {
+			t.Errorf("DateToNative(%v, %#v) succeeded; expected error", tcase.val, tcase.loc)
+		}
+		if !tcase.err && err != nil {
+			t.Errorf("DateToNative(%v, %#v) failed: %v", tcase.val, tcase.loc, err)
+		}
+		if !reflect.DeepEqual(got, tcase.out) {
+			t.Errorf("DateToNative(%v, %#v): %v, want %v", tcase.val, tcase.loc, got, tcase.out)
+		}
+	}
+}


### PR DESCRIPTION
This PR is an alternate take on https://github.com/youtube/vitess/pull/3127, implementing all the relevant logic for `time.Time` conversions in the client (i.e. in `vitessdriver` instead of `sqltypes`).

Please check the original PR for details on the design behind this and the rationale behind keeping the logic isolated in `vitessdriver`.