### PR TITLE
test: Disable mysql_server_test on Travis CI.

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -212,7 +212,7 @@
 			"File": "mysql_server_test.py",
 			"Args": [],
 			"Command": [],
-			"Manual": false,
+			"Manual": true,
 			"Shard": 1,
 			"RetryMax": 0,
 			"Tags": []


### PR DESCRIPTION
It is currently always failing and will be fixed once we switch Travis CI to run the tests within Docker.

I'll merge this right away. No need for review here.

@demmer suggested this temporary measure in https://github.com/youtube/vitess/issues/3203.