### PR TITLE
v3: improve analysis of parenthesized expressions

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -121,6 +121,25 @@
   }
 }
 
+# update by primary keyspace id with parenthesized expression
+"update user set val = 1 where (id = 1)"
+{
+  "Original": "update user set val = 1 where (id = 1)",
+  "Instructions": {
+    "Opcode": "UpdateEqual",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "update user set val = 1 where (id = 1)",
+    "Vindex": "user_index",
+    "Values": [
+      1
+    ],
+    "Table": "user"
+  }
+}
+
 # update by primary keyspace id, changing one vindex column
 "update user_metadata set email = 'juan@vitess.io' where user_id = 1"
 {

--- a/data/test/vtgate/from_cases.txt
+++ b/data/test/vtgate/from_cases.txt
@@ -518,6 +518,21 @@
   }
 }
 
+# mergeable sharded join on unique vindex (parenthesized ON clause)
+"select user.col from user join user_extra on (user.id = user_extra.user_id)"
+{
+  "Original": "select user.col from user join user_extra on (user.id = user_extra.user_id)",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select user.col from user join user_extra on (user.id = user_extra.user_id)",
+    "FieldQuery": "select user.col from user join user_extra on (user.id = user_extra.user_id) where 1 != 1"
+  }
+}
+
 # mergeable sharded join on unique vindex, with a stray condition
 "select user.col from user join user_extra on user.col between 1 and 2 and user.id = user_extra.user_id"
 {

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -246,6 +246,7 @@ func extractValueFromUpdate(upd *sqlparser.UpdateExpr, col sqlparser.ColIdent) (
 func getMatch(node sqlparser.Expr, col sqlparser.ColIdent) (pv sqltypes.PlanValue, ok bool) {
 	filters := splitAndExpression(nil, node)
 	for _, filter := range filters {
+		filter = skipParenthesis(filter)
 		comparison, ok := filter.(*sqlparser.ComparisonExpr)
 		if !ok {
 			continue

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -39,6 +39,17 @@ func splitAndExpression(filters []sqlparser.Expr, node sqlparser.Expr) []sqlpars
 	return append(filters, node)
 }
 
+// skipParenthesis skips the parenthesis (if any) of an expression and
+// returns the innermost unparenthesized expression.
+func skipParenthesis(node sqlparser.Expr) sqlparser.Expr {
+	for {
+		if node, ok := node.(*sqlparser.ParenExpr); ok {
+			return skipParenthesis(node.Expr)
+		}
+		return node
+	}
+}
+
 // findOrigin identifies the right-most origin referenced by expr. In situations where
 // the expression references columns from multiple origins, the expression will be
 // pushed to the right-most origin, and the executor will use the results of

--- a/go/vt/vtgate/planbuilder/expr_test.go
+++ b/go/vt/vtgate/planbuilder/expr_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package planbuilder
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/sqlparser"
@@ -99,6 +100,17 @@ func TestValEqual(t *testing.T) {
 		out := valEqual(tc.in1, tc.in2)
 		if out != tc.out {
 			t.Errorf("valEqual(%#v, %#v): %v, want %v", tc.in1, tc.in2, out, tc.out)
+		}
+	}
+}
+
+func TestSkipParenthesis(t *testing.T) {
+	baseNode := newIntVal("1")
+	paren1 := &sqlparser.ParenExpr{Expr: baseNode}
+	paren2 := &sqlparser.ParenExpr{Expr: paren1}
+	for _, tcase := range []sqlparser.Expr{baseNode, paren1, paren2} {
+		if got, want := skipParenthesis(tcase), baseNode; !reflect.DeepEqual(got, want) {
+			t.Errorf("skipParenthesis(%v): %v, want %v", sqlparser.String(tcase), sqlparser.String(got), sqlparser.String(want))
 		}
 	}
 }

--- a/go/vt/vtgate/planbuilder/route.go
+++ b/go/vt/vtgate/planbuilder/route.go
@@ -205,6 +205,7 @@ func (rb *route) merge(rhs *route, ajoin *sqlparser.JoinTableExpr) (builder, err
 // mergeable by unique vindex. The constraint has to be an equality
 // like a.id = b.id where both columns have the same unique vindex.
 func (rb *route) isSameRoute(rhs *route, filter sqlparser.Expr) bool {
+	filter = skipParenthesis(filter)
 	comparison, ok := filter.(*sqlparser.ComparisonExpr)
 	if !ok {
 		return false


### PR DESCRIPTION
Issue #3283
For DMLs and ON clauses, the expression analysis did not drill
down into trivially parenthesized expressions.
This change performs those drill downs, which will take care of
some queries where OR mappers may conservatively parenthesize.