### PR TITLE
Fix the parsing of # comments

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -634,6 +634,8 @@ var (
 	}, {
 		input: "set /* simple */ a = 3",
 	}, {
+		input: "set #simple\n b = 4",
+	}, {
 		input: "set character_set_results = utf8",
 	}, {
 		input:  "set names utf8 collate foo",

--- a/go/vt/sqlparser/token.go
+++ b/go/vt/sqlparser/token.go
@@ -478,7 +478,6 @@ func (tkn *Tokenizer) Scan() (int, []byte) {
 				return int(ch), nil
 			}
 		case '#':
-			tkn.next()
 			return tkn.scanCommentType1("#")
 		case '-':
 			switch tkn.lastChar {


### PR DESCRIPTION
Which would accidentally chop off the first character within the comment.

Found with https://github.com/dvyukov/go-fuzz/tree/master/examples/sqlparser