### PR TITLE
codegen: consolidate id escaping

### DIFF
--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -587,13 +587,10 @@ func (bls *Streamer) parseEvents(ctx context.Context, events <-chan mysql.Binlog
 
 func (bls *Streamer) appendInserts(statements []FullBinlogStatement, tce *tableCacheEntry, rows *mysql.Rows) []FullBinlogStatement {
 	for i := range rows.Rows {
-		var sql bytes.Buffer
+		sql := sqlparser.NewTrackedBuffer(nil)
+		sql.Myprintf("INSERT INTO %v SET ", sqlparser.NewTableIdent(tce.tm.Name))
 
-		sql.WriteString("INSERT INTO ")
-		sql.WriteString(tce.tm.Name)
-		sql.WriteString(" SET ")
-
-		keyspaceIDCell, pkValues, err := writeValuesAsSQL(&sql, tce, rows, i, tce.pkNames != nil)
+		keyspaceIDCell, pkValues, err := writeValuesAsSQL(sql, tce, rows, i, tce.pkNames != nil)
 		if err != nil {
 			log.Warningf("writeValuesAsSQL(%v) failed: %v", i, err)
 			continue
@@ -626,13 +623,10 @@ func (bls *Streamer) appendInserts(statements []FullBinlogStatement, tce *tableC
 
 func (bls *Streamer) appendUpdates(statements []FullBinlogStatement, tce *tableCacheEntry, rows *mysql.Rows) []FullBinlogStatement {
 	for i := range rows.Rows {
-		var sql bytes.Buffer
+		sql := sqlparser.NewTrackedBuffer(nil)
+		sql.Myprintf("UPDATE %v SET ", sqlparser.NewTableIdent(tce.tm.Name))
 
-		sql.WriteString("UPDATE ")
-		sql.WriteString(tce.tm.Name)
-		sql.WriteString(" SET ")
-
-		keyspaceIDCell, pkValues, err := writeValuesAsSQL(&sql, tce, rows, i, tce.pkNames != nil)
+		keyspaceIDCell, pkValues, err := writeValuesAsSQL(sql, tce, rows, i, tce.pkNames != nil)
 		if err != nil {
 			log.Warningf("writeValuesAsSQL(%v) failed: %v", i, err)
 			continue
@@ -640,7 +634,7 @@ func (bls *Streamer) appendUpdates(statements []FullBinlogStatement, tce *tableC
 
 		sql.WriteString(" WHERE ")
 
-		if _, _, err := writeIdentifiesAsSQL(&sql, tce, rows, i, false); err != nil {
+		if _, _, err := writeIdentifiersAsSQL(sql, tce, rows, i, false); err != nil {
 			log.Warningf("writeIdentifiesAsSQL(%v) failed: %v", i, err)
 			continue
 		}
@@ -672,13 +666,10 @@ func (bls *Streamer) appendUpdates(statements []FullBinlogStatement, tce *tableC
 
 func (bls *Streamer) appendDeletes(statements []FullBinlogStatement, tce *tableCacheEntry, rows *mysql.Rows) []FullBinlogStatement {
 	for i := range rows.Rows {
-		var sql bytes.Buffer
+		sql := sqlparser.NewTrackedBuffer(nil)
+		sql.Myprintf("DELETE FROM %v WHERE ", sqlparser.NewTableIdent(tce.tm.Name))
 
-		sql.WriteString("DELETE FROM ")
-		sql.WriteString(tce.tm.Name)
-		sql.WriteString(" WHERE ")
-
-		keyspaceIDCell, pkValues, err := writeIdentifiesAsSQL(&sql, tce, rows, i, tce.pkNames != nil)
+		keyspaceIDCell, pkValues, err := writeIdentifiersAsSQL(sql, tce, rows, i, tce.pkNames != nil)
 		if err != nil {
 			log.Warningf("writeIdentifiesAsSQL(%v) failed: %v", i, err)
 			continue
@@ -712,7 +703,7 @@ func (bls *Streamer) appendDeletes(statements []FullBinlogStatement, tce *tableC
 // writeValuesAsSQL is a helper method to print the values as SQL in the
 // provided bytes.Buffer. It also returns the value for the keyspaceIDColumn,
 // and the array of values for the PK, if necessary.
-func writeValuesAsSQL(sql *bytes.Buffer, tce *tableCacheEntry, rs *mysql.Rows, rowIndex int, getPK bool) (sqltypes.Value, []sqltypes.Value, error) {
+func writeValuesAsSQL(sql *sqlparser.TrackedBuffer, tce *tableCacheEntry, rs *mysql.Rows, rowIndex int, getPK bool) (sqltypes.Value, []sqltypes.Value, error) {
 	valueIndex := 0
 	data := rs.Rows[rowIndex].Data
 	pos := 0
@@ -730,7 +721,7 @@ func writeValuesAsSQL(sql *bytes.Buffer, tce *tableCacheEntry, rs *mysql.Rows, r
 		if valueIndex > 0 {
 			sql.WriteString(", ")
 		}
-		sql.WriteString(tce.ti.Columns[c].Name.String())
+		sql.Myprintf("%v", tce.ti.Columns[c].Name)
 		sql.WriteByte('=')
 
 		if rs.Rows[rowIndex].NullColumns.Bit(valueIndex) {
@@ -770,10 +761,10 @@ func writeValuesAsSQL(sql *bytes.Buffer, tce *tableCacheEntry, rs *mysql.Rows, r
 	return keyspaceIDCell, pkValues, nil
 }
 
-// writeIdentifiesAsSQL is a helper method to print the identifies as SQL in the
+// writeIdentifiersAsSQL is a helper method to print the identifies as SQL in the
 // provided bytes.Buffer. It also returns the value for the keyspaceIDColumn,
 // and the array of values for the PK, if necessary.
-func writeIdentifiesAsSQL(sql *bytes.Buffer, tce *tableCacheEntry, rs *mysql.Rows, rowIndex int, getPK bool) (sqltypes.Value, []sqltypes.Value, error) {
+func writeIdentifiersAsSQL(sql *sqlparser.TrackedBuffer, tce *tableCacheEntry, rs *mysql.Rows, rowIndex int, getPK bool) (sqltypes.Value, []sqltypes.Value, error) {
 	valueIndex := 0
 	data := rs.Rows[rowIndex].Identify
 	pos := 0
@@ -791,7 +782,7 @@ func writeIdentifiesAsSQL(sql *bytes.Buffer, tce *tableCacheEntry, rs *mysql.Row
 		if valueIndex > 0 {
 			sql.WriteString(" AND ")
 		}
-		sql.WriteString(tce.ti.Columns[c].Name.String())
+		sql.Myprintf("%v", tce.ti.Columns[c].Name)
 
 		if rs.Rows[rowIndex].NullIdentifyColumns.Bit(valueIndex) {
 			// This column is represented, but its value is NULL.

--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -32,7 +32,7 @@ import (
 
 // This file tests the RBR events are parsed correctly.
 
-func TestStreamerParseRBRUpdateEvent(t *testing.T) {
+func TestStreamerParseRBREvents(t *testing.T) {
 	f := mysql.NewMySQL56BinlogFormat()
 	s := mysql.NewFakeBinlogStream()
 	s.ServerID = 62344
@@ -232,6 +232,246 @@ func TestStreamerParseRBRUpdateEvent(t *testing.T) {
 						Sql:      []byte("DELETE FROM vt_a WHERE id=1076895760 AND message='abc'"),
 					},
 					Table: "vt_a",
+				},
+			},
+			eventToken: &querypb.EventToken{
+				Timestamp: 1407805592,
+				Position: mysql.EncodePosition(mysql.Position{
+					GTIDSet: mysql.MariadbGTID{
+						Domain:   0,
+						Server:   62344,
+						Sequence: 0x0d,
+					},
+				}),
+			},
+		},
+	}
+	var got []fullBinlogTransaction
+	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
+		got = append(got, fullBinlogTransaction{
+			eventToken: eventToken,
+			statements: statements,
+		})
+		return nil
+	}
+	bls := NewStreamer("vt_test_keyspace", nil, se, nil, mysql.Position{}, 0, sendTransaction)
+
+	go sendTestEvents(events, input)
+	_, err := bls.parseEvents(context.Background(), events)
+	if err != ErrServerEOF {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("binlogConnStreamer.parseEvents(): got:\n%+v\nwant:\n%+v", got, want)
+		for i, fbt := range got {
+			t.Errorf("Got (%v)=%v", i, fbt.statements)
+		}
+		for i, fbt := range want {
+			t.Errorf("Want(%v)=%v", i, fbt.statements)
+		}
+	}
+}
+
+func TestStreamerParseRBRNameEscapes(t *testing.T) {
+	f := mysql.NewMySQL56BinlogFormat()
+	s := mysql.NewFakeBinlogStream()
+	s.ServerID = 62344
+
+	// Create a schema.Engine for this test using keyword names.
+	se := schema.NewEngineForTests()
+	se.SetTableForTests(&schema.Table{
+		Name: sqlparser.NewTableIdent("insert"),
+		Columns: []schema.TableColumn{
+			{
+				Name: sqlparser.NewColIdent("update"),
+				Type: querypb.Type_INT64,
+			},
+			{
+				Name: sqlparser.NewColIdent("delete"),
+				Type: querypb.Type_VARCHAR,
+			},
+		},
+	})
+
+	// Create a tableMap event on the table.
+	tableID := uint64(0x102030405060)
+	tm := &mysql.TableMap{
+		Flags:    0x8090,
+		Database: "vt_test_keyspace",
+		Name:     "insert",
+		Types: []byte{
+			mysql.TypeLong,
+			mysql.TypeVarchar,
+		},
+		CanBeNull: mysql.NewServerBitmap(2),
+		Metadata: []uint16{
+			0,
+			384, // A VARCHAR(128) in utf8 would result in 384.
+		},
+	}
+	tm.CanBeNull.Set(1, true)
+
+	// Do an insert packet with all fields set.
+	insertRows := mysql.Rows{
+		Flags:       0x1234,
+		DataColumns: mysql.NewServerBitmap(2),
+		Rows: []mysql.Row{
+			{
+				NullColumns: mysql.NewServerBitmap(2),
+				Data: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+					0x04, 0x00, // len('abcd')
+					'a', 'b', 'c', 'd', // 'abcd'
+				},
+			},
+		},
+	}
+	insertRows.DataColumns.Set(0, true)
+	insertRows.DataColumns.Set(1, true)
+
+	// Do an update packet with all fields set.
+	updateRows := mysql.Rows{
+		Flags:           0x1234,
+		IdentifyColumns: mysql.NewServerBitmap(2),
+		DataColumns:     mysql.NewServerBitmap(2),
+		Rows: []mysql.Row{
+			{
+				NullIdentifyColumns: mysql.NewServerBitmap(2),
+				NullColumns:         mysql.NewServerBitmap(2),
+				Identify: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+					0x03, 0x00, // len('abc')
+					'a', 'b', 'c', // 'abc'
+				},
+				Data: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+					0x04, 0x00, // len('abcd')
+					'a', 'b', 'c', 'd', // 'abcd'
+				},
+			},
+		},
+	}
+	updateRows.IdentifyColumns.Set(0, true)
+	updateRows.IdentifyColumns.Set(1, true)
+	updateRows.DataColumns.Set(0, true)
+	updateRows.DataColumns.Set(1, true)
+
+	// Do an update packet with an identify set to NULL, and a
+	// value set to NULL.
+	updateRowsNull := mysql.Rows{
+		Flags:           0x1234,
+		IdentifyColumns: mysql.NewServerBitmap(2),
+		DataColumns:     mysql.NewServerBitmap(2),
+		Rows: []mysql.Row{
+			{
+				NullIdentifyColumns: mysql.NewServerBitmap(2),
+				NullColumns:         mysql.NewServerBitmap(2),
+				Identify: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+				},
+				Data: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+				},
+			},
+		},
+	}
+	updateRowsNull.IdentifyColumns.Set(0, true)
+	updateRowsNull.IdentifyColumns.Set(1, true)
+	updateRowsNull.DataColumns.Set(0, true)
+	updateRowsNull.DataColumns.Set(1, true)
+	updateRowsNull.Rows[0].NullIdentifyColumns.Set(1, true)
+	updateRowsNull.Rows[0].NullColumns.Set(1, true)
+
+	// Do a delete packet with all fields set.
+	deleteRows := mysql.Rows{
+		Flags:           0x1234,
+		IdentifyColumns: mysql.NewServerBitmap(2),
+		Rows: []mysql.Row{
+			{
+				NullIdentifyColumns: mysql.NewServerBitmap(2),
+				Identify: []byte{
+					0x10, 0x20, 0x30, 0x40, // long
+					0x03, 0x00, // len('abc')
+					'a', 'b', 'c', // 'abc'
+				},
+			},
+		},
+	}
+	deleteRows.IdentifyColumns.Set(0, true)
+	deleteRows.IdentifyColumns.Set(1, true)
+
+	input := []mysql.BinlogEvent{
+		mysql.NewRotateEvent(f, s, 0, ""),
+		mysql.NewFormatDescriptionEvent(f, s),
+		mysql.NewTableMapEvent(f, s, tableID, tm),
+		mysql.NewMariaDBGTIDEvent(f, s, mysql.MariadbGTID{Domain: 0, Sequence: 0xd}, false /* hasBegin */),
+		mysql.NewQueryEvent(f, s, mysql.Query{
+			Database: "vt_test_keyspace",
+			SQL:      "BEGIN"}),
+		mysql.NewWriteRowsEvent(f, s, tableID, insertRows),
+		mysql.NewUpdateRowsEvent(f, s, tableID, updateRows),
+		mysql.NewUpdateRowsEvent(f, s, tableID, updateRowsNull),
+		mysql.NewDeleteRowsEvent(f, s, tableID, deleteRows),
+		mysql.NewXIDEvent(f, s),
+	}
+
+	events := make(chan mysql.BinlogEvent)
+
+	want := []fullBinlogTransaction{
+		{
+			statements: []FullBinlogStatement{
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_SET,
+						Sql:      []byte("SET TIMESTAMP=1407805592"),
+					},
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_INSERT,
+						Sql:      []byte("INSERT INTO `insert` SET `update`=1076895760, `delete`='abcd'"),
+					},
+					Table: "insert",
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_SET,
+						Sql:      []byte("SET TIMESTAMP=1407805592"),
+					},
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_UPDATE,
+						Sql:      []byte("UPDATE `insert` SET `update`=1076895760, `delete`='abcd' WHERE `update`=1076895760 AND `delete`='abc'"),
+					},
+					Table: "insert",
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_SET,
+						Sql:      []byte("SET TIMESTAMP=1407805592"),
+					},
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_UPDATE,
+						Sql:      []byte("UPDATE `insert` SET `update`=1076895760, `delete`=NULL WHERE `update`=1076895760 AND `delete` IS NULL"),
+					},
+					Table: "insert",
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_SET,
+						Sql:      []byte("SET TIMESTAMP=1407805592"),
+					},
+				},
+				{
+					Statement: &binlogdatapb.BinlogTransaction_Statement{
+						Category: binlogdatapb.BinlogTransaction_Statement_BL_DELETE,
+						Sql:      []byte("DELETE FROM `insert` WHERE `update`=1076895760 AND `delete`='abc'"),
+					},
+					Table: "insert",
 				},
 			},
 			eventToken: &querypb.EventToken{

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/mysql"
+
 	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )

--- a/go/vt/sqlparser/ast.go
+++ b/go/vt/sqlparser/ast.go
@@ -26,9 +26,10 @@ import (
 	log "github.com/golang/glog"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vterrors"
+
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
-	"github.com/youtube/vitess/go/vt/vterrors"
 )
 
 // Instructions for creating new types: If a type
@@ -728,7 +729,7 @@ type ColumnDefinition struct {
 
 // Format formats the node.
 func (col *ColumnDefinition) Format(buf *TrackedBuffer) {
-	buf.Myprintf("`%s` %v", col.Name.String(), &col.Type)
+	buf.Myprintf("%v %v", col.Name, &col.Type)
 }
 
 // WalkSubtree walks the nodes of the subtree.
@@ -950,9 +951,9 @@ func (idx *IndexDefinition) Format(buf *TrackedBuffer) {
 	buf.Myprintf("%v (", idx.Info)
 	for i, col := range idx.Columns {
 		if i != 0 {
-			buf.Myprintf(", `%s`", col.Column.String())
+			buf.Myprintf(", %v", col.Column)
 		} else {
-			buf.Myprintf("`%s`", col.Column.String())
+			buf.Myprintf("%v", col.Column)
 		}
 		if col.Length != nil {
 			buf.Myprintf("(%v)", col.Length)
@@ -989,17 +990,13 @@ func (ii *IndexInfo) Format(buf *TrackedBuffer) {
 	if ii.Primary {
 		buf.Myprintf("%s", ii.Type)
 	} else {
-		buf.Myprintf("%s `%v`", ii.Type, ii.Name)
+		buf.Myprintf("%s %v", ii.Type, ii.Name)
 	}
 }
 
 // WalkSubtree walks the nodes of the subtree.
 func (ii *IndexInfo) WalkSubtree(visit Visit) error {
-	if err := Walk(visit, ii.Name); err != nil {
-		return err
-	}
-
-	return nil
+	return Walk(visit, ii.Name)
 }
 
 // IndexColumn describes a column in an index definition with optional length
@@ -2415,10 +2412,7 @@ func (node *CaseExpr) WalkSubtree(visit Visit) error {
 			return err
 		}
 	}
-	if err := Walk(visit, node.Else); err != nil {
-		return err
-	}
-	return nil
+	return Walk(visit, node.Else)
 }
 
 // Default represents a DEFAULT expression.

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -728,12 +728,13 @@ var (
 	}, {
 		input: "create table a",
 	}, {
-		input: "create table a (\n\t`a` int\n)",
+		input:  "create table a (\n\t`a` int\n)",
+		output: "create table a (\n\ta int\n)",
 	}, {
 		input: "create table `by` (\n\t`by` char\n)",
 	}, {
 		input:  "create table if not exists a (\n\t`a` int\n)",
-		output: "create table a (\n\t`a` int\n)",
+		output: "create table a (\n\ta int\n)",
 	}, {
 		input:  "create table a ignore me this is garbage",
 		output: "create table a",
@@ -925,7 +926,8 @@ func TestCaseSensitivity(t *testing.T) {
 		input  string
 		output string
 	}{{
-		input: "create table A (\n\t`B` int\n)",
+		input:  "create table A (\n\t`B` int\n)",
+		output: "create table A (\n\tB int\n)",
 	}, {
 		input:  "create index b on A",
 		output: "alter table A",
@@ -986,7 +988,7 @@ func TestCaseSensitivity(t *testing.T) {
 		input: "insert into A(A, B) values (1, 2)",
 	}, {
 		input:  "CREATE TABLE A (\n\t`A` int\n)",
-		output: "create table A (\n\t`A` int\n)",
+		output: "create table A (\n\tA int\n)",
 	}, {
 		input:  "create view A",
 		output: "create table a",
@@ -1205,109 +1207,109 @@ func TestCreateTable(t *testing.T) {
 	validSQL := []string{
 		// test all the data types and options
 		"create table t (\n" +
-			"	`col_bit` bit,\n" +
-			"	`col_tinyint` tinyint auto_increment,\n" +
-			"	`col_tinyint3` tinyint(3) unsigned,\n" +
-			"	`col_smallint` smallint,\n" +
-			"	`col_smallint4` smallint(4) zerofill,\n" +
-			"	`col_mediumint` mediumint,\n" +
-			"	`col_mediumint5` mediumint(5) unsigned not null,\n" +
-			"	`col_int` int,\n" +
-			"	`col_int10` int(10) not null,\n" +
-			"	`col_integer` integer comment 'this is an integer',\n" +
-			"	`col_bigint` bigint,\n" +
-			"	`col_bigint10` bigint(10) zerofill not null default 10,\n" +
-			"	`col_real` real,\n" +
-			"	`col_real2` real(1,2) not null default 1.23,\n" +
-			"	`col_double` double,\n" +
-			"	`col_double2` double(3,4) not null default 1.23,\n" +
-			"	`col_float` float,\n" +
-			"	`col_float2` float(3,4) not null default 1.23,\n" +
-			"	`col_decimal` decimal,\n" +
-			"	`col_decimal2` decimal(2),\n" +
-			"	`col_decimal3` decimal(2,3),\n" +
-			"	`col_numeric` numeric,\n" +
-			"	`col_numeric2` numeric(2),\n" +
-			"	`col_numeric3` numeric(2,3),\n" +
-			"	`col_date` date,\n" +
-			"	`col_time` time,\n" +
-			"	`col_timestamp` timestamp,\n" +
-			"	`col_datetime` datetime,\n" +
-			"	`col_year` year,\n" +
-			"	`col_char` char,\n" +
-			"	`col_char2` char(2),\n" +
-			"	`col_char3` char(3) character set ascii,\n" +
-			"	`col_char4` char(4) character set ascii collate ascii_bin,\n" +
-			"	`col_varchar` varchar,\n" +
-			"	`col_varchar2` varchar(2),\n" +
-			"	`col_varchar3` varchar(3) character set ascii,\n" +
-			"	`col_varchar4` varchar(4) character set ascii collate ascii_bin,\n" +
-			"	`col_binary` binary,\n" +
-			"	`col_varbinary` varbinary(10),\n" +
-			"	`col_tinyblob` tinyblob,\n" +
-			"	`col_blob` blob,\n" +
-			"	`col_mediumblob` mediumblob,\n" +
-			"	`col_longblob` longblob,\n" +
-			"	`col_tinytext` tinytext,\n" +
-			"	`col_text` text,\n" +
-			"	`col_mediumtext` mediumtext,\n" +
-			"	`col_longtext` longtext,\n" +
-			"	`col_text` text character set ascii collate ascii_bin,\n" +
-			"	`col_json` json,\n" +
-			"	`col_enum` enum('a', 'b', 'c', 'd')\n" +
+			"	col_bit bit,\n" +
+			"	col_tinyint tinyint auto_increment,\n" +
+			"	col_tinyint3 tinyint(3) unsigned,\n" +
+			"	col_smallint smallint,\n" +
+			"	col_smallint4 smallint(4) zerofill,\n" +
+			"	col_mediumint mediumint,\n" +
+			"	col_mediumint5 mediumint(5) unsigned not null,\n" +
+			"	col_int int,\n" +
+			"	col_int10 int(10) not null,\n" +
+			"	col_integer integer comment 'this is an integer',\n" +
+			"	col_bigint bigint,\n" +
+			"	col_bigint10 bigint(10) zerofill not null default 10,\n" +
+			"	col_real real,\n" +
+			"	col_real2 real(1,2) not null default 1.23,\n" +
+			"	col_double double,\n" +
+			"	col_double2 double(3,4) not null default 1.23,\n" +
+			"	col_float float,\n" +
+			"	col_float2 float(3,4) not null default 1.23,\n" +
+			"	col_decimal decimal,\n" +
+			"	col_decimal2 decimal(2),\n" +
+			"	col_decimal3 decimal(2,3),\n" +
+			"	col_numeric numeric,\n" +
+			"	col_numeric2 numeric(2),\n" +
+			"	col_numeric3 numeric(2,3),\n" +
+			"	col_date date,\n" +
+			"	col_time time,\n" +
+			"	col_timestamp timestamp,\n" +
+			"	col_datetime datetime,\n" +
+			"	col_year year,\n" +
+			"	col_char char,\n" +
+			"	col_char2 char(2),\n" +
+			"	col_char3 char(3) character set ascii,\n" +
+			"	col_char4 char(4) character set ascii collate ascii_bin,\n" +
+			"	col_varchar varchar,\n" +
+			"	col_varchar2 varchar(2),\n" +
+			"	col_varchar3 varchar(3) character set ascii,\n" +
+			"	col_varchar4 varchar(4) character set ascii collate ascii_bin,\n" +
+			"	col_binary binary,\n" +
+			"	col_varbinary varbinary(10),\n" +
+			"	col_tinyblob tinyblob,\n" +
+			"	col_blob blob,\n" +
+			"	col_mediumblob mediumblob,\n" +
+			"	col_longblob longblob,\n" +
+			"	col_tinytext tinytext,\n" +
+			"	col_text text,\n" +
+			"	col_mediumtext mediumtext,\n" +
+			"	col_longtext longtext,\n" +
+			"	col_text text character set ascii collate ascii_bin,\n" +
+			"	col_json json,\n" +
+			"	col_enum enum('a', 'b', 'c', 'd')\n" +
 			")",
 
 		// test defaults
 		"create table t (\n" +
-			"	`i1` int default 1,\n" +
-			"	`i2` int default null,\n" +
-			"	`f1` float default 1.23,\n" +
-			"	`s1` varchar default 'c',\n" +
-			"	`s2` varchar default 'this is a string',\n" +
-			"	`s3` varchar default null,\n" +
-			"	`s4` timestamp default current_timestamp\n" +
+			"	i1 int default 1,\n" +
+			"	i2 int default null,\n" +
+			"	f1 float default 1.23,\n" +
+			"	s1 varchar default 'c',\n" +
+			"	s2 varchar default 'this is a string',\n" +
+			"	s3 varchar default null,\n" +
+			"	s4 timestamp default current_timestamp\n" +
 			")",
 
 		// test key field options
 		"create table t (\n" +
-			"	`id` int auto_increment primary key,\n" +
-			"	`username` varchar unique key,\n" +
-			"	`email` varchar unique,\n" +
-			"	`full_name` varchar key\n" +
+			"	id int auto_increment primary key,\n" +
+			"	username varchar unique key,\n" +
+			"	email varchar unique,\n" +
+			"	full_name varchar key\n" +
 			")",
 
 		// test defining indexes separately
 		"create table t (\n" +
-			"	`id` int auto_increment,\n" +
-			"	`username` varchar,\n" +
-			"	`email` varchar,\n" +
-			"	`full_name` varchar,\n" +
-			"	`status` varchar,\n" +
-			"	primary key (`id`),\n" +
-			"	unique key `by_username` (`username`),\n" +
-			"	unique `by_username2` (`username`),\n" +
-			"	unique index `by_username3` (`username`),\n" +
-			"	index `by_status` (`status`),\n" +
-			"	key `by_full_name` (`full_name`)\n" +
+			"	id int auto_increment,\n" +
+			"	username varchar,\n" +
+			"	email varchar,\n" +
+			"	full_name varchar,\n" +
+			"	status varchar,\n" +
+			"	primary key (id),\n" +
+			"	unique key by_username (username),\n" +
+			"	unique by_username2 (username),\n" +
+			"	unique index by_username3 (username),\n" +
+			"	index by_status (status),\n" +
+			"	key by_full_name (full_name)\n" +
 			")",
 
 		// multi-column indexes
 		"create table t (\n" +
-			"	`id` int auto_increment,\n" +
-			"	`username` varchar,\n" +
-			"	`email` varchar,\n" +
-			"	`full_name` varchar,\n" +
-			"	`a` int,\n" +
-			"	`b` int,\n" +
-			"	`c` int,\n" +
-			"	primary key (`id`, `username`),\n" +
-			"	unique key `by_abc` (`a`, `b`, `c`),\n" +
-			"	key `by_email` (`email`(10), `username`)\n" +
+			"	id int auto_increment,\n" +
+			"	username varchar,\n" +
+			"	email varchar,\n" +
+			"	full_name varchar,\n" +
+			"	a int,\n" +
+			"	b int,\n" +
+			"	c int,\n" +
+			"	primary key (id, username),\n" +
+			"	unique key by_abc (a, b, c),\n" +
+			"	key by_email (email(10), username)\n" +
 			")",
 
 		// table options
 		"create table t (\n" +
-			"	`id` int auto_increment\n" +
+			"	id int auto_increment\n" +
 			") engine InnoDB,\n" +
 			"  auto_increment 123,\n" +
 			"  avg_row_length 1,\n" +
@@ -1359,6 +1361,35 @@ func TestCreateTable(t *testing.T) {
 	tree, err = ParseStrictDDL(sql)
 	if tree != nil || err == nil {
 		t.Errorf("ParseStrictDDL unexpectedly accepted input %s", sql)
+	}
+}
+
+func TestCreateTableEscaped(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output string
+	}{{
+		input: "create table `a`(`id` int, primary key(`id`))",
+		output: "create table a (\n" +
+			"\tid int,\n" +
+			"\tprimary key (id)\n" +
+			")",
+	}, {
+		input: "create table `insert`(`update` int, primary key(`delete`))",
+		output: "create table `insert` (\n" +
+			"\t`update` int,\n" +
+			"\tprimary key (`delete`)\n" +
+			")",
+	}}
+	for _, tcase := range testCases {
+		tree, err := ParseStrictDDL(tcase.input)
+		if err != nil {
+			t.Errorf("input: %s, err: %v", tcase.input, err)
+			continue
+		}
+		if got, want := String(tree.(*DDL)), tcase.output; got != want {
+			t.Errorf("Parse(%s):\n%s, want\n%s", tcase.input, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
@alainjobart @tirsen @janneku @demmer This change addresses #3297 and #3279.
I still need to write a test for the binlog server. But wanted to make sure you're ok with this approach.

There were a few places where ids were inconsistently escaped.
This change consolidates those places and makes use of the
parser-provided functionality.