### PR TITLE
v3: vindex: allow incompatible input keys

### DIFF
--- a/go/vt/binlog/keyspace_id_resolver.go
+++ b/go/vt/binlog/keyspace_id_resolver.go
@@ -174,7 +174,10 @@ func (r *keyspaceIDResolverFactoryV3) keyspaceID(v sqltypes.Value) ([]byte, erro
 		return nil, err
 	}
 	if len(ksids) != 1 {
-		return nil, fmt.Errorf("maping row to keyspace id returned an invalid array of keyspace ids: %v", ksids)
+		return nil, fmt.Errorf("mapping row to keyspace id returned an invalid array of keyspace ids: %v", ksids)
+	}
+	if ksids[0] == nil {
+		return nil, fmt.Errorf("could not map %v to a keyspace id", v)
 	}
 	return ksids[0], nil
 }

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -813,11 +813,6 @@ func (route *Route) getInsertShardedRoute(vcursor VCursor, bindVars map[string]*
 
 // processPrimary maps the primary vindex values to the kesypace ids.
 func (route *Route) processPrimary(vcursor VCursor, vindexKeys []sqltypes.Value, colVindex *vindexes.ColumnVindex, bv map[string]*querypb.BindVariable) (keyspaceIDs [][]byte, err error) {
-	for _, vindexKey := range vindexKeys {
-		if vindexKey.IsNull() {
-			return nil, fmt.Errorf("value must be supplied for column %v", colVindex.Column)
-		}
-	}
 	mapper := colVindex.Vindex.(vindexes.Unique)
 	keyspaceIDs, err = mapper.Map(vcursor, vindexKeys)
 	if err != nil {

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -319,6 +319,12 @@ func (route *Route) Execute(vcursor VCursor, bindVars, joinVars map[string]*quer
 		return nil, err
 	}
 
+	// If there is no route for a select and we still 'wantfields',
+	// we have to do a GetFields.
+	if len(params.shardVars) == 0 && !isDML && wantfields {
+		return route.GetFields(vcursor, bindVars, joinVars)
+	}
+
 	shardQueries := route.getShardQueries(route.Query, params)
 	result, err := vcursor.ExecuteMultiShard(params.ks, shardQueries, isDML)
 	if err != nil {

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -579,7 +579,7 @@ func (route *Route) resolveShards(vcursor VCursor, bindVars map[string]*querypb.
 			return "", nil, err
 		}
 		for i, ksid := range ksids {
-			if len(ksid) == 0 {
+			if ksid == nil {
 				continue
 			}
 			shard, err := vcursor.GetShardForKeyspaceID(allShards, ksid)
@@ -619,7 +619,7 @@ func (route *Route) resolveSingleShard(vcursor VCursor, bindVars map[string]*que
 		return "", "", nil, err
 	}
 	ksid = ksids[0]
-	if len(ksid) == 0 {
+	if ksid == nil {
 		return "", "", ksid, nil
 	}
 	shard, err = vcursor.GetShardForKeyspaceID(allShards, ksid)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -580,7 +580,7 @@ func (e *Executor) MessageAck(ctx context.Context, keyspace, name string, ids []
 			return 0, err
 		}
 		for i, ksid := range ksids {
-			if len(ksid) == 0 {
+			if ksid == nil {
 				continue
 			}
 			shard, err := getShardForKeyspaceID(allShards, ksid)

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -985,7 +985,7 @@ func TestInsertFail(t *testing.T) {
 	}
 
 	_, err = executorExec(executor, "insert into ksid_table(keyspace_id) values (null)", nil)
-	want = "execInsertSharded: getInsertShardedRoute: value must be supplied for column keyspace_id"
+	want = "execInsertSharded: getInsertShardedRoute: could not map NULL to a keyspace id"
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
@@ -1059,7 +1059,7 @@ func TestInsertFail(t *testing.T) {
 	}
 
 	_, err = executorExec(executor, "insert into noauto_table(id) values (null)", nil)
-	want = "execInsertSharded: getInsertShardedRoute: value must be supplied for column id"
+	want = "execInsertSharded: getInsertShardedRoute: could not map NULL to a keyspace id"
 	if err == nil || !strings.HasPrefix(err.Error(), want) {
 		t.Errorf("executorExec: %v, want prefix %v", err, want)
 	}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -174,14 +174,6 @@ func TestUpdateEqualFail(t *testing.T) {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}
 
-	_, err = executorExec(executor, "update user set a=2 where id = :id", map[string]*querypb.BindVariable{
-		"id": sqltypes.StringBindVariable("aa"),
-	})
-	want = `execUpdateEqual: hash.Map: could not parse value: aa`
-	if err == nil || err.Error() != want {
-		t.Errorf("executorExec: %v, want %v", err, want)
-	}
-
 	s.ShardSpec = "80-"
 	_, err = executorExec(executor, "update user set a=2 where id = :id", map[string]*querypb.BindVariable{
 		"id": sqltypes.Int64BindVariable(1),
@@ -347,14 +339,6 @@ func TestDeleteEqualFail(t *testing.T) {
 		"id": sqltypes.Int64BindVariable(1),
 	})
 	want = "execDeleteEqual: keyspace TestExecutor fetch error: topo error GetSrvKeyspace"
-	if err == nil || err.Error() != want {
-		t.Errorf("executorExec: %v, want %v", err, want)
-	}
-
-	_, err = executorExec(executor, "delete from user where id = :id", map[string]*querypb.BindVariable{
-		"id": sqltypes.StringBindVariable("aa"),
-	})
-	want = `execDeleteEqual: hash.Map: could not parse value: aa`
 	if err == nil || err.Error() != want {
 		t.Errorf("executorExec: %v, want %v", err, want)
 	}

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -536,7 +536,7 @@ func TestSelectEqualNotFound(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	wantResult := &sqltypes.Result{}
+	wantResult := sandboxconn.SingleRowResult
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
@@ -546,7 +546,6 @@ func TestSelectEqualNotFound(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	wantResult = &sqltypes.Result{}
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}

--- a/go/vt/vtgate/vindexes/hash.go
+++ b/go/vt/vtgate/vindexes/hash.go
@@ -60,7 +60,8 @@ func (vind *Hash) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	for _, id := range ids {
 		num, err := sqltypes.ToUint64(id)
 		if err != nil {
-			return nil, fmt.Errorf("hash.Map: %v", err)
+			out = append(out, nil)
+			continue
 		}
 		out = append(out, vhash(num))
 	}

--- a/go/vt/vtgate/vindexes/hash_test.go
+++ b/go/vt/vtgate/vindexes/hash_test.go
@@ -51,6 +51,7 @@ func TestHashMap(t *testing.T) {
 		sqltypes.NewInt64(1),
 		sqltypes.NewInt64(2),
 		sqltypes.NewInt64(3),
+		sqltypes.NULL,
 		sqltypes.NewInt64(4),
 		sqltypes.NewInt64(5),
 		sqltypes.NewInt64(6),
@@ -62,19 +63,13 @@ func TestHashMap(t *testing.T) {
 		[]byte("\x16k@\xb4J\xbaK\xd6"),
 		[]byte("\x06\xe7\xea\"Βp\x8f"),
 		[]byte("N\xb1\x90ɢ\xfa\x16\x9c"),
+		nil,
 		[]byte("\xd2\xfd\x88g\xd5\r-\xfe"),
 		[]byte("p\xbb\x02<\x81\f\xa8z"),
 		[]byte("\xf0\x98H\n\xc4ľq"),
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
-	}
-
-	// Negative Test Case.
-	_, err = hash.(Unique).Map(nil, []sqltypes.Value{sqltypes.NewFloat64(1.2)})
-	wanterr := "hash.Map: could not parse value: 1.2"
-	if err == nil || err.Error() != wanterr {
-		t.Errorf("hash.Map() error: %v, want %s", err, wanterr)
 	}
 }
 

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -74,7 +74,9 @@ func (lh *LookupHash) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, er
 		for _, row := range result.Rows {
 			num, err := sqltypes.ToUint64(row[0])
 			if err != nil {
-				return nil, fmt.Errorf("lookupHash.Map.ToUint64: %v", err)
+				// A failure to convert is equivalent to not being
+				// able to map.
+				continue
 			}
 			ksids = append(ksids, vhash(num))
 		}
@@ -169,7 +171,8 @@ func (lhu *LookupHashUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][]byt
 		case 1:
 			num, err := sqltypes.ToUint64(result.Rows[0][0])
 			if err != nil {
-				return nil, fmt.Errorf("LookupHash.Map: %v", err)
+				out = append(out, nil)
+				continue
 			}
 			out = append(out, vhash(num))
 		default:

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -80,16 +80,19 @@ func TestLookupHashMap(t *testing.T) {
 		sqltypes.MakeTestFields("a", "varbinary"),
 		"notint",
 	)
-	_, err = lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
-	wantErr := "lookupHash.Map.ToUint64: could not parse value: notint"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("lookuphash(query fail) err: %v, want %s", err, wantErr)
+	got, err = lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
+	if err != nil {
+		t.Error(err)
+	}
+	want = [][][]byte{{}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map(): %#v, want %#v", got, want)
 	}
 
 	// Test query fail.
 	vc.mustFail = true
 	_, err = lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
-	wantErr = "lookup.Map: execute failed"
+	wantErr := "lookup.Map: execute failed"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("lookuphash(query fail) err: %v, want %s", err, wantErr)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -75,10 +75,13 @@ func TestLookupHashUniqueMap(t *testing.T) {
 		sqltypes.MakeTestFields("a", "varbinary"),
 		"notint",
 	)
-	_, err = lhu.(Unique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
-	wantErr = "LookupHash.Map: could not parse value: notint"
-	if err == nil || err.Error() != wantErr {
-		t.Errorf("lhu(query fail) err: %v, want %s", err, wantErr)
+	got, err = lhu.(Unique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1)})
+	if err != nil {
+		t.Error(err)
+	}
+	want = [][]byte{nil}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 
 	// Test query fail.

--- a/go/vt/vtgate/vindexes/numeric.go
+++ b/go/vt/vtgate/vindexes/numeric.go
@@ -71,7 +71,8 @@ func (*Numeric) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, error) {
 	for _, id := range ids {
 		num, err := sqltypes.ToUint64(id)
 		if err != nil {
-			return nil, fmt.Errorf("Numeric.Map: %v", err)
+			out = append(out, nil)
+			continue
 		}
 		var keybytes [8]byte
 		binary.BigEndian.PutUint64(keybytes[:], num)

--- a/go/vt/vtgate/vindexes/numeric_static_map.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map.go
@@ -99,7 +99,8 @@ func (vind *NumericStaticMap) Map(_ VCursor, ids []sqltypes.Value) ([][]byte, er
 	for _, id := range ids {
 		num, err := sqltypes.ToUint64(id)
 		if err != nil {
-			return nil, fmt.Errorf("NumericStaticMap.Map: %v", err)
+			out = append(out, nil)
+			continue
 		}
 		lookupNum, ok := vind.lookup[num]
 		if ok {

--- a/go/vt/vtgate/vindexes/numeric_static_map_test.go
+++ b/go/vt/vtgate/vindexes/numeric_static_map_test.go
@@ -67,6 +67,7 @@ func TestNumericStaticMapMap(t *testing.T) {
 		sqltypes.NewInt64(1),
 		sqltypes.NewInt64(2),
 		sqltypes.NewInt64(3),
+		sqltypes.NewFloat64(1.1),
 		sqltypes.NewInt64(4),
 		sqltypes.NewInt64(5),
 		sqltypes.NewInt64(6),
@@ -83,6 +84,7 @@ func TestNumericStaticMapMap(t *testing.T) {
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x02"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x02"),
+		nil,
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x04"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x05"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x06"),
@@ -91,18 +93,6 @@ func TestNumericStaticMapMap(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %+v, want %+v", got, want)
-	}
-}
-
-func TestNumericStaticMapMapBadData(t *testing.T) {
-	numericStaticMap, err := createVindex()
-	if err != nil {
-		t.Fatalf("failed to create vindex: %v", err)
-	}
-	_, err = numericStaticMap.(Unique).Map(nil, []sqltypes.Value{sqltypes.NewFloat64(1.1)})
-	want := `NumericStaticMap.Map: could not parse value: 1.1`
-	if err == nil || err.Error() != want {
-		t.Errorf("NumericStaticMap.Map: %v, want %v", err, want)
 	}
 }
 

--- a/go/vt/vtgate/vindexes/numeric_test.go
+++ b/go/vt/vtgate/vindexes/numeric_test.go
@@ -48,6 +48,7 @@ func TestNumericMap(t *testing.T) {
 		sqltypes.NewInt64(1),
 		sqltypes.NewInt64(2),
 		sqltypes.NewInt64(3),
+		sqltypes.NewFloat64(1.1),
 		sqltypes.NewInt64(4),
 		sqltypes.NewInt64(5),
 		sqltypes.NewInt64(6),
@@ -61,6 +62,7 @@ func TestNumericMap(t *testing.T) {
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x01"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x02"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x03"),
+		nil,
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x04"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x05"),
 		[]byte("\x00\x00\x00\x00\x00\x00\x00\x06"),
@@ -69,14 +71,6 @@ func TestNumericMap(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %+v, want %+v", got, want)
-	}
-}
-
-func TestNumericMapBadData(t *testing.T) {
-	_, err := numeric.(Unique).Map(nil, []sqltypes.Value{sqltypes.NewFloat64(1.1)})
-	want := `Numeric.Map: could not parse value: 1.1`
-	if err == nil || err.Error() != want {
-		t.Errorf("numeric.Map: %v, want %v", err, want)
 	}
 }
 

--- a/go/vt/worker/key_resolver.go
+++ b/go/vt/worker/key_resolver.go
@@ -178,7 +178,10 @@ func (r *v3Resolver) keyspaceID(row []sqltypes.Value) ([]byte, error) {
 		return nil, err
 	}
 	if len(ksids) != 1 {
-		return nil, fmt.Errorf("maping row to keyspace id returned an invalid array of keyspace ids: %v", ksids)
+		return nil, fmt.Errorf("mapping row to keyspace id returned an invalid array of keyspace ids: %v", ksids)
+	}
+	if ksids[0] == nil {
+		return nil, fmt.Errorf("could not map %v to a keyspace id", v)
 	}
 	return ksids[0], nil
 }

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -1401,7 +1401,7 @@ class TestVTGateFunctions(unittest.TestCase):
     try:
       vtgate_conn.begin()
       with self.assertRaisesRegexp(
-          dbexceptions.DatabaseError, '.*value must be supplied.*'):
+          dbexceptions.DatabaseError, '.*could not map NULL to a keyspace id.*'):
         self.execute_on_master(
             vtgate_conn,
             'insert into vt_user_extra (email) values (:email)',


### PR DESCRIPTION
Issue #3151
The numeric vindexes were too strict about requiring number inputs.
This does not work correctly when results of joins are used as
vindex keys. Sometimes, they can be null, or may have invalid types.

In such cases, we should treat them as 'no match' instead of causing
an error. The only time a failure to match should result in an error
is on an insert. At other times, we should just return no results.

* Fixed a bug where a join would panic because the route sometimes
doesn't return field info (if it has no shards to send a query to).
* Fixed the v3 resolvers in worker and binlog to return an error if resolution
is not possible.