### PR TITLE
Changed the Tokenizer to only increment position iff a character was read

### DIFF
--- a/go/vt/sqlparser/parse_next_test.go
+++ b/go/vt/sqlparser/parse_next_test.go
@@ -66,7 +66,7 @@ func TestParseNextErrors(t *testing.T) {
 			continue
 		}
 
-		sql := tcase.input + " ; select 1 from t"
+		sql := tcase.input + "; select 1 from t"
 		tokens := NewStringTokenizer(sql)
 
 		// The first statement should be an error

--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -1454,14 +1454,14 @@ var (
 			"(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(" +
 			"F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F(F" +
 			"(F(F(F(F(F(F(F(F(F(F(F(",
-		output: "syntax error at position 405",
+		output: "syntax error at position 404",
 	}, {
 		// This construct is considered invalid due to a grammar conflict.
 		input:  "insert into a select * from b join c on duplicate key update d=e",
 		output: "syntax error at position 54 near 'key'",
 	}, {
 		input:  "select * from a left join b",
-		output: "syntax error at position 29",
+		output: "syntax error at position 28",
 	}, {
 		input:  "select * from a natural join b on c = d",
 		output: "syntax error at position 34 near 'on'",
@@ -1476,7 +1476,7 @@ var (
 		output: "syntax error at position 29 near 'select'",
 	}, {
 		input:  "select database",
-		output: "syntax error at position 17",
+		output: "syntax error at position 16",
 	}, {
 		input:  "select mod from t",
 		output: "syntax error at position 16 near 'from'",
@@ -1485,7 +1485,7 @@ var (
 		output: "syntax error at position 26 near 'div'",
 	}, {
 		input:  "select 1 from t where binary",
-		output: "syntax error at position 30",
+		output: "syntax error at position 29",
 	}, {
 		input:  "select match(a1, a2) against ('foo' in boolean mode with query expansion) from t",
 		output: "syntax error at position 57 near 'with'",
@@ -1497,7 +1497,7 @@ var (
 		output: "syntax error at position 81 near 'escape'",
 	}, {
 		input:  "(select /* parenthesized select */ * from t)",
-		output: "syntax error at position 46",
+		output: "syntax error at position 45",
 	}, {
 		input:  "select * from t where id = ((select a from t1 union select b from t2) order by a limit 1)",
 		output: "syntax error at position 76 near 'order'",

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -817,15 +817,15 @@ func (tkn *Tokenizer) next() {
 	}
 
 	if tkn.bufPos >= tkn.bufSize {
-		tkn.lastChar = eofChar
+		if tkn.lastChar != eofChar {
+			tkn.Position++
+			tkn.lastChar = eofChar
+		}
 	} else {
+		tkn.Position++
 		tkn.lastChar = uint16(tkn.buf[tkn.bufPos])
 		tkn.bufPos++
 	}
-	tkn.Position++
-	// TODO(bramp) Move tkn.Position++, so it only increments if a char was read.
-	// Many of the test examples, have incorrect "syntax error at position N", due
-	// to calling next() multiple times after EOF.
 }
 
 // reset clears any internal state.


### PR DESCRIPTION
Some Tokenizer flows call next() after EOF has already been reached, which leaves position in the wrong place. This fixes that, and fixes a few of the test cases.