### PR TITLE
Export BUILD_NUMBER in stats.

### DIFF
--- a/tools/build_version_flags.sh
+++ b/tools/build_version_flags.sh
@@ -23,4 +23,5 @@ echo "\
   -X 'github.com/youtube/vitess/go/vt/servenv.buildGitRev=$(git rev-parse --short HEAD)' \
   -X 'github.com/youtube/vitess/go/vt/servenv.buildGitBranch=$(git rev-parse --abbrev-ref HEAD)' \
   -X 'github.com/youtube/vitess/go/vt/servenv.buildTime=$(LC_ALL=C date)' \
+  -X 'github.com/youtube/vitess/go/vt/servenv.jenkinsBuildNumberStr=${BUILD_NUMBER}' \
 "


### PR DESCRIPTION
This is useful for exposing the build information (example:jenkins build number) in the stats

Tested:
```
~$ ./vtctld -version 
Version: 1849db4 (91) (Git branch 'HEAD') built on Thu Oct  5 12:32:03 PDT 2017 by jenkinsslave@build-slave-vitess1604 using go1.8.3 linux/amd64
```
```

{
"BuildGitBranch": "HEAD",
"BuildGitRev": "1849db4",
"BuildHost": "build-slave-vitess1604",
"BuildNumber": 91,
"BuildTimestamp": 1507231923,
"BuildUser": "jenkinsslave",

```