### PR TITLE
Update vindexes

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -108,37 +108,37 @@
 }
 
 # update by primary keyspace id, changing one vindex column
-"update user_metadata set Email = 'juan@vitess.io' where user_id = 1"
+"update user_metadata set email = 'juan@vitess.io' where user_id = 1"
 {
-  "Original": "update user_metadata set Email = 'juan@vitess.io' where user_id = 1",
+  "Original": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
   "Instructions": {
     "Opcode": "UpdateEqual",
     "Keyspace": {
       "Name": "user",
       "Sharded": true
     },
-    "Query": "update user_metadata set Email = 'juan@vitess.io' where user_id = 1",
+    "Query": "update user_metadata set email = 'juan@vitess.io' where user_id = 1",
     "Vindex": "user_index",
     "Values": [1],
     "ChangedVindexValues": {
       "email_user_map": "juan@vitess.io"
     },
     "Table": "user_metadata",
-    "Subquery": "select Email, Address from user_metadata where user_id = 1 for update"
+    "Subquery": "select email, address from user_metadata where user_id = 1 for update"
   }
 }
 
 # update by primary keyspace id, changing multiple vindex columns
-"update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1"
+"update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1"
 {
-  "Original": "update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1",
+  "Original": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
   "Instructions": {
     "Opcode": "UpdateEqual",
     "Keyspace": {
       "Name": "user",
       "Sharded": true
     },
-    "Query": "update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1",
+    "Query": "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1",
     "Vindex": "user_index",
     "Values": [1],
     "ChangedVindexValues": {
@@ -146,7 +146,7 @@
       "email_user_map": "juan@vitess.io"
     },
     "Table": "user_metadata",
-    "Subquery": "select Email, Address from user_metadata where user_id = 1 for update"
+    "Subquery": "select email, address from user_metadata where user_id = 1 for update"
   }
 }
 

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -107,6 +107,49 @@
   }
 }
 
+# update by primary keyspace id, changing one vindex column
+"update user_metadata set Email = 'juan@vitess.io' where user_id = 1"
+{
+  "Original": "update user_metadata set Email = 'juan@vitess.io' where user_id = 1",
+  "Instructions": {
+    "Opcode": "UpdateEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "update user_metadata set Email = 'juan@vitess.io' where user_id = 1",
+    "Vindex": "user_index",
+    "Values": [1],
+    "ChangedVindexValues": {
+      "email_user_map": "juan@vitess.io"
+    },
+    "Table": "user_metadata",
+    "Subquery": "select Email, Lastname, Address from user_metadata where user_id = 1 for update"
+  }
+}
+
+# update by primary keyspace id, changing multiple vindex columns
+"update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1"
+{
+  "Original": "update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1",
+  "Instructions": {
+    "Opcode": "UpdateEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "update user_metadata set Email = 'juan@vitess.io', Address = '155 5th street' where user_id = 1",
+    "Vindex": "user_index",
+    "Values": [1],
+    "ChangedVindexValues": {
+      "address_user_map": "155 5th street",
+      "email_user_map": "juan@vitess.io"
+    },
+    "Table": "user_metadata",
+    "Subquery": "select Email, Lastname, Address from user_metadata where user_id = 1 for update"
+  }
+}
+
 # update by primary keyspace id, stray where clause
 "update user set val = 1 where id = id2 and id = 1"
 {

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -124,7 +124,7 @@
       "email_user_map": "juan@vitess.io"
     },
     "Table": "user_metadata",
-    "Subquery": "select Email, Lastname, Address from user_metadata where user_id = 1 for update"
+    "Subquery": "select Email, Address from user_metadata where user_id = 1 for update"
   }
 }
 
@@ -146,7 +146,7 @@
       "email_user_map": "juan@vitess.io"
     },
     "Table": "user_metadata",
-    "Subquery": "select Email, Lastname, Address from user_metadata where user_id = 1 for update"
+    "Subquery": "select Email, Address from user_metadata where user_id = 1 for update"
   }
 }
 

--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -7,6 +7,9 @@
           "type": "hash_test",
           "owner": "user"
         },
+        "user_md5_index": {
+          "type": "hash_test"
+        },
         "music_user_map": {
           "type": "lookup_test",
           "owner": "music"
@@ -56,12 +59,16 @@
               "name": "user_index"
             },
             {
-              "column": "Email",
+              "column": "email",
               "name": "email_user_map"
             },
             {
-              "column": "Address",
+              "column": "address",
               "name": "address_user_map"
+            },
+            {
+              "column": "md5",
+              "name": "user_md5_index"
             }
           ]
         },

--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -23,10 +23,6 @@
           "type": "lookup_test",
           "owner": "user_metadata"
         },
-        "lastname_user_map": {
-          "type": "lookup_test",
-          "owner": "user_metadata"
-        },
         "costly_map": {
           "type": "costly",
           "owner": "user"
@@ -62,10 +58,6 @@
             {
               "column": "Email",
               "name": "email_user_map"
-            },
-            {
-              "column": "Lastname",
-              "name": "lastname_user_map"
             },
             {
               "column": "Address",

--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -15,6 +15,18 @@
           "type": "multi",
           "owner": "user"
         },
+        "email_user_map": {
+          "type": "lookup_test",
+          "owner": "user_metadata"
+        },
+        "address_user_map": {
+          "type": "lookup_test",
+          "owner": "user_metadata"
+        },
+        "lastname_user_map": {
+          "type": "lookup_test",
+          "owner": "user_metadata"
+        },
         "costly_map": {
           "type": "costly",
           "owner": "user"
@@ -40,6 +52,26 @@
             "column": "id",
             "sequence": "seq"
           }
+        },
+        "user_metadata": {
+          "column_vindexes": [
+            {
+              "column": "user_id",
+              "name": "user_index"
+            },
+            {
+              "column": "Email",
+              "name": "email_user_map"
+            },
+            {
+              "column": "Lastname",
+              "name": "lastname_user_map"
+            },
+            {
+              "column": "Address",
+              "name": "address_user_map"
+            }
+          ]
         },
         "user_extra": {
           "column_vindexes": [

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -303,9 +303,13 @@
 "delete user from user join user_extra on user.id = user_extra.id where user.name = 'foo'"
 "unsupported: multi-table delete statement in sharded keyspace"
 
-# update changes index column
-"update music set id = 1 where id = 1"
-"unsupported: DML cannot change vindex column that is shared by other tables"
+# update changes primary vindex column
+"update user set id = 1 where id = 1"
+"unsupported: You can't update primary vindex columns. Invalid update on column: id"
+
+# update with complex set clause
+"update music set id = id + 1 where id = 1"
+"unsupported: Only values are supported. Invalid update on column: id"
 
 # cross-shard update tables
 "update (select id from user) as u set id = 4"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -307,6 +307,14 @@
 "update user set id = 1 where id = 1"
 "unsupported: You can't update primary vindex columns. Invalid update on column: id"
 
+# update changes non owned vindex column
+"update music_extra set music_id = 1 where user_id = 1"
+"unsupported: You can only update owned vindexes. Invalid update on column: music_id"
+
+# update changes non lookup vindex column
+"update user_metadata set md5 = 1 where user_id = 1"
+"unsupported: You can only update lookup vindexes. Invalid update on column: md5"
+
 # update with complex set clause
 "update music set id = id + 1 where id = 1"
 "unsupported: Only values are supported. Invalid update on column: id"

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -305,7 +305,7 @@
 
 # update changes index column
 "update music set id = 1 where id = 1"
-"unsupported: DML cannot change vindex column"
+"unsupported: DML cannot change vindex column that is shared by other tables"
 
 # cross-shard update tables
 "update (select id from user) as u set id = 4"

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -443,8 +443,7 @@ func (route *Route) execUpdateEqual(vcursor VCursor, bindVars map[string]*queryp
 		}
 		return result, nil
 	}
-	rewritten := sqlannotation.AddKeyspaceIDs(route.Query, [][]byte{ksid}, "")
-	return route.execShard(vcursor, rewritten, bindVars, ks, shard, true /* isDML */)
+	return route.execShard(vcursor, route.Query, bindVars, ks, shard, true /* isDML */)
 }
 
 // execUpdateEqualChangedVindex performs an update when a vindex is being modified
@@ -635,6 +634,9 @@ func (route *Route) updateChangedVindexes(subQueryResult *sqltypes.Result, vcurs
 			}
 			ids := make([]sqltypes.Value, 0, len(subQueryResult.Rows))
 
+			if len(subQueryResult.Rows) > 1 {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: update changes multiple columns in the vindex")
+			}
 			for _, row := range subQueryResult.Rows {
 				ids = append(ids, row[i])
 			}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -55,6 +55,9 @@ type Route struct {
 	Vindex vindexes.Vindex
 	Values []sqltypes.PlanValue
 
+	// ChangedVindexValues contains values for updated Vindexes during an update statement.
+	ChangedVindexValues map[string]sqltypes.PlanValue
+
 	// JoinVars contains the list of joinvar keys that will be used
 	// to extract join variables.
 	JoinVars map[string]struct{}
@@ -110,35 +113,37 @@ func (route *Route) MarshalJSON() ([]byte, error) {
 		vindexName = route.Vindex.String()
 	}
 	marshalRoute := struct {
-		Opcode     RouteOpcode          `json:",omitempty"`
-		Keyspace   *vindexes.Keyspace   `json:",omitempty"`
-		Query      string               `json:",omitempty"`
-		FieldQuery string               `json:",omitempty"`
-		Vindex     string               `json:",omitempty"`
-		Values     []sqltypes.PlanValue `json:",omitempty"`
-		JoinVars   map[string]struct{}  `json:",omitempty"`
-		OrderBy    []OrderbyParams      `json:",omitempty"`
-		Table      string               `json:",omitempty"`
-		Subquery   string               `json:",omitempty"`
-		Generate   *Generate            `json:",omitempty"`
-		Prefix     string               `json:",omitempty"`
-		Mid        []string             `json:",omitempty"`
-		Suffix     string               `json:",omitempty"`
+		Opcode              RouteOpcode                   `json:",omitempty"`
+		Keyspace            *vindexes.Keyspace            `json:",omitempty"`
+		Query               string                        `json:",omitempty"`
+		FieldQuery          string                        `json:",omitempty"`
+		Vindex              string                        `json:",omitempty"`
+		Values              []sqltypes.PlanValue          `json:",omitempty"`
+		ChangedVindexValues map[string]sqltypes.PlanValue `json:",omitempty"`
+		JoinVars            map[string]struct{}           `json:",omitempty"`
+		OrderBy             []OrderbyParams               `json:",omitempty"`
+		Table               string                        `json:",omitempty"`
+		Subquery            string                        `json:",omitempty"`
+		Generate            *Generate                     `json:",omitempty"`
+		Prefix              string                        `json:",omitempty"`
+		Mid                 []string                      `json:",omitempty"`
+		Suffix              string                        `json:",omitempty"`
 	}{
-		Opcode:     route.Opcode,
-		Keyspace:   route.Keyspace,
-		Query:      route.Query,
-		FieldQuery: route.FieldQuery,
-		Vindex:     vindexName,
-		Values:     route.Values,
-		JoinVars:   route.JoinVars,
-		OrderBy:    route.OrderBy,
-		Table:      tname,
-		Subquery:   route.Subquery,
-		Generate:   route.Generate,
-		Prefix:     route.Prefix,
-		Mid:        route.Mid,
-		Suffix:     route.Suffix,
+		Opcode:              route.Opcode,
+		Keyspace:            route.Keyspace,
+		Query:               route.Query,
+		FieldQuery:          route.FieldQuery,
+		Vindex:              vindexName,
+		ChangedVindexValues: route.ChangedVindexValues,
+		Values:              route.Values,
+		JoinVars:            route.JoinVars,
+		OrderBy:             route.OrderBy,
+		Table:               tname,
+		Subquery:            route.Subquery,
+		Generate:            route.Generate,
+		Prefix:              route.Prefix,
+		Mid:                 route.Mid,
+		Suffix:              route.Suffix,
 	}
 	return jsonutil.MarshalNoEscape(marshalRoute)
 }
@@ -431,8 +436,62 @@ func (route *Route) execUpdateEqual(vcursor VCursor, bindVars map[string]*queryp
 	if len(ksid) == 0 {
 		return &sqltypes.Result{}, nil
 	}
-	rewritten := sqlannotation.AddKeyspaceIDs(route.Query, [][]byte{ksid}, "")
-	return route.execShard(vcursor, rewritten, bindVars, ks, shard, true /* isDML */)
+	if len(route.ChangedVindexValues) == 0 {
+		rewritten := sqlannotation.AddKeyspaceIDs(route.Query, [][]byte{ksid}, "")
+		return route.execShard(vcursor, rewritten, bindVars, ks, shard, true /* isDML */)
+	}
+	return route.execUpdateEqualChangedVindex(vcursor, route.Subquery, bindVars, ks, shard, ksid)
+}
+
+// execupdateequalchangedvindex performs an update when a vindex is being modify
+// by the statement. the following operations will be performed:
+// 1) fetch for update changing row
+// 2) delete from vindexes old values
+// 3) insert into secondary vindexes the updated values
+// 4) update row
+//
+// note 1: the order seen above won't neccesarly match the one executed by
+// vttablet. given that dmls will be mapped to existent transactions on each
+// shard, the order could change. for more info on how dml's get mapped to
+// transactions in the tablet see vt/vtgate/safe_sessions.go
+//
+// however, to avoid issues with duplicate key constraints violations in the
+// case that a vindex update (delete/insert) lands in the same shard,
+// it's more convenient to do  the delete first. the following is an example
+// of this sceneario:
+// - an update statement with an unique vindex column that sets a value to
+//   to what already exists in the db:
+//   update user set name='juan' where user_id=1
+//   followed by:
+//   update user set name='juan' where user_id=1
+// if we don't do the delete first, this query will fail because the lookup
+// table already has an entry from name=juan to user_id=1.
+//
+// note 2: while changes are being committed the changing row could be unreachable by
+// either the new or old column values.
+func (route *Route) execUpdateEqualChangedVindex(vcursor VCursor, query string, bindVars map[string]*querypb.BindVariable, keyspace, shard string, keyspaceId []byte) (*sqltypes.Result, error) {
+	var subQueryResult *sqltypes.Result
+	var err error
+	rewritten := sqlannotation.AddKeyspaceIDs(route.Query, [][]byte{keyspaceId}, "")
+	if route.Subquery != "" && len(route.Table.Owned) != 0 {
+		subQueryResult, err = route.execShard(vcursor, route.Subquery, bindVars, keyspace, shard, false /* isDML */)
+		if err != nil {
+			return nil, vterrors.Wrap(err, "execUpdateEqual")
+		}
+	}
+	err = route.deleteUpdatedVindexEntries(subQueryResult, vcursor, bindVars, keyspaceId)
+	if err != nil {
+		return nil, vterrors.Wrap(err, "execUpdateEqual")
+	}
+	err = route.insertUpdatedVindexEntries(vcursor, bindVars, keyspaceId)
+	if err != nil {
+		return nil, vterrors.Wrap(err, "execUpdateEqual")
+	}
+	result, err := route.execShard(vcursor, rewritten, bindVars, keyspace, shard, true /* isDML */)
+	if err != nil {
+		return nil, vterrors.Wrap(err, "execUpdateEqual")
+	}
+	return result, nil
 }
 
 func (route *Route) execDeleteEqual(vcursor VCursor, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
@@ -448,7 +507,12 @@ func (route *Route) execDeleteEqual(vcursor VCursor, bindVars map[string]*queryp
 		return &sqltypes.Result{}, nil
 	}
 	if route.Subquery != "" && len(route.Table.Owned) != 0 {
-		err = route.deleteVindexEntries(vcursor, bindVars, ks, shard, ksid)
+		result, err := route.execShard(vcursor, route.Subquery, bindVars, ks, shard, false /* isDML */)
+		if err != nil {
+			return nil, vterrors.Wrap(err, "execDeleteEqual")
+		}
+
+		err = route.deleteVindexEntries(result, vcursor, bindVars, ksid)
 		if err != nil {
 			return nil, vterrors.Wrap(err, "execDeleteEqual")
 		}
@@ -571,20 +635,35 @@ func (route *Route) resolveSingleShard(vcursor VCursor, bindVars map[string]*que
 	return newKeyspace, shard, ksid, nil
 }
 
-func (route *Route) deleteVindexEntries(vcursor VCursor, bindVars map[string]*querypb.BindVariable, ks, shard string, ksid []byte) error {
-	result, err := route.execShard(vcursor, route.Subquery, bindVars, ks, shard, false /* isDML */)
-	if err != nil {
-		return err
-	}
-	if len(result.Rows) == 0 {
+func (route *Route) deleteUpdatedVindexEntries(subQueryResult *sqltypes.Result, vcursor VCursor, bindVars map[string]*querypb.BindVariable, ksid []byte) error {
+	if len(subQueryResult.Rows) == 0 || len(route.ChangedVindexValues) == 0 {
 		return nil
 	}
 	for i, colVindex := range route.Table.Owned {
-		ids := make([]sqltypes.Value, 0, len(result.Rows))
-		for _, row := range result.Rows {
+		if _, ok := route.ChangedVindexValues[colVindex.Name]; ok {
+			ids := make([]sqltypes.Value, 0, len(subQueryResult.Rows))
+			for _, row := range subQueryResult.Rows {
+				ids = append(ids, row[i])
+			}
+			if err := colVindex.Vindex.(vindexes.Lookup).Delete(vcursor, ids, ksid); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (route *Route) deleteVindexEntries(subQueryResult *sqltypes.Result, vcursor VCursor, bindVars map[string]*querypb.BindVariable, ksid []byte) error {
+	if len(subQueryResult.Rows) == 0 {
+		return nil
+	}
+	// Columns are selected by table.Owned order see generateDeleteSubquery for details
+	for i, colVindex := range route.Table.Owned {
+		ids := make([]sqltypes.Value, 0, len(subQueryResult.Rows))
+		for _, row := range subQueryResult.Rows {
 			ids = append(ids, row[i])
 		}
-		if err = colVindex.Vindex.(vindexes.Lookup).Delete(vcursor, ids, ksid); err != nil {
+		if err := colVindex.Vindex.(vindexes.Lookup).Delete(vcursor, ids, ksid); err != nil {
 			return err
 		}
 	}
@@ -642,6 +721,27 @@ func (route *Route) processGenerate(vcursor VCursor, bindVars map[string]*queryp
 		}
 	}
 	return insertID, nil
+}
+
+// insertUpdatedVindexEntries inserts vindex entries are being changed by an update statement
+func (route *Route) insertUpdatedVindexEntries(vcursor VCursor, bindVars map[string]*querypb.BindVariable, ksid []byte) error {
+	if len(route.ChangedVindexValues) == 0 {
+		return nil
+	}
+
+	for _, colVindex := range route.Table.Owned {
+		if colValue, ok := route.ChangedVindexValues[colVindex.Name]; ok {
+			resolvedVal, err := colValue.ResolveValue(bindVars)
+			if err != nil {
+				return vterrors.Wrap(err, "insertUpdatedVindexEntries")
+			}
+			err = route.processOwned(vcursor, []sqltypes.Value{resolvedVal}, colVindex, bindVars, [][]byte{ksid})
+			if err != nil {
+				return vterrors.Wrap(err, "insertUpdatedVindexEntries")
+			}
+		}
+	}
+	return nil
 }
 
 // getInsertShardedRoute performs all the vindex related work

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -443,7 +443,8 @@ func (route *Route) execUpdateEqual(vcursor VCursor, bindVars map[string]*queryp
 		}
 		return result, nil
 	}
-	return route.execShard(vcursor, route.Query, bindVars, ks, shard, true /* isDML */)
+	rewritten := sqlannotation.AddKeyspaceIDs(route.Query, [][]byte{ksid}, "")
+	return route.execShard(vcursor, rewritten, bindVars, ks, shard, true /* isDML */)
 }
 
 // execUpdateEqualChangedVindex performs an update when a vindex is being modified

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -83,17 +83,9 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 	}
 	er.Opcode = engine.UpdateEqual
 
-	if isSharedVindexChanging(upd.Exprs, er.Table.ColumnVindexes) {
-		return nil, errors.New("unsupported: DML cannot change vindex column that is shared by other tables")
-
-	}
-
-	err = addChangedVindexesValues(er, upd.Exprs, er.Table.Owned)
-
-	if err != nil {
+	if err := addChangedVindexesValues(er, upd.Exprs, er.Table.ColumnVindexes); err != nil {
 		return nil, err
 	}
-
 	if len(er.ChangedVindexValues) != 0 {
 		er.Subquery = generateUpdateSubquery(upd, er.Table)
 	}
@@ -106,39 +98,29 @@ func generateQuery(statement sqlparser.Statement) string {
 	return buf.String()
 }
 
-// isSharedVindexChanging returns true if any of the update
-// expressions modifies a vindex column that is shared by other tables.
-func isSharedVindexChanging(setClauses sqlparser.UpdateExprs, colVindexes []*vindexes.ColumnVindex) bool {
+// addChangedVindexesValues adds to the plan all the lookup vindexes that are changing.
+// Updates can only be performed to secondary lookup vindexes with no complex expressions
+// in the set clause.
+func addChangedVindexesValues(route *engine.Route, setClauses sqlparser.UpdateExprs, colVindexes []*vindexes.ColumnVindex) error {
 	for _, assignment := range setClauses {
-		for _, vcol := range colVindexes {
-			if _, ok := vcol.Vindex.(vindexes.Lookup); ok && vcol.Column.Equal(assignment.Name.Name) && !vcol.Exclusive {
-				return true
+		for i, vcol := range colVindexes {
+			// Column not changing, continue
+			if !vcol.Column.Equal(assignment.Name.Name) {
+				continue
 			}
-		}
-	}
-	return false
-}
-
-// isIndexChanging returns true if any of the update
-// expressions modify a vindex column.
-func isIndexChanging(setClauses sqlparser.UpdateExprs, colVindexes []*vindexes.ColumnVindex) bool {
-	for _, assignment := range setClauses {
-		for _, vcol := range colVindexes {
-			if vcol.Column.Equal(assignment.Name.Name) {
-				return true
+			if i == 0 {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can't update primary vindex columns. Invalid update on column: %v", assignment.Name.Name)
 			}
-		}
-	}
-	return false
-}
-
-func addChangedVindexesValues(route *engine.Route, setClauses sqlparser.UpdateExprs, ownColVindexes []*vindexes.ColumnVindex) error {
-	for _, assignment := range setClauses {
-		for _, vcol := range ownColVindexes {
-			if vcol.Column.Equal(assignment.Name.Name) {
-				pv, ok := extractValueFromUpdate(assignment, vcol.Column)
-				if !ok {
-					return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: Only values are supported. Invalid update on column: %v", assignment.Name.Name)
+			if !vcol.Owned {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can only update owned vindexes. Invalid update on column: %v", assignment.Name.Name)
+			}
+			if _, ok := vcol.Vindex.(vindexes.Lookup); !ok {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can only update lookup vindexes. Invalid update on column: %v", assignment.Name.Name)
+			}
+			if vcol.Owned {
+				pv, err := extractValueFromUpdate(assignment, vcol.Column)
+				if err != nil {
+					return err
 				}
 				route.ChangedVindexValues[vcol.Name] = pv
 			}
@@ -200,25 +182,26 @@ func generateDeleteSubquery(del *sqlparser.Delete, table *vindexes.Table) string
 	}
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.WriteString("select ")
-	prefix := ""
-	for _, cv := range table.Owned {
-		buf.Myprintf("%s%v", prefix, cv.Column)
-		prefix = ", "
+	for i, cv := range table.Owned {
+		if i == 0 {
+			buf.Myprintf("%v", cv.Column)
+		} else {
+			buf.Myprintf(", %v", cv.Column)
+		}
 	}
 	buf.Myprintf(" from %v%v for update", table.Name, del.Where)
 	return buf.String()
 }
 
 func generateUpdateSubquery(upd *sqlparser.Update, table *vindexes.Table) string {
-	if len(table.Owned) == 0 {
-		return ""
-	}
 	buf := sqlparser.NewTrackedBuffer(nil)
 	buf.WriteString("select ")
-	prefix := ""
-	for _, cv := range table.Owned {
-		buf.Myprintf("%s%v", prefix, cv.Column)
-		prefix = ", "
+	for i, cv := range table.Owned {
+		if i == 0 {
+			buf.Myprintf("%v", cv.Column)
+		} else {
+			buf.Myprintf(", %v", cv.Column)
+		}
 	}
 	buf.Myprintf(" from %v%v for update", table.Name, upd.Where)
 	return buf.String()
@@ -243,16 +226,15 @@ func getDMLRouting(where *sqlparser.Where, route *engine.Route) error {
 	return errors.New("unsupported: multi-shard where clause in DML")
 }
 
-func extractValueFromUpdate(upd *sqlparser.UpdateExpr, col sqlparser.ColIdent) (pv sqltypes.PlanValue, ok bool) {
+// extractValueFromUpdate given an UpdateExpr attempts to extracts the Value
+// it's holding. At the moment it only supports: StrVal, HexVal, IntVal, ValArg.
+// If a complex expression is provided (e.g set name = name + 1), the update will be rejected.
+func extractValueFromUpdate(upd *sqlparser.UpdateExpr, col sqlparser.ColIdent) (pv sqltypes.PlanValue, err error) {
 	if !sqlparser.IsValue(upd.Expr) {
-		return sqltypes.PlanValue{}, false
+		err := vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: Only values are supported. Invalid update on column: %v", upd.Name.Name)
+		return sqltypes.PlanValue{}, err
 	}
-	pv, err := sqlparser.NewPlanValue(upd.Expr)
-
-	if err != nil {
-		return sqltypes.PlanValue{}, false
-	}
-	return pv, true
+	return sqlparser.NewPlanValue(upd.Expr)
 }
 
 // getMatch returns the matched value if there is an equality

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -111,19 +111,17 @@ func addChangedVindexesValues(route *engine.Route, setClauses sqlparser.UpdateEx
 			if i == 0 {
 				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can't update primary vindex columns. Invalid update on column: %v", assignment.Name.Name)
 			}
-			if !vcol.Owned {
-				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can only update owned vindexes. Invalid update on column: %v", assignment.Name.Name)
-			}
 			if _, ok := vcol.Vindex.(vindexes.Lookup); !ok {
 				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can only update lookup vindexes. Invalid update on column: %v", assignment.Name.Name)
 			}
-			if vcol.Owned {
-				pv, err := extractValueFromUpdate(assignment, vcol.Column)
-				if err != nil {
-					return err
-				}
-				route.ChangedVindexValues[vcol.Name] = pv
+			if !vcol.Owned {
+				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: You can only update owned vindexes. Invalid update on column: %v", assignment.Name.Name)
 			}
+			pv, err := extractValueFromUpdate(assignment, vcol.Column)
+			if err != nil {
+				return err
+			}
+			route.ChangedVindexValues[vcol.Name] = pv
 		}
 	}
 	return nil

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -95,7 +95,7 @@ func buildInsertShardedPlan(ins *sqlparser.Insert, table *vindexes.Table) (*engi
 		eRoute.Opcode = engine.InsertShardedIgnore
 	}
 	if ins.OnDup != nil {
-		if isIndexChanging(sqlparser.UpdateExprs(ins.OnDup), eRoute.Table.ColumnVindexes) {
+		if isVindexChanging(sqlparser.UpdateExprs(ins.OnDup), eRoute.Table.ColumnVindexes) {
 			return nil, errors.New("unsupported: DML cannot change vindex column")
 		}
 		eRoute.Opcode = engine.InsertShardedIgnore
@@ -206,4 +206,17 @@ func findOrAddColumn(ins *sqlparser.Insert, col sqlparser.ColIdent) int {
 		rows[i] = append(rows[i], &sqlparser.NullVal{})
 	}
 	return len(ins.Columns) - 1
+}
+
+// isVindexChanging returns true if any of the update
+// expressions modify a vindex column.
+func isVindexChanging(setClauses sqlparser.UpdateExprs, colVindexes []*vindexes.ColumnVindex) bool {
+	for _, assignment := range setClauses {
+		for _, vcol := range colVindexes {
+			if vcol.Column.Equal(assignment.Name.Name) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -54,12 +54,11 @@ type Keyspace struct {
 
 // ColumnVindex contains the index info for each index of a table.
 type ColumnVindex struct {
-	Column    sqlparser.ColIdent `json:"column"`
-	Type      string             `json:"type"`
-	Name      string             `json:"name"`
-	Owned     bool               `json:"owned,omitempty"`
-	Exclusive bool               `json:"exlusive"`
-	Vindex    Vindex             `json:"vindex"`
+	Column sqlparser.ColIdent `json:"column"`
+	Type   string             `json:"type"`
+	Name   string             `json:"name"`
+	Owned  bool               `json:"owned,omitempty"`
+	Vindex Vindex             `json:"vindex"`
 }
 
 // KeyspaceSchema contains the schema(table) for a keyspace.
@@ -154,7 +153,6 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 	for ksname, ks := range source.Keyspaces {
 		keyspace := vschema.Keyspaces[ksname].Keyspace
 		vindexes := make(map[string]Vindex)
-		vindexesUsageCount := make(map[string]int)
 		for vname, vindexInfo := range ks.Vindexes {
 			vindex, err := CreateVindex(vindexInfo.Type, vname, vindexInfo.Params)
 			if err != nil {
@@ -168,17 +166,6 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 			}
 			vindexes[vname] = vindex
 		}
-
-		for tname, table := range ks.Tables {
-			for _, ind := range table.ColumnVindexes {
-				_, ok := ks.Vindexes[ind.Name]
-				if !ok {
-					return fmt.Errorf("vindex %s not found for table %s", ind.Name, tname)
-				}
-				vindexesUsageCount[ind.Name] = vindexesUsageCount[ind.Name] + 1
-			}
-		}
-
 		for tname, table := range ks.Tables {
 			t := &Table{
 				Name:     sqlparser.NewTableIdent(tname),
@@ -203,22 +190,15 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 				}
 				vindex := vindexes[ind.Name]
 				owned := false
-				exclusive := true
-
-				if vindexesUsageCount[ind.Name] > 1 {
-					exclusive = false
-				}
-
 				if _, ok := vindex.(Lookup); ok && vindexInfo.Owner == tname {
 					owned = true
 				}
 				columnVindex := &ColumnVindex{
-					Column:    sqlparser.NewColIdent(ind.Column),
-					Type:      vindexInfo.Type,
-					Name:      ind.Name,
-					Owned:     owned,
-					Vindex:    vindex,
-					Exclusive: exclusive,
+					Column: sqlparser.NewColIdent(ind.Column),
+					Type:   vindexInfo.Type,
+					Name:   ind.Name,
+					Owned:  owned,
+					Vindex: vindex,
 				}
 				if i == 0 {
 					// Perform Primary vindex check.

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -192,9 +192,10 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Column: sqlparser.NewColIdent("c1"),
-				Type:   "stfu",
-				Name:   "stfu1",
+				Column:    sqlparser.NewColIdent("c1"),
+				Type:      "stfu",
+				Name:      "stfu1",
+				Exclusive: true,
 				Vindex: &stFU{
 					name: "stfu1",
 					Params: map[string]string{
@@ -203,11 +204,12 @@ func TestShardedVSchemaOwned(t *testing.T) {
 				},
 			},
 			{
-				Column: sqlparser.NewColIdent("c2"),
-				Type:   "stln",
-				Name:   "stln1",
-				Owned:  true,
-				Vindex: &stLN{name: "stln1"},
+				Column:    sqlparser.NewColIdent("c2"),
+				Type:      "stln",
+				Name:      "stln1",
+				Owned:     true,
+				Exclusive: true,
+				Vindex:    &stLN{name: "stln1"},
 			},
 		},
 	}
@@ -287,18 +289,20 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Column: sqlparser.NewColIdent("c1"),
-				Type:   "stlu",
-				Name:   "stlu1",
-				Owned:  false,
-				Vindex: &stLU{name: "stlu1"},
+				Column:    sqlparser.NewColIdent("c1"),
+				Type:      "stlu",
+				Name:      "stlu1",
+				Owned:     false,
+				Exclusive: true,
+				Vindex:    &stLU{name: "stlu1"},
 			},
 			{
-				Column: sqlparser.NewColIdent("c2"),
-				Type:   "stfu",
-				Name:   "stfu1",
-				Owned:  false,
-				Vindex: &stFU{name: "stfu1"},
+				Column:    sqlparser.NewColIdent("c2"),
+				Type:      "stfu",
+				Name:      "stfu1",
+				Owned:     false,
+				Exclusive: true,
+				Vindex:    &stFU{name: "stfu1"},
 			},
 		},
 	}
@@ -327,7 +331,9 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("BuildVSchema:s\n%v, want\n%v", got, want)
+		gotjson, _ := json.Marshal(got)
+		wantjson, _ := json.Marshal(want)
+		t.Errorf("BuildVSchema:s\n%s, want\n%s", gotjson, wantjson)
 	}
 }
 
@@ -1118,11 +1124,12 @@ func TestVSchemaJSON(t *testing.T) {
 				"t3": {
 					Name: sqlparser.NewTableIdent("n3"),
 					ColumnVindexes: []*ColumnVindex{{
-						Column: sqlparser.NewColIdent("aa"),
-						Type:   "vtype",
-						Name:   "vname",
-						Owned:  true,
-						Vindex: lkp,
+						Column:    sqlparser.NewColIdent("aa"),
+						Type:      "vtype",
+						Name:      "vname",
+						Owned:     true,
+						Exclusive: true,
+						Vindex:    lkp,
 					}},
 				},
 			},
@@ -1145,6 +1152,7 @@ func TestVSchemaJSON(t *testing.T) {
             "type": "vtype",
             "name": "vname",
             "owned": true,
+            "exlusive": true,
             "vindex": {
               "table": "t",
               "from": "f",

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -192,10 +192,9 @@ func TestShardedVSchemaOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Column:    sqlparser.NewColIdent("c1"),
-				Type:      "stfu",
-				Name:      "stfu1",
-				Exclusive: true,
+				Column: sqlparser.NewColIdent("c1"),
+				Type:   "stfu",
+				Name:   "stfu1",
 				Vindex: &stFU{
 					name: "stfu1",
 					Params: map[string]string{
@@ -204,12 +203,11 @@ func TestShardedVSchemaOwned(t *testing.T) {
 				},
 			},
 			{
-				Column:    sqlparser.NewColIdent("c2"),
-				Type:      "stln",
-				Name:      "stln1",
-				Owned:     true,
-				Exclusive: true,
-				Vindex:    &stLN{name: "stln1"},
+				Column: sqlparser.NewColIdent("c2"),
+				Type:   "stln",
+				Name:   "stln1",
+				Owned:  true,
+				Vindex: &stLN{name: "stln1"},
 			},
 		},
 	}
@@ -289,20 +287,18 @@ func TestShardedVSchemaNotOwned(t *testing.T) {
 		Keyspace: ks,
 		ColumnVindexes: []*ColumnVindex{
 			{
-				Column:    sqlparser.NewColIdent("c1"),
-				Type:      "stlu",
-				Name:      "stlu1",
-				Owned:     false,
-				Exclusive: true,
-				Vindex:    &stLU{name: "stlu1"},
+				Column: sqlparser.NewColIdent("c1"),
+				Type:   "stlu",
+				Name:   "stlu1",
+				Owned:  false,
+				Vindex: &stLU{name: "stlu1"},
 			},
 			{
-				Column:    sqlparser.NewColIdent("c2"),
-				Type:      "stfu",
-				Name:      "stfu1",
-				Owned:     false,
-				Exclusive: true,
-				Vindex:    &stFU{name: "stfu1"},
+				Column: sqlparser.NewColIdent("c2"),
+				Type:   "stfu",
+				Name:   "stfu1",
+				Owned:  false,
+				Vindex: &stFU{name: "stfu1"},
 			},
 		},
 	}
@@ -1124,12 +1120,11 @@ func TestVSchemaJSON(t *testing.T) {
 				"t3": {
 					Name: sqlparser.NewTableIdent("n3"),
 					ColumnVindexes: []*ColumnVindex{{
-						Column:    sqlparser.NewColIdent("aa"),
-						Type:      "vtype",
-						Name:      "vname",
-						Owned:     true,
-						Exclusive: true,
-						Vindex:    lkp,
+						Column: sqlparser.NewColIdent("aa"),
+						Type:   "vtype",
+						Name:   "vname",
+						Owned:  true,
+						Vindex: lkp,
 					}},
 				},
 			},
@@ -1152,7 +1147,6 @@ func TestVSchemaJSON(t *testing.T) {
             "type": "vtype",
             "name": "vname",
             "owned": true,
-            "exlusive": true,
             "vindex": {
               "table": "t",
               "from": "f",

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -923,7 +923,7 @@ class TestVTGateFunctions(unittest.TestCase):
         result,
         (('buendia', 5L),))
 
-    # It works when you updating to same value on unique index
+    # It works when you update to same value on unique index
     vtgate_conn.begin()
     result = self.execute_on_master(
         vtgate_conn,

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -54,6 +54,13 @@ email varchar(64),
 primary key (user_id)
 ) Engine=InnoDB'''
 
+create_vt_user_extra2 = '''create table vt_user_extra2 (
+user_id bigint,
+lastname varchar(64),
+address varchar(64),
+primary key (user_id)
+) Engine=InnoDB'''
+
 create_vt_music = '''create table vt_music (
 user_id bigint,
 id bigint,
@@ -133,6 +140,18 @@ user2_id bigint,
 primary key (name, user2_id)
 ) Engine=InnoDB'''
 
+create_lastname_user_extra2_map = '''create table lastname_user_extra2_map (
+lastname varchar(64),
+user_id bigint,
+primary key (lastname, user_id)
+) Engine=InnoDB'''
+
+create_address_user_extra2_map = '''create table address_user_extra2_map (
+address varchar(64),
+user_id bigint,
+primary key (address)
+) Engine=InnoDB'''
+
 create_music_user_map = '''create table music_user_map (
 music_id bigint,
 user_id bigint,
@@ -181,6 +200,24 @@ vschema = {
             "to": "user2_id"
           },
           "owner": "vt_user2"
+        },
+        "lastname_user_extra2_map": {
+          "type": "lookup_hash",
+          "params": {
+            "table": "lastname_user_extra2_map",
+            "from": "lastname",
+            "to": "user_id"
+          },
+          "owner": "vt_user_extra2"
+        },
+        "address_user_extra2_map": {
+          "type": "lookup_hash_unique",
+          "params": {
+            "table": "address_user_extra2_map",
+            "from": "address",
+            "to": "user_id"
+          },
+          "owner": "vt_user_extra2"
         },
         "music_user_map": {
           "type": "lookup_hash_unique",
@@ -239,6 +276,22 @@ vschema = {
             {
               "column": "user_id",
               "name": "user_index"
+            }
+          ]
+        },
+        "vt_user_extra2": {
+          "column_vindexes": [
+            {
+              "column": "user_id",
+              "name": "user_index"
+            },
+            {
+              "column": "lastname",
+              "name": "lastname_user_extra2_map"
+            },
+            {
+              "column": "address",
+              "name": "address_user_extra2_map"
             }
           ]
         },
@@ -334,6 +387,8 @@ vschema = {
         },
         "music_user_map": {},
         "name_user2_map": {},
+        "lastname_user_extra2_map": {},
+        "address_user_extra2_map": {},
         "upsert_primary": {},
         "upsert_owned": {},
         "main": {
@@ -366,6 +421,7 @@ def setUpModule():
             create_vt_user,
             create_vt_user2,
             create_vt_user_extra,
+            create_vt_user_extra2,
             create_vt_music,
             create_vt_music_extra,
             create_upsert,
@@ -385,6 +441,8 @@ def setUpModule():
             create_vt_main_seq,
             create_music_user_map,
             create_name_user2_map,
+            create_lastname_user_extra2_map,
+            create_address_user_extra2_map,
             create_upsert_primary,
             create_upsert_owned,
             create_main,
@@ -800,6 +858,112 @@ class TestVTGateFunctions(unittest.TestCase):
         'delete from  vt_user_extra where user_id = :user_id',
         {'user_id': 3})
     vtgate_conn.commit()
+
+  def test_user_extra2(self):
+    # user_extra2 is for testing updates to secondary vindexes
+    vtgate_conn = get_connection()
+    vtgate_conn.begin()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'insert into vt_user_extra2 (user_id, lastname, address) '
+        'values (:user_id, :lastname, :address)',
+        {'user_id': 5, 'lastname': 'nieves', 'address': 'invernalia'})
+    self.assertEqual(result, ([], 1L, 0L, []))
+    vtgate_conn.commit()
+
+    # Updating both vindexes
+    vtgate_conn.begin()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'update vt_user_extra2 set lastname = :lastname, address = :address where user_id = :user_id',
+        {'user_id': 5, 'lastname': 'buendia', 'address': 'macondo'})
+    self.assertEqual(result, ([], 1L, 0L, []))
+    vtgate_conn.commit()
+    result = self.execute_on_master(
+        vtgate_conn, 'select lastname, address from vt_user_extra2 where user_id = 5', {})
+    self.assertEqual(
+        result,
+        ([('buendia', 'macondo')], 1, 0,
+         [('lastname', self.string_type),
+          ('address', self.string_type)]))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select lastname, user_id from lastname_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('buendia', 5L),))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select address, user_id from address_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('macondo', 5L),))
+
+    # Updating only one vindex
+    vtgate_conn.begin()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'update vt_user_extra2 set address = :address where user_id = :user_id',
+        {'user_id': 5, 'address': 'yoknapatawpha'})
+    self.assertEqual(result, ([], 1L, 0L, []))
+    vtgate_conn.commit()
+    result = self.execute_on_master(
+        vtgate_conn, 'select lastname, address from vt_user_extra2 where user_id = 5', {})
+    self.assertEqual(
+        result,
+        ([('buendia', 'yoknapatawpha')], 1, 0,
+         [('lastname', self.string_type),
+          ('address', self.string_type)]))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select address, user_id from address_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('yoknapatawpha', 5L),))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select lastname, user_id from lastname_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('buendia', 5L),))
+
+    # It works when you updating to same value on unique index
+    vtgate_conn.begin()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'update vt_user_extra2 set address = :address where user_id = :user_id',
+        {'user_id': 5, 'address': 'yoknapatawpha'})
+    self.assertEqual(result, ([], 0L, 0L, []))
+    vtgate_conn.commit()
+    result = self.execute_on_master(
+        vtgate_conn, 'select lastname, address from vt_user_extra2 where user_id = 5', {})
+    self.assertEqual(
+        result,
+        ([('buendia', 'yoknapatawpha')], 1, 0,
+         [('lastname', self.string_type),
+          ('address', self.string_type)]))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select lastname, user_id from lastname_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('buendia', 5L),))
+    result = lookup_master.mquery(
+        'vt_lookup', 'select address, user_id from address_user_extra2_map')
+    self.assertEqual(
+        result,
+        (('yoknapatawpha', 5L),))
+
+    # you can find the record by either vindex
+    result = self.execute_on_master(
+        vtgate_conn, 'select lastname, address from vt_user_extra2 where lastname = "buendia"', {})
+    self.assertEqual(
+        result,
+        ([('buendia', 'yoknapatawpha')], 1, 0,
+         [('lastname', self.string_type),
+          ('address', self.string_type)]))
+    result = self.execute_on_master(
+        vtgate_conn, 'select lastname, address from vt_user_extra2 where address = "yoknapatawpha"', {})
+    self.assertEqual(
+        result,
+        ([('buendia', 'yoknapatawpha')], 1, 0,
+         [('lastname', self.string_type),
+          ('address', self.string_type)]))
 
   def test_music(self):
     # music is for testing owned lookup index


### PR DESCRIPTION
### Description

Implements https://github.com/youtube/vitess/issues/3177. Only change from the proposal is that we will be doing the operations in the following order:

1. Select for update the current vindex column value from the row being updated. In this way we can get the existent values for all the columns that might have vindexes.
2. Delete the old vindex entry.
3. Insert into a secondary owned vindexes the row with the updated column values.
4. Execute update statement to change the actual column.

Motivation for this is explained in comments in the PR. 

### Tests

So far I've tested this is my local cluster and with unit/integration tests. 

