### PR TITLE
Prune post-init data from tablet entries on tablet shutdown.

### DIFF
--- a/go/cmd/vttablet/vttablet.go
+++ b/go/cmd/vttablet/vttablet.go
@@ -140,6 +140,9 @@ func main() {
 	}
 
 	servenv.OnClose(func() {
+		// stop the agent so that our topo entry gets pruned properly
+		agent.Close()
+
 		// We will still use the topo server during lameduck period
 		// to update our state, so closing it in OnClose()
 		ts.Close()


### PR DESCRIPTION
This was the result of our slack conversation last night. We should be wiping post-init tablet data such as IP address etc from the tablet on shutdown.

@sougou did I miss anything?