### PR TITLE
mysql: revert ComQuery to use string

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -111,7 +111,7 @@ type DB struct {
 
 // QueryHandler is the interface used by the DB to simulate executed queries
 type QueryHandler interface {
-	HandleQuery(*mysql.Conn, []byte, func(*sqltypes.Result) error) error
+	HandleQuery(*mysql.Conn, string, func(*sqltypes.Result) error) error
 }
 
 // ExpectedResult holds the data for a matched query.
@@ -310,17 +310,16 @@ func (db *DB) ConnectionClosed(c *mysql.Conn) {
 }
 
 // ComQuery is part of the mysql.Handler interface.
-func (db *DB) ComQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
-	return db.Handler.HandleQuery(c, q, callback)
+func (db *DB) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
+	return db.Handler.HandleQuery(c, query, callback)
 }
 
 // HandleQuery is the default implementation of the QueryHandler interface
-func (db *DB) HandleQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
+func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	if db.AllowAll {
 		return callback(&sqltypes.Result{})
 	}
 
-	query := string(q)
 	if db.t != nil {
 		db.t.Logf("ComQuery(%v): client %v: %v", db.name, c.ConnectionID, query)
 	}

--- a/go/mysql/query_test.go
+++ b/go/mysql/query_test.go
@@ -404,7 +404,7 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 		if comQuery[0] != ComQuery {
 			t.Fatalf("server got bad packet: %v", comQuery)
 		}
-		got := string(sConn.parseComQuery(comQuery))
+		got := sConn.parseComQuery(comQuery)
 		if got != query {
 			t.Errorf("server got query '%v' but expected '%v'", got, query)
 		}
@@ -418,11 +418,11 @@ func checkQueryInternal(t *testing.T, query string, sConn, cConn *Conn, result *
 }
 
 func writeResult(conn *Conn, result *sqltypes.Result) error {
+	if len(result.Fields) == 0 {
+		return conn.writeOKPacket(result.RowsAffected, result.InsertID, conn.StatusFlags, 0)
+	}
 	if err := conn.writeFields(result); err != nil {
 		return err
-	}
-	if len(result.Fields) == 0 {
-		return nil
 	}
 	if err := conn.writeRows(result); err != nil {
 		return err

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -73,7 +73,7 @@ type Handler interface {
 	// Note the contents of the query slice may change after
 	// the first call to callback. So the Handler should not
 	// hang on to the byte slice.
-	ComQuery(c *Conn, query []byte, callback func(*sqltypes.Result) error) error
+	ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error
 }
 
 // Listener is the MySQL server protocol listener.
@@ -320,9 +320,9 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		case ComQuery:
 			queryStart := time.Now()
 			query := c.parseComQuery(data)
+			c.recycleReadPacket()
 			fieldSent := false
-			// sendFinished is set if a response has completed and
-			// no further packets must be sent.
+			// sendFinished is set if the response should just be an OK packet.
 			sendFinished := false
 			err := l.handler.ComQuery(c, query, func(qr *sqltypes.Result) error {
 				if sendFinished {
@@ -331,12 +331,12 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 				}
 
 				if !fieldSent {
-					c.recycleReadPacket()
 					fieldSent = true
 
 					if len(qr.Fields) == 0 {
-						// We should not send any more packets after this.
 						sendFinished = true
+						// We should not send any more packets after this.
+						return c.writeOKPacket(qr.RowsAffected, qr.InsertID, c.StatusFlags, 0)
 					}
 					if err := c.writeFields(qr); err != nil {
 						return err
@@ -348,7 +348,6 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 
 			// If no field was sent, we expect an error.
 			if !fieldSent {
-				c.recycleReadPacket()
 				// This is just a failsafe. Should never happen.
 				if err == nil || err == io.EOF {
 					err = NewSQLErrorFromError(errors.New("unexpected: query ended without no results and no error"))
@@ -368,7 +367,7 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 				return
 			}
 
-			// Send the end packet only is sendFinished is false (not a DML).
+			// Send the end packet only sendFinished is false (results were streamed).
 			if !sendFinished {
 				if err := c.writeEndResult(); err != nil {
 					log.Errorf("Error writing result to %s: %v", c, err)
@@ -630,8 +629,5 @@ func (c *Conn) writeAuthSwitchRequest(pluginName string, pluginData []byte) erro
 	if pos != len(data) {
 		return fmt.Errorf("error building AuthSwitchRequestPacket packet: got %v bytes expected %v", pos, len(data))
 	}
-	if err := c.writeEphemeralPacket(true); err != nil {
-		return err
-	}
-	return nil
+	return c.writeEphemeralPacket(true)
 }

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -72,8 +72,8 @@ func (th *testHandler) NewConnection(c *Conn) {
 func (th *testHandler) ConnectionClosed(c *Conn) {
 }
 
-func (th *testHandler) ComQuery(c *Conn, q []byte, callback func(*sqltypes.Result) error) error {
-	switch query := string(q); query {
+func (th *testHandler) ComQuery(c *Conn, query string, callback func(*sqltypes.Result) error) error {
+	switch query {
 	case "error":
 		return NewSQLError(ERUnknownComError, SSUnknownComError, "forced query handling error for: %v", query)
 	case "panic":

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -285,8 +285,7 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 }
 
 // HandleQuery implements the fakesqldb query handler interface
-func (t *explainTablet) HandleQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
-	query := string(q)
+func (t *explainTablet) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	if !strings.Contains(query, "1 != 1") {
 		t.mysqlQueries = append(t.mysqlQueries, &MysqlQuery{
 			Time: t.currentTime,

--- a/go/vt/vtgate/plugin_mysql_server_test.go
+++ b/go/vt/vtgate/plugin_mysql_server_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package vtgate
 
 import (
-	"golang.org/x/net/context"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -38,7 +39,7 @@ func (th *testHandler) NewConnection(c *mysql.Conn) {
 func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
 }
 
-func (th *testHandler) ComQuery(c *mysql.Conn, q []byte, callback func(*sqltypes.Result) error) error {
+func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
 	return nil
 }
 


### PR DESCRIPTION
Issue #3304
Sending the internal bytes through ComQuery would cause problems
if the callee misbehaved. Sending a newly copied string is safer.
As mentioned in the bug, this should not have any performance impact.