### PR TITLE
messages: fix two message stream bugs

### DIFF
--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -464,7 +464,7 @@ func (stc *ScatterConn) MessageStream(ctx context.Context, keyspace string, shar
 				return err
 			}
 
-			// There was no error. We have see if we need to retry.
+			// There was no error. We have to see if we need to retry.
 			// If context was canceled, likely due to client disconnect,
 			// return normally without retrying.
 			select {

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -301,7 +301,14 @@ func (sbc *SandboxConn) BeginExecuteBatch(ctx context.Context, target *querypb.T
 
 // MessageStream is part of the QueryService interface.
 func (sbc *SandboxConn) MessageStream(ctx context.Context, target *querypb.Target, name string, callback func(*sqltypes.Result) error) (err error) {
-	callback(SingleRowResult)
+	if err := sbc.getError(); err != nil {
+		return err
+	}
+	r := sbc.getNextResult()
+	if r == nil {
+		return nil
+	}
+	callback(r)
 	return nil
 }
 

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -103,16 +103,14 @@ func (me *Engine) Close() {
 // usually triggered by Close. It's the responsibility of the send
 // function to promptly return if the done channel is closed. Otherwise,
 // the engine's Close function will hang indefinitely.
-func (me *Engine) Subscribe(name string, send func(*sqltypes.Result) error) (done chan struct{}, err error) {
+func (me *Engine) Subscribe(ctx context.Context, name string, send func(*sqltypes.Result) error) (done <-chan struct{}, err error) {
 	me.mu.Lock()
 	defer me.mu.Unlock()
 	mm := me.managers[name]
 	if mm == nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "message table %s not found", name)
 	}
-	rcv, done := newMessageReceiver(send)
-	mm.Subscribe(rcv)
-	return done, nil
+	return mm.Subscribe(ctx, send), nil
 }
 
 // LockDB obtains db locks for all messages that need to

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -42,7 +42,7 @@ type messageReceiver struct {
 	ctx     context.Context
 	errChan chan error
 	send    func(*sqltypes.Result) error
-	cancel  func()
+	cancel  context.CancelFunc
 }
 
 func newMessageReceiver(ctx context.Context, send func(*sqltypes.Result) error) (*messageReceiver, <-chan struct{}) {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -209,7 +209,7 @@ func (qre *QueryExecutor) MessageStream(callback func(*sqltypes.Result) error) e
 		return err
 	}
 
-	done, err := qre.tsv.messager.Subscribe(qre.plan.TableName().String(), func(r *sqltypes.Result) error {
+	done, err := qre.tsv.messager.Subscribe(qre.ctx, qre.plan.TableName().String(), func(r *sqltypes.Result) error {
 		select {
 		case <-qre.ctx.Done():
 			return io.EOF

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -223,7 +223,7 @@ func TestQueryExecutorPlanInsertMessage(t *testing.T) {
 	checkPlanID(t, planbuilder.PlanInsertMessage, qre.plan.PlanID)
 	ch1 := make(chan *sqltypes.Result)
 	count := 0
-	tsv.messager.Subscribe("msg", func(qr *sqltypes.Result) error {
+	tsv.messager.Subscribe(context.Background(), "msg", func(qr *sqltypes.Result) error {
 		if count > 1 {
 			return io.EOF
 		}


### PR DESCRIPTION
### vtgate should retry ended streams
BUG=65414820
When one shard out of several does failover, vtgate closes MessageStream
RPCs to the old master, but doesn't reopen them to the new master.

The bug is fixed at the ScatterConn level. I've introduced a new
flag message_stream_grace_period. If a vttablet becomes unavailable,
the scatter conn will retry until that time. Then, it will interrupt
all streams and return an error.

### proactively drop closed connections
BUG=65416566
When client closes MessageStream RPC, vtgate notices that immediately
and closes RPC to vttablet. But vttablet doesn't notice that until next
time it tries to send message on that RPC.

I've refactored the code a bit and addressed a few other issues:
* messageReceiver is now internal to MessageManager. There was no
  reason to expose it to the engine. This leads to a simpler API.
* The Subscribe call takes the context as input and watches over
  it. It also adds its own cancelability before returning the
  'done' channel.
* The new cancelable context is tracked by a separate goroutine
  that unsubscribes the receiver if it's closed.
* For good measure the send function also watches over it while
  sending.
* This has led to some simplification in tests because this code
  pattern removes some deadlocks that were previously possible.