### PR TITLE
sqltypes: arithmetic.go unit test: Check for error code as well.

### DIFF
--- a/go/sqltypes/arithmetic_test.go
+++ b/go/sqltypes/arithmetic_test.go
@@ -151,10 +151,10 @@ func TestNullsafeCompare(t *testing.T) {
 			errstr = err.Error()
 		}
 		if errstr != tcase.err {
-			t.Errorf("NullsafeLess(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), err, tcase.err)
+			t.Errorf("NullsafeCompare(%v, %v) error: %v, want %v", printValue(tcase.v1), printValue(tcase.v2), err, tcase.err)
 		}
 		if got != tcase.out {
-			t.Errorf("NullsafeLess(%v, %v): %v, want %v", printValue(tcase.v1), printValue(tcase.v2), got, tcase.out)
+			t.Errorf("NullsafeCompare(%v, %v): %v, want %v", printValue(tcase.v1), printValue(tcase.v2), got, tcase.out)
 		}
 	}
 }

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -83,3 +83,25 @@ func Code(err error) vtrpcpb.Code {
 	}
 	return vtrpcpb.Code_UNKNOWN
 }
+
+// Equals returns true iff the error message and the code returned by Code()
+// is equal.
+func Equals(a, b error) bool {
+	if a == nil && b == nil {
+		// Both are nil.
+		return true
+	}
+
+	if a == nil && b != nil || a != nil && b == nil {
+		// One of the two is nil.
+		return false
+	}
+
+	return a.Error() == b.Error() && Code(a) == Code(b)
+}
+
+// Print is meant to print the vtError object in test failures.
+// For comparing two vterrors, use Equals() instead.
+func Print(err error) string {
+	return fmt.Sprintf("%v: %v", Code(err), err.Error())
+}


### PR DESCRIPTION
Since github.com/youtube/vitess/pull/3134 we started to return a vterrors Code. As it is part of the API now, we should also properly test it. Otherwise, it would be possible to remove the recently added lines where the error is wrapped into an INVALID_ARGUMENT vterror and the test would still pass.

To simplify comparison and debugging, I added two new static methods Equals() and Print() to the vterrors package.

Other changes:
- Return INVALID_ARGUMENT in newNumeric() as well. (It was added in newIntegralNumeric() before.)
- Changed newIntegralNumeric() and newNumeric() to not use naked returns. This results in shorter code and less errors because variables are limited in scope now.