### PR TITLE
Reduce allocations in go driver for time conversions

### DIFF
--- a/go/vt/vitessdriver/time.go
+++ b/go/vt/vitessdriver/time.go
@@ -106,16 +106,15 @@ func DateToNative(v sqltypes.Value, loc *time.Location) (time.Time, error) {
 
 // NewDatetime builds a Datetime Value
 func NewDatetime(t time.Time, defaultLoc *time.Location) sqltypes.Value {
-	if t.Location() != defaultLoc {
-		t = t.In(defaultLoc)
-	}
-
 	// using this backing array and AppendFormat reduces heap allocations
 	var b = make([]byte, 0, 64)
 
 	if t.IsZero() {
 		b = append(b, "0000-00-00"...)
 	} else {
+		if t.Location() != defaultLoc {
+			t = t.In(defaultLoc)
+		}
 		b = t.AppendFormat(b, isoTimeFormat)
 	}
 

--- a/go/vt/vitessdriver/time.go
+++ b/go/vt/vitessdriver/time.go
@@ -109,5 +109,16 @@ func NewDatetime(t time.Time, defaultLoc *time.Location) sqltypes.Value {
 	if t.Location() != defaultLoc {
 		t = t.In(defaultLoc)
 	}
-	return sqltypes.MakeTrusted(sqltypes.Datetime, []byte(t.Format(isoTimeFormat)))
+
+	// using this backing array and AppendFormat reduces heap allocations
+	var a [64]byte
+	var b = a[:0]
+
+	if t.IsZero() {
+		b = append(b, "0000-00-00"...)
+	} else {
+		b = t.AppendFormat(b, isoTimeFormat)
+	}
+
+	return sqltypes.MakeTrusted(sqltypes.Datetime, b)
 }

--- a/go/vt/vitessdriver/time.go
+++ b/go/vt/vitessdriver/time.go
@@ -111,8 +111,7 @@ func NewDatetime(t time.Time, defaultLoc *time.Location) sqltypes.Value {
 	}
 
 	// using this backing array and AppendFormat reduces heap allocations
-	var a [64]byte
-	var b = a[:0]
+	var b = make([]byte, 0, 64)
 
 	if t.IsZero() {
 		b = append(b, "0000-00-00"...)


### PR DESCRIPTION
Admittedly cargo culting this change to reduce go allocations. The original author is @achille-roussel as a PR here: https://github.com/go-sql-driver/mysql/pull/615

More detail behind the change at https://segment.com/blog/allocation-efficiency-in-high-performance-go-services/

We could probably also move the `t.Location()` check inside the else statement here for zero time.