### PR TITLE
make show vitess_shards not fail if one keyspace is invalid

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -376,7 +376,9 @@ func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sq
 		for _, keyspace := range keyspaces {
 			_, _, shards, err := getKeyspaceShards(ctx, e.serv, e.cell, keyspace, target.TabletType)
 			if err != nil {
-				return nil, err
+				// There might be a misconfigured keyspace or no shards in the keyspace.
+				// Skip any errors and move on.
+				continue
 			}
 
 			for _, shard := range shards {


### PR DESCRIPTION
Instead of failing to return anything if there is a misconfigured
keyspace, simply skip the keyspace that isn't working and return the
shards for the other(s).

This was originally part of #3137 but since that PR got held up in some
back and forth with @sougou on the grammar, I've just pulled out the
non-controversial fix here and we can add the enhancements to support
LIKE "X" in a separate PR.
