### PR TITLE
worker: address issues

### DIFF
--- a/go/vt/worker/chunk.go
+++ b/go/vt/worker/chunk.go
@@ -95,10 +95,10 @@ func generateChunks(ctx context.Context, wr *wrangler.Wrangler, tablet *topodata
 	qr, err := wr.TabletManagerClient().ExecuteFetchAsApp(shortCtx, tablet, true, []byte(query), 1)
 	cancel()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot determine MIN and MAX of the first primary key column. ExecuteFetchAsApp: %v", err)
+		return nil, fmt.Errorf("tablet: %v, table: %v: cannot determine MIN and MAX of the first primary key column. ExecuteFetchAsApp: %v", topoproto.TabletAliasString(tablet.Alias), td.Name, err)
 	}
 	if len(qr.Rows) != 1 {
-		return nil, fmt.Errorf("Cannot determine MIN and MAX of the first primary key column. Zero rows were returned for the following query: %v", query)
+		return nil, fmt.Errorf("tablet: %v, table: %v: cannot determine MIN and MAX of the first primary key column. Zero rows were returned", topoproto.TabletAliasString(tablet.Alias), td.Name)
 	}
 
 	result := sqltypes.Proto3ToResult(qr)
@@ -155,7 +155,7 @@ func generateChunks(ctx context.Context, wr *wrangler.Wrangler, tablet *topodata
 		end := add(start, interval)
 		chunk, err := toChunk(start, end, i+1, chunkCount)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("tablet: %v, table: %v: %v", topoproto.TabletAliasString(tablet.Alias), td.Name, err)
 		}
 		chunks[i] = chunk
 		start = end
@@ -185,11 +185,11 @@ func add(start, interval interface{}) interface{} {
 func toChunk(start, end interface{}, number, total int) (chunk, error) {
 	startValue, err := sqltypes.InterfaceToValue(start)
 	if err != nil {
-		return chunk{}, fmt.Errorf("Failed to convert calculated start value (%v) into internal sqltypes.Value: %v", start, err)
+		return chunk{}, fmt.Errorf("failed to convert calculated start value (%v) into internal sqltypes.Value: %v", start, err)
 	}
 	endValue, err := sqltypes.InterfaceToValue(end)
 	if err != nil {
-		return chunk{}, fmt.Errorf("Failed to convert calculated end value (%v) into internal sqltypes.Value: %v", end, err)
+		return chunk{}, fmt.Errorf("failed to convert calculated end value (%v) into internal sqltypes.Value: %v", end, err)
 	}
 	return chunk{startValue, endValue, number, total}, nil
 }


### PR DESCRIPTION
## retry if startStream fails
Issue #3401
With the new grpc, some calls tend to fail with "Unavailable" errors.
So, we need to add retries in those places. This is one of them.

## improved error message on generateChunks
Issue #3407
Error messages did not specify the tablet or table they were failing on.