### PR TITLE
messages: improve readability of cache

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/cache.go
+++ b/go/vt/vttablet/tabletserver/messager/cache.go
@@ -32,6 +32,10 @@ type MessageRow struct {
 	Epoch       int64
 	TimeCreated int64
 	Row         []sqltypes.Value
+
+	// defunct is set if the row was asked to be removed
+	// from cache.
+	defunct bool
 }
 
 type messageHeap []*MessageRow
@@ -65,19 +69,35 @@ func (mh *messageHeap) Pop() interface{} {
 
 //_______________________________________________
 
-// cache is the cache for the messager.
+// cache is the cache for the messager. Messages initially
+// start in the sendQueue. When they are popped, they move
+// to the inFlight set. They are eventually discarded
+// after being successfully sent. Messages can be discarded
+// early (while still in the send queue) by any kind of
+// update to a message (like an ack). If so, such messages
+// are marked as defunct in the cache, and are eventually
+// discarded when popped.
 type cache struct {
-	mu        sync.Mutex
-	size      int
+	mu   sync.Mutex
+	size int
+
 	sendQueue messageHeap
-	messages  map[string]*MessageRow
+	// inQueue is used to efficiently find items in sendQueue.
+	// The message id is the key.
+	inQueue map[string]*MessageRow
+
+	// inFlight are messages that are still being sent.
+	// They guard from such messages from being added back prematurely.
+	// The message id is the key.
+	inFlight map[string]bool
 }
 
 // NewMessagerCache creates a new cache.
 func newCache(size int) *cache {
 	mc := &cache{
 		size:     size,
-		messages: make(map[string]*MessageRow),
+		inQueue:  make(map[string]*MessageRow),
+		inFlight: make(map[string]bool),
 	}
 	return mc
 }
@@ -87,7 +107,8 @@ func (mc *cache) Clear() {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	mc.sendQueue = nil
-	mc.messages = make(map[string]*MessageRow)
+	mc.inQueue = make(map[string]*MessageRow)
+	mc.inFlight = make(map[string]bool)
 }
 
 // Add adds a MessageRow to the cache. It returns
@@ -99,13 +120,14 @@ func (mc *cache) Add(mr *MessageRow) bool {
 		return false
 	}
 	id := mr.Row[0].ToString()
-	// Don't check for nil. Messages that are popped for
-	// send are nilled out.
-	if _, ok := mc.messages[id]; ok {
+	if mc.inFlight[id] {
+		return true
+	}
+	if _, ok := mc.inQueue[id]; ok {
 		return true
 	}
 	heap.Push(&mc.sendQueue, mr)
-	mc.messages[id] = mr
+	mc.inQueue[id] = mr
 	return true
 }
 
@@ -123,16 +145,16 @@ func (mc *cache) Pop() *MessageRow {
 			return nil
 		}
 		mr := heap.Pop(&mc.sendQueue).(*MessageRow)
-		id := mr.Row[0].ToString()
 		// If message was previously marked as defunct, drop
 		// it and continue.
-		if id == "" {
+		if mr.defunct {
 			continue
 		}
-		// Point the message entry to nil. If there is a race
-		// with Discard while the item is being sent, it won't
-		// be reachable.
-		mc.messages[id] = nil
+		id := mr.Row[0].ToString()
+
+		// Move the message from inQueue to inFlight.
+		delete(mc.inQueue, id)
+		mc.inFlight[id] = true
 		return mr
 	}
 }
@@ -142,12 +164,13 @@ func (mc *cache) Discard(ids []string) {
 	mc.mu.Lock()
 	defer mc.mu.Unlock()
 	for _, id := range ids {
-		if mr := mc.messages[id]; mr != nil {
+		if mr := mc.inQueue[id]; mr != nil {
 			// The row is still in the queue somewhere. Mark
 			// it as defunct. It will be "garbage collected" later.
-			mr.Row[0] = sqltypes.NULL
+			mr.defunct = true
 		}
-		delete(mc.messages, id)
+		delete(mc.inQueue, id)
+		delete(mc.inFlight, id)
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/messager/message_manager_test.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager_test.go
@@ -219,7 +219,7 @@ func TestMessageManagerSend(t *testing.T) {
 	}
 
 	// Verify item has been removed from cache.
-	if _, ok := mm.cache.messages["1"]; ok {
+	if _, ok := mm.cache.inQueue["1"]; ok {
 		t.Error("Message 1 is still present in cache")
 	}
 


### PR DESCRIPTION
Make a separate inFlight map to differentiate messages that
have been popped for sending.
Add an explicit flag in MessageRow to mark it as defunct.