### PR TITLE
vtexplain get query result types from schema

### DIFF
--- a/data/test/vtexplain/comments-output.json
+++ b/data/test/vtexplain/comments-output.json
@@ -20,7 +20,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -32,7 +34,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [

--- a/data/test/vtexplain/deletesharded-output.json
+++ b/data/test/vtexplain/deletesharded-output.json
@@ -42,23 +42,23 @@
                     {
                         "SQL": "select name from user where id = :vtg1 for update",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "10"
                         }
                     },
                     {
                         "SQL": "delete from user where id = :vtg1 /* vtgate:: keyspace_id:594764e1a2b2d98e */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "10"
                         }
                     }
                 ],
                 "MysqlQueries": [
+                    "begin",
                     "select name from user where 1 != 1",
-                    "begin",
                     "select name from user where id = 10 limit 10001 for update",
-                    "commit",
-                    "begin",
-                    "delete from user where id in (10)",
+                    "delete from user where id in (10) /* vtgate:: keyspace_id:594764e1a2b2d98e */",
                     "commit"
                 ]
             },
@@ -67,6 +67,7 @@
                     {
                         "SQL": "delete from name_user_map where name = :name and user_id = :user_id /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'name_val_1'",
                             "user_id": "10"
                         }
@@ -74,7 +75,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "delete from name_user_map where (name = 'name_val_1' and user_id = 10)",
+                    "delete from name_user_map where (name = 'name_val_1' and user_id = 10) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */",
                     "commit"
                 ]
             }

--- a/data/test/vtexplain/deletesharded-output.json
+++ b/data/test/vtexplain/deletesharded-output.json
@@ -1,0 +1,83 @@
+[
+    {
+        "SQL": "delete from user where id=10",
+        "Plans": [
+            {
+                "Original": "delete from name_user_map where name = :name and user_id = :user_id",
+                "Instructions": {
+                    "Opcode": "DeleteEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "delete from name_user_map where name = :name and user_id = :user_id",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
+                    ],
+                    "Table": "name_user_map"
+                }
+            },
+            {
+                "Original": "delete from user where id = :vtg1",
+                "Instructions": {
+                    "Opcode": "DeleteEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "delete from user where id = :vtg1",
+                    "Vindex": "hash",
+                    "Values": [
+                        ":vtg1"
+                    ],
+                    "Table": "user",
+                    "Subquery": "select name from user where id = :vtg1 for update"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select name from user where id = :vtg1 for update",
+                        "BindVars": {
+                            "vtg1": "10"
+                        }
+                    },
+                    {
+                        "SQL": "delete from user where id = :vtg1 /* vtgate:: keyspace_id:594764e1a2b2d98e */",
+                        "BindVars": {
+                            "vtg1": "10"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select name from user where 1 != 1",
+                    "begin",
+                    "select name from user where id = 10 limit 10001 for update",
+                    "commit",
+                    "begin",
+                    "delete from user where id in (10)",
+                    "commit"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "delete from name_user_map where name = :name and user_id = :user_id /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */",
+                        "BindVars": {
+                            "name": "'name_val_1'",
+                            "user_id": "10"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "delete from name_user_map where (name = 'name_val_1' and user_id = 10)",
+                    "commit"
+                ]
+            }
+        }
+    }
+]

--- a/data/test/vtexplain/deletesharded-output.txt
+++ b/data/test/vtexplain/deletesharded-output.txt
@@ -1,0 +1,18 @@
+----------------------------------------------------------------------
+delete from user where id=10
+
+[ks_sharded/-80]:
+select name from user where 1 != 1
+begin
+select name from user where id = 10 limit 10001 for update
+commit
+begin
+delete from user where id in (10)
+commit
+
+[ks_sharded/80-]:
+begin
+delete from name_user_map where (name = 'name_val_1' and user_id = 10)
+commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/deletesharded-output.txt
+++ b/data/test/vtexplain/deletesharded-output.txt
@@ -2,17 +2,15 @@
 delete from user where id=10
 
 [ks_sharded/-80]:
+begin
 select name from user where 1 != 1
-begin
 select name from user where id = 10 limit 10001 for update
-commit
-begin
-delete from user where id in (10)
+delete from user where id in (10) /* vtgate:: keyspace_id:594764e1a2b2d98e */
 commit
 
 [ks_sharded/80-]:
 begin
-delete from name_user_map where (name = 'name_val_1' and user_id = 10)
+delete from name_user_map where (name = 'name_val_1' and user_id = 10) /* vtgate:: keyspace_id:a6e89b54b129c33051b76db219595660 */
 commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/deletesharded-queries.sql
+++ b/data/test/vtexplain/deletesharded-queries.sql
@@ -1,0 +1,5 @@
+delete from user where id=10;
+--delete from user where name='billy';
+
+/* not supported - multi-shard delete */
+--delete from user where pet='rover';

--- a/data/test/vtexplain/insertsharded-output.json
+++ b/data/test/vtexplain/insertsharded-output.json
@@ -54,6 +54,7 @@
                     {
                         "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'alice'",
                             "name0": "'alice'",
                             "user_id0": "1"
@@ -62,6 +63,7 @@
                     {
                         "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "1",
                             "_name0": "'alice'",
                             "vtg1": "1",
@@ -71,10 +73,8 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into name_user_map(name, user_id) values ('alice', 1)",
-                    "commit",
-                    "begin",
-                    "insert into user(id, name) values (1, 'alice')",
+                    "insert into name_user_map(name, user_id) values ('alice', 1) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */",
+                    "insert into user(id, name) values (1, 'alice') /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                     "commit"
                 ]
             }
@@ -135,6 +135,7 @@
                     {
                         "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'",
                             "vtg1": "2",
@@ -144,7 +145,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into user(id, name) values (2, 'bob')",
+                    "insert into user(id, name) values (2, 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -153,6 +154,7 @@
                     {
                         "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -161,7 +163,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into name_user_map(name, user_id) values ('bob', 2)",
+                    "insert into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                     "commit"
                 ]
             }
@@ -238,6 +240,7 @@
                     {
                         "SQL": "insert ignore into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'",
                             "vtg1": "2",
@@ -247,7 +250,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into user(id, name) values (2, 'bob')",
+                    "insert ignore into user(id, name) values (2, 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -256,6 +259,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -264,6 +268,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -271,10 +276,10 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                    "commit",
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                     "select name from name_user_map where 1 != 1",
-                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "commit"
                 ]
             }
         }
@@ -350,6 +355,7 @@
                     {
                         "SQL": "insert ignore into user(id, name, nickname) values (:_id0, :_name0, :vtg3) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'",
                             "vtg1": "2",
@@ -360,7 +366,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into user(id, name, nickname) values (2, 'bob', 'bob')",
+                    "insert ignore into user(id, name, nickname) values (2, 'bob', 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -369,6 +375,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -377,6 +384,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -384,9 +392,9 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                    "commit",
-                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "commit"
                 ]
             }
         }
@@ -467,6 +475,7 @@
                     {
                         "SQL": "insert ignore into user(id, name) values (:_id0, :_name0),(:_id1, :_name1) /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_id1": "3",
                             "_name0": "'bob'",
@@ -480,7 +489,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie')",
+                    "insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie') /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */",
                     "commit"
                 ]
             },
@@ -489,6 +498,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0),(:_name1, :user_id1) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b,91f3487c9b6830974afd7308bdf9c10d */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "_name1": "'charlie'",
                             "name0": "'bob'",
@@ -500,6 +510,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -507,6 +518,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'charlie'",
                             "user_id": "3"
                         }
@@ -514,10 +526,10 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3)",
-                    "commit",
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b,91f3487c9b6830974afd7308bdf9c10d */",
                     "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
-                    "select name from name_user_map where name = 'charlie' and user_id = 3 limit 10001"
+                    "select name from name_user_map where name = 'charlie' and user_id = 3 limit 10001",
+                    "commit"
                 ]
             }
         }
@@ -594,6 +606,7 @@
                     {
                         "SQL": "insert into user(id, name, nickname) values (:_id0, :_name0, :vtg3) on duplicate key update nickname = :vtg4 /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'",
                             "vtg1": "2",
@@ -605,7 +618,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into user(id, name, nickname) values (2, 'bob', 'bobby') on duplicate key update nickname = 'bobby'",
+                    "insert into user(id, name, nickname) values (2, 'bob', 'bobby') on duplicate key update nickname = 'bobby' /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -614,6 +627,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -622,6 +636,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -629,9 +644,9 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                    "commit",
-                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "commit"
                 ]
             }
         }
@@ -708,6 +723,7 @@
                     {
                         "SQL": "insert into user(id, name, nickname, address) values (:_id0, :_name0, :vtg3, :vtg4) on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'",
                             "vtg1": "2",
@@ -719,7 +735,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address)",
+                    "insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -728,6 +744,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -736,6 +753,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -743,9 +761,9 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                    "commit",
-                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "commit"
                 ]
             }
         }
@@ -827,6 +845,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name1, :user_id1) /* vtgate:: keyspace_id:2833d31717650107c367cdd51cb7d90c */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "_name1": "'jane'",
                             "name0": "'bob'",
@@ -838,6 +857,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'jane'",
                             "user_id": "3"
                         }
@@ -845,6 +865,7 @@
                     {
                         "SQL": "insert into user(id, name, nickname, address) values (:_id0, :_name0, :vtg3, :vtg4),(:_id1, :_name1, :vtg7, :vtg8) on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_id1": "3",
                             "_name0": "'bob'",
@@ -862,12 +883,10 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('jane', 3)",
-                    "commit",
+                    "insert ignore into name_user_map(name, user_id) values ('jane', 3) /* vtgate:: keyspace_id:2833d31717650107c367cdd51cb7d90c */",
                     "select name from name_user_map where 1 != 1",
                     "select name from name_user_map where name = 'jane' and user_id = 3 limit 10001",
-                    "begin",
-                    "insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st') on duplicate key update nickname = values(nickname), address = values(address)",
+                    "insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */",
                     "commit"
                 ]
             },
@@ -876,6 +895,7 @@
                     {
                         "SQL": "insert ignore into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "_name1": "'jane'",
                             "name0": "'bob'",
@@ -887,6 +907,7 @@
                     {
                         "SQL": "select name from name_user_map where name = :name and user_id = :user_id",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'",
                             "user_id": "2"
                         }
@@ -894,9 +915,9 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert ignore into name_user_map(name, user_id) values ('bob', 2)",
-                    "commit",
-                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001"
+                    "insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
+                    "select name from name_user_map where name = 'bob' and user_id = 2 limit 10001",
+                    "commit"
                 ]
             }
         }

--- a/data/test/vtexplain/insertsharded-output.txt
+++ b/data/test/vtexplain/insertsharded-output.txt
@@ -3,10 +3,8 @@ insert into user (id, name) values(1, 'alice')
 
 [ks_sharded/-80]:
 begin
-insert into name_user_map(name, user_id) values ('alice', 1)
-commit
-begin
-insert into user(id, name) values (1, 'alice')
+insert into name_user_map(name, user_id) values ('alice', 1) /* vtgate:: keyspace_id:475e26c086f437f36bd72ecd883504a7 */
+insert into user(id, name) values (1, 'alice') /* vtgate:: keyspace_id:166b40b44aba4bd6 */
 commit
 
 ----------------------------------------------------------------------
@@ -14,12 +12,12 @@ insert into user (id, name) values(2, 'bob')
 
 [ks_sharded/-80]:
 begin
-insert into user(id, name) values (2, 'bob')
+insert into user(id, name) values (2, 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/80-]:
 begin
-insert into name_user_map(name, user_id) values ('bob', 2)
+insert into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 commit
 
 ----------------------------------------------------------------------
@@ -27,90 +25,88 @@ insert ignore into user (id, name) values(2, 'bob')
 
 [ks_sharded/-80]:
 begin
-insert ignore into user(id, name) values (2, 'bob')
+insert ignore into user(id, name) values (2, 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 select name from name_user_map where 1 != 1
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+commit
 
 ----------------------------------------------------------------------
 insert ignore into user (id, name, nickname) values(2, 'bob', 'bob')
 
 [ks_sharded/-80]:
 begin
-insert ignore into user(id, name, nickname) values (2, 'bob', 'bob')
+insert ignore into user(id, name, nickname) values (2, 'bob', 'bob') /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+commit
 
 ----------------------------------------------------------------------
 insert ignore into user (id, name) values(2, 'bob'),(3, 'charlie')
 
 [ks_sharded/-80]:
 begin
-insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie')
+insert ignore into user(id, name) values (2, 'bob'), (3, 'charlie') /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2), ('charlie', 3) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b,91f3487c9b6830974afd7308bdf9c10d */
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
 select name from name_user_map where name = 'charlie' and user_id = 3 limit 10001
+commit
 
 ----------------------------------------------------------------------
 insert into user (id, name, nickname) values(2, 'bob', 'bobby') on duplicate key update nickname='bobby'
 
 [ks_sharded/-80]:
 begin
-insert into user(id, name, nickname) values (2, 'bob', 'bobby') on duplicate key update nickname = 'bobby'
+insert into user(id, name, nickname) values (2, 'bob', 'bobby') on duplicate key update nickname = 'bobby' /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+commit
 
 ----------------------------------------------------------------------
 insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 main st') on duplicate key update nickname=values(nickname), address=values(address)
 
 [ks_sharded/-80]:
 begin
-insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address)
+insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+commit
 
 ----------------------------------------------------------------------
 insert into user (id, name, nickname, address) values(2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st')on duplicate key update nickname=values(nickname), address=values(address)
 
 [ks_sharded/-80]:
 begin
-insert ignore into name_user_map(name, user_id) values ('jane', 3)
-commit
+insert ignore into name_user_map(name, user_id) values ('jane', 3) /* vtgate:: keyspace_id:2833d31717650107c367cdd51cb7d90c */
 select name from name_user_map where 1 != 1
 select name from name_user_map where name = 'jane' and user_id = 3 limit 10001
-begin
-insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st') on duplicate key update nickname = values(nickname), address = values(address)
+insert into user(id, name, nickname, address) values (2, 'bob', 'bobby', '123 main st'), (3, 'jane', 'janie', '456 elm st') on duplicate key update nickname = values(nickname), address = values(address) /* vtgate:: keyspace_id:06e7ea22ce92708f,4eb190c9a2fa169c */
 commit
 
 [ks_sharded/80-]:
 begin
-insert ignore into name_user_map(name, user_id) values ('bob', 2)
-commit
+insert ignore into name_user_map(name, user_id) values ('bob', 2) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 select name from name_user_map where name = 'bob' and user_id = 2 limit 10001
+commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/options-output.json
+++ b/data/test/vtexplain/options-output.json
@@ -20,7 +20,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user where email = 'null@void.com'",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -32,7 +34,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user where email = 'null@void.com'",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -44,7 +48,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user where email = 'null@void.com'",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -56,7 +62,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user where email = 'null@void.com'",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -101,6 +109,7 @@
                     {
                         "SQL": "select * from user where id in ::__vals",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "__vals": "(1, 2)"
                         }
                     }
@@ -115,6 +124,7 @@
                     {
                         "SQL": "select * from user where id in ::__vals",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "__vals": "(3, 5)"
                         }
                     }
@@ -129,6 +139,7 @@
                     {
                         "SQL": "select * from user where id in ::__vals",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "__vals": "(4, 6, 7, 8)"
                         }
                     }
@@ -195,6 +206,7 @@
                     {
                         "SQL": "insert into user(id, name) values (:_id0, :_name0) /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_id0": "2",
                             "_name0": "'bob'"
                         }
@@ -202,7 +214,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */",
+                    "insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */ /* vtgate:: keyspace_id:06e7ea22ce92708f */",
                     "commit"
                 ]
             },
@@ -211,6 +223,7 @@
                     {
                         "SQL": "insert into name_user_map(name, user_id) values (:_name0, :user_id0) /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "_name0": "'bob'",
                             "name0": "'bob'",
                             "user_id0": "2"
@@ -219,7 +232,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */",
+                    "insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */ /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */",
                     "commit"
                 ]
             }

--- a/data/test/vtexplain/options-output.txt
+++ b/data/test/vtexplain/options-output.txt
@@ -37,12 +37,12 @@ insert into user (id, name) values(2, 'bob')
 
 [ks_sharded/-40]:
 begin
-insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */
+insert into user(id, name) values (2, 'bob') /* _stream user (id ) (2 ); */ /* vtgate:: keyspace_id:06e7ea22ce92708f */
 commit
 
 [ks_sharded/c0-]:
 begin
-insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */
+insert into name_user_map(name, user_id) values ('bob', 2) /* _stream name_user_map (name user_id ) ('Ym9i' 2 ); */ /* vtgate:: keyspace_id:da8a82595aa28154c17717955ffeed8b */
 commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/selectsharded-output.json
+++ b/data/test/vtexplain/selectsharded-output.json
@@ -20,24 +20,28 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from user /* scatter */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user limit 10001"
+                    "select * from user limit 10001 /* scatter */"
                 ]
             },
             "ks_sharded/80-": {
                 "TabletQueries": [
                     {
                         "SQL": "select * from user /* scatter */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user limit 10001"
+                    "select * from user limit 10001 /* scatter */"
                 ]
             }
         }
@@ -68,13 +72,14 @@
                     {
                         "SQL": "select * from user where id = :vtg1 /* equal unique */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where id = 1 limit 10001"
+                    "select * from user where id = 1 limit 10001 /* equal unique */"
                 ]
             }
         }
@@ -101,13 +106,14 @@
                     {
                         "SQL": "select * from user where id > :vtg1 /* scatter range */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "100"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where id > 100 limit 10001"
+                    "select * from user where id > 100 limit 10001 /* scatter range */"
                 ]
             },
             "ks_sharded/80-": {
@@ -115,13 +121,14 @@
                     {
                         "SQL": "select * from user where id > :vtg1 /* scatter range */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "100"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where id > 100 limit 10001"
+                    "select * from user where id > 100 limit 10001 /* scatter range */"
                 ]
             }
         }
@@ -168,13 +175,14 @@
                     {
                         "SQL": "select * from user where name = :vtg1/* vindex lookup */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "'bob'"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where name = 'bob' limit 10001"
+                    "select * from user where name = 'bob' limit 10001/* vindex lookup */"
                 ]
             },
             "ks_sharded/80-": {
@@ -182,13 +190,14 @@
                     {
                         "SQL": "select user_id from name_user_map where name = :name/* vindex lookup */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select user_id from name_user_map where 1 != 1",
-                    "select user_id from name_user_map where name = 'bob' limit 10001"
+                    "select user_id from name_user_map where name = 'bob' limit 10001/* vindex lookup */"
                 ]
             }
         }
@@ -215,13 +224,14 @@
                     {
                         "SQL": "select * from user where (name = :vtg1 or nickname = :vtg1)/* vindex lookup */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "'bob'"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where (name = 'bob' or nickname = 'bob') limit 10001"
+                    "select * from user where (name = 'bob' or nickname = 'bob') limit 10001/* vindex lookup */"
                 ]
             },
             "ks_sharded/80-": {
@@ -229,13 +239,14 @@
                     {
                         "SQL": "select * from user where (name = :vtg1 or nickname = :vtg1)/* vindex lookup */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "'bob'"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from user where 1 != 1",
-                    "select * from user where (name = 'bob' or nickname = 'bob') limit 10001"
+                    "select * from user where (name = 'bob' or nickname = 'bob') limit 10001/* vindex lookup */"
                 ]
             }
         }
@@ -289,39 +300,45 @@
                 "TabletQueries": [
                     {
                         "SQL": "select u.id, u.name, u.nickname from user as u /* join on varchar */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     },
                     {
                         "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "u_name": "'name_val_2'"
                         }
                     },
                     {
                         "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "u_name": "'name_val_2'"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select u.id, u.name, u.nickname from user as u where 1 != 1",
-                    "select u.id, u.name, u.nickname from user as u limit 10001",
+                    "select u.id, u.name, u.nickname from user as u limit 10001 /* join on varchar */",
                     "select n.info from name_info as n where 1 != 1",
-                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001",
-                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001"
+                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001 /* join on varchar */",
+                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001 /* join on varchar */"
                 ]
             },
             "ks_sharded/80-": {
                 "TabletQueries": [
                     {
                         "SQL": "select u.id, u.name, u.nickname from user as u /* join on varchar */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select u.id, u.name, u.nickname from user as u where 1 != 1",
-                    "select u.id, u.name, u.nickname from user as u limit 10001"
+                    "select u.id, u.name, u.nickname from user as u limit 10001 /* join on varchar */"
                 ]
             }
         }
@@ -379,6 +396,7 @@
                     {
                         "SQL": "select e.extra from music_extra as e where e.id = :m_id /* join on int */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "m_id": "1",
                             "vtg1": "100"
                         }
@@ -386,7 +404,7 @@
                 ],
                 "MysqlQueries": [
                     "select e.extra from music_extra as e where 1 != 1",
-                    "select e.extra from music_extra as e where e.id = 1 limit 10001"
+                    "select e.extra from music_extra as e where e.id = 1 limit 10001 /* join on int */"
                 ]
             },
             "ks_sharded/80-": {
@@ -394,13 +412,14 @@
                     {
                         "SQL": "select m.id, m.song from music as m where m.user_id = :vtg1 /* join on int */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "100"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select m.id, m.song from music as m where 1 != 1",
-                    "select m.id, m.song from music as m where m.user_id = 100 limit 10001"
+                    "select m.id, m.song from music as m where m.user_id = 100 limit 10001 /* join on int */"
                 ]
             }
         }
@@ -431,13 +450,14 @@
                     {
                         "SQL": "select count(*) from user where id = :vtg1 /* point aggregate */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1"
                         }
                     }
                 ],
                 "MysqlQueries": [
                     "select count(*) from user where 1 != 1",
-                    "select count(*) from user where id = 1 limit 10001"
+                    "select count(*) from user where id = 1 limit 10001 /* point aggregate */"
                 ]
             }
         }
@@ -493,12 +513,14 @@
                     {
                         "SQL": "select user_id from name_user_map where name = :name /* scatter aggregate */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'alice'"
                         }
                     },
                     {
                         "SQL": "select count(*) from user where name in ::__vals /* scatter aggregate */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "__vals": "('alice', 'bob')",
                             "vtg1": "('alice', 'bob')"
                         }
@@ -506,9 +528,9 @@
                 ],
                 "MysqlQueries": [
                     "select user_id from name_user_map where 1 != 1",
-                    "select user_id from name_user_map where name = 'alice' limit 10001",
+                    "select user_id from name_user_map where name = 'alice' limit 10001 /* scatter aggregate */",
                     "select count(*) from user where 1 != 1",
-                    "select count(*) from user where name in ('alice', 'bob') limit 10001"
+                    "select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */"
                 ]
             },
             "ks_sharded/80-": {
@@ -516,13 +538,13 @@
                     {
                         "SQL": "select user_id from name_user_map where name = :name /* scatter aggregate */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'bob'"
                         }
                     }
                 ],
                 "MysqlQueries": [
-                    "select user_id from name_user_map where 1 != 1",
-                    "select user_id from name_user_map where name = 'bob' limit 10001"
+                    "select user_id from name_user_map where name = 'bob' limit 10001 /* scatter aggregate */"
                 ]
             }
         }
@@ -548,24 +570,28 @@
                 "TabletQueries": [
                     {
                         "SQL": "select name, count(*) from user group by name /* scatter aggregate */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select name, count(*) from user where 1 != 1 group by name",
-                    "select name, count(*) from user group by name limit 10001"
+                    "select name, count(*) from user group by name limit 10001 /* scatter aggregate */"
                 ]
             },
             "ks_sharded/80-": {
                 "TabletQueries": [
                     {
                         "SQL": "select name, count(*) from user group by name /* scatter aggregate */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select name, count(*) from user where 1 != 1 group by name",
-                    "select name, count(*) from user group by name limit 10001"
+                    "select name, count(*) from user group by name limit 10001 /* scatter aggregate */"
                 ]
             }
         }
@@ -596,6 +622,7 @@
                     {
                         "SQL": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4 /* select constant sql values */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1",
                             "vtg2": "'hello'",
                             "vtg3": "3.14",
@@ -604,7 +631,7 @@
                     }
                 ],
                 "MysqlQueries": [
-                    "select 1, 'hello', 3.14 from user limit 10"
+                    "select 1, 'hello', 3.14 from user limit 10 /* select constant sql values */"
                 ]
             },
             "ks_sharded/80-": {
@@ -612,6 +639,7 @@
                     {
                         "SQL": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4 /* select constant sql values */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1",
                             "vtg2": "'hello'",
                             "vtg3": "3.14",
@@ -620,7 +648,7 @@
                     }
                 ],
                 "MysqlQueries": [
-                    "select 1, 'hello', 3.14 from user limit 10"
+                    "select 1, 'hello', 3.14 from user limit 10 /* select constant sql values */"
                 ]
             }
         }
@@ -646,24 +674,28 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from (select id from user) as s /* scatter paren select */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from (select id from user where 1 != 1) as s where 1 != 1",
-                    "select * from (select id from user) as s limit 10001"
+                    "select * from (select id from user) as s limit 10001 /* scatter paren select */"
                 ]
             },
             "ks_sharded/80-": {
                 "TabletQueries": [
                     {
                         "SQL": "select * from (select id from user) as s /* scatter paren select */",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
                     "select * from (select id from user where 1 != 1) as s where 1 != 1",
-                    "select * from (select id from user) as s limit 10001"
+                    "select * from (select id from user) as s limit 10001 /* scatter paren select */"
                 ]
             }
         }

--- a/data/test/vtexplain/selectsharded-output.json
+++ b/data/test/vtexplain/selectsharded-output.json
@@ -148,7 +148,7 @@
             {
                 "Original": "select * from user where name = :vtg1",
                 "Instructions": {
-                    "Opcode": "SelectEqual",
+                    "Opcode": "SelectEqualUnique",
                     "Keyspace": {
                         "Name": "ks_sharded",
                         "Sharded": true
@@ -241,10 +241,10 @@
         }
     },
     {
-        "SQL": "select u.name, n.info from user u join name_info n on u.name = n.name /* join on varchar */",
+        "SQL": "select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */",
         "Plans": [
             {
-                "Original": "select u.name, n.info from user as u join name_info as n on u.name = n.name",
+                "Original": "select u.id, u.name, u.nickname, n.info from user as u join name_info as n on u.name = n.name",
                 "Instructions": {
                     "Opcode": "Join",
                     "Left": {
@@ -253,8 +253,8 @@
                             "Name": "ks_sharded",
                             "Sharded": true
                         },
-                        "Query": "select u.name from user as u",
-                        "FieldQuery": "select u.name from user as u where 1 != 1"
+                        "Query": "select u.id, u.name, u.nickname from user as u",
+                        "FieldQuery": "select u.id, u.name, u.nickname from user as u where 1 != 1"
                     },
                     "Right": {
                         "Opcode": "SelectEqualUnique",
@@ -274,10 +274,12 @@
                     },
                     "Cols": [
                         -1,
+                        -2,
+                        -3,
                         1
                     ],
                     "Vars": {
-                        "u_name": 0
+                        "u_name": 1
                     }
                 }
             }
@@ -286,40 +288,40 @@
             "ks_sharded/-80": {
                 "TabletQueries": [
                     {
-                        "SQL": "select u.name from user as u /* join on varchar */",
+                        "SQL": "select u.id, u.name, u.nickname from user as u /* join on varchar */",
                         "BindVars": {}
+                    },
+                    {
+                        "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
+                        "BindVars": {
+                            "u_name": "'name_val_2'"
+                        }
+                    },
+                    {
+                        "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
+                        "BindVars": {
+                            "u_name": "'name_val_2'"
+                        }
                     }
                 ],
                 "MysqlQueries": [
-                    "select u.name from user as u where 1 != 1",
-                    "select u.name from user as u limit 10001"
+                    "select u.id, u.name, u.nickname from user as u where 1 != 1",
+                    "select u.id, u.name, u.nickname from user as u limit 10001",
+                    "select n.info from name_info as n where 1 != 1",
+                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001",
+                    "select n.info from name_info as n where n.name = 'name_val_2' limit 10001"
                 ]
             },
             "ks_sharded/80-": {
                 "TabletQueries": [
                     {
-                        "SQL": "select u.name from user as u /* join on varchar */",
+                        "SQL": "select u.id, u.name, u.nickname from user as u /* join on varchar */",
                         "BindVars": {}
-                    },
-                    {
-                        "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
-                        "BindVars": {
-                            "u_name": "1"
-                        }
-                    },
-                    {
-                        "SQL": "select n.info from name_info as n where n.name = :u_name /* join on varchar */",
-                        "BindVars": {
-                            "u_name": "1"
-                        }
                     }
                 ],
                 "MysqlQueries": [
-                    "select u.name from user as u where 1 != 1",
-                    "select u.name from user as u limit 10001",
-                    "select n.info from name_info as n where 1 != 1",
-                    "select n.info from name_info as n where n.name = 1 limit 10001",
-                    "select n.info from name_info as n where n.name = 1 limit 10001"
+                    "select u.id, u.name, u.nickname from user as u where 1 != 1",
+                    "select u.id, u.name, u.nickname from user as u limit 10001"
                 ]
             }
         }
@@ -399,6 +401,269 @@
                 "MysqlQueries": [
                     "select m.id, m.song from music as m where 1 != 1",
                     "select m.id, m.song from music as m where m.user_id = 100 limit 10001"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "select count(*) from user where id = 1 /* point aggregate */",
+        "Plans": [
+            {
+                "Original": "select count(*) from user where id = :vtg1",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select count(*) from user where id = :vtg1",
+                    "FieldQuery": "select count(*) from user where 1 != 1",
+                    "Vindex": "hash",
+                    "Values": [
+                        ":vtg1"
+                    ]
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select count(*) from user where id = :vtg1 /* point aggregate */",
+                        "BindVars": {
+                            "vtg1": "1"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select count(*) from user where 1 != 1",
+                    "select count(*) from user where id = 1 limit 10001"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "select count(*) from user where name in ('alice','bob') /* scatter aggregate */",
+        "Plans": [
+            {
+                "Original": "select user_id from name_user_map where name = :name",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select user_id from name_user_map where name = :name",
+                    "FieldQuery": "select user_id from name_user_map where 1 != 1",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
+                    ]
+                }
+            },
+            {
+                "Original": "select count(*) from user where name in ::vtg1",
+                "Instructions": {
+                    "Aggregates": [
+                        {
+                            "Opcode": "count",
+                            "Col": 0
+                        }
+                    ],
+                    "Keys": null,
+                    "Input": {
+                        "Opcode": "SelectIN",
+                        "Keyspace": {
+                            "Name": "ks_sharded",
+                            "Sharded": true
+                        },
+                        "Query": "select count(*) from user where name in ::__vals",
+                        "FieldQuery": "select count(*) from user where 1 != 1",
+                        "Vindex": "name_user_map",
+                        "Values": [
+                            "::vtg1"
+                        ]
+                    }
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select user_id from name_user_map where name = :name /* scatter aggregate */",
+                        "BindVars": {
+                            "name": "'alice'"
+                        }
+                    },
+                    {
+                        "SQL": "select count(*) from user where name in ::__vals /* scatter aggregate */",
+                        "BindVars": {
+                            "__vals": "('alice', 'bob')",
+                            "vtg1": "('alice', 'bob')"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select user_id from name_user_map where 1 != 1",
+                    "select user_id from name_user_map where name = 'alice' limit 10001",
+                    "select count(*) from user where 1 != 1",
+                    "select count(*) from user where name in ('alice', 'bob') limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select user_id from name_user_map where name = :name /* scatter aggregate */",
+                        "BindVars": {
+                            "name": "'bob'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select user_id from name_user_map where 1 != 1",
+                    "select user_id from name_user_map where name = 'bob' limit 10001"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "select name, count(*) from user group by name /* scatter aggregate */",
+        "Plans": [
+            {
+                "Original": "select name, count(*) from user group by name",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select name, count(*) from user group by name",
+                    "FieldQuery": "select name, count(*) from user where 1 != 1 group by name"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select name, count(*) from user group by name /* scatter aggregate */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select name, count(*) from user where 1 != 1 group by name",
+                    "select name, count(*) from user group by name limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select name, count(*) from user group by name /* scatter aggregate */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select name, count(*) from user where 1 != 1 group by name",
+                    "select name, count(*) from user group by name limit 10001"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "select 1, \"hello\", 3.14 from user limit 10 /* select constant sql values */",
+        "Plans": [
+            {
+                "Original": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4",
+                "Instructions": {
+                    "Opcode": "Limit",
+                    "Count": ":vtg4",
+                    "Input": {
+                        "Opcode": "SelectScatter",
+                        "Keyspace": {
+                            "Name": "ks_sharded",
+                            "Sharded": true
+                        },
+                        "Query": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4",
+                        "FieldQuery": "select :vtg1, :vtg2, :vtg3 from user where 1 != 1"
+                    }
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4 /* select constant sql values */",
+                        "BindVars": {
+                            "vtg1": "1",
+                            "vtg2": "'hello'",
+                            "vtg3": "3.14",
+                            "vtg4": "10"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select 1, 'hello', 3.14 from user limit 10"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select :vtg1, :vtg2, :vtg3 from user limit :vtg4 /* select constant sql values */",
+                        "BindVars": {
+                            "vtg1": "1",
+                            "vtg2": "'hello'",
+                            "vtg3": "3.14",
+                            "vtg4": "10"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select 1, 'hello', 3.14 from user limit 10"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "select * from (select id from user) s /* scatter paren select */",
+        "Plans": [
+            {
+                "Original": "select * from (select id from user) as s",
+                "Instructions": {
+                    "Opcode": "SelectScatter",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select * from (select id from user) as s",
+                    "FieldQuery": "select * from (select id from user where 1 != 1) as s where 1 != 1"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from (select id from user) as s /* scatter paren select */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from (select id from user where 1 != 1) as s where 1 != 1",
+                    "select * from (select id from user) as s limit 10001"
+                ]
+            },
+            "ks_sharded/80-": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select * from (select id from user) as s /* scatter paren select */",
+                        "BindVars": {}
+                    }
+                ],
+                "MysqlQueries": [
+                    "select * from (select id from user where 1 != 1) as s where 1 != 1",
+                    "select * from (select id from user) as s limit 10001"
                 ]
             }
         }

--- a/data/test/vtexplain/selectsharded-output.txt
+++ b/data/test/vtexplain/selectsharded-output.txt
@@ -3,126 +3,125 @@ select * from user /* scatter */
 
 [ks_sharded/-80]:
 select * from user where 1 != 1
-select * from user limit 10001
+select * from user limit 10001 /* scatter */
 
 [ks_sharded/80-]:
 select * from user where 1 != 1
-select * from user limit 10001
+select * from user limit 10001 /* scatter */
 
 ----------------------------------------------------------------------
 select * from user where id = 1 /* equal unique */
 
 [ks_sharded/-80]:
 select * from user where 1 != 1
-select * from user where id = 1 limit 10001
+select * from user where id = 1 limit 10001 /* equal unique */
 
 ----------------------------------------------------------------------
 select * from user where id > 100 /* scatter range */
 
 [ks_sharded/-80]:
 select * from user where 1 != 1
-select * from user where id > 100 limit 10001
+select * from user where id > 100 limit 10001 /* scatter range */
 
 [ks_sharded/80-]:
 select * from user where 1 != 1
-select * from user where id > 100 limit 10001
+select * from user where id > 100 limit 10001 /* scatter range */
 
 ----------------------------------------------------------------------
 select * from user where name = 'bob'/* vindex lookup */
 
 [ks_sharded/-80]:
 select * from user where 1 != 1
-select * from user where name = 'bob' limit 10001
+select * from user where name = 'bob' limit 10001/* vindex lookup */
 
 [ks_sharded/80-]:
 select user_id from name_user_map where 1 != 1
-select user_id from name_user_map where name = 'bob' limit 10001
+select user_id from name_user_map where name = 'bob' limit 10001/* vindex lookup */
 
 ----------------------------------------------------------------------
 select * from user where name = 'bob' or nickname = 'bob'/* vindex lookup */
 
 [ks_sharded/-80]:
 select * from user where 1 != 1
-select * from user where (name = 'bob' or nickname = 'bob') limit 10001
+select * from user where (name = 'bob' or nickname = 'bob') limit 10001/* vindex lookup */
 
 [ks_sharded/80-]:
 select * from user where 1 != 1
-select * from user where (name = 'bob' or nickname = 'bob') limit 10001
+select * from user where (name = 'bob' or nickname = 'bob') limit 10001/* vindex lookup */
 
 ----------------------------------------------------------------------
 select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */
 
 [ks_sharded/-80]:
 select u.id, u.name, u.nickname from user as u where 1 != 1
-select u.id, u.name, u.nickname from user as u limit 10001
+select u.id, u.name, u.nickname from user as u limit 10001 /* join on varchar */
 select n.info from name_info as n where 1 != 1
-select n.info from name_info as n where n.name = 'name_val_2' limit 10001
-select n.info from name_info as n where n.name = 'name_val_2' limit 10001
+select n.info from name_info as n where n.name = 'name_val_2' limit 10001 /* join on varchar */
+select n.info from name_info as n where n.name = 'name_val_2' limit 10001 /* join on varchar */
 
 [ks_sharded/80-]:
 select u.id, u.name, u.nickname from user as u where 1 != 1
-select u.id, u.name, u.nickname from user as u limit 10001
+select u.id, u.name, u.nickname from user as u limit 10001 /* join on varchar */
 
 ----------------------------------------------------------------------
 select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id where m.user_id = 100 /* join on int */
 
 [ks_sharded/-80]:
 select e.extra from music_extra as e where 1 != 1
-select e.extra from music_extra as e where e.id = 1 limit 10001
+select e.extra from music_extra as e where e.id = 1 limit 10001 /* join on int */
 
 [ks_sharded/80-]:
 select m.id, m.song from music as m where 1 != 1
-select m.id, m.song from music as m where m.user_id = 100 limit 10001
+select m.id, m.song from music as m where m.user_id = 100 limit 10001 /* join on int */
 
 ----------------------------------------------------------------------
 select count(*) from user where id = 1 /* point aggregate */
 
 [ks_sharded/-80]:
 select count(*) from user where 1 != 1
-select count(*) from user where id = 1 limit 10001
+select count(*) from user where id = 1 limit 10001 /* point aggregate */
 
 ----------------------------------------------------------------------
 select count(*) from user where name in ('alice','bob') /* scatter aggregate */
 
 [ks_sharded/-80]:
 select user_id from name_user_map where 1 != 1
-select user_id from name_user_map where name = 'alice' limit 10001
+select user_id from name_user_map where name = 'alice' limit 10001 /* scatter aggregate */
 select count(*) from user where 1 != 1
-select count(*) from user where name in ('alice', 'bob') limit 10001
+select count(*) from user where name in ('alice', 'bob') limit 10001 /* scatter aggregate */
 
 [ks_sharded/80-]:
-select user_id from name_user_map where 1 != 1
-select user_id from name_user_map where name = 'bob' limit 10001
+select user_id from name_user_map where name = 'bob' limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select name, count(*) from user group by name /* scatter aggregate */
 
 [ks_sharded/-80]:
 select name, count(*) from user where 1 != 1 group by name
-select name, count(*) from user group by name limit 10001
+select name, count(*) from user group by name limit 10001 /* scatter aggregate */
 
 [ks_sharded/80-]:
 select name, count(*) from user where 1 != 1 group by name
-select name, count(*) from user group by name limit 10001
+select name, count(*) from user group by name limit 10001 /* scatter aggregate */
 
 ----------------------------------------------------------------------
 select 1, "hello", 3.14 from user limit 10 /* select constant sql values */
 
 [ks_sharded/-80]:
-select 1, 'hello', 3.14 from user limit 10
+select 1, 'hello', 3.14 from user limit 10 /* select constant sql values */
 
 [ks_sharded/80-]:
-select 1, 'hello', 3.14 from user limit 10
+select 1, 'hello', 3.14 from user limit 10 /* select constant sql values */
 
 ----------------------------------------------------------------------
 select * from (select id from user) s /* scatter paren select */
 
 [ks_sharded/-80]:
 select * from (select id from user where 1 != 1) as s where 1 != 1
-select * from (select id from user) as s limit 10001
+select * from (select id from user) as s limit 10001 /* scatter paren select */
 
 [ks_sharded/80-]:
 select * from (select id from user where 1 != 1) as s where 1 != 1
-select * from (select id from user) as s limit 10001
+select * from (select id from user) as s limit 10001 /* scatter paren select */
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/selectsharded-output.txt
+++ b/data/test/vtexplain/selectsharded-output.txt
@@ -50,18 +50,18 @@ select * from user where 1 != 1
 select * from user where (name = 'bob' or nickname = 'bob') limit 10001
 
 ----------------------------------------------------------------------
-select u.name, n.info from user u join name_info n on u.name = n.name /* join on varchar */
+select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */
 
 [ks_sharded/-80]:
-select u.name from user as u where 1 != 1
-select u.name from user as u limit 10001
+select u.id, u.name, u.nickname from user as u where 1 != 1
+select u.id, u.name, u.nickname from user as u limit 10001
+select n.info from name_info as n where 1 != 1
+select n.info from name_info as n where n.name = 'name_val_2' limit 10001
+select n.info from name_info as n where n.name = 'name_val_2' limit 10001
 
 [ks_sharded/80-]:
-select u.name from user as u where 1 != 1
-select u.name from user as u limit 10001
-select n.info from name_info as n where 1 != 1
-select n.info from name_info as n where n.name = 1 limit 10001
-select n.info from name_info as n where n.name = 1 limit 10001
+select u.id, u.name, u.nickname from user as u where 1 != 1
+select u.id, u.name, u.nickname from user as u limit 10001
 
 ----------------------------------------------------------------------
 select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id where m.user_id = 100 /* join on int */
@@ -73,5 +73,56 @@ select e.extra from music_extra as e where e.id = 1 limit 10001
 [ks_sharded/80-]:
 select m.id, m.song from music as m where 1 != 1
 select m.id, m.song from music as m where m.user_id = 100 limit 10001
+
+----------------------------------------------------------------------
+select count(*) from user where id = 1 /* point aggregate */
+
+[ks_sharded/-80]:
+select count(*) from user where 1 != 1
+select count(*) from user where id = 1 limit 10001
+
+----------------------------------------------------------------------
+select count(*) from user where name in ('alice','bob') /* scatter aggregate */
+
+[ks_sharded/-80]:
+select user_id from name_user_map where 1 != 1
+select user_id from name_user_map where name = 'alice' limit 10001
+select count(*) from user where 1 != 1
+select count(*) from user where name in ('alice', 'bob') limit 10001
+
+[ks_sharded/80-]:
+select user_id from name_user_map where 1 != 1
+select user_id from name_user_map where name = 'bob' limit 10001
+
+----------------------------------------------------------------------
+select name, count(*) from user group by name /* scatter aggregate */
+
+[ks_sharded/-80]:
+select name, count(*) from user where 1 != 1 group by name
+select name, count(*) from user group by name limit 10001
+
+[ks_sharded/80-]:
+select name, count(*) from user where 1 != 1 group by name
+select name, count(*) from user group by name limit 10001
+
+----------------------------------------------------------------------
+select 1, "hello", 3.14 from user limit 10 /* select constant sql values */
+
+[ks_sharded/-80]:
+select 1, 'hello', 3.14 from user limit 10
+
+[ks_sharded/80-]:
+select 1, 'hello', 3.14 from user limit 10
+
+----------------------------------------------------------------------
+select * from (select id from user) s /* scatter paren select */
+
+[ks_sharded/-80]:
+select * from (select id from user where 1 != 1) as s where 1 != 1
+select * from (select id from user) as s limit 10001
+
+[ks_sharded/80-]:
+select * from (select id from user where 1 != 1) as s where 1 != 1
+select * from (select id from user) as s limit 10001
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/selectsharded-queries.sql
+++ b/data/test/vtexplain/selectsharded-queries.sql
@@ -3,5 +3,13 @@ select * from user where id = 1 /* equal unique */;
 select * from user where id > 100 /* scatter range */;
 select * from user where name = 'bob'/* vindex lookup */;
 select * from user where name = 'bob' or nickname = 'bob'/* vindex lookup */;
-select u.name, n.info from user u join name_info n on u.name = n.name /* join on varchar */;
+
+select u.id, u.name, u.nickname, n.info from user u join name_info n on u.name = n.name /* join on varchar */;
 select m.id, m.song, e.extra from music m join music_extra e on m.id = e.id where m.user_id = 100 /* join on int */;
+
+select count(*) from user where id = 1 /* point aggregate */;
+select count(*) from user where name in ('alice','bob') /* scatter aggregate */;
+select name, count(*) from user group by name /* scatter aggregate */;
+
+select 1, "hello", 3.14 from user limit 10 /* select constant sql values */;
+select * from (select id from user) s /* scatter paren select */;

--- a/data/test/vtexplain/test-schema.sql
+++ b/data/test/vtexplain/test-schema.sql
@@ -8,6 +8,8 @@ create table user (
 	id bigint,
 	name varchar(64),
 	email varchar(64),
+	nickname varchar(64),
+	pet varchar(64),
 	primary key (id)
 ) Engine=InnoDB;
 

--- a/data/test/vtexplain/test-vschema.json
+++ b/data/test/vtexplain/test-vschema.json
@@ -19,7 +19,7 @@
 				}
 			},
 			"name_user_map": {
-				"type": "lookup_hash",
+				"type": "lookup_hash_unique",
 				"owner": "user",
 				"params": {
 					"table": "name_user_map",

--- a/data/test/vtexplain/unsharded-output.json
+++ b/data/test/vtexplain/unsharded-output.json
@@ -20,7 +20,9 @@
                 "TabletQueries": [
                     {
                         "SQL": "select * from t1",
-                        "BindVars": {}
+                        "BindVars": {
+                            "#maxLimit": "10001"
+                        }
                     }
                 ],
                 "MysqlQueries": [
@@ -52,6 +54,7 @@
                     {
                         "SQL": "insert into t1(id, val) values (:vtg1, :vtg2)",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1",
                             "vtg2": "2"
                         }
@@ -86,6 +89,7 @@
                     {
                         "SQL": "update t1 set val = :vtg1",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "10"
                         }
                     }
@@ -120,6 +124,7 @@
                     {
                         "SQL": "delete from t1 where id = :vtg1",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "100"
                         }
                     }
@@ -154,6 +159,7 @@
                     {
                         "SQL": "insert into t1(id, val) values (:vtg1, :vtg2) on duplicate key update val = :vtg3",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "1",
                             "vtg2": "2",
                             "vtg3": "3"

--- a/data/test/vtexplain/updatesharded-output.json
+++ b/data/test/vtexplain/updatesharded-output.json
@@ -1,0 +1,143 @@
+[
+    {
+        "SQL": "update user set nickname='alice' where id=1",
+        "Plans": [
+            {
+                "Original": "update user set nickname = :vtg1 where id = :vtg2",
+                "Instructions": {
+                    "Opcode": "UpdateEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "update user set nickname = :vtg1 where id = :vtg2",
+                    "Vindex": "hash",
+                    "Values": [
+                        ":vtg2"
+                    ],
+                    "Table": "user"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "update user set nickname = :vtg1 where id = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                        "BindVars": {
+                            "vtg1": "'alice'",
+                            "vtg2": "1"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "update user set nickname = 'alice' where id in (1)",
+                    "commit"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "update user set nickname='alice' where name='alice'",
+        "Plans": [
+            {
+                "Original": "select user_id from name_user_map where name = :name",
+                "Instructions": {
+                    "Opcode": "SelectEqualUnique",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "select user_id from name_user_map where name = :name",
+                    "FieldQuery": "select user_id from name_user_map where 1 != 1",
+                    "Vindex": "md5",
+                    "Values": [
+                        ":name"
+                    ]
+                }
+            },
+            {
+                "Original": "update user set nickname = :vtg1 where name = :vtg1",
+                "Instructions": {
+                    "Opcode": "UpdateEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "update user set nickname = :vtg1 where name = :vtg1",
+                    "Vindex": "name_user_map",
+                    "Values": [
+                        ":vtg1"
+                    ],
+                    "Table": "user"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "select user_id from name_user_map where name = :name",
+                        "BindVars": {
+                            "name": "'alice'"
+                        }
+                    },
+                    {
+                        "SQL": "update user set nickname = :vtg1 where name = :vtg1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                        "BindVars": {
+                            "vtg1": "'alice'"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "select user_id from name_user_map where 1 != 1",
+                    "select user_id from name_user_map where name = 'alice' limit 10001",
+                    "begin",
+                    "select id from user where name = 'alice' limit 10001 for update",
+                    "update user set nickname = 'alice' where id in (1)",
+                    "commit"
+                ]
+            }
+        }
+    },
+    {
+        "SQL": "update user set pet='fido' where id=1",
+        "Plans": [
+            {
+                "Original": "update user set pet = :vtg1 where id = :vtg2",
+                "Instructions": {
+                    "Opcode": "UpdateEqual",
+                    "Keyspace": {
+                        "Name": "ks_sharded",
+                        "Sharded": true
+                    },
+                    "Query": "update user set pet = :vtg1 where id = :vtg2",
+                    "Vindex": "hash",
+                    "Values": [
+                        ":vtg2"
+                    ],
+                    "Table": "user"
+                }
+            }
+        ],
+        "TabletActions": {
+            "ks_sharded/-80": {
+                "TabletQueries": [
+                    {
+                        "SQL": "update user set pet = :vtg1 where id = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                        "BindVars": {
+                            "vtg1": "'fido'",
+                            "vtg2": "1"
+                        }
+                    }
+                ],
+                "MysqlQueries": [
+                    "begin",
+                    "update user set pet = 'fido' where id in (1)",
+                    "commit"
+                ]
+            }
+        }
+    }
+]

--- a/data/test/vtexplain/updatesharded-output.json
+++ b/data/test/vtexplain/updatesharded-output.json
@@ -25,6 +25,7 @@
                     {
                         "SQL": "update user set nickname = :vtg1 where id = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "'alice'",
                             "vtg2": "1"
                         }
@@ -32,7 +33,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "update user set nickname = 'alice' where id in (1)",
+                    "update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                     "commit"
                 ]
             }
@@ -58,17 +59,17 @@
                 }
             },
             {
-                "Original": "update user set nickname = :vtg1 where name = :vtg1",
+                "Original": "update user set nickname = :vtg1 where name = :vtg2",
                 "Instructions": {
                     "Opcode": "UpdateEqual",
                     "Keyspace": {
                         "Name": "ks_sharded",
                         "Sharded": true
                     },
-                    "Query": "update user set nickname = :vtg1 where name = :vtg1",
+                    "Query": "update user set nickname = :vtg1 where name = :vtg2",
                     "Vindex": "name_user_map",
                     "Values": [
-                        ":vtg1"
+                        ":vtg2"
                     ],
                     "Table": "user"
                 }
@@ -80,22 +81,25 @@
                     {
                         "SQL": "select user_id from name_user_map where name = :name",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "name": "'alice'"
                         }
                     },
                     {
-                        "SQL": "update user set nickname = :vtg1 where name = :vtg1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                        "SQL": "update user set nickname = :vtg1 where name = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                         "BindVars": {
-                            "vtg1": "'alice'"
+                            "#maxLimit": "10001",
+                            "vtg1": "'alice'",
+                            "vtg2": "'alice'"
                         }
                     }
                 ],
                 "MysqlQueries": [
+                    "begin",
                     "select user_id from name_user_map where 1 != 1",
                     "select user_id from name_user_map where name = 'alice' limit 10001",
-                    "begin",
-                    "select id from user where name = 'alice' limit 10001 for update",
-                    "update user set nickname = 'alice' where id in (1)",
+                    "select id from user where name = 'alice' limit 10001 for update /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+                    "update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                     "commit"
                 ]
             }
@@ -127,6 +131,7 @@
                     {
                         "SQL": "update user set pet = :vtg1 where id = :vtg2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                         "BindVars": {
+                            "#maxLimit": "10001",
                             "vtg1": "'fido'",
                             "vtg2": "1"
                         }
@@ -134,7 +139,7 @@
                 ],
                 "MysqlQueries": [
                     "begin",
-                    "update user set pet = 'fido' where id in (1)",
+                    "update user set pet = 'fido' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
                     "commit"
                 ]
             }

--- a/data/test/vtexplain/updatesharded-output.txt
+++ b/data/test/vtexplain/updatesharded-output.txt
@@ -1,0 +1,28 @@
+----------------------------------------------------------------------
+update user set nickname='alice' where id=1
+
+[ks_sharded/-80]:
+begin
+update user set nickname = 'alice' where id in (1)
+commit
+
+----------------------------------------------------------------------
+update user set nickname='alice' where name='alice'
+
+[ks_sharded/-80]:
+select user_id from name_user_map where 1 != 1
+select user_id from name_user_map where name = 'alice' limit 10001
+begin
+select id from user where name = 'alice' limit 10001 for update
+update user set nickname = 'alice' where id in (1)
+commit
+
+----------------------------------------------------------------------
+update user set pet='fido' where id=1
+
+[ks_sharded/-80]:
+begin
+update user set pet = 'fido' where id in (1)
+commit
+
+----------------------------------------------------------------------

--- a/data/test/vtexplain/updatesharded-output.txt
+++ b/data/test/vtexplain/updatesharded-output.txt
@@ -3,18 +3,18 @@ update user set nickname='alice' where id=1
 
 [ks_sharded/-80]:
 begin
-update user set nickname = 'alice' where id in (1)
+update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
 commit
 
 ----------------------------------------------------------------------
 update user set nickname='alice' where name='alice'
 
 [ks_sharded/-80]:
+begin
 select user_id from name_user_map where 1 != 1
 select user_id from name_user_map where name = 'alice' limit 10001
-begin
-select id from user where name = 'alice' limit 10001 for update
-update user set nickname = 'alice' where id in (1)
+select id from user where name = 'alice' limit 10001 for update /* vtgate:: keyspace_id:166b40b44aba4bd6 */
+update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
 commit
 
 ----------------------------------------------------------------------
@@ -22,7 +22,7 @@ update user set pet='fido' where id=1
 
 [ks_sharded/-80]:
 begin
-update user set pet = 'fido' where id in (1)
+update user set pet = 'fido' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
 commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/updatesharded-queries.sql
+++ b/data/test/vtexplain/updatesharded-queries.sql
@@ -1,0 +1,6 @@
+update user set nickname='alice' where id=1;
+update user set nickname='alice' where name='alice';
+update user set pet='fido' where id=1;
+
+/* not supported - multi-shard update */
+-- update user set pet='rover' where name='alice';

--- a/go/vt/discovery/fake_healthcheck.go
+++ b/go/vt/discovery/fake_healthcheck.go
@@ -144,10 +144,11 @@ func (fhc *FakeHealthCheck) Reset() {
 	fhc.items = make(map[string]*fhcItem)
 }
 
-// AddTestTablet inserts a fake entry into FakeHealthCheck.
+// AddFakeTablet inserts a fake entry into FakeHealthCheck.
 // The Tablet can be talked to using the provided connection.
 // The Listener is called, as if AddTablet had been called.
-func (fhc *FakeHealthCheck) AddTestTablet(cell, host string, port int32, keyspace, shard string, tabletType topodatapb.TabletType, serving bool, reparentTS int64, err error) *sandboxconn.SandboxConn {
+// For flexibility the connection is created via a connFactory callback
+func (fhc *FakeHealthCheck) AddFakeTablet(cell, host string, port int32, keyspace, shard string, tabletType topodatapb.TabletType, serving bool, reparentTS int64, err error, connFactory func(*topodatapb.Tablet) queryservice.QueryService) queryservice.QueryService {
 	t := topo.NewTablet(0, cell, host)
 	t.Keyspace = keyspace
 	t.Shard = shard
@@ -177,13 +178,22 @@ func (fhc *FakeHealthCheck) AddTestTablet(cell, host string, port int32, keyspac
 	item.ts.TabletExternallyReparentedTimestamp = reparentTS
 	item.ts.Stats = &querypb.RealtimeStats{}
 	item.ts.LastError = err
-	conn := sandboxconn.NewSandboxConn(t)
+	conn := connFactory(t)
 	item.conn = conn
 
 	if fhc.listener != nil {
 		fhc.listener.StatsUpdate(item.ts)
 	}
 	return conn
+}
+
+// AddTestTablet adds a fake tablet for tests using the SandboxConn and returns
+// the fake connection
+func (fhc *FakeHealthCheck) AddTestTablet(cell, host string, port int32, keyspace, shard string, tabletType topodatapb.TabletType, serving bool, reparentTS int64, err error) *sandboxconn.SandboxConn {
+	conn := fhc.AddFakeTablet(cell, host, port, keyspace, shard, tabletType, serving, reparentTS, err, func(tablet *topodatapb.Tablet) queryservice.QueryService {
+		return sandboxconn.NewSandboxConn(tablet)
+	})
+	return conn.(*sandboxconn.SandboxConn)
 }
 
 // GetAllTablets returns all the tablets we have.

--- a/go/vt/vtexplain/vtexplain.go
+++ b/go/vt/vtexplain/vtexplain.go
@@ -182,6 +182,7 @@ func Run(sql string) ([]*Explain, error) {
 		}
 
 		if sql != "" {
+			log.V(100).Infof("explain %s", sql)
 			e, err := explain(sql)
 			if err != nil {
 				return nil, err

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -123,6 +123,14 @@ func TestInsertSharded(t *testing.T) {
 	testExplain("insertsharded", defaultTestOpts(), t)
 }
 
+func TestUpdateSharded(t *testing.T) {
+	testExplain("updatesharded", defaultTestOpts(), t)
+}
+
+func TestDeleteSharded(t *testing.T) {
+	testExplain("deletesharded", defaultTestOpts(), t)
+}
+
 func TestOptions(t *testing.T) {
 	opts := &Options{
 		ReplicationMode: "STATEMENT",

--- a/go/vt/vtexplain/vtexplain_test.go
+++ b/go/vt/vtexplain/vtexplain_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/youtube/vitess/go/testfiles"
 )
 
+var testOutputTempDir string
+
 func defaultTestOpts() *Options {
 	return &Options{
 		ReplicationMode: "ROW",
@@ -79,11 +81,13 @@ func testExplain(testcase string, opts *Options, t *testing.T) {
 		t.Errorf("json output did not match")
 		t.Logf("got:\n%s\n", string(explainJSON))
 
-		tempDir, err := ioutil.TempDir("", "vtexplain_output")
-		if err != nil {
-			t.Fatalf("error getting tempdir: %v", err)
+		if testOutputTempDir == "" {
+			testOutputTempDir, err = ioutil.TempDir("", "vtexplain_output")
+			if err != nil {
+				t.Fatalf("error getting tempdir: %v", err)
+			}
 		}
-		gotFile := fmt.Sprintf("%s/%s-output.json", tempDir, testcase)
+		gotFile := fmt.Sprintf("%s/%s-output.json", testOutputTempDir, testcase)
 		ioutil.WriteFile(gotFile, []byte(explainJSON), 0644)
 
 		command := exec.Command("diff", "-u", jsonOutFile, gotFile)
@@ -98,11 +102,13 @@ func testExplain(testcase string, opts *Options, t *testing.T) {
 		t.Errorf("Text output did not match")
 		t.Logf("got:\n%s\n", string(explainText))
 
-		tempDir, err := ioutil.TempDir("", "vtexplain_output")
-		if err != nil {
-			t.Fatalf("error getting tempdir: %v", err)
+		if testOutputTempDir == "" {
+			testOutputTempDir, err = ioutil.TempDir("", "vtexplain_output")
+			if err != nil {
+				t.Fatalf("error getting tempdir: %v", err)
+			}
 		}
-		gotFile := fmt.Sprintf("%s/%s-output.txt", tempDir, testcase)
+		gotFile := fmt.Sprintf("%s/%s-output.txt", testOutputTempDir, testcase)
 		ioutil.WriteFile(gotFile, []byte(explainText), 0644)
 
 		command := exec.Command("diff", "-u", textOutFile, gotFile)

--- a/go/vt/vtexplain/vtexplain_topo.go
+++ b/go/vt/vtexplain/vtexplain_topo.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/topo"
-	"github.com/youtube/vitess/go/vt/vttablet/sandboxconn"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 	vschemapb "github.com/youtube/vitess/go/vt/proto/vschema"
@@ -37,7 +36,7 @@ type ExplainTopo struct {
 	Keyspaces map[string]*vschemapb.Keyspace
 
 	// Map of ks/shard to test tablet connection
-	TabletConns map[string]*sandboxconn.SandboxConn
+	TabletConns map[string]*fakeTablet
 
 	// Synchronization lock
 	Lock sync.Mutex

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -17,7 +17,12 @@ limitations under the License.
 package vtexplain
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"golang.org/x/net/context"
+
+	log "github.com/golang/glog"
 
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/mysql/fakesqldb"
@@ -25,7 +30,7 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/sqlparser"
-	"github.com/youtube/vitess/go/vt/vttablet/sandboxconn"
+
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
@@ -34,23 +39,29 @@ import (
 )
 
 var (
+	// map of schema introspection queries to their expected results
 	schemaQueries map[string]*sqltypes.Result
+
+	// map for each table from the column name to its type
+	tableColumns map[string]map[string]querypb.Type
 )
 
 type fakeTablet struct {
-	db  *fakesqldb.DB
-	tsv *tabletserver.TabletServer
-
+	db      *fakesqldb.DB
+	tsv     *tabletserver.TabletServer
 	queries []string
 }
 
 func newFakeTablet() *fakeTablet {
-	db := newFakeDB()
+	db := fakesqldb.New(nil)
 
 	// XXX much of this is cloned from the tabletserver tests
 	config := tabletenv.DefaultQsConfig
 	config.EnableAutoCommit = true
 	tsv := tabletserver.NewTabletServerWithNilTopoServer(config)
+
+	tablet := fakeTablet{db: db, tsv: tsv}
+	db.Handler = &tablet
 
 	dbcfgs := dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
@@ -67,10 +78,9 @@ func newFakeTablet() *fakeTablet {
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	tsv.StartService(target, dbcfgs, mysqld)
 
-	tablet := fakeTablet{db: db, tsv: tsv}
-	db.QueryLogger = func(query string, result *sqltypes.Result, err error) {
-		tablet.queries = append(tablet.queries, query)
-	}
+	// clear all the schema initialization queries out of the tablet
+	// to avoid clutttering the output
+	tablet.queries = nil
 
 	return &tablet
 }
@@ -93,6 +103,7 @@ func (tablet *fakeTablet) Execute(ctx context.Context, target *querypb.Target, q
 }
 
 func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
+	tableColumns = make(map[string]map[string]querypb.Type)
 	schemaQueries = map[string]*sqltypes.Result{
 		"select unix_timestamp()": {
 			Fields: []*querypb.Field{{
@@ -175,6 +186,8 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 
 		describeTableRows := make([][]sqltypes.Value, 0, 4)
 		rowTypes := make([]*querypb.Field, 0, 4)
+		tableColumns[table] = make(map[string]querypb.Type)
+
 		for _, col := range ddl.TableSpec.Columns {
 			colName := col.Name.String()
 			defaultVal := ""
@@ -193,6 +206,8 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 				Type: col.Type.SQLType(),
 			}
 			rowTypes = append(rowTypes, rowType)
+
+			tableColumns[table][colName] = col.Type.SQLType()
 		}
 
 		schemaQueries["describe "+table] = &sqltypes.Result{
@@ -209,17 +224,143 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 	return nil
 }
 
-// Set up the fakesqldb with queries needed to resolve the schema and accept
-// all other queries
-func newFakeDB() *fakesqldb.DB {
-	// XXX passing nil for testing.t?
-	db := fakesqldb.New(nil)
+// HandleQuery implements the fakesqldb query handler interface
+func (tablet *fakeTablet) HandleQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
+	query := string(q)
+	tablet.queries = append(tablet.queries, query)
 
-	for q, r := range schemaQueries {
-		db.AddQuery(q, r)
+	// return the pre-computed results for any schema introspection queries
+	result, ok := schemaQueries[query]
+	if ok {
+		return callback(result)
 	}
 
-	db.AddQueryPattern(".*", sandboxconn.SingleRowResult)
+	switch sqlparser.Preview(query) {
+	case sqlparser.StmtSelect:
+		// Parse the select statement to figure out the table and columns
+		// that were referenced so that the synthetic response has the
+		// expected field names and types.
+		stmt, err := sqlparser.Parse(query)
+		if err != nil {
+			return err
+		}
 
-	return db
+		selStmt := stmt.(*sqlparser.Select)
+
+		if len(selStmt.From) != 1 {
+			return fmt.Errorf("unsupported select with multiple from clauses")
+		}
+
+		var table sqlparser.TableIdent
+		switch node := selStmt.From[0].(type) {
+		case *sqlparser.AliasedTableExpr:
+			table = sqlparser.GetTableName(node.Expr)
+			break
+		}
+
+		// For complex select queries just return an empty result
+		// since it's too hard to figure out the real columns
+		if table.IsEmpty() {
+			log.V(100).Infof("query %s result {}\n", query)
+			return callback(&sqltypes.Result{})
+		}
+
+		colTypeMap := tableColumns[table.String()]
+		if colTypeMap == nil {
+			return fmt.Errorf("unable to resolve table name %s", table.String())
+		}
+
+		colNames := make([]string, 0, 4)
+		colTypes := make([]querypb.Type, 0, 4)
+		for _, node := range selStmt.SelectExprs {
+			switch node := node.(type) {
+			case *sqlparser.AliasedExpr:
+				switch node := node.Expr.(type) {
+				case *sqlparser.ColName:
+					col := node.Name.String()
+					colType := colTypeMap[col]
+					if colType == querypb.Type_NULL_TYPE {
+						return fmt.Errorf("invalid column %s", col)
+					}
+					colNames = append(colNames, col)
+					colTypes = append(colTypes, colType)
+					break
+				case *sqlparser.FuncExpr:
+					// As a shortcut, functions are integral types
+					colNames = append(colNames, sqlparser.String(node))
+					colTypes = append(colTypes, querypb.Type_INT32)
+					break
+				case *sqlparser.SQLVal:
+					colNames = append(colNames, sqlparser.String(node))
+					switch node.Type {
+					case sqlparser.IntVal:
+						colTypes = append(colTypes, querypb.Type_INT32)
+						break
+					case sqlparser.StrVal:
+						colTypes = append(colTypes, querypb.Type_VARCHAR)
+						break
+					case sqlparser.FloatVal:
+						colTypes = append(colTypes, querypb.Type_VARCHAR)
+						break
+					default:
+						return fmt.Errorf("unsupported sql value %s", sqlparser.String(node))
+					}
+					break
+				default:
+					return fmt.Errorf("unsupported select expression %s", sqlparser.String(node))
+				}
+				break
+			case *sqlparser.StarExpr:
+				for col, colType := range colTypeMap {
+					colNames = append(colNames, col)
+					colTypes = append(colTypes, colType)
+				}
+			}
+		}
+
+		// Generate a fake value for the given column. For numeric types,
+		// use the column index. For strings, use the column name + index.
+		fields := make([]*querypb.Field, len(colNames))
+		values := make([]sqltypes.Value, len(colNames))
+		for i, col := range colNames {
+			colType := colTypes[i]
+			fields[i] = &querypb.Field{
+				Name: col,
+				Type: colType,
+			}
+
+			if sqltypes.IsIntegral(colType) {
+				values[i] = sqltypes.NewInt32(int32(i + 1))
+			} else if sqltypes.IsFloat(colType) {
+				values[i] = sqltypes.NewFloat64(1.0 + float64(i))
+			} else if sqltypes.IsBinary(colType) || sqltypes.IsText(colType) {
+				values[i] = sqltypes.NewVarChar(fmt.Sprintf("%s_val_%d", col, i+1))
+			} else {
+				return fmt.Errorf("unhandled type %d for col %s", colType, col)
+			}
+		}
+		result = &sqltypes.Result{
+			Fields:       fields,
+			RowsAffected: 1,
+			InsertID:     0,
+			Rows:         [][]sqltypes.Value{values},
+		}
+
+		resultJSON, _ := json.MarshalIndent(result, "", "    ")
+		log.V(100).Infof("query %s result %s\n", query, string(resultJSON))
+
+		break
+	case sqlparser.StmtBegin, sqlparser.StmtCommit:
+		result = &sqltypes.Result{}
+		break
+	case sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete:
+		result = &sqltypes.Result{
+			RowsAffected: 1,
+		}
+		break
+	default:
+		return fmt.Errorf("unsupported query %s", query)
+	}
+
+	return callback(result)
 }

--- a/go/vt/vtexplain/vtexplain_vttablet_test.go
+++ b/go/vt/vtexplain/vtexplain_vttablet_test.go
@@ -19,6 +19,8 @@ package vtexplain
 import (
 	"encoding/json"
 	"testing"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 func TestParseSchema(t *testing.T) {
@@ -40,7 +42,10 @@ create table t2 (
 	}
 	initTabletEnvironment(ddls, defaultTestOpts())
 
-	tablet := newFakeTablet()
+	tablet := newFakeTablet(&topodatapb.Tablet{
+		Keyspace: "test_keyspace",
+		Shard:    "-80",
+	})
 	se := tablet.tsv.SchemaEngine()
 	tables := se.GetSchema()
 

--- a/go/vt/vttablet/sandboxconn/sandboxconn.go
+++ b/go/vt/vttablet/sandboxconn/sandboxconn.go
@@ -80,10 +80,6 @@ type SandboxConn struct {
 	// no results left, SingleRowResult is returned.
 	results []*sqltypes.Result
 
-	// Executor contains an optional interface to get results, otherwise
-	// it uses the static results
-	Executor SandboxExecutor
-
 	// ReadTransactionResults is used for returning results for ReadTransaction.
 	ReadTransactionResults []*querypb.TransactionMetadata
 
@@ -91,12 +87,6 @@ type SandboxConn struct {
 
 	// transaction id generator
 	TransactionID sync2.AtomicInt64
-}
-
-// SandboxExecutor is an interface to allow test clients to obtain query
-// results via a callback
-type SandboxExecutor interface {
-	Execute(ctx context.Context, target *querypb.Target, query string, bindVars map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions) (*sqltypes.Result, error)
 }
 
 var _ queryservice.QueryService = (*SandboxConn)(nil) // compile-time interface check
@@ -139,9 +129,6 @@ func (sbc *SandboxConn) Execute(ctx context.Context, target *querypb.Target, que
 	sbc.Options = append(sbc.Options, options)
 	if err := sbc.getError(); err != nil {
 		return nil, err
-	}
-	if sbc.Executor != nil {
-		return sbc.Executor.Execute(ctx, target, query, bindVars, transactionID, options)
 	}
 	return sbc.getNextResult(), nil
 }


### PR DESCRIPTION
NOT YET FOR MERGE: Depends on changes in #3264 and #3265.

Previously, when returning results from queries, vtexplain used the default SingleRowResult that was used in the various tablet tests and as such had a fixed schema of two fields. This caused confusing results for queries involving secondary indexes as the results are used as part of the plan generation.

Instead, rework the implementation so that it tries to parse the query sent to the fake mysql and in the cases of simple select expressions, uses the knowledge of the table schema to produce Result objects with the correct types and synthetic values.

As part of this work, replace the QueryLogger hook in fakesqldb with a more generic hook that enables overriding the query handler.
