### PR TITLE
connpool: improved error handling

### DIFF
--- a/go/mysql/constants.go
+++ b/go/mysql/constants.go
@@ -420,9 +420,10 @@ const (
 	ERIllegalReference             = 1247
 	ERDerivedMustHaveAlias         = 1248
 	ERTableNameNotAllowedHere      = 1250
+	ERQueryInterrupted             = 1317
+	ERTruncatedWrongValueForField  = 1366
 	ERDataTooLong                  = 1406
 	ERDataOutOfRange               = 1690
-	ERTruncatedWrongValueForField  = 1366
 )
 
 // Sql states for errors.
@@ -542,14 +543,7 @@ func IsNum(typ uint8) bool {
 func IsConnErr(err error) bool {
 	if sqlErr, ok := err.(*SQLError); ok {
 		num := sqlErr.Number()
-		// ServerLost means that the query has already been
-		// received by MySQL and may have already been executed.
-		// Since we don't know if the query is idempotent, we don't
-		// count this error as connection error which could be retried.
-		if num == CRServerLost {
-			return false
-		}
-		return num >= CRUnknownError && num <= CRNamedPipeStateError
+		return (num >= CRUnknownError && num <= CRNamedPipeStateError) || num == ERQueryInterrupted
 	}
 	return false
 }

--- a/go/mysql/constants_test.go
+++ b/go/mysql/constants_test.go
@@ -36,7 +36,10 @@ func TestIsConnErr(t *testing.T) {
 		want: true,
 	}, {
 		in:   NewSQLError(CRServerLost, "", ""),
-		want: false,
+		want: true,
+	}, {
+		in:   NewSQLError(ERQueryInterrupted, "", ""),
+		want: true,
 	}, {
 		in:   NewSQLError(CRCantReadCharset, "", ""),
 		want: false,

--- a/go/vt/binlog/binlogplayer/dbclient.go
+++ b/go/vt/binlog/binlogplayer/dbclient.go
@@ -41,14 +41,8 @@ func NewDbClient(params *mysql.ConnParams) *DBClient {
 }
 
 func (dc *DBClient) handleError(err error) {
-	// log.Errorf("in DBClient handleError %v", err.(error))
-	if sqlErr, ok := err.(*mysql.SQLError); ok {
-		if sqlErr.Number() >= 2000 && sqlErr.Number() <= 2018 { // mysql connection errors
-			dc.Close()
-		}
-		if sqlErr.Number() == 1317 { // Query was interrupted
-			dc.Close()
-		}
+	if mysql.IsConnErr(err) {
+		dc.Close()
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -23,14 +23,16 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
-	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
-	"golang.org/x/net/context"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // BinlogFormat is used for for specifying the binlog format.
@@ -95,23 +97,26 @@ func (dbc *DBConn) Exec(ctx context.Context, query string, maxrows int, wantfiel
 		r, err := dbc.execOnce(ctx, query, maxrows, wantfields)
 		switch {
 		case err == nil:
+			// Success.
 			return r, nil
 		case !mysql.IsConnErr(err):
-			// MySQL error that isn't due to a connection issue
+			// Not a connection error. Don't retry.
 			return nil, err
 		case attempt == 2:
-			// If the MySQL connection is bad, we assume that there is nothing wrong with
-			// the query itself, and retrying it might succeed. The MySQL connection might
-			// fix itself, or the query could succeed on a different VtTablet.
+			// Reached the retry limit.
 			return nil, err
 		}
 
-		// Connection error. Try to reconnect.
+		// Connection error. Retry if context has not expired.
+		select {
+		case <-ctx.Done():
+			return nil, err
+		default:
+		}
+
 		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
-			// Reconnect failed.
 			dbc.pool.checker.CheckMySQL()
 			// Return the error of the reconnect and not the original connection error.
-			// NOTE: We return a tryable error code here.
 			return nil, reconnectErr
 		}
 
@@ -147,8 +152,8 @@ func (dbc *DBConn) Stream(ctx context.Context, query string, callback func(*sqlt
 	span.StartClient("DBConn.Stream")
 	defer span.Finish()
 
+	resultSent := false
 	for attempt := 1; attempt <= 2; attempt++ {
-		resultSent := false
 		err := dbc.streamOnce(
 			ctx,
 			query,
@@ -163,15 +168,29 @@ func (dbc *DBConn) Stream(ctx context.Context, query string, callback func(*sqlt
 		)
 		switch {
 		case err == nil:
+			// Success.
 			return nil
-		case !mysql.IsConnErr(err) || resultSent || attempt == 2:
-			// MySQL error that isn't due to a connection issue
+		case !mysql.IsConnErr(err):
+			// Not a connection error. Don't retry.
+			return err
+		case attempt == 2:
+			// Reached the retry limit.
+			return err
+		case resultSent:
+			// Don't retry if streaming has started.
 			return err
 		}
-		err2 := dbc.reconnect()
-		if err2 != nil {
-			dbc.pool.checker.CheckMySQL()
+
+		// Connection error. Retry if context has not expired.
+		select {
+		case <-ctx.Done():
 			return err
+		default:
+		}
+		if reconnectErr := dbc.reconnect(); reconnectErr != nil {
+			dbc.pool.checker.CheckMySQL()
+			// Return the error of the reconnect and not the original connection error.
+			return reconnectErr
 		}
 	}
 	panic("unreachable")
@@ -269,9 +288,9 @@ func (dbc *DBConn) Recycle() {
 // Kill kills the currently executing query both on MySQL side
 // and on the connection side. If no query is executing, it's a no-op.
 // Kill will also not kill a query more than once.
-func (dbc *DBConn) Kill(reason string) error {
+func (dbc *DBConn) Kill(reason string, elapsed time.Duration) error {
 	tabletenv.KillStats.Add("Queries", 1)
-	log.Infof("Due to %s, killing query %s", reason, dbc.Current())
+	log.Infof("Due to %s, elapsed time: %v, killing query %s", reason, elapsed, dbc.Current())
 	killConn, err := dbc.pool.dbaPool.Get(context.TODO())
 	if err != nil {
 		log.Warningf("Failed to get conn from dba pool: %v", err)
@@ -323,7 +342,7 @@ func (dbc *DBConn) setDeadline(ctx context.Context) (chan bool, *sync.WaitGroup)
 		startTime := time.Now()
 		select {
 		case <-ctx.Done():
-			dbc.Kill(ctx.Err().Error())
+			dbc.Kill(ctx.Err().Error(), time.Since(startTime))
 		case <-done:
 			return
 		}

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -91,7 +91,7 @@ func TestDBConnKill(t *testing.T) {
 	db.AddQuery(query, &sqltypes.Result{})
 	// Kill failed because we are not able to connect to the database
 	db.EnableConnFail()
-	err = dbConn.Kill("test kill")
+	err = dbConn.Kill("test kill", 0)
 	want := "errno 2013"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Exec: %v, want %s", err, want)
@@ -99,7 +99,7 @@ func TestDBConnKill(t *testing.T) {
 	db.DisableConnFail()
 
 	// Kill succeed
-	err = dbConn.Kill("test kill")
+	err = dbConn.Kill("test kill", 0)
 	if err != nil {
 		t.Fatalf("kill should succeed, but got error: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestDBConnKill(t *testing.T) {
 	newKillQuery := fmt.Sprintf("kill %d", dbConn.ID())
 	// Kill failed because "kill query_id" failed
 	db.AddRejectedQuery(newKillQuery, errors.New("rejected"))
-	err = dbConn.Kill("test kill")
+	err = dbConn.Kill("test kill", 0)
 	want = "rejected"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Exec: %v, want %s", err, want)
@@ -164,9 +164,8 @@ func TestDBConnStream(t *testing.T) {
 			return nil
 		}, 10, querypb.ExecuteOptions_ALL)
 	db.DisableConnFail()
-	want1 := "Connection is closed"
-	want2 := "use of closed network connection"
-	if err == nil || (!strings.Contains(err.Error(), want1) && !strings.Contains(err.Error(), want2)) {
-		t.Errorf("Error: '%v', must contain '%s' or '%s'\n", err, want1, want2)
+	want := "no such file or directory (errno 2002)"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Error: '%v', must contain '%s'", err, want)
 	}
 }

--- a/go/vt/vttablet/tabletserver/query_list.go
+++ b/go/vt/vttablet/tabletserver/query_list.go
@@ -38,7 +38,7 @@ type QueryDetail struct {
 type killable interface {
 	Current() string
 	ID() int64
-	Kill(string) error
+	Kill(message string, startTime time.Duration) error
 }
 
 // NewQueryDetail creates a new QueryDetail
@@ -79,7 +79,7 @@ func (ql *QueryList) Terminate(connID int64) error {
 	if qd == nil {
 		return fmt.Errorf("query %v not found", connID)
 	}
-	qd.conn.Kill("QueryList.Terminate()")
+	qd.conn.Kill("QueryList.Terminate()", time.Since(qd.start))
 	return nil
 }
 
@@ -88,7 +88,7 @@ func (ql *QueryList) TerminateAll() {
 	ql.mu.Lock()
 	defer ql.mu.Unlock()
 	for _, qd := range ql.queryDetails {
-		qd.conn.Kill("QueryList.TerminateAll()")
+		qd.conn.Kill("QueryList.TerminateAll()", time.Since(qd.start))
 	}
 }
 

--- a/go/vt/vttablet/tabletserver/query_list_test.go
+++ b/go/vt/vttablet/tabletserver/query_list_test.go
@@ -18,6 +18,7 @@ package tabletserver
 
 import (
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 )
@@ -32,7 +33,7 @@ func (tc *testConn) Current() string { return tc.query }
 
 func (tc *testConn) ID() int64 { return tc.id }
 
-func (tc *testConn) Kill(string) error {
+func (tc *testConn) Kill(string, time.Duration) error {
 	tc.killed = true
 	return nil
 }


### PR DESCRIPTION
The connpool error handling had some flaws that were causing
issues during resharding of very big tables. The root cause
was that a code path in streaming query would return a closed
connection to the pool.

The following fixes were made to improve overall user experience:
* FetchNext in Stream will close the connection if a streaming
  error was encountered.
* IsConnErr returns true for all conn errors. No exceptions.
* If a conn error is seen, the connection is always closed.
* The retry logic for queries now relies on the context being
  canceled instead of detecting a conn error. This way, a query
  that was interrupted for any reason other than our context,
  will be retried until the context expires.
* The kill message now records the elapsed time for a query
  which is useful information.