### PR TITLE
grpc: switch to new scheme

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -122,7 +122,7 @@ ln -snf $consul_dist/consul $VTROOT/bin/consul
 # install gRPC C++ base, so we can install the python adapters.
 # this also installs protobufs
 grpc_dist=$VTROOT/dist/grpc
-grpc_ver=v1.0.0
+grpc_ver=v1.7.0
 if [ $SKIP_ROOT_INSTALLS == "True" ]; then
   echo "skipping grpc build, as root version was already installed."
 elif [[ -f $grpc_dist/.build_finished && "$(cat $grpc_dist/.build_finished)" == "$grpc_ver" ]]; then

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -20,6 +20,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	// grpc doesn't return underlying errors. So, we have
+	// to rely on logs to know the root cause if a request
+	// fails.
+	_ "google.golang.org/grpc/grpclog/glogger"
+
 	"github.com/youtube/vitess/go/vt/grpccommon"
 	"github.com/youtube/vitess/go/vt/vttls"
 )
@@ -31,14 +36,6 @@ func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 			grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
 			grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
 		),
-		// FailOnNonTempDialError makes the grpc fail faster on chronic errors.
-		// Additionally, the error messages are more specific, which
-		// is more helpful for troubleshooting.
-		grpc.FailOnNonTempDialError(true),
-		// With grpc 1.7.0, some requests are failing with
-		// 'the connection is unavailable' error. Adding this
-		// WithBlock option mitigates the problem.
-		grpc.WithBlock(),
 	}
 	newopts = append(newopts, opts...)
 	return grpc.Dial(target, newopts...)

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -51,5 +51,5 @@ fi
 
 # Install gRPC python libraries from PyPI.
 # Dependencies like protobuf python will be installed automatically.
-grpcio_ver=1.6.0
+grpcio_ver=1.7.0
 $PIP install --upgrade grpcio==$grpcio_ver

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1041,6 +1041,20 @@
 			"versionExact": "v1.7.1"
 		},
 		{
+			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "QyasSHZlgle+PHSIQ2/p+fr+ihY=",
+			"path": "google.golang.org/grpc/grpclog/glogger",
+			"revision": "08a45354194cd00490a5d926825670fb928b5f76",
+			"revisionTime": "2017-11-01T20:14:29Z"
+		},
+		{
 			"checksumSHA1": "U9vDe05/tQrvFBojOQX8Xk12W9I=",
 			"path": "google.golang.org/grpc/internal",
 			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -977,164 +977,148 @@
 			"revisionTime": "2017-05-31T20:35:52Z"
 		},
 		{
-			"checksumSHA1": "Q6UL8p/2c+DmwlZaNLaYnZ5KISY=",
+			"checksumSHA1": "y6h+XSUljIi7QBgKWGNl9cRtdZA=",
 			"path": "google.golang.org/grpc",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "OCBWpefHJ05ZkENccs7COJjWIvk=",
 			"path": "google.golang.org/grpc/balancer",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "Dkjgw1HasWvqct0IuiZdjbD7O0c=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "XH2WYcDNwVO47zYShREJjcYXm0Y=",
 			"path": "google.golang.org/grpc/connectivity",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "5ylThBvJnIcyWhL17AC9+Sdbw2E=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "QbufP1o0bXrtd5XecqdRCK/Vl0M=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
-		},
-		{
-			"checksumSHA1": "XbDzI4GeUt2/8WAS5mLKm5ghVWo=",
-			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "WxP3QV0Y4fIx5NsT0dwBp6JsrJE=",
 			"path": "google.golang.org/grpc/grpclb/grpc_lb_v1/messages",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
-		},
-		{
-			"checksumSHA1": "taQS6p0HLyrMJZc0hvxPLrcBTVI=",
-			"path": "google.golang.org/grpc/grpclb/messages_only/grpc_lb_v1",
-			"revision": "9b6ac7ddb739a2bdfe5692fc29284db555756acd",
-			"revisionTime": "2017-08-23T20:45:01Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "ntHev01vgZgeIh5VFRmbLx/BSTo=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "U9vDe05/tQrvFBojOQX8Xk12W9I=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "hcuHgKp8W0wIzoCnNfKI8NUss5o=",
 			"path": "google.golang.org/grpc/keepalive",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "KeUmTZV+2X46C49cKyjp+xM7fvw=",
 			"path": "google.golang.org/grpc/metadata",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "556Vl75S7EVxgScPckfELwn6+xo=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "n5EgDdBqFMa2KQFhtl+FF/4gIFo=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "ifLyU1wZH521mt8htJZpGB/XVgQ=",
 			"path": "google.golang.org/grpc/resolver",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "G9lgXNi7qClo5sM2s6TbTHLFR3g=",
 			"path": "google.golang.org/grpc/stats",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "3Dwz4RLstDHMPyDA7BUsYe+JP4w=",
 			"path": "google.golang.org/grpc/status",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "qvArRhlrww5WvRmbyMF2mUfbJew=",
 			"path": "google.golang.org/grpc/tap",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "Bxregh/v5pH6fVa1rIo2zLCb5NI=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "f7bf885db0b7479a537ec317c6e48ce53145f3db",
-			"revisionTime": "2017-10-11T17:41:09Z",
-			"version": "=v1.7.0",
-			"versionExact": "v1.7.0"
+			"revision": "61d37c5d657a47e4404fd6823bd598341a2595de",
+			"revisionTime": "2017-10-25T22:03:47Z",
+			"version": "=v1.7.1",
+			"versionExact": "v1.7.1"
 		},
 		{
 			"checksumSHA1": "wSu8owMAP7GixsYoSZ4CmKUVhnU=",


### PR DESCRIPTION
This is a work-around for: https://github.com/grpc/grpc-go/issues/1633.

Commit 1
```
1.7.1 has a fix for the case where a request would fast-fail if a
connection is not ready yet. This behavior is needed for the next
change where we're going to change all our dials to be non-blocking.
```

Commit 2
```
grpc is moving towards error-less dialing. Failures can happen
only during requests. However, all requests currently fail with
'Unavailable' error due to a design constraint. There is currently
no way to programmatically get to the underlying error.

Due to this, we have to rely on grpc's logging to find the root
cause of failures. This is now turned on for all programs that
use the grpc client.

For now, I'm leaving the dial timeout parameters in. They'll just
be ignored. Once we're confident that this approach works, we
can clean them all up.
```

