### PR TITLE
messaging: end2end tests

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -227,6 +227,7 @@ func (mm *messageManager) Close() {
 // cancel or timeout, or tabletserver shutdown, etc.
 func (mm *messageManager) Subscribe(ctx context.Context, send func(*sqltypes.Result) error) <-chan struct{} {
 	receiver, done := newMessageReceiver(ctx, send)
+	MessageStats.Add([]string{mm.name.String(), "ClientCount"}, 1)
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 	withStatus := &receiverWithStatus{
@@ -248,6 +249,7 @@ func (mm *messageManager) Subscribe(ctx context.Context, send func(*sqltypes.Res
 }
 
 func (mm *messageManager) unsubscribe(receiver *messageReceiver) {
+	MessageStats.Add([]string{mm.name.String(), "ClientCount"}, -1)
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
 	for i, rcv := range mm.receivers {

--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -410,6 +410,10 @@ func (mm *messageManager) send(receiver *receiverWithStatus, qr *sqltypes.Result
 }
 
 func (mm *messageManager) postpone(tsv TabletService, name string, ackWaitTime time.Duration, ids []string) {
+	// ids can be empty if it's the field info being sent.
+	if len(ids) == 0 {
+		return
+	}
 	// Use the semaphore to limit parallelism.
 	if !mm.postponeSema.Acquire() {
 		// Unreachable.

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -299,7 +299,7 @@ func TestMessageManagerPostponeThrottle(t *testing.T) {
 		runtime.Gosched()
 		time.Sleep(10 * time.Millisecond)
 	}
-	if got, want := tsv.postponeCount.Get(), int64(2); got != want {
+	if got, want := tsv.postponeCount.Get(), int64(1); got != want {
 		t.Errorf("tsv.postponeCount: %d, want %d", got, want)
 	}
 	<-ch

--- a/test/messaging.py
+++ b/test/messaging.py
@@ -17,6 +17,7 @@
 
 
 import logging
+import time
 import unittest
 
 import environment
@@ -29,6 +30,7 @@ from vtdb import vtgate_client
 
 
 shard_0_master = None
+shard_0_replica = None
 shard_1_master = None
 lookup_master = None
 
@@ -95,6 +97,7 @@ vschema = {
 def setUpModule():
   global keyspace_env
   global shard_0_master
+  global shard_0_replica
   global shard_1_master
   global lookup_master
   logging.debug('in setUpModule')
@@ -117,13 +120,15 @@ def setUpModule():
             ],
         )
     shard_0_master = keyspace_env.tablet_map['user.-80.master']
+    shard_0_replica = keyspace_env.tablet_map['user.-80.replica.0']
     shard_1_master = keyspace_env.tablet_map['user.80-.master']
     lookup_master = keyspace_env.tablet_map['lookup.0.master']
 
     utils.apply_vschema(vschema)
     utils.VtGate().start(
-        tablets=[shard_0_master, shard_1_master, lookup_master])
+        tablets=[shard_0_master, shard_0_replica, shard_1_master, lookup_master])
     utils.vtgate.wait_for_endpoints('user.-80.master', 1)
+    utils.vtgate.wait_for_endpoints('user.-80.replica', 1)
     utils.vtgate.wait_for_endpoints('user.80-.master', 1)
     utils.vtgate.wait_for_endpoints('lookup.0.master', 1)
   except:
@@ -153,6 +158,11 @@ def get_connection(timeout=15.0):
   except Exception:
     logging.exception('Connection to vtgate (timeout=%s) failed.', timeout)
     raise
+
+
+def get_client_count(tablet):
+    debugvars = utils.get_vars(tablet.port)
+    return debugvars['Messages'].get('sharded_message.ClientCount', 0)
 
 
 class TestMessaging(unittest.TestCase):
@@ -207,6 +217,98 @@ class TestMessaging(unittest.TestCase):
     # Only one should be acked.
     count = vtgate_conn.message_ack(name, [1, 4])
     self.assertEqual(count, 1)
+    it.close()
+
+  def test_connections(self):
+    name = 'sharded_message'
+    keyspace = 'user'
+
+    self.assertEqual(get_client_count(shard_0_master), 0)
+    self.assertEqual(get_client_count(shard_1_master), 0)
+
+    vtgate_conn1 = get_connection()
+    (it1, fields1) = vtgate_conn1.message_stream(keyspace, name)
+    self.assertEqual(get_client_count(shard_0_master), 1)
+    self.assertEqual(get_client_count(shard_1_master), 1)
+
+    vtgate_conn2 = get_connection()
+    (it2, fields2) = vtgate_conn2.message_stream(keyspace, name)
+    self.assertEqual(get_client_count(shard_0_master), 2)
+    self.assertEqual(get_client_count(shard_1_master), 2)
+
+    cursor = vtgate_conn1.cursor(
+        tablet_type='master', keyspace=None, writable=True)
+    query = 'insert into %s(id, message) values(:id, :message)'%(name)
+    cursor.begin()
+    cursor.execute(query, {'id': 2, 'message': 'hello world 2'})
+    cursor.execute(query, {'id': 5, 'message': 'hello world 5'})
+    cursor.commit()
+
+    # Each connection should get one message.
+    it1.next()
+    it2.next()
+
+    # Ack the messages.
+    count = vtgate_conn1.message_ack(name, [2, 5])
+
+    # After closing one stream, ensure vttablets have dropped it.
+    it1.close()
+    time.sleep(1)
+    self.assertEqual(get_client_count(shard_0_master), 1)
+    self.assertEqual(get_client_count(shard_1_master), 1)
+
+    it2.close()
+
+  def test_reparent(self):
+    name = 'sharded_message'
+    keyspace = 'user'
+
+    # Start a stream. Use a timeout that's greater than how long
+    # the test will take to run.
+    vtgate_conn = get_connection(120)
+    (it, fields) = vtgate_conn.message_stream(keyspace, name)
+    self.assertEqual(get_client_count(shard_0_master), 1)
+    self.assertEqual(get_client_count(shard_0_replica), 0)
+    self.assertEqual(get_client_count(shard_1_master), 1)
+
+    # Perform a graceful reparent to the replica.
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'user/-80',
+                     '-new_master', shard_0_replica.tablet_alias], auto_log=True)
+    utils.validate_topology()
+
+    # Verify connection has migrated.
+    # The wait must be at least 6s which is how long vtgate will
+    # wait before retrying: that is 30s/5 where 30s is the default
+    # message_stream_grace_period.
+    time.sleep(10)
+    self.assertEqual(get_client_count(shard_0_master), 0)
+    self.assertEqual(get_client_count(shard_0_replica), 1)
+    self.assertEqual(get_client_count(shard_1_master), 1)
+
+    cursor = vtgate_conn.cursor(
+        tablet_type='master', keyspace=None, writable=True)
+    query = 'insert into %s(id, message) values(:id, :message)'%(name)
+    cursor.begin()
+    cursor.execute(query, {'id': 3, 'message': 'hello world 3'})
+    cursor.commit()
+
+    # Receive the message.
+    it.next()
+
+    # Reparent back to old master.
+    utils.run_vtctl(['PlannedReparentShard',
+                     '-keyspace_shard', 'user/-80',
+                     '-new_master', shard_0_master.tablet_alias], auto_log=True)
+    utils.validate_topology()
+
+    time.sleep(10)
+    self.assertEqual(get_client_count(shard_0_master), 1)
+    self.assertEqual(get_client_count(shard_0_replica), 0)
+    self.assertEqual(get_client_count(shard_1_master), 1)
+
+    # Ack the message.
+    count = vtgate_conn.message_ack(name, [3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
BUG=65853541
* Make sure vttablet proactively drops the connection if a
  messaging client disconnects.
* Make sure vtgate reconnects to the new master and continues
  streaming if one of the vttablets is reparented.
* Minor fix: don't postpone if there are no ids, which happens when only field info is being sent.