### PR TITLE
Moving optional RebuildKeyspace out of tests.

### DIFF
--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -271,6 +271,10 @@ func NewActionAgent(
 		return nil, err
 	}
 
+	// Run a background task to rebuild the SrvKeyspace in our cell/keyspace
+	// if it doesn't exist yet.
+	go agent.maybeRebuildKeyspace(agent.initialTablet.Alias.Cell, agent.initialTablet.Keyspace)
+
 	// register the RPC services from the agent
 	servenv.OnRun(func() {
 		agent.registerQueryService()
@@ -637,10 +641,6 @@ func (agent *ActionAgent) Start(ctx context.Context, mysqlHost string, mysqlPort
 	startingTablet := proto.Clone(agent.initialTablet).(*topodatapb.Tablet)
 	startingTablet.Type = topodatapb.TabletType_UNKNOWN
 	agent.setTablet(startingTablet)
-
-	// run a background task to rebuild the SrvKeyspace in our cell/keyspace
-	// if it doesn't exist yet
-	go agent.maybeRebuildKeyspace(agent.initialTablet.Alias.Cell, agent.initialTablet.Keyspace)
 
 	return nil
 }


### PR DESCRIPTION
vttablet's ActionAgent has three startup methods:
1. real production tablet
2. vtcombo in-memory tablet
3. in-memory test tablet for unit tests
The optional RebuildKeyspace when SrvKeyspace doesn't exist only needs
to be done in case .1, not 2. and 3. vtcombo does an explicit rebuild
after having fully created the keyspace (so we don't need the background
intermediate ones that will fail and spam the logs anyway). in-memory
tests don't ususally need the SrvKeyspace (and if they do, they could
call it).