### PR TITLE
upgrade grpc to 1.6

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -975,106 +975,164 @@
 			"revisionTime": "2017-05-31T20:35:52Z"
 		},
 		{
-			"checksumSHA1": "zoNC4xFysyYBRILPrhcULrVDP+U=",
+			"checksumSHA1": "SMXFUf293CEiLOAmKk7ku1bSCeo=",
 			"path": "google.golang.org/grpc",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
+		},
+		{
+			"checksumSHA1": "AS14kO6FrzuQ/8wP+a/n55SNW6U=",
+			"path": "google.golang.org/grpc/balancer",
+			"revision": "067cb1fcbf74396966d96d4727b43ca880e9581a",
+			"revisionTime": "2017-09-07T16:57:31Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "Dkjgw1HasWvqct0IuiZdjbD7O0c=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "5ylThBvJnIcyWhL17AC9+Sdbw2E=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "TTx8t1Cvkp0nz2burZz6BN4fIeY=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
-			"checksumSHA1": "OvYpodREHfhAVizxPNnx4Wh3Yqw=",
+			"checksumSHA1": "XbDzI4GeUt2/8WAS5mLKm5ghVWo=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
+		},
+		{
+			"checksumSHA1": "WxP3QV0Y4fIx5NsT0dwBp6JsrJE=",
+			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "taQS6p0HLyrMJZc0hvxPLrcBTVI=",
 			"path": "google.golang.org/grpc/grpclb/messages_only/grpc_lb_v1",
 			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revisionTime": "2017-08-23T20:45:01Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "U9vDe05/tQrvFBojOQX8Xk12W9I=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
-			"checksumSHA1": "h6S0QC4uAtF11dTpGeuUkTx9aQo=",
+			"checksumSHA1": "KeUmTZV+2X46C49cKyjp+xM7fvw=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "dgwdT20kXe4ZbXBOFbTwVQt8rmA=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
-			"checksumSHA1": "WdY487BYWJOOoLdJk42M/ZOBSDY=",
+			"checksumSHA1": "bJJaQUbZqEpTlnXTXgGwOZWijs4=",
+			"path": "google.golang.org/grpc/resolver",
+			"revision": "067cb1fcbf74396966d96d4727b43ca880e9581a",
+			"revisionTime": "2017-09-07T16:57:31Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
+		},
+		{
+			"checksumSHA1": "mN8hVA1AgNCqERfkX/4l/EM6srY=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "3Dwz4RLstDHMPyDA7BUsYe+JP4w=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
-			"checksumSHA1": "dERr7A9chxd+AUu0zV6gSr9b/64=",
+			"checksumSHA1": "eaAukoLg7xWreNDm68Vs3dVc4UY=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z"
+			"revision": "f92cdcd7dcdc69e81b2d7b338479a19a8723cfa3",
+			"revisionTime": "2017-08-30T18:24:17Z",
+			"version": "v1.6.0",
+			"versionExact": "v1.6.0"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
https://github.com/grpc/grpc-go/releases/tag/v1.6.0

This includes the fix for a connection leak i found in the GOAWAY code

I also attempted to update protobuf, but there was nothing. 

@alainjobart @sougou 