### PR TITLE
Messaging: Export messaging queue delay

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/cache.go
+++ b/go/vt/vttablet/tabletserver/messager/cache.go
@@ -28,9 +28,10 @@ import (
 // MessageRow represents a message row.
 // The first column in Row is always the "id".
 type MessageRow struct {
-	TimeNext int64
-	Epoch    int64
-	Row      []sqltypes.Value
+	TimeNext    int64
+	Epoch       int64
+	TimeCreated int64
+	Row         []sqltypes.Value
 }
 
 type messageHeap []*MessageRow

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -217,7 +217,7 @@ func TestGenerateLoadMessagesQuery(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want := "select time_next, epoch, id, time_scheduled, message from t1 where :#pk"
+	want := "select time_next, epoch, time_created, id, time_scheduled, message from t1 where :#pk"
 	if q.Query != want {
 		t.Errorf("GenerateLoadMessagesQuery: %s, want %s", q.Query, want)
 	}

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -340,9 +340,10 @@ func TestMessageManagerPoller(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, time_scheduled, message from foo.*",
+		"select time_next, epoch, time_created, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
 				{Type: sqltypes.Int64},
@@ -352,18 +353,21 @@ func TestMessageManagerPoller(t *testing.T) {
 			Rows: [][]sqltypes.Value{{
 				sqltypes.NewInt64(1),
 				sqltypes.NewInt64(0),
+				sqltypes.NewInt64(0),
 				sqltypes.NewInt64(1),
 				sqltypes.NewInt64(10),
 				sqltypes.NewVarBinary("01"),
 			}, {
 				sqltypes.NewInt64(2),
 				sqltypes.NewInt64(0),
+				sqltypes.NewInt64(1),
 				sqltypes.NewInt64(2),
 				sqltypes.NewInt64(20),
 				sqltypes.NewVarBinary("02"),
 			}, {
 				sqltypes.NewInt64(1),
 				sqltypes.NewInt64(1),
+				sqltypes.NewInt64(0),
 				sqltypes.NewInt64(3),
 				sqltypes.NewInt64(30),
 				sqltypes.NewVarBinary("11"),
@@ -421,7 +425,7 @@ func TestMessagesPending1(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, time_scheduled, message from foo.*",
+		"select time_next, epoch, time_created, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
 				{Type: sqltypes.Int64},
@@ -488,7 +492,7 @@ func TestMessagesPending2(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQueryPattern(
-		"select time_next, epoch, id, time_scheduled, message from foo.*",
+		"select time_next, epoch, time_created, id, time_scheduled, message from foo.*",
 		&sqltypes.Result{
 			Fields: []*querypb.Field{
 				{Type: sqltypes.Int64},


### PR DESCRIPTION
The delay is measured from time when a message is queued to when it is sent to clients.
Caveats:
Sending does not mean the client would ack the message.
Retries are included which will inflate the latency.

BUG=65728475