### PR TITLE
skip invalid keyspaces in vtctld /api/srv_keyspace

### DIFF
--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -251,7 +251,12 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 		for _, keyspaceName := range keyspaceNamesList {
 			err := addSrvkeyspace(ctx, ts, cell, keyspaceName, srvKeyspaces)
 			if err != nil {
-				return nil, err
+				// If a keyspace is in the process of being set up, it exists
+				// in the list of keyspaces but GetSrvKeyspace fails
+				//
+				// Instead of returning this error, simply skip it in the
+				// loop so we still return the other valid keyspaces.
+				continue
 			}
 		}
 		return srvKeyspaces, nil

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -121,15 +121,6 @@ func unmarshalRequest(r *http.Request, v interface{}) error {
 	return json.Unmarshal(data, v)
 }
 
-func addSrvkeyspace(ctx context.Context, ts topo.Server, cell, keyspace string, srvKeyspaces map[string]interface{}) error {
-	srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, keyspace)
-	if err != nil {
-		return fmt.Errorf("invalid keyspace name: %q ", keyspace)
-	}
-	srvKeyspaces[keyspace] = srvKeyspace
-	return nil
-}
-
 func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, realtimeStats *realtimeStats) {
 	tabletHealthCache := newTabletHealthCache(ts)
 	tmClient := tmclient.NewTabletManagerClient()
@@ -249,7 +240,7 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 			return nil, fmt.Errorf("can't get list of SrvKeyspaceNames for cell %q: GetSrvKeyspaceNames returned: %v", cell, err)
 		}
 		for _, keyspaceName := range keyspaceNamesList {
-			err := addSrvkeyspace(ctx, ts, cell, keyspaceName, srvKeyspaces)
+			srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, keyspaceName)
 			if err != nil {
 				// If a keyspace is in the process of being set up, it exists
 				// in the list of keyspaces but GetSrvKeyspace fails
@@ -258,6 +249,7 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 				// loop so we still return the other valid keyspaces.
 				continue
 			}
+			srvKeyspaces[keyspaceName] = srvKeyspace
 		}
 		return srvKeyspaces, nil
 

--- a/go/vt/vtctld/api.go
+++ b/go/vt/vtctld/api.go
@@ -243,7 +243,7 @@ func initAPI(ctx context.Context, ts topo.Server, actions *ActionRepository, rea
 			srvKeyspace, err := ts.GetSrvKeyspace(ctx, cell, keyspaceName)
 			if err != nil {
 				// If a keyspace is in the process of being set up, it exists
-				// in the list of keyspaces but GetSrvKeyspace fails
+				// in the list of keyspaces but GetSrvKeyspace fails.
 				//
 				// Instead of returning this error, simply skip it in the
 				// loop so we still return the other valid keyspaces.


### PR DESCRIPTION
When a keyspace is in the process of being initialized, for some
time it exists in the topo's keyspaces list but doesn't yet have a
valid SrvKeyspace to return.

This caused the /api/srv_keyspace/local handler to return a 500
error. Instead, change the handler to skip over any invalid keyspaces
so it still returns the list of valid ones.