### PR TITLE
Removing topo.TabletComplete.

### DIFF
--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -115,18 +115,6 @@ func IsSlaveType(tt topodatapb.TabletType) bool {
 	return true
 }
 
-// TabletComplete validates and normalizes the tablet. If the shard name
-// contains a '-' it is going to try to infer the keyrange from it.
-func TabletComplete(tablet *topodatapb.Tablet) error {
-	shard, kr, err := ValidateShardName(tablet.Shard)
-	if err != nil {
-		return err
-	}
-	tablet.Shard = shard
-	tablet.KeyRange = kr
-	return nil
-}
-
 // NewTablet create a new Tablet record with the given id, cell, and hostname.
 func NewTablet(uid uint32, cell, host string) *topodatapb.Tablet {
 	return &topodatapb.Tablet{

--- a/go/vt/vttablet/tabletmanager/init_tablet.go
+++ b/go/vt/vttablet/tabletmanager/init_tablet.go
@@ -71,7 +71,7 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 	}
 
 	// parse and validate shard name
-	shard, _, err := topo.ValidateShardName(*initShard)
+	shard, keyRange, err := topo.ValidateShardName(*initShard)
 	if err != nil {
 		return fmt.Errorf("cannot validate shard name %v: %v", *initShard, err)
 	}
@@ -155,7 +155,8 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 		Hostname:       hostname,
 		PortMap:        make(map[string]int32),
 		Keyspace:       *initKeyspace,
-		Shard:          *initShard,
+		Shard:          shard,
+		KeyRange:       keyRange,
 		Type:           tabletType,
 		DbNameOverride: *initDbNameOverride,
 		Tags:           initTags,
@@ -165,9 +166,6 @@ func (agent *ActionAgent) InitTablet(port, gRPCPort int32) error {
 	}
 	if gRPCPort != 0 {
 		tablet.PortMap["grpc"] = gRPCPort
-	}
-	if err := topo.TabletComplete(tablet); err != nil {
-		return fmt.Errorf("InitTablet TabletComplete failed: %v", err)
 	}
 
 	// Now try to create the record (it will also fix up the

--- a/go/vt/wrangler/tablet.go
+++ b/go/vt/wrangler/tablet.go
@@ -39,12 +39,14 @@ import (
 // If a tablet is created as master, and there is already a different
 // master in the shard, allowMasterOverride must be set.
 func (wr *Wrangler) InitTablet(ctx context.Context, tablet *topodatapb.Tablet, allowMasterOverride, createShardAndKeyspace, allowUpdate bool) error {
-	if err := topo.TabletComplete(tablet); err != nil {
+	shard, kr, err := topo.ValidateShardName(tablet.Shard)
+	if err != nil {
 		return err
 	}
+	tablet.Shard = shard
+	tablet.KeyRange = kr
 
 	// get the shard, possibly creating it
-	var err error
 	var si *topo.ShardInfo
 
 	if createShardAndKeyspace {

--- a/go/vt/wrangler/tablet_test.go
+++ b/go/vt/wrangler/tablet_test.go
@@ -1,0 +1,42 @@
+package wrangler
+
+import (
+	"testing"
+
+	"github.com/youtube/vitess/go/vt/logutil"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+	"github.com/youtube/vitess/go/vt/topo/memorytopo"
+	"golang.org/x/net/context"
+)
+
+// TestInitTabletShardConversion makes sure InitTablet converts the
+// shard name to lower case when it's a keyrange, and populates
+// KeyRange properly.
+func TestInitTabletShardConversion(t *testing.T) {
+	cell := "cell1"
+	ts := memorytopo.NewServer(cell)
+	wr := New(logutil.NewConsoleLogger(), ts, nil)
+
+	tablet := &topodatapb.Tablet{
+		Alias: &topodatapb.TabletAlias{
+			Cell: cell,
+			Uid:  1,
+		},
+		Shard: "80-C0",
+	}
+
+	if err := wr.InitTablet(context.Background(), tablet, false /*allowMasterOverride*/, true /*createShardAndKeyspace*/, false /*allowUpdate*/); err != nil {
+		t.Fatalf("InitTablet failed: %v", err)
+	}
+
+	ti, err := ts.GetTablet(context.Background(), tablet.Alias)
+	if err != nil {
+		t.Fatalf("GetTablet failed: %v", err)
+	}
+	if ti.Shard != "80-c0" {
+		t.Errorf("Got wrong tablet.Shard, got %v expected 80-c0", ti.Shard)
+	}
+	if string(ti.KeyRange.Start) != "\x80" || string(ti.KeyRange.End) != "\xc0" {
+		t.Errorf("Got wrong tablet.KeyRange, got %v expected 80-c0", ti.KeyRange)
+	}
+}


### PR DESCRIPTION
It was a silly wrapper, called only in two places, and in one of the
two, the wrapped method was called before anyway.

Also adding unit test cases for both changes.