### PR TITLE
messager: Move "isOpen" into the same group as the mutex.

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -160,8 +160,6 @@ type messageManager struct {
 	DBLock sync.Mutex
 	tsv    TabletService
 
-	isOpen bool
-
 	name         sqlparser.TableIdent
 	fieldResult  *sqltypes.Result
 	ackWaitTime  time.Duration
@@ -172,7 +170,8 @@ type messageManager struct {
 	conns        *connpool.Pool
 	postponeSema *sync2.Semaphore
 
-	mu sync.Mutex
+	mu     sync.Mutex
+	isOpen bool
 	// cond gets triggered if a receiver becomes available (curReceiver != -1),
 	// an item gets added to the cache, or if the manager is closed.
 	// The trigger wakes up the runSend thread.


### PR DESCRIPTION
This way we document that "isOpen" can only be accessed if a lock on the mutex is obtained.