### PR TITLE
travis: Temporarily disable "unit" and "mysql_server_test" on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,12 +128,13 @@ before_script:
 script:
   # Log GOMAXPROCS (should be 2 as of 07/2015).
   - go run travis/log_gomaxprocs.go
+  # TODO(mberlin): Remove the "tests_broken_on_travis" exclude tag when we switch to Docker based tests.
   - |
     if [[ $TRAVIS_PULL_REQUEST = "false" ]]; then
-      go run test.go $TEST_FLAGS $TEST_MATRIX
+      go run test.go $TEST_FLAGS $TEST_MATRIX -exclude=tests_broken_on_travis
     else
       # Exclude webdriver tests on Travis PRs since the sauce addon does not work for PRs
-      go run test.go $TEST_FLAGS $TEST_MATRIX -exclude=webdriver
+      go run test.go $TEST_FLAGS $TEST_MATRIX -exclude=webdriver,tests_broken_on_travis
     fi
 after_script:
   # Stop Sauce Connect at the end

--- a/test/config.json
+++ b/test/config.json
@@ -212,10 +212,12 @@
 			"File": "mysql_server_test.py",
 			"Args": [],
 			"Command": [],
-			"Manual": true,
+			"Manual": false,
 			"Shard": 1,
 			"RetryMax": 0,
-			"Tags": []
+			"Tags": [
+				"tests_broken_on_travis"
+			]
 		},
 		"mysqlctl": {
 			"File": "mysqlctl.py",
@@ -362,7 +364,9 @@
 			"Manual": false,
 			"Shard": 1,
 			"RetryMax": 1,
-			"Tags": []
+			"Tags": [
+				"tests_broken_on_travis"
+			]
 		},
 		"unit_race": {
 			"File": "",


### PR DESCRIPTION
They always fail/timeout. See also: https://github.com/youtube/vitess/issues/3203

We'll undo this change when we switch to running the tests in Docker on Travis.

Note that I'm undoing the change from https://github.com/youtube/vitess/pull/3205 where I disabled "mysql_server_test" for all executions through test.go.