### PR TITLE
Fix reconfigure components at runtime without restart

### DIFF
--- a/go/vt/servenv/run.go
+++ b/go/vt/servenv/run.go
@@ -34,16 +34,16 @@ var (
 // Run starts listening for RPC and HTTP requests,
 // and blocks until it the process gets a signal.
 func Run(port int) {
+	l, err := proc.Listen(fmt.Sprintf("%v", port))
+	if err != nil {
+		log.Fatal(err)
+	}
 	populateListeningURL()
 	createGRPCServer()
 	onRunHooks.Fire()
 	serveGRPC()
 	serveSocketFile()
 
-	l, err := proc.Listen(fmt.Sprintf("%v", port))
-	if err != nil {
-		log.Fatal(err)
-	}
 	go http.Serve(l, nil)
 
 	proc.Wait()


### PR DESCRIPTION
### Description 

* This PR fixes the following: https://github.com/youtube/vitess/issues/2983
* `proc.Listen()` already [kills](https://github.com/youtube/vitess/blob/master/go/proc/proc.go#L45) the old process before binding to the given port.
  This commit moves `proc.Listen()` to the top in `servenv.Run()`. In this way, the
  old process will die and it will release all the ports before the new one
  starts serving grpc.

### Tests

* Locally.