### PR TITLE
Move sqlparser.Backtick to a new package, "sqlescape"

### DIFF
--- a/go/sqlescape/ids.go
+++ b/go/sqlescape/ids.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlescape
+
+import (
+	"bytes"
+)
+
+// EscapeID returns a backticked identifier given an input string.
+func EscapeID(in string) string {
+	var buf bytes.Buffer
+	WriteEscapeID(&buf, in)
+	return buf.String()
+}
+
+// WriteEscapeID writes a backticked identifier from an input string into buf.
+func WriteEscapeID(buf *bytes.Buffer, in string) {
+	buf.WriteByte('`')
+	for _, c := range in {
+		buf.WriteRune(c)
+		if c == '`' {
+			buf.WriteByte('`')
+		}
+	}
+	buf.WriteByte('`')
+}

--- a/go/sqlescape/ids_test.go
+++ b/go/sqlescape/ids_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 Google Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlescape
+
+import (
+	"testing"
+)
+
+func TestEscapeID(t *testing.T) {
+	testcases := []struct {
+		in, out string
+	}{{
+		in:  "aa",
+		out: "`aa`",
+	}, {
+		in:  "a`a",
+		out: "`a``a`",
+	}}
+	for _, tc := range testcases {
+		out := EscapeID(tc.in)
+		if out != tc.out {
+			t.Errorf("EscapeID(%s): %s, want %s", tc.in, out, tc.out)
+		}
+	}
+}

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -2758,20 +2758,6 @@ func (node *TableIdent) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Backtick produces a backticked literal given an input string.
-func Backtick(in string) string {
-	var buf bytes.Buffer
-	buf.WriteByte('`')
-	for _, c := range in {
-		buf.WriteRune(c)
-		if c == '`' {
-			buf.WriteByte('`')
-		}
-	}
-	buf.WriteByte('`')
-	return buf.String()
-}
-
 func formatID(buf *TrackedBuffer, original, lowered string) {
 	for i, c := range original {
 		if !isLetter(uint16(c)) {

--- a/go/vt/sqlparser/ast_test.go
+++ b/go/vt/sqlparser/ast_test.go
@@ -387,24 +387,6 @@ func TestCompliantName(t *testing.T) {
 	}
 }
 
-func TestEscape(t *testing.T) {
-	testcases := []struct {
-		in, out string
-	}{{
-		in:  "aa",
-		out: "`aa`",
-	}, {
-		in:  "a`a",
-		out: "`a``a`",
-	}}
-	for _, tc := range testcases {
-		out := Backtick(tc.in)
-		if out != tc.out {
-			t.Errorf("Escape(%s): %s, want %s", tc.in, out, tc.out)
-		}
-	}
-}
-
 func TestColumns_FindColumn(t *testing.T) {
 	cols := Columns{NewColIdent("a"), NewColIdent("c"), NewColIdent("b"), NewColIdent("0")}
 

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/hack"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/timer"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -87,7 +88,7 @@ func (r *Reader) Init(dbc dbconfigs.DBConfigs, target query.Target) {
 	if !r.enabled {
 		return
 	}
-	r.dbName = sqlparser.Backtick(dbc.SidecarDBName)
+	r.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
 	r.keyspaceShard = fmt.Sprintf("%s:%s", target.Keyspace, target.Shard)
 }
 

--- a/go/vt/vttablet/heartbeat/reader_test.go
+++ b/go/vt/vttablet/heartbeat/reader_test.go
@@ -24,10 +24,10 @@ import (
 	"math/rand"
 
 	"github.com/youtube/vitess/go/mysql/fakesqldb"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/proto/query"
-	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -112,7 +112,7 @@ func newReader(db *fakesqldb.DB, nowFunc func() time.Time) *Reader {
 	}
 
 	tr := NewReader(&fakeMysqlChecker{}, config)
-	tr.dbName = sqlparser.Backtick(dbc.SidecarDBName)
+	tr.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
 	tr.keyspaceShard = "test:0"
 	tr.now = nowFunc
 	tr.pool.Open(&dbc.App, &dbc.Dba, &dbc.AppDebug)

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/youtube/vitess/go/hack"
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/timer"
@@ -95,7 +96,7 @@ func (w *Writer) Init(dbc dbconfigs.DBConfigs, target query.Target) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	log.Info("Initializing heartbeat table.")
-	w.dbName = sqlparser.Backtick(dbc.SidecarDBName)
+	w.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
 	w.keyspaceShard = fmt.Sprintf("%s:%s", target.Keyspace, target.Shard)
 	err := w.initializeTables(&dbc.Dba)
 	if err != nil {

--- a/go/vt/vttablet/heartbeat/writer_test.go
+++ b/go/vt/vttablet/heartbeat/writer_test.go
@@ -23,10 +23,10 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/mysql/fakesqldb"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -120,7 +120,7 @@ func newTestWriter(db *fakesqldb.DB, nowFunc func() time.Time) *Writer {
 	tw := NewWriter(&fakeMysqlChecker{},
 		topodatapb.TabletAlias{Cell: "test", Uid: 1111},
 		config)
-	tw.dbName = sqlparser.Backtick(dbc.SidecarDBName)
+	tw.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
 	tw.keyspaceShard = "test:0"
 	tw.now = nowFunc
 	tw.pool.Open(&dbc.App, &dbc.Dba, &dbc.AppDebug)

--- a/go/vt/vttablet/tabletserver/twopc.go
+++ b/go/vt/vttablet/tabletserver/twopc.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/youtube/vitess/go/hack"
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
@@ -128,7 +129,7 @@ func NewTwoPC(readPool *connpool.Pool) *TwoPC {
 // Init initializes TwoPC. If the metadata database or tables
 // are not present, they are created.
 func (tpc *TwoPC) Init(sidecarDBName string, dbaparams *mysql.ConnParams) error {
-	dbname := sqlparser.Backtick(sidecarDBName)
+	dbname := sqlescape.EscapeID(sidecarDBName)
 	conn, err := dbconnpool.NewDBConnection(dbaparams, stats.NewTimings(""))
 	if err != nil {
 		return err

--- a/go/vt/worker/chunk.go
+++ b/go/vt/worker/chunk.go
@@ -21,6 +21,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/wrangler"
@@ -89,7 +90,7 @@ func generateChunks(ctx context.Context, wr *wrangler.Wrangler, tablet *topodata
 	}
 
 	// Get the MIN and MAX of the leading column of the primary key.
-	query := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v.%v", escape(td.PrimaryKeyColumns[0]), escape(td.PrimaryKeyColumns[0]), escape(topoproto.TabletDbName(tablet)), escape(td.Name))
+	query := fmt.Sprintf("SELECT MIN(%v), MAX(%v) FROM %v.%v", sqlescape.EscapeID(td.PrimaryKeyColumns[0]), sqlescape.EscapeID(td.PrimaryKeyColumns[0]), sqlescape.EscapeID(topoproto.TabletDbName(tablet)), sqlescape.EscapeID(td.Name))
 	shortCtx, cancel := context.WithTimeout(ctx, *remoteActionsTimeout)
 	qr, err := wr.TabletManagerClient().ExecuteFetchAsApp(shortCtx, tablet, true, []byte(query), 1)
 	cancel()

--- a/go/vt/worker/clone_utils.go
+++ b/go/vt/worker/clone_utils.go
@@ -25,6 +25,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/discovery"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -111,27 +112,11 @@ func makeValueString(fields []*querypb.Field, rows [][]sqltypes.Value) string {
 	return buf.String()
 }
 
-// escape adds surrounding backticks (`) to an MySQL identifier.
-// This is required for identifiers which are reserved words e.g. "CREATE".
-func escape(identifier string) string {
-	b := bytes.Buffer{}
-	writeEscaped(&b, identifier)
-	return b.String()
-}
-
-// escapeAll runs escape() for all entries in the slice.
+// escapeAll runs sqlescape.EscapeID() for all entries in the slice.
 func escapeAll(identifiers []string) []string {
 	result := make([]string, len(identifiers))
 	for i := range identifiers {
-		result[i] = escape(identifiers[i])
+		result[i] = sqlescape.EscapeID(identifiers[i])
 	}
 	return result
-}
-
-// writeEscaped escapes the SQL "identifier" before writing it to "b".
-// See also escape().
-func writeEscaped(b *bytes.Buffer, identifier string) {
-	b.WriteByte('`')
-	b.WriteString(identifier)
-	b.WriteByte('`')
 }

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/event"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
 	"github.com/youtube/vitess/go/vt/discovery"
@@ -699,7 +700,7 @@ func (scw *LegacySplitCloneWorker) processData(ctx context.Context, dbNames []st
 	// different dbName.
 	baseCmds := make([]string, len(dbNames))
 	for i, dbName := range dbNames {
-		baseCmds[i] = "INSERT INTO " + escape(dbName) + "." + escape(td.Name) + " (" + strings.Join(escapeAll(td.Columns), ", ") + ") VALUES "
+		baseCmds[i] = "INSERT INTO " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID(td.Name) + " (" + strings.Join(escapeAll(td.Columns), ", ") + ") VALUES "
 	}
 	sr := rowSplitter.StartSplit()
 	packCount := 0

--- a/go/vt/worker/row_aggregator.go
+++ b/go/vt/worker/row_aggregator.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/stats"
 
@@ -186,7 +187,7 @@ func NewInsertsQueryBuilder(dbName string, td *tabletmanagerdatapb.TableDefiniti
 	// Example: INSERT INTO test (id, sub_id, msg) VALUES (0, 10, 'a'), (1, 11, 'b')
 	return &InsertsQueryBuilder{
 		BaseQueryBuilder{
-			head:      "INSERT INTO " + escape(dbName) + "." + escape(td.Name) + " (" + strings.Join(escapeAll(td.Columns), ", ") + ") VALUES ",
+			head:      "INSERT INTO " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID(td.Name) + " (" + strings.Join(escapeAll(td.Columns), ", ") + ") VALUES ",
 			separator: ",",
 		},
 	}
@@ -226,7 +227,7 @@ func NewUpdatesQueryBuilder(dbName string, td *tabletmanagerdatapb.TableDefiniti
 	// and not the primary key).
 	return &UpdatesQueryBuilder{
 		BaseQueryBuilder: BaseQueryBuilder{
-			head: "UPDATE " + escape(dbName) + "." + escape(td.Name) + " SET ",
+			head: "UPDATE " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID(td.Name) + " SET ",
 		},
 		td: td,
 		// Build list of non-primary key columns (required for update statements).
@@ -248,7 +249,7 @@ func (b *UpdatesQueryBuilder) WriteRow(buffer *bytes.Buffer, row []sqltypes.Valu
 		if i > 0 {
 			buffer.WriteByte(',')
 		}
-		writeEscaped(buffer, column)
+		sqlescape.WriteEscapeID(buffer, column)
 		buffer.WriteByte('=')
 		row[nonPrimaryOffset+i].EncodeSQL(buffer)
 	}
@@ -257,7 +258,7 @@ func (b *UpdatesQueryBuilder) WriteRow(buffer *bytes.Buffer, row []sqltypes.Valu
 		if i > 0 {
 			buffer.WriteString(" AND ")
 		}
-		writeEscaped(buffer, pkColumn)
+		sqlescape.WriteEscapeID(buffer, pkColumn)
 		buffer.WriteByte('=')
 		row[i].EncodeSQL(buffer)
 	}
@@ -278,7 +279,7 @@ func NewDeletesQueryBuilder(dbName string, td *tabletmanagerdatapb.TableDefiniti
 	// for such a query. (We haven't confirmed this ourselves.)
 	return &DeletesQueryBuilder{
 		BaseQueryBuilder: BaseQueryBuilder{
-			head:      "DELETE FROM " + escape(dbName) + "." + escape(td.Name) + " WHERE ",
+			head:      "DELETE FROM " + sqlescape.EscapeID(dbName) + "." + sqlescape.EscapeID(td.Name) + " WHERE ",
 			separator: " OR ",
 		},
 		td: td,
@@ -293,7 +294,7 @@ func (b *DeletesQueryBuilder) WriteRow(buffer *bytes.Buffer, row []sqltypes.Valu
 		if i > 0 {
 			buffer.WriteString(" AND ")
 		}
-		writeEscaped(buffer, pkColumn)
+		sqlescape.WriteEscapeID(buffer, pkColumn)
 		buffer.WriteByte('=')
 		row[i].EncodeSQL(buffer)
 	}

--- a/go/vt/wrangler/reparent.go
+++ b/go/vt/wrangler/reparent.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/youtube/vitess/go/event"
 	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/vt/concurrency"
-	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/topotools"
@@ -301,7 +301,7 @@ func (wr *Wrangler) initShardMasterLocked(ctx context.Context, ev *events.Repare
 	// assume that whatever data is on all the slaves is what they intended.
 	// If the database doesn't exist, it means the user intends for these tablets
 	// to begin serving with no data (i.e. first time initialization).
-	createDB := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", sqlparser.Backtick(topoproto.TabletDbName(masterElectTabletInfo.Tablet)))
+	createDB := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", sqlescape.EscapeID(topoproto.TabletDbName(masterElectTabletInfo.Tablet)))
 	if _, err := wr.tmc.ExecuteFetchAsDba(ctx, masterElectTabletInfo.Tablet, false, []byte(createDB), 1, false, true); err != nil {
 		return fmt.Errorf("failed to create database: %v", err)
 	}


### PR DESCRIPTION
Escaping identifiers is useful in Vitess clients. Rename the function to match the expected use.

This pull request also removes duplicated function in vt worker, in order to prevent SQL injection (it was not escaping backticks in middle of identifiers).