### PR TITLE
worker: bug fixes

### DIFF
--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -30,6 +30,7 @@ func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
 			grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
+			grpc.FailFast(false),
 		),
 	}
 	newopts = append(newopts, opts...)

--- a/go/vt/grpcclient/client_test.go
+++ b/go/vt/grpcclient/client_test.go
@@ -33,13 +33,13 @@ func TestDialErrors(t *testing.T) {
 		address, err string
 	}{{
 		address: "badhost",
-		err:     "Unavailable",
+		err:     "DeadlineExceeded",
 	}, {
 		address: "badhost:123456",
-		err:     "Unavailable",
+		err:     "DeadlineExceeded",
 	}, {
 		address: "[::]:12346",
-		err:     "Unavailable",
+		err:     "DeadlineExceeded",
 	}}
 	for _, tcase := range tcases {
 		gconn, err := Dial(tcase.address, grpc.WithInsecure())

--- a/go/vt/worker/chunk.go
+++ b/go/vt/worker/chunk.go
@@ -95,10 +95,10 @@ func generateChunks(ctx context.Context, wr *wrangler.Wrangler, tablet *topodata
 	qr, err := wr.TabletManagerClient().ExecuteFetchAsApp(shortCtx, tablet, true, []byte(query), 1)
 	cancel()
 	if err != nil {
-		return nil, fmt.Errorf("Cannot determine MIN and MAX of the first primary key column. ExecuteFetchAsApp: %v", err)
+		return nil, fmt.Errorf("tablet: %v, table: %v: cannot determine MIN and MAX of the first primary key column. ExecuteFetchAsApp: %v", topoproto.TabletAliasString(tablet.Alias), td.Name, err)
 	}
 	if len(qr.Rows) != 1 {
-		return nil, fmt.Errorf("Cannot determine MIN and MAX of the first primary key column. Zero rows were returned for the following query: %v", query)
+		return nil, fmt.Errorf("tablet: %v, table: %v: cannot determine MIN and MAX of the first primary key column. Zero rows were returned", topoproto.TabletAliasString(tablet.Alias), td.Name)
 	}
 
 	result := sqltypes.Proto3ToResult(qr)
@@ -155,7 +155,7 @@ func generateChunks(ctx context.Context, wr *wrangler.Wrangler, tablet *topodata
 		end := add(start, interval)
 		chunk, err := toChunk(start, end, i+1, chunkCount)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("tablet: %v, table: %v: %v", topoproto.TabletAliasString(tablet.Alias), td.Name, err)
 		}
 		chunks[i] = chunk
 		start = end
@@ -185,11 +185,11 @@ func add(start, interval interface{}) interface{} {
 func toChunk(start, end interface{}, number, total int) (chunk, error) {
 	startValue, err := sqltypes.InterfaceToValue(start)
 	if err != nil {
-		return chunk{}, fmt.Errorf("Failed to convert calculated start value (%v) into internal sqltypes.Value: %v", start, err)
+		return chunk{}, fmt.Errorf("failed to convert calculated start value (%v) into internal sqltypes.Value: %v", start, err)
 	}
 	endValue, err := sqltypes.InterfaceToValue(end)
 	if err != nil {
-		return chunk{}, fmt.Errorf("Failed to convert calculated end value (%v) into internal sqltypes.Value: %v", end, err)
+		return chunk{}, fmt.Errorf("failed to convert calculated end value (%v) into internal sqltypes.Value: %v", end, err)
 	}
 	return chunk{startValue, endValue, number, total}, nil
 }


### PR DESCRIPTION
## grpc: disable FailFast
Issues #3401, #3412
When we upgraded to 1.7.1, we had to make dialing asynchronous to
get things working. However, the default behavior of requests was
to immediately fail if a connection is not ready yet, which can
happen if a request is made as soon as dial returned. To circumvent
this, the FailFast flag must be disabled, which will make grpc
retry requests until the timeout.

## worker: improved error message on generateChunks
Issue #3407
Error messages did not specify the tablet or table they were
failing on.