### PR TITLE
Disable strict mode enforcement when running vtcombo.

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -99,6 +99,9 @@ func main() {
 	flag.Set("enable_realtime_stats", "true")
 	flag.Set("log_dir", "$VTDATAROOT/tmp")
 
+	// vttablet config. Strict mode is enabled by default, however vtcombo dont need to enforce it
+	flag.Set("enforce_strict_trans_tables", "false")
+
 	// Create topo server. We use a 'memorytopo' implementation.
 	ts = memorytopo.NewServer(tpb.Cells...)
 	servenv.Init()


### PR DESCRIPTION
Vttablet enforces strict mode, however, it can be disabled. As vtcombo
is meant to be run as a test env, we don't need to enforce strict mode.

I am open to suggestions here. Not sure if this should be an option in vtcombo.
I just found easier to disable as this is just a enforcement check

Our use case:
We are not running on strict mode yet, and we are using vtcombo into our CI. So we need to start it without the enforcement. 

thoughts @vmg @sougou 