### PR TITLE
docker: More tweaks for build.sh

### DIFF
--- a/docker/lite/Dockerfile
+++ b/docker/lite/Dockerfile
@@ -2,7 +2,7 @@
 FROM debian:jessie
 
 # Install dependencies
-RUN apt-key adv --recv-keys --keyserver pgp.mit.edu 5072E1F5 \
+RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 5072E1F5 \
  && echo 'deb http://repo.mysql.com/apt/debian/ jessie mysql-5.7' > /etc/apt/sources.list.d/mysql.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive \

--- a/docker/lite/Dockerfile.mysql56
+++ b/docker/lite/Dockerfile.mysql56
@@ -2,7 +2,7 @@
 FROM debian:jessie
 
 # Install dependencies
-RUN apt-key adv --recv-keys --keyserver pgp.mit.edu 5072E1F5 \
+RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 5072E1F5 \
  && echo 'deb http://repo.mysql.com/apt/debian/ jessie mysql-5.6' > /etc/apt/sources.list.d/mysql.list \
  && apt-get update \
  && DEBIAN_FRONTEND=noninteractive \

--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -71,6 +71,12 @@ END
   read
 fi
 
+# cleanup both temporary folders when exiting, even in case of errors
+function cleanup {
+  rm -rf $PWD/base $PWD/lite
+}
+trap cleanup EXIT
+
 # Extract files from vitess/base image
 mkdir base
 # Ignore permission errors. They occur for directories we do not care e.g. ".git".
@@ -94,13 +100,11 @@ mkdir -p $lite/$vttop/config
 cp -R base/$vttop/config/* $lite/$vttop/config/
 ln -s /$vttop/config $lite/vt/config
 
-rm -rf base
+# remove the base folder now -- not needed for the final build
+rm -rf $PWD/base
 
 # Fix permissions for AUFS workaround
 chmod -R o=g lite
 
 # Build vitess/lite image
 docker build --no-cache -f $dockerfile -t $lite_image .
-
-# Clean up temporary files
-rm -rf lite


### PR DESCRIPTION
Hiiii! Sorry for the small trickle of commits here -- these are things we're finding out the hard way while wiring up infrastructure to build these Docker images inhouse.

1. We've found that `pgp.mit.edu` is _very_ flaky. Fetching the keys for MySQL 5.7 when building the Docker images fails randomly with a timeout very often. Canonical's keyserver has always been 100% reliable and is always synced and up to date.

2. The cleanup of temporary data in the build script should be run as an exit trap, just to ensure we're always cleaning up between builds.