### PR TITLE
throttler: client unit test: Register the test server before calling gRPC's Serve().

### DIFF
--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -143,6 +143,11 @@ func serveGRPC() {
 	}
 
 	// and serve on it
+	// NOTE: Before we call Serve(), all services must have registered themselves
+	//       with "GRPCServer". This is the case because go/vt/servenv/run.go
+	//       runs all OnRun() hooks after createGRPCServer() and before
+	//       serveGRPC(). If this was not the case, the binary would crash with
+	//       the error "grpc: Server.RegisterService after Server.Serve".
 	go GRPCServer.Serve(listener)
 
 	OnTermSync(func() {

--- a/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
+++ b/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
@@ -100,15 +100,15 @@ func (s *Server) ResetConfiguration(_ context.Context, request *throttlerdata.Re
 	}, nil
 }
 
-// StartServer registers the Server instance with the gRPC server.
-func StartServer(s *grpc.Server, m throttler.Manager) {
+// RegisterServer registers a new throttler server instance with the gRPC server.
+func RegisterServer(s *grpc.Server, m throttler.Manager) {
 	throttlerservice.RegisterThrottlerServer(s, NewServer(m))
 }
 
 func init() {
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("throttler") {
-			StartServer(servenv.GRPCServer, throttler.GlobalManager)
+			RegisterServer(servenv.GRPCServer, throttler.GlobalManager)
 		}
 	})
 }

--- a/go/vt/wrangler/testlib/throttler_test.go
+++ b/go/vt/wrangler/testlib/throttler_test.go
@@ -41,8 +41,8 @@ func TestVtctlThrottlerCommands(t *testing.T) {
 		t.Fatalf("Cannot listen: %v", err)
 	}
 	s := grpc.NewServer()
+	grpcthrottlerserver.RegisterServer(s, throttler.GlobalManager)
 	go s.Serve(listener)
-	grpcthrottlerserver.StartServer(s, throttler.GlobalManager)
 
 	addr := fmt.Sprintf("localhost:%v", listener.Addr().(*net.TCPAddr).Port)
 


### PR DESCRIPTION
Fixes https://github.com/youtube/vitess/issues/3260.

I also clarified in grpc_server.go that we are adhering to this requirement when starting up the binary.