### PR TITLE
Function names should be quoted sometimes.

### DIFF
--- a/go/vt/sqlparser/parse_test.go
+++ b/go/vt/sqlparser/parse_test.go
@@ -901,6 +901,8 @@ var (
 		input: "select name, group_concat(score) from t group by name",
 	}, {
 		input: "select name, group_concat(distinct id, score order by id desc separator ':') from t group by name",
+	}, {
+		input: "select `a``b`() from t",
 	}}
 )
 


### PR DESCRIPTION
In MySQL it is valid to have function names with characters which would not normally be allowed, as long as the function name is quoted. This change ensures the function name is quoted when needed, allowing reserved words to stay unquoted.