### PR TITLE
add error log if split_diff fails

### DIFF
--- a/go/vt/worker/split_diff.go
+++ b/go/vt/worker/split_diff.go
@@ -124,6 +124,7 @@ func (sdw *SplitDiffWorker) Run(ctx context.Context) error {
 		}
 	}
 	if err != nil {
+		sdw.wr.Logger().Errorf("Run() error: %v", err)
 		sdw.SetState(WorkerStateError)
 		return err
 	}


### PR DESCRIPTION
Add an error log since in some cases SplitDiff can fail silently.

(As suggested by @sougou )