### PR TITLE
Bind vtgate to all interfaces not just localhost

### DIFF
--- a/go/vt/vttest/local_cluster.go
+++ b/go/vt/vttest/local_cluster.go
@@ -84,6 +84,10 @@ type Config struct {
 	// not be started.
 	OnlyMySQL bool
 
+	// MySQL protocol bind address.
+	// vtcombo will bind to this address when exposing the mysql protocol socket
+	MySQLBindHost string
+
 	// SnapshotFile is the path to the MySQL Snapshot that will be used to
 	// initialize the mysqld instance in the cluster. Note that some environments
 	// do not suppport initialization through snapshot files.

--- a/go/vt/vttest/vtprocess.go
+++ b/go/vt/vttest/vtprocess.go
@@ -243,10 +243,15 @@ func VtcomboProcess(env Environment, args *Config, mysql MySQLManager) *VtProces
 	}
 
 	vtcomboMysqlPort := env.PortForProtocol("vtcombo_mysql_port", "")
+	vtcomboMysqlBindAddress := "localhost"
+	if args.MySQLBindHost != "" {
+		vtcomboMysqlBindAddress = args.MySQLBindHost
+	}
+
 	vt.ExtraArgs = append(vt.ExtraArgs, []string{
 		"-mysql_auth_server_impl", "none",
 		"-mysql_server_port", fmt.Sprintf("%d", vtcomboMysqlPort),
-		"-mysql_server_bind_address", "localhost",
+		"-mysql_server_bind_address", vtcomboMysqlBindAddress,
 	}...)
 
 	return vt


### PR DESCRIPTION
I am running vtcombo inside a Docker container and need to expose the
mysql protocol port to the host, so I can use it in my app.
Thus, binding mysql to localhost will not allow me to expose it to
the host.