### PR TITLE
SplitClone logging - show percentage of table copied

### DIFF
--- a/go/vt/worker/table_status.go
+++ b/go/vt/worker/table_status.go
@@ -120,7 +120,11 @@ func (t *tableStatusList) format() ([]string, time.Time) {
 			result[i] = fmt.Sprintf("%v: copy done, processed %v rows", ts.name, ts.copiedRows)
 		} else {
 			// copy is running
-			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount)
+			var pct float32
+			if ts.rowCount > 0 {
+				pct = float32(ts.copiedRows) / float32(ts.rowCount)
+			}
+			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed, %.1f%%)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount, pct)
 		}
 		copiedRows += ts.copiedRows
 		rowCount += ts.rowCount

--- a/go/vt/worker/table_status.go
+++ b/go/vt/worker/table_status.go
@@ -120,11 +120,13 @@ func (t *tableStatusList) format() ([]string, time.Time) {
 			result[i] = fmt.Sprintf("%v: copy done, processed %v rows", ts.name, ts.copiedRows)
 		} else {
 			// copy is running
-			var pct float32
+			// Display 0% if rowCount is 0 because the actual number of rows can be > 0
+			// due to InnoDB's imperfect statistics.
+			percentage := 0.0
 			if ts.rowCount > 0 {
-				pct = float32(ts.copiedRows) / float32(ts.rowCount) * 100.0
+				percentage = float64(ts.copiedRows) / float64(ts.rowCount) * 100.0
 			}
-			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed, %.1f%%)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount, pct)
+			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed, %.1f%%)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount, percentage)
 		}
 		copiedRows += ts.copiedRows
 		rowCount += ts.rowCount

--- a/go/vt/worker/table_status.go
+++ b/go/vt/worker/table_status.go
@@ -122,7 +122,7 @@ func (t *tableStatusList) format() ([]string, time.Time) {
 			// copy is running
 			var pct float32
 			if ts.rowCount > 0 {
-				pct = float32(ts.copiedRows) / float32(ts.rowCount)
+				pct = float32(ts.copiedRows) / float32(ts.rowCount) * 100.0
 			}
 			result[i] = fmt.Sprintf("%v: copy running using %v threads (%v/%v rows processed, %.1f%%)", ts.name, ts.threadsStarted-ts.threadsDone, ts.copiedRows, ts.rowCount, pct)
 		}


### PR DESCRIPTION
e.g.
Copying from: cell1-0000000001 cell1-0000000002 cell1-0000000003 cell1-0000000004 cell1-0000000005 cell1-0000000006
ETA: 2017-10-10 20:06:13.722315714 +0000 UTC m=+1854.452740746
my_big_table: copy running using 10 threads (577847/3893834 rows processed, 0.1%)

Tiny change but the percentage is easier to read.