### PR TITLE
discovery: Always init a target's error counter to 0.

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -517,6 +517,12 @@ func (hcc *healthCheckConn) processResponse(hc *HealthCheckImpl, shr *querypb.St
 		}
 	}
 
+	// In this case where a new tablet is initialized or a tablet type changes, we want to
+	// initialize the counter so the rate can be calculated correctly.
+	if hcc.tabletStats.Target.TabletType != shr.Target.TabletType {
+		hcErrorCounters.Add([]string{shr.Target.Keyspace, shr.Target.Shard, topoproto.TabletTypeLString(shr.Target.TabletType)}, 0)
+	}
+
 	// Update our record, and notify downstream for tabletType and
 	// realtimeStats change.
 	ts := hcc.update(shr, serving, healthErr)


### PR DESCRIPTION
Without it, monitoring tools cannot correctly compute the rate the first time the value becomes non-zero.

This change was already LGTM'd internally.