### PR TITLE
doc: Fix links to anchors of the same page.

### DIFF
--- a/doc/HorizontalReshardingWorkflowGuide.md
+++ b/doc/HorizontalReshardingWorkflowGuide.md
@@ -12,9 +12,9 @@ The horizontal resharding process mainly contains the following steps
     (**Phase: CopySchemaShard**) 
 1.  Copy the data with a batch process called *vtworker*
     (**Phase: SplitClone**).
-    [more details](horizontal-sharding-workflow.html#details-in-splitclone-phase)
+    [more details](#details-in-splitclone-phase)
 1.  Check filtered replication (**Phase: WaitForFilteredReplication**).
-    [more details](horizontal-sharding-workflow.html#details-in-waitforfilteredreplication-phase) 
+    [more details](#details-in-waitforfilteredreplication-phase)
 1.  Check copied data integrity using *vtworker* batch process in the mode
     to compare the source and destination data. (**Phase: SplitDiff**)
 1.  Migrate all the serving rdonly tablets in the original shards.
@@ -23,7 +23,7 @@ The horizontal resharding process mainly contains the following steps
     (**Phase: MigrateServedTypeReplica**)
 1.  Migrate all the serving master tablets in the original shards.
     (**Phase: MigrateServedTypeMaster**)
-    [more details](horizontal-sharding-workflow.html#details-in-migrateservedtypemaste-phase) 
+    [more details](#details-in-migrateservedtypemaste-phase)
 
 ## Prerequisites
 

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -328,13 +328,13 @@ The <code class="prettyprint">kubectl</code> steps will apply to any Kubernetes 
 
 <h2 id="prerequisites">Prerequisites</h2>
 
-<p>To complete the exercise in this guide, you must locally install Go 1.8+,
+<p>To complete the exercise in this guide, you must locally install Go 1.9+,
 Vitess&#39; <code class="prettyprint">vtctlclient</code> tool, and Google Cloud SDK. The
 following sections explain how to set these up in your environment.</p>
 
-<h3 id="install-go-1-8">Install Go 1.8+</h3>
+<h3 id="install-go-1-9">Install Go 1.9+</h3>
 
-<p>You need to install <a href="http://golang.org/doc/install">Go 1.8+</a> to build the
+<p>You need to install <a href="http://golang.org/doc/install">Go 1.9+</a> to build the
 <code class="prettyprint">vtctlclient</code> tool, which issues commands to Vitess.</p>
 
 <p>After installing Go, make sure your <code class="prettyprint">GOPATH</code> environment

--- a/docs/getting-started/local-instance/index.html
+++ b/docs/getting-started/local-instance/index.html
@@ -384,7 +384,7 @@ OS X 10.11 (El Capitan) should work as well, the installation instructions are b
 <p>In addition, Vitess requires the software and libraries listed below.</p>
 
 <ol>
-<li><p><a href="http://golang.org/doc/install">Install Go 1.8+</a>.</p></li>
+<li><p><a href="http://golang.org/doc/install">Install Go 1.9+</a>.</p></li>
 <li><p>Install <a href="https://downloads.mariadb.org/">MariaDB 10.0</a> or
 <a href="http://dev.mysql.com/downloads/mysql">MySQL 5.6</a>. You can use any
 installation method (src/bin/rpm/deb), but be sure to include the client

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -25,22 +25,22 @@
     <loc>http://vitess.io/user-guide/horizontal-sharding/</loc>
   </url>
   <url>
+    <loc>http://vitess.io/contributing/</loc>
+  </url>
+  <url>
+    <loc>http://vitess.io/getting-started/</loc>
+  </url>
+  <url>
     <loc>http://vitess.io/internal/</loc>
   </url>
   <url>
     <loc>http://vitess.io/overview/</loc>
   </url>
   <url>
-    <loc>http://vitess.io/terms/</loc>
-  </url>
-  <url>
     <loc>http://vitess.io/search/</loc>
   </url>
   <url>
-    <loc>http://vitess.io/getting-started/</loc>
-  </url>
-  <url>
-    <loc>http://vitess.io/contributing/</loc>
+    <loc>http://vitess.io/terms/</loc>
   </url>
   <url>
     <loc>http://vitess.io/</loc>

--- a/docs/user-guide/horizontal-sharding-workflow/index.html
+++ b/docs/user-guide/horizontal-sharding-workflow/index.html
@@ -332,9 +332,9 @@ from 1 shard &quot;0&quot; into 2 shards &quot;-80&quot; and &quot;80-&quot;.</p
 (<strong>Phase: CopySchemaShard</strong>) </li>
 <li> Copy the data with a batch process called <em>vtworker</em>
 (<strong>Phase: SplitClone</strong>).
-<a href="horizontal-sharding-workflow.html#details-in-splitclone-phase">more details</a></li>
+<a href="#details-in-splitclone-phase">more details</a></li>
 <li> Check filtered replication (<strong>Phase: WaitForFilteredReplication</strong>).
-<a href="horizontal-sharding-workflow.html#details-in-waitforfilteredreplication-phase">more details</a> </li>
+<a href="#details-in-waitforfilteredreplication-phase">more details</a></li>
 <li> Check copied data integrity using <em>vtworker</em> batch process in the mode
 to compare the source and destination data. (<strong>Phase: SplitDiff</strong>)</li>
 <li> Migrate all the serving rdonly tablets in the original shards.
@@ -343,7 +343,7 @@ to compare the source and destination data. (<strong>Phase: SplitDiff</strong>)<
 (<strong>Phase: MigrateServedTypeReplica</strong>)</li>
 <li> Migrate all the serving master tablets in the original shards.
 (<strong>Phase: MigrateServedTypeMaster</strong>)
-<a href="horizontal-sharding-workflow.html#details-in-migrateservedtypemaste-phase">more details</a> </li>
+<a href="#details-in-migrateservedtypemaste-phase">more details</a></li>
 </ol>
 
 <h2 id="prerequisites">Prerequisites</h2>


### PR DESCRIPTION
Affected page: http://vitess.io/user-guide/horizontal-sharding-workflow/

This broke when I changed the URL format in https://github.com/youtube/vitess/pull/3183.

I fixed it by removing the file name from the link. Note that the links should not have included the file name to begin with.

Fixes https://github.com/youtube/vitess/issues/3238.