### PR TITLE
 vttest: Properly wait for child processes

### DIFF
--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -127,7 +127,7 @@ func (vtp *VtProcess) WaitStart() (err error) {
 	vtp.proc.Args = append(vtp.proc.Args, vtp.ExtraArgs...)
 
 	logfile := path.Join(vtp.LogDirectory, fmt.Sprintf("%s.%d.log", vtp.Name, vtp.Port))
-	vtp.proc.Stdout, err = os.Create(logfile)
+	vtp.proc.Stderr, err = os.Create(logfile)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Oops! The code to handle health checks for spawned Vitess processes was not correct. When `vtcombo` crashes at startup, it would report a timeout after 60s instead of immediately noticing that the process had an early exit.

Fix is as follows:

```
The previous implementation of graceful startup/shutdown for Vitess
processes was not correct: We cannot check for an alive/dead process by
sending it a zero signal, because the process is our child and we have
not `wait`-ed on it in our existing process.

If we don't explicitly `wait` for the child, it'll stay alive as a
zombie even after an early exit, swallowing our check signal.

To properly manage the lifetime of the process, we spawn a new goroutine
that waits for the exit code of the process in the background. Simply
polling the return channel of the goroutine can let us know if the
process has terminated early.

The `WaitTerminate` API has also been adjusted to use the return channel
of the goroutine as the only source for process health.
```

cc @sougou @arthurnn 