### PR TITLE
grpc improvements

### DIFF
--- a/go/cmd/automation_client/automation_client.go
+++ b/go/cmd/automation_client/automation_client.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	automationpb "github.com/youtube/vitess/go/vt/proto/automation"
 	automationservicepb "github.com/youtube/vitess/go/vt/proto/automationservice"
 )
@@ -52,7 +53,7 @@ func (p *cmdParams) Set(v string) error {
 	if v != "" {
 		keyAndValue := strings.SplitN(v, "=", 2)
 		if len(keyAndValue) < 2 {
-			return fmt.Errorf("No key specified: '%v' Expected format: key=value.", v)
+			return fmt.Errorf("no key specified: '%v' Expected format: key=value", v)
 		}
 		if p.parameters == nil {
 			p.parameters = make(map[string]string)
@@ -78,7 +79,7 @@ func main() {
 
 	fmt.Println("Connecting to Automation Server:", *automationServer)
 
-	conn, err := grpc.Dial(*automationServer, grpc.WithInsecure())
+	conn, err := grpcclient.Dial(*automationServer, grpc.WithInsecure())
 	if err != nil {
 		fmt.Println("Cannot create connection:", err)
 		os.Exit(3)

--- a/go/cmd/l2vtgate/plugin_grpcqueryservice.go
+++ b/go/cmd/l2vtgate/plugin_grpcqueryservice.go
@@ -26,7 +26,6 @@ import (
 )
 
 func init() {
-	servenv.RegisterGRPCFlags()
 	l2vtgate.RegisterL2VTGates = append(l2vtgate.RegisterL2VTGates, func(qs queryservice.QueryService) {
 		if servenv.GRPCCheckServiceMap("queryservice") {
 			grpcqueryservice.Register(servenv.GRPCServer, qs)

--- a/go/cmd/vtcombo/plugin_grpcvtgateservice.go
+++ b/go/cmd/vtcombo/plugin_grpcvtgateservice.go
@@ -19,10 +19,5 @@ package main
 // Imports and register the gRPC vtgateservice server
 
 import (
-	"github.com/youtube/vitess/go/vt/servenv"
 	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 )
-
-func init() {
-	servenv.RegisterGRPCFlags()
-}

--- a/go/cmd/vtctlclient/main.go
+++ b/go/cmd/vtctlclient/main.go
@@ -35,7 +35,6 @@ import (
 // actionnode modules, as we do't want to depend on them at all.
 var (
 	actionTimeout = flag.Duration("action_timeout", time.Hour, "timeout for the total command")
-	dialTimeout   = flag.Duration("dial_timeout", 30*time.Second, "time to wait for the dial phase")
 	server        = flag.String("server", "", "server to use for connection")
 )
 
@@ -54,7 +53,7 @@ func main() {
 
 	err := vtctlclient.RunCommandAndWait(
 		context.Background(), *server, flag.Args(),
-		*dialTimeout, *actionTimeout,
+		*actionTimeout,
 		func(e *logutilpb.Event) {
 			logutil.LogEvent(logger, e)
 		})

--- a/go/cmd/vtctld/plugin_grpcvtctlserver.go
+++ b/go/cmd/vtctld/plugin_grpcvtctlserver.go
@@ -22,7 +22,6 @@ import (
 )
 
 func init() {
-	servenv.RegisterGRPCFlags()
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtctl") {
 			grpcvtctlserver.StartServer(servenv.GRPCServer, ts)

--- a/go/cmd/vtgate/plugin_grpcvtgateservice.go
+++ b/go/cmd/vtgate/plugin_grpcvtgateservice.go
@@ -19,10 +19,5 @@ package main
 // Imports and register the gRPC vtgateservice server
 
 import (
-	"github.com/youtube/vitess/go/vt/servenv"
 	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 )
-
-func init() {
-	servenv.RegisterGRPCFlags()
-}

--- a/go/cmd/vtgateclienttest/plugin_grpcvtgateservice.go
+++ b/go/cmd/vtgateclienttest/plugin_grpcvtgateservice.go
@@ -19,10 +19,5 @@ package main
 // Imports and register the gRPC vtgateservice server
 
 import (
-	"github.com/youtube/vitess/go/vt/servenv"
 	_ "github.com/youtube/vitess/go/vt/vtgate/grpcvtgateservice"
 )
-
-func init() {
-	servenv.RegisterGRPCFlags()
-}

--- a/go/cmd/vttablet/plugin_grpcqueryservice.go
+++ b/go/cmd/vttablet/plugin_grpcqueryservice.go
@@ -25,7 +25,6 @@ import (
 )
 
 func init() {
-	servenv.RegisterGRPCFlags()
 	tabletserver.RegisterFunctions = append(tabletserver.RegisterFunctions, func(qsc tabletserver.Controller) {
 		if servenv.GRPCCheckServiceMap("queryservice") {
 			grpcqueryservice.Register(servenv.GRPCServer, qsc.QueryService())

--- a/go/cmd/vtworker/plugin_grpcvtworkerserver.go
+++ b/go/cmd/vtworker/plugin_grpcvtworkerserver.go
@@ -22,7 +22,6 @@ import (
 )
 
 func init() {
-	servenv.RegisterGRPCFlags()
 	servenv.OnRun(func() {
 		if servenv.GRPCCheckServiceMap("vtworker") {
 			grpcvtworkerserver.StartServer(servenv.GRPCServer, wi)

--- a/go/mysql/client.go
+++ b/go/mysql/client.go
@@ -24,9 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/youtube/vitess/go/vt/vttls"
 	"golang.org/x/net/context"
-
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 )
 
 // connectResult is used by Connect.
@@ -237,7 +236,7 @@ func (c *Conn) clientHandshake(characterSet uint8, params *ConnParams) error {
 		}
 
 		// Build the TLS config.
-		clientConfig, err := grpcutils.TLSClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName)
+		clientConfig, err := vttls.ClientConfig(params.SslCert, params.SslKey, params.SslCa, serverName)
 		if err != nil {
 			return NewSQLError(CRSSLConnectionError, SSUnknownSQLState, "error loading client cert and ca: %v", err)
 		}

--- a/go/mysql/handshake_test.go
+++ b/go/mysql/handshake_test.go
@@ -27,8 +27,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/tlstest"
+	"github.com/youtube/vitess/go/vt/vttls"
 )
 
 // This file tests the handshake scenarios between our client and our server.
@@ -120,7 +120,7 @@ func TestSSLConnection(t *testing.T) {
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
 
 	// Create the server with TLS config.
-	serverConfig, err := grpcutils.TLSServerConfig(
+	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"))

--- a/go/mysql/ldapauthserver/auth_server_ldap.go
+++ b/go/mysql/ldapauthserver/auth_server_ldap.go
@@ -29,7 +29,7 @@ import (
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/netutil"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/vttls"
 	"gopkg.in/ldap.v2"
 )
 
@@ -227,7 +227,7 @@ func (lci *ClientImpl) Connect(network string, config *ServerConfig) error {
 	if err != nil {
 		return err
 	}
-	tlsConfig, err := grpcutils.TLSClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName)
+	tlsConfig, err := vttls.ClientConfig(config.LdapCert, config.LdapKey, config.LdapCA, serverName)
 	if err != nil {
 		return err
 	}

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	vtenv "github.com/youtube/vitess/go/vt/env"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/tlstest"
+	"github.com/youtube/vitess/go/vt/vttls"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -665,7 +665,7 @@ func TestTLSServer(t *testing.T) {
 	tlstest.CreateSignedCert(root, tlstest.CA, "02", "client", "Client Cert")
 
 	// Create the server with TLS config.
-	serverConfig, err := grpcutils.TLSServerConfig(
+	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-cert.pem"),
 		path.Join(root, "server-key.pem"),
 		path.Join(root, "ca-cert.pem"))

--- a/go/vt/automation/vtctlclient_wrapper.go
+++ b/go/vt/automation/vtctlclient_wrapper.go
@@ -45,9 +45,8 @@ func ExecuteVtctl(ctx context.Context, server string, args []string) (string, er
 
 	err := vtctlclient.RunCommandAndWait(
 		ctx, server, args,
-		// TODO(mberlin): Should these values be configurable as flags?
-		30*time.Second, // dialTimeout
-		time.Hour,      // actionTimeout
+		// TODO(mberlin): Should this value be configurable as flags?
+		time.Hour, // actionTimeout
 		loggerToBufferFunc)
 
 	endMsg := fmt.Sprintf("Executed remote vtctl command: %v server: %v err: %v", args, server, err)

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 
 	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	binlogservicepb "github.com/youtube/vitess/go/vt/proto/binlogservice"
@@ -40,7 +41,7 @@ type client struct {
 func (client *client) Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error {
 	addr := netutil.JoinHostPort(tablet.Hostname, tablet.PortMap["grpc"])
 	var err error
-	client.cc, err = grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(connTimeout))
+	client.cc, err = grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(connTimeout))
 	if err != nil {
 		return err
 	}

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -41,7 +41,7 @@ type client struct {
 func (client *client) Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error {
 	addr := netutil.JoinHostPort(tablet.Hostname, tablet.PortMap["grpc"])
 	var err error
-	client.cc, err = grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(connTimeout))
+	client.cc, err = grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connTimeout))
 	if err != nil {
 		return err
 	}

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -7,25 +7,37 @@ You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreedto in writing, software
+Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpcutils
+package grpcclient
 
 import (
-	"github.com/youtube/vitess/go/vt/vttls"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/youtube/vitess/go/vt/grpccommon"
+	"github.com/youtube/vitess/go/vt/vttls"
 )
 
-// ClientSecureDialOption returns the gRPC dial option to use for the
+// Dial creates a grpc connection to the given target.
+func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	newopts := []grpc.DialOption{grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
+		grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
+	)}
+	newopts = append(newopts, opts...)
+	return grpc.Dial(target, newopts...)
+}
+
+// SecureDialOption returns the gRPC dial option to use for the
 // given client connection. It is either using TLS, or Insecure if
 // nothing is set.
-func ClientSecureDialOption(cert, key, ca, name string) (grpc.DialOption, error) {
+func SecureDialOption(cert, key, ca, name string) (grpc.DialOption, error) {
 	// No security options set, just return.
 	if (cert == "" || key == "") && ca == "" {
 		return grpc.WithInsecure(), nil

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -26,10 +26,20 @@ import (
 
 // Dial creates a grpc connection to the given target.
 func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	newopts := []grpc.DialOption{grpc.WithDefaultCallOptions(
-		grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
-		grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
-	)}
+	newopts := []grpc.DialOption{
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
+			grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
+		),
+		// FailOnNonTempDialError makes the grpc fail faster on chronic errors.
+		// Additionally, the error messages are more specific, which
+		// is more helpful for troubleshooting.
+		grpc.FailOnNonTempDialError(true),
+		// With grpc 1.7.0, some requests are failing with
+		// 'the connection is unavailable' error. Adding this
+		// WithBlock option mitigates the problem.
+		grpc.WithBlock(),
+	}
 	newopts = append(newopts, opts...)
 	return grpc.Dial(target, newopts...)
 }

--- a/go/vt/grpcclient/client_test.go
+++ b/go/vt/grpcclient/client_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpcclient
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+)
+
+func TestDialErrors(t *testing.T) {
+	tcases := []struct {
+		address, err string
+	}{{
+		address: "badhost",
+		err:     "dial tcp: address badhost: missing port in address",
+	}, {
+		address: "badhost:123456",
+		err:     "dial tcp: address 123456: invalid port",
+	}, {
+		address: "[::]:12346",
+		err:     "dial tcp [::]:12346: getsockopt: connection refused",
+	}}
+	for _, tcase := range tcases {
+		_, err := Dial(tcase.address, grpc.WithInsecure())
+		if err == nil || !strings.Contains(err.Error(), tcase.err) {
+			t.Errorf("Dial(%s): %v, must contain %s", tcase.address, err, tcase.err)
+		}
+	}
+}

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package grpcutils
+package grpccommon
 
 import (
 	"flag"
@@ -24,12 +24,7 @@ var (
 	defaultMaxMessageSize = 4 * 1024 * 1024
 	// MaxMessageSize is the maximum message size which the gRPC server will
 	// accept. Larger messages will be rejected.
-	MaxMessageSize = &defaultMaxMessageSize
-)
-
-// RegisterFlags registers the command line flags for common grpc options
-func RegisterFlags() {
 	// Note: We're using 4 MiB as default value because that's the default in the
 	// gRPC 1.0.0 Go server.
 	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
-}
+)

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -26,6 +26,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/mysqlctl/mysqlctlclient"
 
 	mysqlctlpb "github.com/youtube/vitess/go/vt/proto/mysqlctl"
@@ -38,7 +39,7 @@ type client struct {
 
 func factory(network, addr string, dialTimeout time.Duration) (mysqlctlclient.MysqlctlClient, error) {
 	// create the RPC client
-	cc, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+	cc, err := grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(network, addr, timeout)
 	}))
 	if err != nil {

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -39,7 +39,7 @@ type client struct {
 
 func factory(network, addr string, dialTimeout time.Duration) (mysqlctlclient.MysqlctlClient, error) {
 	// create the RPC client
-	cc, err := grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithBlock(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+	cc, err := grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(network, addr, timeout)
 	}))
 	if err != nil {

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -29,6 +29,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/vttls"
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -94,7 +95,7 @@ func createGRPCServer() {
 
 	var opts []grpc.ServerOption
 	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
-		config, err := grpcutils.TLSServerConfig(*GRPCCert, *GRPCKey, *GRPCCA)
+		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA)
 		if err != nil {
 			log.Fatalf("Failed to log gRPC cert/key/ca: %v", err)
 		}

--- a/go/vt/servenv/grpcutils/client_tls.go
+++ b/go/vt/servenv/grpcutils/client_tls.go
@@ -17,49 +17,10 @@ limitations under the License.
 package grpcutils
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"io/ioutil"
-
+	"github.com/youtube/vitess/go/vt/vttls"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
-
-// TLSClientConfig returns the TLS config to use for a client to
-// connect to a server with the provided parameters.
-func TLSClientConfig(cert, key, ca, name string) (*tls.Config, error) {
-	config := &tls.Config{}
-
-	// Load the client-side cert & key if any.
-	if cert != "" && key != "" {
-		crt, err := tls.LoadX509KeyPair(cert, key)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load cert/key: %v", err)
-		}
-		config.Certificates = []tls.Certificate{crt}
-	}
-
-	// Load the server CA if any.
-	if ca != "" {
-		b, err := ioutil.ReadFile(ca)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read ca file: %v", err)
-		}
-		cp := x509.NewCertPool()
-		if !cp.AppendCertsFromPEM(b) {
-			return nil, fmt.Errorf("failed to append certificates")
-		}
-		config.RootCAs = cp
-	}
-
-	// Set the server name if any.
-	if name != "" {
-		config.ServerName = name
-	}
-
-	return config, nil
-}
 
 // ClientSecureDialOption returns the gRPC dial option to use for the
 // given client connection. It is either using TLS, or Insecure if
@@ -71,7 +32,7 @@ func ClientSecureDialOption(cert, key, ca, name string) (grpc.DialOption, error)
 	}
 
 	// Load the config.
-	config, err := TLSClientConfig(cert, key, ca, name)
+	config, err := vttls.ClientConfig(cert, key, ca, name)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
@@ -22,9 +22,9 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
 	"github.com/youtube/vitess/go/vt/proto/throttlerservice"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/throttler/throttlerclient"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"google.golang.org/grpc"
@@ -43,11 +43,11 @@ type client struct {
 }
 
 func factory(addr string) (throttlerclient.Client, error) {
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpc.Dial(addr, opt)
+	conn, err := grpcclient.Dial(addr, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/tlstest/tlstest_test.go
+++ b/go/vt/tlstest/tlstest_test.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/vttls"
 )
 
 // TestClientServer generates:
@@ -51,14 +51,14 @@ func TestClientServer(t *testing.T) {
 
 	CreateSignedCert(root, CA, "02", "clients", "Clients CA")
 	CreateSignedCert(root, "clients", "01", "client-instance", "Client Instance")
-	serverConfig, err := grpcutils.TLSServerConfig(
+	serverConfig, err := vttls.ServerConfig(
 		path.Join(root, "server-instance-cert.pem"),
 		path.Join(root, "server-instance-key.pem"),
 		path.Join(root, "clients-cert.pem"))
 	if err != nil {
 		t.Fatalf("TLSServerConfig failed: %v", err)
 	}
-	clientConfig, err := grpcutils.TLSClientConfig(
+	clientConfig, err := vttls.ClientConfig(
 		path.Join(root, "client-instance-cert.pem"),
 		path.Join(root, "client-instance-key.pem"),
 		path.Join(root, "servers-cert.pem"),
@@ -114,7 +114,7 @@ func TestClientServer(t *testing.T) {
 	// server cert on the client side).
 	//
 
-	badClientConfig, err := grpcutils.TLSClientConfig(
+	badClientConfig, err := vttls.ClientConfig(
 		path.Join(root, "server-instance-cert.pem"),
 		path.Join(root, "server-instance-key.pem"),
 		path.Join(root, "servers-cert.pem"),

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -50,7 +50,7 @@ func gRPCVtctlClientFactory(addr string, dialTimeout time.Duration) (vtctlclient
 		return nil, err
 	}
 	// create the RPC client
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(dialTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -21,8 +21,8 @@ import (
 	"flag"
 	"time"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/vtctl/vtctlclient"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -45,12 +45,12 @@ type gRPCVtctlClient struct {
 }
 
 func gRPCVtctlClientFactory(addr string, dialTimeout time.Duration) (vtctlclient.VtctlClient, error) {
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
 	// create the RPC client
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/vtctlclient/wrapper.go
+++ b/go/vt/vtctl/vtctlclient/wrapper.go
@@ -30,12 +30,12 @@ import (
 // RunCommandAndWait executes a single command on a given vtctld and blocks until the command did return or timed out.
 // Output from vtctld is streamed as logutilpb.Event messages which
 // have to be consumed by the caller who has to specify a "recv" function.
-func RunCommandAndWait(ctx context.Context, server string, args []string, dialTimeout, actionTimeout time.Duration, recv func(*logutilpb.Event)) error {
+func RunCommandAndWait(ctx context.Context, server string, args []string, actionTimeout time.Duration, recv func(*logutilpb.Event)) error {
 	if recv == nil {
 		return errors.New("No function closure for Event stream specified")
 	}
 	// create the client
-	client, err := New(server, dialTimeout)
+	client, err := New(server, 30*time.Second /* dialTimeout */)
 	if err != nil {
 		return fmt.Errorf("Cannot dial to server %v: %v", server, err)
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/callerid"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 	"golang.org/x/net/context"
@@ -54,11 +54,11 @@ type vtgateConn struct {
 }
 
 func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.Impl, error) {
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -58,7 +58,7 @@ func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.I
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(timeout))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(timeout))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -30,10 +30,10 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttls"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 )
 
 var (
@@ -150,7 +150,7 @@ func initMySQLProtocol() {
 			log.Fatalf("mysql.NewListener failed: %v", err)
 		}
 		if *mysqlSslCert != "" && *mysqlSslKey != "" {
-			mysqlListener.TLSConfig, err = grpcutils.TLSServerConfig(*mysqlSslCert, *mysqlSslKey, *mysqlSslCa)
+			mysqlListener.TLSConfig, err = vttls.ServerConfig(*mysqlSslCert, *mysqlSslKey, *mysqlSslCa)
 			if err != nil {
 				log.Fatalf("grpcutils.TLSServerConfig failed: %v", err)
 				return

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -25,7 +25,7 @@ import (
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/callerid"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletconn"
 	"golang.org/x/net/context"
@@ -69,7 +69,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	} else {
 		addr = tablet.Hostname
 	}
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
@@ -77,8 +77,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if timeout > 0 {
 		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
 	}
-	opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*grpcutils.MaxMessageSize), grpc.MaxCallSendMsgSize(*grpcutils.MaxMessageSize)))
-	cc, err := grpc.Dial(addr, opts...)
+	cc, err := grpcclient.Dial(addr, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -75,7 +75,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	}
 	opts := []grpc.DialOption{opt}
 	if timeout > 0 {
-		opts = append(opts, grpc.WithBlock(), grpc.WithTimeout(timeout))
+		opts = append(opts, grpc.WithTimeout(timeout))
 	}
 	cc, err := grpcclient.Dial(addr, opts...)
 	if err != nil {

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -25,10 +25,10 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/youtube/vitess/go/netutil"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/hook"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttablet/tmclient"
 	"golang.org/x/net/context"
@@ -79,11 +79,11 @@ func NewClient() *Client {
 // dial returns a client to use
 func (client *Client) dial(tablet *topodatapb.Tablet) (*grpc.ClientConn, tabletmanagerservicepb.TabletManagerClient, error) {
 	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, nil, err
 	}
-	cc, err := grpc.Dial(addr, opt)
+	cc, err := grpcclient.Dial(addr, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -92,7 +92,7 @@ func (client *Client) dial(tablet *topodatapb.Tablet) (*grpc.ClientConn, tabletm
 
 func (client *Client) dialPool(tablet *topodatapb.Tablet) (tabletmanagerservicepb.TabletManagerClient, error) {
 	addr := netutil.JoinHostPort(tablet.Hostname, int32(tablet.PortMap["grpc"]))
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (client *Client) dialPool(tablet *topodatapb.Tablet) (tabletmanagerservicep
 		client.mu.Unlock()
 
 		for i := 0; i < cap(c); i++ {
-			cc, err := grpc.Dial(addr, opt)
+			cc, err := grpcclient.Dial(addr, opt)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -24,8 +24,8 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/servenv/grpcutils"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclient"
 
@@ -49,13 +49,13 @@ type gRPCVtworkerClient struct {
 
 func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.Client, error) {
 	// create the RPC client
-	opt, err := grpcutils.ClientSecureDialOption(*cert, *key, *ca, *name)
+	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpc.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
 	if err != nil {
-		return nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "grpc.Dial() err: %v", err)
+		return nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "grpcclient.Dial() err: %v", err)
 	}
 	c := vtworkerservicepb.NewVtworkerClient(cc)
 

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -53,7 +53,7 @@ func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworker
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithBlock(), grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(dialTimeout))
 	if err != nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "grpcclient.Dial() err: %v", err)
 	}

--- a/go/vt/worker/vtworkerclient/wrapper.go
+++ b/go/vt/worker/vtworkerclient/wrapper.go
@@ -22,8 +22,9 @@ import (
 
 	"golang.org/x/net/context"
 
-	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 	"github.com/youtube/vitess/go/vt/vterrors"
+
+	logutilpb "github.com/youtube/vitess/go/vt/proto/logutil"
 )
 
 // RunCommandAndWait executes a single command on a given vtworker and blocks until the command did return or timed out.
@@ -34,7 +35,6 @@ func RunCommandAndWait(ctx context.Context, server string, args []string, recv f
 		panic("no function closure for Event stream specified")
 	}
 	// create the client
-	// TODO(mberlin): vtctlclient exposes dialTimeout as flag. If there are no use cases, remove it there as well to be consistent?
 	client, err := New(server, 30*time.Second /* dialTimeout */)
 	if err != nil {
 		return vterrors.Wrapf(err, "cannot dial to server %v", server)

--- a/test/utils.py
+++ b/test/utils.py
@@ -983,7 +983,9 @@ def run_vtworker(clargs, auto_log=False, expect_fail=False, **kwargs):
 def run_vtworker_bg(clargs, auto_log=False, **kwargs):
   """Starts a background vtworker process."""
   cmd, port, rpc_port = _get_vtworker_cmd(clargs, auto_log)
-  return run_bg(cmd, **kwargs), port, rpc_port
+  proc = run_bg(cmd, **kwargs), port, rpc_port
+  wait_for_vars('vtworker', port)
+  return proc
 
 
 def _get_vtworker_cmd(clargs, auto_log=False):


### PR DESCRIPTION
@sjmudd @tirsen This should address all the bad grpc error messages as well as the max message size issue, which can now be specified for any tool that uses grpc.


tls: moved tls functionality into vttls
tls functionality was defined in grpcutils which mysql module
was using, which was introducing an unnecessary dependency of
mysql to grpc.

grpc: standardize client and server flags
Issue #3293
* Created a new grpcclient package that always uses the
  specified grpc_max_message_size option. Changed all grpc
  dials to use grpcclient.
* Renamed grpcutils->grpccommon. It defines grpc_max_message_size.
* Changed servenv to use grpccommon.
* Moved all flag initializations to init functions. Otherwise, repeat
  of common flag initialzations can cause crashes.

Going forward, server-only flags should go to servenv, client-only
flags should go to grpcclient, and flags common to both should go
to grpccommon.

grpc: improved error messages
Issues #3291, #3211, #3194
It turns out that the default grpc settings almost always make it return
a 'deadline exceeded' error no matter what the failure is.

I've now added a new flag: FailOnNonTempDialError, which fails faster
on chronic errors and returns a better error message along with the
address, etc. This should address most of the issues that were reporting
that error messages that were too vague.