### PR TITLE
vtexplain improvements

### DIFF
--- a/data/test/vtexplain/comments-output.json
+++ b/data/test/vtexplain/comments-output.json
@@ -15,27 +15,31 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select * from user",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user limit 10001"
+                ]
+            }
         }
     }
 ]

--- a/data/test/vtexplain/comments-output.json
+++ b/data/test/vtexplain/comments-output.json
@@ -1,0 +1,41 @@
+[
+    {
+        "SQL": "SELECT * from user",
+        "Plans": [
+            {
+                "Original": "SELECT * from user",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user",
+                    "FieldQuery": "select * from user where 1 != 1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "select * from user",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "select * from user",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user limit 10001"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/data/test/vtexplain/comments-output.txt
+++ b/data/test/vtexplain/comments-output.txt
@@ -1,0 +1,12 @@
+----------------------------------------------------------------------
+SELECT * from user
+
+[ks_sharded/-80]:
+select * from user where 1 != 1
+select * from user limit 10001
+
+[ks_sharded/80-]:
+select * from user where 1 != 1
+select * from user limit 10001
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/comments-queries.sql
+++ b/data/test/vtexplain/comments-queries.sql
@@ -1,0 +1,14 @@
+
+/* this is a comment about a commented query */
+/* SELECT * from users; */
+
+/* this is a comment about another commented query */
+-- SELECT * from users;
+
+/* this is a comment about a query with a semicolon; or two; */
+SELECT * from user;
+
+/* this is a semicolon with no query */
+;
+
+-- this is a single line comment at the end of the file

--- a/data/test/vtexplain/insertsharded-output.json
+++ b/data/test/vtexplain/insertsharded-output.json
@@ -1,0 +1,281 @@
+[
+    {
+        "SQL": "insert into user (id, name) values(1, \"alice\")",
+        "Plans": [
+            {
+                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+                    "Values": [
+                        [
+                            ":name0"
+                        ]
+                    ],
+                    "Table": "name_user_map",
+                    "Prefix": "insert into name_user_map(name, user_id) values ",
+                    "Mid": [
+                        "(:_name0, :user_id0)"
+                    ]
+                }
+            },
+            {
+                "Original": "insert into user (id, name) values(1, \"alice\")",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+                    "Values": [
+                        [
+                            1
+                        ],
+                        [
+                            "alice"
+                        ]
+                    ],
+                    "Table": "user",
+                    "Prefix": "insert into user(id, name) values ",
+                    "Mid": [
+                        "(:_id0, :_name0)"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
+                    "BindVars": {
+                        "_name0": "'alice'",
+                        "name0": "'alice'",
+                        "user_id0": "1"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into name_user_map(name, user_id) values ('alice', 1)",
+                        "commit",
+                        "begin",
+                        "insert into user(id, name) values (1, 'alice')",
+                        "commit"
+                    ]
+                },
+                {
+                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                    "BindVars": {
+                        "_id0": "1",
+                        "_name0": "'alice'"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into name_user_map(name, user_id) values ('alice', 1)",
+                        "commit",
+                        "begin",
+                        "insert into user(id, name) values (1, 'alice')",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "insert into user (id, name) values(2, \"bob\")",
+        "Plans": [
+            {
+                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+                    "Values": [
+                        [
+                            ":name0"
+                        ]
+                    ],
+                    "Table": "name_user_map",
+                    "Prefix": "insert into name_user_map(name, user_id) values ",
+                    "Mid": [
+                        "(:_name0, :user_id0)"
+                    ]
+                }
+            },
+            {
+                "Original": "insert into user (id, name) values(2, \"bob\")",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+                    "Values": [
+                        [
+                            2
+                        ],
+                        [
+                            "bob"
+                        ]
+                    ],
+                    "Table": "user",
+                    "Prefix": "insert into user(id, name) values ",
+                    "Mid": [
+                        "(:_id0, :_name0)"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                    "BindVars": {
+                        "_id0": "2",
+                        "_name0": "'bob'"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into user(id, name) values (2, 'bob')",
+                        "commit"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "BindVars": {
+                        "_name0": "'bob'",
+                        "name0": "'bob'",
+                        "user_id0": "2"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into name_user_map(name, user_id) values ('bob', 2)",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "insert ignore into user (id, name) values(2, \"bob\")",
+        "Plans": [
+            {
+                "Original": "select name from name_user_map where name = :name and user_id = :user_id",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select name from name_user_map where name = :name and user_id = :user_id",
+                    "FieldQuery": "select name from name_user_map where 1 != 1",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
+                    ]
+                }
+            },
+            {
+                "Original": "insert ignore into name_user_map(name, user_id) values(:name0, :user_id0)",
+                "Instructions": {
+                    "Opcode": "InsertShardedIgnore",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0)",
+                    "Values": [
+                        [
+                            ":name0"
+                        ]
+                    ],
+                    "Table": "name_user_map",
+                    "Prefix": "insert ignore into name_user_map(name, user_id) values ",
+                    "Mid": [
+                        "(:_name0, :user_id0)"
+                    ]
+                }
+            },
+            {
+                "Original": "insert ignore into user (id, name) values(2, \"bob\")",
+                "Instructions": {
+                    "Opcode": "InsertShardedIgnore",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert ignore into user(id, name) values (:_id0, :_name0)",
+                    "Values": [
+                        [
+                            2
+                        ],
+                        [
+                            "bob"
+                        ]
+                    ],
+                    "Table": "user",
+                    "Prefix": "insert ignore into user(id, name) values ",
+                    "Mid": [
+                        "(:_id0, :_name0)"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                    "BindVars": {
+                        "_id0": "2",
+                        "_name0": "'bob'"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert ignore into user(id, name) values (2, 'bob')",
+                        "commit"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "BindVars": {
+                        "_name0": "'bob'",
+                        "name0": "'bob'",
+                        "user_id0": "2"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
+                        "commit",
+                        "select name from name_user_map where 1 != 1",
+                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    ]
+                },
+                {
+                    "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
+                    "BindVars": {
+                        "name": "'bob'",
+                        "user_id": "2"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
+                        "commit",
+                        "select name from name_user_map where 1 != 1",
+                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/data/test/vtexplain/insertsharded-output.json
+++ b/data/test/vtexplain/insertsharded-output.json
@@ -48,40 +48,34 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
-                    "BindVars": {
-                        "_name0": "'alice'",
-                        "name0": "'alice'",
-                        "user_id0": "1"
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
+                        "BindVars": {
+                            "_name0": "'alice'",
+                            "name0": "'alice'",
+                            "user_id0": "1"
+                        }
                     },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('alice', 1)",
-                        "commit",
-                        "begin",
-                        "insert into user(id, name) values (1, 'alice')",
-                        "commit"
-                    ]
-                },
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-                    "BindVars": {
-                        "_id0": "1",
-                        "_name0": "'alice'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('alice', 1)",
-                        "commit",
-                        "begin",
-                        "insert into user(id, name) values (1, 'alice')",
-                        "commit"
-                    ]
-                }
-            ]
+                    {
+                        "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                        "BindVars": {
+                            "_id0": "1",
+                            "_name0": "'alice'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into name_user_map(name, user_id) values ('alice', 1)",
+                    "commit",
+                    "begin",
+                    "insert into user(id, name) values (1, 'alice')",
+                    "commit"
+                ]
+            }
         }
     },
     {
@@ -133,36 +127,40 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "_id0": "2",
-                        "_name0": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into user(id, name) values (2, 'bob')",
-                        "commit"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('bob', 2)",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                        "BindVars": {
+                            "_id0": "2",
+                            "_name0": "'bob'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into user(id, name) values (2, 'bob')",
+                    "commit"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                        "BindVars": {
+                            "_name0": "'bob'",
+                            "name0": "'bob'",
+                            "user_id0": "2"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into name_user_map(name, user_id) values ('bob', 2)",
+                    "commit"
+                ]
+            }
         }
     },
     {
@@ -230,52 +228,176 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "_id0": "2",
-                        "_name0": "'bob'"
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                        "BindVars": {
+                            "_id0": "2",
+                            "_name0": "'bob'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert ignore into user(id, name) values (2, 'bob')",
+                    "commit"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                        "BindVars": {
+                            "_name0": "'bob'",
+                            "name0": "'bob'",
+                            "user_id0": "2"
+                        }
                     },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert ignore into user(id, name) values (2, 'bob')",
-                        "commit"
+                    {
+                        "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
+                        "BindVars": {
+                            "name": "'bob'",
+                            "user_id": "2"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
+                    "commit",
+                    "select name from name_user_map where 1 != 1",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "insert ignore into user (id, name) values(2, \"bob\"),(3, \"charlie\")",
+        "Plans": [
+            {
+                "Original": "select name from name_user_map where name = :name and user_id = :user_id",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select name from name_user_map where name = :name and user_id = :user_id",
+                    "FieldQuery": "select name from name_user_map where 1 != 1",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
                     ]
                 }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
+            },
+            {
+                "Original": "insert ignore into name_user_map(name, user_id) values(:name0, :user_id0), (:name1, :user_id1)",
+                "Instructions": {
+                    "Opcode": "InsertShardedIgnore",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
                     },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                        "commit",
-                        "select name from name_user_map where 1 != 1",
-                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
-                    ]
-                },
-                {
-                    "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
-                    "BindVars": {
-                        "name": "'bob'",
-                        "user_id": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                        "commit",
-                        "select name from name_user_map where 1 != 1",
-                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "Query": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0), (:_name1, :user_id1)",
+                    "Values": [
+                        [
+                            ":name0",
+                            ":name1"
+                        ]
+                    ],
+                    "Table": "name_user_map",
+                    "Prefix": "insert ignore into name_user_map(name, user_id) values ",
+                    "Mid": [
+                        "(:_name0, :user_id0)",
+                        "(:_name1, :user_id1)"
                     ]
                 }
-            ]
+            },
+            {
+                "Original": "insert ignore into user (id, name) values(2, \"bob\"),(3, \"charlie\")",
+                "Instructions": {
+                    "Opcode": "InsertShardedIgnore",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert ignore into user(id, name) values (:_id0, :_name0), (:_id1, :_name1)",
+                    "Values": [
+                        [
+                            2,
+                            3
+                        ],
+                        [
+                            "bob",
+                            "charlie"
+                        ]
+                    ],
+                    "Table": "user",
+                    "Prefix": "insert ignore into user(id, name) values ",
+                    "Mid": [
+                        "(:_id0, :_name0)",
+                        "(:_id1, :_name1)"
+                    ]
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert ignore into user(id, name) values (:_id0, :_name0),(:_id1, :_name1) /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */",
+                        "BindVars": {
+                            "_id0": "2",
+                            "_id1": "3",
+                            "_name0": "'bob'",
+                            "_name1": "'charlie'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie')",
+                    "commit"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0),(:_name1, :user_id1) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b,91f3487c9b6830974afd7308bdf9c10d */",
+                        "BindVars": {
+                            "_name0": "'bob'",
+                            "_name1": "'charlie'",
+                            "name0": "'bob'",
+                            "name1": "'charlie'",
+                            "user_id0": "2",
+                            "user_id1": "3"
+                        }
+                    },
+                    {
+                        "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
+                        "BindVars": {
+                            "name": "'bob'",
+                            "user_id": "2"
+                        }
+                    },
+                    {
+                        "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
+                        "BindVars": {
+                            "name": "'charlie'",
+                            "user_id": "3"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3)",
+                    "commit",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "select name from name_user_map where name = 'charlie' and user_id = 3 limit 10001"
+                ]
+            }
         }
     }
 ]

--- a/data/test/vtexplain/insertsharded-output.txt
+++ b/data/test/vtexplain/insertsharded-output.txt
@@ -8,12 +8,6 @@ commit
 begin
 insert into user(id, name) values (1, 'alice')
 commit
-begin
-insert into name_user_map(name, user_id) values ('alice', 1)
-commit
-begin
-insert into user(id, name) values (1, 'alice')
-commit
 
 ----------------------------------------------------------------------
 insert into user (id, name) values(2, "bob")
@@ -42,10 +36,20 @@ insert ignore into name_user_map(name, user_id) values ('bob', 2)
 commit
 select name from name_user_map where 1 != 1
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+
+----------------------------------------------------------------------
+insert ignore into user (id, name) values(2, "bob"),(3, "charlie")
+
+[ks_sharded/-80]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
+insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie')
 commit
-select name from name_user_map where 1 != 1
+
+[ks_sharded/80-]:
+begin
+insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3)
+commit
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+select name from name_user_map where name = 'charlie' and user_id = 3 limit 10001
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/insertsharded-output.txt
+++ b/data/test/vtexplain/insertsharded-output.txt
@@ -1,0 +1,51 @@
+----------------------------------------------------------------------
+insert into user (id, name) values(1, "alice")
+
+[ks_sharded/-80]:
+begin
+insert into name_user_map(name, user_id) values ('alice', 1)
+commit
+begin
+insert into user(id, name) values (1, 'alice')
+commit
+begin
+insert into name_user_map(name, user_id) values ('alice', 1)
+commit
+begin
+insert into user(id, name) values (1, 'alice')
+commit
+
+----------------------------------------------------------------------
+insert into user (id, name) values(2, "bob")
+
+[ks_sharded/-80]:
+begin
+insert into user(id, name) values (2, 'bob')
+commit
+
+[ks_sharded/80-]:
+begin
+insert into name_user_map(name, user_id) values ('bob', 2)
+commit
+
+----------------------------------------------------------------------
+insert ignore into user (id, name) values(2, "bob")
+
+[ks_sharded/-80]:
+begin
+insert ignore into user(id, name) values (2, 'bob')
+commit
+
+[ks_sharded/80-]:
+begin
+insert ignore into name_user_map(name, user_id) values ('bob', 2)
+commit
+select name from name_user_map where 1 != 1
+select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+begin
+insert ignore into name_user_map(name, user_id) values ('bob', 2)
+commit
+select name from name_user_map where 1 != 1
+select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/insertsharded-queries.sql
+++ b/data/test/vtexplain/insertsharded-queries.sql
@@ -1,0 +1,3 @@
+insert into user (id, name) values(1, "alice");
+insert into user (id, name) values(2, "bob");
+insert ignore into user (id, name) values(2, "bob");

--- a/data/test/vtexplain/insertsharded-queries.sql
+++ b/data/test/vtexplain/insertsharded-queries.sql
@@ -1,3 +1,4 @@
 insert into user (id, name) values(1, "alice");
 insert into user (id, name) values(2, "bob");
 insert ignore into user (id, name) values(2, "bob");
+insert ignore into user (id, name) values(2, "bob"),(3, "charlie");

--- a/data/test/vtexplain/options-output.json
+++ b/data/test/vtexplain/options-output.json
@@ -15,55 +15,63 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/40-80": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-c0": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-40": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where email = :vtg1",
+                        "BindVars": {
+                            "vtg1": "'null@void.com'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where email = 'null@void.com' limit 10001"
+                ]
+            },
+            "ks_sharded/40-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where email = :vtg1",
+                        "BindVars": {
+                            "vtg1": "'null@void.com'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where email = 'null@void.com' limit 10001"
+                ]
+            },
+            "ks_sharded/80-c0": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where email = :vtg1",
+                        "BindVars": {
+                            "vtg1": "'null@void.com'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where email = 'null@void.com' limit 10001"
+                ]
+            },
+            "ks_sharded/c0-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where email = :vtg1",
+                        "BindVars": {
+                            "vtg1": "'null@void.com'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where email = 'null@void.com' limit 10001"
+                ]
+            }
         }
     },
     {
@@ -86,46 +94,52 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "__vals": "(1, 2)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id in (1, 2) limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/40-80": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "__vals": "(3, 5)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id in (3, 5) limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "__vals": "(4, 6, 7, 8)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id in (4, 6, 7, 8) limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-40": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id in ::__vals",
+                        "BindVars": {
+                            "__vals": "(1, 2)",
+                            "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id in (1, 2) limit 10001"
+                ]
+            },
+            "ks_sharded/40-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id in ::__vals",
+                        "BindVars": {
+                            "__vals": "(3, 5)",
+                            "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id in (3, 5) limit 10001"
+                ]
+            },
+            "ks_sharded/c0-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id in ::__vals",
+                        "BindVars": {
+                            "__vals": "(4, 6, 7, 8)",
+                            "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id in (4, 6, 7, 8) limit 10001"
+                ]
+            }
         }
     },
     {
@@ -177,38 +191,42 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "_id0": "2",
-                        "_name0": "'bob'",
-                        "vtg1": "2",
-                        "vtg2": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
-                        "commit"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-40": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                        "BindVars": {
+                            "_id0": "2",
+                            "_name0": "'bob'",
+                            "vtg1": "2",
+                            "vtg2": "'bob'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
+                    "commit"
+                ]
+            },
+            "ks_sharded/c0-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                        "BindVars": {
+                            "_name0": "'bob'",
+                            "name0": "'bob'",
+                            "user_id0": "2"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
+                    "commit"
+                ]
+            }
         }
     }
 ]

--- a/data/test/vtexplain/options-output.json
+++ b/data/test/vtexplain/options-output.json
@@ -1,0 +1,214 @@
+[
+    {
+        "SQL": "select * from user where email=\"null@void.com\"",
+        "Plans": [
+            {
+                "Original": "select * from user where email = :vtg1",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user where email = :vtg1",
+                    "FieldQuery": "select * from user where 1 != 1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-40": [
+                {
+                    "SQL": "select * from user where email = :vtg1",
+                    "BindVars": {
+                        "vtg1": "'null@void.com'"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where email = 'null@void.com' limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/40-80": [
+                {
+                    "SQL": "select * from user where email = :vtg1",
+                    "BindVars": {
+                        "vtg1": "'null@void.com'"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where email = 'null@void.com' limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/80-c0": [
+                {
+                    "SQL": "select * from user where email = :vtg1",
+                    "BindVars": {
+                        "vtg1": "'null@void.com'"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where email = 'null@void.com' limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/c0-": [
+                {
+                    "SQL": "select * from user where email = :vtg1",
+                    "BindVars": {
+                        "vtg1": "'null@void.com'"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where email = 'null@void.com' limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "select * from user where id in (1,2,3,4,5,6,7,8)",
+        "Plans": [
+            {
+                "Original": "select * from user where id in ::vtg1",
+                "Instructions": {
+                    "Opcode": "SelectIN",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user where id in ::__vals",
+                    "FieldQuery": "select * from user where 1 != 1",
+                    "Vindex": "hash",
+                    "Values": [
+                        "::vtg1"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-40": [
+                {
+                    "SQL": "select * from user where id in ::__vals",
+                    "BindVars": {
+                        "__vals": "(1, 2)",
+                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id in (1, 2) limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/40-80": [
+                {
+                    "SQL": "select * from user where id in ::__vals",
+                    "BindVars": {
+                        "__vals": "(3, 5)",
+                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id in (3, 5) limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/c0-": [
+                {
+                    "SQL": "select * from user where id in ::__vals",
+                    "BindVars": {
+                        "__vals": "(4, 6, 7, 8)",
+                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+                    },
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id in (4, 6, 7, 8) limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "insert into user (id, name) values(2, \"bob\")",
+        "Plans": [
+            {
+                "Original": "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+                    "Values": [
+                        [
+                            ":name0"
+                        ]
+                    ],
+                    "Table": "name_user_map",
+                    "Prefix": "insert into name_user_map(name, user_id) values ",
+                    "Mid": [
+                        "(:_name0, :user_id0)"
+                    ]
+                }
+            },
+            {
+                "Original": "insert into user(id, name) values (:vtg1, :vtg2)",
+                "Instructions": {
+                    "Opcode": "InsertSharded",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+                    "Values": [
+                        [
+                            ":vtg1"
+                        ],
+                        [
+                            ":vtg2"
+                        ]
+                    ],
+                    "Table": "user",
+                    "Prefix": "insert into user(id, name) values ",
+                    "Mid": [
+                        "(:_id0, :_name0)"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-40": [
+                {
+                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+                    "BindVars": {
+                        "_id0": "2",
+                        "_name0": "'bob'",
+                        "vtg1": "2",
+                        "vtg2": "'bob'"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
+                        "commit"
+                    ]
+                }
+            ],
+            "ks_sharded/c0-": [
+                {
+                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "BindVars": {
+                        "_name0": "'bob'",
+                        "name0": "'bob'",
+                        "user_id0": "2"
+                    },
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/data/test/vtexplain/options-output.txt
+++ b/data/test/vtexplain/options-output.txt
@@ -1,0 +1,48 @@
+----------------------------------------------------------------------
+select * from user where email="null@void.com"
+
+[ks_sharded/-40]:
+select * from user where 1 != 1
+select * from user where email = 'null@void.com' limit 10001
+
+[ks_sharded/40-80]:
+select * from user where 1 != 1
+select * from user where email = 'null@void.com' limit 10001
+
+[ks_sharded/80-c0]:
+select * from user where 1 != 1
+select * from user where email = 'null@void.com' limit 10001
+
+[ks_sharded/c0-]:
+select * from user where 1 != 1
+select * from user where email = 'null@void.com' limit 10001
+
+----------------------------------------------------------------------
+select * from user where id in (1,2,3,4,5,6,7,8)
+
+[ks_sharded/-40]:
+select * from user where 1 != 1
+select * from user where id in (1, 2) limit 10001
+
+[ks_sharded/40-80]:
+select * from user where 1 != 1
+select * from user where id in (3, 5) limit 10001
+
+[ks_sharded/c0-]:
+select * from user where 1 != 1
+select * from user where id in (4, 6, 7, 8) limit 10001
+
+----------------------------------------------------------------------
+insert into user (id, name) values(2, "bob")
+
+[ks_sharded/-40]:
+begin
+insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */
+commit
+
+[ks_sharded/c0-]:
+begin
+insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */
+commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/options-queries.sql
+++ b/data/test/vtexplain/options-queries.sql
@@ -1,0 +1,3 @@
+select * from user where email="null@void.com";
+select * from user where id in (1,2,3,4,5,6,7,8);
+insert into user (id, name) values(2, "bob");

--- a/data/test/vtexplain/selectsharded-output.json
+++ b/data/test/vtexplain/selectsharded-output.json
@@ -15,27 +15,31 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user /* scatter */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select * from user /* scatter */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user /* scatter */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user /* scatter */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user limit 10001"
+                ]
+            }
         }
     },
     {
@@ -58,17 +62,19 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user where id = 1 /* equal unique */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id = 1 limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id = 1 /* equal unique */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id = 1 limit 10001"
+                ]
+            }
         }
     },
     {
@@ -87,27 +93,31 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user where id > 100 /* scatter range */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id > 100 limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select * from user where id > 100 /* scatter range */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where id > 100 limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id > 100 /* scatter range */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id > 100 limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where id > 100 /* scatter range */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where id > 100 limit 10001"
+                ]
+            }
         }
     },
     {
@@ -146,29 +156,33 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user where name = 'bob'/* vindex lookup */",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from user where 1 != 1",
-                        "select * from user where name = 'bob' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
-                    "BindVars": {
-                        "name": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "select user_id from name_user_map where 1 != 1",
-                        "select user_id from name_user_map where name = 'bob' limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from user where name = 'bob'/* vindex lookup */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from user where 1 != 1",
+                    "select * from user where name = 'bob' limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
+                        "BindVars": {
+                            "name": "'bob'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select user_id from name_user_map where 1 != 1",
+                    "select user_id from name_user_map where name = 'bob' limit 10001"
+                ]
+            }
         }
     }
 ]

--- a/data/test/vtexplain/selectsharded-output.json
+++ b/data/test/vtexplain/selectsharded-output.json
@@ -1,0 +1,174 @@
+[
+    {
+        "SQL": "select * from user /* scatter */",
+        "Plans": [
+            {
+                "Original": "select * from user",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user",
+                    "FieldQuery": "select * from user where 1 != 1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "select * from user /* scatter */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "select * from user /* scatter */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "select * from user where id = 1 /* equal unique */",
+        "Plans": [
+            {
+                "Original": "select * from user where id = 1",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user where id = 1",
+                    "FieldQuery": "select * from user where 1 != 1",
+                    "Vindex": "hash",
+                    "Values": [
+                        1
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "select * from user where id = 1 /* equal unique */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id = 1 limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "select * from user where id > 100 /* scatter range */",
+        "Plans": [
+            {
+                "Original": "select * from user where id > 100",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user where id > 100",
+                    "FieldQuery": "select * from user where 1 != 1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "select * from user where id > 100 /* scatter range */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id > 100 limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "select * from user where id > 100 /* scatter range */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where id > 100 limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "select * from user where name = 'bob'/* vindex lookup */",
+        "Plans": [
+            {
+                "Original": "select user_id from name_user_map where name = :name",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select user_id from name_user_map where name = :name",
+                    "FieldQuery": "select user_id from name_user_map where 1 != 1",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
+                    ]
+                }
+            },
+            {
+                "Original": "select * from user where name = 'bob'",
+                "Instructions": {
+                    "Opcode": "SelectEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from user where name = 'bob'",
+                    "FieldQuery": "select * from user where 1 != 1",
+                    "Vindex": "name_user_map",
+                    "Values": [
+                        "bob"
+                    ]
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_sharded/-80": [
+                {
+                    "SQL": "select * from user where name = 'bob'/* vindex lookup */",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from user where 1 != 1",
+                        "select * from user where name = 'bob' limit 10001"
+                    ]
+                }
+            ],
+            "ks_sharded/80-": [
+                {
+                    "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
+                    "BindVars": {
+                        "name": "'bob'"
+                    },
+                    "MysqlQueries": [
+                        "select user_id from name_user_map where 1 != 1",
+                        "select user_id from name_user_map where name = 'bob' limit 10001"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/data/test/vtexplain/selectsharded-output.txt
+++ b/data/test/vtexplain/selectsharded-output.txt
@@ -1,0 +1,41 @@
+----------------------------------------------------------------------
+select * from user /* scatter */
+
+[ks_sharded/-80]:
+select * from user where 1 != 1
+select * from user limit 10001
+
+[ks_sharded/80-]:
+select * from user where 1 != 1
+select * from user limit 10001
+
+----------------------------------------------------------------------
+select * from user where id = 1 /* equal unique */
+
+[ks_sharded/-80]:
+select * from user where 1 != 1
+select * from user where id = 1 limit 10001
+
+----------------------------------------------------------------------
+select * from user where id > 100 /* scatter range */
+
+[ks_sharded/-80]:
+select * from user where 1 != 1
+select * from user where id > 100 limit 10001
+
+[ks_sharded/80-]:
+select * from user where 1 != 1
+select * from user where id > 100 limit 10001
+
+----------------------------------------------------------------------
+select * from user where name = 'bob'/* vindex lookup */
+
+[ks_sharded/-80]:
+select * from user where 1 != 1
+select * from user where name = 'bob' limit 10001
+
+[ks_sharded/80-]:
+select user_id from name_user_map where 1 != 1
+select user_id from name_user_map where name = 'bob' limit 10001
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/selectsharded-queries.sql
+++ b/data/test/vtexplain/selectsharded-queries.sql
@@ -1,0 +1,4 @@
+select * from user /* scatter */;
+select * from user where id = 1 /* equal unique */;
+select * from user where id > 100 /* scatter range */;
+select * from user where name = 'bob'/* vindex lookup */;

--- a/data/test/vtexplain/test-schema.sql
+++ b/data/test/vtexplain/test-schema.sql
@@ -1,0 +1,30 @@
+create table t1 (
+	id bigint(20) unsigned not null,
+	val bigint(20) unsigned not null default 0,
+	primary key (id)
+);
+
+create table user (
+	id bigint,
+	name varchar(64),
+	email varchar(64),
+	primary key (id)
+) Engine=InnoDB;
+
+create table name_user_map (
+	name varchar(64),
+	user_id bigint,
+	primary key (name, user_id)
+) Engine=InnoDB;
+
+create table music (
+	user_id bigint,
+	id bigint,
+	song varchar(64),
+	primary key (user_id, id)
+) Engine=InnoDB;
+
+create table table_not_in_vschema (
+	id bigint,
+	primary key (id)
+) Engine=InnoDB;

--- a/data/test/vtexplain/test-vschema.json
+++ b/data/test/vtexplain/test-vschema.json
@@ -1,0 +1,72 @@
+{
+	"ks_unsharded": {
+		"Sharded": false,
+		"Tables": {
+			"t1": {},
+			"table_not_in_schema": {}
+		}
+	},
+	"ks_sharded": {
+		"Sharded": true,
+		"vindexes": {
+			"music_user_map": {
+				"type": "lookup_hash_unique",
+				"owner": "music",
+				"params": {
+					"table": "music_user_map",
+					"from": "music_id",
+					"to": "user_id"
+				}
+			},
+			"name_user_map": {
+				"type": "lookup_hash",
+				"owner": "user",
+				"params": {
+					"table": "name_user_map",
+					"from": "name",
+					"to": "user_id"
+				}
+			},
+			"hash": {
+				"type": "hash"
+			},
+			"md5": {
+				"type": "unicode_loose_md5"
+			}
+		},
+		"tables": {
+			"user": {
+				"column_vindexes": [
+					{
+						"column": "id",
+						"name": "hash"
+					},
+					{
+						"column": "name",
+						"name": "name_user_map"
+					}
+				]
+			},
+			"music": {
+				"column_vindexes": [
+					{
+						"column": "user_id",
+						"name": "hash"
+					},
+					{
+						"column": "id",
+						"name": "music_user_map"
+					}
+				]
+			},
+			"name_user_map": {
+				"column_vindexes": [
+					{
+						"column": "name",
+						"name": "md5"
+					}
+				]
+			}
+		}
+	}
+}

--- a/data/test/vtexplain/unsharded-output.json
+++ b/data/test/vtexplain/unsharded-output.json
@@ -1,0 +1,150 @@
+[
+    {
+        "SQL": "select * from t1",
+        "Plans": [
+            {
+                "Original": "select * from t1",
+                "Instructions": {
+                    "Opcode": "SelectUnsharded",
+                    "Keyspace": {
+                        "Name": "ks_unsharded",
+                        "Sharded": false
+                    },
+                    "Query": "select * from t1",
+                    "FieldQuery": "select * from t1 where 1 != 1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_unsharded/-": [
+                {
+                    "SQL": "select * from t1",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "select * from t1 where 1 != 1",
+                        "select * from t1 limit 10001"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "insert into t1 (id,val) values (1,2)",
+        "Plans": [
+            {
+                "Original": "insert into t1 (id,val) values (1,2)",
+                "Instructions": {
+                    "Opcode": "InsertUnsharded",
+                    "Keyspace": {
+                        "Name": "ks_unsharded",
+                        "Sharded": false
+                    },
+                    "Query": "insert into t1(id, val) values (1, 2)",
+                    "Table": "t1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_unsharded/-": [
+                {
+                    "SQL": "insert into t1(id, val) values (1, 2)",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into t1(id, val) values (1, 2)",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "update t1 set val = 10",
+        "Plans": [
+            {
+                "Original": "update t1 set val = 10",
+                "Instructions": {
+                    "Opcode": "UpdateUnsharded",
+                    "Keyspace": {
+                        "Name": "ks_unsharded",
+                        "Sharded": false
+                    },
+                    "Query": "update t1 set val = 10"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_unsharded/-": [
+                {
+                    "SQL": "update t1 set val = 10",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "begin",
+                        "select id from t1 limit 10001 for update",
+                        "update t1 set val = 10 where id in (1)",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "delete from t1 where id = 100",
+        "Plans": [
+            {
+                "Original": "delete from t1 where id = 100",
+                "Instructions": {
+                    "Opcode": "DeleteUnsharded",
+                    "Keyspace": {
+                        "Name": "ks_unsharded",
+                        "Sharded": false
+                    },
+                    "Query": "delete from t1 where id = 100"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_unsharded/-": [
+                {
+                    "SQL": "delete from t1 where id = 100",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "begin",
+                        "delete from t1 where id in (100)",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "SQL": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
+        "Plans": [
+            {
+                "Original": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
+                "Instructions": {
+                    "Opcode": "InsertUnsharded",
+                    "Keyspace": {
+                        "Name": "ks_unsharded",
+                        "Sharded": false
+                    },
+                    "Query": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+                    "Table": "t1"
+                }
+            }
+        ],
+        "TabletQueries": {
+            "ks_unsharded/-": [
+                {
+                    "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+                    "BindVars": {},
+                    "MysqlQueries": [
+                        "begin",
+                        "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+                        "commit"
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/data/test/vtexplain/unsharded-output.json
+++ b/data/test/vtexplain/unsharded-output.json
@@ -15,17 +15,19 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "select * from t1",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "select * from t1 where 1 != 1",
-                        "select * from t1 limit 10001"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_unsharded/-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from t1",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from t1 where 1 != 1",
+                    "select * from t1 limit 10001"
+                ]
+            }
         }
     },
     {
@@ -44,18 +46,20 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "insert into t1(id, val) values (1, 2)",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into t1(id, val) values (1, 2)",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_unsharded/-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into t1(id, val) values (1, 2)",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into t1(id, val) values (1, 2)",
+                    "commit"
+                ]
+            }
         }
     },
     {
@@ -73,19 +77,21 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "update t1 set val = 10",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "begin",
-                        "select id from t1 limit 10001 for update",
-                        "update t1 set val = 10 where id in (1)",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_unsharded/-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "update t1 set val = 10",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "select id from t1 limit 10001 for update",
+                    "update t1 set val = 10 where id in (1)",
+                    "commit"
+                ]
+            }
         }
     },
     {
@@ -103,18 +109,20 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "delete from t1 where id = 100",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "begin",
-                        "delete from t1 where id in (100)",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_unsharded/-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "delete from t1 where id = 100",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "delete from t1 where id in (100)",
+                    "commit"
+                ]
+            }
         }
     },
     {
@@ -133,18 +141,20 @@
                 }
             }
         ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
-                    "BindVars": {},
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
-                        "commit"
-                    ]
-                }
-            ]
+        "TabletActions": {
+            "ks_unsharded/-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+                    "commit"
+                ]
+            }
         }
     }
 ]

--- a/data/test/vtexplain/unsharded-output.txt
+++ b/data/test/vtexplain/unsharded-output.txt
@@ -1,0 +1,41 @@
+----------------------------------------------------------------------
+select * from t1
+
+[ks_unsharded/-]:
+select * from t1 where 1 != 1
+select * from t1 limit 10001
+
+----------------------------------------------------------------------
+insert into t1 (id,val) values (1,2)
+
+[ks_unsharded/-]:
+begin
+insert into t1(id, val) values (1, 2)
+commit
+
+----------------------------------------------------------------------
+update t1 set val = 10
+
+[ks_unsharded/-]:
+begin
+select id from t1 limit 10001 for update
+update t1 set val = 10 where id in (1)
+commit
+
+----------------------------------------------------------------------
+delete from t1 where id = 100
+
+[ks_unsharded/-]:
+begin
+delete from t1 where id in (100)
+commit
+
+----------------------------------------------------------------------
+insert into t1 (id,val) values (1,2) on duplicate key update val=3
+
+[ks_unsharded/-]:
+begin
+insert into t1(id, val) values (1, 2) on duplicate key update val = 3
+commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/unsharded-queries.sql
+++ b/data/test/vtexplain/unsharded-queries.sql
@@ -1,0 +1,5 @@
+select * from t1;
+insert into t1 (id,val) values (1,2);
+update t1 set val = 10;
+delete from t1 where id = 100;
+insert into t1 (id,val) values (1,2) on duplicate key update val=3;

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -181,9 +181,9 @@ func parseAndRun() error {
 	}
 
 	if *outputMode == "text" {
-		fmt.Print(vtexplain.PlansAsText(plans))
+		fmt.Print(vtexplain.ExplainsAsText(plans))
 	} else {
-		fmt.Print(vtexplain.PlansAsJSON(plans))
+		fmt.Print(vtexplain.ExplainsAsJSON(plans))
 	}
 
 	return nil

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -24,7 +24,6 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
-	"github.com/youtube/vitess/go/jsonutil"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vtexplain"
@@ -38,7 +37,7 @@ var (
 	vschemaFlag     = flag.String("vschema", "", "Identifies the VTGate routing schema")
 	vschemaFileFlag = flag.String("vschema-file", "", "Identifies the VTGate routing schema file")
 	numShards       = flag.Int("shards", 2, "Number of shards per keyspace")
-	replicationMode = flag.String("replication-mode", "", "The replication mode to simulate -- must be set to either ROW or STATEMENT")
+	replicationMode = flag.String("replication-mode", "ROW", "The replication mode to simulate -- must be set to either ROW or STATEMENT")
 	normalize       = flag.Bool("normalize", false, "Whether to enable vtgate normalization")
 	outputMode      = flag.String("output-mode", "text", "Output in human-friendly text or json")
 
@@ -182,32 +181,10 @@ func parseAndRun() error {
 	}
 
 	if *outputMode == "text" {
-		printPlans(plans)
+		fmt.Print(vtexplain.PlansAsText(plans))
 	} else {
-		planJSON, err := jsonutil.MarshalIndentNoEscape(plans, "", "   ")
-		if err != nil {
-			return err
-		}
-
-		fmt.Printf(string(planJSON))
+		fmt.Print(vtexplain.PlansAsJSON(plans))
 	}
 
 	return nil
-}
-
-func printPlans(plans []*vtexplain.Plan) {
-	for _, plan := range plans {
-		fmt.Printf("----------------------------------------------------------------------\n")
-		fmt.Printf("%s\n\n", plan.SQL)
-		for tablet, queries := range plan.TabletQueries {
-			fmt.Printf("[%s]:\n", tablet)
-			for _, tq := range queries {
-				for _, sql := range tq.MysqlQueries {
-					fmt.Printf("%s\n", sql)
-				}
-			}
-			fmt.Printf("\n")
-		}
-	}
-	fmt.Printf("----------------------------------------------------------------------\n")
 }

--- a/go/cmd/vtexplain/vtexplain.go
+++ b/go/cmd/vtexplain/vtexplain.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -25,6 +24,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/exit"
+	"github.com/youtube/vitess/go/jsonutil"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vtexplain"
@@ -184,7 +184,7 @@ func parseAndRun() error {
 	if *outputMode == "text" {
 		printPlans(plans)
 	} else {
-		planJSON, err := json.MarshalIndent(plans, "", "    ")
+		planJSON, err := jsonutil.MarshalIndentNoEscape(plans, "", "   ")
 		if err != nil {
 			return err
 		}

--- a/go/jsonutil/json.go
+++ b/go/jsonutil/json.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jsonutil contains json-related utility functions
+package jsonutil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// MarshalNoEscape is the same functionality as json.Marshal but
+// with HTML escaping disabled
+func MarshalNoEscape(v interface{}) ([]byte, error) {
+	buf := bytes.Buffer{}
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(v)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// MarshalIndentNoEscape is the same functionality as json.MarshalIndent but with HTML escaping
+// disabled
+func MarshalIndentNoEscape(v interface{}, prefix, indent string) ([]byte, error) {
+	buf := bytes.Buffer{}
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent(prefix, indent)
+	err := enc.Encode(v)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -126,7 +126,7 @@ func StripLeadingComments(sql string) string {
 			// Single line comment
 			index := strings.Index(sql, "\n")
 			if index == -1 {
-				return sql
+				return ""
 			}
 			sql = sql[index+1:]
 		}

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -143,7 +143,7 @@ bar`,
 		outSQL: "bar",
 	}, {
 		input:  "-- /* foo */ bar",
-		outSQL: "-- /* foo */ bar",
+		outSQL: "",
 	}, {
 		input:  "foo -- bar */",
 		outSQL: "foo -- bar */",
@@ -157,7 +157,7 @@ a`,
 		outSQL: "a",
 	}, {
 		input:  `-- foo bar`,
-		outSQL: "-- foo bar",
+		outSQL: "",
 	}}
 	for _, testCase := range testCases {
 		gotSQL := StripLeadingComments(testCase.input)

--- a/go/vt/vtexplain/test.out
+++ b/go/vt/vtexplain/test.out
@@ -1,0 +1,1662 @@
+--- FAIL: TestUnsharded (0.24s)
+	vtexplain_test.go:71: ERROR: got [
+		    {
+		        "SQL": "select * from t1",
+		        "Plans": [
+		            {
+		                "Original": "select * from t1",
+		                "Instructions": {
+		                    "Opcode": "SelectUnsharded",
+		                    "Keyspace": {
+		                        "Name": "ks_unsharded",
+		                        "Sharded": false
+		                    },
+		                    "Query": "select * from t1",
+		                    "FieldQuery": "select * from t1 where 1 != 1"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_unsharded/-": [
+		                {
+		                    "SQL": "select * from t1",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from t1 where 1 != 1",
+		                        "select * from t1 limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "insert into t1 (id,val) values (1,2)",
+		        "Plans": [
+		            {
+		                "Original": "insert into t1 (id,val) values (1,2)",
+		                "Instructions": {
+		                    "Opcode": "InsertUnsharded",
+		                    "Keyspace": {
+		                        "Name": "ks_unsharded",
+		                        "Sharded": false
+		                    },
+		                    "Query": "insert into t1(id, val) values (1, 2)",
+		                    "Table": "t1"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_unsharded/-": [
+		                {
+		                    "SQL": "insert into t1(id, val) values (1, 2)",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from t1 where 1 != 1",
+		                        "select * from t1 limit 10001",
+		                        "begin",
+		                        "insert into t1(id, val) values (1, 2)",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "update t1 set val = 10",
+		        "Plans": [
+		            {
+		                "Original": "update t1 set val = 10",
+		                "Instructions": {
+		                    "Opcode": "UpdateUnsharded",
+		                    "Keyspace": {
+		                        "Name": "ks_unsharded",
+		                        "Sharded": false
+		                    },
+		                    "Query": "update t1 set val = 10"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_unsharded/-": [
+		                {
+		                    "SQL": "update t1 set val = 10",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from t1 where 1 != 1",
+		                        "select * from t1 limit 10001",
+		                        "begin",
+		                        "insert into t1(id, val) values (1, 2)",
+		                        "commit",
+		                        "begin",
+		                        "select id from t1 limit 10001 for update",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "delete from t1 where id = 100",
+		        "Plans": [
+		            {
+		                "Original": "delete from t1 where id = 100",
+		                "Instructions": {
+		                    "Opcode": "DeleteUnsharded",
+		                    "Keyspace": {
+		                        "Name": "ks_unsharded",
+		                        "Sharded": false
+		                    },
+		                    "Query": "delete from t1 where id = 100"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_unsharded/-": [
+		                {
+		                    "SQL": "delete from t1 where id = 100",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from t1 where 1 != 1",
+		                        "select * from t1 limit 10001",
+		                        "begin",
+		                        "insert into t1(id, val) values (1, 2)",
+		                        "commit",
+		                        "begin",
+		                        "select id from t1 limit 10001 for update",
+		                        "commit",
+		                        "begin",
+		                        "delete from t1 where id in (100)",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
+		        "Plans": [
+		            {
+		                "Original": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
+		                "Instructions": {
+		                    "Opcode": "InsertUnsharded",
+		                    "Keyspace": {
+		                        "Name": "ks_unsharded",
+		                        "Sharded": false
+		                    },
+		                    "Query": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+		                    "Table": "t1"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_unsharded/-": [
+		                {
+		                    "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from t1 where 1 != 1",
+		                        "select * from t1 limit 10001",
+		                        "begin",
+		                        "insert into t1(id, val) values (1, 2)",
+		                        "commit",
+		                        "begin",
+		                        "select id from t1 limit 10001 for update",
+		                        "commit",
+		                        "begin",
+		                        "delete from t1 where id in (100)",
+		                        "commit",
+		                        "begin",
+		                        "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    }
+		]...
+	vtexplain_test.go:72: json diff:  [
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from t1 where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_unsharded",
+		             "Sharded": false
+		           },
+		           "Opcode": "SelectUnsharded",
+		           "Query": "select * from t1"
+		         },
+		         "Original": "select * from t1"
+		       }
+		     ],
+		     "SQL": "select * from t1",
+		     "TabletQueries": {
+		       "ks_unsharded/-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from t1 where 1 != 1"
+		           ],
+		           "SQL": "select * from t1"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_unsharded",
+		             "Sharded": false
+		           },
+		           "Opcode": "InsertUnsharded",
+		           "Query": "insert into t1(id, val) values (1, 2)",
+		           "Table": "t1"
+		         },
+		         "Original": "insert into t1 (id,val) values (1,2)"
+		       }
+		     ],
+		     "SQL": "insert into t1 (id,val) values (1,2)",
+		     "TabletQueries": {
+		       "ks_unsharded/-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from t1 where 1 != 1",
+		-            "select * from t1 limit 10001",
+		             "commit"
+		           ],
+		           "SQL": "insert into t1(id, val) values (1, 2)"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_unsharded",
+		             "Sharded": false
+		           },
+		           "Opcode": "UpdateUnsharded",
+		           "Query": "update t1 set val = 10"
+		         },
+		         "Original": "update t1 set val = 10"
+		       }
+		     ],
+		     "SQL": "update t1 set val = 10",
+		     "TabletQueries": {
+		       "ks_unsharded/-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from t1 where 1 != 1",
+		-            "select * from t1 limit 10001",
+		-            "begin"
+		           ],
+		           "SQL": "update t1 set val = 10"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_unsharded",
+		             "Sharded": false
+		           },
+		           "Opcode": "DeleteUnsharded",
+		           "Query": "delete from t1 where id = 100"
+		         },
+		         "Original": "delete from t1 where id = 100"
+		       }
+		     ],
+		     "SQL": "delete from t1 where id = 100",
+		     "TabletQueries": {
+		       "ks_unsharded/-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from t1 where 1 != 1",
+		-            "select * from t1 limit 10001",
+		-            "begin"
+		           ],
+		           "SQL": "delete from t1 where id = 100"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_unsharded",
+		             "Sharded": false
+		           },
+		           "Opcode": "InsertUnsharded",
+		           "Query": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
+		           "Table": "t1"
+		         },
+		         "Original": "insert into t1 (id,val) values (1,2) on duplicate key update val=3"
+		       }
+		     ],
+		     "SQL": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
+		     "TabletQueries": {
+		       "ks_unsharded/-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from t1 where 1 != 1",
+		-            "select * from t1 limit 10001",
+		-            "begin"
+		           ],
+		           "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3"
+		         }
+		       ]
+		     }
+		   }
+		 ]
+--- FAIL: TestSelectSharded (0.12s)
+	vtexplain_test.go:71: ERROR: got [
+		    {
+		        "SQL": "select * from user /* scatter */",
+		        "Plans": [
+		            {
+		                "Original": "select * from user",
+		                "Instructions": {
+		                    "Opcode": "SelectScatter",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select * from user",
+		                    "FieldQuery": "select * from user where 1 != 1"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-80": [
+		                {
+		                    "SQL": "select * from user /* scatter */",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/80-": [
+		                {
+		                    "SQL": "select * from user /* scatter */",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "select * from user where id = 1 /* equal unique */",
+		        "Plans": [
+		            {
+		                "Original": "select * from user where id = 1",
+		                "Instructions": {
+		                    "Opcode": "SelectEqualUnique",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select * from user where id = 1",
+		                    "FieldQuery": "select * from user where 1 != 1",
+		                    "Vindex": "hash",
+		                    "Values": [
+		                        1
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-80": [
+		                {
+		                    "SQL": "select * from user where id = 1 /* equal unique */",
+		                    "BindVars": {},
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id = 1 limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "select * from user where name = 'bob'/* vindex lookup */",
+		        "Plans": [
+		            {
+		                "Original": "select user_id from name_user_map where name = :name",
+		                "Instructions": {
+		                    "Opcode": "SelectEqualUnique",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select user_id from name_user_map where name = :name",
+		                    "FieldQuery": "select user_id from name_user_map where 1 != 1",
+		                    "Vindex": "md5",
+		                    "Values": [
+		                        ":name"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "select * from user where name = 'bob'",
+		                "Instructions": {
+		                    "Opcode": "SelectEqual",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select * from user where name = 'bob'",
+		                    "FieldQuery": "select * from user where 1 != 1",
+		                    "Vindex": "name_user_map",
+		                    "Values": [
+		                        "bob"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/80-": [
+		                {
+		                    "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
+		                    "BindVars": {
+		                        "name": "'bob'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user limit 10001",
+		                        "select user_id from name_user_map where 1 != 1",
+		                        "select user_id from name_user_map where name = 'bob' limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    }
+		]...
+	vtexplain_test.go:72: json diff:  [
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from user where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectScatter",
+		           "Query": "select * from user"
+		         },
+		         "Original": "select * from user"
+		       }
+		     ],
+		     "SQL": "select * from user /* scatter */",
+		     "TabletQueries": {
+		       "ks_sharded/-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user /* scatter */"
+		         }
+		       ],
+		       "ks_sharded/80-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user /* scatter */"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from user where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectEqualUnique",
+		           "Query": "select * from user where id = 1",
+		           "Values": [
+		             1
+		           ],
+		           "Vindex": "hash"
+		         },
+		         "Original": "select * from user where id = 1"
+		       }
+		     ],
+		     "SQL": "select * from user where id = 1 /* equal unique */",
+		     "TabletQueries": {
+		       "ks_sharded/-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001"
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where id = 1 /* equal unique */"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select user_id from name_user_map where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectEqualUnique",
+		           "Query": "select user_id from name_user_map where name = :name",
+		           "Values": [
+		             ":name"
+		           ],
+		           "Vindex": "md5"
+		         },
+		         "Original": "select user_id from name_user_map where name = :name"
+		       },
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from user where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectEqual",
+		           "Query": "select * from user where name = 'bob'",
+		           "Values": [
+		             "bob"
+		           ],
+		           "Vindex": "name_user_map"
+		         },
+		         "Original": "select * from user where name = 'bob'"
+		       }
+		     ],
+		     "SQL": "select * from user where name = 'bob'/* vindex lookup */",
+		     "TabletQueries": {
+		+      "ks_sharded/-80": [
+		+        {
+		+          "BindVars": {
+		+            "#maxLimit": "10001"
+		+          },
+		+          "MysqlQueries": [
+		+            "select * from user where name = 'bob' limit 10001"
+		+          ],
+		+          "SQL": "select * from user where name = 'bob'/* vindex lookup */"
+		+        }
+		+      ],
+		       "ks_sharded/80-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "name": "'bob'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */"
+		         }
+		       ],
+		+      "ks_sharded/-80": [
+		+        {
+		+          "BindVars": {
+		+            "#maxLimit": "10001"
+		+          },
+		+          "MysqlQueries": [
+		+            "select * from user where name = 'bob' limit 10001"
+		+          ],
+		+          "SQL": "select * from user where name = 'bob'/* vindex lookup */"
+		+        }
+		+      ]
+		     }
+		   }
+		 ]
+--- FAIL: TestInsertSharded (0.48s)
+	vtexplain_test.go:71: ERROR: got [
+		    {
+		        "SQL": "insert into user (id, name) values(1, \"alice\")",
+		        "Plans": [
+		            {
+		                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		                    "Values": [
+		                        [
+		                            ":name0"
+		                        ]
+		                    ],
+		                    "Table": "name_user_map",
+		                    "Prefix": "insert into name_user_map(name, user_id) values ",
+		                    "Mid": [
+		                        "(:_name0, :user_id0)"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "insert into user (id, name) values(1, \"alice\")",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		                    "Values": [
+		                        [
+		                            1
+		                        ],
+		                        [
+		                            "alice"
+		                        ]
+		                    ],
+		                    "Table": "user",
+		                    "Prefix": "insert into user(id, name) values ",
+		                    "Mid": [
+		                        "(:_id0, :_name0)"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-80": [
+		                {
+		                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
+		                    "BindVars": {
+		                        "_name0": "'alice'",
+		                        "name0": "'alice'",
+		                        "user_id0": "1"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('alice', 1)",
+		                        "commit",
+		                        "begin",
+		                        "insert into user(id, name) values (1, 'alice')",
+		                        "commit"
+		                    ]
+		                },
+		                {
+		                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		                    "BindVars": {
+		                        "_id0": "1",
+		                        "_name0": "'alice'"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('alice', 1)",
+		                        "commit",
+		                        "begin",
+		                        "insert into user(id, name) values (1, 'alice')",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "insert into user (id, name) values(2, \"bob\")",
+		        "Plans": [
+		            {
+		                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		                    "Values": [
+		                        [
+		                            ":name0"
+		                        ]
+		                    ],
+		                    "Table": "name_user_map",
+		                    "Prefix": "insert into name_user_map(name, user_id) values ",
+		                    "Mid": [
+		                        "(:_name0, :user_id0)"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "insert into user (id, name) values(2, \"bob\")",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		                    "Values": [
+		                        [
+		                            2
+		                        ],
+		                        [
+		                            "bob"
+		                        ]
+		                    ],
+		                    "Table": "user",
+		                    "Prefix": "insert into user(id, name) values ",
+		                    "Mid": [
+		                        "(:_id0, :_name0)"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-80": [
+		                {
+		                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+		                    "BindVars": {
+		                        "_id0": "2",
+		                        "_name0": "'bob'"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('alice', 1)",
+		                        "commit",
+		                        "begin",
+		                        "insert into user(id, name) values (1, 'alice')",
+		                        "commit",
+		                        "begin",
+		                        "insert into user(id, name) values (2, 'bob')",
+		                        "commit"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/80-": [
+		                {
+		                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+		                    "BindVars": {
+		                        "_name0": "'bob'",
+		                        "name0": "'bob'",
+		                        "user_id0": "2"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('bob', 2)",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "insert ignore into user (id, name) values(2, \"bob\")",
+		        "Plans": [
+		            {
+		                "Original": "select name from name_user_map where name = :name and user_id = :user_id",
+		                "Instructions": {
+		                    "Opcode": "SelectEqualUnique",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select name from name_user_map where name = :name and user_id = :user_id",
+		                    "FieldQuery": "select name from name_user_map where 1 != 1",
+		                    "Vindex": "md5",
+		                    "Values": [
+		                        ":name"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "insert ignore into name_user_map(name, user_id) values(:name0, :user_id0)",
+		                "Instructions": {
+		                    "Opcode": "InsertShardedIgnore",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		                    "Values": [
+		                        [
+		                            ":name0"
+		                        ]
+		                    ],
+		                    "Table": "name_user_map",
+		                    "Prefix": "insert ignore into name_user_map(name, user_id) values ",
+		                    "Mid": [
+		                        "(:_name0, :user_id0)"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "insert ignore into user (id, name) values(2, \"bob\")",
+		                "Instructions": {
+		                    "Opcode": "InsertShardedIgnore",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert ignore into user(id, name) values (:_id0, :_name0)",
+		                    "Values": [
+		                        [
+		                            2
+		                        ],
+		                        [
+		                            "bob"
+		                        ]
+		                    ],
+		                    "Table": "user",
+		                    "Prefix": "insert ignore into user(id, name) values ",
+		                    "Mid": [
+		                        "(:_id0, :_name0)"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/80-": [
+		                {
+		                    "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+		                    "BindVars": {
+		                        "_name0": "'bob'",
+		                        "name0": "'bob'",
+		                        "user_id0": "2"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('bob', 2)",
+		                        "commit",
+		                        "begin",
+		                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
+		                        "commit",
+		                        "select name from name_user_map where 1 != 1",
+		                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+		                    ]
+		                },
+		                {
+		                    "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
+		                    "BindVars": {
+		                        "name": "'bob'",
+		                        "user_id": "2"
+		                    },
+		                    "MysqlQueries": [
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('bob', 2)",
+		                        "commit",
+		                        "begin",
+		                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
+		                        "commit",
+		                        "select name from name_user_map where 1 != 1",
+		                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    }
+		]...
+	vtexplain_test.go:72: json diff:  [
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_name0, :user_id0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into name_user_map(name, user_id) values ",
+		           "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		           "Table": "name_user_map",
+		           "Values": [
+		             [
+		               ":name0"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)"
+		       },
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_id0, :_name0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into user(id, name) values ",
+		           "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		           "Table": "user",
+		           "Values": [
+		             [
+		               1
+		             ],
+		             [
+		               "alice"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into user (id, name) values(1, "alice")"
+		       }
+		     ],
+		     "SQL": "insert into user (id, name) values(1, "alice")",
+		     "TabletQueries": {
+		       "ks_sharded/-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_name0": "'alice'",
+		             "name0": "'alice'",
+		             "user_id0": "1",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		             "begin",
+		             "insert into name_user_map(name, user_id) values ('alice', 1)",
+		-            "commit"
+		           ],
+		           "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */"
+		         },
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_id0": "1",
+		             "_name0": "'alice'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "begin",
+		-            "insert into name_user_map(name, user_id) values ('alice', 1)",
+		-            "commit"
+		           ],
+		           "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_name0, :user_id0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into name_user_map(name, user_id) values ",
+		           "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		           "Table": "name_user_map",
+		           "Values": [
+		             [
+		               ":name0"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)"
+		       },
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_id0, :_name0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into user(id, name) values ",
+		           "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		           "Table": "user",
+		           "Values": [
+		             [
+		               2
+		             ],
+		             [
+		               "bob"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into user (id, name) values(2, "bob")"
+		       }
+		     ],
+		     "SQL": "insert into user (id, name) values(2, "bob")",
+		     "TabletQueries": {
+		       "ks_sharded/-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_id0": "2",
+		             "_name0": "'bob'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "begin",
+		-            "insert into name_user_map(name, user_id) values ('alice', 1)",
+		-            "commit"
+		           ],
+		           "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */"
+		         }
+		       ],
+		       "ks_sharded/80-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_name0": "'bob'",
+		             "name0": "'bob'",
+		             "user_id0": "2",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		             "begin",
+		             "insert into name_user_map(name, user_id) values ('bob', 2)",
+		             "commit"
+		           ],
+		           "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select name from name_user_map where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectEqualUnique",
+		           "Query": "select name from name_user_map where name = :name and user_id = :user_id",
+		           "Values": [
+		             ":name"
+		           ],
+		           "Vindex": "md5"
+		         },
+		         "Original": "select name from name_user_map where name = :name and user_id = :user_id"
+		       },
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_name0, :user_id0)"
+		           ],
+		           "Opcode": "InsertShardedIgnore",
+		           "Prefix": "insert ignore into name_user_map(name, user_id) values ",
+		           "Query": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		           "Table": "name_user_map",
+		           "Values": [
+		             [
+		               ":name0"
+		             ]
+		           ]
+		         },
+		         "Original": "insert ignore into name_user_map(name, user_id) values(:name0, :user_id0)"
+		       },
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_id0, :_name0)"
+		           ],
+		           "Opcode": "InsertShardedIgnore",
+		           "Prefix": "insert ignore into user(id, name) values ",
+		           "Query": "insert ignore into user(id, name) values (:_id0, :_name0)",
+		           "Table": "user",
+		           "Values": [
+		             [
+		               2
+		             ],
+		             [
+		               "bob"
+		             ]
+		           ]
+		         },
+		         "Original": "insert ignore into user (id, name) values(2, "bob")"
+		       }
+		     ],
+		     "SQL": "insert ignore into user (id, name) values(2, "bob")",
+		     "TabletQueries": {
+		+      "ks_sharded/-80": [
+		+        {
+		+          "BindVars": {
+		+            "#maxLimit": "10001",
+		+            "_id0": "2",
+		+            "_name0": "'bob'"
+		+          },
+		+          "MysqlQueries": [
+		+            "begin",
+		+            "insert ignore into user(id, name) values (2, 'bob')",
+		+            "commit"
+		+          ],
+		+          "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */"
+		+        }
+		+      ],
+		       "ks_sharded/80-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_name0": "'bob'",
+		             "name0": "'bob'",
+		             "user_id0": "2",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "begin",
+		-            "insert into name_user_map(name, user_id) values ('bob', 2)",
+		-            "commit"
+		           ],
+		           "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */"
+		         },
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "name": "'bob'",
+		             "user_id": "2",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "begin"
+		           ],
+		           "SQL": "select name from name_user_map where name = :name and user_id = :user_id"
+		         }
+		       ],
+		+      "ks_sharded/-80": [
+		+        {
+		+          "BindVars": {
+		+            "#maxLimit": "10001",
+		+            "_id0": "2",
+		+            "_name0": "'bob'"
+		+          },
+		+          "MysqlQueries": [
+		+            "begin",
+		+            "insert ignore into user(id, name) values (2, 'bob')",
+		+            "commit"
+		+          ],
+		+          "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */"
+		+        }
+		+      ]
+		     }
+		   }
+		 ]
+--- FAIL: TestOptions (0.26s)
+	vtexplain_test.go:71: ERROR: got [
+		    {
+		        "SQL": "select * from user where email=\"null@void.com\"",
+		        "Plans": [
+		            {
+		                "Original": "select * from user where email = :vtg1",
+		                "Instructions": {
+		                    "Opcode": "SelectScatter",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select * from user where email = :vtg1",
+		                    "FieldQuery": "select * from user where 1 != 1"
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-40": [
+		                {
+		                    "SQL": "select * from user where email = :vtg1",
+		                    "BindVars": {
+		                        "vtg1": "'null@void.com'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/40-80": [
+		                {
+		                    "SQL": "select * from user where email = :vtg1",
+		                    "BindVars": {
+		                        "vtg1": "'null@void.com'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/80-c0": [
+		                {
+		                    "SQL": "select * from user where email = :vtg1",
+		                    "BindVars": {
+		                        "vtg1": "'null@void.com'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/c0-": [
+		                {
+		                    "SQL": "select * from user where email = :vtg1",
+		                    "BindVars": {
+		                        "vtg1": "'null@void.com'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "select * from user where id in (1,2,3,4,5,6,7,8)",
+		        "Plans": [
+		            {
+		                "Original": "select * from user where id in ::vtg1",
+		                "Instructions": {
+		                    "Opcode": "SelectIN",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "select * from user where id in ::__vals",
+		                    "FieldQuery": "select * from user where 1 != 1",
+		                    "Vindex": "hash",
+		                    "Values": [
+		                        "::vtg1"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-40": [
+		                {
+		                    "SQL": "select * from user where id in ::__vals",
+		                    "BindVars": {
+		                        "__vals": "(1, 2)",
+		                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id in (1, 2) limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/40-80": [
+		                {
+		                    "SQL": "select * from user where id in ::__vals",
+		                    "BindVars": {
+		                        "__vals": "(3, 5)",
+		                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id in (3, 5) limit 10001"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/c0-": [
+		                {
+		                    "SQL": "select * from user where id in ::__vals",
+		                    "BindVars": {
+		                        "__vals": "(4, 6, 7, 8)",
+		                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id in (4, 6, 7, 8) limit 10001"
+		                    ]
+		                }
+		            ]
+		        }
+		    },
+		    {
+		        "SQL": "insert into user (id, name) values(2, \"bob\")",
+		        "Plans": [
+		            {
+		                "Original": "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		                    "Values": [
+		                        [
+		                            ":name0"
+		                        ]
+		                    ],
+		                    "Table": "name_user_map",
+		                    "Prefix": "insert into name_user_map(name, user_id) values ",
+		                    "Mid": [
+		                        "(:_name0, :user_id0)"
+		                    ]
+		                }
+		            },
+		            {
+		                "Original": "insert into user(id, name) values (:vtg1, :vtg2)",
+		                "Instructions": {
+		                    "Opcode": "InsertSharded",
+		                    "Keyspace": {
+		                        "Name": "ks_sharded",
+		                        "Sharded": true
+		                    },
+		                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		                    "Values": [
+		                        [
+		                            ":vtg1"
+		                        ],
+		                        [
+		                            ":vtg2"
+		                        ]
+		                    ],
+		                    "Table": "user",
+		                    "Prefix": "insert into user(id, name) values ",
+		                    "Mid": [
+		                        "(:_id0, :_name0)"
+		                    ]
+		                }
+		            }
+		        ],
+		        "TabletQueries": {
+		            "ks_sharded/-40": [
+		                {
+		                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
+		                    "BindVars": {
+		                        "_id0": "2",
+		                        "_name0": "'bob'",
+		                        "vtg1": "2",
+		                        "vtg2": "'bob'"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id in (1, 2) limit 10001",
+		                        "begin",
+		                        "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
+		                        "commit"
+		                    ]
+		                }
+		            ],
+		            "ks_sharded/c0-": [
+		                {
+		                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+		                    "BindVars": {
+		                        "_name0": "'bob'",
+		                        "name0": "'bob'",
+		                        "user_id0": "2"
+		                    },
+		                    "MysqlQueries": [
+		                        "select * from user where 1 != 1",
+		                        "select * from user where email = 'null@void.com' limit 10001",
+		                        "select * from user where 1 != 1",
+		                        "select * from user where id in (4, 6, 7, 8) limit 10001",
+		                        "begin",
+		                        "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
+		                        "commit"
+		                    ]
+		                }
+		            ]
+		        }
+		    }
+		]...
+	vtexplain_test.go:72: json diff:  [
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from user where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectScatter",
+		           "Query": "select * from user where email = :vtg1"
+		         },
+		         "Original": "select * from user where email = :vtg1"
+		       }
+		     ],
+		     "SQL": "select * from user where email="null@void.com"",
+		     "TabletQueries": {
+		       "ks_sharded/-40": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "vtg1": "'null@void.com'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where email = :vtg1"
+		         }
+		       ],
+		       "ks_sharded/40-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "vtg1": "'null@void.com'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where email = :vtg1"
+		         }
+		       ],
+		       "ks_sharded/80-c0": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "vtg1": "'null@void.com'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where email = :vtg1"
+		         }
+		       ],
+		       "ks_sharded/c0-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "vtg1": "'null@void.com'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where email = :vtg1"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "FieldQuery": "select * from user where 1 != 1",
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Opcode": "SelectIN",
+		           "Query": "select * from user where id in ::__vals",
+		           "Values": [
+		             "::vtg1"
+		           ],
+		           "Vindex": "hash"
+		         },
+		         "Original": "select * from user where id in ::vtg1"
+		       }
+		     ],
+		     "SQL": "select * from user where id in (1,2,3,4,5,6,7,8)",
+		     "TabletQueries": {
+		       "ks_sharded/-40": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "__vals": "(1, 2)",
+		             "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where id in ::__vals"
+		         }
+		       ],
+		       "ks_sharded/40-80": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "__vals": "(3, 5)",
+		             "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where id in ::__vals"
+		         }
+		       ],
+		       "ks_sharded/c0-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "__vals": "(4, 6, 7, 8)",
+		             "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "select * from user where id in ::__vals"
+		         }
+		       ]
+		     }
+		   },
+		   {
+		     "Plans": [
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_name0, :user_id0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into name_user_map(name, user_id) values ",
+		           "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
+		           "Table": "name_user_map",
+		           "Values": [
+		             [
+		               ":name0"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into name_user_map(name, user_id) values (:name0, :user_id0)"
+		       },
+		       {
+		         "Instructions": {
+		           "Keyspace": {
+		             "Name": "ks_sharded",
+		             "Sharded": true
+		           },
+		           "Mid": [
+		             "(:_id0, :_name0)"
+		           ],
+		           "Opcode": "InsertSharded",
+		           "Prefix": "insert into user(id, name) values ",
+		           "Query": "insert into user(id, name) values (:_id0, :_name0)",
+		           "Table": "user",
+		           "Values": [
+		             [
+		               ":vtg1"
+		             ],
+		             [
+		               ":vtg2"
+		             ]
+		           ]
+		         },
+		         "Original": "insert into user(id, name) values (:vtg1, :vtg2)"
+		       }
+		     ],
+		     "SQL": "insert into user (id, name) values(2, "bob")",
+		     "TabletQueries": {
+		       "ks_sharded/-40": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_id0": "2",
+		             "_name0": "'bob'",
+		             "vtg1": "2",
+		             "vtg2": "'bob'",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1",
+		-            "select * from user where email = 'null@void.com' limit 10001",
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */"
+		         }
+		       ],
+		       "ks_sharded/c0-": [
+		         {
+		           "BindVars": {
+		+            "#maxLimit": "10001",
+		             "_name0": "'bob'",
+		             "name0": "'bob'",
+		             "user_id0": "2",
+		+            "#maxLimit": "10001"
+		           },
+		           "MysqlQueries": [
+		-            "select * from user where 1 != 1",
+		-            "select * from user where email = 'null@void.com' limit 10001",
+		-            "select * from user where 1 != 1"
+		           ],
+		           "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */"
+		         }
+		       ]
+		     }
+		   }
+		 ]
+--- FAIL: TestErrors (0.02s)
+	vtexplain_test.go:1061: Run(INVALID SQL): vtgate Execute: error processing sql INVALID SQL: unrecognized statement: INVALID SQL, want vtgate Execute: unrecognized statement: INVALID SQL
+	vtexplain_test.go:1061: Run(SELECT * FROM THIS IS NOT SQL): vtgate Execute: error processing sql SELECT * FROM THIS IS NOT SQL: syntax error at position 22 near 'is', want vtgate Execute: syntax error at position 22 near 'is'
+	vtexplain_test.go:1061: Run(SELECT * FROM table_not_in_vschema): vtgate Execute: error processing sql SELECT * FROM table_not_in_vschema: table table_not_in_vschema not found, want vtgate Execute: table table_not_in_vschema not found
+	vtexplain_test.go:1061: Run(SELECT * FROM table_not_in_schema): vtgate Execute: error processing sql SELECT * FROM table_not_in_schema: target: ks_unsharded.-.master, used tablet: explainCell-0 (ks_unsharded/-), table table_not_in_schema not found in schema, want fakeTabletExecute: table table_not_in_schema not found in schema
+FAIL
+exit status 1
+FAIL	github.com/youtube/vitess/go/vt/vtexplain	1.371s

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -21,12 +21,12 @@ package vtexplain
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	log "github.com/golang/glog"
 
+	"github.com/youtube/vitess/go/jsonutil"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/engine"
 
@@ -69,7 +69,7 @@ func (tq *TabletQuery) MarshalJSON() ([]byte, error) {
 		bindVars[k] = b.String()
 	}
 
-	return json.Marshal(&struct {
+	return jsonutil.MarshalNoEscape(&struct {
 		SQL          string
 		BindVars     map[string]string
 		MysqlQueries []string

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -64,47 +64,46 @@ func testExplain(testcase string, opts *Options, t *testing.T) {
 	textOutFile := testfiles.Locate(fmt.Sprintf("vtexplain/%s-output.txt", testcase))
 	textOut, err := ioutil.ReadFile(textOutFile)
 
-	plans, err := Run(string(sql))
+	explains, err := Run(string(sql))
 	if err != nil {
 		t.Fatalf("vtexplain error: %v", err)
 	}
-	if plans == nil {
-		t.Fatalf("vtexplain error running %s: no plan", string(sql))
+	if explains == nil {
+		t.Fatalf("vtexplain error running %s: no explain", string(sql))
 	}
 
-	planJSON := PlansAsJSON(plans)
-
-	if strings.TrimSpace(string(planJSON)) != strings.TrimSpace(string(jsonOut)) {
+	explainJSON := ExplainsAsJSON(explains)
+	if strings.TrimSpace(string(explainJSON)) != strings.TrimSpace(string(jsonOut)) {
 		// Print the json that was actually returned and also dump to a
 		// temp file to be able to diff the results.
 		t.Errorf("json output did not match")
-		t.Logf("got:\n%s\n", string(planJSON))
+		t.Logf("got:\n%s\n", string(explainJSON))
 
 		tempDir, err := ioutil.TempDir("", "vtexplain_output")
 		if err != nil {
 			t.Fatalf("error getting tempdir: %v", err)
 		}
 		gotFile := fmt.Sprintf("%s/%s-output.json", tempDir, testcase)
-		ioutil.WriteFile(gotFile, []byte(planJSON), 0644)
+		ioutil.WriteFile(gotFile, []byte(explainJSON), 0644)
 
 		command := exec.Command("diff", "-u", jsonOutFile, gotFile)
 		out, _ := command.CombinedOutput()
 		t.Logf("diff:\n%s\n", out)
 	}
 
-	planText := PlansAsText(plans)
-	if strings.TrimSpace(string(planText)) != strings.TrimSpace(string(textOut)) {
+	explainText := ExplainsAsText(explains)
+	if strings.TrimSpace(string(explainText)) != strings.TrimSpace(string(textOut)) {
 		// Print the Text that was actually returned and also dump to a
 		// temp file to be able to diff the results.
 		t.Errorf("Text output did not match")
-		t.Logf("got:\n%s\n", string(planText))
+		t.Logf("got:\n%s\n", string(explainText))
 
 		tempDir, err := ioutil.TempDir("", "vtexplain_output")
 		if err != nil {
 			t.Fatalf("error getting tempdir: %v", err)
 		}
 		gotFile := fmt.Sprintf("%s/%s-output.txt", tempDir, testcase)
-		ioutil.WriteFile(gotFile, []byte(planText), 0644)
+		ioutil.WriteFile(gotFile, []byte(explainText), 0644)
 
 		command := exec.Command("diff", "-u", textOutFile, gotFile)
 		out, _ := command.CombinedOutput()

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package vtexplain
 
 import (
-	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
 	"testing"
 
-	jsondiff "github.com/yudai/gojsondiff"
-	"github.com/yudai/gojsondiff/formatter"
+	"github.com/youtube/vitess/go/testfiles"
 )
 
 func defaultTestOpts() *Options {
@@ -32,1003 +34,112 @@ func defaultTestOpts() *Options {
 	}
 }
 
-func testExplain(sqlStr, expected string, opts *Options, t *testing.T) {
-	err := Init(testVSchemaStr, testSchemaStr, opts)
+func initTest(opts *Options, t *testing.T) {
+	schema, err := ioutil.ReadFile(testfiles.Locate("vtexplain/test-schema.sql"))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	vSchema, err := ioutil.ReadFile(testfiles.Locate("vtexplain/test-vschema.json"))
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	err = Init(string(vSchema), string(schema), opts)
 	if err != nil {
 		t.Fatalf("vtexplain Init error: %v", err)
 	}
 
-	plans, err := Run(sqlStr)
+}
+
+func testExplain(testcase string, opts *Options, t *testing.T) {
+	initTest(opts, t)
+
+	sqlFile := testfiles.Locate(fmt.Sprintf("vtexplain/%s-queries.sql", testcase))
+	sql, err := ioutil.ReadFile(sqlFile)
+
+	jsonOutFile := testfiles.Locate(fmt.Sprintf("vtexplain/%s-output.json", testcase))
+	jsonOut, err := ioutil.ReadFile(jsonOutFile)
+
+	textOutFile := testfiles.Locate(fmt.Sprintf("vtexplain/%s-output.txt", testcase))
+	textOut, err := ioutil.ReadFile(textOutFile)
+
+	plans, err := Run(string(sql))
 	if err != nil {
 		t.Fatalf("vtexplain error: %v", err)
 	}
 	if plans == nil {
-		t.Fatalf("vtexplain error running %s: no plan", sqlStr)
+		t.Fatalf("vtexplain error running %s: no plan", string(sql))
 	}
 
-	planJSON, err := json.MarshalIndent(plans, "", "    ")
-	if err != nil {
-		t.Error(err)
+	planJSON := PlansAsJSON(plans)
+
+	if strings.TrimSpace(string(planJSON)) != strings.TrimSpace(string(jsonOut)) {
+		// Print the json that was actually returned and also dump to a
+		// temp file to be able to diff the results.
+		t.Errorf("json output did not match")
+		t.Logf("got:\n%s\n", string(planJSON))
+
+		tempDir, err := ioutil.TempDir("", "vtexplain_output")
+		if err != nil {
+			t.Fatalf("error getting tempdir: %v", err)
+		}
+		gotFile := fmt.Sprintf("%s/%s-output.json", tempDir, testcase)
+		ioutil.WriteFile(gotFile, []byte(planJSON), 0644)
+
+		command := exec.Command("diff", "-u", jsonOutFile, gotFile)
+		out, _ := command.CombinedOutput()
+		t.Logf("diff:\n%s\n", out)
 	}
 
-	var gotArray, wantArray []interface{}
-	err = json.Unmarshal(planJSON, &gotArray)
-	if err != nil {
-		t.Fatalf("json unmarshal: %v", err)
-	}
+	planText := PlansAsText(plans)
+	if strings.TrimSpace(string(planText)) != strings.TrimSpace(string(textOut)) {
+		// Print the Text that was actually returned and also dump to a
+		// temp file to be able to diff the results.
+		t.Errorf("Text output did not match")
+		t.Logf("got:\n%s\n", string(planText))
 
-	err = json.Unmarshal([]byte(expected), &wantArray)
-	if err != nil {
-		t.Fatalf("json unmarshal: %v", err)
-	}
+		tempDir, err := ioutil.TempDir("", "vtexplain_output")
+		if err != nil {
+			t.Fatalf("error getting tempdir: %v", err)
+		}
+		gotFile := fmt.Sprintf("%s/%s-output.txt", tempDir, testcase)
+		ioutil.WriteFile(gotFile, []byte(planText), 0644)
 
-	d := jsondiff.New().CompareArrays(gotArray, wantArray)
-
-	if d.Modified() {
-		config := formatter.AsciiFormatterConfig{}
-		formatter := formatter.NewAsciiFormatter(wantArray, config)
-		diffString, _ := formatter.Format(d)
-		t.Logf("ERROR: got %s...", string(planJSON))
-		t.Errorf("json diff: %s", diffString)
+		command := exec.Command("diff", "-u", textOutFile, gotFile)
+		out, _ := command.CombinedOutput()
+		t.Logf("diff:\n%s\n", out)
 	}
 }
-
-var testVSchemaStr = `
-{
-	"ks_unsharded": {
-		"Sharded": false,
-		"Tables": {
-			"t1": {},
-			"table_not_in_schema": {}
-		}
-	},
-	"ks_sharded": {
-		"Sharded": true,
-		"vindexes": {
-			"music_user_map": {
-				"type": "lookup_hash_unique",
-				"owner": "music",
-				"params": {
-					"table": "music_user_map",
-					"from": "music_id",
-					"to": "user_id"
-				}
-			},
-			"name_user_map": {
-				"type": "lookup_hash",
-				"owner": "user",
-				"params": {
-					"table": "name_user_map",
-					"from": "name",
-					"to": "user_id"
-				}
-			},
-			"hash": {
-				"type": "hash"
-			},
-			"md5": {
-				"type": "unicode_loose_md5"
-			}
-		},
-		"tables": {
-			"user": {
-				"column_vindexes": [
-					{
-						"column": "id",
-						"name": "hash"
-					},
-					{
-						"column": "name",
-						"name": "name_user_map"
-					}
-				]
-			},
-			"music": {
-				"column_vindexes": [
-					{
-						"column": "user_id",
-						"name": "hash"
-					},
-					{
-						"column": "id",
-						"name": "music_user_map"
-					}
-				]
-			},
-			"name_user_map": {
-				"column_vindexes": [
-					{
-						"column": "name",
-						"name": "md5"
-					}
-				]
-			}
-		}
-	}
-}
-`
-
-var testSchemaStr = `
-create table t1 (
-	id bigint(20) unsigned not null,
-	val bigint(20) unsigned not null default 0,
-	primary key (id)
-);
-
-create table user (
-	id bigint,
-	name varchar(64),
-	email varchar(64),
-	primary key (id)
-) Engine=InnoDB;
-
-create table name_user_map (
-	name varchar(64),
-	user_id bigint,
-	primary key (name, user_id)
-) Engine=InnoDB;
-
-create table music (
-	user_id bigint,
-	id bigint,
-	song varchar(64),
-	primary key (user_id, id)
-) Engine=InnoDB;
-
-create table table_not_in_vschema (
-	id bigint,
-	primary key (id)
-) Engine=InnoDB;
-`
 
 func TestUnsharded(t *testing.T) {
-	sqlStr := `
-select * from t1;
-insert into t1 (id,val) values (1,2);
-update t1 set val = 10;
-delete from t1 where id = 100;
-insert into t1 (id,val) values (1,2) on duplicate key update val=3;
-`
-	expected := `[
-    {
-        "SQL": "select * from t1",
-        "Plans": [
-            {
-                "Original": "select * from t1",
-                "Instructions": {
-                    "Opcode": "SelectUnsharded",
-                    "Keyspace": {
-                        "Name": "ks_unsharded",
-                        "Sharded": false
-                    },
-                    "Query": "select * from t1",
-                    "FieldQuery": "select * from t1 where 1 != 1"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "select * from t1",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "select * from t1 limit 10001"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "insert into t1 (id,val) values (1,2)",
-        "Plans": [
-            {
-                "Original": "insert into t1 (id,val) values (1,2)",
-                "Instructions": {
-                    "Opcode": "InsertUnsharded",
-                    "Keyspace": {
-                        "Name": "ks_unsharded",
-                        "Sharded": false
-                    },
-                    "Query": "insert into t1(id, val) values (1, 2)",
-                    "Table": "t1"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "insert into t1(id, val) values (1, 2)",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into t1(id, val) values (1, 2)",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "update t1 set val = 10",
-        "Plans": [
-            {
-                "Original": "update t1 set val = 10",
-                "Instructions": {
-                    "Opcode": "UpdateUnsharded",
-                    "Keyspace": {
-                        "Name": "ks_unsharded",
-                        "Sharded": false
-                    },
-                    "Query": "update t1 set val = 10"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "update t1 set val = 10",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "select id from t1 limit 10001 for update",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "delete from t1 where id = 100",
-        "Plans": [
-            {
-                "Original": "delete from t1 where id = 100",
-                "Instructions": {
-                    "Opcode": "DeleteUnsharded",
-                    "Keyspace": {
-                        "Name": "ks_unsharded",
-                        "Sharded": false
-                    },
-                    "Query": "delete from t1 where id = 100"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "delete from t1 where id = 100",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "delete from t1 where id in (100)",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
-        "Plans": [
-            {
-                "Original": "insert into t1 (id,val) values (1,2) on duplicate key update val=3",
-                "Instructions": {
-                    "Opcode": "InsertUnsharded",
-                    "Keyspace": {
-                        "Name": "ks_unsharded",
-                        "Sharded": false
-                    },
-                    "Query": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
-                    "Table": "t1"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_unsharded/-": [
-                {
-                    "SQL": "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into t1(id, val) values (1, 2) on duplicate key update val = 3",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    }
-]`
-	testExplain(sqlStr, expected, defaultTestOpts(), t)
+	testExplain("unsharded", defaultTestOpts(), t)
 }
 
 func TestSelectSharded(t *testing.T) {
-	sqlStr := `
-select * from user /* scatter */;
-select * from user where id = 1 /* equal unique */;
-select * from user where name = 'bob'/* vindex lookup */;
-`
-	expected := `
-[
-    {
-        "SQL": "select * from user /* scatter */",
-        "Plans": [
-            {
-                "Original": "select * from user",
-                "Instructions": {
-                    "Opcode": "SelectScatter",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select * from user",
-                    "FieldQuery": "select * from user where 1 != 1"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user /* scatter */",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "select * from user limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select * from user /* scatter */",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "select * from user limit 10001"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "select * from user where id = 1 /* equal unique */",
-        "Plans": [
-            {
-                "Original": "select * from user where id = 1",
-                "Instructions": {
-                    "Opcode": "SelectEqualUnique",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select * from user where id = 1",
-                    "FieldQuery": "select * from user where 1 != 1",
-                    "Vindex": "hash",
-                    "Values": [
-                        1
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user where id = 1 /* equal unique */",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where id = 1 limit 10001"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "select * from user where name = 'bob'/* vindex lookup */",
-        "Plans": [
-            {
-                "Original": "select user_id from name_user_map where name = :name",
-                "Instructions": {
-                    "Opcode": "SelectEqualUnique",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select user_id from name_user_map where name = :name",
-                    "FieldQuery": "select user_id from name_user_map where 1 != 1",
-                    "Vindex": "md5",
-                    "Values": [
-                        ":name"
-                    ]
-                }
-            },
-            {
-                "Original": "select * from user where name = 'bob'",
-                "Instructions": {
-                    "Opcode": "SelectEqual",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select * from user where name = 'bob'",
-                    "FieldQuery": "select * from user where 1 != 1",
-                    "Vindex": "name_user_map",
-                    "Values": [
-                        "bob"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "select * from user where name = 'bob'/* vindex lookup */",
-                    "BindVars": {
-                        "#maxLimit": "10001"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where name = 'bob' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "name": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "select user_id from name_user_map where name = 'bob' limit 10001"
-                    ]
-                }
-            ]
-        }
-    }
-]
-`
-
-	testExplain(sqlStr, expected, defaultTestOpts(), t)
+	testExplain("selectsharded", defaultTestOpts(), t)
 }
 
 func TestInsertSharded(t *testing.T) {
-	sqlStr := `
-insert into user (id, name) values(1, "alice");
-insert into user (id, name) values(2, "bob");
-insert ignore into user (id, name) values(2, "bob");
-`
-
-	expected := `
-[
-    {
-        "SQL": "insert into user (id, name) values(1, \"alice\")",
-        "Plans": [
-            {
-                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
-                    "Values": [
-                        [
-                            ":name0"
-                        ]
-                    ],
-                    "Table": "name_user_map",
-                    "Prefix": "insert into name_user_map(name, user_id) values ",
-                    "Mid": [
-                        "(:_name0, :user_id0)"
-                    ]
-                }
-            },
-            {
-                "Original": "insert into user (id, name) values(1, \"alice\")",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
-                    "Values": [
-                        [
-                            1
-                        ],
-                        [
-                            "alice"
-                        ]
-                    ],
-                    "Table": "user",
-                    "Prefix": "insert into user(id, name) values ",
-                    "Mid": [
-                        "(:_id0, :_name0)"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_name0": "'alice'",
-                        "name0": "'alice'",
-                        "user_id0": "1"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('alice', 1)",
-                        "commit"
-                    ]
-                },
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_id0": "1",
-                        "_name0": "'alice'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into user(id, name) values (1, 'alice')",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "insert into user (id, name) values(2, \"bob\")",
-        "Plans": [
-            {
-                "Original": "insert into name_user_map(name, user_id) values(:name0, :user_id0)",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
-                    "Values": [
-                        [
-                            ":name0"
-                        ]
-                    ],
-                    "Table": "name_user_map",
-                    "Prefix": "insert into name_user_map(name, user_id) values ",
-                    "Mid": [
-                        "(:_name0, :user_id0)"
-                    ]
-                }
-            },
-            {
-                "Original": "insert into user (id, name) values(2, \"bob\")",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
-                    "Values": [
-                        [
-                            2
-                        ],
-                        [
-                            "bob"
-                        ]
-                    ],
-                    "Table": "user",
-                    "Prefix": "insert into user(id, name) values ",
-                    "Mid": [
-                        "(:_id0, :_name0)"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_id0": "2",
-                        "_name0": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into user(id, name) values (2, 'bob')",
-                        "commit"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('bob', 2)",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "insert ignore into user (id, name) values(2, \"bob\")",
-        "Plans": [
-            {
-                "Original": "select name from name_user_map where name = :name and user_id = :user_id",
-                "Instructions": {
-                    "Opcode": "SelectEqualUnique",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select name from name_user_map where name = :name and user_id = :user_id",
-                    "FieldQuery": "select name from name_user_map where 1 != 1",
-                    "Vindex": "md5",
-                    "Values": [
-                        ":name"
-                    ]
-                }
-            },
-            {
-                "Original": "insert ignore into name_user_map(name, user_id) values(:name0, :user_id0)",
-                "Instructions": {
-                    "Opcode": "InsertShardedIgnore",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0)",
-                    "Values": [
-                        [
-                            ":name0"
-                        ]
-                    ],
-                    "Table": "name_user_map",
-                    "Prefix": "insert ignore into name_user_map(name, user_id) values ",
-                    "Mid": [
-                        "(:_name0, :user_id0)"
-                    ]
-                }
-            },
-            {
-                "Original": "insert ignore into user (id, name) values(2, \"bob\")",
-                "Instructions": {
-                    "Opcode": "InsertShardedIgnore",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert ignore into user(id, name) values (:_id0, :_name0)",
-                    "Values": [
-                        [
-                            2
-                        ],
-                        [
-                            "bob"
-                        ]
-                    ],
-                    "Table": "user",
-                    "Prefix": "insert ignore into user(id, name) values ",
-                    "Mid": [
-                        "(:_id0, :_name0)"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-80": [
-                {
-                    "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_id0": "2",
-                        "_name0": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert ignore into user(id, name) values (2, 'bob')",
-                        "commit"
-                    ]
-                }
-            ],
-            "ks_sharded/80-": [
-                {
-                    "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                        "commit"
-                    ]
-                },
-                {
-                    "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "name": "'bob'",
-                        "user_id": "2"
-                    },
-                    "MysqlQueries": [
-                        "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
-                    ]
-                }
-            ]
-        }
-    }
-]
-`
-	testExplain(sqlStr, expected, defaultTestOpts(), t)
+	testExplain("insertsharded", defaultTestOpts(), t)
 }
 
 func TestOptions(t *testing.T) {
-	sqlStr := `
-select * from user where email="null@void.com";
-select * from user where id in (1,2,3,4,5,6,7,8);
-insert into user (id, name) values(2, "bob");
-`
-
-	expected := `
-[
-    {
-        "SQL": "select * from user where email=\"null@void.com\"",
-        "Plans": [
-            {
-                "Original": "select * from user where email = :vtg1",
-                "Instructions": {
-                    "Opcode": "SelectScatter",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select * from user where email = :vtg1",
-                    "FieldQuery": "select * from user where 1 != 1"
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/40-80": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/80-c0": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "select * from user where email = :vtg1",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "vtg1": "'null@void.com'"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where email = 'null@void.com' limit 10001"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "select * from user where id in (1,2,3,4,5,6,7,8)",
-        "Plans": [
-            {
-                "Original": "select * from user where id in ::vtg1",
-                "Instructions": {
-                    "Opcode": "SelectIN",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "select * from user where id in ::__vals",
-                    "FieldQuery": "select * from user where 1 != 1",
-                    "Vindex": "hash",
-                    "Values": [
-                        "::vtg1"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "__vals": "(1, 2)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where id in (1, 2) limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/40-80": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "__vals": "(3, 5)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where id in (3, 5) limit 10001"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "select * from user where id in ::__vals",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "__vals": "(4, 6, 7, 8)",
-                        "vtg1": "(1, 2, 3, 4, 5, 6, 7, 8)"
-                    },
-                    "MysqlQueries": [
-                        "select * from user where id in (4, 6, 7, 8) limit 10001"
-                    ]
-                }
-            ]
-        }
-    },
-    {
-        "SQL": "insert into user (id, name) values(2, \"bob\")",
-        "Plans": [
-            {
-                "Original": "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into name_user_map(name, user_id) values (:_name0, :user_id0)",
-                    "Values": [
-                        [
-                            ":name0"
-                        ]
-                    ],
-                    "Table": "name_user_map",
-                    "Prefix": "insert into name_user_map(name, user_id) values ",
-                    "Mid": [
-                        "(:_name0, :user_id0)"
-                    ]
-                }
-            },
-            {
-                "Original": "insert into user(id, name) values (:vtg1, :vtg2)",
-                "Instructions": {
-                    "Opcode": "InsertSharded",
-                    "Keyspace": {
-                        "Name": "ks_sharded",
-                        "Sharded": true
-                    },
-                    "Query": "insert into user(id, name) values (:_id0, :_name0)",
-                    "Values": [
-                        [
-                            ":vtg1"
-                        ],
-                        [
-                            ":vtg2"
-                        ]
-                    ],
-                    "Table": "user",
-                    "Prefix": "insert into user(id, name) values ",
-                    "Mid": [
-                        "(:_id0, :_name0)"
-                    ]
-                }
-            }
-        ],
-        "TabletQueries": {
-            "ks_sharded/-40": [
-                {
-                    "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_id0": "2",
-                        "_name0": "'bob'",
-                        "vtg1": "2",
-                        "vtg2": "'bob'"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
-                        "commit"
-                    ]
-                }
-            ],
-            "ks_sharded/c0-": [
-                {
-                    "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
-                    "BindVars": {
-                        "#maxLimit": "10001",
-                        "_name0": "'bob'",
-                        "name0": "'bob'",
-                        "user_id0": "2"
-                    },
-                    "MysqlQueries": [
-                        "begin",
-                        "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
-                        "commit"
-                    ]
-                }
-            ]
-        }
-    }
-]
-`
-
 	opts := &Options{
 		ReplicationMode: "STATEMENT",
 		NumShards:       4,
 		Normalize:       true,
 	}
 
-	testExplain(sqlStr, expected, opts, t)
+	testExplain("options", opts, t)
+}
+
+func TestComments(t *testing.T) {
+	testExplain("comments", defaultTestOpts(), t)
 }
 
 func TestErrors(t *testing.T) {
-	err := Init(testVSchemaStr, testSchemaStr, defaultTestOpts())
-	if err != nil {
-		t.Fatalf("vtexplain Init error: %v", err)
-	}
+	initTest(defaultTestOpts(), t)
 
 	tests := []struct {
 		SQL string
@@ -1036,27 +147,27 @@ func TestErrors(t *testing.T) {
 	}{
 		{
 			SQL: "INVALID SQL",
-			Err: "vtgate Execute: unrecognized statement: INVALID SQL",
+			Err: "vtexplain execute error: unrecognized statement: INVALID SQL in INVALID SQL",
 		},
 
 		{
 			SQL: "SELECT * FROM THIS IS NOT SQL",
-			Err: "vtgate Execute: syntax error at position 22 near 'is'",
+			Err: "vtexplain execute error: syntax error at position 22 near 'is' in SELECT * FROM THIS IS NOT SQL",
 		},
 
 		{
 			SQL: "SELECT * FROM table_not_in_vschema",
-			Err: "vtgate Execute: table table_not_in_vschema not found",
+			Err: "vtexplain execute error: table table_not_in_vschema not found in SELECT * FROM table_not_in_vschema",
 		},
 
 		{
 			SQL: "SELECT * FROM table_not_in_schema",
-			Err: "fakeTabletExecute: table table_not_in_schema not found in schema",
+			Err: "vtexplain execute error: target: ks_unsharded.-.master, used tablet: explainCell-0 (ks_unsharded/-), table table_not_in_schema not found in schema in SELECT * FROM table_not_in_schema",
 		},
 	}
 
 	for _, test := range tests {
-		_, err = Run(test.SQL)
+		_, err := Run(test.SQL)
 		if err == nil || err.Error() != test.Err {
 			t.Errorf("Run(%s): %v, want %s", test.SQL, err, test.Err)
 		}

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -40,11 +40,8 @@ create table t2 (
 	}
 	initTabletEnvironment(ddls, defaultTestOpts())
 
-	db, tsv := startFakeTablet()
-	defer db.Close()
-	defer tsv.StopService()
-
-	se := tsv.SchemaEngine()
+	tablet := newFakeTablet()
+	se := tablet.tsv.SchemaEngine()
 	tables := se.GetSchema()
 
 	t1 := tables["t1"]

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -17,13 +17,13 @@ limitations under the License.
 package engine
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 
 	"strconv"
 	"strings"
 
+	"github.com/youtube/vitess/go/jsonutil"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/sqlannotation"
 	"github.com/youtube/vitess/go/vt/vterrors"
@@ -140,7 +140,7 @@ func (route *Route) MarshalJSON() ([]byte, error) {
 		Mid:        route.Mid,
 		Suffix:     route.Suffix,
 	}
-	return json.Marshal(marshalRoute)
+	return jsonutil.MarshalNoEscape(marshalRoute)
 }
 
 // Generate represents the instruction to generate


### PR DESCRIPTION
# Overview

This PR contains a number of improvements / changes to `vtexplain` that I've found as part of using it for query analysis.

It also updates behavior of a couple core utility functions.

## vtexplain query routing change
Instead of the prior approach in which the vtgate and vttablet phases of query execution were treated as distinct operations, hook into the sandboxconn so the queries processed by the simulated vtgate are routed to the fake tablets in one phase, which is how vtgate -> vttablet queries actually flow.

This means that all the query results come from the tablet, which for now still returns the same `SingleRowResult` object from sandboxconn thus not changing current behavior.

However this paves the way for a future enhancement in which the fake tablet can return different Result objects based on the query and schema.

## strip out all queries starting with `--`

Previously a sql statement starting with `--` and having no newline was returned unmodified by `StripLeadingComments`.

This seems inconsistent and disingenuous with respect to the API contract, so I changed the behavior to strip the whole line in that case.

## add `jsonutil.MarshalNoEscape` utility

For some inexplicable reason, the default golang json.Marshal causes certain characters like < and > to be html-encoded by default. Since this can be avoided by explicitly using the underlying Encoder object, implement a one-line equivalent to json.Marshal that disables the html escaping.

Use this new non-escaped JSON output when json encoding vtgate plan objects and for the vtexplain json output, so that queries with < and > don't show up with html quoting.

## vtexplain tests

Rework all the vtexplain tests to use separate text files rather than large multiline strings in the test file.

This makes things much easier to manage and reason about, and means we can add / modify tests by just running the vtexplain command line tool rather than copy-paste.

