### PR TITLE
Replace tablet in cache when alias does not match

### DIFF
--- a/go/vt/discovery/fake_healthcheck.go
+++ b/go/vt/discovery/fake_healthcheck.go
@@ -106,6 +106,12 @@ func (fhc *FakeHealthCheck) RemoveTablet(tablet *topodatapb.Tablet) {
 	delete(fhc.items, key)
 }
 
+// ReplaceTablet removes the old tablet and adds the new.
+func (fhc *FakeHealthCheck) ReplaceTablet(old, new *topodatapb.Tablet, name string) {
+	fhc.RemoveTablet(old)
+	fhc.AddTablet(new, name)
+}
+
 // GetConnection returns the TabletConn of the given tablet.
 func (fhc *FakeHealthCheck) GetConnection(key string) queryservice.QueryService {
 	fhc.mu.RLock()

--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -635,6 +635,14 @@ func (hc *HealthCheckImpl) RemoveTablet(tablet *topodatapb.Tablet) {
 	go hc.deleteConn(tablet)
 }
 
+// ReplaceTablet removes the old tablet and adds the new tablet.
+func (hc *HealthCheckImpl) ReplaceTablet(old, new *topodatapb.Tablet, name string) {
+	go func() {
+		hc.deleteConn(old)
+		hc.AddTablet(new, name)
+	}()
+}
+
 // WaitForInitialStatsUpdates waits until all tablets added via AddTablet() call
 // were propagated to downstream via corresponding StatsUpdate() calls.
 func (hc *HealthCheckImpl) WaitForInitialStatsUpdates() {

--- a/go/vt/discovery/topology_watcher.go
+++ b/go/vt/discovery/topology_watcher.go
@@ -43,7 +43,7 @@ type TabletRecorder interface {
 	// RemoveTablet removes the tablet.
 	RemoveTablet(tablet *topodatapb.Tablet)
 
-	// ReplaceTablet does an AddTablet and RemoveTablet within a lock.
+	// ReplaceTablet does an AddTablet and RemoveTablet in one call, effectively replacing the old tablet with the new.
 	ReplaceTablet(old, new *topodatapb.Tablet, name string)
 }
 


### PR DESCRIPTION
This seemed the least invasive fix for https://github.com/youtube/vitess/issues/3156, and is working for us internally.

ReplaceTablet is a new function which first calls deleteConn in-line, then calls AddTablet. AddTablet launches a goroutine, and so does ReplaceTablet. Both are short lived, so shouldn't be a problem? If it is I can refactor AddTablet to allow calling it without a goroutine.

@alainjobart thoughts? I added one simple test, not sure if there are others you'd recommend.