### PR TITLE
go/vtgateconn: Sessions should always set `Autocommit`

### DIFF
--- a/go/vt/vitessdriver/fakeserver_test.go
+++ b/go/vt/vitessdriver/fakeserver_test.go
@@ -266,6 +266,7 @@ var execMap = map[string]struct {
 			},
 			Session: &vtgatepb.Session{
 				TargetString: "@rdonly",
+				Autocommit:   true,
 			},
 		},
 		result:  &result1,
@@ -279,6 +280,7 @@ var execMap = map[string]struct {
 			},
 			Session: &vtgatepb.Session{
 				TargetString: "@rdonly",
+				Autocommit:   true,
 			},
 		},
 		result:  &result2,
@@ -300,6 +302,7 @@ var execMap = map[string]struct {
 			SQL: "begin",
 			Session: &vtgatepb.Session{
 				TargetString: "@master",
+				Autocommit:   true,
 			},
 		},
 		result:  &sqltypes.Result{},
@@ -313,6 +316,7 @@ var execMap = map[string]struct {
 		result: &sqltypes.Result{},
 		session: &vtgatepb.Session{
 			TargetString: "@master",
+			Autocommit:   true,
 		},
 	},
 	"rollback": {

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -50,6 +50,7 @@ func (conn *VTGateConn) Session(targetString string, options *querypb.ExecuteOpt
 		session: &vtgatepb.Session{
 			TargetString: targetString,
 			Options:      options,
+			Autocommit:   true,
 		},
 		impl: conn.impl,
 	}

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -2226,6 +2226,7 @@ var execMap = map[string]struct {
 			Session: &vtgatepb.Session{
 				TargetString: "connection_ks@rdonly",
 				Options:      testExecuteOptions,
+				Autocommit:   true,
 			},
 		},
 		shardQuery: &queryExecuteShards{


### PR DESCRIPTION
As discussed with @sougou in Slack:

This makes the behavior of the GRPC driver for Go in-line to what one would get by using a direct MySQL connection to a MySQL server with `autcommit=1`.

Users who don't want autocommit to be true can explicitly disable it with an SQL statement.