### PR TITLE
fix an off by one bug in the sequence allocation code

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -448,7 +448,7 @@ func (qre *QueryExecutor) execNextval() (*sqltypes.Result, error) {
 				return nil, fmt.Errorf("invalid cache value for sequence %s: %d", tableName, cache)
 			}
 			newLast := nextID + cache
-			for newLast <= t.SequenceInfo.NextVal+inc {
+			for newLast < t.SequenceInfo.NextVal+inc {
 				newLast += cache
 			}
 			query = fmt.Sprintf("update %s set next_id = %d where id = 0", sqlparser.String(tableName), newLast)


### PR DESCRIPTION
The sequences logic erroneously used <= instead of < when figuring out
the next id to write to the database, which had the effect of allocating
the next batch too soon.

In practice this only really matters in the case where the batch size is
small, and specifically in the case of batch size == 1 where we really do
want each allocation to come out of mysql to avoid gaps when reparenting.