### PR TITLE
ParseTabletAlias: Put quotes in format string instead of relying on t…

### DIFF
--- a/go/vt/topo/topoproto/tablet.go
+++ b/go/vt/topo/topoproto/tablet.go
@@ -75,11 +75,11 @@ func TabletAliasUIDStr(ta *topodatapb.TabletAlias) string {
 func ParseTabletAlias(aliasStr string) (*topodatapb.TabletAlias, error) {
 	nameParts := strings.Split(aliasStr, "-")
 	if len(nameParts) != 2 {
-		return nil, fmt.Errorf("invalid tablet alias: %q, expecting format: %q", aliasStr, "<cell>-<uid>")
+		return nil, fmt.Errorf("invalid tablet alias: '%s', expecting format: '<cell>-<uid>'", aliasStr)
 	}
 	uid, err := ParseUID(nameParts[1])
 	if err != nil {
-		return nil, fmt.Errorf("invalid tablet uid %v: %v", aliasStr, err)
+		return nil, fmt.Errorf("invalid tablet uid in alias '%s': %v", aliasStr, err)
 	}
 	return &topodatapb.TabletAlias{
 		Cell: nameParts[0],


### PR DESCRIPTION
…he %q behavior when printing strings.

This way the format string is more explicit and it's easier to see what the actual output will be.

I also adjusted another error message in the same function.