### PR TITLE
bug: fix failing test: exporting from internal fix

### DIFF
--- a/go/vt/vttablet/tabletserver/txthrottler/mock_healthcheck_test.go
+++ b/go/vt/vttablet/tabletserver/txthrottler/mock_healthcheck_test.go
@@ -101,6 +101,10 @@ func (_mr *_MockHealthCheckRecorder) RemoveTablet(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveTablet", arg0)
 }
 
+func (_m *MockHealthCheck) ReplaceTablet(old, new *topodata.Tablet, name string) {
+	panic("unimplemented")
+}
+
 func (_m *MockHealthCheck) SetListener(_param0 discovery.HealthCheckStatsListener, _param1 bool) {
 	_m.ctrl.Call(_m, "SetListener", _param0, _param1)
 }


### PR DESCRIPTION
I plan push this through because this breaks imports.

This mock got somehow left out. I was not able to regenerate
the mocks correctly due to some version incompatibility. So,
I've just handfixed the file to allow the test to pass.