### PR TITLE
v3: bug: detect unreferenceable order by correctly

### DIFF
--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -65,7 +65,7 @@
 
 # scatter order by with * expression
 "select * from user order by id"
-"unsupported: scatter order by with a '*' in select expression"
+"unsupported: in scatter query: order by must reference a column in the select list: id asc"
 
 # filtering on a cross-shard subquery
 "select id from (select user.id, user.col from user join user_extra) as t where id=5"

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -405,7 +405,7 @@ func (rb *route) PushOrderBy(order *sqlparser.Order) error {
 	}
 
 	// If it's a scatter, we have to populate the OrderBy field.
-	var colnum int
+	colnum := -1
 	switch expr := order.Expr.(type) {
 	case *sqlparser.SQLVal:
 		var err error
@@ -414,8 +414,6 @@ func (rb *route) PushOrderBy(order *sqlparser.Order) error {
 		}
 	case *sqlparser.ColName:
 		c := expr.Metadata.(*column)
-		// The column is guaranteed to be found because this function is called
-		// only after a successful symbol resolution that points to this route.
 		for i, rc := range rb.resultColumns {
 			if rc.column == c {
 				colnum = i
@@ -423,11 +421,12 @@ func (rb *route) PushOrderBy(order *sqlparser.Order) error {
 			}
 		}
 	default:
-		return fmt.Errorf("unsupported: in scatter query: complex order by expression: %v", sqlparser.String(expr))
+		return fmt.Errorf("unsupported: in scatter query: complex order by expression: %s", sqlparser.String(expr))
 	}
-	// Ensure that it's not an anonymous column (* expression).
-	if rb.resultColumns[colnum].alias.IsEmpty() {
-		return errors.New("unsupported: scatter order by with a '*' in select expression")
+	// If column is not found, then the order by is referencing
+	// a column that's not on the select list.
+	if colnum == -1 {
+		return fmt.Errorf("unsupported: in scatter query: order by must reference a column in the select list: %s", sqlparser.String(order))
 	}
 	rb.ERoute.OrderBy = append(rb.ERoute.OrderBy, engine.OrderbyParams{
 		Col:  colnum,


### PR DESCRIPTION
Issue #3173 @tirsen
For a scatter plan, if an order by expression does not reference
a column in the select list, then we cannot perform that orderding
right now.

Eventually, we will need to add that column to the select list,
and later remove it before returning the result.