### PR TITLE
ParseTabletAlias: Help the user by explaining the expected format.

### DIFF
--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -75,7 +75,7 @@ func TabletAliasUIDStr(ta *topodatapb.TabletAlias) string {
 func ParseTabletAlias(aliasStr string) (*topodatapb.TabletAlias, error) {
 	nameParts := strings.Split(aliasStr, "-")
 	if len(nameParts) != 2 {
-		return nil, fmt.Errorf("invalid tablet alias: %v", aliasStr)
+		return nil, fmt.Errorf("invalid tablet alias: %q, expecting format: %q", aliasStr, "<cell>-<uid>")
 	}
 	uid, err := ParseUID(nameParts[1])
 	if err != nil {


### PR DESCRIPTION
Another tiny patch to help the user. Quote the alias name and poke the user telling him the right format to use. Why? I bumped into this and didn't figure out what I was doing.  I'd have figured out my mistake more quickly had I seen the expected format.