### PR TITLE
Vttablet logging improvements

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/tabletenv.go
@@ -86,6 +86,12 @@ var (
 	TableaclDenied = stats.NewMultiCounters("TableACLDenied", []string{"TableName", "TableGroup", "PlanID", "Username"})
 	// TableaclPseudoDenied tracks the number of pseudo denies.
 	TableaclPseudoDenied = stats.NewMultiCounters("TableACLPseudoDenied", []string{"TableName", "TableGroup", "PlanID", "Username"})
+	// Infof can be overridden during tests
+	Infof = log.Infof
+	// Warningf can be overridden during tests
+	Warningf = log.Warningf
+	// Errorf can be overridden during tests
+	Errorf = log.Errorf
 )
 
 // RecordUserQuery records the query data against the user.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1920,13 +1920,13 @@ func (tsv *TabletServer) MaxDMLRows() int {
 // and also truncates data if it's too long
 func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable) string {
 	buf := &bytes.Buffer{}
-	fmt.Fprintf(buf, "Sql: %q, BindVars: {", sqlparser.TruncateForLog(sql))
+	fmt.Fprintf(buf, "Sql: %q, BindVars: {", sql)
 	for k, v := range bindVariables {
 		valString := fmt.Sprintf("%v", v)
-		fmt.Fprintf(buf, "%s: %q", k, sqlparser.TruncateForLog(valString))
+		fmt.Fprintf(buf, "%s: %q", k, valString)
 	}
 	fmt.Fprintf(buf, "}")
-	return string(buf.Bytes())
+	return sqlparser.TruncateForLog(string(buf.Bytes()))
 }
 
 // withTimeout returns a context based on the specified timeout.

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1294,27 +1294,55 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 	if err == nil {
 		return nil
 	}
-	err = tsv.convertError(ctx, sql, bindVariables, err)
+
+	errStr := err.Error()
+	errCode := tsv.convertErrorCode(err)
+	tabletenv.ErrorStats.Add(errCode.String(), 1)
+
+	logMethod := tabletenv.Errorf
+	// Suppress or demote some errors in logs.
+	switch errCode {
+	case vtrpcpb.Code_FAILED_PRECONDITION, vtrpcpb.Code_ALREADY_EXISTS:
+		logMethod = nil
+	case vtrpcpb.Code_RESOURCE_EXHAUSTED:
+		logMethod = logTxPoolFull.Errorf
+	case vtrpcpb.Code_ABORTED:
+		logMethod = tabletenv.Warningf
+	case vtrpcpb.Code_INVALID_ARGUMENT, vtrpcpb.Code_DEADLINE_EXCEEDED:
+		logMethod = tabletenv.Infof
+	}
+
+	origErr := err
+	err = formatErrorWithCallerID(ctx, vterrors.New(errCode, errStr))
+	if logMethod != nil {
+		logMethod("%v: %v", err, queryAsString(sql, bindVariables))
+	}
+
+	// If TerseErrors is on, strip the error message returned by MySQL and only
+	// keep the error number and sql state.
+	// We assume that bind variable have PII, which are included in the MySQL
+	// query and come back as part of the error message. Removing the MySQL
+	// error helps us avoid leaking PII.
+	// There are two exceptions:
+	// 1. If no bind vars were specified, it's likely that the query was issued
+	// by someone manually. So, we don't suppress the error.
+	// 2. FAILED_PRECONDITION errors. These are caused when a failover is in progress.
+	// If so, we don't want to suppress the error. This will allow VTGate to
+	// detect and perform buffering during failovers.
+	if tsv.TerseErrors && len(bindVariables) != 0 && errCode != vtrpcpb.Code_FAILED_PRECONDITION {
+		sqlErr, ok := origErr.(*mysql.SQLError)
+		if ok {
+			sqlState := sqlErr.SQLState()
+			errnum := sqlErr.Number()
+			errStr = fmt.Sprintf("(errno %d) (sqlstate %s) during query: %s", errnum, sqlState, sqlparser.TruncateForLog(sql))
+			err = formatErrorWithCallerID(ctx, vterrors.New(errCode, errStr))
+		}
+	}
 
 	if logStats != nil {
 		logStats.Error = err
 	}
-	errCode := vterrors.Code(err)
-	tabletenv.ErrorStats.Add(errCode.String(), 1)
 
-	logMethod := log.Errorf
-	// Suppress or demote some errors in logs.
-	switch errCode {
-	case vtrpcpb.Code_FAILED_PRECONDITION, vtrpcpb.Code_ALREADY_EXISTS:
-		return err
-	case vtrpcpb.Code_RESOURCE_EXHAUSTED:
-		logMethod = logTxPoolFull.Errorf
-	case vtrpcpb.Code_ABORTED:
-		logMethod = log.Warningf
-	case vtrpcpb.Code_INVALID_ARGUMENT, vtrpcpb.Code_DEADLINE_EXCEEDED:
-		logMethod = log.Infof
-	}
-	logMethod("%v: %v", err, queryAsString(sql, bindVariables))
 	return err
 }
 
@@ -1329,17 +1357,15 @@ func formatErrorWithCallerID(ctx context.Context, err error) error {
 	return vterrors.Errorf(vterrors.Code(err), "%v, CallerID: %s", err, callerID.Username)
 }
 
-func (tsv *TabletServer) convertError(ctx context.Context, sql string, bindVariables map[string]*querypb.BindVariable, err error) error {
+func (tsv *TabletServer) convertErrorCode(err error) vtrpcpb.Code {
+	errCode := vterrors.Code(err)
 	sqlErr, ok := err.(*mysql.SQLError)
 	if !ok {
-		return formatErrorWithCallerID(ctx, err)
+		return errCode
 	}
 
-	errCode := vterrors.Code(err)
 	errstr := err.Error()
 	errnum := sqlErr.Number()
-	sqlState := sqlErr.SQLState()
-
 	switch errnum {
 	case mysql.ERNotSupportedYet:
 		errCode = vtrpcpb.Code_UNIMPLEMENTED
@@ -1402,21 +1428,7 @@ func (tsv *TabletServer) convertError(ctx context.Context, sql string, bindVaria
 		errCode = vtrpcpb.Code_DEADLINE_EXCEEDED
 	}
 
-	// If TerseErrors is on, strip the error message returned by MySQL and only
-	// keep the error number and sql state.
-	// We assume that bind variable have PII, which are included in the MySQL
-	// query and come back as part of the error message. Removing the MySQL
-	// error helps us avoid leaking PII.
-	// There are two exceptions:
-	// 1. If no bind vars were specified, it's likely that the query was issued
-	// by someone manually. So, we don't suppress the error.
-	// 2. FAILED_PRECONDITION errors. These are caused when a failover is in progress.
-	// If so, we don't want to suppress the error. This will allow VTGate to
-	// detect and perform buffering during failovers.
-	if tsv.TerseErrors && len(bindVariables) != 0 && errCode != vtrpcpb.Code_FAILED_PRECONDITION {
-		errstr = fmt.Sprintf("(errno %d) (sqlstate %s) during query: %s", errnum, sqlState, sqlparser.TruncateForLog(sql))
-	}
-	return formatErrorWithCallerID(ctx, vterrors.New(errCode, errstr))
+	return errCode
 }
 
 // validateSplitQueryParameters perform some validations on the SplitQuery parameters

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1295,7 +1295,6 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 		return nil
 	}
 
-	errStr := err.Error()
 	errCode := tsv.convertErrorCode(err)
 	tabletenv.ErrorStats.Add(errCode.String(), 1)
 
@@ -1313,7 +1312,7 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 	}
 
 	origErr := err
-	err = formatErrorWithCallerID(ctx, vterrors.New(errCode, errStr))
+	err = formatErrorWithCallerID(ctx, vterrors.New(errCode, err.Error()))
 	if logMethod != nil {
 		logMethod("%v: %v", err, queryAsString(sql, bindVariables))
 	}
@@ -1334,8 +1333,8 @@ func (tsv *TabletServer) convertAndLogError(ctx context.Context, sql string, bin
 		if ok {
 			sqlState := sqlErr.SQLState()
 			errnum := sqlErr.Number()
-			errStr = fmt.Sprintf("(errno %d) (sqlstate %s) during query: %s", errnum, sqlState, sqlparser.TruncateForLog(sql))
-			err = formatErrorWithCallerID(ctx, vterrors.New(errCode, errStr))
+			err = vterrors.Errorf(errCode, "(errno %d) (sqlstate %s) during query: %s", errnum, sqlState, sqlparser.TruncateForLog(sql))
+			err = formatErrorWithCallerID(ctx, err)
 		}
 	}
 

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	log "github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
@@ -2246,20 +2247,59 @@ func TestHandleExecUnknownError(t *testing.T) {
 	panic("unknown exec error")
 }
 
+var testLogs []string
+
+func recordInfof(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	testLogs = append(testLogs, msg)
+	log.Infof(msg)
+}
+
+func recordErrorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	testLogs = append(testLogs, msg)
+	log.Errorf(msg)
+}
+
+func setupTestLogger() {
+	testLogs = make([]string, 0)
+	tabletenv.Infof = recordInfof
+	tabletenv.Errorf = recordErrorf
+}
+
+func clearTestLogger() {
+	tabletenv.Infof = log.Infof
+	tabletenv.Errorf = log.Errorf
+}
+
+func getTestLog(i int) string {
+	if i < len(testLogs) {
+		return testLogs[i]
+	}
+	return fmt.Sprintf("ERROR: log %d/%d does not exist", i, len(testLogs))
+}
+
 func TestHandleExecTabletError(t *testing.T) {
 	ctx := context.Background()
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	err := tsv.convertError(
+	setupTestLogger()
+	defer clearTestLogger()
+	err := tsv.convertAndLogError(
 		ctx,
 		"select * from test_table",
 		nil,
 		vterrors.Errorf(vtrpcpb.Code_INTERNAL, "tablet error"),
+		nil,
 	)
 	want := "tablet error"
 	if err == nil || err.Error() != want {
 		t.Errorf("%v, want '%s'", err, want)
+	}
+	wantLog := "tablet error: Sql: \"select * from test_table\", BindVars: {}"
+	if wantLog != getTestLog(0) {
+		t.Errorf("error log %s, want '%s'", getTestLog(0), wantLog)
 	}
 }
 
@@ -2269,15 +2309,22 @@ func TestTerseErrorsNonSQLError(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.TerseErrors = true
 	tsv := NewTabletServerWithNilTopoServer(config)
-	err := tsv.convertError(
+	setupTestLogger()
+	defer clearTestLogger()
+	err := tsv.convertAndLogError(
 		ctx,
 		"select * from test_table",
 		nil,
 		vterrors.Errorf(vtrpcpb.Code_INTERNAL, "tablet error"),
+		nil,
 	)
 	want := "tablet error"
 	if err == nil || err.Error() != want {
 		t.Errorf("%v, want '%s'", err, want)
+	}
+	wantLog := "tablet error: Sql: \"select * from test_table\", BindVars: {}"
+	if wantLog != getTestLog(0) {
+		t.Errorf("error log %s, want '%s'", getTestLog(0), wantLog)
 	}
 }
 
@@ -2287,15 +2334,22 @@ func TestTerseErrorsBindVars(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.TerseErrors = true
 	tsv := NewTabletServerWithNilTopoServer(config)
-	err := tsv.convertError(
+	setupTestLogger()
+	defer clearTestLogger()
+	err := tsv.convertAndLogError(
 		ctx,
 		"select * from test_table",
 		map[string]*querypb.BindVariable{"a": sqltypes.Int64BindVariable(1)},
-		mysql.NewSQLError(10, "HY000", "msg"),
+		mysql.NewSQLError(10, "HY000", "sensitive message"),
+		nil,
 	)
 	want := "(errno 10) (sqlstate HY000) during query: select * from test_table"
 	if err == nil || err.Error() != want {
 		t.Errorf("%v, want '%s'", err, want)
+	}
+	wantLog := "sensitive message (errno 10) (sqlstate HY000): Sql: \"select * from test_table\", BindVars: {a: \"type:INT64 value:\\\"1\\\" \"}"
+	if wantLog != getTestLog(0) {
+		t.Errorf("error log '%s', want '%s'", getTestLog(0), wantLog)
 	}
 }
 
@@ -2305,10 +2359,16 @@ func TestTerseErrorsNoBindVars(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.TerseErrors = true
 	tsv := NewTabletServerWithNilTopoServer(config)
-	err := tsv.convertError(ctx, "", nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "msg"))
-	want := "msg"
+	setupTestLogger()
+	defer clearTestLogger()
+	err := tsv.convertAndLogError(ctx, "", nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "sensitive message"), nil)
+	want := "sensitive message"
 	if err == nil || err.Error() != want {
 		t.Errorf("%v, want '%s'", err, want)
+	}
+	wantLog := "sensitive message: Sql: \"\", BindVars: {}"
+	if wantLog != getTestLog(0) {
+		t.Errorf("error log '%s', want '%s'", getTestLog(0), wantLog)
 	}
 }
 
@@ -2318,13 +2378,20 @@ func TestTerseErrorsIgnoreFailoverInProgress(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.TerseErrors = true
 	tsv := NewTabletServerWithNilTopoServer(config)
-
-	err := tsv.convertError(ctx, "select * from test_table where id = :a",
+	setupTestLogger()
+	defer clearTestLogger()
+	err := tsv.convertAndLogError(ctx, "select * from test_table where id = :a",
 		map[string]*querypb.BindVariable{"a": sqltypes.Int64BindVariable(1)},
 		mysql.NewSQLError(1227, "42000", "failover in progress"),
+		nil,
 	)
 	if got, want := err.Error(), "failover in progress (errno 1227) (sqlstate 42000)"; got != want {
 		t.Fatalf("'failover in progress' text must never be stripped: got = %v, want = %v", got, want)
+	}
+
+	// errors during failover aren't logged at all
+	if len(testLogs) != 0 {
+		t.Errorf("unexpected error log during failover")
 	}
 }
 


### PR DESCRIPTION
Rework the implementation of the TerseErrors feature so that the original
mysql error is included in the local tablet logs, but still not returned
back to vtgate. That way we don't lose the mysql error string altogether.

This is safe because even with -queryserver-terse-errors enabled, the
local tablet logs may contain sensitive data since the bind variables
are printed in the local tablet log when there is a query error, so adding
the potentially sensitive original mysql error string is still not adding
any additional PII risk.

Also, when the optional log length cap is enabled, apply it to the combined
Sql + BindVars string instead of individually truncating each element.
This keeps the overall line length bounded even when there are a lot
of long bind variables.
