### PR TITLE
Write the creation of the heartbeat table to the binlogs

### DIFF
--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -162,7 +162,7 @@ func (w *Writer) initializeTables(cp *mysql.ConnParams) error {
 	}
 	defer conn.Close()
 	statements := []string{
-		sqlTurnoffBinlog,
+		// sqlTurnoffBinlog,   - disabled as the slaves will not pick up the create table statement otherwise.
 		fmt.Sprintf(sqlCreateSidecarDB, w.dbName),
 		fmt.Sprintf(sqlCreateHeartbeatTable, w.dbName),
 	}


### PR DESCRIPTION
This is required for the slaves to see the table. See: https://github.com/youtube/vitess/issues/3404

Without this change replication breaks as there's no table on the slave. It seems this wasn't seen as other users of the code are taking a backup of a single tablet after having made it a master and therefore the table has already been created.

If you create a few tablets at the same time then this will not work and doing a backup first while a good idea should not be a requirement I think.