### PR TITLE
Etcd2 / consul browser fix.

### DIFF
--- a/go/vt/topo/consultopo/directory.go
+++ b/go/vt/topo/consultopo/directory.go
@@ -32,6 +32,11 @@ func (s *Server) ListDir(ctx context.Context, cell, dirPath string) ([]string, e
 		return nil, err
 	}
 	nodePath := path.Join(c.root, dirPath) + "/"
+	if nodePath == "//" {
+		// Special case where c.root is "/", dirPath is empty,
+		// we would end up with "//". in that case, we want "/".
+		nodePath = "/"
+	}
 
 	keys, _, err := c.kv.Keys(nodePath, "", nil)
 	if err != nil {

--- a/go/vt/topo/etcd2topo/directory.go
+++ b/go/vt/topo/etcd2topo/directory.go
@@ -33,6 +33,11 @@ func (s *Server) ListDir(ctx context.Context, cell, dirPath string) ([]string, e
 		return nil, err
 	}
 	nodePath := path.Join(c.root, dirPath) + "/"
+	if nodePath == "//" {
+		// Special case where c.root is "/", dirPath is empty,
+		// we would end up with "//". in that case, we want "/".
+		nodePath = "/"
+	}
 	resp, err := c.cli.Get(ctx, nodePath,
 		clientv3.WithPrefix(),
 		clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend),


### PR DESCRIPTION
When listing the toplevel directory of a cell, the computed node path
was "//". It needs to be "/" to properly match the keys.