### PR TITLE
Bump the minimum Go version to 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: precise
 sudo: false
 language: go
 go:
-  - 1.8
+  - 1.9
 go_import_path: github.com/youtube/vitess
 addons:
   apt:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,6 +48,24 @@ mkdir -p $VTROOT/vthook
 echo "Updating git submodules..."
 git submodule update --init
 
+# Install "protoc" protobuf compiler binary.
+protoc_version=3.4.0
+protoc_dist=$VTROOT/dist/protoc
+protoc_version_file=$protoc_dist/version
+if [[ -f $protoc_version_file && "$(cat $protoc_version_file)" == "$protoc_version" ]]; then
+  echo "skipping protoc install. remove $protoc_version_file to force re-install."
+else
+  rm -rf $protoc_dist
+  mkdir -p $protoc_dist
+  download_url=https://github.com/google/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
+  (cd $protoc_dist && \
+    wget $download_url && \
+    unzip protoc-${protoc_version}-linux-x86_64.zip)
+  [ $? -eq 0 ] || fail "protoc download failed"
+  echo "$protoc_version" > $protoc_version_file
+fi
+ln -snf $protoc_dist/bin/protoc $VTROOT/bin/protoc
+
 # install zookeeper
 zk_ver=3.4.6
 zk_dist=$VTROOT/dist/vt-zookeeper-$zk_ver

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": ">=5.5.0",
     "stanley-cheung/protobuf-php": "v0.6",
     "google/auth": "v0.10",
-    "grpc/grpc": "v1.0.0"
+    "grpc/grpc": "v1.6.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b37bde69302058ef01f45bfe5858e396",
-    "content-hash": "64f1877959de9ad06d22633049abb636",
+    "content-hash": "4ff760bfd869bb1225c1cfd1b5d3cb8b",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -48,7 +47,7 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2015-07-22 18:31:08"
+            "time": "2015-07-22T18:31:08+00:00"
         },
         {
             "name": "google/auth",
@@ -96,69 +95,75 @@
                 "google",
                 "oauth2"
             ],
-            "time": "2016-08-02 22:00:48"
+            "time": "2016-08-02T22:00:48+00:00"
         },
         {
             "name": "grpc/grpc",
-            "version": "v1.0.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/grpc/grpc.git",
-                "reference": "2a69139aa7f609e439c24a46754252a5f9d37500"
+                "url": "https://github.com/grpc/grpc-php.git",
+                "reference": "8d190d91ddb9d980f685d9caf79bca62d7edc1e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/grpc/grpc/zipball/2a69139aa7f609e439c24a46754252a5f9d37500",
-                "reference": "2a69139aa7f609e439c24a46754252a5f9d37500",
+                "url": "https://api.github.com/repos/grpc/grpc-php/zipball/8d190d91ddb9d980f685d9caf79bca62d7edc1e6",
+                "reference": "8d190d91ddb9d980f685d9caf79bca62d7edc1e6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.0",
-                "stanley-cheung/protobuf-php": "v0.6"
+                "php": ">=5.5.0"
             },
             "require-dev": {
                 "google/auth": "v0.9"
             },
+            "suggest": {
+                "ext-protobuf": "For better performance, install the protobuf C extension.",
+                "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
+            },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Grpc\\": "src/php/lib/Grpc/"
+                    "Grpc\\": "src/lib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "Apache-2.0"
             ],
             "description": "gRPC library for PHP",
-            "homepage": "http://grpc.io",
+            "homepage": "https://grpc.io",
             "keywords": [
                 "rpc"
             ],
-            "time": "2016-08-19 00:55:10"
+            "time": "2017-09-11T20:50:39+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "dev-master",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "3b45e7675e8997ac96142b0265d158343958f708"
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3b45e7675e8997ac96142b0265d158343958f708",
-                "reference": "3b45e7675e8997ac96142b0265d158343958f708",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.3.1",
+                "guzzlehttp/psr7": "^1.4",
                 "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.0 || ^5.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
@@ -196,32 +201,32 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-08-04 00:05:49"
+            "time": "2017-06-22T18:50:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.2.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579"
+                "reference": "09e549f5534380c68761260a71f847644d8f65aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/c10d860e2a9595f8883527fa0021c7da9e65f579",
-                "reference": "c10d860e2a9595f8883527fa0021c7da9e65f579",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e549f5534380c68761260a71f847644d8f65aa",
+                "reference": "09e549f5534380c68761260a71f847644d8f65aa",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -247,7 +252,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-05-18 16:56:05"
+            "time": "2017-05-20T23:14:18+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -255,12 +260,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "64862e854f876bc5aee2996cab2f552db8586065"
+                "reference": "811b676fbab9c99e359885032e5ebc70e442f5b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/64862e854f876bc5aee2996cab2f552db8586065",
-                "reference": "64862e854f876bc5aee2996cab2f552db8586065",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/811b676fbab9c99e359885032e5ebc70e442f5b8",
+                "reference": "811b676fbab9c99e359885032e5ebc70e442f5b8",
                 "shasum": ""
             },
             "require": {
@@ -312,7 +317,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-08-03 09:33:34"
+            "time": "2017-07-17T09:11:21+00:00"
         },
         {
             "name": "psr/cache",
@@ -320,12 +325,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/cache.git",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+                "reference": "78c5a01ddbf11cf731f1338a4f5aba23b14d5b47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/78c5a01ddbf11cf731f1338a4f5aba23b14d5b47",
+                "reference": "78c5a01ddbf11cf731f1338a4f5aba23b14d5b47",
                 "shasum": ""
             },
             "require": {
@@ -358,7 +363,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06 20:24:11"
+            "time": "2016-10-13T14:48:10+00:00"
         },
         {
             "name": "psr/http-message",
@@ -408,7 +413,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "stanley-cheung/protobuf-php",
@@ -460,7 +465,7 @@
                 "protocol buffer",
                 "serializing"
             ],
-            "time": "2016-07-22 02:12:15"
+            "time": "2016-07-22T02:12:15+00:00"
         }
     ],
     "packages-dev": [],

--- a/dev.env
+++ b/dev.env
@@ -34,8 +34,6 @@ mkdir -p $VTDATAROOT
 
 export VTPORTSTART=15000
 
-export GO15VENDOREXPERIMENT=1
-
 for pypath in $(find $VTROOT/dist -name site-packages -or -name dist-packages | grep -v src/python/grpcio/.tox/py27/lib/python2.7/site-packages)
 do
   export PYTHONPATH=$(prepend_path $PYTHONPATH $pypath)

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -73,7 +73,7 @@ OS X 10.11 (El Capitan) should work as well, the installation instructions are b
 
 In addition, Vitess requires the software and libraries listed below.
 
-1.  [Install Go 1.8+](http://golang.org/doc/install).
+1.  [Install Go 1.9+](http://golang.org/doc/install).
 
 2.  Install [MariaDB 10.0](https://downloads.mariadb.org/) or
     [MySQL 5.6](http://dev.mysql.com/downloads/mysql). You can use any

--- a/doc/GettingStartedKubernetes.md
+++ b/doc/GettingStartedKubernetes.md
@@ -9,13 +9,13 @@ The `kubectl` steps will apply to any Kubernetes cluster.
 
 ## Prerequisites
 
-To complete the exercise in this guide, you must locally install Go 1.8+,
+To complete the exercise in this guide, you must locally install Go 1.9+,
 Vitess' `vtctlclient` tool, and Google Cloud SDK. The
 following sections explain how to set these up in your environment.
 
-### Install Go 1.8+
+### Install Go 1.9+
 
-You need to install [Go 1.8+](http://golang.org/doc/install) to build the
+You need to install [Go 1.9+](http://golang.org/doc/install) to build the
 `vtctlclient` tool, which issues commands to Vitess.
 
 After installing Go, make sure your `GOPATH` environment

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -1,7 +1,8 @@
-FROM golang:1.8
+FROM golang:1.9
 
 # Install Vitess build dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    # TODO(mberlin): Group these to make it easier to understand which library actually requires them.
     automake \
     bison \
     bzip2 \
@@ -13,27 +14,24 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     libssl-dev \
     libtool \
     make \
-    openjdk-7-jdk \
-    php-pear \
-    php5-cli \
-    php5-dev \
+    openjdk-8-jdk \
     pkg-config \
     python-crypto \
     python-dev \
     python-mysqldb \
+    python-pip \
     ruby \
     ruby-dev \
     software-properties-common \
     virtualenv \
     unzip \
     xvfb \
+    # gRPC PHP requirements \
+    libz-dev \
+    php-pear \
+    php7.0-cli \
+    php7.0-dev \
     && rm -rf /var/lib/apt/lists/*
-
-# Install newer pip
-# We can't use the apt package from jessie because it depends
-# on a version of python-six that's too old for gRPC.
-RUN curl -sL --connect-timeout 10 --retry 3 \
-    https://bootstrap.pypa.io/get-pip.py | python
 
 # Install PHP modules for running tests
 RUN export MAKEFLAGS="-j$(nproc)" && \
@@ -44,7 +42,7 @@ RUN export MAKEFLAGS="-j$(nproc)" && \
     curl -sL --connect-timeout 10 --retry 3 \
         https://getcomposer.org/installer | php -- --install-dir=/vt/bin --filename=composer && \
     pecl install xdebug && \
-    echo "zend_extension=$(pecl config-get ext_dir default)/xdebug.so" > /etc/php5/cli/conf.d/20-xdebug.ini
+    echo "zend_extension=$(pecl config-get ext_dir default)/xdebug.so" > /etc/php/7.0/cli/conf.d/20-xdebug.ini
 
 # Install Maven 3.1+
 RUN mkdir -p /vt/dist && \
@@ -52,22 +50,6 @@ RUN mkdir -p /vt/dist && \
     curl -sL --connect-timeout 10 --retry 3 \
         http://www-us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz | tar -xz && \
     mv apache-maven-3.3.9 maven
-
-# Install etcd v3.0.15 binaries
-RUN mkdir -p /vt/dist && \
-    cd /vt/dist && \
-    curl -sL --connect-timeout 10 --retry 3 \
-         https://github.com/coreos/etcd/releases/download/v3.0.15/etcd-v3.0.15-linux-amd64.tar.gz | tar -xz && \
-    mv etcd-v3.0.15-linux-amd64 etcd
-
-# Install consul 0.7.2 binaries
-RUN mkdir -p /vt/dist/consul && \
-    cd /vt/dist/consul && \
-    curl -sL --connect-timeout 10 --retry 3 \
-         -o consul_0.7.2_linux_amd64.zip \
-         https://releases.hashicorp.com/consul/0.7.2/consul_0.7.2_linux_amd64.zip && \
-    unzip consul_0.7.2_linux_amd64.zip && \
-    rm -f consul_0.7.2_linux_amd64.zip
 
 # Set up Vitess environment (equivalent to '. dev.env')
 ENV VTTOP /vt/src/github.com/youtube/vitess
@@ -79,10 +61,9 @@ ENV VTPORTSTART 15000
 ENV PYTHONPATH $VTROOT/dist/py-mock-1.0.1/lib/python2.7/site-packages:$VTROOT/py-vtdb:$VTROOT/dist/selenium/lib/python2.7/site-packages
 ENV GOBIN $VTROOT/bin
 ENV GOPATH $VTROOT
-ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$VTROOT/dist/etcd:$VTROOT/dist/consul:$VTROOT/dist/chromedriver:$PATH
+ENV PATH $VTROOT/bin:$VTROOT/dist/maven/bin:$VTROOT/dist/chromedriver:$PATH
 ENV VT_MYSQL_ROOT /usr
 ENV PKG_CONFIG_PATH $VTROOT/lib
-ENV GO15VENDOREXPERIMENT 1
 
 # Copy files needed for bootstrap
 COPY bootstrap.sh dev.env /vt/src/github.com/youtube/vitess/
@@ -99,16 +80,17 @@ RUN cd /vt/src/github.com/youtube/vitess && \
     govendor sync && \
     rm -rf /vt/.cache
 
-# Install gRPC (and protobuf) as root
+# Install gRPC as root
 RUN export MAKEFLAGS="-j$(nproc)" && \
-    cd /vt/dist && \
-    INSTALL_GRPC_PHP=`php-config --extension-dir` $VTTOP/travis/install_grpc.sh && \
-    echo 'extension=grpc.so' > /etc/php5/cli/conf.d/20-grpc.ini && \
+    $VTTOP/travis/install_grpc.sh && \
     rm -rf /vt/dist/grpc
 
 # Install gRPC PHP dependencies
-RUN cd /vt/src/github.com/youtube/vitess && \
+RUN export MAKEFLAGS="-j$(nproc)" && \
+    pecl install grpc && \
+    cd /vt/src/github.com/youtube/vitess && \
     composer install && \
+    echo 'extension=grpc.so' > /etc/php/7.0/cli/conf.d/20-grpc.ini && \
     find php/vendor/grpc/grpc -mindepth 1 -maxdepth 1 ! -name src | xargs rm -rf && \
     find php/vendor/grpc/grpc/src -mindepth 1 -maxdepth 1 ! -name php | xargs rm -rf
 

--- a/docker/bootstrap/Dockerfile.mariadb
+++ b/docker/bootstrap/Dockerfile.mariadb
@@ -1,11 +1,10 @@
 FROM vitess/bootstrap:common
 
-# Install MariaDB 10.0.x
-RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xcbcb082a1bb943db && \
-    add-apt-repository 'deb http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.0/debian jessie main' && \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server libmariadbclient-dev && \
-    rm -rf /var/lib/apt/lists/*
+# Install MariaDB 10.
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    mariadb-server \
+    libmariadbclient-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Bootstrap Vitess
 WORKDIR /vt/src/github.com/youtube/vitess

--- a/docker/bootstrap/Dockerfile.mysql56
+++ b/docker/bootstrap/Dockerfile.mysql56
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 5.6
 RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ jessie mysql-5.6' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.6' && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/bootstrap/Dockerfile.mysql57
+++ b/docker/bootstrap/Dockerfile.mysql57
@@ -2,7 +2,7 @@ FROM vitess/bootstrap:common
 
 # Install MySQL 5.7
 RUN apt-key adv --recv-keys --keyserver ha.pool.sks-keyservers.net 5072E1F5 && \
-    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ jessie mysql-5.7' && \
+    add-apt-repository 'deb http://repo.mysql.com/apt/debian/ stretch mysql-5.7' && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/bootstrap/Dockerfile.percona
+++ b/docker/bootstrap/Dockerfile.percona
@@ -3,7 +3,7 @@ FROM vitess/bootstrap:common
 # Install Percona 5.6
 RUN apt-key adv --keyserver keys.gnupg.net \
         --recv-keys 8507EFA5 && \
-    add-apt-repository 'deb http://repo.percona.com/apt jessie main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.6 percona-server-server/root_password password 'unused'; \

--- a/docker/bootstrap/Dockerfile.percona57
+++ b/docker/bootstrap/Dockerfile.percona57
@@ -3,7 +3,7 @@ FROM vitess/bootstrap:common
 # Install Percona 5.7
 RUN apt-key adv --keyserver keys.gnupg.net \
         --recv-keys 8507EFA5 && \
-    add-apt-repository 'deb http://repo.percona.com/apt jessie main' && \
+    add-apt-repository 'deb http://repo.percona.com/apt stretch main' && \
     { \
         echo debconf debconf/frontend select Noninteractive; \
         echo percona-server-server-5.7 percona-server-server/root_password password 'unused'; \

--- a/test/cluster/keytar/config/vitess_config.yaml
+++ b/test/cluster/keytar/config/vitess_config.yaml
@@ -3,8 +3,8 @@ install:
     - python-mysqldb
   extra:
     - apt-get update
-    - wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
-    - tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
+    - wget https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz
+    - tar -C /usr/local -xzf go1.9.linux-amd64.tar.gz
     - wget https://storage.googleapis.com/kubernetes-helm/helm-v2.1.3-linux-amd64.tar.gz
     - tar -zxvf helm-v2.1.3-linux-amd64.tar.gz
     - pip install numpy

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -19,18 +19,17 @@
 # as root in the image.
 set -ex
 
-# Import prepend_path function.
-dir="$(dirname "${BASH_SOURCE[0]}")"
-source "${dir}/../tools/shell_functions.inc"
-if [ $? -ne 0 ]; then
-  echo "failed to load ../tools/shell_functions.inc"
-  return 1
-fi
-
 # grpc_dist can be empty, in which case we just install to the default paths
 grpc_dist="$1"
 if [ -n "$grpc_dist" ]; then
   cd $grpc_dist
+fi
+
+if [[ -z "$PIP" ]]; then
+  # PIP is not set i.e. dev.env was not loaded.
+  # We're probably doing a system-wide installation when building the Docker
+  # bootstrap image. Set the variable now.
+  PIP=pip
 fi
 
 # Python requires a very recent version of virtualenv.
@@ -40,84 +39,17 @@ fi
 # https://github.com/pypa/setuptools/issues/945
 # (and setuptools is used by grpc install).
 if [ -n "$grpc_dist" ]; then
-  # Create a virtualenv, which also creates a virualenv-boxed pip.
+  # Non-system wide installation. Create a virtualenv, which also creates a
+  # virtualenv-boxed pip.
+
   # Update both pip and virtualenv.
   $VIRTUALENV -v $grpc_dist/usr/local
   PIP=$grpc_dist/usr/local/bin/pip
   $PIP install --upgrade pip
   $PIP install --upgrade --ignore-installed virtualenv
-else
-  PIP=pip
-  $PIP install --upgrade pip
-  # System wide installations require an explicit upgrade of
-  # certain gRPC Python dependencies e.g. "six" on Debian Jessie.
-  $PIP install --upgrade --ignore-installed six
-fi
-
-# clone the repository, setup the submodules
-git clone https://github.com/grpc/grpc.git
-cd grpc
-git checkout v1.0.0
-git submodule update --init
-
-# OSX specific setting + dependencies
-if [ `uname -s` == "Darwin" ]; then
-  export GRPC_PYTHON_BUILD_WITH_CYTHON=1
-  $PIP install Cython
-
-  # Work-around macOS Sierra blocker, see: https://github.com/youtube/vitess/issues/2115
-  # TODO(mberlin): Remove this when the underlying issue is fixed and available
-  #                in the gRPC version used by Vitess.
-  #                See: https://github.com/google/protobuf/issues/2182
-  export CPPFLAGS="-Wno-deprecated-declarations"
-fi
-
-# build everything
-make
-
-# install protobuf side (it was already built by the 'make' earlier)
-cd third_party/protobuf
-if [ -n "$grpc_dist" ]; then
-  make install prefix=$grpc_dist/usr/local
-else
-  make install
-fi
-
-# now install grpc itself
-cd ../..
-if [ -n "$grpc_dist" ]; then
-  make install prefix=$grpc_dist/usr/local
-
-  # Add bin directory to the path such that gRPC python won't complain that
-  # it cannot find "grpc_python_plugin".
-  export PATH=$(prepend_path $PATH $grpc_dist/usr/local/bin)
-else
-  make install
 fi
 
 # Install gRPC python libraries from PyPI.
 # Dependencies like protobuf python will be installed automatically.
-grpcio_ver=1.0.4
+grpcio_ver=1.6.0
 $PIP install --upgrade grpcio==$grpcio_ver
-
-# Build PHP extension, only if requested.
-if [ -n "$INSTALL_GRPC_PHP" ]; then
-  echo "Building gRPC PHP extension..."
-  cd src/php/ext/grpc
-  if [[ "$TRAVIS" == "true" ]]; then
-    # On Travis, we get an old glibc version that doesn't yet
-    # have clock_*() functions built in, so we need -lrt.
-    # Temporarily turn off --as-needed because the lib doesn't
-    # request rt, since it assumes a newer glibc.
-    export LDFLAGS="-Wl,--no-as-needed -lrt -Wl,--as-needed"
-  fi
-  phpize
-  if ! ./configure --enable-grpc=$grpc_dist/usr/local; then
-    cat config.log
-    echo "Failed to configure build for gRPC PHP extension."
-    exit 1
-  fi
-  make
-  mkdir -p $INSTALL_GRPC_PHP
-  mv modules/grpc.so $INSTALL_GRPC_PHP
-fi


### PR DESCRIPTION
This is tracked here: #3219 

Note that this also triggers a Debian version upgrade to their latest
stable version "stretch" which was released this summer.

This required several additional changes and cleanups:

- Remove outdated GO15VENDOREXPERIMENT.
- Docker: Upgrade Java to 8 (from 7).
- Docker: Upgrade PHP to 7 (from 5).
- Docker: Use "pip" from distribution and do not install it ourselves.
- Docker: PHP: Use "pecl install grpc" and no longer compile it ourselves. Relevant parts in travis/install_grpc.sh have been removed.
- Docker: Do no longer install etcd and consule in the common image because we call bootstrap.sh when building the flavored image and that installs these two as well.
- travis/install_grpc.sh changes:
  - Do no longer compile gRPC because for PHP and Python we can use other ways to install the shared library.
  - Do no longer compile protobuf. Instead, download pre-compiled "protoc" binary in bootstrap.sh.
  - Updated Python and PHP versions to 1.6 as we did earlier for Go.
