### PR TITLE
Added query cache metrics

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/cache"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/sqlannotation"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -91,6 +92,12 @@ func NewExecutor(ctx context.Context, serv topo.SrvTopoServer, cell, statsName s
 	}
 	e.watchSrvVSchema(ctx, cell)
 	executorOnce.Do(func() {
+		stats.Publish("QueryCacheLength", stats.IntFunc(e.plans.Length))
+		stats.Publish("QueryCacheSize", stats.IntFunc(e.plans.Size))
+		stats.Publish("QueryCacheCapacity", stats.IntFunc(e.plans.Capacity))
+		stats.Publish("QueryCacheOldest", stats.StringFunc(func() string {
+			return fmt.Sprintf("%v", e.plans.Oldest())
+		}))
 		http.Handle("/debug/query_plans", e)
 		http.Handle("/debug/vschema", e)
 	})

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -92,10 +92,10 @@ func NewExecutor(ctx context.Context, serv topo.SrvTopoServer, cell, statsName s
 	}
 	e.watchSrvVSchema(ctx, cell)
 	executorOnce.Do(func() {
-		stats.Publish("QueryCacheLength", stats.IntFunc(e.plans.Length))
-		stats.Publish("QueryCacheSize", stats.IntFunc(e.plans.Size))
-		stats.Publish("QueryCacheCapacity", stats.IntFunc(e.plans.Capacity))
-		stats.Publish("QueryCacheOldest", stats.StringFunc(func() string {
+		stats.Publish("QueryPlanCacheLength", stats.IntFunc(e.plans.Length))
+		stats.Publish("QueryPlanCacheSize", stats.IntFunc(e.plans.Size))
+		stats.Publish("QueryPlanCacheCapacity", stats.IntFunc(e.plans.Capacity))
+		stats.Publish("QueryPlanCacheOldest", stats.StringFunc(func() string {
 			return fmt.Sprintf("%v", e.plans.Oldest())
 		}))
 		http.Handle("/debug/query_plans", e)


### PR DESCRIPTION
### Description 

Exposed metrics for query cache. 

Should we call this metric `PlanCache*` to make it consistent with the code?  

I think it makes more sense to keep it  like this (`QueryCache*`), so it's consistent with the one in tabletserver. But curious to read what people think about this.  

### Tests

* Locally and dev cluster