### PR TITLE
go/vttest: Implement natively

### DIFF
--- a/go/cmd/vttestserver/main.go
+++ b/go/cmd/vttestserver/main.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	log "github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
+	"github.com/youtube/vitess/go/vt/vttest"
+)
+
+type topoFlags struct {
+	cells     string
+	keyspaces string
+	shards    string
+	replicas  int
+	rdonly    int
+}
+
+func (t *topoFlags) buildTopology() (*vttestpb.VTTestTopology, error) {
+	topo := &vttestpb.VTTestTopology{}
+	topo.Cells = strings.Split(t.cells, ",")
+
+	keyspaces := strings.Split(t.keyspaces, ",")
+	shardCounts := strings.Split(t.shards, ",")
+	if len(keyspaces) != len(shardCounts) {
+		return nil, fmt.Errorf("--keyspaces must be same length as --shards")
+	}
+
+	for i := range keyspaces {
+		name := keyspaces[i]
+		numshards, err := strconv.ParseInt(shardCounts[i], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+
+		ks := &vttestpb.Keyspace{
+			Name:         name,
+			ReplicaCount: int32(t.replicas),
+			RdonlyCount:  int32(t.rdonly),
+		}
+
+		for _, shardname := range vttest.GetShardNames(int(numshards)) {
+			ks.Shards = append(ks.Shards, &vttestpb.Shard{
+				Name: shardname,
+			})
+		}
+
+		topo.Keyspaces = append(topo.Keyspaces, ks)
+	}
+
+	return topo, nil
+}
+
+func parseFlags() (config vttest.Config, env vttest.Environment, err error) {
+	var seed vttest.SeedConfig
+	var topo topoFlags
+
+	var basePort int
+	var protoTopo string
+	var doSeed bool
+	var mycnf string
+
+	flag.IntVar(&basePort, "port", 0,
+		"Port to use for vtcombo. If this is 0, a random port will be chosen.")
+
+	flag.StringVar(&protoTopo, "proto_topo", "",
+		"Define the fake cluster topology as a compact text format encoded"+
+			" vttest proto. See vttest.proto for more information.")
+
+	flag.StringVar(&config.SchemaDir, "schema_dir", "",
+		"Directory for initial schema files. Within this dir,"+
+			" there should be a subdir for each keyspace. Within"+
+			" each keyspace dir, each file is executed as SQL"+
+			" after the database is created on each shard."+
+			" If the directory contains a vschema.json file, it"+
+			" will be used as the vschema for the V3 API.")
+
+	flag.StringVar(&config.DefaultSchemaDir, "default_schema_dir", "",
+		"Default directory for initial schema files. If no schema is found"+
+			" in schema_dir, default to this location.")
+
+	flag.BoolVar(&config.OnlyMySQL, "mysql_only", false,
+		"If this flag is set only mysql is initialized."+
+			" The rest of the vitess components are not started."+
+			" Also, the output specifies the mysql unix socket"+
+			" instead of the vtgate port.")
+
+	flag.BoolVar(&doSeed, "initialize_with_random_data", false,
+		"If this flag is each table-shard will be initialized"+
+			" with random data. See also the 'rng_seed' and 'min_shard_size'"+
+			" and 'max_shard_size' flags.")
+
+	flag.IntVar(&seed.RngSeed, "rng_seed", 123,
+		"The random number generator seed to use when initializing"+
+			" with random data (see also --initialize_with_random_data)."+
+			" Multiple runs with the same seed will result with the same"+
+			" initial data.")
+
+	flag.IntVar(&seed.MinSize, "min_table_shard_size", 1000,
+		"The minimum number of initial rows in a table shard. Ignored if"+
+			"--initialize_with_random_data is false. The actual number is chosen"+
+			" randomly.")
+
+	flag.IntVar(&seed.MaxSize, "max_table_shard_size", 10000,
+		"The maximum number of initial rows in a table shard. Ignored if"+
+			"--initialize_with_random_data is false. The actual number is chosen"+
+			" randomly")
+
+	flag.Float64Var(&seed.NullProbability, "null_probability", 0.1,
+		"The probability to initialize a field with 'NULL' "+
+			" if --initialize_with_random_data is true. Only applies to fields"+
+			" that can contain NULL values.")
+
+	flag.StringVar(&config.WebDir, "web_dir", "",
+		"location of the vtctld web server files.")
+
+	flag.StringVar(&config.WebDir2, "web_dir2", "",
+		"location of the vtctld2 web server files.")
+
+	flag.StringVar(&mycnf, "extra_my_cnf", "",
+		"extra files to add to the config, separated by ':'")
+
+	flag.StringVar(&topo.cells, "cells", "test", "Comma separated list of cells")
+	flag.StringVar(&topo.keyspaces, "keyspaces", "test_keyspace",
+		"Comma separated list of keyspaces")
+	flag.StringVar(&topo.shards, "num_shards", "2",
+		"Comma separated shard count (one per keyspace)")
+	flag.IntVar(&topo.replicas, "replica_count", 2,
+		"Replica tablets per shard (includes master)")
+	flag.IntVar(&topo.rdonly, "rdonly_count", 1,
+		"Rdonly tablets per shard")
+
+	flag.StringVar(&config.Charset, "charset", "utf8", "MySQL charset")
+	flag.StringVar(&config.SnapshotFile, "snapshot_file", "",
+		"A MySQL DB snapshot file")
+
+	flag.Parse()
+
+	if basePort != 0 {
+		env, err = vttest.NewLocalTestEnv("", basePort)
+		if err != nil {
+			return
+		}
+	}
+
+	if protoTopo == "" {
+		config.Topology, err = topo.buildTopology()
+		if err != nil {
+			return
+		}
+	} else {
+		var topology vttestpb.VTTestTopology
+		err = proto.UnmarshalText(protoTopo, &topology)
+		if err != nil {
+			return
+		}
+		if len(topology.Cells) == 0 {
+			topology.Cells = append(topology.Cells, "test")
+		}
+		config.Topology = &topology
+	}
+
+	if doSeed {
+		config.Seed = &seed
+	}
+
+	if mycnf != "" {
+		config.ExtraMyCnf = strings.Split(mycnf, ":")
+	}
+
+	return
+}
+
+func main() {
+	config, env, err := parseFlags()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Infof("Starting local cluster...")
+	log.Infof("config: %#v", config)
+
+	cluster := vttest.LocalCluster{
+		Config: config,
+		Env:    env,
+	}
+
+	err = cluster.Setup()
+	defer cluster.TearDown()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	kvconf := cluster.JSONConfig()
+	if err := json.NewEncoder(os.Stdout).Encode(kvconf); err != nil {
+		log.Fatal(err)
+	}
+
+	log.Info("Local cluster started. Waiting for stdin input...")
+
+	_, err = fmt.Scanln()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Info("Shutting down cleanly")
+}

--- a/go/vt/vttest/environment.go
+++ b/go/vt/vttest/environment.go
@@ -267,3 +267,13 @@ func NewLocalTestEnv(flavor string, basePort int) (*LocalTestEnv, error) {
 		},
 	}, nil
 }
+
+func defaultEnvFactory() (Environment, error) {
+	return NewLocalTestEnv("", 0)
+}
+
+// NewDefaultEnv is an user-configurable callback that returns a new Environment
+// instance with the default settings.
+// This callback is only used in cases where the user hasn't explicitly set
+// the Env variable when intializing a LocalCluster
+var NewDefaultEnv = defaultEnvFactory

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Google Inc.
+Copyright 2017 GitHub Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,426 +14,433 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package vttest provides the functionality to bring
-// up a test cluster.
 package vttest
 
 import (
+	"bufio"
+	"bytes"
+	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
-	"strconv"
+	"path/filepath"
 	"strings"
+	"unicode"
+
+	"github.com/youtube/vitess/go/sqltypes"
 
 	log "github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-
 	"github.com/youtube/vitess/go/mysql"
 	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
 )
 
-// Handle allows you to interact with the processes launched by vttest.
-type Handle struct {
-	Data map[string]interface{}
+// Config are the settings used to configure the self-contained Vitess cluster.
+// The LocalCluster struct embeds Config so it's possible to either initialize
+// a LocalCluster with the given settings, or set the settings directly after
+// initialization.
+// All settings must be set before LocalCluster.Setup() is called.
+type Config struct {
+	// Topology defines the fake cluster's topology. This field is mandatory.
+	// See: vt/proto/vttest.VTTestTopology
+	Topology *vttestpb.VTTestTopology
 
-	cmd   *exec.Cmd
-	stdin io.WriteCloser
+	// Seed can be set with a SeedConfig struct to enable
+	// auto-initialization of the database cluster with random data.
+	// If nil, no random initialization will be performed.
+	// See: SeedConfig
+	Seed *SeedConfig
 
-	// schemaDir is the directory which will be passed as --schema_dir flag.
-	// We store it here because the VSchema() option must reference it.
-	schemaDir string
+	// SchemaDir is the directory for schema files. Within this dir,
+	// there should be a subdir for each keyspace. Within each keyspace
+	// dir, each file is executed as SQL after the database is created on
+	// each shard.
+	// If the directory contains a `vschema.json`` file, it will be used
+	// as the VSchema for the V3 API
+	SchemaDir string
 
-	// dbname is valid only for LaunchMySQL.
-	dbname string
+	// DefaultSchemaDir is the default directory for initial schema files.
+	// If no schema is found in SchemaDir, default to this location.
+	DefaultSchemaDir string
+
+	// Charset is the default charset used by MySQL
+	Charset string
+
+	// WebDir is the location of the vtcld web server files
+	WebDir string
+
+	// WebDir2 is the location of the vtcld2 web server files
+	WebDir2 string
+
+	// ExtraMyCnf are the extra .CNF files to be added to the MySQL config
+	ExtraMyCnf []string
+
+	// OnlyMySQL can be set so only MySQL is initialized as part of the
+	// local cluster configuration. The rest of the Vitess components will
+	// not be started.
+	OnlyMySQL bool
+
+	// SnapshotFile is the path to the MySQL Snapshot that will be used to
+	// initialize the mysqld instance in the cluster. Note that some environments
+	// do not suppport initialization through snapshot files.
+	SnapshotFile string
 }
 
-// VtgateAddress returns the address under which vtgate is reachable e.g.
-// "localhost:15991".
-// An error is returned if the data is not available.
-func (hdl *Handle) VtgateAddress() (string, error) {
-	if hdl.Data == nil {
-		return "", errors.New("Data field in Handle is empty")
+// DbName returns the default name for a database in this cluster.
+// If OnlyMySQL is set, this will be the name of the single database
+// created in MySQL. Otherwise, this will be the database that stores
+// the first keyspace in the topology.
+func (cfg *Config) DbName() string {
+	ns := cfg.Topology.GetKeyspaces()
+	if len(ns) > 0 {
+		return ns[0].Name
 	}
-	portName := "port"
-	if vtgateProtocol() == "grpc" {
-		portName = "grpc_port"
-	}
-	fport, ok := hdl.Data[portName]
-	if !ok {
-		return "", fmt.Errorf("port %v not found in map", portName)
-	}
-	port := int(fport.(float64))
-	return fmt.Sprintf("localhost:%d", port), nil
+	return ""
 }
 
-// VitessOption is the type for generic options to be passed in to LaunchVitess.
-type VitessOption struct {
-	// beforeRun is executed before we start run_local_database.py.
-	beforeRun func(*Handle) error
+// LocalCluster controls a local Vitess setup for testing, containing
+// a MySQL instance and one or more vtgate-equivalent access points.
+// To use, simply create a new LocalCluster instance and either pass in
+// the desired Config, or manually set each field on the struct itself.
+// Once the struct is configured, call LocalCluster.Setup() to instantiate
+// the cluster.
+// The Env for the local cluster can also be set before calling Setup(); if
+// not set, Setup() will instantiate a LocalTestEnv with the default values
+// See: Config for configuration settings on the cluster
+type LocalCluster struct {
+	Config
+	Env Environment
 
-	// afterRun is executed after run_local_database.py has been
-	// started and is running (and is done reading and applying
-	// the schema).
-	afterRun func()
+	mysql MySQLManager
+	vt    *VtProcess
 }
 
-// Verbose makes the underlying local_cluster verbose.
-func Verbose(verbose bool) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if verbose {
-				hdl.cmd.Args = append(hdl.cmd.Args, "--verbose")
-			}
-			return nil
-		},
-	}
+// MySQLConnParams returns a mysql.ConnParams struct that can be used
+// to connect directly to the mysqld service in the self-contained cluster
+// This connection should be used for debug/introspection purposes; normal
+// cluster access should be performed through the vtgate port.
+func (db *LocalCluster) MySQLConnParams() mysql.ConnParams {
+	return db.mysql.Params(db.DbName())
 }
 
-// NoStderr makes the underlying local_cluster stderr output disapper.
-func NoStderr() VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			hdl.cmd.Stderr = nil
-			return nil
-		},
+// Setup brings up the self-contained Vitess cluster by spinning up
+// MySQL and Vitess instances. The spawned processes will be running
+// until the TearDown() method is called.
+// Please ensure to `defer db.TearDown()` after calling this method
+func (db *LocalCluster) Setup() error {
+	var err error
+
+	if db.Env == nil {
+		log.Info("No environment in cluster settings. Creating default...")
+		db.Env, err = NewLocalTestEnv("", 0)
+		if err != nil {
+			return err
+		}
 	}
+
+	log.Infof("LocalCluster environment: %+v", db.Env)
+
+	db.mysql, err = db.Env.MySQLManager(db.ExtraMyCnf, db.SnapshotFile)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Initializing MySQL Manager (%T)...", db.mysql)
+
+	if err := db.mysql.Setup(); err != nil {
+		log.Errorf("Mysqlctl failed to start: %s", err)
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Errorf("stderr: %s", err.Stderr)
+		}
+		return err
+	}
+
+	mycfg, _ := json.Marshal(db.mysql.Params(""))
+	log.Infof("MySQL up: %s", mycfg)
+
+	if err := db.createDatabases(); err != nil {
+		return err
+	}
+
+	if err := db.loadSchema(); err != nil {
+		return err
+	}
+
+	if db.Seed != nil {
+		if err := db.populateWithRandomData(); err != nil {
+			return err
+		}
+	}
+
+	if !db.OnlyMySQL {
+		log.Infof("Starting vtcombo...")
+		db.vt = VtcomboProcess(db.Env, &db.Config, db.mysql)
+		if err := db.vt.WaitStart(); err != nil {
+			return err
+		}
+		log.Infof("vtcombo up: %s", db.vt.Address())
+	}
+
+	return nil
 }
 
-// SchemaDirectory is used to specify a directory to read schema from.
-// It cannot be used at the same time as Schema.
-func SchemaDirectory(dir string) VitessOption {
-	if dir == "" {
-		log.Fatal("BUG: provided directory must not be empty")
+// TearDown shuts down all the processes in the local cluster
+// and cleans up any temporary on-disk data.
+// If an error is returned, some of the running processes may not
+// have been shut down cleanly and may need manual cleanup.
+func (db *LocalCluster) TearDown() error {
+	var errors []string
+
+	if db.vt != nil {
+		db.vt.Kill()
+		if err := db.vt.Wait(); err != nil {
+			errors = append(errors, fmt.Sprintf("vtprocess: %s", err))
+		}
 	}
 
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if hdl.schemaDir != "" {
-				return fmt.Errorf("SchemaDirectory option (%v) would overwrite directory set by another option (%v)", dir, hdl.schemaDir)
-			}
-			hdl.schemaDir = dir
-			return nil
-		},
+	if err := db.mysql.TearDown(); err != nil {
+		errors = append(errors, fmt.Sprintf("mysql: %s", err))
+
+		log.Errorf("failed to shutdown MySQL: %s", err)
+		if err, ok := err.(*exec.ExitError); ok {
+			log.Errorf("stderr: %s", err.Stderr)
+		}
 	}
+
+	if err := db.Env.TearDown(); err != nil {
+		errors = append(errors, fmt.Sprintf("environment: %s", err))
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to teardown LocalCluster:\n%s",
+			strings.Join(errors, "\n"))
+	}
+
+	return nil
 }
 
-// ProtoTopo is used to pass in the topology as a vttest proto definition.
-// See vttest.proto for more information.
-// It cannot be used at the same time as MySQLOnly.
-func ProtoTopo(topo *vttestpb.VTTestTopology) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if hdl.dbname != "" {
-				return fmt.Errorf("duplicate MySQLOnly option or conflicting ProtoTopo option. You can only use one")
-			}
-
-			if len(topo.GetKeyspaces()) > 0 {
-				hdl.dbname = topo.GetKeyspaces()[0].Name
-			}
-			hdl.cmd.Args = append(hdl.cmd.Args, "--proto_topo", proto.CompactTextString(topo))
-			return nil
-		},
+func (db *LocalCluster) shardNames(keyspace *vttestpb.Keyspace) (names []string) {
+	for _, spb := range keyspace.Shards {
+		dbname := spb.DbNameOverride
+		if dbname == "" {
+			dbname = fmt.Sprintf("vt_%s_%s", keyspace.Name, spb.Name)
+		}
+		names = append(names, dbname)
 	}
+	return
 }
 
-// MySQLOnly is used to launch only a mysqld instance, with the specified db name.
-// It cannot be used at the same as ProtoTopo.
-func MySQLOnly(dbName string) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if hdl.dbname != "" {
-				return fmt.Errorf("duplicate MySQLOnly option or conflicting ProtoTopo option. You can only use one")
-			}
-
-			// the way to pass the dbname for creation in
-			// is to provide a topology
-			topo := &vttestpb.VTTestTopology{
-				Keyspaces: []*vttestpb.Keyspace{
-					{
-						Name: dbName,
-						Shards: []*vttestpb.Shard{
-							{
-								Name:           "0",
-								DbNameOverride: dbName,
-							},
-						},
-					},
-				},
-			}
-
-			hdl.dbname = dbName
-			hdl.cmd.Args = append(hdl.cmd.Args,
-				"--mysql_only",
-				"--proto_topo", proto.CompactTextString(topo))
-			return nil
-		},
-	}
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
-// Schema is used to specify SQL commands to run at startup.
-// It conflicts with SchemaDirectory.
-// This option requires a ProtoTopo or MySQLOnly option before.
-func Schema(schema string) VitessOption {
-	if schema == "" {
-		log.Fatal("BUG: provided schema must not be empty")
+func (db *LocalCluster) loadSchema() error {
+	if db.SchemaDir == "" {
+		return nil
 	}
 
-	tempSchemaDir := ""
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if hdl.dbname == "" {
-				return fmt.Errorf("Schema option requires a previously passed MySQLOnly option")
-			}
-			if hdl.schemaDir != "" {
-				return fmt.Errorf("Schema option would overwrite directory set by another option (%v)", hdl.schemaDir)
-			}
+	log.Info("Loading custom schema...")
 
-			var err error
-			tempSchemaDir, err = ioutil.TempDir("", "vt")
+	if !isDir(db.SchemaDir) {
+		return fmt.Errorf("LoadSchema(): SchemaDir does not exist")
+	}
+
+	for _, kpb := range db.Topology.Keyspaces {
+		if kpb.ServedFrom != "" {
+			// redirected keyspaces have no underlying database
+			continue
+		}
+
+		keyspace := kpb.Name
+		keyspaceDir := path.Join(db.SchemaDir, keyspace)
+
+		schemaDir := keyspaceDir
+		if !isDir(schemaDir) {
+			schemaDir = db.DefaultSchemaDir
+			if schemaDir == "" || !isDir(schemaDir) {
+				return fmt.Errorf("LoadSchema: schema dir for ks `%s` does not exist (%s)", keyspace, schemaDir)
+			}
+		}
+
+		glob, _ := filepath.Glob(path.Join(schemaDir, "*.sql"))
+		for _, filepath := range glob {
+			cmds, err := LoadSQLFile(filepath, schemaDir)
 			if err != nil {
 				return err
 			}
-			ksDir := path.Join(tempSchemaDir, hdl.dbname)
-			err = os.Mkdir(ksDir, os.ModeDir|0775)
-			if err != nil {
-				return err
-			}
-			fileName := path.Join(ksDir, "schema.sql")
-			f, err := os.Create(fileName)
-			if err != nil {
-				return err
-			}
-			n, err := f.WriteString(schema)
-			if n != len(schema) {
-				return errors.New("short write")
-			}
-			if err != nil {
-				return err
-			}
-			err = f.Close()
-			if err != nil {
-				return err
-			}
-			hdl.schemaDir = tempSchemaDir
-			return nil
-		},
-		afterRun: func() {
-			if tempSchemaDir != "" {
-				os.RemoveAll(tempSchemaDir)
-			}
-		},
-	}
-}
 
-// VSchema is used to create a vschema.json file in the --schema_dir directory.
-// It must be used *after* the Schema or SchemaDirectory option was provided.
-func VSchema(vschema interface{}) VitessOption {
-	if vschema == "" {
-		log.Fatal("BUG: provided vschema object must not be nil")
+			for _, dbname := range db.shardNames(kpb) {
+				if err := db.Execute(cmds, dbname); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
-	vschemaFilePath := ""
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			if hdl.schemaDir == "" {
-				return errors.New("VSchema option must be specified after a Schema or SchemaDirectory option")
-			}
+	return nil
+}
 
-			vschemaFilePath := path.Join(hdl.schemaDir, "vschema.json")
-			if _, err := os.Stat(vschemaFilePath); err == nil {
-				return fmt.Errorf("temporary vschema.json already exists at %v. delete it first", vschemaFilePath)
-			}
+func (db *LocalCluster) createDatabases() error {
+	log.Info("Creating databases in cluster...")
 
-			vschemaJSON, err := json.Marshal(vschema)
-			if err != nil {
-				return err
-			}
-			if err := ioutil.WriteFile(vschemaFilePath, vschemaJSON, 0644); err != nil {
-				return err
-			}
-			return nil
-		},
-		afterRun: func() {
-			os.Remove(vschemaFilePath)
-		},
+	var sql []string
+	for _, kpb := range db.Topology.Keyspaces {
+		if kpb.ServedFrom != "" {
+			continue
+		}
+		for _, dbname := range db.shardNames(kpb) {
+			sql = append(sql, fmt.Sprintf("create database `%s`", dbname))
+		}
 	}
+	return db.Execute(sql, "")
 }
 
-// ExtraMyCnf adds one or more 'my.cnf'-style config files to MySQL.
-// (if more than one, the ':' separator should be used).
-func ExtraMyCnf(extraMyCnf string) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			hdl.cmd.Args = append(hdl.cmd.Args, "--extra_my_cnf", extraMyCnf)
-			return nil
-		},
+// Execute runs a series of SQL statements on the MySQL instance backing
+// this local cluster. This is provided for debug/introspection purposes;
+// normal cluster access should be performed through the Vitess GRPC interface.
+func (db *LocalCluster) Execute(sql []string, dbname string) error {
+	params := db.mysql.Params(dbname)
+	conn, err := mysql.Connect(context.Background(), &params)
+	if err != nil {
+		return err
 	}
-}
+	defer conn.Close()
 
-// InitDataOptions contain the command line arguments that configure
-// initialization of vttest with random data. See the documentation of
-// the corresponding command line flags in py/vttest/run_local_database.py
-// for the meaning of each field. If a field is nil, the flag will not be
-// specified when running 'run_local_database.py' and the default value for
-// the flag will be used.
-type InitDataOptions struct {
-	rngSeed           *int
-	minTableShardSize *int
-	maxTableShardSize *int
-	nullProbability   *float64
-}
-
-// InitData returns a VitessOption that sets the InitDataOptions parameters.
-func InitData(i *InitDataOptions) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			hdl.cmd.Args = append(hdl.cmd.Args, "--initialize_with_random_data")
-			if i.rngSeed != nil {
-				hdl.cmd.Args = append(hdl.cmd.Args, "--rng_seed", fmt.Sprintf("%v", *i.rngSeed))
-			}
-			if i.minTableShardSize != nil {
-				hdl.cmd.Args = append(hdl.cmd.Args, "--min_table_shard_size", fmt.Sprintf("%v", *i.minTableShardSize))
-			}
-			if i.maxTableShardSize != nil {
-				hdl.cmd.Args = append(hdl.cmd.Args, "--max_table_shard_size", fmt.Sprintf("%v", *i.maxTableShardSize))
-			}
-			if i.nullProbability != nil {
-				hdl.cmd.Args = append(hdl.cmd.Args, "--null_probability", fmt.Sprintf("%v", *i.nullProbability))
-			}
-			return nil
-		},
+	_, err = conn.ExecuteFetch("START TRANSACTION", 0, false)
+	if err != nil {
+		return err
 	}
+
+	for _, cmd := range sql {
+		log.Infof("Execute(%s): \"%s\"", dbname, cmd)
+		_, err := conn.ExecuteFetch(cmd, 0, false)
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = conn.ExecuteFetch("COMMIT", 0, false)
+	return err
 }
 
-// LaunchVitess launches a vitess test cluster.
-func LaunchVitess(
-	options ...VitessOption,
-) (hdl *Handle, err error) {
-	hdl = &Handle{}
-	err = hdl.run(options...)
+// Query runs a  SQL query on the MySQL instance backing this local cluster and returns
+// its result. This is provided for debug/introspection purposes;
+// normal cluster access should be performed through the Vitess GRPC interface.
+func (db *LocalCluster) Query(sql, dbname string, limit int) (*sqltypes.Result, error) {
+	params := db.mysql.Params(dbname)
+	conn, err := mysql.Connect(context.Background(), &params)
 	if err != nil {
 		return nil, err
 	}
-	return hdl, nil
+	defer conn.Close()
+
+	return conn.ExecuteFetch(sql, limit, false)
 }
 
-// TearDown tears down the launched processes.
-func (hdl *Handle) TearDown() error {
-	_, err := hdl.stdin.Write([]byte("\n"))
-	if err != nil {
-		return err
+// JSONConfig returns a key/value object with the configuration
+// settings for the local cluster. It should be serialized with
+// `json.Marshal`
+func (db *LocalCluster) JSONConfig() interface{} {
+	if db.OnlyMySQL {
+		return db.mysql.Params("")
 	}
-	return hdl.cmd.Wait()
+
+	config := map[string]interface{}{
+		"port":               db.vt.Port,
+		"socket":             db.mysql.UnixSocket(),
+		"vtcombo_mysql_port": db.Env.PortForProtocol("vtcombo_mysql_port", ""),
+	}
+
+	if grpc := db.vt.PortGrpc; grpc != 0 {
+		config["grpc_port"] = grpc
+	}
+
+	return config
 }
 
-// MySQLConnParams builds the MySQL connection params.
-// It's valid only if you used MySQLOnly option.
-func (hdl *Handle) MySQLConnParams() (mysql.ConnParams, error) {
-	params := mysql.ConnParams{
-		Charset: "utf8",
-		DbName:  hdl.dbname,
-	}
-	if hdl.Data == nil {
-		return params, errors.New("no data")
-	}
-	iuser, ok := hdl.Data["username"]
-	if !ok {
-		return params, errors.New("no username")
-	}
-	user, ok := iuser.(string)
-	if !ok {
-		return params, fmt.Errorf("invalid user type: %T", iuser)
-	}
-	params.Uname = user
-	if ipassword, ok := hdl.Data["password"]; ok {
-		password, ok := ipassword.(string)
-		if !ok {
-			return params, fmt.Errorf("invalid password type: %T", ipassword)
-		}
-		params.Pass = password
-	}
-	if ihost, ok := hdl.Data["host"]; ok {
-		host, ok := ihost.(string)
-		if !ok {
-			return params, fmt.Errorf("invalid host type: %T", ihost)
-		}
-		params.Host = host
-	}
-	if iport, ok := hdl.Data["port"]; ok {
-		port, ok := iport.(float64)
-		if !ok {
-			return params, fmt.Errorf("invalid port type: %T", iport)
-		}
-		params.Port = int(port)
-	}
-	if isocket, ok := hdl.Data["socket"]; ok {
-		socket, ok := isocket.(string)
-		if !ok {
-			return params, fmt.Errorf("invalid socket type: %T", isocket)
-		}
-		params.UnixSocket = socket
-	}
-	return params, nil
-}
-
-// MySQLAppDebugConnParams builds the MySQL connection params for appdebug user.
-// It's valid only if you used MySQLOnly option.
-func (hdl *Handle) MySQLAppDebugConnParams() (mysql.ConnParams, error) {
-	connParams, err := hdl.MySQLConnParams()
-	connParams.Uname = "vt_appdebug"
-	return connParams, err
-}
-
-func (hdl *Handle) run(
-	options ...VitessOption,
-) error {
-	launcher, err := launcherPath()
-	if err != nil {
-		return err
-	}
-	port := randomPort()
-	hdl.cmd = exec.Command(
-		launcher,
-		"--port", strconv.Itoa(port),
+// LoadSQLFile loads a parses a .sql file from disk, removing all the
+// different comments that mysql/mysqldump inserts in these, and returning
+// each individual SQL statement as its own string.
+// If sourceroot is set, that directory will be used when resolving `source `
+// statements in the SQL file.
+func LoadSQLFile(filename, sourceroot string) ([]string, error) {
+	var (
+		cmd  bytes.Buffer
+		sql  []string
+		inSQ bool
+		inDQ bool
 	)
-	hdl.cmd.Stderr = os.Stderr
 
-	for _, option := range options {
-		if err := option.beforeRun(hdl); err != nil {
-			return err
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		line = strings.TrimRightFunc(line, unicode.IsSpace)
+
+		if !inSQ && !inDQ && strings.HasPrefix(line, "--") {
+			continue
 		}
-		if option.afterRun != nil {
-			defer option.afterRun()
+
+		var i, next int
+		for {
+			i = next
+			if i >= len(line) {
+				break
+			}
+
+			next = i + 1
+
+			if line[i] == '\\' {
+				next = i + 2
+			} else if line[i] == '\'' && !inDQ {
+				inSQ = !inSQ
+			} else if line[i] == '"' && !inSQ {
+				inDQ = !inDQ
+			} else if !inSQ && !inDQ {
+				if line[i] == '#' || strings.HasPrefix(line[i:], "-- ") {
+					line = line[:i]
+					break
+				}
+				if line[i] == ';' {
+					cmd.WriteString(line[:i])
+					sql = append(sql, cmd.String())
+					cmd.Reset()
+
+					line = line[i+1:]
+					next = 0
+				}
+			}
+		}
+
+		if strings.TrimSpace(line) != "" {
+			if sourceroot != "" && cmd.Len() == 0 && strings.HasPrefix(line, "source ") {
+				srcfile := path.Join(sourceroot, line[7:])
+				sql2, err := LoadSQLFile(srcfile, sourceroot)
+				if err != nil {
+					return nil, err
+				}
+				sql = append(sql, sql2...)
+			} else {
+				cmd.WriteString(line)
+				cmd.WriteByte('\n')
+			}
 		}
 	}
-	if hdl.schemaDir != "" {
-		hdl.cmd.Args = append(hdl.cmd.Args, "--schema_dir", hdl.schemaDir)
+
+	if cmd.Len() != 0 {
+		sql = append(sql, cmd.String())
 	}
 
-	log.Infof("executing: %v", strings.Join(hdl.cmd.Args, " "))
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
 
-	stdout, err := hdl.cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	decoder := json.NewDecoder(stdout)
-	hdl.stdin, err = hdl.cmd.StdinPipe()
-	if err != nil {
-		return err
-	}
-	err = hdl.cmd.Start()
-	if err != nil {
-		return err
-	}
-	err = decoder.Decode(&hdl.Data)
-	if err != nil {
-		err = fmt.Errorf(
-			"error (%v) parsing JSON output from command: %v", err, launcher)
-	}
-	return err
+	return sql, nil
 }

--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -105,11 +105,14 @@ func (cfg *Config) DbName() string {
 // the desired Config, or manually set each field on the struct itself.
 // Once the struct is configured, call LocalCluster.Setup() to instantiate
 // the cluster.
-// The Env for the local cluster can also be set before calling Setup(); if
-// not set, Setup() will instantiate a LocalTestEnv with the default values
 // See: Config for configuration settings on the cluster
 type LocalCluster struct {
 	Config
+
+	// Env is the Environment which will be used for unning this local cluster.
+	// It can be set by the user before calling Setup(). If not set, Setup() will
+	// use the NewDefaultEnv callback to instantiate an environment with the system
+	// default settings
 	Env Environment
 
 	mysql MySQLManager
@@ -133,7 +136,7 @@ func (db *LocalCluster) Setup() error {
 
 	if db.Env == nil {
 		log.Info("No environment in cluster settings. Creating default...")
-		db.Env, err = NewLocalTestEnv("", 0)
+		db.Env, err = NewDefaultEnv()
 		if err != nil {
 			return err
 		}

--- a/go/vt/vttest/local_cluster_old.go
+++ b/go/vt/vttest/local_cluster_old.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vttest provides the functionality to bring
+// up a test cluster.
+package vttest
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/mysql"
+	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
+)
+
+// Handle allows you to interact with the processes launched by vttest.
+// Deprecated: this is a legacy interface kept for backwards compatibility
+// reasons. Consider using LocalCluster directly instead.
+type Handle struct {
+	db *LocalCluster
+}
+
+// VtgateAddress returns the address under which vtgate is reachable e.g.
+// "localhost:15991".
+func (hdl *Handle) VtgateAddress() (string, error) {
+	proto := hdl.db.Env.DefaultProtocol()
+	port := hdl.db.Env.PortForProtocol("vtcombo", proto)
+	return fmt.Sprintf("localhost:%d", port), nil
+}
+
+// VitessOption is the type for generic options to be passed in to LaunchVitess.
+// Deprecated: this is a legacy interface kept for backwards compatibility
+// reasons. Consider setting the Config struct in LocalCluster instead.
+type VitessOption struct {
+	beforeRun func(*Handle) error
+	afterRun  func()
+}
+
+// WithEnvironment allows the user to configure the default Environment
+// used when launching the local cluster
+// See: Environment
+// Deprecated: It's recommended to use LocalCluster directly
+func WithEnvironment(env Environment) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			hdl.db.Env = env
+			return nil
+		},
+	}
+}
+
+// Verbose makes the underlying local_cluster verbose.
+// Deprecated: See LocalCluster, Config
+func Verbose(verbose bool) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if verbose {
+				flag.Set("alsologtostderr", "true")
+				flag.Set("v", "5")
+			}
+			return nil
+		},
+	}
+}
+
+// NoStderr makes the underlying local_cluster stderr output disapper.
+// Deprecated: See LocalCluster, Config
+func NoStderr() VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			flag.Set("alsologtostderr", "false")
+			return nil
+		},
+	}
+}
+
+// SchemaDirectory is used to specify a directory to read schema from.
+// It cannot be used at the same time as Schema.
+// Deprecated: See LocalCluster, Config
+func SchemaDirectory(dir string) VitessOption {
+	if dir == "" {
+		log.Fatal("BUG: provided directory must not be empty")
+	}
+
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if hdl.db.SchemaDir != "" {
+				return fmt.Errorf("SchemaDirectory option (%v) would overwrite directory set by another option (%v)", dir, hdl.db.SchemaDir)
+			}
+			hdl.db.SchemaDir = dir
+			return nil
+		},
+	}
+}
+
+// ProtoTopo is used to pass in the topology as a vttest proto definition.
+// See vttest.proto for more information.
+// It cannot be used at the same time as MySQLOnly.
+// Deprecated: See LocalCluster, Config
+func ProtoTopo(topo *vttestpb.VTTestTopology) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if hdl.db.DbName() != "" {
+				return fmt.Errorf("duplicate MySQLOnly option or conflicting ProtoTopo option. You can only use one")
+			}
+
+			hdl.db.Topology = topo
+			return nil
+		},
+	}
+}
+
+// MySQLOnly is used to launch only a mysqld instance, with the specified db name.
+// It cannot be used at the same as ProtoTopo.
+// Deprecated: See LocalCluster, Config
+func MySQLOnly(dbName string) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if hdl.db.DbName() != "" {
+				return fmt.Errorf("duplicate MySQLOnly option or conflicting ProtoTopo option. You can only use one")
+			}
+
+			// the way to pass the dbname for creation in
+			// is to provide a topology
+			topo := &vttestpb.VTTestTopology{
+				Keyspaces: []*vttestpb.Keyspace{
+					{
+						Name: dbName,
+						Shards: []*vttestpb.Shard{
+							{
+								Name:           "0",
+								DbNameOverride: dbName,
+							},
+						},
+					},
+				},
+			}
+
+			hdl.db.Topology = topo
+			hdl.db.OnlyMySQL = true
+			return nil
+		},
+	}
+}
+
+// Schema is used to specify SQL commands to run at startup.
+// It conflicts with SchemaDirectory.
+// This option requires a ProtoTopo or MySQLOnly option before.
+// Deprecated: See LocalCluster, Config
+func Schema(schema string) VitessOption {
+	if schema == "" {
+		log.Fatal("BUG: provided schema must not be empty")
+	}
+
+	tempSchemaDir := ""
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if hdl.db.DbName() == "" {
+				return fmt.Errorf("Schema option requires a previously passed MySQLOnly option")
+			}
+			if hdl.db.SchemaDir != "" {
+				return fmt.Errorf("Schema option would overwrite directory set by another option (%v)", hdl.db.SchemaDir)
+			}
+
+			var err error
+			tempSchemaDir, err = ioutil.TempDir("", "vt")
+			if err != nil {
+				return err
+			}
+			ksDir := path.Join(tempSchemaDir, hdl.db.DbName())
+			err = os.Mkdir(ksDir, os.ModeDir|0775)
+			if err != nil {
+				return err
+			}
+			fileName := path.Join(ksDir, "schema.sql")
+			err = ioutil.WriteFile(fileName, []byte(schema), 0666)
+			if err != nil {
+				return err
+			}
+			hdl.db.SchemaDir = tempSchemaDir
+			return nil
+		},
+		afterRun: func() {
+			if tempSchemaDir != "" {
+				os.RemoveAll(tempSchemaDir)
+			}
+		},
+	}
+}
+
+// VSchema is used to create a vschema.json file in the --schema_dir directory.
+// It must be used *after* the Schema or SchemaDirectory option was provided.
+// Deprecated: See LocalCluster, Config
+func VSchema(vschema interface{}) VitessOption {
+	if vschema == "" {
+		log.Fatal("BUG: provided vschema object must not be nil")
+	}
+
+	vschemaFilePath := ""
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			if hdl.db.SchemaDir == "" {
+				return errors.New("VSchema option must be specified after a Schema or SchemaDirectory option")
+			}
+
+			vschemaFilePath := path.Join(hdl.db.SchemaDir, "vschema.json")
+			if _, err := os.Stat(vschemaFilePath); err == nil {
+				return fmt.Errorf("temporary vschema.json already exists at %v. delete it first", vschemaFilePath)
+			}
+
+			vschemaJSON, err := json.Marshal(vschema)
+			if err != nil {
+				return err
+			}
+			if err := ioutil.WriteFile(vschemaFilePath, vschemaJSON, 0644); err != nil {
+				return err
+			}
+			return nil
+		},
+		afterRun: func() {
+			os.Remove(vschemaFilePath)
+		},
+	}
+}
+
+// ExtraMyCnf adds one or more 'my.cnf'-style config files to MySQL.
+// (if more than one, the ':' separator should be used).
+// Deprecated: See LocalCluster, Config
+func ExtraMyCnf(extraMyCnf string) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			hdl.db.ExtraMyCnf = strings.Split(extraMyCnf, ":")
+			return nil
+		},
+	}
+}
+
+// InitDataOptions contain the command line arguments that configure
+// initialization of vttest with random data.
+// Deprecated: See LocalCluster, Config
+type InitDataOptions struct{}
+
+// InitData returns a VitessOption that sets the InitDataOptions parameters.
+// Deprecated: This interface has never really worked because InitDataOptions
+// is not properly exported. See SeedData, LocalCluster, Config
+func InitData(i *InitDataOptions) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			return fmt.Errorf("InitData is not supported. Use SeedData instead")
+		},
+	}
+}
+
+// SeedData returns a VitessOption that sets the InitDataOptions parameters.
+// Deprecated: See LocalCluster, Config
+func SeedData(seed *SeedConfig) VitessOption {
+	return VitessOption{
+		beforeRun: func(hdl *Handle) error {
+			hdl.db.Seed = seed
+			return nil
+		},
+	}
+}
+
+// LaunchVitess launches a vitess test cluster.
+// Deprecated: this is a legacy interface kept for backwards compatibility
+// reasons. Consider using LocalCluster directly instead.
+func LaunchVitess(options ...VitessOption) (hdl *Handle, err error) {
+	hdl = &Handle{&LocalCluster{}}
+	err = hdl.run(options...)
+	return
+}
+
+// TearDown tears down the launched processes.
+// Deprecated: See LocalCluster, Config
+func (hdl *Handle) TearDown() error {
+	return hdl.db.TearDown()
+}
+
+// MySQLConnParams builds the MySQL connection params.
+// It's valid only if you used MySQLOnly option.
+// Deprecated: See LocalCluster, Config
+func (hdl *Handle) MySQLConnParams() (mysql.ConnParams, error) {
+	return hdl.db.MySQLConnParams(), nil
+}
+
+// MySQLAppDebugConnParams builds the MySQL connection params for appdebug user.
+// It's valid only if you used MySQLOnly option.
+// Deprecated: See LocalCluster, Config
+func (hdl *Handle) MySQLAppDebugConnParams() (mysql.ConnParams, error) {
+	connParams, err := hdl.MySQLConnParams()
+	connParams.Uname = "vt_appdebug"
+	return connParams, err
+}
+
+func (hdl *Handle) run(options ...VitessOption) error {
+	for _, option := range options {
+		if err := option.beforeRun(hdl); err != nil {
+			return err
+		}
+		if option.afterRun != nil {
+			defer option.afterRun()
+		}
+	}
+
+	return hdl.db.Setup()
+}

--- a/go/vt/vttest/local_cluster_old.go
+++ b/go/vt/vttest/local_cluster_old.go
@@ -57,19 +57,6 @@ type VitessOption struct {
 	afterRun  func()
 }
 
-// WithEnvironment allows the user to configure the default Environment
-// used when launching the local cluster
-// See: Environment
-// Deprecated: It's recommended to use LocalCluster directly
-func WithEnvironment(env Environment) VitessOption {
-	return VitessOption{
-		beforeRun: func(hdl *Handle) error {
-			hdl.db.Env = env
-			return nil
-		},
-	}
-}
-
 // Verbose makes the underlying local_cluster verbose.
 // Deprecated: See LocalCluster, Config
 func Verbose(verbose bool) VitessOption {

--- a/go/vt/vttest/local_cluster_old_test.go
+++ b/go/vt/vttest/local_cluster_old_test.go
@@ -89,7 +89,9 @@ func TestVitess(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	conn, err := vtgateconn.DialProtocol(ctx, vtgateProtocol(), vtgateAddr, 5*time.Second)
+
+	proto := hdl.db.Env.DefaultProtocol()
+	conn, err := vtgateconn.DialProtocol(ctx, proto, vtgateAddr, 5*time.Second)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/vttest/mysqlctl.go
+++ b/go/vt/vttest/mysqlctl.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/youtube/vitess/go/mysql"
+)
+
+// MySQLManager is an interface to a mysqld process manager, capable
+// of starting/shutting down mysqld services and initializing them.
+type MySQLManager interface {
+	Setup() error
+	TearDown() error
+	Auth() (string, string)
+	Address() (string, int)
+	UnixSocket() string
+	Params(dbname string) mysql.ConnParams
+}
+
+// Mysqlctl implements MySQLManager through Vitess' mysqlctld tool
+type Mysqlctl struct {
+	Binary    string
+	InitFile  string
+	Directory string
+	Port      int
+	MyCnf     []string
+	Env       []string
+}
+
+// Setup spawns a new mysqld service and initializes it with the defaults.
+// The service is kept running in the background until TearDown() is called.
+func (ctl *Mysqlctl) Setup() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		ctl.Binary,
+		"-alsologtostderr",
+		"-tablet_uid", "1",
+		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
+		"-db-config-dba-charset", "utf8",
+		"-db-config-dba-uname", "vt_dba",
+		"init",
+		"-init_db_sql_file", ctl.InitFile,
+	)
+
+	myCnf := strings.Join(ctl.MyCnf, ":")
+
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, ctl.Env...)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("EXTRA_MY_CNF=%s", myCnf))
+
+	_, err := cmd.Output()
+	return err
+}
+
+// TearDown shutdowns the running mysqld service
+func (ctl *Mysqlctl) TearDown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx,
+		ctl.Binary,
+		"-alsologtostderr",
+		"-tablet_uid", "1",
+		"-mysql_port", fmt.Sprintf("%d", ctl.Port),
+		"-db-config-dba-charset", "utf8",
+		"-db-config-dba-uname", "vt_dba",
+		"shutdown",
+	)
+
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, ctl.Env...)
+
+	_, err := cmd.Output()
+	return err
+}
+
+// Auth returns the username/password tuple required to log in to mysqld
+func (ctl *Mysqlctl) Auth() (string, string) {
+	return "vt_dba", ""
+}
+
+// Address returns the hostname/tcp port pair required to connect to mysqld
+func (ctl *Mysqlctl) Address() (string, int) {
+	return "", ctl.Port
+}
+
+// UnixSocket returns the path to the local Unix socket required to connect to mysqld
+func (ctl *Mysqlctl) UnixSocket() string {
+	return path.Join(ctl.Directory, "vt_0000000001", "mysql.sock")
+}
+
+// Params returns the mysql.ConnParams required to connect directly to mysqld
+// using Vitess' mysql client.
+func (ctl *Mysqlctl) Params(dbname string) mysql.ConnParams {
+	return mysql.ConnParams{
+		Charset:    DefaultCharset,
+		DbName:     dbname,
+		Uname:      "vt_dba",
+		UnixSocket: ctl.UnixSocket(),
+	}
+}

--- a/go/vt/vttest/randomdata.go
+++ b/go/vt/vttest/randomdata.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttest
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+// FieldGenerator is a callback that generates the value of a random field in
+// when seeding the database with random data. `name` is the name of the column
+// where the field belongs, `t` is its SQL tyoe, and `rng` is the the RNG currently
+// being used, as to ensure reproducible generation between runs.
+// A FieldGenerator must return the raw SQL data for the field, ready to be
+// placed into a SQL statement. The returned value will _NOT_ be escaped.
+type FieldGenerator func(name, t string, rng *rand.Rand) (string, error)
+
+// SeedConfig are the settings to enable the initialization of the
+// local cluster with random data. This struct must be set in Config
+// before Setup() is called.
+type SeedConfig struct {
+	// RngSeed is the seed uset to initialize the random number
+	// generator that will be used to fill the database with
+	// random data. Multiple runs with the same seed will result
+	// in the same initial data
+	RngSeed int
+
+	// MinSize is the minimum number of initial rows in each tale shard
+	MinSize int
+
+	// MaxSize is the maximum number of initial rows in each table shard
+	MaxSize int
+
+	// NullProbability is the chance to initialize a field a NULL value.
+	// Only applies to fields that can contain NULL values
+	NullProbability float64
+
+	// RandomField is a callback to generate the value of a random field
+	RandomField FieldGenerator
+}
+
+// SeedConfigDefaults returns the default values for SeedConfig
+func SeedConfigDefaults() *SeedConfig {
+	return &SeedConfig{
+		RngSeed:         rand.Int(),
+		MinSize:         1000,
+		MaxSize:         10000,
+		NullProbability: 0.1,
+	}
+}
+
+const batchInsertSize = 1000
+
+func (db *LocalCluster) batchInsert(dbname, table string, fields []string, rows [][]string) error {
+	var (
+		fieldNames = strings.Join(fields, ",")
+		values     []string
+		sql        string
+	)
+
+	for _, row := range rows {
+		values = append(values, "("+strings.Join(row, ",")+")")
+	}
+
+	sql = fmt.Sprintf("INSERT IGNORE INTO %s (%s) VALUES %s",
+		table, fieldNames, strings.Join(values, ","),
+	)
+
+	return db.Execute([]string{sql}, dbname)
+}
+
+func (db *LocalCluster) randomField(name, t string, allowNull bool, rng *rand.Rand) (string, error) {
+	if allowNull && rng.Float64() < db.Seed.NullProbability {
+		return "NULL", nil
+	}
+	return db.Seed.RandomField(name, t, rng)
+}
+
+func (db *LocalCluster) populateTable(dbname, table string, rng *rand.Rand) error {
+	fieldInfo, err := db.Query(fmt.Sprintf("DESCRIBE %s", table), dbname, 1024)
+	if err != nil {
+		return err
+	}
+
+	var (
+		minRows    = db.Seed.MinSize
+		maxRows    = db.Seed.MaxSize
+		numRows    = rng.Intn(maxRows-minRows) + minRows
+		rows       [][]string
+		fieldNames []string
+	)
+
+	for i := 0; i < numRows; i++ {
+		var fields []string
+		for _, row := range fieldInfo.Rows {
+			fieldName := row[0].ToString()
+			fieldType := row[1].ToString()
+			allowNull := row[2].ToString() == "YES"
+
+			f, err := db.randomField(fieldName, fieldType, allowNull, rng)
+			if err != nil {
+				return err
+			}
+			fields = append(fields, f)
+		}
+		rows = append(rows, fields)
+	}
+
+	for _, row := range fieldInfo.Rows {
+		fieldNames = append(fieldNames, row[0].ToString())
+	}
+
+	for i := 0; i < len(rows); i += batchInsertSize {
+		if err := db.batchInsert(dbname, table, fieldNames, rows); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *LocalCluster) populateShard(dbname string, rng *rand.Rand) error {
+	q, err := db.Query("SHOW TABLES", dbname, 1024)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range q.Rows {
+		if err := db.populateTable(dbname, row[0].ToString(), rng); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *LocalCluster) populateWithRandomData() error {
+	rng := rand.New(rand.NewSource(int64(db.Seed.RngSeed)))
+	for _, kpb := range db.Topology.Keyspaces {
+		if kpb.ServedFrom != "" {
+			continue
+		}
+		for _, dbname := range db.shardNames(kpb) {
+			if err := db.populateShard(dbname, rng); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/go/vt/vttest/util.go
+++ b/go/vt/vttest/util.go
@@ -1,0 +1,32 @@
+package vttest
+
+import (
+	"fmt"
+)
+
+// GetShardName returns an appropriate shard name, as a string.
+// A single shard name is simply 0; otherwise it will attempt to split up 0x100
+// into multiple shards.  For example, in a two sharded keyspace, shard 0 is
+// -80, shard 1 is 80-.  This function currently only applies to sharding setups
+// where the shard count is 256 or less, and all shards are equal width.
+func GetShardName(shard, total int) string {
+	width := 0x100 / total
+	switch {
+	case total == 1:
+		return "0"
+	case shard == 0:
+		return fmt.Sprintf("-%02x", width)
+	case shard == total-1:
+		return fmt.Sprintf("%02x-", shard*width)
+	default:
+		return fmt.Sprintf("%02x-%02x", shard*width, (shard+1)*width)
+	}
+}
+
+// GetShardNames creates a slice of shard names for N shards
+func GetShardNames(total int) (names []string) {
+	for i := 0; i < total; i++ {
+		names = append(names, GetShardName(i, total))
+	}
+	return
+}

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2017 GitHub Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vttest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"syscall"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+)
+
+// HealthChecker is a callback that impements a service-specific health check
+// It must return true if the service at the given `addr` is reachable, false
+// otherwerise.
+type HealthChecker func(addr string) bool
+
+// VtProcess is a generic handle for a running Vitess process.
+// It can be spawned manually or through one of the available
+// helper methods.
+type VtProcess struct {
+	Name         string
+	Directory    string
+	LogDirectory string
+	Binary       string
+	ExtraArgs    []string
+	Env          []string
+	Port         int
+	PortGrpc     int
+	HealthCheck  HealthChecker
+
+	proc *exec.Cmd
+}
+
+// GetVars returns the JSON contents of the `/debug/vars` endpoint
+// of this Vitess-based process. If an error is returned, it probably
+// means that the Vitess service has not started successfully.
+func (vtp *VtProcess) GetVars() ([]byte, error) {
+	url := fmt.Sprintf("http://%s/debug/vars", vtp.Address())
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+// IsHealthy returns whether the monitored Vitess process has started
+// successfully.
+func (vtp *VtProcess) IsHealthy() bool {
+	if vtp.HealthCheck != nil && !vtp.HealthCheck(vtp.Address()) {
+		return false
+	}
+	_, err := vtp.GetVars()
+	return err == nil
+}
+
+// Address returns the main address for this Vitess process.
+// This is usually the main HTTP endpoint for the service.
+func (vtp *VtProcess) Address() string {
+	return fmt.Sprintf("localhost:%d", vtp.Port)
+}
+
+// Kill kills the running Vitess process. If the process is not running,
+// this is a no-op.
+func (vtp *VtProcess) Kill() {
+	if vtp.proc != nil && vtp.proc.Process != nil {
+		vtp.proc.Process.Kill()
+	}
+}
+
+// Wait waits for the Vitess process to terminate and returns any exit errors.
+// Note that most Vitess processes are long-running services, so you will need
+// to call Kill on them before you can Wait.
+func (vtp *VtProcess) Wait() error {
+	if vtp.proc == nil {
+		return nil
+	}
+
+	err := vtp.proc.Wait()
+	if _, ok := err.(*exec.ExitError); ok {
+		return nil
+	}
+
+	return err
+}
+
+// WaitStart spawns this Vitess process and waits for it to be up
+// and running. The process is considered "up" when it starts serving
+// its debug HTTP endpoint -- this means the process was successfully
+// started.
+// If the process is not healthy after 60s, this method will timeout and
+// return an error.
+func (vtp *VtProcess) WaitStart() (err error) {
+	vtp.proc = exec.Command(
+		vtp.Binary,
+		"-port", fmt.Sprintf("%d", vtp.Port),
+		"-log_dir", vtp.LogDirectory,
+		"-alsologtostderr",
+	)
+
+	if vtp.PortGrpc != 0 {
+		vtp.proc.Args = append(vtp.proc.Args, "-grpc_port")
+		vtp.proc.Args = append(vtp.proc.Args, fmt.Sprintf("%d", vtp.PortGrpc))
+	}
+
+	vtp.proc.Args = append(vtp.proc.Args, vtp.ExtraArgs...)
+
+	logfile := path.Join(vtp.LogDirectory, fmt.Sprintf("%s.%d.log", vtp.Name, vtp.Port))
+	vtp.proc.Stdout, err = os.Create(logfile)
+	if err != nil {
+		return
+	}
+
+	vtp.proc.Env = append(vtp.proc.Env, os.Environ()...)
+	vtp.proc.Env = append(vtp.proc.Env, vtp.Env...)
+
+	err = vtp.proc.Start()
+	if err != nil {
+		return
+	}
+
+	timeout := time.Now().Add(60 * time.Second)
+	for time.Now().Before(timeout) {
+		if vtp.IsHealthy() {
+			return nil
+		}
+
+		if err := vtp.proc.Process.Signal(syscall.Signal(0)); err != nil {
+			return fmt.Errorf("process '%s' exited prematurely", vtp.Name)
+		}
+
+		time.Sleep(300 * time.Millisecond)
+	}
+
+	vtp.proc.Process.Kill()
+	return fmt.Errorf("process '%s' timed out after 60s", vtp.Name)
+}
+
+// DefaultCharset is the default charset used by MySQL instances
+const DefaultCharset = "utf8"
+
+// QueryServerArgs are the default arguments passed to all Vitess query servers
+var QueryServerArgs = []string{
+	"-queryserver-config-pool-size", "4",
+	"-queryserver-config-query-timeout", "300",
+	"-queryserver-config-schema-reload-time", "60",
+	"-queryserver-config-stream-pool-size", "4",
+	"-queryserver-config-transaction-cap", "4",
+	"-queryserver-config-transaction-timeout", "300",
+	"-queryserver-config-txpool-timeout", "300",
+}
+
+// VtcomboProcess returns a VtProcess handle for a local `vtcombo` service,
+// configured with the given Config.
+// The process must be manually started by calling WaitStart()
+func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProcess {
+	vt := &VtProcess{
+		Name:         "vtcombo",
+		Directory:    env.Directory(),
+		LogDirectory: env.LogDirectory(),
+		Binary:       env.BinaryPath("vtcombo"),
+		Port:         env.PortForProtocol("vtcombo", ""),
+		PortGrpc:     env.PortForProtocol("vtcombo", "grpc"),
+		HealthCheck:  env.ProcessHealthCheck("vtcombo"),
+		Env:          env.EnvVars(),
+	}
+
+	user, pass := mysql.Auth()
+	socket := mysql.UnixSocket()
+	charset := args.Charset
+	if charset == "" {
+		charset = DefaultCharset
+	}
+
+	vt.ExtraArgs = append(vt.ExtraArgs, []string{
+		"-db-config-app-charset", charset,
+		"-db-config-app-uname", user,
+		"-db-config-app-pass", pass,
+		"-db-config-dba-charset", charset,
+		"-db-config-dba-uname", user,
+		"-db-config-dba-pass", pass,
+		"-proto_topo", proto.CompactTextString(args.Topology),
+		"-mycnf_server_id", "1",
+		"-mycnf_socket_file", socket,
+		"-normalize_queries",
+	}...)
+
+	vt.ExtraArgs = append(vt.ExtraArgs, QueryServerArgs...)
+	vt.ExtraArgs = append(vt.ExtraArgs, env.VtcomboArguments()...)
+
+	if args.SchemaDir != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-schema_dir", args.SchemaDir}...)
+	}
+	if args.WebDir != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-web_dir", args.WebDir}...)
+	}
+	if args.WebDir2 != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{"-web_dir2", args.WebDir2}...)
+	}
+
+	if socket != "" {
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{
+			"-db-config-app-unixsocket", socket,
+			"-db-config-dba-unixsocket", socket,
+		}...)
+	} else {
+		hostname, p := mysql.Address()
+		port := fmt.Sprintf("%d", p)
+
+		vt.ExtraArgs = append(vt.ExtraArgs, []string{
+			"-db-config-app-host", hostname,
+			"-db-config-app-port", port,
+			"-db-config-dba-host", hostname,
+			"-db-config-dba-port", port,
+		}...)
+	}
+
+	vtcomboMysqlPort := env.PortForProtocol("vtcombo_mysql_port", "")
+	vt.ExtraArgs = append(vt.ExtraArgs, []string{
+		"-mysql_auth_server_impl", "none",
+		"-mysql_server_port", fmt.Sprintf("%d", vtcomboMysqlPort),
+		"-mysql_server_bind_address", "localhost",
+	}...)
+
+	return vt
+}


### PR DESCRIPTION
:wave: Hiii @sougou! I think @arthurnn briefly discussed this on Slack, but wouldn't it be cool if `vttest` didn't depend on a Python environment for spawning local test clusters?

I think that'd be N E A T, so this PR does that. Here's the commit message inlined with the details:

```
The vttest package is used by Go code (both internally and outside the
vitess project) as a way to configure and spawn a local self-contained
Vitess cluster that can be used for testing the service's behavior
without having to launch a fleet of hosts.

The self-contained cluster is composed of several processes (most
notably: a mysqld instance and a vtcombo service, which contains the
vtgate and vttablet parts of a normal Vitess deployment). These external
processes are currently controlled by `run_local_server.py`, a Python
script that configures and manages the deployment.

The current version of the `vttest` package simply keeps a
`run_local_server.py` process running in the background and reads
metadata from the cluster as JSON through stdout. This makes using
`vttest` for testing Go services a bit of a convoluted process, as you'd
require a full Python environment + all the dependencies of the Python
script (Python Protobufs + GRPC) just to control the service.
Introspection is also difficult as the information which can be queried
from the cluster's status is limited to the initial JSON payload that
`run_local_server.py` prints on startup.

To improve the situation of local testing through `vttest`, this commit
reimplements all the process-management logic from the original script
as native Go code.

The core of this implementation is the LocalCluster struct, the Go
equivalent to Python's LocalDatabase. This struct can be configured in
depth and then used to spawn and manage the services of the Vitess
cluster.

Here are some of the technical choices made during the rewrite:

- The existing `LaunchVitess(VitessOption...) *Handle` interface has
been kept intact for backwards compatibility reasons. Instead of
spawning the Python process, it now acts as a thin wrapper over
`LocalCluster`. The `VitessOption` calls are likewise used to set
configuration options on the `LocalCluster` struct, so overall the
external behavior of the service should remain 100% identical. All these
public APIs, however, have been marked as deprecated on their
documentation. The new `LocalCluster` interface is much more ergonomic,
and as such new users should ideally use it directly.

- The only exception to this backwards-compatibility is the `InitData()`
call: this option callback to setup random initialization of databases
was _not_ working at all, as the `InitDataOptions` struct that it
requires has no exported fields, and hence couldn't be used outside of
the library to configure the cluster.

- The `InitData` functionality has been exposed through the
`LocalCluster` interface with a properly exported `SeedConfig` struct.
However: the implementation for random initialization has not been fully
completed (randomized fields are not implemented) as it's not currently
used anywhere.

- The initialization and control of the `mysqld` service is performed
through an the `mysqlctl` command. `mysqlctl` is both a Go binary and a
Go package in the Vitess source tree; since this new `vttest`
implementation is fully native, it could in theory be possibly to import
the `go/vt/mysqlctl` package directly from Go and use it to initialize
the cluster. We have opted against this because the `mysqlctl` package
is principally configured through global flags, and hence not
threadsafe. By spawning a separate `mysqlctl` binary, we can ensure that
any Go test suite can use several `LocalCluster`s concurrently from many
goroutines without polluting the global namespace.

- With the same rationale, special care has been taken to ensure that
all the operations in `LocalCluster` are thread-safe and do not pollute
the global environment. Most notably, the `vttest` package doesn't
create any global flags or set any environment variables that could race
or break other concurrent tests. The environment variables for all
spawned processes are passed directly through `*spawn` and not inherited
from the parent.
```

There are a few things I'd like to follow up on, namely:

- [ ] Fix the `go/vt/mysqlctl` package so it's threadsafe and doesn't depend on global flags
- [ ] Change the `Mysqlctl` manager in `vttest` to use the `mysqlctl` package directly
- [ ] Design a more advanced interface in `SeedConfig` to configure how we're actually generating the random values, and support more kinds of column types for data generation (the Python script can only generate numerical columns right now!)
- [ ] Write a `go/cmd/vtlocalcluster` equivalent to `run_local_server.py`. Ideally it would be compatible with the Python script and a drop-in replacement! A statically linked binary for spawning the cluster would be very cool for projects that use Vitess and are not written in either Go or Python.

That's a long TODO list! I'll get there soon, but I'd appreciate if you could take a look at the current state of the PR and let me know whether it's going in the right direction.

Cheers!