### PR TITLE
Add JDBC support for workload and client found rows

### DIFF
--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -145,8 +145,8 @@ public class ConnectionProperties {
     );
     private BooleanConnectionProperty useAffectedRows = new BooleanConnectionProperty(
         "useAffectedRows",
-        "Don't set the CLIENT_FOUND_ROWS flag when connecting to the server",
-        false);
+        "Don't set the CLIENT_FOUND_ROWS flag when connecting to the server. The vitess default (useAffectedRows=true) is the opposite of mysql-connector-j.",
+        true);
 
     private BooleanConnectionProperty grpcRetriesEnabled = new BooleanConnectionProperty(
         "grpcRetriesEnabled",

--- a/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
+++ b/java/jdbc/src/main/java/io/vitess/jdbc/ConnectionProperties.java
@@ -138,6 +138,16 @@ public class ConnectionProperties {
         Constants.Property.INCLUDED_FIELDS,
         "What fields to return from MySQL to the Driver. Limiting the fields returned can improve performance, but ALL is required for maximum JDBC API support",
         Constants.DEFAULT_INCLUDED_FIELDS);
+    private EnumConnectionProperty<Query.ExecuteOptions.Workload> workload = new EnumConnectionProperty<>(
+        "workload",
+        "The workload type to use when executing queries",
+        Query.ExecuteOptions.Workload.UNSPECIFIED
+    );
+    private BooleanConnectionProperty useAffectedRows = new BooleanConnectionProperty(
+        "useAffectedRows",
+        "Don't set the CLIENT_FOUND_ROWS flag when connecting to the server",
+        false);
+
     private BooleanConnectionProperty grpcRetriesEnabled = new BooleanConnectionProperty(
         "grpcRetriesEnabled",
         "If enabled, a gRPC interceptor will ensure retries happen in the case of TRANSIENT gRPC errors.",
@@ -245,7 +255,8 @@ public class ConnectionProperties {
         this.simpleExecuteTypeCache = this.executeType.getValueAsEnum() == Constants.QueryExecuteType.SIMPLE;
         this.characterEncodingAsString = this.characterEncoding.getValueAsString();
         this.userNameCache = this.userName.getValueAsString();
-        this.executeOptionsCache = Query.ExecuteOptions.newBuilder().setIncludedFields(this.includedFieldsCache).build();
+
+        setExecuteOptions();
     }
 
     /**
@@ -368,8 +379,30 @@ public class ConnectionProperties {
         this.setExecuteOptions();
     }
 
+    public Query.ExecuteOptions.Workload getWorkload() {
+        return this.workload.getValueAsEnum();
+    }
+
+    public void setWorkload(Query.ExecuteOptions.Workload workload) {
+        this.workload.setValue(workload);
+        setExecuteOptions();
+    }
+
+    public boolean getUseAffectedRows() {
+        return useAffectedRows.getValueAsBoolean();
+    }
+
+    public void setUseAffectedRows(boolean useAffectedRows) {
+        this.useAffectedRows.setValue(useAffectedRows);
+        setExecuteOptions();
+    }
+
     private void setExecuteOptions() {
-        this.executeOptionsCache = Query.ExecuteOptions.newBuilder().setIncludedFields(this.includedFieldsCache).build();
+        this.executeOptionsCache = Query.ExecuteOptions.newBuilder()
+            .setIncludedFields(getIncludedFields())
+            .setWorkload(getWorkload())
+            .setClientFoundRows(!getUseAffectedRows())
+            .build();
     }
 
     public Query.ExecuteOptions getExecuteOptions() {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -20,13 +20,6 @@ import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Properties;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import io.vitess.proto.Query;
-import io.vitess.proto.Topodata;
-import io.vitess.util.Constants;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,7 +31,7 @@ import io.vitess.util.Constants;
 
 public class ConnectionPropertiesTest {
 
-    private static final int NUM_PROPS = 32;
+    private static final int NUM_PROPS = 34;
 
     @Test
     public void testReflection() throws Exception {

--- a/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/ConnectionPropertiesTest.java
@@ -66,6 +66,7 @@ public class ConnectionPropertiesTest {
         Assert.assertEquals("includedFieldsCache", true, props.isIncludeAllFields());
         Assert.assertEquals("tabletType", Constants.DEFAULT_TABLET_TYPE, props.getTabletType());
         Assert.assertEquals("useSSL", false, props.getUseSSL());
+        Assert.assertEquals("useAffectedRows", true, props.getUseAffectedRows());
     }
 
     @Test

--- a/java/jdbc/src/test/java/io/vitess/jdbc/VitessConnectionTest.java
+++ b/java/jdbc/src/test/java/io/vitess/jdbc/VitessConnectionTest.java
@@ -197,4 +197,31 @@ public class VitessConnectionTest extends BaseTest {
         Assert.assertEquals(Topodata.TabletType.REPLICA, conn.getTabletType());
         Assert.assertEquals(true, conn.getBlobsAreStrings());
     }
+
+    @Test public void testClientFoundRows() throws SQLException {
+        String url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&useAffectedRows=true";
+        VitessConnection conn = new VitessConnection(url, new Properties());
+
+        Assert.assertEquals(true, conn.getUseAffectedRows());
+        Assert.assertEquals(false, conn.getVtSession().getSession().getOptions().getClientFoundRows());
+
+        url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&useAffectedRows=false";
+        conn = new VitessConnection(url, new Properties());
+
+        Assert.assertEquals(false, conn.getUseAffectedRows());
+        Assert.assertEquals(true, conn.getVtSession().getSession().getOptions().getClientFoundRows());
+    }
+
+    @Test public void testWorkload() throws SQLException {
+        for (Query.ExecuteOptions.Workload workload : Query.ExecuteOptions.Workload.values()) {
+            if (workload == Query.ExecuteOptions.Workload.UNRECOGNIZED) {
+                continue;
+            }
+            String url = "jdbc:vitess://locahost:9000/vt_keyspace/keyspace?TABLET_TYPE=replica&workload=" + workload.toString().toLowerCase();
+            VitessConnection conn = new VitessConnection(url, new Properties());
+
+            Assert.assertEquals(workload, conn.getWorkload());
+            Assert.assertEquals(workload, conn.getVtSession().getSession().getOptions().getWorkload());
+        }
+    }
 }


### PR DESCRIPTION
We've been running with this code for a few weeks. I finally got us rebased back on master with @harshit-gangal's v3 code so can upstream this now.

Note: This makes us compatible with the existing mysql-connector-j `useAffectedRows` setting. It's slightly confusing that `clientFoundRows == !useAffectedRows`, but I think it would be more confusing for us to diverge from mysql-connector-j on this.