### PR TITLE
vtctl register all commands at init

### DIFF
--- a/go/cmd/vtctl/vtctl.go
+++ b/go/cmd/vtctl/vtctl.go
@@ -33,6 +33,7 @@ import (
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vtctl"
 	"github.com/youtube/vitess/go/vt/vttablet/tmclient"
+	"github.com/youtube/vitess/go/vt/workflow"
 	"github.com/youtube/vitess/go/vt/wrangler"
 	"golang.org/x/net/context"
 )
@@ -95,6 +96,8 @@ func main() {
 
 	ts := topo.Open()
 	defer ts.Close()
+
+	vtctl.WorkflowManager = workflow.NewManager(ts)
 
 	ctx, cancel := context.WithTimeout(context.Background(), *waitTime)
 	wr := wrangler.New(logutil.NewConsoleLogger(), ts, tmclient.NewTabletManagerClient())

--- a/go/vt/vtctl/query.go
+++ b/go/vt/vtctl/query.go
@@ -161,7 +161,7 @@ func parseExecuteOptions(value string) (*querypb.ExecuteOptions, error) {
 
 func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	server := subFlags.String("server", "", "VtGate server to connect to")
@@ -207,7 +207,7 @@ func commandVtGateExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 
 func commandVtGateExecuteShards(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	server := subFlags.String("server", "", "VtGate server to connect to")
@@ -262,7 +262,7 @@ func commandVtGateExecuteShards(ctx context.Context, wr *wrangler.Wrangler, subF
 
 func commandVtGateExecuteKeyspaceIds(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	server := subFlags.String("server", "", "VtGate server to connect to")
@@ -324,7 +324,7 @@ func commandVtGateExecuteKeyspaceIds(ctx context.Context, wr *wrangler.Wrangler,
 
 func commandVtGateSplitQuery(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	server := subFlags.String("server", "", "VtGate server to connect to")
@@ -396,7 +396,7 @@ func commandVtGateSplitQuery(ctx context.Context, wr *wrangler.Wrangler, subFlag
 
 func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -459,7 +459,7 @@ func commandVtTabletExecute(ctx context.Context, wr *wrangler.Wrangler, subFlags
 
 func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -507,7 +507,7 @@ func commandVtTabletBegin(ctx context.Context, wr *wrangler.Wrangler, subFlags *
 
 func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -552,7 +552,7 @@ func commandVtTabletCommit(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 
 func commandVtTabletRollback(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	username := subFlags.String("username", "", "If set, value is set as immediate caller id in the request and used by vttablet for TableACL check")
@@ -597,7 +597,7 @@ func commandVtTabletRollback(ctx context.Context, wr *wrangler.Wrangler, subFlag
 
 func commandVtTabletStreamHealth(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	count := subFlags.Int("count", 1, "number of responses to wait for")
@@ -647,7 +647,7 @@ func commandVtTabletStreamHealth(ctx context.Context, wr *wrangler.Wrangler, sub
 
 func commandVtTabletUpdateStream(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if !*enableQueries {
-		return fmt.Errorf("query commands are disabled")
+		return fmt.Errorf("query commands are disabled (set the -enable_queries flag to enable)")
 	}
 
 	count := subFlags.Int("count", 1, "number of responses to wait for")

--- a/go/vt/vtctl/reparent.go
+++ b/go/vt/vtctl/reparent.go
@@ -30,11 +30,9 @@ import (
 
 var (
 	// DisableActiveReparents is a flag to disable active
-	// reparents for safety reasons. It is used in two places:
-	// 1. in this file to skip registering the commands.
-	// 2. in vtctld so it can be exported to the UI (different
-	// package, that's why it's exported). That way we can disable
-	// menu items there, using features.
+	// reparents for safety reasons. It is used in vtctld so it can be
+	// exported to the UI (different package, that's why it's exported).
+	// That way we can disable menu items there, using features.
 	DisableActiveReparents = flag.Bool("disable_active_reparents", false, "if set, do not allow active reparents. Use this to protect a cluster using external reparents.")
 )
 
@@ -64,7 +62,7 @@ func init() {
 
 func commandReparentTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if *DisableActiveReparents {
-		return fmt.Errorf("active reparent commands disabled")
+		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
 	if err := subFlags.Parse(args); err != nil {
@@ -82,7 +80,7 @@ func commandReparentTablet(ctx context.Context, wr *wrangler.Wrangler, subFlags 
 
 func commandInitShardMaster(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if *DisableActiveReparents {
-		return fmt.Errorf("active reparent commands disabled")
+		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
 	force := subFlags.Bool("force", false, "will force the reparent even if the provided tablet is not a master or the shard master")
@@ -106,7 +104,7 @@ func commandInitShardMaster(ctx context.Context, wr *wrangler.Wrangler, subFlags
 
 func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if *DisableActiveReparents {
-		return fmt.Errorf("active reparent commands disabled")
+		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
 	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for slaves to catch up in reparenting")
@@ -149,7 +147,7 @@ func commandPlannedReparentShard(ctx context.Context, wr *wrangler.Wrangler, sub
 
 func commandEmergencyReparentShard(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {
 	if *DisableActiveReparents {
-		return fmt.Errorf("active reparent commands disabled")
+		return fmt.Errorf("active reparent commands disabled (unset the -disable_active_reparents flag to enable)")
 	}
 
 	waitSlaveTimeout := subFlags.Duration("wait_slave_timeout", 30*time.Second, "time to wait for slaves to catch up in reparenting")

--- a/go/vt/vtctl/workflow.go
+++ b/go/vt/vtctl/workflow.go
@@ -22,7 +22,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/workflow"
 	"github.com/youtube/vitess/go/vt/wrangler"
 )
@@ -32,56 +31,50 @@ import (
 const workflowsGroupName = "Workflows"
 
 var (
-	// WorkflowManager contains our manager. It needs to be set before
-	// servenv.Run is called, or this command group will be disabled.
+	// WorkflowManager contains our manager. It needs to be set or else all
+	// commands will be disabled.
 	WorkflowManager *workflow.Manager
 )
 
 func init() {
-	servenv.OnRun(func() {
-		if WorkflowManager == nil {
-			return
-		}
+	addCommandGroup(workflowsGroupName)
 
-		addCommandGroup(workflowsGroupName)
+	addCommand(workflowsGroupName, command{
+		"WorkflowCreate",
+		commandWorkflowCreate,
+		"[-skip_start] <factoryName> [parameters...]",
+		"Creates the workflow with the provided parameters. The workflow is also started, unless -skip_start is specified."})
+	addCommand(workflowsGroupName, command{
+		"WorkflowStart",
+		commandWorkflowStart,
+		"<uuid>",
+		"Starts the workflow."})
+	addCommand(workflowsGroupName, command{
+		"WorkflowStop",
+		commandWorkflowStop,
+		"<uuid>",
+		"Stops the workflow."})
+	addCommand(workflowsGroupName, command{
+		"WorkflowDelete",
+		commandWorkflowDelete,
+		"<uuid>",
+		"Deletes the finished or not started workflow."})
+	addCommand(workflowsGroupName, command{
+		"WorkflowWait",
+		commandWorkflowWait,
+		"<uuid>",
+		"Waits for the workflow to finish."})
 
-		addCommand(workflowsGroupName, command{
-			"WorkflowCreate",
-			commandWorkflowCreate,
-			"[-skip_start] <factoryName> [parameters...]",
-			"Creates the workflow with the provided parameters. The workflow is also started, unless -skip_start is specified."})
-		addCommand(workflowsGroupName, command{
-			"WorkflowStart",
-			commandWorkflowStart,
-			"<uuid>",
-			"Starts the workflow."})
-		addCommand(workflowsGroupName, command{
-			"WorkflowStop",
-			commandWorkflowStop,
-			"<uuid>",
-			"Stops the workflow."})
-		addCommand(workflowsGroupName, command{
-			"WorkflowDelete",
-			commandWorkflowDelete,
-			"<uuid>",
-			"Deletes the finished or not started workflow."})
-		addCommand(workflowsGroupName, command{
-			"WorkflowWait",
-			commandWorkflowWait,
-			"<uuid>",
-			"Waits for the workflow to finish."})
-
-		addCommand(workflowsGroupName, command{
-			"WorkflowTree",
-			commandWorkflowTree,
-			"",
-			"Displays a JSON representation of the workflow tree."})
-		addCommand(workflowsGroupName, command{
-			"WorkflowAction",
-			commandWorkflowAction,
-			"<path> <name>",
-			"Sends the provided action name on the specified path."})
-	})
+	addCommand(workflowsGroupName, command{
+		"WorkflowTree",
+		commandWorkflowTree,
+		"",
+		"Displays a JSON representation of the workflow tree."})
+	addCommand(workflowsGroupName, command{
+		"WorkflowAction",
+		commandWorkflowAction,
+		"<path> <name>",
+		"Sends the provided action name on the specified path."})
 }
 
 func commandWorkflowCreate(ctx context.Context, wr *wrangler.Wrangler, subFlags *flag.FlagSet, args []string) error {


### PR DESCRIPTION
Register all the vtctl commands statically in `init()` handlers rather than deferring some to `servenv.OnRun`. 

Previously,  because the command registration was deferred into the `OnRun` handler, when running `vtctl -help` or if certain runtime options aren't included, some groups of commands (workflow management, reparenting, querying, wouldn't be included in the command line usage printout.

With this change, all commands are included in the usage printout no matter what, and the runtime checks that were used to control whether certain commands were enabled or not are moved into the command handlers themselves. I believe that the mutex protecting the command data structure is no longer strictly needed, but I left it there since it also isn't harming anything.

Finally, create a `WorkflowManager` in the tool so that the workflow management commands are enabled.


