### PR TITLE
messages: Recategorize purge failures as normal

### DIFF
--- a/go/vt/vttablet/tabletserver/messager/message_manager.go
+++ b/go/vt/vttablet/tabletserver/messager/message_manager.go
@@ -615,10 +615,11 @@ func purge(tsv TabletService, name string, purgeAfter, purgeInterval time.Durati
 	for {
 		count, err := tsv.PurgeMessages(ctx, nil, name, time.Now().Add(-purgeAfter).UnixNano())
 		if err != nil {
-			tabletenv.InternalErrors.Add("Messages", 1)
+			MessageStats.Add([]string{name, "PurgeFailed"}, 1)
 			log.Errorf("Unable to delete messages: %v", err)
+		} else {
+			MessageStats.Add([]string{name, "Purged"}, count)
 		}
-		MessageStats.Add([]string{name, "Purged"}, count)
 		// If deleted 500 or more, we should continue.
 		if count < 500 {
 			return


### PR DESCRIPTION
BUG=67486800
Purge can fail during emergency reparents. So, it should not be
treated as an internal error. We instead increment a normal counter
so that it can be used to alert if a failure is more chronic.