### PR TITLE
go/vterror: Panic instead of logging invalid error codes

### DIFF
--- a/go/vt/vterrors/aggregate_test.go
+++ b/go/vt/vterrors/aggregate_test.go
@@ -47,14 +47,6 @@ func TestAggregateVtGateErrorCodes(t *testing.T) {
 			expected: vtrpcpb.Code_INVALID_ARGUMENT,
 		},
 		{
-			// OK should be converted to INTERNAL
-			input: []error{
-				errFromCode(vtrpcpb.Code_OK),
-				errFromCode(vtrpcpb.Code_UNAVAILABLE),
-			},
-			expected: vtrpcpb.Code_INTERNAL,
-		},
-		{
 			// aggregate two codes to the highest priority
 			input: []error{
 				errFromCode(vtrpcpb.Code_UNAVAILABLE),

--- a/go/vt/vterrors/vterrors.go
+++ b/go/vt/vterrors/vterrors.go
@@ -18,16 +18,11 @@ package vterrors
 
 import (
 	"fmt"
-	"time"
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/tb"
-	"github.com/youtube/vitess/go/vt/logutil"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
-
-var logger = logutil.NewThrottledLogger("vterror", 5*time.Second)
 
 type vtError struct {
 	code vtrpcpb.Code
@@ -37,8 +32,7 @@ type vtError struct {
 // New creates a new error using the code and input string.
 func New(code vtrpcpb.Code, in string) error {
 	if code == vtrpcpb.Code_OK {
-		logger.Errorf("OK is an invalid code, using INTERNAL instead: %s\n%s", in, tb.Stack(2))
-		code = vtrpcpb.Code_INTERNAL
+		panic("OK is an invalid error code; use INTERNAL instead")
 	}
 	return &vtError{
 		code: code,

--- a/go/vt/vterrors/vterrors_test.go
+++ b/go/vt/vterrors/vterrors_test.go
@@ -34,10 +34,6 @@ func TestCreation(t *testing.T) {
 	}, {
 		in:   vtrpcpb.Code_UNKNOWN,
 		want: vtrpcpb.Code_UNKNOWN,
-	}, {
-		// Invalid code OK should be converted to INTERNAL.
-		in:   vtrpcpb.Code_OK,
-		want: vtrpcpb.Code_INTERNAL,
 	}}
 	for _, tcase := range testcases {
 		if got := Code(New(tcase.in, "")); got != tcase.want {


### PR DESCRIPTION
@sougou: This is a pretty big issue we've found when migrating our Go apps to use the Vitess driver. I'm proposing what I think is a rather sensible fix that doesn't hide the programmer's error behind logging. Let me know what you think or if you can come up with an alternative. :)

```
The `go/vt/vterror` package is a core dependency of many other Vitess
packages, both internal and external to the codebase.

Right now, the constructor for `vterror.New` has a logic check that
ensures that `vtrpcpb.Code_OK` is never used to create new `vtError`
instances, as this is not an actual error code.

To enforce this constraint, `New` uses the `go/vt/logutil` package to
print a log error (which should actually be better described as a
warning) before changing the `Code_OK` to `Code_INTERNAL`.

This is an issue because it creates a dependency on the `logutil`
package for `vterrors`: the `logutil` package is very intrusive and does
not belong in any codebase outside Vitess. Most notably, upon importing,
the `logutil` package hijacks the default logger from the Go standard
library so all the loging is routed through `glog`.

This can be very unexpected for third party users of Vitess' packages.
Right now, any Go app that depends on `vitessdriver` or `vtgrpcconn` to
communicate with a Vitess cluster will transitively bring the `logutil`
package as a dependency, with the consequent changes to the app's logging.

To work around the issue, we propose dropping the dependency on
`logutil` from `vterror`:

The current behavior of using a `logutil.Logger` just to report cases
where `vterrors.New` is called with `Code_OK` does not seem correct to
begin with. The code already changes `Code_OK` into `Code_INTERNAL`, so
the log "error" should rather be a warning -- and it doesn't seem like a
warning in production logs would be the ideal place to catch the issue.

Because of this, we propose replacing this "almost silent fix" to the
error code with an actual `panic`. Passing a `Code_OK` to the error
constructor is a program logic error, not a runtime error, and should be
caught in CI, not in production. We have already verified that no
existing callsite in the codebase passes a `Code_OK` to `vterrors.New`,
so the `panic` will also become a reliable way to detect this mistake if
it's ever introduced in the future.

This simple change drops the dependency on `logutil` for `vterrors`,
allowing third party applications that depend on `vitessdriver` or
`grpcconn` to use these dependencies without having their log system
affected.
```

cc @arthurnn 