### PR TITLE
CopySchemaShard: if no master found suggest using a non-master alias

### DIFF
--- a/go/vt/wrangler/schema.go
+++ b/go/vt/wrangler/schema.go
@@ -279,7 +279,7 @@ func (wr *Wrangler) CopySchemaShardFromShard(ctx context.Context, tables, exclud
 		return err
 	}
 	if sourceShardInfo.MasterAlias == nil {
-		return fmt.Errorf("no master in shard record %v/%v. Consider to run 'vtctl InitShardMaster' in case of a new shard or to reparent the shard to fix the topology data", sourceKeyspace, sourceShard)
+		return fmt.Errorf("no master in shard record %v/%v. Consider running 'vtctl InitShardMaster' in case of a new shard or to reparent the shard to fix the topology data, or providing a non-master tablet alias", sourceKeyspace, sourceShard)
 	}
 
 	return wr.CopySchemaShard(ctx, sourceShardInfo.MasterAlias, tables, excludeTables, includeViews, destKeyspace, destShard, waitSlaveTimeout)


### PR DESCRIPTION
Tiny change to suggest another alternative if no master tablet is available.