### PR TITLE
messages: documentation & more proactive sending

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package messager
 
 import (
+	"errors"
 	"reflect"
 	"runtime"
 	"testing"
@@ -308,8 +309,30 @@ func TestMessageManagerPostponeThrottle(t *testing.T) {
 func TestMessageManagerSendEOF(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()
-	tsv := newFakeTabletServer()
-	mm := newMessageManager(tsv, mmTable, newMMConnPool(db), sync2.NewSemaphore(1, 0))
+	db.AddQueryPattern(
+		"select time_next, epoch, time_created, id, time_scheduled, message from foo.*",
+		&sqltypes.Result{
+			Fields: []*querypb.Field{
+				{Type: sqltypes.Int64},
+				{Type: sqltypes.Int64},
+				{Type: sqltypes.Int64},
+				{Type: sqltypes.Int64},
+				{Type: sqltypes.VarBinary},
+			},
+			Rows: [][]sqltypes.Value{{
+				sqltypes.NewInt64(1),
+				sqltypes.NewInt64(0),
+				sqltypes.NewInt64(2),
+				sqltypes.NewInt64(10),
+				sqltypes.NewVarBinary("a"),
+			}},
+		},
+	)
+	// Set a large polling interval.
+	ti := newMMTable()
+	ti.MessageInfo.CacheSize = 2
+	ti.MessageInfo.PollInterval = 30 * time.Second
+	mm := newMessageManager(newFakeTabletServer(), ti, newMMConnPool(db), sync2.NewSemaphore(1, 0))
 	mm.Open()
 	defer mm.Close()
 	r1 := newTestReceiver(0)
@@ -318,28 +341,82 @@ func TestMessageManagerSendEOF(t *testing.T) {
 	// Pull field info.
 	<-r1.ch
 
+	r2 := newTestReceiver(0)
+	mm.Subscribe(context.Background(), r2.rcv)
+	// Pull field info.
+	<-r2.ch
+
 	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.NewVarBinary("1"), sqltypes.NULL}})
-	// Wait for send to enqueue
+	// Wait for send to enqueue.
+	// After this is enquened, runSend will go into a wait state because
+	// there's nothing more to send.
 	r1.WaitForCount(2)
 
 	// Now cancel, which will send an EOF to the sender.
 	cancel()
-	// messagesPending should get turned on.
-	messagesWerePending := false
-	for i := 0; i < 10; i++ {
-		runtime.Gosched()
-		mm.mu.Lock()
-		if mm.messagesPending {
-			messagesWerePending = true
-			mm.mu.Unlock()
-			break
+
+	// The EOF should immediately trigger the poller, which will result
+	// in a message being sent on r2. Verify that this happened in a timely fashion.
+	start := time.Now()
+	<-r2.ch
+	if d := time.Since(start); d > 15*time.Second {
+		t.Errorf("pending work trigger did not happen. Duration: %v", d)
+	}
+}
+
+func TestMessageManagerSendError(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	tsv := newFakeTabletServer()
+	mm := newMessageManager(tsv, mmTable, newMMConnPool(db), sync2.NewSemaphore(1, 0))
+	mm.Open()
+	defer mm.Close()
+	ctx := context.Background()
+
+	ch := make(chan *sqltypes.Result)
+	fieldSent := false
+	mm.Subscribe(ctx, func(qr *sqltypes.Result) error {
+		ch <- qr
+		if !fieldSent {
+			fieldSent = true
+			return nil
 		}
-		mm.mu.Unlock()
-		time.Sleep(10 * time.Millisecond)
+		return errors.New("non-eof")
+	})
+	// Pull field info.
+	<-ch
+
+	postponech := make(chan string, 20)
+	tsv.SetChannel(postponech)
+	mm.Add(&MessageRow{Row: []sqltypes.Value{sqltypes.NewVarBinary("1"), sqltypes.NULL}})
+	<-ch
+
+	// Ensure Postpone got called.
+	if got, want := <-postponech, "postpone"; got != want {
+		t.Errorf("Postpone: %s, want %v", got, want)
 	}
-	if !messagesWerePending {
-		t.Error("Send with EOF did not trigger pending messages")
-	}
+}
+
+func TestMessageManagerFieldSendError(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	tsv := newFakeTabletServer()
+	mm := newMessageManager(tsv, mmTable, newMMConnPool(db), sync2.NewSemaphore(1, 0))
+	mm.Open()
+	defer mm.Close()
+	ctx := context.Background()
+
+	ch := make(chan *sqltypes.Result)
+	done := mm.Subscribe(ctx, func(qr *sqltypes.Result) error {
+		ch <- qr
+		return errors.New("non-eof")
+	})
+	// Pull field info.
+	<-ch
+
+	// This should not hang because a field send error must terminate
+	// subscription.
+	<-done
 }
 
 func TestMessageManagerBatchSend(t *testing.T) {


### PR DESCRIPTION
BUG=66901091
I've documented the components of the messageManager and how they
interacted with each other. I've also sprayed a few more comments
where things might not have been clear.

If a send returns an EOF, then we enter messagesPending mode, but
we also proactively wake up the sender, in case it went to sleep.
The sender will then wake up the poller because of the messagesPending
state.

I found a rare corner case: If the field send fails, then we should not
send rows on that connection. It should instead be closed. This should
almost never happen. But if it does, there is protection.

Added tests for all the new corner cases.