### PR TITLE
messages: handle auto-inc columns

### DIFF
--- a/go/vt/vttablet/endtoend/main_test.go
+++ b/go/vt/vttablet/endtoend/main_test.go
@@ -225,6 +225,13 @@ var tableACLConfig = `{
       "admins": ["dev"]
     },
     {
+      "name": "vitess_message_auto",
+      "table_names_or_prefixes": ["vitess_message_auto"],
+      "readers": ["dev"],
+      "writers": ["dev"],
+      "admins": ["dev"]
+    },
+    {
       "name": "vitess_acl_unmatched",
       "table_names_or_prefixes": ["vitess_acl_unmatched"],
       "readers": ["dev"],

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -528,6 +528,26 @@ func (qre *QueryExecutor) execInsertMessage(conn *TxConnection) (*sqltypes.Resul
 		return nil, err
 	}
 
+	// If an auto-inc value was generated, it could be the id column.
+	// If so, we have to populate it.
+	if qr.InsertID != 0 {
+		id := int64(qr.InsertID)
+		idPKIndex := qre.plan.Table.MessageInfo.IDPKIndex
+		for _, row := range pkRows {
+			if !row[idPKIndex].IsNull() {
+				// If a value was supplied, either it was not the auto-inc column
+				// or values were partially supplied for an auto-inc column.
+				// If it's the former, there is nothing more to do.
+				// If it's the latter, we cannot predict the values for subsequent
+				// rows. So, we still break out of this loop, and will rely on
+				// the poller to eventually pick up the rows from the database.
+				break
+			}
+			row[idPKIndex] = sqltypes.NewInt64(id)
+			id++
+		}
+	}
+
 	// Re-read the inserted rows to prime the cache.
 	extras := map[string]sqlparser.Encodable{
 		"#pk": &sqlparser.TupleEqualityList{


### PR DESCRIPTION
BUG=67490100
There are legitimate use cases for using auto_increment columns
for id.

In such situations, the insert code uses the last insert id returned
by the insert to read back the inserted rows.

It's possible for a rogue application to partially supply values
for the auto-inc column. If so, we cannot predict all the values.
In such cases, the code does the best it can.

Tests have been written for these use cases.

Also fixed client count bug.
BUG=67498764