### PR TITLE
resharding: binlog streamer must open schema engine before streaming

### DIFF
--- a/go/vt/binlog/binlog_streamer.go
+++ b/go/vt/binlog/binlog_streamer.go
@@ -171,6 +171,11 @@ func NewStreamer(dbname string, mysqld mysqlctl.MysqlDaemon, se *schema.Engine, 
 
 // Stream starts streaming binlog events using the settings from NewStreamer().
 func (bls *Streamer) Stream(ctx context.Context) (err error) {
+	// Ensure se is Open. If vttablet came up in a non_serving role,
+	// the schema engine may not have been initialized.
+	if err := bls.se.Open(); err != nil {
+		return err
+	}
 	stopPos := bls.startPos
 	defer func() {
 		if err != nil && err != mysqlctl.ErrBinlogUnavailable {

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -49,6 +49,8 @@ const (
 // table against the current time at read time. This value is reported in metrics and
 // also to the healthchecks.
 type Reader struct {
+	dbconfigs dbconfigs.DBConfigs
+
 	enabled       bool
 	interval      time.Duration
 	keyspaceShard string
@@ -82,19 +84,24 @@ func NewReader(checker connpool.MySQLChecker, config tabletenv.TabletConfig) *Re
 	}
 }
 
+// InitDBConfig must be called before Init.
+func (r *Reader) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+	r.dbconfigs = dbcfgs
+}
+
 // Init does last minute initialization of db settings, such as dbName
 // and keyspaceShard
-func (r *Reader) Init(dbc dbconfigs.DBConfigs, target query.Target) {
+func (r *Reader) Init(target query.Target) {
 	if !r.enabled {
 		return
 	}
-	r.dbName = sqlescape.EscapeID(dbc.SidecarDBName)
+	r.dbName = sqlescape.EscapeID(r.dbconfigs.SidecarDBName)
 	r.keyspaceShard = fmt.Sprintf("%s:%s", target.Keyspace, target.Shard)
 }
 
 // Open starts the heartbeat ticker and opens the db pool. It may be called multiple
 // times, as long as it was closed since last invocation.
-func (r *Reader) Open(dbc dbconfigs.DBConfigs) {
+func (r *Reader) Open() {
 	if !r.enabled {
 		return
 	}
@@ -105,7 +112,7 @@ func (r *Reader) Open(dbc dbconfigs.DBConfigs) {
 	}
 
 	log.Info("Beginning heartbeat reads")
-	r.pool.Open(&dbc.App, &dbc.Dba, &dbc.AppDebug)
+	r.pool.Open(&r.dbconfigs.App, &r.dbconfigs.Dba, &r.dbconfigs.AppDebug)
 	r.ticks.Start(func() { r.readHeartbeat() })
 	r.isOpen = true
 }

--- a/go/vt/vttablet/tabletserver/messager/engine.go
+++ b/go/vt/vttablet/tabletserver/messager/engine.go
@@ -46,6 +46,8 @@ type TabletService interface {
 
 // Engine is the engine for handling messages.
 type Engine struct {
+	dbconfigs dbconfigs.DBConfigs
+
 	mu       sync.Mutex
 	isOpen   bool
 	managers map[string]*messageManager
@@ -72,12 +74,17 @@ func NewEngine(tsv TabletService, se *schema.Engine, config tabletenv.TabletConf
 	}
 }
 
+// InitDBConfig must be called before Open.
+func (me *Engine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+	me.dbconfigs = dbcfgs
+}
+
 // Open starts the Engine service.
-func (me *Engine) Open(dbconfigs dbconfigs.DBConfigs) error {
+func (me *Engine) Open() error {
 	if me.isOpen {
 		return nil
 	}
-	me.conns.Open(&dbconfigs.App, &dbconfigs.Dba, &dbconfigs.AppDebug)
+	me.conns.Open(&me.dbconfigs.App, &me.dbconfigs.Dba, &me.dbconfigs.AppDebug)
 	me.se.RegisterNotifier("messages", me.schemaChanged)
 	me.isOpen = true
 	return nil

--- a/go/vt/vttablet/tabletserver/messager/engine_test.go
+++ b/go/vt/vttablet/tabletserver/messager/engine_test.go
@@ -261,11 +261,11 @@ func newTestEngine(db *fakesqldb.DB) *Engine {
 	tsv := newFakeTabletServer()
 	se := schema.NewEngine(tsv, config)
 	te := NewEngine(tsv, se, config)
-	dbconfigs := dbconfigs.DBConfigs{
+	te.InitDBConfig(dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
 		SidecarDBName: "_vt",
-	}
-	te.Open(dbconfigs)
+	})
+	te.Open()
 	return te
 }
 

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -244,9 +244,13 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	return qe
 }
 
+// InitDBConfig must be called before Open.
+func (qe *QueryEngine) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
+	qe.dbconfigs = dbcfgs
+}
+
 // Open must be called before sending requests to QueryEngine.
-func (qe *QueryEngine) Open(dbconfigs dbconfigs.DBConfigs) error {
-	qe.dbconfigs = dbconfigs
+func (qe *QueryEngine) Open() error {
 	qe.conns.Open(&qe.dbconfigs.App, &qe.dbconfigs.Dba, &qe.dbconfigs.AppDebug)
 
 	conn, err := qe.conns.Get(tabletenv.LocalContext())

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -34,7 +35,7 @@ import (
 func TestQueryzHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/schemaz", nil)
-	qe := newTestQueryEngine(100, 10*time.Second, true)
+	qe := newTestQueryEngine(100, 10*time.Second, true, dbconfigs.DBConfigs{})
 
 	plan1 := &TabletPlan{
 		Plan: &planbuilder.Plan{

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -83,9 +83,9 @@ func TestTabletServerAllowQueriesFailBadConn(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
 	checkTabletServerState(t, tsv, StateNotConnected)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err == nil {
 		t.Fatalf("TabletServer.StartService should fail")
 	}
@@ -99,17 +99,17 @@ func TestTabletServerAllowQueries(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
 	checkTabletServerState(t, tsv, StateNotConnected)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	tsv.setState(StateServing)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	tsv.StopService()
 	want := "InitDBConfig failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("TabletServer.StartService: %v, must contain %s", err, want)
 	}
 	tsv.setState(StateShuttingDown)
-	err = tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err = tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err == nil {
 		t.Fatalf("TabletServer.StartService should fail")
 	}
@@ -124,14 +124,14 @@ func TestTabletServerInitDBConfig(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	tsv.setState(StateServing)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	dbconfigs := testUtils.newDBConfigs(db)
-	err := tsv.InitDBConfig(target, dbconfigs, nil)
+	dbcfgs := testUtils.newDBConfigs(db)
+	err := tsv.InitDBConfig(target, dbcfgs, nil)
 	want := "InitDBConfig failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("InitDBConfig: %v, must contain %s", err, want)
 	}
 	tsv.setState(StateNotConnected)
-	err = tsv.InitDBConfig(target, dbconfigs, nil)
+	err = tsv.InitDBConfig(target, dbcfgs, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -144,8 +144,8 @@ func TestDecideAction(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	dbconfigs := testUtils.newDBConfigs(db)
-	err := tsv.InitDBConfig(target, dbconfigs, nil)
+	dbcfgs := testUtils.newDBConfigs(db)
+	err := tsv.InitDBConfig(target, dbcfgs, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -250,9 +250,9 @@ func TestSetServingType(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.InitDBConfig(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.InitDBConfig(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Error(err)
 	}
@@ -332,10 +332,10 @@ func TestTabletServerSingleSchemaFailure(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	originalSchemaErrorCount := tabletenv.InternalErrors.Counts()["Schema"]
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatalf("TabletServer should successfully start even if a table's schema is unloadable, but got error: %v", err)
@@ -364,9 +364,9 @@ func TestTabletServerAllSchemaFailure(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	defer tsv.StopService()
 	// tabletsever shouldn't start if it can't access schema for any tables
 	wantErr := "could not get schema for any tables"
@@ -381,9 +381,9 @@ func TestTabletServerCheckMysql(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatal(err)
@@ -410,9 +410,9 @@ func TestTabletServerCheckMysqlFailInvalidConn(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatalf("TabletServer.StartService should succeed, but got error: %v", err)
@@ -457,9 +457,9 @@ func TestTabletServerReconnect(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	defer tsv.StopService()
 
 	if tsv.GetState() != "SERVING" {
@@ -488,8 +488,8 @@ func TestTabletServerReconnect(t *testing.T) {
 	db = setUpTabletServerTest(t)
 	db.AddQuery(query, want)
 	db.AddQuery("select addr from test_table where 1 != 1", &sqltypes.Result{})
-	dbconfigs = testUtils.newDBConfigs(db)
-	err = tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	dbcfgs = testUtils.newDBConfigs(db)
+	err = tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Error(err)
 	}
@@ -505,13 +505,13 @@ func TestTabletServerTarget(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target1 := querypb.Target{
 		Keyspace:   "test_keyspace",
 		Shard:      "test_shard",
 		TabletType: topodatapb.TabletType_MASTER,
 	}
-	err := tsv.StartService(target1, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target1, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -965,9 +965,9 @@ func TestTabletServerBeginFail(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.TransactionCap = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1000,9 +1000,9 @@ func TestTabletServerCommitTransaction(t *testing.T) {
 	db.AddQuery(executeSQL, executeSQLResult)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1026,9 +1026,9 @@ func TestTabletServerCommiRollbacktFail(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1063,9 +1063,9 @@ func TestTabletServerRollback(t *testing.T) {
 	db.AddQuery(executeSQL, executeSQLResult)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1167,9 +1167,9 @@ func TestTabletServerStreamExecute(t *testing.T) {
 
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1194,9 +1194,9 @@ func TestTabletServerExecuteBatch(t *testing.T) {
 	db.AddQuery(expanedSQL, sqlResult)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1218,9 +1218,9 @@ func TestTabletServerExecuteBatchFailEmptyQueryList(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1239,9 +1239,9 @@ func TestTabletServerExecuteBatchFailAsTransaction(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1267,9 +1267,9 @@ func TestTabletServerExecuteBatchBeginFail(t *testing.T) {
 	db.AddRejectedQuery("begin", errRejected)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1293,9 +1293,9 @@ func TestTabletServerExecuteBatchCommitFail(t *testing.T) {
 	db.AddRejectedQuery("commit", errRejected)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1332,9 +1332,9 @@ func TestTabletServerExecuteBatchSqlExecFailInTransaction(t *testing.T) {
 
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1375,9 +1375,9 @@ func TestTabletServerExecuteBatchSqlSucceedInTransaction(t *testing.T) {
 	config := testUtils.newQueryServiceConfig()
 	config.EnableAutoCommit = true
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1399,9 +1399,9 @@ func TestTabletServerExecuteBatchCallCommitWithoutABegin(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1429,9 +1429,9 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 	db.AddQuery(expanedSQL, sqlResult)
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1481,9 +1481,9 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	// Reduce the txpool to 2 because we should never consume more than two slots.
 	config.TransactionCap = 2
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1608,9 +1608,9 @@ func TestSerializeTransactionsSameRow_ExecuteBatchAsTransaction(t *testing.T) {
 	// Reduce the txpool to 2 because we should never consume more than two slots.
 	config.TransactionCap = 2
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1726,9 +1726,9 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 	// Reduce the txpool to 2 because we should never consume more than two slots.
 	config.TransactionCap = 2
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1867,9 +1867,9 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 	config.HotRowProtectionMaxQueueSize = 1
 	config.HotRowProtectionConcurrentTransactions = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1956,9 +1956,9 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests_ExecuteBatchAsTrans
 	config.HotRowProtectionMaxQueueSize = 1
 	config.HotRowProtectionConcurrentTransactions = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -2048,9 +2048,9 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	config.EnableHotRowProtection = true
 	config.HotRowProtectionConcurrentTransactions = 1
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -2342,9 +2342,9 @@ func TestTabletServerSplitQuery(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2373,9 +2373,9 @@ func TestTabletServerSplitQueryInvalidQuery(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2403,9 +2403,9 @@ func TestTabletServerSplitQueryInvalidParams(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2432,9 +2432,9 @@ func TestTabletServerSplitQueryEqualSplitsOnStringColumn(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2680,9 +2680,9 @@ func TestConfigChanges(t *testing.T) {
 	testUtils := newTestUtils()
 	config := testUtils.newQueryServiceConfig()
 	tsv := NewTabletServerWithNilTopoServer(config)
-	dbconfigs := testUtils.newDBConfigs(db)
+	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -65,6 +65,7 @@ func (util *testUtils) newMysqld(dbcfgs *dbconfigs.DBConfigs) mysqlctl.MysqlDaem
 func (util *testUtils) newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {
 	return dbconfigs.DBConfigs{
 		App:           *db.ConnParams(),
+		Dba:           *db.ConnParams(),
 		SidecarDBName: "_vt",
 	}
 }

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -102,7 +102,7 @@ func (tqsc *Controller) AddStatusPart() {
 }
 
 // InitDBConfig is part of the tabletserver.Controller interface
-func (tqsc *Controller) InitDBConfig(target querypb.Target, dbConfigs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) error {
+func (tqsc *Controller) InitDBConfig(target querypb.Target, dbcfgs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) error {
 	tqsc.mu.Lock()
 	defer tqsc.mu.Unlock()
 

--- a/go/vt/vttest/local_cluster_old_test.go
+++ b/go/vt/vttest/local_cluster_old_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package vttest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -72,6 +73,8 @@ func TestVitess(t *testing.T) {
 	}
 
 	hdl, err := LaunchVitess(ProtoTopo(topology), Schema(schema), VSchema(vschema))
+	fmt.Printf("sleeping\n")
+	time.Sleep(1 * time.Minute)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Issue #3326

This required some refactoring to make sure the sub-components of TabletServer remembered their dbconfigs. This allowed me to simplify the Open call for most of them to be parameter-less.

The binlog streamer now calls se.Open to ensure that the schema engine is open before it starts streaming.