### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/php/tests/ProtoUtilsTest.php
+++ b/php/tests/ProtoUtilsTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Vitess;
 
+use PHPUnit\Framework\TestCase;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/TestUtils.php';
 
-class ProtoUtilsTest extends \PHPUnit_Framework_TestCase
+class ProtoUtilsTest extends TestCase
 {
 
     public function testBoundQuery()

--- a/php/tests/VTGateConnTest.php
+++ b/php/tests/VTGateConnTest.php
@@ -1,10 +1,12 @@
 <?php
 namespace Vitess;
 
+use PHPUnit\Framework\TestCase;
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/TestUtils.php';
 
-class VTGateConnTest extends \PHPUnit_Framework_TestCase
+class VTGateConnTest extends TestCase
 {
 
     private static $proc;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).