### PR TITLE
Enhance /debug/health to be usable as a liveness probe

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -565,7 +565,7 @@ func (tsv *TabletServer) IsHealthy() error {
 	tabletType := tsv.target.TabletType
 	tsv.mu.Unlock()
 	switch tabletType {
-	case topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_BATCH:
+	case topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_BATCH, topodatapb.TabletType_EXPERIMENTAL:
 		_, err := tsv.Execute(
 			tabletenv.LocalContext(),
 			nil,

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1743,8 +1743,7 @@ func (tsv *TabletServer) registerDebugHealthHandler() {
 		}
 		w.Header().Set("Content-Type", "text/plain")
 		if err := tsv.IsHealthy(); err != nil {
-			w.WriteHeader(500)
-			w.Write([]byte(fmt.Sprintf("not ok: %v", err)))
+			http.Error(w, fmt.Sprintf("not ok: %v", err), http.StatusInternalServerError)
 			return
 		}
 		w.Write([]byte("ok"))

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -561,7 +561,10 @@ func (tsv *TabletServer) setTimeBomb() chan struct{} {
 // connect to the database and serving traffic), or an error explaining
 // the unhealthiness otherwise.
 func (tsv *TabletServer) IsHealthy() error {
-	switch tsv.target.TabletType {
+	tsv.mu.Lock()
+	tabletType := tsv.target.TabletType
+	tsv.mu.Unlock()
+	switch tabletType {
 	case topodatapb.TabletType_MASTER, topodatapb.TabletType_REPLICA, topodatapb.TabletType_BATCH:
 		_, err := tsv.Execute(
 			tabletenv.LocalContext(),


### PR DESCRIPTION
Only report health for serving types, namely master, replica, batch. Fix api to return 500 if in error

This should be useful for those in kubernetes or who otherwise want to use a probe to determine whether the vttablet process is healthy. This is distinct from /healthz, which is used for load balancers and returns unhealthy in more cases.

Open question: should we also whitelist the `StateTransitioning` state?  Maybe not, as this should probably be called with a heuristic that allows for a certain number of failures, like many probe implementations do.

@sougou @adkhare 