### PR TITLE
Quote vindex names in some error messages where they might be empty

### DIFF
--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -129,7 +129,7 @@ func Register(vindexType string, newVindexFunc NewVindexFunc) {
 func CreateVindex(vindexType, name string, params map[string]string) (Vindex, error) {
 	f, ok := registry[vindexType]
 	if !ok {
-		return nil, fmt.Errorf("vindexType %s not found", vindexType)
+		return nil, fmt.Errorf("vindexType %q not found", vindexType)
 	}
 	return f(name, params)
 }

--- a/go/vt/vtgate/vindexes/vschema.go
+++ b/go/vt/vtgate/vindexes/vschema.go
@@ -162,7 +162,7 @@ func buildTables(source *vschemapb.SrvVSchema, vschema *VSchema) error {
 			case Unique:
 			case NonUnique:
 			default:
-				return fmt.Errorf("vindex %s needs to be Unique or NonUnique", vname)
+				return fmt.Errorf("vindex %q needs to be Unique or NonUnique", vname)
 			}
 			vindexes[vname] = vindex
 		}


### PR DESCRIPTION
* Seen in a couple of error messages the vindex name was empty.
* Quoting the name and showing an empty string makes it clearer.