### PR TITLE
clip out the TableExprs from Delete and Update statement types 

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -76,6 +76,20 @@
   }
 }
 
+# update with join subquery
+"update unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id set col1 = 'asdf' where keepers.id is null and foo.col is not null and foo.col < 1000"
+{
+  "Original": "update unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id set col1 = 'asdf' where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+  "Instructions": {
+    "Opcode": "UpdateUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "update unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id set col1 = 'asdf' where keepers.id is null and foo.col is not null and foo.col \u003c 1000"
+  }
+}
+
 # delete unsharded
 "delete from unsharded"
 {
@@ -337,6 +351,21 @@
       "Sharded": false
     },
     "Query": "insert into unsharded select id from unsharded_auto",
+    "Table": "unsharded"
+  }
+}
+
+# insert unsharded with select with join
+"insert into unsharded select id from unsharded join unsharded_auto"
+{
+  "Original": "insert into unsharded select id from unsharded join unsharded_auto",
+  "Instructions": {
+    "Opcode": "InsertUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "insert into unsharded select id from unsharded join unsharded_auto",
     "Table": "unsharded"
   }
 }

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -187,6 +187,20 @@
   }
 }
 
+#delete with join from subquery
+"delete foo from unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col < 1000"
+{
+  "Original": "delete foo from unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000",
+  "Instructions": {
+    "Opcode": "DeleteUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "delete foo from unsharded as foo left join (select id from unsharded where col is not null order by col desc limit 10) as keepers on foo.id = keepers.id where keepers.id is null and foo.col is not null and foo.col \u003c 1000"
+  }
+}
+
 # update by lookup
 "update music set val = 1 where id = 1"
 {

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -358,6 +358,7 @@ func (node *Union) WalkSubtree(visit Visit) error {
 // the row and re-inserts with new values. For that reason we keep it as an Insert struct.
 // Replaces are currently disallowed in sharded schemas because
 // of the implications the deletion part may have on vindexes.
+// If you add fields here, consider adding them to calls to validateSubquerySamePlan.
 type Insert struct {
 	Action   string
 	Comments Comments
@@ -409,6 +410,7 @@ func (Values) iInsertRows()       {}
 func (*ParenSelect) iInsertRows() {}
 
 // Update represents an UPDATE statement.
+// If you add fields here, consider adding them to calls to validateSubquerySamePlan.
 type Update struct {
 	Comments   Comments
 	TableExprs TableExprs
@@ -442,6 +444,7 @@ func (node *Update) WalkSubtree(visit Visit) error {
 }
 
 // Delete represents a DELETE statement.
+// If you add fields here, consider adding them to calls to validateSubquerySamePlan.
 type Delete struct {
 	Comments   Comments
 	Targets    TableNames

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -51,6 +51,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
+		// We only validate non-table subexpressions because the previous analysis has already validated them.
 		if !validateSubquerySamePlan(rb.ERoute, vschema, upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
@@ -118,6 +119,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, err
 	}
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
+		// We only validate non-table subexpressions because the previous analysis has already validated them.
 		if !validateSubquerySamePlan(rb.ERoute, vschema, del.Targets, del.Where, del.OrderBy, del.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -103,7 +103,7 @@ func isIndexChanging(setClauses sqlparser.UpdateExprs, colVindexes []*vindexes.C
 	return false
 }
 
-// buildUpdatePlan builds the instructions for a DELETE statement.
+// buildDeletePlan builds the instructions for a DELETE statement.
 func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, error) {
 	er := &engine.Route{
 		Query: generateQuery(del),

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -51,7 +51,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
-		if !validateSubquerySamePlan(upd, rb.ERoute, vschema) {
+		if !validateSubquerySamePlan(rb.ERoute, vschema, upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		er.Opcode = engine.UpdateUnsharded
@@ -118,7 +118,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, err
 	}
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
-		if !validateSubquerySamePlan(del, rb.ERoute, vschema) {
+		if !validateSubquerySamePlan(rb.ERoute, vschema, del.Targets, del.Where, del.OrderBy, del.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		er.Opcode = engine.DeleteUnsharded

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -48,7 +48,7 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		Table:    table,
 		Keyspace: table.Keyspace,
 	}
-	if !validateSubquerySamePlan(ins, eRoute, vschema) {
+	if !validateSubquerySamePlan(eRoute, vschema, ins) {
 		return nil, errors.New("unsupported: sharded subquery in insert values")
 	}
 	var rows sqlparser.Values


### PR DESCRIPTION
in validateSubquerySamePlan

they've already been analyzed, so we can't analyze them again

for background reading:
https://github.com/youtube/vitess/pull/2852
https://github.com/youtube/vitess/issues/2439