### PR TITLE
worker: Fix flaky vtworker unit test.

### DIFF
--- a/go/vt/worker/legacy_split_clone_test.go
+++ b/go/vt/worker/legacy_split_clone_test.go
@@ -465,6 +465,11 @@ func TestLegacySplitCloneV2_NoMasterAvailable(t *testing.T) {
 
 	// Wait for a retry due to NoMasterAvailable to happen, expect the 30th write
 	// on leftReplica and change leftReplica from REPLICA to MASTER.
+	//
+	// Reset the retry stats now. It also happens when the worker starts but that
+	// is too late because this Go routine potentially reads it before the worker
+	// resets the old value.
+	statsRetryCounters.Reset()
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()

--- a/go/vt/worker/split_clone_test.go
+++ b/go/vt/worker/split_clone_test.go
@@ -1010,6 +1010,10 @@ func TestSplitCloneV2_NoMasterAvailable(t *testing.T) {
 
 	// Wait for a retry due to NoMasterAvailable to happen, expect the 30th write
 	// on leftReplica and change leftReplica from REPLICA to MASTER.
+	//
+	// Reset the stats now. It also happens when the worker starts but that's too
+	// late because this Go routine looks at it and can run before the worker.
+	statsRetryCounters.Reset()
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()


### PR DESCRIPTION
The two Test*SplitCloneV2_NoMasterAvailable methods both change the
"statsRetryCounters" global variable. If one test runs before the other,
the Go routine launched by the second test method may observe the old
retries and therefore simulate the MASTER failover too fast.

Resetting the stats counter in each test fixes this problem.

Most likely, this fixes https://github.com/youtube/vitess/issues/3353 as
well.

@sougou After this is fixed, you can revert your change on this file in the go test -race PR.