### PR TITLE
Terminate parsing after a ';'

### DIFF
--- a/go/vt/sqlparser/sql.y
+++ b/go/vt/sqlparser/sql.y
@@ -273,7 +273,7 @@ any_command:
 
 semicolon_opt:
 /*empty*/ {}
-| ';' {}
+| ';' force_eof {}
 
 command:
   select_statement


### PR DESCRIPTION
By forcing the EOF after a ';' the parser can correctly parse just the first statement in a string containing multiple SQL statements. Otherwise the parse returns a syntax error trying to read beyond the ';'. This is useful for projects like https://github.com/xwb1989/sqlparser which make use of this parser outside of vitess.