### PR TITLE
Ensure vttablet does not crash if not given all parameters it expects

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -84,7 +84,11 @@ func main() {
 		log.Exitf("mycnf read failed: %v", err)
 	}
 
-	dbcfgs, err := dbconfigs.Init(mycnf.SocketFile, dbconfigFlags)
+	var socketFile string
+	if mycnf != nil {
+		socketFile = mycnf.SocketFile
+	}
+	dbcfgs, err := dbconfigs.Init(socketFile, dbconfigFlags)
 	if err != nil {
 		log.Warning(err)
 	}


### PR DESCRIPTION
Specifically I managed to crash it when mycnf was empty and it tried to reference the socket name to talk to mysqld on. Even if that setting is not present the binary should not fail and given it's possible via the appropraite `dbconfig-XXXX` settings to configure access to a remote mysqld then the requirement for the socket should not be there.

If you see a better fix then feel free to implement this.