### PR TITLE
vitess.io: Make dev and "prod" Jekyll config consistent again.

### DIFF
--- a/vitess.io/_config_dev.yml
+++ b/vitess.io/_config_dev.yml
@@ -14,7 +14,7 @@ repo: https://github.com/youtube/vitess
 sass:
   sass_dir: _sass
   style: compressed
-permalink: /:categories/:title/
+permalink: pretty
 highlighter: pygments
 plugins:
   - jekyll-sitemap


### PR DESCRIPTION
I forgot to update the dev version when I changed the URL format last
week.