### PR TITLE
pull zookeeper 3.4.6 from apache archive

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,7 +74,7 @@ if [ -f $zk_dist/.build_finished ]; then
 else
   rm -rf $zk_dist
   (cd $VTROOT/dist && \
-    wget http://apache.org/dist/zookeeper/zookeeper-$zk_ver/zookeeper-$zk_ver.tar.gz && \
+    wget http://archive.apache.org/dist/zookeeper/zookeeper-$zk_ver/zookeeper-$zk_ver.tar.gz && \
     tar -xzf zookeeper-$zk_ver.tar.gz && \
     mkdir -p $zk_dist/lib && \
     cp zookeeper-$zk_ver/contrib/fatjar/zookeeper-$zk_ver-fatjar.jar $zk_dist/lib && \


### PR DESCRIPTION
apache no longer hosts version 3.4.6 on the main page. this will get our builds working again while we figure out what zk version we want to run on in the future.
@hmcgonig 
@sougou 