### PR TITLE
bootstrap.sh: check being called from the right directory

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,7 +33,7 @@ function fail() {
   exit 1
 }
 
-[ -f bootstrap.sh ] || fail "bootstrap.sh must be run from its current directory"
+[ "$(dirname $0)" = '.' ] || fail "bootstrap.sh must be run from its current directory"
 
 go version 2>&1 >/dev/null || fail "Go is not installed or is not on \$PATH"
 


### PR DESCRIPTION
* Fix the check that bootstrap.sh is called from the current directory. While the existing check works it does not actually check what it says it is checking.