### PR TITLE
Minor change to allow the Tokenizer to accept a io.ByteReader

### DIFF
--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -19,6 +19,7 @@ package sqlparser
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/youtube/vitess/go/bytes2"
@@ -30,7 +31,7 @@ const eofChar = 0x100
 // Tokenizer is the struct used to generate SQL
 // tokens for the parser.
 type Tokenizer struct {
-	InStream      *strings.Reader
+	InStream      io.ByteReader
 	AllowComments bool
 	ForceEOF      bool
 	lastChar      uint16


### PR DESCRIPTION
This makes it possible to use the Tokenizer with other types of Readers, not just strings.