### PR TITLE
Null vindex

### DIFF
--- a/go/vt/vtgate/vindexes/null.go
+++ b/go/vt/vtgate/vindexes/null.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"bytes"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+var (
+	_        Functional = (*Null)(nil)
+	nullksid            = []byte{0}
+)
+
+// Null defines a vindex that always return 0. It's Unique and
+// Functional.
+// This is useful for rows that always go into the first shard.
+// This Vindex can be used for validating an unsharded->sharded transition.
+// Unlike other vindexes, this one will work even for NULL input values. This
+// will allow you to keep MySQL auto-inc columns unchanged.
+type Null struct {
+	name string
+}
+
+// NewNull creates a new Null.
+func NewNull(name string, m map[string]string) (Vindex, error) {
+	return &Null{name: name}, nil
+}
+
+// String returns the name of the vindex.
+func (vind *Null) String() string {
+	return vind.name
+}
+
+// Cost returns the cost of this index as 0.
+func (vind *Null) Cost() int {
+	return 0
+}
+
+// Map returns the corresponding KeyspaceId values for the given ids.
+func (vind *Null) Map(cursor VCursor, ids []sqltypes.Value) ([]KsidOrRange, error) {
+	out := make([]KsidOrRange, 0, len(ids))
+	for i := 0; i < len(ids); i++ {
+		out = append(out, KsidOrRange{ID: nullksid})
+	}
+	return out, nil
+}
+
+// Verify returns true if ids maps to ksids.
+func (vind *Null) Verify(cursor VCursor, ids []sqltypes.Value, ksids [][]byte) ([]bool, error) {
+	out := make([]bool, len(ids))
+	for i := range ids {
+		out[i] = bytes.Compare(nullksid, ksids[i]) == 0
+	}
+	return out, nil
+}
+
+func init() {
+	Register("null", NewNull)
+}

--- a/go/vt/vtgate/vindexes/null_test.go
+++ b/go/vt/vtgate/vindexes/null_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vindexes
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+var null Vindex
+
+func init() {
+	hv, err := CreateVindex("null", "nn", map[string]string{"Table": "t", "Column": "c"})
+	if err != nil {
+		panic(err)
+	}
+	null = hv
+}
+
+func TestNullCost(t *testing.T) {
+	if null.Cost() != 0 {
+		t.Errorf("Cost(): %d, want 0", null.Cost())
+	}
+}
+
+func TestNullString(t *testing.T) {
+	if strings.Compare("nn", null.String()) != 0 {
+		t.Errorf("String(): %s, want null", null.String())
+	}
+}
+
+func TestNullMap(t *testing.T) {
+	got, err := null.(Unique).Map(nil, []sqltypes.Value{
+		sqltypes.NewInt64(1),
+		sqltypes.NewInt64(2),
+		sqltypes.NewInt64(3),
+		sqltypes.NewInt64(4),
+		sqltypes.NewInt64(5),
+		sqltypes.NewInt64(6),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	want := []KsidOrRange{
+		{ID: []byte{0}},
+		{ID: []byte{0}},
+		{ID: []byte{0}},
+		{ID: []byte{0}},
+		{ID: []byte{0}},
+		{ID: []byte{0}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map(): %#v, want %+v", got, want)
+	}
+}
+
+func TestNullVerify(t *testing.T) {
+	ids := []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}
+	ksids := [][]byte{{0}, {1}}
+	got, err := null.Verify(nil, ids, ksids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []bool{true, false}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("binaryMD5.Verify: %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Useful for rows that should always go into the first shard or when you want to gradually roll out a sharded keyspace without using sequences (the hash vindex requires sequences).