### PR TITLE
Measure times of killed and closed transactions

### DIFF
--- a/go/vt/vttablet/endtoend/transaction_test.go
+++ b/go/vt/vttablet/endtoend/transaction_test.go
@@ -106,7 +106,7 @@ func TestCommit(t *testing.T) {
 		tag:  "Transactions/TotalCount",
 		diff: 2,
 	}, {
-		tag:  "Transactions/Histograms/Completed/Count",
+		tag:  "Transactions/Histograms/commit/Count",
 		diff: 2,
 	}, {
 		tag:  "Queries/TotalCount",
@@ -187,7 +187,7 @@ func TestRollback(t *testing.T) {
 		tag:  "Transactions/TotalCount",
 		diff: 1,
 	}, {
-		tag:  "Transactions/Histograms/Aborted/Count",
+		tag:  "Transactions/Histograms/rollback/Count",
 		diff: 1,
 	}, {
 		tag:  "Queries/Histograms/BEGIN/Count",
@@ -269,7 +269,7 @@ func TestAutoCommit(t *testing.T) {
 		tag:  "Transactions/TotalCount",
 		diff: 2,
 	}, {
-		tag:  "Transactions/Histograms/Completed/Count",
+		tag:  "Transactions/Histograms/commit/Count",
 		diff: 2,
 	}, {
 		tag:  "Queries/TotalCount",


### PR DESCRIPTION
Instead of just "Completed" or "Aborted" stats, exported the conclusion
to match per-user transaction stats.
BUG=69414609