### PR TITLE
Switch <title> tag ordering for SEO

### DIFF
--- a/vitess.io/_layouts/base.liquid
+++ b/vitess.io/_layouts/base.liquid
@@ -4,7 +4,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ page.title }} | {{ site.title }}</title>
+    {% if page.url == '/' %}
+      <title>{{ page.title }}</title>
+    {% else %}
+      <title>{{ page.title }} | {{ site.title }}</title>
+    {% endif %}
 
     {% include styles.liquid %}
 

--- a/vitess.io/_layouts/base.liquid
+++ b/vitess.io/_layouts/base.liquid
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ site.title }} / {{ page.title }}</title>
+    <title>{{ page.title }} | {{ site.title }}</title>
 
     {% include styles.liquid %}
 


### PR DESCRIPTION
Page titles should always come before the site title