### PR TITLE
Adds vtctlclient bin to lite image

### DIFF
--- a/docker/lite/build.sh
+++ b/docker/lite/build.sh
@@ -89,7 +89,7 @@ vttop=vt/src/github.com/youtube/vitess
 mkdir -p $lite/vt/vtdataroot
 
 mkdir -p $lite/vt/bin
-(cd base/vt/bin; cp mysqlctld vtctld vtgate vttablet vtworker $lite/vt/bin/)
+(cd base/vt/bin; cp mysqlctld vtctld vtctlclient vtgate vttablet vtworker $lite/vt/bin/)
 
 mkdir -p $lite/$vttop/web
 cp -R base/$vttop/web/vtctld $lite/$vttop/web/


### PR DESCRIPTION
@enisoc @sougou 

We build a Vitess image with the binaries so we can run vtgate, vtctld. 
However, we need vtctlclient to execute some topology calls, we could run it from the vitess image. Thus, we need to vtctlclient binary in the lite image.

cc @vmg 