### PR TITLE
messages: better fix for vtgate retries

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -106,13 +106,8 @@ func (me *Engine) Close() {
 func (me *Engine) Subscribe(ctx context.Context, name string, send func(*sqltypes.Result) error) (done <-chan struct{}, err error) {
 	me.mu.Lock()
 	defer me.mu.Unlock()
-	// Return a closed channel if engine is not open.
-	// This means that we are not the master, and will
-	// prompt vtgate to look for the new master.
 	if !me.isOpen {
-		ch := make(chan struct{})
-		close(ch)
-		return ch, nil
+		return nil, vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "messager engine is closed, probably because this is not a master any more")
 	}
 	mm := me.managers[name]
 	if mm == nil {

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -30,7 +30,9 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
@@ -124,14 +126,9 @@ func TestSubscribe(t *testing.T) {
 
 	// After close, Subscribe should return a closed channel.
 	engine.Close()
-	done, err := engine.Subscribe(context.Background(), "t1", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	select {
-	case <-done:
-	default:
-		t.Error("done should be closed, but was not")
+	_, err = engine.Subscribe(context.Background(), "t1", nil)
+	if got, want := vterrors.Code(err), vtrpcpb.Code_UNAVAILABLE; got != want {
+		t.Errorf("Subscribed on closed engine error code: %v, want %v", got, want)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -275,7 +275,7 @@ func TestMessageManagerSendEOF(t *testing.T) {
 
 	// Now cancel, which will send an EOF to the sender.
 	cancel()
-	// Wait for send to enqueue
+	// messagesPending should get turned on.
 	messagesWerePending := false
 	for i := 0; i < 10; i++ {
 		runtime.Gosched()


### PR DESCRIPTION
BUG=65414820
This fix changes the way we calculate the last error time. The
time gets set the first time an error is returned, and it remains
set that way until vttablet sends a successul result.
This method is reliable because vttable always returns the field
info as soon as it receives a new subscription.

Additionally, I've changed the behavior of the engine to return
EOF if it's not open. We forgot about this use case where a VTGate
could retry on a tablet that has become a replica.