### PR TITLE
docker: Do not run with `-ti`

### DIFF
--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -17,6 +17,8 @@
 # This is the script to build the vitess/lite Docker image by extracting
 # the pre-built binaries from a vitess/base image.
 
+set -ex
+
 # Parse command line arguments.
 prompt_notice=true
 if [[ "$1" == "--prompt"* ]]; then
@@ -73,7 +75,7 @@ fi
 mkdir base
 # Ignore permission errors. They occur for directories we do not care e.g. ".git".
 # (Copying them fails because they are owned by root and not $UID and have stricter permissions.)
-docker run -ti --rm -v $PWD/base:/base -u $UID $base_image bash -c 'cp -R /vt /base/ 2>&1 | grep -v "Permission denied"'
+docker run --rm -v $PWD/base:/base -u $UID $base_image bash -c 'cp -R /vt /base/ 2>&1 | grep -v "Permission denied"' || true
 
 # Grab only what we need
 lite=$PWD/lite


### PR DESCRIPTION
Here's an issue we've encountered when trying to build Vitess images in our infrastructure:

The `docker/lite/build.sh` script attempts to extract the relevant Vitess files from the base image. It does that by running the image with a local mount point, where it can copy the files. But for some reason, it passes `-ti` as arguments to the `docker run` command...

The `-ti` flags are used when running images locally (namely -- they attach a TTY to the container and open `stdin`), and these cause the build to fail if `build.sh` is running in an environment without TTY. Simply removing these flags allows the extraction to succeed in any environment.

While I was at it, I added `set -ex` to add visibility to the script and ensure it exits if any of the build steps fail (it wasn't doing that previously, resulting in Docker images which were empty!).