### PR TITLE
SplitClone: log while waiting for specific tablets to aid user (if things go wrong)

### DIFF
--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -777,6 +777,11 @@ func (scw *SplitCloneWorker) findDestinationMasters(ctx context.Context) error {
 func (scw *SplitCloneWorker) waitForTablets(ctx context.Context, shardInfos []*topo.ShardInfo, timeout time.Duration) error {
 	var wg sync.WaitGroup
 	rec := concurrency.AllErrorRecorder{}
+
+	if len(shardInfos) > 0 {
+		scw.wr.Logger().Infof("Waiting %v for %d %s/%s RDONLY tablet(s)", timeout, scw.minHealthyRdonlyTablets, shardInfos[0].Keyspace(), shardInfos[0].ShardName())
+	}
+
 	for _, si := range shardInfos {
 		wg.Add(1)
 		go func(keyspace, shard string) {


### PR DESCRIPTION
This adds logging of the form:
```
I1121 14:49:09.111655   56657 split_clone.go:782] Waiting 1m0s for 1 keyspace/-80 RDONLY tablet(s)
...
I1121 14:49:09.111818   56657 split_clone.go:782] Waiting 1m0s for 1 keyspace/0 RDONLY tablet(s)
```

If this fails at least you can see in the logging what type of tablet split_clone.go was looking for.  The extra couple of lines shouldn't cause any harm and given the use of SplitClone, plus later filtered replication use different tablet types this helps clarify what's needed especially if they are not available.