### PR TITLE
vtworker: Do not log subsequent errors.

### DIFF
--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -575,6 +575,7 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 					defer sema.Release()
 
 					scw.tableStatusList.threadStarted(tableIndex)
+					defer scw.tableStatusList.threadDone(tableIndex)
 
 					// Start streaming from the source tablets.
 					tp := newSingleTabletProvider(ctx, scw.wr.TopoServer(), scw.sourceAliases[shardIndex])
@@ -594,7 +595,6 @@ func (scw *LegacySplitCloneWorker) copy(ctx context.Context) error {
 					if err := scw.processData(ctx, dbNames, td, tableIndex, rr, rowSplitter, insertChannels, scw.destinationPackCount); err != nil {
 						processError("processData failed: %v", err)
 					}
-					scw.tableStatusList.threadDone(tableIndex)
 				}(td, shardIndex, tableIndex, c)
 			}
 		}

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -967,7 +967,7 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 					}
 					sourceResultReader, err := NewRestartableResultReader(ctx, scw.wr.Logger(), tp, td, chunk, allowMultipleRetries)
 					if err != nil {
-						processError("%v: NewRestartableResultReader for source, %v failed: %v", errPrefix, tp.description(), err)
+						processError("%v: NewRestartableResultReader for source: %v failed: %v", errPrefix, tp.description(), err)
 						return
 					}
 					defer sourceResultReader.Close(ctx)

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -933,6 +933,7 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 				defer sema.Release()
 
 				tableStatusList.threadStarted(tableIndex)
+				defer tableStatusList.threadDone(tableIndex)
 
 				if state == WorkerStateCloneOnline {
 					// Wait for enough healthy tablets (they might have become unhealthy
@@ -1033,8 +1034,6 @@ func (scw *SplitCloneWorker) clone(ctx context.Context, state StatusWorkerState)
 					processError("%v: RowDiffer2 failed: %v", errPrefix, err)
 					return
 				}
-
-				tableStatusList.threadDone(tableIndex)
 			}(td, tableIndex, c)
 		}
 	}


### PR DESCRIPTION
There will always be one thread which sees the error first and logs it. After that, it will cancel the context and therefore stop all other threads as well.

This is an improvement over the change in #2968.

I've also changed the return early case if the context is already done. Now offline clones are covered as well.

Besides this change, I also did two small fixes, see the commits.