### PR TITLE
travis: Temporarily disable the unit_race test on Travis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ unit_test: build
 unit_test_cover: build
 	go test $(VT_GO_PARALLEL) -cover ./go/... | misc/parse_cover.py
 
+# TODO(mberlin): This is currently disabled in test/config.json for automatic
+# runs on Travis (manual=false). Re-enable it there once we switched the Travis
+# tests to using Docker and we verified that this is no longer flaky e.g. in
+# doubt increase timeouts in all tests.
 unit_test_race: build
 	tools/unit_test_race.sh
 

--- a/test/config.json
+++ b/test/config.json
@@ -371,7 +371,7 @@
 				"make",
 				"unit_test_race"
 			],
-			"Manual": false,
+			"Manual": true,
 			"Shard": 0,
 			"RetryMax": 0,
 			"Tags": []


### PR DESCRIPTION
It is too flaky at this point because tests are running too slow and we run into test timeouts hardcoded in the unit test.

Before we try to re-enable this, let me switch the Travis tests to run in the new VM infrastructure via Docker first.