### PR TITLE
Don't rewrite log_dir when passing it. [vtcombo]

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -97,7 +97,9 @@ func main() {
 	// vtctld UI requires the cell flag
 	flag.Set("cell", tpb.Cells[0])
 	flag.Set("enable_realtime_stats", "true")
-	flag.Set("log_dir", "$VTDATAROOT/tmp")
+	if flag.Lookup("log_dir") == nil {
+		flag.Set("log_dir", "$VTDATAROOT/tmp")
+	}
 
 	// Create topo server. We use a 'memorytopo' implementation.
 	ts = memorytopo.NewServer(tpb.Cells...)


### PR DESCRIPTION
We were setting the `log_dir` to vtcombo, however, it was still using the
default value. This should make it only set a default value when
log_dir was not given as input.

Spoke with @sougou about that, and he confirmed that the logs were not going to the folder it was supposed to. This should fix the problem

cc @vmg 