### PR TITLE
Refactor QueryCache to QueryPlanCache

### DIFF
--- a/doc/ServerConfiguration.md
+++ b/doc/ServerConfiguration.md
@@ -461,7 +461,7 @@ There are other internal pools used by VTTablet that are not very consequential.
 
 The above three variables table acl stats broken out by table, plan and user.
 
-##### QueryCacheSize
+##### QueryPlanCacheSize
 
 If the application does not make good use of bind variables, this value would reach the QueryCacheCapacity. If so, inspecting the current query cache will give you a clue about where the misuse is happening.
 

--- a/docs/user-guide/server-configuration/index.html
+++ b/docs/user-guide/server-configuration/index.html
@@ -808,7 +808,7 @@ the binlogs in <code class="prettyprint">/mnt/bin-logs</code>:</p>
 
 <p>The above three variables table acl stats broken out by table, plan and user.</p>
 
-<h5 id="querycachesize">QueryCacheSize</h5>
+<h5 id="queryplancachesize">QueryPlanCacheSize</h5>
 
 <p>If the application does not make good use of bind variables, this value would reach the QueryCacheCapacity. If so, inspecting the current query cache will give you a clue about where the misuse is happening.</p>
 

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -63,8 +63,8 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 	}
 
 	streamSize := 10
-	queryCacheSize := int64(10)
-	vtgateExecutor = vtgate.NewExecutor(context.Background(), explainTopo, vtexplainCell, "", resolver, opts.Normalize, streamSize, queryCacheSize)
+	queryPlanCacheSize := int64(10)
+	vtgateExecutor = vtgate.NewExecutor(context.Background(), explainTopo, vtexplainCell, "", resolver, opts.Normalize, streamSize, queryPlanCacheSize)
 
 	return nil
 }

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -79,14 +79,14 @@ type Executor struct {
 var executorOnce sync.Once
 
 // NewExecutor creates a new Executor.
-func NewExecutor(ctx context.Context, serv topo.SrvTopoServer, cell, statsName string, resolver *Resolver, normalize bool, streamSize int, queryCacheSize int64) *Executor {
+func NewExecutor(ctx context.Context, serv topo.SrvTopoServer, cell, statsName string, resolver *Resolver, normalize bool, streamSize int, queryPlanCacheSize int64) *Executor {
 	e := &Executor{
 		serv:        serv,
 		cell:        cell,
 		resolver:    resolver,
 		scatterConn: resolver.scatterConn,
 		txConn:      resolver.scatterConn.txConn,
-		plans:       cache.NewLRUCache(queryCacheSize),
+		plans:       cache.NewLRUCache(queryPlanCacheSize),
 		normalize:   normalize,
 		streamSize:  streamSize,
 	}

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -52,10 +52,10 @@ import (
 )
 
 var (
-	transactionMode  = flag.String("transaction_mode", "MULTI", "SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit")
-	normalizeQueries = flag.Bool("normalize_queries", true, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
-	streamBufferSize = flag.Int("stream_buffer_size", 32*1024, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
-	queryCacheSize   = flag.Int64("gate_query_cache_size", 10000, "gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
+	transactionMode    = flag.String("transaction_mode", "MULTI", "SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit")
+	normalizeQueries   = flag.Bool("normalize_queries", true, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
+	streamBufferSize   = flag.Int("stream_buffer_size", 32*1024, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
+	queryPlanCacheSize = flag.Int64("gate_query_cache_size", 10000, "gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
 )
 
 func getTxMode() vtgatepb.TransactionMode {
@@ -161,7 +161,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer topo.Server,
 	resolver := NewResolver(serv, cell, sc)
 
 	rpcVTGate = &VTGate{
-		executor:     NewExecutor(ctx, serv, cell, "VTGateExecutor", resolver, *normalizeQueries, *streamBufferSize, *queryCacheSize),
+		executor:     NewExecutor(ctx, serv, cell, "VTGateExecutor", resolver, *normalizeQueries, *streamBufferSize, *queryPlanCacheSize),
 		resolver:     resolver,
 		txConn:       tc,
 		timings:      stats.NewMultiTimings("VtgateApi", []string{"Operation", "Keyspace", "DbType"}),

--- a/go/vt/vttablet/endtoend/config_test.go
+++ b/go/vt/vttablet/endtoend/config_test.go
@@ -76,7 +76,7 @@ func TestConfigVars(t *testing.T) {
 		val: tabletenv.Config.WarnResultSize,
 	}, {
 		tag: "QueryCacheCapacity",
-		val: tabletenv.Config.QueryCacheSize,
+		val: tabletenv.Config.QueryPlanCacheSize,
 	}, {
 		tag: "QueryTimeout",
 		val: int(tabletenv.Config.QueryTimeout * 1e9),
@@ -154,9 +154,9 @@ func TestPoolSize(t *testing.T) {
 	}
 }
 
-func TestQueryCache(t *testing.T) {
-	defer framework.Server.SetQueryCacheCap(framework.Server.QueryCacheCap())
-	framework.Server.SetQueryCacheCap(1)
+func TestQueryPlanCache(t *testing.T) {
+	defer framework.Server.SetQueryPlanCacheCap(framework.Server.QueryPlanCacheCap())
+	framework.Server.SetQueryPlanCacheCap(1)
 
 	bindVars := map[string]*querypb.BindVariable{
 		"ival1": sqltypes.Int64BindVariable(1),
@@ -176,7 +176,7 @@ func TestQueryCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	framework.Server.SetQueryCacheCap(10)
+	framework.Server.SetQueryPlanCacheCap(10)
 	_, _ = client.Execute("select * from vitess_test where intval=:ival1", bindVars)
 	vend = framework.DebugVars()
 	if err := verifyIntValue(vend, "QueryCacheLength", 2); err != nil {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -111,7 +111,7 @@ type QueryEngine struct {
 	// mu protects the following fields.
 	mu               sync.RWMutex
 	tables           map[string]*schema.Table
-	queries          *cache.LRUCache
+	plans            *cache.LRUCache
 	queryRuleSources *rules.Map
 
 	// Pools
@@ -160,7 +160,7 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 	qe := &QueryEngine{
 		se:               se,
 		tables:           make(map[string]*schema.Table),
-		queries:          cache.NewLRUCache(int64(config.QueryCacheSize)),
+		plans:            cache.NewLRUCache(int64(config.QueryPlanCacheSize)),
 		queryRuleSources: rules.NewMap(),
 	}
 
@@ -217,11 +217,11 @@ func NewQueryEngine(checker connpool.MySQLChecker, se *schema.Engine, config tab
 		stats.Publish("StreamBufferSize", stats.IntFunc(qe.streamBufferSize.Get))
 		stats.Publish("TableACLExemptCount", stats.IntFunc(qe.tableaclExemptCount.Get))
 
-		stats.Publish("QueryCacheLength", stats.IntFunc(qe.queries.Length))
-		stats.Publish("QueryCacheSize", stats.IntFunc(qe.queries.Size))
-		stats.Publish("QueryCacheCapacity", stats.IntFunc(qe.queries.Capacity))
+		stats.Publish("QueryCacheLength", stats.IntFunc(qe.plans.Length))
+		stats.Publish("QueryCacheSize", stats.IntFunc(qe.plans.Size))
+		stats.Publish("QueryCacheCapacity", stats.IntFunc(qe.plans.Capacity))
 		stats.Publish("QueryCacheOldest", stats.StringFunc(func() string {
-			return fmt.Sprintf("%v", qe.queries.Oldest())
+			return fmt.Sprintf("%v", qe.plans.Oldest())
 		}))
 		_ = stats.NewMultiCountersFunc("QueryCounts", []string{"Table", "Plan"}, qe.getQueryCount)
 		_ = stats.NewMultiCountersFunc("QueryTimesNs", []string{"Table", "Plan"}, qe.getQueryTime)
@@ -277,7 +277,7 @@ func (qe *QueryEngine) Open() error {
 func (qe *QueryEngine) Close() {
 	// Close in reverse order of Open.
 	qe.se.UnregisterNotifier("qe")
-	qe.queries.Clear()
+	qe.plans.Clear()
 	qe.tables = make(map[string]*schema.Table)
 	qe.streamConns.Close()
 	qe.conns.Close()
@@ -331,7 +331,7 @@ func (qe *QueryEngine) GetPlan(ctx context.Context, logStats *tabletenv.LogStats
 		return plan, nil
 	}
 	if !skipQueryPlanCache {
-		qe.queries.Set(sql, plan)
+		qe.plans.Set(sql, plan)
 	}
 	return plan, nil
 }
@@ -367,7 +367,7 @@ func (qe *QueryEngine) GetMessageStreamPlan(name string) (*TabletPlan, error) {
 
 // ClearQueryPlanCache should be called if query plan cache is potentially obsolete
 func (qe *QueryEngine) ClearQueryPlanCache() {
-	qe.queries.Clear()
+	qe.plans.Clear()
 }
 
 // IsMySQLReachable returns true if we can connect to MySQL.
@@ -389,13 +389,13 @@ func (qe *QueryEngine) schemaChanged(tables map[string]*schema.Table, created, a
 	defer qe.mu.Unlock()
 	qe.tables = tables
 	if len(altered) != 0 || len(dropped) != 0 {
-		qe.queries.Clear()
+		qe.plans.Clear()
 	}
 }
 
 // getQuery fetches the plan and makes it the most recent.
 func (qe *QueryEngine) getQuery(sql string) *TabletPlan {
-	if cacheResult, ok := qe.queries.Get(sql); ok {
+	if cacheResult, ok := qe.plans.Get(sql); ok {
 		return cacheResult.(*TabletPlan)
 	}
 	return nil
@@ -403,23 +403,23 @@ func (qe *QueryEngine) getQuery(sql string) *TabletPlan {
 
 // peekQuery fetches the plan without changing the LRU order.
 func (qe *QueryEngine) peekQuery(sql string) *TabletPlan {
-	if cacheResult, ok := qe.queries.Peek(sql); ok {
+	if cacheResult, ok := qe.plans.Peek(sql); ok {
 		return cacheResult.(*TabletPlan)
 	}
 	return nil
 }
 
-// SetQueryCacheCap sets the query cache capacity.
-func (qe *QueryEngine) SetQueryCacheCap(size int) {
+// SetQueryPlanCap sets the query cache capacity.
+func (qe *QueryEngine) SetQueryPlanCacheCap(size int) {
 	if size <= 0 {
 		size = 1
 	}
-	qe.queries.SetCapacity(int64(size))
+	qe.plans.SetCapacity(int64(size))
 }
 
-// QueryCacheCap returns the capacity of the query cache.
-func (qe *QueryEngine) QueryCacheCap() int {
-	return int(qe.queries.Capacity())
+// QueryPlanCacheCap returns the capacity of the query cache.
+func (qe *QueryEngine) QueryPlanCacheCap() int {
+	return int(qe.plans.Capacity())
 }
 
 func (qe *QueryEngine) getQueryCount() map[string]int64 {
@@ -457,7 +457,7 @@ func (qe *QueryEngine) getQueryErrorCount() map[string]int64 {
 type queryStatsFunc func(*TabletPlan) int64
 
 func (qe *QueryEngine) getQueryStats(f queryStatsFunc) map[string]int64 {
-	keys := qe.queries.Keys()
+	keys := qe.plans.Keys()
 	qstats := make(map[string]int64)
 	for _, v := range keys {
 		if plan := qe.peekQuery(v); plan != nil {
@@ -504,7 +504,7 @@ func (qe *QueryEngine) ServeHTTP(response http.ResponseWriter, request *http.Req
 }
 
 func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, request *http.Request) {
-	keys := qe.queries.Keys()
+	keys := qe.plans.Keys()
 	response.Header().Set("Content-Type", "text/plain")
 	response.Write([]byte(fmt.Sprintf("Length: %d\n", len(keys))))
 	for _, v := range keys {
@@ -521,7 +521,7 @@ func (qe *QueryEngine) handleHTTPQueryPlans(response http.ResponseWriter, reques
 }
 
 func (qe *QueryEngine) handleHTTPQueryStats(response http.ResponseWriter, request *http.Request) {
-	keys := qe.queries.Keys()
+	keys := qe.plans.Keys()
 	response.Header().Set("Content-Type", "application/json; charset=utf-8")
 	qstats := make([]perQueryStats, 0, len(keys))
 	for _, v := range keys {

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -409,7 +409,7 @@ func (qe *QueryEngine) peekQuery(sql string) *TabletPlan {
 	return nil
 }
 
-// SetQueryPlanCap sets the query cache capacity.
+// SetQueryPlanCacheCap sets the query plan cache capacity.
 func (qe *QueryEngine) SetQueryPlanCacheCap(size int) {
 	if size <= 0 {
 		size = 1

--- a/go/vt/vttablet/tabletserver/query_engine_test.go
+++ b/go/vt/vttablet/tabletserver/query_engine_test.go
@@ -157,7 +157,7 @@ func TestQueryPlanCache(t *testing.T) {
 
 	ctx := context.Background()
 	logStats := tabletenv.NewLogStats(ctx, "GetPlanStats")
-	qe.SetQueryCacheCap(1)
+	qe.SetQueryPlanCacheCap(1)
 	firstPlan, err := qe.GetPlan(ctx, logStats, firstQuery, false)
 	if err != nil {
 		t.Fatal(err)
@@ -175,7 +175,7 @@ func TestQueryPlanCache(t *testing.T) {
 	expvar.Do(func(kv expvar.KeyValue) {
 		_ = kv.Value.String()
 	})
-	if qe.queries.Size() == 0 {
+	if qe.plans.Size() == 0 {
 		t.Fatalf("query plan cache should not be 0")
 	}
 	qe.ClearQueryPlanCache()
@@ -201,7 +201,7 @@ func TestNoQueryPlanCache(t *testing.T) {
 
 	ctx := context.Background()
 	logStats := tabletenv.NewLogStats(ctx, "GetPlanStats")
-	qe.SetQueryCacheCap(1)
+	qe.SetQueryPlanCacheCap(1)
 	firstPlan, err := qe.GetPlan(ctx, logStats, firstQuery, true)
 	if err != nil {
 		t.Fatal(err)
@@ -209,7 +209,7 @@ func TestNoQueryPlanCache(t *testing.T) {
 	if firstPlan == nil {
 		t.Fatalf("plan should not be nil")
 	}
-	if qe.queries.Size() != 0 {
+	if qe.plans.Size() != 0 {
 		t.Fatalf("query plan cache should be 0")
 	}
 	qe.ClearQueryPlanCache()
@@ -251,9 +251,9 @@ func TestStatsURL(t *testing.T) {
 	qe.ServeHTTP(response, request)
 }
 
-func newTestQueryEngine(queryCacheSize int, idleTimeout time.Duration, strict bool, dbcfgs dbconfigs.DBConfigs) *QueryEngine {
+func newTestQueryEngine(queryPlanCacheSize int, idleTimeout time.Duration, strict bool, dbcfgs dbconfigs.DBConfigs) *QueryEngine {
 	config := tabletenv.DefaultQsConfig
-	config.QueryCacheSize = queryCacheSize
+	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.IdleTimeout = float64(idleTimeout) / 1e9
 	se := schema.NewEngine(DummyChecker, config)
 	qe := NewQueryEngine(DummyChecker, se, config)

--- a/go/vt/vttablet/tabletserver/queryz.go
+++ b/go/vt/vttablet/tabletserver/queryz.go
@@ -137,14 +137,14 @@ func queryzHandler(qe *QueryEngine, w http.ResponseWriter, r *http.Request) {
 	defer logz.EndHTMLTable(w)
 	w.Write(queryzHeader)
 
-	keys := qe.queries.Keys()
+	keys := qe.plans.Keys()
 	sorter := queryzSorter{
 		rows: make([]*queryzRow, 0, len(keys)),
 		less: func(row1, row2 *queryzRow) bool {
 			return row1.timePQ() > row2.timePQ()
 		},
 	}
-	for _, v := range qe.queries.Keys() {
+	for _, v := range qe.plans.Keys() {
 		plan := qe.peekQuery(v)
 		if plan == nil {
 			continue

--- a/go/vt/vttablet/tabletserver/queryz_test.go
+++ b/go/vt/vttablet/tabletserver/queryz_test.go
@@ -45,7 +45,7 @@ func TestQueryzHandler(t *testing.T) {
 		},
 	}
 	plan1.AddStats(10, 2*time.Second, 1*time.Second, 2, 0)
-	qe.queries.Set("select name from test_table", plan1)
+	qe.plans.Set("select name from test_table", plan1)
 
 	plan2 := &TabletPlan{
 		Plan: &planbuilder.Plan{
@@ -55,7 +55,7 @@ func TestQueryzHandler(t *testing.T) {
 		},
 	}
 	plan2.AddStats(1, 2*time.Millisecond, 1*time.Millisecond, 1, 0)
-	qe.queries.Set("insert into test_table values 1", plan2)
+	qe.plans.Set("insert into test_table values 1", plan2)
 
 	plan3 := &TabletPlan{
 		Plan: &planbuilder.Plan{
@@ -65,8 +65,8 @@ func TestQueryzHandler(t *testing.T) {
 		},
 	}
 	plan3.AddStats(1, 75*time.Millisecond, 50*time.Millisecond, 1, 0)
-	qe.queries.Set("show tables", plan3)
-	qe.queries.Set("", (*TabletPlan)(nil))
+	qe.plans.Set("show tables", plan3)
+	qe.plans.Set("", (*TabletPlan)(nil))
 
 	plan4 := &TabletPlan{
 		Plan: &planbuilder.Plan{
@@ -80,8 +80,8 @@ func TestQueryzHandler(t *testing.T) {
 	for i := 1; i < 1000; i++ {
 		hugeInsert = hugeInsert + fmt.Sprintf(", %d", i)
 	}
-	qe.queries.Set(hugeInsert, plan4)
-	qe.queries.Set("", (*TabletPlan)(nil))
+	qe.plans.Set(hugeInsert, plan4)
+	qe.plans.Set("", (*TabletPlan)(nil))
 
 	queryzHandler(qe, resp, req)
 	body, _ := ioutil.ReadAll(resp.Body)

--- a/go/vt/vttablet/tabletserver/schema/engine_test.go
+++ b/go/vt/vttablet/tabletserver/schema/engine_test.go
@@ -423,9 +423,9 @@ func (dummyChecker) CheckMySQL() {}
 
 var DummyChecker = dummyChecker{}
 
-func newEngine(queryCacheSize int, reloadTime time.Duration, idleTimeout time.Duration, strict bool, db *fakesqldb.DB) *Engine {
+func newEngine(queryPlanCacheSize int, reloadTime time.Duration, idleTimeout time.Duration, strict bool, db *fakesqldb.DB) *Engine {
 	config := tabletenv.DefaultQsConfig
-	config.QueryCacheSize = queryCacheSize
+	config.QueryPlanCacheSize = queryPlanCacheSize
 	config.SchemaReloadTime = float64(reloadTime) / 1e9
 	config.IdleTimeout = float64(idleTimeout) / 1e9
 	se := NewEngine(DummyChecker, config)

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -59,7 +59,7 @@ func init() {
 	flag.IntVar(&Config.WarnResultSize, "queryserver-config-warn-result-size", DefaultQsConfig.WarnResultSize, "query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this")
 	flag.IntVar(&Config.MaxDMLRows, "queryserver-config-max-dml-rows", DefaultQsConfig.MaxDMLRows, "query server max dml rows per statement, maximum number of rows allowed to return at a time for an upadte or delete with either 1) an equality where clauses on primary keys, or 2) a subselect statement. For update and delete statements in above two categories, vttablet will split the original query into multiple small queries based on this configuration value. ")
 	flag.IntVar(&Config.StreamBufferSize, "queryserver-config-stream-buffer-size", DefaultQsConfig.StreamBufferSize, "query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size.")
-	flag.IntVar(&Config.QueryCacheSize, "queryserver-config-query-cache-size", DefaultQsConfig.QueryCacheSize, "query server query cache size, maximum number of queries to be cached. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
+	flag.IntVar(&Config.QueryPlanCacheSize, "queryserver-config-query-cache-size", DefaultQsConfig.QueryPlanCacheSize, "query server query cache size, maximum number of queries to be cached. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
 	flag.Float64Var(&Config.SchemaReloadTime, "queryserver-config-schema-reload-time", DefaultQsConfig.SchemaReloadTime, "query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance in seconds. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time.")
 	flag.Float64Var(&Config.QueryTimeout, "queryserver-config-query-timeout", DefaultQsConfig.QueryTimeout, "query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed.")
 	flag.Float64Var(&Config.TxPoolTimeout, "queryserver-config-txpool-timeout", DefaultQsConfig.TxPoolTimeout, "query server transaction pool timeout, it is how long vttablet waits if tx pool is full")
@@ -111,7 +111,7 @@ type TabletConfig struct {
 	WarnResultSize          int
 	MaxDMLRows              int
 	StreamBufferSize        int
-	QueryCacheSize          int
+	QueryPlanCacheSize      int
 	SchemaReloadTime        float64
 	QueryTimeout            float64
 	TxPoolTimeout           float64
@@ -162,7 +162,7 @@ var DefaultQsConfig = TabletConfig{
 	MaxResultSize:           10000,
 	WarnResultSize:          0,
 	MaxDMLRows:              500,
-	QueryCacheSize:          5000,
+	QueryPlanCacheSize:      5000,
 	SchemaReloadTime:        30 * 60,
 	QueryTimeout:            30,
 	TxPoolTimeout:           1,

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1921,15 +1921,15 @@ func (tsv *TabletServer) TxTimeout() time.Duration {
 	return tsv.te.txPool.Timeout()
 }
 
-// SetQueryCacheCap changes the pool size to the specified value.
+// SetQueryPlanCacheCap changes the pool size to the specified value.
 // This function should only be used for testing.
-func (tsv *TabletServer) SetQueryCacheCap(val int) {
-	tsv.qe.SetQueryCacheCap(val)
+func (tsv *TabletServer) SetQueryPlanCacheCap(val int) {
+	tsv.qe.SetQueryPlanCacheCap(val)
 }
 
-// QueryCacheCap returns the pool size.
-func (tsv *TabletServer) QueryCacheCap() int {
-	return int(tsv.qe.QueryCacheCap())
+// QueryPlanCacheCap returns the pool size.
+func (tsv *TabletServer) QueryPlanCacheCap() int {
+	return int(tsv.qe.QueryPlanCacheCap())
 }
 
 // SetAutoCommit sets autocommit on or off.

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2723,12 +2723,12 @@ func TestConfigChanges(t *testing.T) {
 		t.Errorf("tsv.te.txPool.Timeout: %v, want %v", val, newDuration)
 	}
 
-	tsv.SetQueryCacheCap(newSize)
-	if val := tsv.QueryCacheCap(); val != newSize {
-		t.Errorf("QueryCacheCap: %d, want %d", val, newSize)
+	tsv.SetQueryPlanCacheCap(newSize)
+	if val := tsv.QueryPlanCacheCap(); val != newSize {
+		t.Errorf("QueryPlanCacheCap: %d, want %d", val, newSize)
 	}
-	if val := int(tsv.qe.QueryCacheCap()); val != newSize {
-		t.Errorf("tsv.qe.QueryCacheCap: %d, want %d", val, newSize)
+	if val := int(tsv.qe.QueryPlanCacheCap()); val != newSize {
+		t.Errorf("tsv.qe.QueryPlanCacheCap: %d, want %d", val, newSize)
 	}
 
 	tsv.SetAutoCommit(true)


### PR DESCRIPTION
### Desc

In this PR https://github.com/youtube/vitess/pull/3245, @bbeaudreault suggested we should refactor `QueryCache` to `PlanCache`. This PR takes a first stab at doing that. 

* To be more accurate, this commit refactors QueryCache to QueryPlanCache
* It also renames queries to plans. This is consistent with the naming in vtgate
* TODO - Refactor published metrics. This will be done in a separate commit