### PR TITLE
Performance improvements to sqlparser and changed the interface to allow io.Reader

### DIFF
--- a/go/vt/sqlparser/parse_next_test.go
+++ b/go/vt/sqlparser/parse_next_test.go
@@ -32,7 +32,7 @@ func TestParseNextValid(t *testing.T) {
 		sql.WriteRune(';')
 	}
 
-	tokens := NewStringTokenizer(sql.String())
+	tokens := NewTokenizer(&sql)
 	for i, tcase := range validSQL {
 		input := tcase.input + ";"
 		want := tcase.output

--- a/go/vt/sqlparser/token_test.go
+++ b/go/vt/sqlparser/token_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package sqlparser
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestLiteralID(t *testing.T) {
 	testcases := []struct {
@@ -58,6 +61,78 @@ func TestLiteralID(t *testing.T) {
 		id, out := tkn.Scan()
 		if tcase.id != id || string(out) != tcase.out {
 			t.Errorf("Scan(%s): %d, %s, want %d, %s", tcase.in, id, out, tcase.id, tcase.out)
+		}
+	}
+}
+
+func tokenName(id int) string {
+	if id == STRING {
+		return "STRING"
+	} else if id == LEX_ERROR {
+		return "LEX_ERROR"
+	}
+	return fmt.Sprintf("%d", id)
+}
+
+func TestString(t *testing.T) {
+	testcases := []struct {
+		in   string
+		id   int
+		want string
+	}{{
+		in:   "''",
+		id:   STRING,
+		want: "",
+	}, {
+		in:   "''''",
+		id:   STRING,
+		want: "'",
+	}, {
+		in:   "'hello'",
+		id:   STRING,
+		want: "hello",
+	}, {
+		in:   "'\\n'",
+		id:   STRING,
+		want: "\n",
+	}, {
+		in:   "'\\nhello\\n'",
+		id:   STRING,
+		want: "\nhello\n",
+	}, {
+		in:   "'a''b'",
+		id:   STRING,
+		want: "a'b",
+	}, {
+		in:   "'a\\'b'",
+		id:   STRING,
+		want: "a'b",
+	}, {
+		in:   "'\\'",
+		id:   LEX_ERROR,
+		want: "'",
+	}, {
+		in:   "'",
+		id:   LEX_ERROR,
+		want: "",
+	}, {
+		in:   "'hello\\'",
+		id:   LEX_ERROR,
+		want: "hello'",
+	}, {
+		in:   "'hello",
+		id:   LEX_ERROR,
+		want: "hello",
+	}, {
+		in:   "'hello\\",
+		id:   LEX_ERROR,
+		want: "hello",
+	}}
+
+	for _, tcase := range testcases {
+		id, got := NewStringTokenizer(tcase.in).Scan()
+		if tcase.id != id || string(got) != tcase.want {
+			t.Errorf("Scan(%q) = (%s, %q), want (%s, %q)", tcase.in, tokenName(id), got, tokenName(tcase.id), tcase.want)
 		}
 	}
 }


### PR DESCRIPTION
* Changed the Tokenizer to maintain an internal buffer.
* Changed the Tokenizer to also accept a io.Reader, instead of requiring strings.
* Change the scanString implementation to make use of the internal buffer, to improve performance.
* Added various tests for scanString, and added a benchmark.

The benchmarks (after 5 runs) show a ~5% speed up on the sqlparser Parse2 benchmark, and a ~25% speedup on the vtgate WithNormalizer test (which is testing a huge SQL query). Otherwise no performance changes.

```
# eg. go test -bench=. -count=5 -run=^$ > new.txt

go/vt/sqlparser$ benchstat old.txt new.txt 
name      old time/op  new time/op  delta
Parse1-8  15.8µs ± 4%  15.9µs ± 3%    ~     (p=0.841 n=5+5)
Parse2-8  44.8µs ± 3%  42.3µs ± 2%  -5.53%  (p=0.008 n=5+5)

go/vt/vttablet/tabletserver$ benchstat old.txt new.txt 
name                 old time/op  new time/op  delta
ExecuteVarBinary-8   5.36ms ± 0%  5.34ms ± 1%   ~     (p=0.151 n=5+5)
ExecuteExpression-8  1.46ms ± 1%  1.46ms ± 1%   ~     (p=0.310 n=5+5)

go/vt/vtgate$ benchstat old.txt new.txt 
name                       old time/op  new time/op  delta
WithNormalizer-8           5.68ms ± 8%  4.24ms ± 1%  -25.32%  (p=0.016 n=5+4)
WithoutNormalizer-8        8.81µs ± 2%  8.74µs ± 1%     ~     (p=0.310 n=5+5)
ResolveKeyRangeToShards-8   138ns ± 1%   138ns ± 2%     ~     (p=0.429 n=5+5)
```

I went through various iterations of these optimisation. This seemed to be the shortest, most maintainable, while still providing a performance bump. Some random observations

1) Changing from strings.Reader, to io.Reader, meant the compiler was no longer able to inline the reader's ReadByte(), and the Tokenizer's next() function, because they were no longer leaf functions.

2) Changing scanString to search for the next delim/escape char, gave some of the best speed ups. Scanning in a tight loop avoiding the next() calls gave a nice speed, as did calling buffer.Write() over buffer.WriteByte().

3) Manually inlining the Tokenizer's next() gave some good speed ups, but made the code harder to read, so I left them out.

4) There are many other scan functions that could now make use of the internal buffer, such as scanIdentifer. I've left them along for the moment to try and keep it simple.
