### PR TITLE
Fixing flaky test for mysql TestKill.

### DIFF
--- a/go/mysql/endtoend/replication_test.go
+++ b/go/mysql/endtoend/replication_test.go
@@ -308,7 +308,7 @@ func TestStatementReplicationWithRealDatabase(t *testing.T) {
 
 }
 
-func testRowReplicationWithRealDatabase(t *testing.T) {
+func TestRowReplicationWithRealDatabase(t *testing.T) {
 	conn, f := connectForReplication(t, true /* rbr */)
 	defer conn.Close()
 

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -299,6 +299,12 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		data, err := c.readEphemeralPacket()
 		if err != nil {
 			// Don't log EOF errors. They cause too much spam.
+			// Note the EOF detection is not 100%
+			// guaranteed, in the case where the client
+			// connection is already closed before we call
+			// 'readEphemeralPacket'.  This is a corner
+			// case though, and very unlikely to happen,
+			// and the only downside is we log a bit more then.
 			if err != io.EOF {
 				log.Errorf("Error reading packet from %s: %v", c, err)
 			}


### PR DESCRIPTION
It seems the error message we're getting on a closed connection depends
on if the read was started before or after the connection. The error
codes have always been right, but the message may be different.
Adding comments.

Also fixing one unused method, and two new gofmt errors.

Fixes go/mysql/endtoend/replication_test.go