### PR TITLE
vtgate query logging infrastructure

### DIFF
--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -136,6 +136,7 @@ func main() {
 
 	vtgate.QueryLogHandler = "/debug/vtgate/querylog"
 	vtgate.QueryLogzHandler = "/debug/vtgate/querylogz"
+	vtgate.QueryzHandler = "/debug/vtgate/queryz"
 	vtgate.Init(context.Background(), healthCheck, ts, resilientSrvTopoServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
 
 	// vtctld configuration and init

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -133,6 +133,8 @@ func main() {
 		topodatapb.TabletType_REPLICA,
 		topodatapb.TabletType_RDONLY,
 	}
+
+	vtgate.QueryLogHandler = "/debug/vtgate/querylog"
 	vtgate.Init(context.Background(), healthCheck, ts, resilientSrvTopoServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
 
 	// vtctld configuration and init

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -135,6 +135,7 @@ func main() {
 	}
 
 	vtgate.QueryLogHandler = "/debug/vtgate/querylog"
+	vtgate.QueryLogzHandler = "/debug/vtgate/querylogz"
 	vtgate.Init(context.Background(), healthCheck, ts, resilientSrvTopoServer, tpb.Cells[0], 2 /*retryCount*/, tabletTypesToWait)
 
 	// vtctld configuration and init

--- a/go/cmd/vtgate/status.go
+++ b/go/cmd/vtgate/status.go
@@ -28,6 +28,9 @@ import (
 var onStatusRegistered func()
 
 func addStatusParts(vtg *vtgate.VTGate) {
+	servenv.AddStatusPart("Executor", vtgate.ExecutorTemplate, func() interface{} {
+		return nil
+	})
 	servenv.AddStatusPart("VSchema", vtgate.VSchemaTemplate, func() interface{} {
 		return vtg.VSchemaStats()
 	})

--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -94,6 +94,40 @@ func Preview(sql string) int {
 	return StmtUnknown
 }
 
+// StmtType returns the statement type as a string
+func StmtType(stmtType int) string {
+	switch stmtType {
+	case StmtSelect:
+		return "SELECT"
+	case StmtInsert:
+		return "INSERT"
+	case StmtReplace:
+		return "REPLACE"
+	case StmtUpdate:
+		return "UPDATE"
+	case StmtDelete:
+		return "DELETE"
+	case StmtDDL:
+		return "DDL"
+	case StmtBegin:
+		return "BEGIN"
+	case StmtCommit:
+		return "COMMIT"
+	case StmtRollback:
+		return "ROLLBACK"
+	case StmtSet:
+		return "SET"
+	case StmtShow:
+		return "SHOW"
+	case StmtUse:
+		return "USE"
+	case StmtOther:
+		return "OTHER"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // IsDML returns true if the query is an INSERT, UPDATE or DELETE statement.
 func IsDML(sql string) bool {
 	switch Preview(sql) {

--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -113,7 +113,7 @@ func buildTopology(vschemaStr string, numShardsPerKeyspace int) error {
 }
 
 func vtgateExecute(sql string) ([]*engine.Plan, map[string]*TabletActions, error) {
-	_, err := vtgateExecutor.Execute(context.Background(), vtgateSession, sql, nil)
+	_, err := vtgateExecutor.Execute(context.Background(), "VtexplainExecute", vtgateSession, sql, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("vtexplain execute error: %v in %s", err, sql)
 	}

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -338,7 +338,7 @@ func (t *fakeVcursor) Context() context.Context {
 	return context.Background()
 }
 
-func (t *fakeVcursor) Execute(query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (t *fakeVcursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -39,7 +39,7 @@ const ListVarName = "__vals"
 type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
-	Execute(query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
 	ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML bool) (*sqltypes.Result, error)
 	ExecuteStandalone(query string, bindvars map[string]*querypb.BindVariable, keyspace, shard string) (*sqltypes.Result, error)
 	StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -64,19 +64,19 @@ type Plan struct {
 	// Mutex to protect the stats
 	mu sync.Mutex
 	// Count of times this plan was executed
-	ExecCount int64
+	ExecCount uint64
 	// Total execution time
 	ExecTime time.Duration
 	// Total number of shard queries
-	ShardQueries int64
+	ShardQueries uint64
 	// Total number of rows
-	Rows int64
+	Rows uint64
 	// Total number of errors
-	Errors int64
+	Errors uint64
 }
 
 // AddStats updates the plan execution statistics
-func (p *Plan) AddStats(execCount int64, execTime time.Duration, shardQueries, rows, errors int64) {
+func (p *Plan) AddStats(execCount uint64, execTime time.Duration, shardQueries, rows, errors uint64) {
 	p.mu.Lock()
 	p.ExecCount += execCount
 	p.ExecTime += execTime
@@ -87,7 +87,7 @@ func (p *Plan) AddStats(execCount int64, execTime time.Duration, shardQueries, r
 }
 
 // Stats returns a copy of the plan execution statistics
-func (p *Plan) Stats() (execCount int64, execTime time.Duration, shardQueries, rows, errors int64) {
+func (p *Plan) Stats() (execCount uint64, execTime time.Duration, shardQueries, rows, errors uint64) {
 	p.mu.Lock()
 	execCount = p.ExecCount
 	execTime = p.ExecTime

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -294,6 +294,7 @@ func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql
 	}
 
 	execStart := time.Now()
+	logStats.PlanTime = execStart.Sub(logStats.StartTime)
 	result, err := e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -137,7 +137,7 @@ func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb
 
 		// In legacy mode, we ignore autocommit settings.
 		if e.legacyAutocommit {
-			return e.handleExec(ctx, session, sql, bindVars, target)
+			return e.handleExec(ctx, session, sql, bindVars, target, logStats)
 		}
 
 		nsf := NewSafeSession(session)

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -108,7 +108,7 @@ func NewExecutor(ctx context.Context, serv topo.SrvTopoServer, cell, statsName s
 }
 
 // Execute executes a non-streaming query.
-func (e *Executor) Execute(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	// Start an implicit transaction if necessary.
 	// TODO(sougou): deprecate legacyMode after all users are migrated out.
 	if !e.legacyAutocommit && !session.Autocommit && !session.InTransaction {

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -125,10 +125,16 @@ func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb
 		bindVars = make(map[string]*querypb.BindVariable)
 	}
 
-	switch sqlparser.Preview(sql) {
+	stmtType := sqlparser.Preview(sql)
+	switch stmtType {
 	case sqlparser.StmtSelect:
-		return e.handleExec(ctx, session, sql, bindVars, target)
+		logStats := NewLogStats(ctx, method, "SELECT")
+		defer logStats.Send()
+		return e.handleExec(ctx, session, sql, bindVars, target, logStats)
 	case sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete:
+		logStats := NewLogStats(ctx, method, sqlparser.StmtType(stmtType))
+		defer logStats.Send()
+
 		// In legacy mode, we ignore autocommit settings.
 		if e.legacyAutocommit {
 			return e.handleExec(ctx, session, sql, bindVars, target)
@@ -146,19 +152,24 @@ func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb
 			defer e.txConn.Rollback(ctx, nsf)
 		}
 
-		qr, err := e.handleExec(ctx, session, sql, bindVars, target)
+		qr, err := e.handleExec(ctx, session, sql, bindVars, target, logStats)
 		if err != nil {
 			return nil, err
 		}
 
 		if autocommit {
+			commitStart := time.Now()
 			if err := e.txConn.Commit(ctx, nsf); err != nil {
 				return nil, err
 			}
+			logStats.CommitTime = time.Since(commitStart)
 		}
 		return qr, nil
 	case sqlparser.StmtDDL:
-		return e.handleDDL(ctx, session, sql, bindVars, target)
+		logStats := NewLogStats(ctx, method, "DDL")
+		defer logStats.Send()
+
+		return e.handleDDL(ctx, session, sql, bindVars, target, logStats)
 	case sqlparser.StmtBegin:
 		if target.TabletType != topodatapb.TabletType_MASTER {
 			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "transactions are supported only for master tablet types, current type: %v", target.TabletType)
@@ -174,16 +185,20 @@ func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb
 	case sqlparser.StmtSet:
 		return e.handleSet(ctx, session, sql, bindVars)
 	case sqlparser.StmtShow:
-		return e.handleShow(ctx, session, sql, bindVars, target)
+		logStats := NewLogStats(ctx, method, "SHOW")
+		defer logStats.Send()
+		return e.handleShow(ctx, session, sql, bindVars, target, logStats)
 	case sqlparser.StmtUse:
 		return e.handleUse(ctx, session, sql, bindVars)
 	case sqlparser.StmtOther:
-		return e.handleOther(ctx, session, sql, bindVars, target)
+		logStats := NewLogStats(ctx, method, "OTHER")
+		defer logStats.Send()
+		return e.handleOther(ctx, session, sql, bindVars, target, logStats)
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unrecognized statement: %s", sql)
 }
 
-func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target) (*sqltypes.Result, error) {
+func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Shard != "" {
 		// V1 mode or V3 mode with a forced shard target
 		sql = sqlannotation.AnnotateIfDML(sql, nil)
@@ -198,21 +213,41 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 			normalized := sqlparser.String(stmt)
 			sql = normalized + comments
 		}
-		return e.shardExec(ctx, session, sql, bindVars, target)
+
+		logStats.SQL = sql
+		logStats.BindVariables = bindVars
+
+		execStart := time.Now()
+		logStats.PlanTime = execStart.Sub(logStats.StartTime)
+
+		result, err := e.shardExec(ctx, session, sql, bindVars, target, logStats)
+		logStats.ExecuteTime = time.Now().Sub(execStart)
+
+		logStats.ShardQueries = 1
+
+		return result, err
 	}
 
 	// V3 mode.
 	query, comments := sqlparser.SplitTrailingComments(sql)
-	vcursor := newVCursorImpl(ctx, session, target, comments, e)
-	plan, err := e.getPlan(vcursor,
+	vcursor := newVCursorImpl(ctx, session, target, comments, e, logStats)
+	plan, err := e.getPlan(
+		vcursor,
 		query,
+		comments,
 		bindVars,
 		skipQueryPlanCache(session),
+		logStats,
 	)
+	execStart := time.Now()
+	logStats.PlanTime = execStart.Sub(logStats.StartTime)
+
 	if err != nil {
+		logStats.Error = err
 		return nil, err
 	}
 	qr, err := plan.Instructions.Execute(vcursor, bindVars, make(map[string]*querypb.BindVariable), true)
+	logStats.ExecuteTime = time.Since(execStart)
 	// Check if there was partial DML execution. If so, rollback the transaction.
 	if err != nil && session.InTransaction && vcursor.hasPartialDML {
 		_ = e.txConn.Rollback(ctx, NewSafeSession(session))
@@ -221,14 +256,14 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 	return qr, err
 }
 
-func (e *Executor) shardExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target) (*sqltypes.Result, error) {
+func (e *Executor) shardExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	f := func(keyspace string) (string, []string, error) {
 		return keyspace, []string{target.Shard}, nil
 	}
-	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options)
+	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options, logStats)
 }
 
-func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target) (*sqltypes.Result, error) {
+func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Keyspace == "" {
 		return nil, errNoKeyspace
 	}
@@ -252,7 +287,7 @@ func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql
 		}
 		return keyspace, shards, nil
 	}
-	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options)
+	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options, logStats)
 }
 
 func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
@@ -381,7 +416,7 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 	return &sqltypes.Result{}, nil
 }
 
-func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target) (*sqltypes.Result, error) {
+func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	stmt, err := sqlparser.Parse(sql)
 	if err != nil {
 		return nil, err
@@ -462,7 +497,7 @@ func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sq
 	}
 
 	// Any other show statement is passed through
-	return e.handleOther(ctx, session, sql, bindVars, target)
+	return e.handleOther(ctx, session, sql, bindVars, target, logStats)
 }
 
 func (e *Executor) handleUse(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
@@ -483,7 +518,7 @@ func (e *Executor) handleUse(ctx context.Context, session *vtgatepb.Session, sql
 	return &sqltypes.Result{}, nil
 }
 
-func (e *Executor) handleOther(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target) (*sqltypes.Result, error) {
+func (e *Executor) handleOther(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Keyspace == "" {
 		return nil, errNoKeyspace
 	}
@@ -494,26 +529,30 @@ func (e *Executor) handleOther(ctx context.Context, session *vtgatepb.Session, s
 			return nil, err
 		}
 	}
-	return e.shardExec(ctx, session, sql, bindVars, target)
+	return e.shardExec(ctx, session, sql, bindVars, target, logStats)
 }
 
 // StreamExecute executes a streaming query.
 func (e *Executor) StreamExecute(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, callback func(*sqltypes.Result) error) error {
+	logStats := NewLogStats(ctx, "StreamExecute", sqlparser.StmtType(sqlparser.Preview(sql)))
+	defer logStats.Send()
 	if bindVars == nil {
 		bindVars = make(map[string]*querypb.BindVariable)
 	}
 	query, comments := sqlparser.SplitTrailingComments(sql)
-	vcursor := newVCursorImpl(ctx, session, target, comments, e)
+	vcursor := newVCursorImpl(ctx, session, target, comments, e, logStats)
 	plan, err := e.getPlan(
 		vcursor,
 		query,
+		comments,
 		bindVars,
 		skipQueryPlanCache(session),
+		logStats,
 	)
 	if err != nil {
+		logStats.Error = err
 		return err
 	}
-
 	// Some of the underlying primitives may send results one row at a time.
 	// So, we need the ability to consolidate those into reasonable chunks.
 	// The callback wrapper below accumulates rows and sends them as chunks
@@ -574,6 +613,7 @@ func (e *Executor) MessageAck(ctx context.Context, keyspace, name string, ids []
 		},
 		"",
 		e,
+		nil,
 	)
 
 	newKeyspace, _, allShards, err := getKeyspaceShards(ctx, e.serv, e.cell, table.Keyspace.Name, topodatapb.TabletType_MASTER)
@@ -778,7 +818,12 @@ func (e *Executor) ParseTarget(targetString string) querypb.Target {
 
 // getPlan computes the plan for the given query. If one is in
 // the cache, it reuses it.
-func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, bindVars map[string]*querypb.BindVariable, skipQueryPlanCache bool) (*engine.Plan, error) {
+func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments string, bindVars map[string]*querypb.BindVariable, skipQueryPlanCache bool, logStats *LogStats) (*engine.Plan, error) {
+	if logStats != nil {
+		logStats.SQL = sql + comments
+		logStats.BindVariables = bindVars
+	}
+
 	if e.VSchema() == nil {
 		return nil, errors.New("vschema not initialized")
 	}
@@ -807,6 +852,12 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, bindVars map[string
 	}
 	sqlparser.Normalize(stmt, bindVars, "vtg")
 	normalized := sqlparser.String(stmt)
+
+	if logStats != nil {
+		logStats.SQL = normalized + comments
+		logStats.BindVariables = bindVars
+	}
+
 	normkey := normalized
 	if keyspace != "" {
 		normkey = keyspace + ":" + normalized

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -249,12 +249,12 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 
 	qr, err := plan.Instructions.Execute(vcursor, bindVars, make(map[string]*querypb.BindVariable), true)
 	logStats.ExecuteTime = time.Since(execStart)
-	var errCount int64
+	var errCount uint64
 	if err != nil {
 		logStats.Error = err
 		errCount = 1
 	} else {
-		logStats.Rows = qr.Rows
+		logStats.RowsAffected = qr.RowsAffected
 	}
 
 	// Check if there was partial DML execution. If so, rollback the transaction.
@@ -263,7 +263,7 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 		err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "transaction rolled back due to partial DML execution: %v", err)
 	}
 
-	plan.AddStats(1, time.Since(logStats.StartTime), int64(logStats.ShardQueries), int64(len(logStats.Rows)), errCount)
+	plan.AddStats(1, time.Since(logStats.StartTime), uint64(logStats.ShardQueries), logStats.RowsAffected, errCount)
 
 	return qr, err
 }

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1081,6 +1081,7 @@ func TestInsertPartialFail1(t *testing.T) {
 
 	_, err := executor.Execute(
 		context.Background(),
+		"TestExecute",
 		&vtgatepb.Session{InTransaction: true},
 		"insert into user(id, v, name) values (1, 2, 'myname')",
 		nil,
@@ -1102,6 +1103,7 @@ func TestInsertPartialFail2(t *testing.T) {
 
 	_, err := executor.Execute(
 		context.Background(),
+		"TestExecute",
 		&vtgatepb.Session{InTransaction: true},
 		"insert into user(id, v, name) values (1, 2, 'myname')",
 		nil,

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -35,6 +35,9 @@ import (
 func TestUpdateEqual(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
 	_, err := executorExec(executor, "update user set a=2 where id = 1", nil)
 	if err != nil {
 		t.Error(err)
@@ -49,6 +52,7 @@ func TestUpdateEqual(t *testing.T) {
 	if sbc2.Queries != nil {
 		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
 	}
+	testQueryLog(t, logChan, "TestExecute", "UPDATE", "update user set a=2 where id = 1", 1)
 
 	sbc1.Queries = nil
 	_, err = executorExec(executor, "update user set a=2 where id = 3", nil)
@@ -357,6 +361,9 @@ func TestDeleteEqualFail(t *testing.T) {
 func TestInsertSharded(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
 	_, err := executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
 	if err != nil {
 		t.Error(err)
@@ -385,6 +392,9 @@ func TestInsertSharded(t *testing.T) {
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: \n%+v, want \n%+v", sbclookup.Queries, wantQueries)
 	}
+
+	testQueryLog(t, logChan, "VindexCreate", "INSERT", "insert into name_user_map(name, user_id) values(:name0, :user_id0)", 1)
+	testQueryLog(t, logChan, "TestExecute", "INSERT", "insert into user(id, v, name) values (1, 2, 'myname')", 1)
 
 	sbc1.Queries = nil
 	sbclookup.Queries = nil

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -236,7 +236,9 @@ func createExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandboxconn
 }
 
 func executorExec(executor *Executor, sql string, bv map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	return executor.Execute(context.Background(),
+	return executor.Execute(
+		context.Background(),
+		"TestExecute",
 		masterSession,
 		sql,
 		bv)

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -330,7 +330,10 @@ func testQueryLog(t *testing.T, logChan chan interface{}, method, stmtType, sql 
 	}
 	testPlannedQueries[sql] = true
 
-	testNonZeroDuration(t, "ExecuteTime", fields[9])
+	// fields[9] is ExecuteTime which is not set for certain statements SET, BEGIN, COMMIT, ROLLBACK, etc
+	if stmtType != "BEGIN" && stmtType != "COMMIT" && stmtType != "ROLLBACK" && stmtType != "SET" {
+		testNonZeroDuration(t, "ExecuteTime", fields[9])
+	}
 
 	// fields[10] is CommitTime which is set only in autocommit mode and
 	// tested separately

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -254,6 +254,7 @@ func executorStream(executor *Executor, sql string) (qr *sqltypes.Result, err er
 	results := make(chan *sqltypes.Result, 100)
 	err = executor.StreamExecute(
 		context.Background(),
+		"TestExecuteStream",
 		masterSession,
 		sql,
 		nil,

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -59,6 +59,7 @@ func TestExecDBA(t *testing.T) {
 	query := "select * from INFORMATION_SCHEMA.foo"
 	_, err := executor.Execute(
 		context.Background(),
+		"TestExecDBA",
 		&vtgatepb.Session{TargetString: "TestExecutor"},
 		query,
 		map[string]*querypb.BindVariable{},

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -283,7 +283,6 @@ func TestShardFail(t *testing.T) {
 
 func TestSelectBindvars(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
-
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
@@ -836,7 +835,6 @@ func TestSelectScatter(t *testing.T) {
 		conns = append(conns, sbc)
 	}
 	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
-
 	logChan := QueryLogger.Subscribe("Test")
 	defer QueryLogger.Unsubscribe(logChan)
 
@@ -1371,7 +1369,11 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 // Could reuse code,
 func TestSimpleJoin(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
-	result, err := executorExec(executor, "select u1.id, u2.id from user u1 join user u2 where u1.id = 1 and u2.id = 3", nil)
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
+	sql := "select u1.id, u2.id from user u1 join user u2 where u1.id = 1 and u2.id = 3"
+	result, err := executorExec(executor, sql, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1405,11 +1407,17 @@ func TestSimpleJoin(t *testing.T) {
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
+
+	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
 }
 
 func TestJoinComments(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
-	_, err := executorExec(executor, "select u1.id, u2.id from user u1 join user u2 where u1.id = 1 and u2.id = 3 /* trailing */", nil)
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
+	sql := "select u1.id, u2.id from user u1 join user u2 where u1.id = 1 and u2.id = 3 /* trailing */"
+	_, err := executorExec(executor, sql, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1469,6 +1477,9 @@ func TestSimpleJoinStream(t *testing.T) {
 
 func TestVarJoin(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
+
 	result1 := []*sqltypes.Result{{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -1482,7 +1493,8 @@ func TestVarJoin(t *testing.T) {
 		}},
 	}}
 	sbc1.SetResults(result1)
-	_, err := executorExec(executor, "select u1.id, u2.id from user u1 join user u2 on u2.id = u1.col where u1.id = 1", nil)
+	sql := "select u1.id, u2.id from user u1 join user u2 on u2.id = u1.col where u1.id = 1"
+	_, err := executorExec(executor, sql, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1499,6 +1511,8 @@ func TestVarJoin(t *testing.T) {
 	if got != want {
 		t.Errorf("sbc2.Queries: %s, want %s\n", got, want)
 	}
+
+	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
 }
 
 func TestVarJoinStream(t *testing.T) {
@@ -1541,6 +1555,8 @@ func TestVarJoinStream(t *testing.T) {
 
 func TestLeftJoin(t *testing.T) {
 	executor, sbc1, sbc2, _ := createExecutorEnv()
+	logChan := QueryLogger.Subscribe("Test")
+	defer QueryLogger.Unsubscribe(logChan)
 	result1 := []*sqltypes.Result{{
 		Fields: []*querypb.Field{
 			{Name: "id", Type: sqltypes.Int32},
@@ -1560,7 +1576,8 @@ func TestLeftJoin(t *testing.T) {
 	}}
 	sbc1.SetResults(result1)
 	sbc2.SetResults(emptyResult)
-	result, err := executorExec(executor, "select u1.id, u2.id from user u1 left join user u2 on u2.id = u1.col where u1.id = 1", nil)
+	sql := "select u1.id, u2.id from user u1 left join user u2 on u2.id = u1.col where u1.id = 1"
+	result, err := executorExec(executor, sql, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1580,6 +1597,9 @@ func TestLeftJoin(t *testing.T) {
 	if !result.Equal(wantResult) {
 		t.Errorf("result: %+v, want %+v", result, wantResult)
 	}
+
+	testQueryLog(t, logChan, "TestExecute", "SELECT", sql, 2)
+
 }
 
 func TestLeftJoinStream(t *testing.T) {

--- a/go/vt/vtgate/executor_stats.go
+++ b/go/vt/vtgate/executor_stats.go
@@ -30,8 +30,8 @@ const (
 
 <td width="50%" style="padding: 20px;">
   <a href="/debug/health">Health</a><br>
-  <a href="/debug/queryz">Query Log Stats</a><br>
   <a href="/debug/querylogz">Current Query Log</a><br>
+  <a href="/debug/queryz">Query Plan Stats</a><br>
   <a href="/debug/query_plans">Query Plans</a><br>
 </td>
 </tr>

--- a/go/vt/vtgate/executor_stats.go
+++ b/go/vt/vtgate/executor_stats.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+const (
+	// ExecutorTemplate is the HTML template to display ExecutorStats.
+	ExecutorTemplate = `
+<table style="vertical-align: middle; width: 100%">
+<tr>
+<td width="50%">
+  <div>
+  <!-- The div in the next line will be overwritten by the JavaScript graph. -->
+    <div id="qps_chart">QPS</div>
+  </div>
+</td>
+
+<td width="50%" style="padding: 20px;">
+  <a href="/debug/health">Health</a><br>
+  <a href="/debug/queryz">Query Log Stats</a><br>
+  <a href="/debug/querylogz">Current Query Log</a><br>
+  <a href="/debug/query_plans">Query Plans</a><br>
+</td>
+</tr>
+</table>
+
+
+<script type="text/javascript" src="https://www.google.com/jsapi"></script>
+<script type="text/javascript">
+
+google.load("jquery", "1.4.0");
+google.load("visualization", "1", {packages:["corechart"]});
+
+function sampleDate(d, i) {
+  var copy = new Date(d);
+  copy.setTime(copy.getTime() - i*60/5*1000);
+  return copy
+}
+
+function drawQPSChart() {
+  var div = $('#qps_chart').height(500).width(900).unwrap()[0]
+  var chart = new google.visualization.LineChart(div);
+
+  var options = {
+    title: "QPS By Keyspace",
+    focusTarget: 'category',
+    vAxis: {
+      viewWindow: {min: 0},
+    }
+  };
+
+  // If we're accessing status through a proxy that requires a URL prefix,
+  // add the prefix to the vars URL.
+  var vars_url = '/debug/vars';
+  var pos = window.location.pathname.lastIndexOf('/debug/status');
+  if (pos > 0) {
+    vars_url = window.location.pathname.substring(0, pos) + vars_url;
+  }
+
+  var redraw = function() {
+    $.getJSON(vars_url, function(input_data) {
+      var now = new Date();
+      var qps = input_data.QPSByKeyspace;
+      var planTypes = Object.keys(qps);
+      if (planTypes.length === 0) {
+        planTypes = ["All"];
+        qps["All"] = [];
+      }
+
+      var data = [["Time"].concat(planTypes)];
+
+      // Create data points, starting with the most recent timestamp.
+      // (On the graph this means going from right to left.)
+      // Time span: 15 minutes in 1 minute intervals.
+      for (var i = 0; i < 15; i++) {
+        var datum = [sampleDate(now, i)];
+        for (var j = 0; j < planTypes.length; j++) {
+          if (i < qps[planTypes[j]].length) {
+          	// Rates are ordered from least recent to most recent.
+          	// Therefore, we have to start reading from the end of the array.
+          	var idx = qps[planTypes[j]].length - i - 1;
+            datum.push(+qps[planTypes[j]][idx].toFixed(2));
+          } else {
+            // Assume 0.0 QPS for older, non-existant data points.
+            datum.push(0);
+          }
+        }
+        data.push(datum)
+      }
+      chart.draw(google.visualization.arrayToDataTable(data), options);
+    })
+  };
+
+  redraw();
+
+  // redraw every 2.5 seconds.
+  window.setInterval(redraw, 2500);
+}
+google.setOnLoadCallback(drawQPSChart);
+</script>
+`
+)

--- a/go/vt/vtgate/executor_stats.go
+++ b/go/vt/vtgate/executor_stats.go
@@ -55,7 +55,7 @@ function drawQPSChart() {
   var chart = new google.visualization.LineChart(div);
 
   var options = {
-    title: "QPS By Keyspace",
+    title: "QPS By DB Type",
     focusTarget: 'category',
     vAxis: {
       viewWindow: {min: 0},
@@ -73,7 +73,7 @@ function drawQPSChart() {
   var redraw = function() {
     $.getJSON(vars_url, function(input_data) {
       var now = new Date();
-      var qps = input_data.QPSByKeyspace;
+      var qps = input_data.QPSByDbType;
       var planTypes = Object.keys(qps);
       if (planTypes.length === 0) {
         planTypes = ["All"];

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -39,7 +39,7 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 	session := &vtgatepb.Session{TargetString: "@master"}
 
 	// begin.
-	_, err := executor.Execute(context.Background(), session, "begin", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,11 +52,11 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 	}
 
 	// commit.
-	_, err = executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "commit", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "commit", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,15 +69,15 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 	}
 
 	// rollback.
-	_, err = executor.Execute(context.Background(), session, "begin", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "rollback", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "rollback", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 
 	// Prevent transactions on non-master.
 	session = &vtgatepb.Session{TargetString: "@replica", InTransaction: true}
-	_, err = executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	want := "transactions are supported only for master tablet types, current type: REPLICA"
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute(@replica, in_transaction) err: %v, want %s", err, want)
@@ -99,14 +99,14 @@ func TestExecutorTransactionsNoAutoCommit(t *testing.T) {
 
 	// Prevent begin on non-master.
 	session = &vtgatepb.Session{TargetString: "@replica"}
-	_, err = executor.Execute(context.Background(), session, "begin", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute(@replica, in_transaction) err: %v, want %s", err, want)
 	}
 
 	// Prevent use of non-master if in_transaction is on.
 	session = &vtgatepb.Session{TargetString: "@master", InTransaction: true}
-	_, err = executor.Execute(context.Background(), session, "use @replica", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "use @replica", nil)
 	want = "cannot change to a non-master type in the middle of a transaction: REPLICA"
 	if err == nil || err.Error() != want {
 		t.Errorf("Execute(@replica, in_transaction) err: %v, want %s", err, want)
@@ -118,7 +118,7 @@ func TestExecutorTransactionsAutoCommit(t *testing.T) {
 	session := &vtgatepb.Session{TargetString: "@master", Autocommit: true}
 
 	// begin.
-	_, err := executor.Execute(context.Background(), session, "begin", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,11 +131,11 @@ func TestExecutorTransactionsAutoCommit(t *testing.T) {
 	}
 
 	// commit.
-	_, err = executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "commit", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "commit", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,15 +148,15 @@ func TestExecutorTransactionsAutoCommit(t *testing.T) {
 	}
 
 	// rollback.
-	_, err = executor.Execute(context.Background(), session, "begin", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "rollback", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "rollback", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestExecutorSet(t *testing.T) {
 	}}
 	for _, tcase := range testcases {
 		session := &vtgatepb.Session{Autocommit: true}
-		_, err := executor.Execute(context.Background(), session, tcase.in, nil)
+		_, err := executor.Execute(context.Background(), "TestExecute", session, tcase.in, nil)
 		if err != nil {
 			if err.Error() != tcase.err {
 				t.Errorf("%s error: %v, want %s", tcase.in, err, tcase.err)
@@ -309,7 +309,7 @@ func TestExecutorAutocommit(t *testing.T) {
 
 	// autocommit = 0
 	startCount := sbclookup.CommitCount.Get()
-	_, err := executor.Execute(context.Background(), session, "select id from main1", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestExecutorAutocommit(t *testing.T) {
 	}
 
 	// autocommit = 1
-	_, err = executor.Execute(context.Background(), session, "set autocommit=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "set autocommit=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func TestExecutorAutocommit(t *testing.T) {
 	}
 
 	startCount = sbclookup.CommitCount.Get()
-	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,11 +345,11 @@ func TestExecutorAutocommit(t *testing.T) {
 
 	// autocommit = 1, "begin"
 	startCount = sbclookup.CommitCount.Get()
-	_, err = executor.Execute(context.Background(), session, "begin", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +362,7 @@ func TestExecutorAutocommit(t *testing.T) {
 	if got, want := sbclookup.CommitCount.Get(), startCount; got != want {
 		t.Errorf("Commit count: %d, want %d", got, want)
 	}
-	_, err = executor.Execute(context.Background(), session, "commit", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "commit", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -377,18 +377,18 @@ func TestExecutorAutocommit(t *testing.T) {
 	// transition autocommit from 0 to 1 in the middle of a transaction.
 	startCount = sbclookup.CommitCount.Get()
 	session = &vtgatepb.Session{TargetString: "@master"}
-	_, err = executor.Execute(context.Background(), session, "begin", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got, want := sbclookup.CommitCount.Get(), startCount; got != want {
 		t.Errorf("Commit count: %d, want %d", got, want)
 	}
-	_, err = executor.Execute(context.Background(), session, "set autocommit=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "set autocommit=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +408,7 @@ func TestExecutorLegacyAutocommit(t *testing.T) {
 	// If legacy is on, there should be no implicit transaction.
 	executor.legacyAutocommit = true
 	startCount := sbclookup.BeginCount.Get()
-	_, err := executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func TestExecutorLegacyAutocommit(t *testing.T) {
 
 	// If legacy is off, there should be an implicit begin.
 	executor.legacyAutocommit = false
-	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	_, err = executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestExecutorShow(t *testing.T) {
 	session := &vtgatepb.Session{TargetString: "@master"}
 
 	for _, query := range []string{"show databases", "show vitess_keyspaces"} {
-		qr, err := executor.Execute(context.Background(), session, query, nil)
+		qr, err := executor.Execute(context.Background(), "TestExecute", session, query, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -451,7 +451,7 @@ func TestExecutorShow(t *testing.T) {
 		}
 	}
 
-	qr, err := executor.Execute(context.Background(), session, "show vitess_shards", nil)
+	qr, err := executor.Execute(context.Background(), "TestExecute", session, "show vitess_shards", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -471,7 +471,7 @@ func TestExecutorShow(t *testing.T) {
 
 	// Make sure it still works when one of the keyspaces is in a bad state
 	getSandbox("TestExecutor").SrvKeyspaceMustFail++
-	qr, err = executor.Execute(context.Background(), session, "show vitess_shards", nil)
+	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vitess_shards", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -490,7 +490,7 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	session = &vtgatepb.Session{TargetString: KsTestUnsharded}
-	qr, err = executor.Execute(context.Background(), session, "show vschema_tables", nil)
+	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema_tables", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -512,20 +512,20 @@ func TestExecutorShow(t *testing.T) {
 	}
 
 	session = &vtgatepb.Session{}
-	qr, err = executor.Execute(context.Background(), session, "show vschema_tables", nil)
+	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema_tables", nil)
 	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}
 
-	qr, err = executor.Execute(context.Background(), session, "show 10", nil)
+	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show 10", nil)
 	want = "syntax error at position 8 near '10'"
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
 	}
 
 	session = &vtgatepb.Session{TargetString: "no_such_keyspace"}
-	qr, err = executor.Execute(context.Background(), session, "show vschema_tables", nil)
+	qr, err = executor.Execute(context.Background(), "TestExecute", session, "show vschema_tables", nil)
 	want = "keyspace no_such_keyspace not found in vschema"
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
@@ -545,7 +545,7 @@ func TestExecutorUse(t *testing.T) {
 		"ks:-80@master",
 	}
 	for i, stmt := range stmts {
-		_, err := executor.Execute(context.Background(), session, stmt, nil)
+		_, err := executor.Execute(context.Background(), "TestExecute", session, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -555,7 +555,7 @@ func TestExecutorUse(t *testing.T) {
 		}
 	}
 
-	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "use 1", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{}, "use 1", nil)
 	wantErr := "syntax error at position 6 near '1'"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("use 1: %v, want %v", err, wantErr)
@@ -576,7 +576,7 @@ func TestExecutorOther(t *testing.T) {
 	}
 	wantCount := []int64{0, 0, 0}
 	for _, stmt := range stmts {
-		_, err := executor.Execute(context.Background(), &vtgatepb.Session{TargetString: KsTestUnsharded}, stmt, nil)
+		_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{TargetString: KsTestUnsharded}, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -590,7 +590,7 @@ func TestExecutorOther(t *testing.T) {
 			t.Errorf("Exec %s: %v, want %v", stmt, gotCount, wantCount)
 		}
 
-		_, err = executor.Execute(context.Background(), &vtgatepb.Session{TargetString: "TestExecutor"}, stmt, nil)
+		_, err = executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{TargetString: "TestExecutor"}, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -605,7 +605,7 @@ func TestExecutorOther(t *testing.T) {
 		}
 	}
 
-	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "analyze", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{}, "analyze", nil)
 	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
@@ -623,7 +623,7 @@ func TestExecutorDDL(t *testing.T) {
 	}
 	wantCount := []int64{0, 0, 0}
 	for _, stmt := range stmts {
-		_, err := executor.Execute(context.Background(), &vtgatepb.Session{TargetString: KsTestUnsharded}, stmt, nil)
+		_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{TargetString: KsTestUnsharded}, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -637,7 +637,7 @@ func TestExecutorDDL(t *testing.T) {
 			t.Errorf("Exec %s: %v, want %v", stmt, gotCount, wantCount)
 		}
 
-		_, err = executor.Execute(context.Background(), &vtgatepb.Session{TargetString: "TestExecutor"}, stmt, nil)
+		_, err = executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{TargetString: "TestExecutor"}, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -652,7 +652,7 @@ func TestExecutorDDL(t *testing.T) {
 			t.Errorf("Exec %s: %v, want %v", stmt, gotCount, wantCount)
 		}
 
-		_, err = executor.Execute(context.Background(), &vtgatepb.Session{TargetString: "TestExecutor/-20"}, stmt, nil)
+		_, err = executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{TargetString: "TestExecutor/-20"}, stmt, nil)
 		if err != nil {
 			t.Error(err)
 		}
@@ -667,7 +667,7 @@ func TestExecutorDDL(t *testing.T) {
 		}
 	}
 
-	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "create", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{}, "create", nil)
 	want := errNoKeyspace.Error()
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)
@@ -676,7 +676,7 @@ func TestExecutorDDL(t *testing.T) {
 
 func TestExecutorUnrecognized(t *testing.T) {
 	executor, _, _, _ := createExecutorEnv()
-	_, err := executor.Execute(context.Background(), &vtgatepb.Session{}, "invalid statement", nil)
+	_, err := executor.Execute(context.Background(), "TestExecute", &vtgatepb.Session{}, "invalid statement", nil)
 	want := "unrecognized statement: invalid statement"
 	if err == nil || err.Error() != want {
 		t.Errorf("show vschema_tables: %v, want %v", err, want)

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -42,8 +42,8 @@ type LogStats struct {
 	BindVariables map[string]*querypb.BindVariable
 	StartTime     time.Time
 	EndTime       time.Time
-	ShardQueries  int
-	RowsAffected  int
+	ShardQueries  int32
+	RowsAffected  int32
 	PlanTime      time.Duration
 	ExecuteTime   time.Duration
 	CommitTime    time.Duration

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -52,12 +52,13 @@ type LogStats struct {
 
 // NewLogStats constructs a new LogStats with supplied Method and ctx
 // field values, and the StartTime field set to the present time.
-func NewLogStats(ctx context.Context, methodName, stmtType string) *LogStats {
+func NewLogStats(ctx context.Context, methodName, sql string, bindVars map[string]*querypb.BindVariable) *LogStats {
 	return &LogStats{
-		Ctx:       ctx,
-		Method:    methodName,
-		StmtType:  stmtType,
-		StartTime: time.Now(),
+		Ctx:           ctx,
+		Method:        methodName,
+		SQL:           sql,
+		BindVariables: bindVars,
+		StartTime:     time.Now(),
 	}
 }
 

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -42,12 +42,11 @@ type LogStats struct {
 	BindVariables map[string]*querypb.BindVariable
 	StartTime     time.Time
 	EndTime       time.Time
-	ShardQueries  int32
-	RowsAffected  int32
+	ShardQueries  uint32
+	RowsAffected  uint64
 	PlanTime      time.Duration
 	ExecuteTime   time.Duration
 	CommitTime    time.Duration
-	Rows          [][]sqltypes.Value
 	Error         error
 }
 
@@ -91,22 +90,6 @@ func (stats *LogStats) EventTime() time.Time {
 // TotalTime returns how long this query has been running
 func (stats *LogStats) TotalTime() time.Duration {
 	return stats.EndTime.Sub(stats.StartTime)
-}
-
-// SizeOfResponse returns the approximate size of the response in
-// bytes (this does not take in account protocol encoding). It will return
-// 0 for streaming requests.
-func (stats *LogStats) SizeOfResponse() int {
-	if stats.Rows == nil {
-		return 0
-	}
-	size := 0
-	for _, row := range stats.Rows {
-		for _, field := range row {
-			size += field.Len()
-		}
-	}
-	return size
 }
 
 // FmtBindVariables returns the map of bind variables as JSON. For
@@ -167,7 +150,7 @@ func (stats *LogStats) Format(params url.Values) string {
 	// TODO: remove username here we fully enforce immediate caller id
 	remoteAddr, username := stats.RemoteAddrUsername()
 	return fmt.Sprintf(
-		"%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%.6f\t%.6f\t%.6f\t%v\t%q\t%v\t%v\t%v\t%v\t%q\t\n",
+		"%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%.6f\t%.6f\t%.6f\t%v\t%q\t%v\t%v\t%v\t%q\t\n",
 		stats.Method,
 		remoteAddr,
 		username,
@@ -184,7 +167,6 @@ func (stats *LogStats) Format(params url.Values) string {
 		formattedBindVars,
 		stats.ShardQueries,
 		stats.RowsAffected,
-		stats.SizeOfResponse(),
 		stats.ErrorStr(),
 	)
 }

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"fmt"
+	"html/template"
+	"net/url"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/callerid"
+	"github.com/youtube/vitess/go/vt/callinfo"
+	"github.com/youtube/vitess/go/vt/servenv"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// LogStats records the stats for a single vtgate query
+type LogStats struct {
+	Ctx           context.Context
+	Method        string
+	Target        *querypb.Target
+	StmtType      string
+	SQL           string
+	BindVariables map[string]*querypb.BindVariable
+	StartTime     time.Time
+	EndTime       time.Time
+	ShardQueries  int
+	RowsAffected  int
+	PlanTime      time.Duration
+	ExecuteTime   time.Duration
+	CommitTime    time.Duration
+	Rows          [][]sqltypes.Value
+	Error         error
+}
+
+// NewLogStats constructs a new LogStats with supplied Method and ctx
+// field values, and the StartTime field set to the present time.
+func NewLogStats(ctx context.Context, methodName, stmtType string) *LogStats {
+	return &LogStats{
+		Ctx:       ctx,
+		Method:    methodName,
+		StmtType:  stmtType,
+		StartTime: time.Now(),
+	}
+}
+
+// Send finalizes a record and sends it
+func (stats *LogStats) Send() {
+	stats.EndTime = time.Now()
+	QueryLogger.Send(stats)
+}
+
+// Context returns the context used by LogStats.
+func (stats *LogStats) Context() context.Context {
+	return stats.Ctx
+}
+
+// ImmediateCaller returns the immediate caller stored in LogStats.Ctx
+func (stats *LogStats) ImmediateCaller() string {
+	return callerid.GetUsername(callerid.ImmediateCallerIDFromContext(stats.Ctx))
+}
+
+// EffectiveCaller returns the effective caller stored in LogStats.Ctx
+func (stats *LogStats) EffectiveCaller() string {
+	return callerid.GetPrincipal(callerid.EffectiveCallerIDFromContext(stats.Ctx))
+}
+
+// EventTime returns the time the event was created.
+func (stats *LogStats) EventTime() time.Time {
+	return stats.EndTime
+}
+
+// TotalTime returns how long this query has been running
+func (stats *LogStats) TotalTime() time.Duration {
+	return stats.EndTime.Sub(stats.StartTime)
+}
+
+// SizeOfResponse returns the approximate size of the response in
+// bytes (this does not take in account protocol encoding). It will return
+// 0 for streaming requests.
+func (stats *LogStats) SizeOfResponse() int {
+	if stats.Rows == nil {
+		return 0
+	}
+	size := 0
+	for _, row := range stats.Rows {
+		for _, field := range row {
+			size += field.Len()
+		}
+	}
+	return size
+}
+
+// FmtBindVariables returns the map of bind variables as JSON. For
+// values that are strings or byte slices it only reports their type
+// and length.
+func (stats *LogStats) FmtBindVariables(full bool) string {
+	var out map[string]*querypb.BindVariable
+	if full {
+		out = stats.BindVariables
+	} else {
+		// NOTE(szopa): I am getting rid of potentially large bind
+		// variables.
+		out = make(map[string]*querypb.BindVariable)
+		for k, v := range stats.BindVariables {
+			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
+				out[k] = v
+			} else {
+				out[k] = sqltypes.StringBindVariable(fmt.Sprintf("%v bytes", len(v.Value)))
+			}
+		}
+	}
+	return fmt.Sprintf("%v", out)
+}
+
+// ContextHTML returns the HTML version of the context that was used, or "".
+// This is a method on LogStats instead of a field so that it doesn't need
+// to be passed by value everywhere.
+func (stats *LogStats) ContextHTML() template.HTML {
+	return callinfo.HTMLFromContext(stats.Ctx)
+}
+
+// ErrorStr returns the error string or ""
+func (stats *LogStats) ErrorStr() string {
+	if stats.Error != nil {
+		return stats.Error.Error()
+	}
+	return ""
+}
+
+// RemoteAddrUsername returns some parts of CallInfo if set
+func (stats *LogStats) RemoteAddrUsername() (string, string) {
+	ci, ok := callinfo.FromContext(stats.Ctx)
+	if !ok {
+		return "", ""
+	}
+	return ci.RemoteAddr(), ci.Username()
+}
+
+// Format returns a tab separated list of logged fields.
+func (stats *LogStats) Format(params url.Values) string {
+	formattedBindVars := "[REDACTED]"
+
+	if !*servenv.RedactDebugUIQueries {
+		_, fullBindParams := params["full"]
+		formattedBindVars = stats.FmtBindVariables(fullBindParams)
+	}
+
+	// TODO: remove username here we fully enforce immediate caller id
+	remoteAddr, username := stats.RemoteAddrUsername()
+	return fmt.Sprintf(
+		"%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%.6f\t%.6f\t%.6f\t%v\t%q\t%v\t%v\t%v\t%v\t%q\t\n",
+		stats.Method,
+		remoteAddr,
+		username,
+		stats.ImmediateCaller(),
+		stats.EffectiveCaller(),
+		stats.StartTime.Format(time.StampMicro),
+		stats.EndTime.Format(time.StampMicro),
+		stats.TotalTime().Seconds(),
+		stats.PlanTime.Seconds(),
+		stats.ExecuteTime.Seconds(),
+		stats.CommitTime.Seconds(),
+		stats.StmtType,
+		stats.SQL,
+		formattedBindVars,
+		stats.ShardQueries,
+		stats.RowsAffected,
+		stats.SizeOfResponse(),
+		stats.ErrorStr(),
+	)
+}

--- a/go/vt/vtgate/logstats.go
+++ b/go/vt/vtgate/logstats.go
@@ -25,9 +25,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/callinfo"
-	"github.com/youtube/vitess/go/vt/servenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -143,7 +143,7 @@ func (stats *LogStats) RemoteAddrUsername() (string, string) {
 func (stats *LogStats) Format(params url.Values) string {
 	formattedBindVars := "[REDACTED]"
 
-	if !*servenv.RedactDebugUIQueries {
+	if !*streamlog.RedactDebugUIQueries {
 		_, fullBindParams := params["full"]
 		formattedBindVars = stats.FmtBindVariables(fullBindParams)
 	}

--- a/go/vt/vtgate/logstats_test.go
+++ b/go/vt/vtgate/logstats_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/streamlog"
+	"github.com/youtube/vitess/go/vt/callinfo"
+	"github.com/youtube/vitess/go/vt/callinfo/fakecallinfo"
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestLogStatsFormat(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1)})
+	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
+	logStats.EndTime = time.Date(2017, time.January, 1, 1, 2, 4, 0, time.UTC)
+	params := map[string][]string{"full": {}}
+
+	*streamlog.RedactDebugUIQueries = false
+	*streamlog.QueryLogFormat = "text"
+	got := logStats.Format(url.Values(params))
+	want := "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[intVal:type:INT64 value:\"1\" ]\t0\t0\t\"\"\t\n"
+	if got != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
+	}
+
+	*streamlog.RedactDebugUIQueries = true
+	*streamlog.QueryLogFormat = "text"
+	got = logStats.Format(url.Values(params))
+	want = "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\t\"[REDACTED]\"\t0\t0\t\"\"\t\n"
+	if got != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
+	}
+
+	*streamlog.RedactDebugUIQueries = false
+	*streamlog.QueryLogFormat = "json"
+	got = logStats.Format(url.Values(params))
+	var parsed map[string]interface{}
+	err := json.Unmarshal([]byte(got), &parsed)
+	if err != nil {
+		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
+	}
+	formatted, err := json.MarshalIndent(parsed, "", "    ")
+	if err != nil {
+		t.Errorf("logstats format: error marshaling json: %v -- got:\n%v", err, got)
+	}
+	want = "{\n    \"BindVars\": {\n        \"intVal\": {\n            \"type\": \"INT64\",\n            \"value\": 1\n        }\n    },\n    \"CommitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ExecuteTime\": 0,\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"PlanTime\": 0,\n    \"RemoteAddr\": \"\",\n    \"RowsAffected\": 0,\n    \"SQL\": \"sql1\",\n    \"ShardQueries\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"StmtType\": \"\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
+	if string(formatted) != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%v\n", string(formatted), want)
+	}
+
+	*streamlog.RedactDebugUIQueries = true
+	*streamlog.QueryLogFormat = "json"
+	got = logStats.Format(url.Values(params))
+	err = json.Unmarshal([]byte(got), &parsed)
+	if err != nil {
+		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
+	}
+	formatted, err = json.MarshalIndent(parsed, "", "    ")
+	if err != nil {
+		t.Errorf("logstats format: error marshaling json: %v -- got:\n%v", err, got)
+	}
+	want = "{\n    \"BindVars\": \"[REDACTED]\",\n    \"CommitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ExecuteTime\": 0,\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"PlanTime\": 0,\n    \"RemoteAddr\": \"\",\n    \"RowsAffected\": 0,\n    \"SQL\": \"sql1\",\n    \"ShardQueries\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"StmtType\": \"\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
+	if string(formatted) != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%v\n", string(formatted), want)
+	}
+
+	*streamlog.RedactDebugUIQueries = false
+
+	// Make sure formatting works for string bind vars. We can't do this as part of a single
+	// map because the output ordering is undefined.
+	logStats.BindVariables = map[string]*querypb.BindVariable{"strVal": sqltypes.StringBindVariable("abc")}
+
+	*streamlog.QueryLogFormat = "text"
+	got = logStats.Format(url.Values(params))
+	want = "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t0.000000\t0.000000\t0.000000\t\t\"sql1\"\tmap[strVal:type:VARCHAR value:\"abc\" ]\t0\t0\t\"\"\t\n"
+	if got != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
+	}
+
+	*streamlog.QueryLogFormat = "json"
+	got = logStats.Format(url.Values(params))
+	err = json.Unmarshal([]byte(got), &parsed)
+	if err != nil {
+		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
+	}
+	formatted, err = json.MarshalIndent(parsed, "", "    ")
+	if err != nil {
+		t.Errorf("logstats format: error marshaling json: %v -- got:\n%v", err, got)
+	}
+	want = "{\n    \"BindVars\": {\n        \"strVal\": {\n            \"type\": \"VARCHAR\",\n            \"value\": \"abc\"\n        }\n    },\n    \"CommitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ExecuteTime\": 0,\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"PlanTime\": 0,\n    \"RemoteAddr\": \"\",\n    \"RowsAffected\": 0,\n    \"SQL\": \"sql1\",\n    \"ShardQueries\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"StmtType\": \"\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
+	if string(formatted) != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%v\n", string(formatted), want)
+	}
+
+	*streamlog.QueryLogFormat = "text"
+}
+
+func TestLogStatsFormatBindVariables(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{
+		"key_1": sqltypes.StringBindVariable("val_1"),
+		"key_2": sqltypes.Int64BindVariable(789),
+	})
+
+	formattedStr := logStats.FmtBindVariables(true)
+	if !strings.Contains(formattedStr, "key_1") ||
+		!strings.Contains(formattedStr, "val_1") {
+		t.Fatalf("bind variable 'key_1': 'val_1' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_2") ||
+		!strings.Contains(formattedStr, "789") {
+		t.Fatalf("bind variable 'key_2': '789' is not formatted")
+	}
+
+	logStats.BindVariables["key_3"] = sqltypes.BytesBindVariable([]byte("val_3"))
+	formattedStr = logStats.FmtBindVariables(false)
+	if !strings.Contains(formattedStr, "key_1") {
+		t.Fatalf("bind variable 'key_1' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_2") ||
+		!strings.Contains(formattedStr, "789") {
+		t.Fatalf("bind variable 'key_2': '789' is not formatted")
+	}
+	if !strings.Contains(formattedStr, "key_3") {
+		t.Fatalf("bind variable 'key_3' is not formatted")
+	}
+}
+
+func TestLogStatsContextHTML(t *testing.T) {
+	html := "HtmlContext"
+	callInfo := &fakecallinfo.FakeCallInfo{
+		Html: html,
+	}
+	ctx := callinfo.NewContext(context.Background(), callInfo)
+	logStats := NewLogStats(ctx, "test", "sql1", map[string]*querypb.BindVariable{})
+	if string(logStats.ContextHTML()) != html {
+		t.Fatalf("expect to get html: %s, but got: %s", html, string(logStats.ContextHTML()))
+	}
+}
+
+func TestLogStatsErrorStr(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{})
+	if logStats.ErrorStr() != "" {
+		t.Fatalf("should not get error in stats, but got: %s", logStats.ErrorStr())
+	}
+	errStr := "unknown error"
+	logStats.Error = errors.New(errStr)
+	if !strings.Contains(logStats.ErrorStr(), errStr) {
+		t.Fatalf("expect string '%s' in error message, but got: %s", errStr, logStats.ErrorStr())
+	}
+}
+
+func TestLogStatsRemoteAddrUsername(t *testing.T) {
+	logStats := NewLogStats(context.Background(), "test", "sql1", map[string]*querypb.BindVariable{})
+	addr, user := logStats.RemoteAddrUsername()
+	if addr != "" {
+		t.Fatalf("remote addr should be empty")
+	}
+	if user != "" {
+		t.Fatalf("username should be empty")
+	}
+
+	remoteAddr := "1.2.3.4"
+	username := "vt"
+	callInfo := &fakecallinfo.FakeCallInfo{
+		Remote: remoteAddr,
+		User:   username,
+	}
+	ctx := callinfo.NewContext(context.Background(), callInfo)
+	logStats = NewLogStats(ctx, "test", "sql1", map[string]*querypb.BindVariable{})
+	addr, user = logStats.RemoteAddrUsername()
+	if addr != remoteAddr {
+		t.Fatalf("expected to get remote addr: %s, but got: %s", remoteAddr, addr)
+	}
+	if user != username {
+		t.Fatalf("expected to get username: %s, but got: %s", username, user)
+	}
+}

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -21,13 +21,13 @@ import (
 )
 
 var (
-	// Handler path for exposing query logs
-	queryLogHandler = "/debug/querylog"
+	// QueryLogHandler is the debug UI path for exposing query logs
+	QueryLogHandler = "/debug/querylog"
 
 	// QueryLogger enables streaming logging of queries
 	QueryLogger = streamlog.New("VTGate", 10)
 )
 
 func initQueryLogger() {
-	QueryLogger.ServeLogs(queryLogHandler, streamlog.GetFormatter(QueryLogger))
+	QueryLogger.ServeLogs(QueryLogHandler, streamlog.GetFormatter(QueryLogger))
 }

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"github.com/youtube/vitess/go/streamlog"
+)
+
+var (
+	// Handler path for exposing query logs
+	queryLogHandler = "/debug/querylog"
+
+	// QueryLogger enables streaming logging of queries
+	QueryLogger = streamlog.New("VTGate", 10)
+)
+
+func initQueryLogger() {
+	QueryLogger.ServeLogs(queryLogHandler, streamlog.GetFormatter(QueryLogger))
+}

--- a/go/vt/vtgate/querylog.go
+++ b/go/vt/vtgate/querylog.go
@@ -24,6 +24,9 @@ var (
 	// QueryLogHandler is the debug UI path for exposing query logs
 	QueryLogHandler = "/debug/querylog"
 
+	// QueryLogzHandler is the debug UI path for exposing query logs
+	QueryLogzHandler = "/debug/querylogz"
+
 	// QueryLogger enables streaming logging of queries
 	QueryLogger = streamlog.New("VTGate", 10)
 )

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/acl"
+	"github.com/youtube/vitess/go/vt/logz"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+var (
+	querylogzHeader = []byte(`
+		<thead>
+			<tr>
+				<th>Method</th>
+				<th>Context</th>
+				<th>Effective Caller</th>
+				<th>Immediate Caller</th>
+				<th>Start</th>
+				<th>End</th>
+				<th>Duration</th>
+				<th>Plan Time</th>
+				<th>Execute Time</th>
+				<th>Commit Time</th>
+				<th>Stmt Type</th>
+				<th>SQL</th>
+				<th>ShardQueries</th>
+				<th>RowsAffected</th>
+				<th>Error</th>
+			</tr>
+		</thead>
+	`)
+	querylogzFuncMap = template.FuncMap{
+		"stampMicro":    func(t time.Time) string { return t.Format(time.StampMicro) },
+		"cssWrappable":  logz.Wrappable,
+		"truncateQuery": sqlparser.TruncateForUI,
+		"unquote":       func(s string) string { return strings.Trim(s, "\"") },
+	}
+	querylogzTmpl = template.Must(template.New("example").Funcs(querylogzFuncMap).Parse(`
+		<tr class="{{.ColorLevel}}">
+			<td>{{.Method}}</td>
+			<td>{{.ContextHTML}}</td>
+			<td>{{.EffectiveCaller}}</td>
+			<td>{{.ImmediateCaller}}</td>
+			<td>{{.StartTime | stampMicro}}</td>
+			<td>{{.EndTime | stampMicro}}</td>
+			<td>{{.TotalTime.Seconds}}</td>
+			<td>{{.PlanTime.Seconds}}</td>
+			<td>{{.ExecuteTime.Seconds}}</td>
+			<td>{{.CommitTime.Seconds}}</td>
+			<td>{{.StmtType}}</td>
+			<td>{{.SQL | truncateQuery | unquote | cssWrappable}}</td>
+			<td>{{.ShardQueries}}</td>
+			<td>{{.RowsAffected}}</td>
+			<td>{{.ErrorStr}}</td>
+		</tr>
+	`))
+)
+
+func init() {
+	http.HandleFunc("/debug/querylogz", func(w http.ResponseWriter, r *http.Request) {
+		ch := QueryLogger.Subscribe("querylogz")
+		defer QueryLogger.Unsubscribe(ch)
+		querylogzHandler(ch, w, r)
+	})
+}
+
+// querylogzHandler serves a human readable snapshot of the
+// current query log.
+func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Request) {
+	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		acl.SendError(w, err)
+		return
+	}
+	timeout, limit := parseTimeoutLimitParams(r)
+	logz.StartHTMLTable(w)
+	defer logz.EndHTMLTable(w)
+	w.Write(querylogzHeader)
+
+	tmr := time.NewTimer(timeout)
+	defer tmr.Stop()
+	for i := 0; i < limit; i++ {
+		select {
+		case out := <-ch:
+			select {
+			case <-tmr.C:
+				return
+			default:
+			}
+			stats, ok := out.(*LogStats)
+			if !ok {
+				err := fmt.Errorf("Unexpected value in %s: %#v (expecting value of type %T)", tabletenv.TxLogger.Name(), out, &LogStats{})
+				io.WriteString(w, `<tr class="error">`)
+				io.WriteString(w, err.Error())
+				io.WriteString(w, "</tr>")
+				log.Error(err)
+				continue
+			}
+			var level string
+			if stats.TotalTime().Seconds() < 0.01 {
+				level = "low"
+			} else if stats.TotalTime().Seconds() < 0.1 {
+				level = "medium"
+			} else {
+				level = "high"
+			}
+			tmplData := struct {
+				*LogStats
+				ColorLevel string
+			}{stats, level}
+			if err := querylogzTmpl.Execute(w, tmplData); err != nil {
+				log.Errorf("querylogz: couldn't execute template: %v", err)
+			}
+		case <-tmr.C:
+			return
+		}
+	}
+}
+
+func parseTimeoutLimitParams(req *http.Request) (time.Duration, int) {
+	timeout := 10
+	limit := 300
+	if ts, ok := req.URL.Query()["timeout"]; ok {
+		if t, err := strconv.Atoi(ts[0]); err == nil {
+			timeout = adjustValue(t, 0, 60)
+		}
+	}
+	if l, ok := req.URL.Query()["limit"]; ok {
+		if lim, err := strconv.Atoi(l[0]); err == nil {
+			limit = adjustValue(lim, 1, 200000)
+		}
+	}
+	return time.Duration(timeout) * time.Second, limit
+}
+
+func adjustValue(val int, lower int, upper int) int {
+	if val < lower {
+		return lower
+	} else if val > upper {
+		return upper
+	}
+	return val
+}

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -81,14 +81,6 @@ var (
 	`))
 )
 
-func init() {
-	http.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
-		ch := QueryLogger.Subscribe("querylogz")
-		defer QueryLogger.Unsubscribe(ch)
-		querylogzHandler(ch, w, r)
-	})
-}
-
 // querylogzHandler serves a human readable snapshot of the
 // current query log.
 func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Request) {

--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -82,7 +82,7 @@ var (
 )
 
 func init() {
-	http.HandleFunc("/debug/querylogz", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(QueryLogzHandler, func(w http.ResponseWriter, r *http.Request) {
 		ch := QueryLogger.Subscribe("querylogz")
 		defer QueryLogger.Unsubscribe(ch)
 		querylogzHandler(ch, w, r)

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/callerid"
+	"golang.org/x/net/context"
+)
+
+func TestQuerylogzHandlerInvalidLogStats(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
+	response := httptest.NewRecorder()
+	ch := make(chan interface{}, 1)
+	ch <- "test msg"
+	querylogzHandler(ch, response, req)
+	close(ch)
+	if !strings.Contains(response.Body.String(), "error") {
+		t.Fatalf("should show an error page for an non LogStats")
+	}
+}
+
+func TestQuerylogzHandlerFormatting(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
+	logStats := NewLogStats(context.Background(), "Execute", "select")
+	logStats.SQL = "select name from test_table limit 1000"
+	logStats.RowsAffected = 1000
+	logStats.ShardQueries = 1
+	logStats.StartTime, _ = time.Parse("Jan 2 15:04:05", "Nov 29 13:33:09")
+	logStats.PlanTime = 1 * time.Millisecond
+	logStats.ExecuteTime = 2 * time.Millisecond
+	logStats.CommitTime = 3 * time.Millisecond
+	logStats.Ctx = callerid.NewContext(
+		context.Background(),
+		callerid.NewEffectiveCallerID("effective-caller", "component", "subcomponent"),
+		callerid.NewImmediateCallerID("immediate-caller"),
+	)
+
+	// fast query
+	fastQueryPattern := []string{
+		`<tr class="low">`,
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>effective-caller</td>`,
+		`<td>immediate-caller</td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.001000</td>`,
+		`<td>0.001</td>`,
+		`<td>0.001</td>`,
+		`<td>0.002</td>`,
+		`<td>0.003</td>`,
+		`<td>select</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>1000</td>`,
+		`<td></td>`,
+		`</tr>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(1 * time.Millisecond)
+	response := httptest.NewRecorder()
+	ch := make(chan interface{}, 1)
+	ch <- logStats
+	querylogzHandler(ch, response, req)
+	close(ch)
+	body, _ := ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, fastQueryPattern, logStats, body)
+
+	// medium query
+	mediumQueryPattern := []string{
+		`<tr class="medium">`,
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>effective-caller</td>`,
+		`<td>immediate-caller</td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.020000</td>`,
+		`<td>0.02</td>`,
+		`<td>0.001</td>`,
+		`<td>0.002</td>`,
+		`<td>0.003</td>`,
+		`<td>select</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>1000</td>`,
+		`<td></td>`,
+		`</tr>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(20 * time.Millisecond)
+	response = httptest.NewRecorder()
+	ch = make(chan interface{}, 1)
+	ch <- logStats
+	querylogzHandler(ch, response, req)
+	close(ch)
+	body, _ = ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, mediumQueryPattern, logStats, body)
+
+	// slow query
+	slowQueryPattern := []string{
+		`<tr class="high">`,
+		`<td>Execute</td>`,
+		`<td></td>`,
+		`<td>effective-caller</td>`,
+		`<td>immediate-caller</td>`,
+		`<td>Nov 29 13:33:09.000000</td>`,
+		`<td>Nov 29 13:33:09.500000</td>`,
+		`<td>0.5</td>`,
+		`<td>0.001</td>`,
+		`<td>0.002</td>`,
+		`<td>0.003</td>`,
+		`<td>select</td>`,
+		`<td>select name from test_table limit 1000</td>`,
+		`<td>1</td>`,
+		`<td>1000</td>`,
+		`<td></td>`,
+		`</tr>`,
+	}
+	logStats.EndTime = logStats.StartTime.Add(500 * time.Millisecond)
+	ch = make(chan interface{}, 1)
+	ch <- logStats
+	querylogzHandler(ch, response, req)
+	close(ch)
+	body, _ = ioutil.ReadAll(response.Body)
+	checkQuerylogzHasStats(t, slowQueryPattern, logStats, body)
+}
+
+func checkQuerylogzHasStats(t *testing.T, pattern []string, logStats *LogStats, page []byte) {
+	t.Helper()
+	matcher := regexp.MustCompile(strings.Join(pattern, `\s*`))
+	if !matcher.Match(page) {
+		t.Fatalf("querylogz page does not contain stats: %v, pattern: %v, page: %s", logStats, pattern, string(page))
+	}
+}

--- a/go/vt/vtgate/querylogz_test.go
+++ b/go/vt/vtgate/querylogz_test.go
@@ -43,8 +43,8 @@ func TestQuerylogzHandlerInvalidLogStats(t *testing.T) {
 
 func TestQuerylogzHandlerFormatting(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/querylogz?timeout=10&limit=1", nil)
-	logStats := NewLogStats(context.Background(), "Execute", "select")
-	logStats.SQL = "select name from test_table limit 1000"
+	logStats := NewLogStats(context.Background(), "Execute", "select name from test_table limit 1000", nil)
+	logStats.StmtType = "select"
 	logStats.RowsAffected = 1000
 	logStats.ShardQueries = 1
 	logStats.StartTime, _ = time.Parse("Jan 2 15:04:05", "Nov 29 13:33:09")

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -70,11 +70,11 @@ type queryzRow struct {
 	Table        string
 	Plan         planbuilder.PlanType
 	Reason       planbuilder.ReasonType
-	Count        int64
+	Count        uint64
 	tm           time.Duration
-	ShardQueries int64
-	Rows         int64
-	Errors       int64
+	ShardQueries uint64
+	Rows         uint64
+	Errors       uint64
 	Color        string
 }
 
@@ -141,12 +141,12 @@ func queryzHandler(e *Executor, w http.ResponseWriter, r *http.Request) {
 		}
 		plan := result.(*engine.Plan)
 		Value := &queryzRow{
-			Query: logz.Wrappable(sqlparser.TruncateForUI(v)),
+			Query: logz.Wrappable(sqlparser.TruncateForUI(plan.Original)),
 		}
 		Value.Count, Value.tm, Value.ShardQueries, Value.Rows, Value.Errors = plan.Stats()
 		var timepq time.Duration
 		if Value.Count != 0 {
-			timepq = time.Duration(int64(Value.tm) / Value.Count)
+			timepq = time.Duration(uint64(Value.tm) / Value.Count)
 		}
 		if timepq < 10*time.Millisecond {
 			Value.Color = "low"

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+	"sort"
+	"time"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/acl"
+	"github.com/youtube/vitess/go/vt/logz"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
+)
+
+var (
+	queryzHeader = []byte(`<thead>
+		<tr>
+			<th>Query</th>
+			<th>Count</th>
+			<th>Time</th>
+			<th>Shard Queries</th>
+			<th>Rows</th>
+			<th>Errors</th>
+			<th>Time per query</th>
+			<th>Shard queries per query</th>
+			<th>Rows per query</th>
+			<th>Errors per query</th>
+		</tr>
+        </thead>
+	`)
+	queryzTmpl = template.Must(template.New("example").Parse(`
+		<tr class="{{.Color}}">
+			<td>{{.Query}}</td>
+			<td>{{.Count}}</td>
+			<td>{{.Time}}</td>
+			<td>{{.ShardQueries}}</td>
+			<td>{{.Rows}}</td>
+			<td>{{.Errors}}</td>
+			<td>{{.TimePQ}}</td>
+			<td>{{.ShardQueriesPQ}}</td>
+			<td>{{.RowsPQ}}</td>
+			<td>{{.ErrorsPQ}}</td>
+		</tr>
+	`))
+)
+
+// queryzRow is used for rendering query stats
+// using go's template.
+type queryzRow struct {
+	Query        string
+	Table        string
+	Plan         planbuilder.PlanType
+	Reason       planbuilder.ReasonType
+	Count        int64
+	tm           time.Duration
+	ShardQueries int64
+	Rows         int64
+	Errors       int64
+	Color        string
+}
+
+// Time returns the total time as a string.
+func (qzs *queryzRow) Time() string {
+	return fmt.Sprintf("%.6f", float64(qzs.tm)/1e9)
+}
+
+func (qzs *queryzRow) timePQ() float64 {
+	return float64(qzs.tm) / (1e9 * float64(qzs.Count))
+}
+
+// TimePQ returns the time per query as a string.
+func (qzs *queryzRow) TimePQ() string {
+	return fmt.Sprintf("%.6f", qzs.timePQ())
+}
+
+// ShardQueriesPQ returns the shard query count per query as a string.
+func (qzs *queryzRow) ShardQueriesPQ() string {
+	val := float64(qzs.ShardQueries) / float64(qzs.Count)
+	return fmt.Sprintf("%.6f", val)
+}
+
+// RowsPQ returns the row count per query as a string.
+func (qzs *queryzRow) RowsPQ() string {
+	val := float64(qzs.Rows) / float64(qzs.Count)
+	return fmt.Sprintf("%.6f", val)
+}
+
+// ErrorsPQ returns the error count per query as a string.
+func (qzs *queryzRow) ErrorsPQ() string {
+	return fmt.Sprintf("%.6f", float64(qzs.Errors)/float64(qzs.Count))
+}
+
+type queryzSorter struct {
+	rows []*queryzRow
+	less func(row1, row2 *queryzRow) bool
+}
+
+func (s *queryzSorter) Len() int           { return len(s.rows) }
+func (s *queryzSorter) Swap(i, j int)      { s.rows[i], s.rows[j] = s.rows[j], s.rows[i] }
+func (s *queryzSorter) Less(i, j int) bool { return s.less(s.rows[i], s.rows[j]) }
+
+func queryzHandler(e *Executor, w http.ResponseWriter, r *http.Request) {
+	if err := acl.CheckAccessHTTP(r, acl.DEBUGGING); err != nil {
+		acl.SendError(w, err)
+		return
+	}
+	logz.StartHTMLTable(w)
+	defer logz.EndHTMLTable(w)
+	w.Write(queryzHeader)
+
+	keys := e.plans.Keys()
+	sorter := queryzSorter{
+		rows: make([]*queryzRow, 0, len(keys)),
+		less: func(row1, row2 *queryzRow) bool {
+			return row1.timePQ() > row2.timePQ()
+		},
+	}
+	for _, v := range e.plans.Keys() {
+		result, ok := e.plans.Get(v)
+		if !ok {
+			continue
+		}
+		plan := result.(*engine.Plan)
+		Value := &queryzRow{
+			Query: logz.Wrappable(sqlparser.TruncateForUI(v)),
+		}
+		Value.Count, Value.tm, Value.ShardQueries, Value.Rows, Value.Errors = plan.Stats()
+		var timepq time.Duration
+		if Value.Count != 0 {
+			timepq = time.Duration(int64(Value.tm) / Value.Count)
+		}
+		if timepq < 10*time.Millisecond {
+			Value.Color = "low"
+		} else if timepq < 100*time.Millisecond {
+			Value.Color = "medium"
+		} else {
+			Value.Color = "high"
+		}
+		sorter.rows = append(sorter.rows, Value)
+	}
+	sort.Sort(&sorter)
+	for _, Value := range sorter.rows {
+		if err := queryzTmpl.Execute(w, Value); err != nil {
+			log.Errorf("queryz: couldn't execute template: %v", err)
+		}
+	}
+}

--- a/go/vt/vtgate/queryz_test.go
+++ b/go/vt/vtgate/queryz_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/vtgate/engine"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+func TestQueryzHandler(t *testing.T) {
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/schemaz", nil)
+
+	executor, _, _, _ := createExecutorEnv()
+
+	// single shard query
+	sql := "select id from user where id = 1"
+	_, err := executorExec(executor, sql, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	result, ok := executor.plans.Get(sql)
+	if !ok {
+		t.Fatalf("couldn't get plan from cache")
+	}
+	plan1 := result.(*engine.Plan)
+	plan1.ExecTime = time.Duration(1 * time.Millisecond)
+
+	// scatter
+	sql = "select id from user"
+	_, err = executorExec(executor, sql, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	result, ok = executor.plans.Get(sql)
+	if !ok {
+		t.Fatalf("couldn't get plan from cache")
+	}
+	plan2 := result.(*engine.Plan)
+	plan2.ExecTime = time.Duration(1 * time.Second)
+
+	sql = "insert into user (id, name) values (:id, :name)"
+	_, err = executorExec(executor, sql, map[string]*querypb.BindVariable{
+		"id":   sqltypes.Uint64BindVariable(1),
+		"name": sqltypes.BytesBindVariable([]byte("myname")),
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	result, ok = executor.plans.Get(sql)
+	if !ok {
+		t.Fatalf("couldn't get plan from cache")
+	}
+	plan3 := result.(*engine.Plan)
+
+	// vindex insert from above execution
+	result, ok = executor.plans.Get("insert into name_user_map(name, user_id) values(:name0, :user_id0)")
+	if !ok {
+		t.Fatalf("couldn't get plan from cache")
+	}
+	plan4 := result.(*engine.Plan)
+
+	// same query again should add query counts to existing plans
+	sql = "insert into user (id, name) values (:id, :name)"
+	_, err = executorExec(executor, sql, map[string]*querypb.BindVariable{
+		"id":   sqltypes.Uint64BindVariable(1),
+		"name": sqltypes.BytesBindVariable([]byte("myname")),
+	})
+
+	plan3.ExecTime = time.Duration(100 * time.Millisecond)
+	plan4.ExecTime = time.Duration(200 * time.Millisecond)
+
+	queryzHandler(executor, resp, req)
+	body, _ := ioutil.ReadAll(resp.Body)
+	planPattern1 := []string{
+		`<tr class="low">`,
+		`<td>select id from user where id = 1</td>`,
+		`<td>1</td>`,
+		`<td>0.001000</td>`,
+		`<td>1</td>`,
+		`<td>1</td>`,
+		`<td>0</td>`,
+		`<td>0.001000</td>`,
+		`<td>1.000000</td>`,
+		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
+		`</tr>`,
+	}
+	checkQueryzHasPlan(t, planPattern1, plan1, body)
+	planPattern2 := []string{
+		`<tr class="high">`,
+		`<td>select id from user</td>`,
+		`<td>1</td>`,
+		`<td>1.000000</td>`,
+		`<td>8</td>`,
+		`<td>8</td>`,
+		`<td>0</td>`,
+		`<td>1.000000</td>`,
+		`<td>8.000000</td>`,
+		`<td>8.000000</td>`,
+		`<td>0.000000</td>`,
+		`</tr>`,
+	}
+	checkQueryzHasPlan(t, planPattern2, plan2, body)
+	planPattern3 := []string{
+		`<tr class="medium">`,
+		`<td>insert into user.*</td>`,
+		`<td>2</td>`,
+		`<td>0.100000</td>`,
+		`<td>2</td>`,
+		`<td>2</td>`,
+		`<td>0</td>`,
+		`<td>0.050000</td>`,
+		`<td>1.000000</td>`,
+		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
+		`</tr>`,
+	}
+	checkQueryzHasPlan(t, planPattern3, plan3, body)
+	planPattern4 := []string{
+		`<tr class="high">`,
+		`<td>insert into name_user_map.*</td>`,
+		`<td>2</td>`,
+		`<td>0.200000</td>`,
+		`<td>2</td>`,
+		`<td>2</td>`,
+		`<td>0</td>`,
+		`<td>0.100000</td>`,
+		`<td>1.000000</td>`,
+		`<td>1.000000</td>`,
+		`<td>0.000000</td>`,
+		`</tr>`,
+	}
+	checkQueryzHasPlan(t, planPattern4, plan4, body)
+}
+
+func checkQueryzHasPlan(t *testing.T, planPattern []string, plan *engine.Plan, page []byte) {
+	t.Helper()
+	matcher := regexp.MustCompile(strings.Join(planPattern, `\s*`))
+	if !matcher.Match(page) {
+		t.Fatalf("queryz page does not contain\nplan:\n%v\npattern:\n%v\npage:\n%s", plan, strings.Join(planPattern, `\s*`), string(page))
+	}
+}

--- a/go/vt/vtgate/resolver.go
+++ b/go/vt/vtgate/resolver.go
@@ -123,7 +123,7 @@ func (res *Resolver) Execute(
 		return nil, err
 	}
 	if logStats != nil {
-		logStats.ShardQueries = len(shards)
+		logStats.ShardQueries = int32(len(shards))
 	}
 	for {
 		qr, err := res.scatterConn.Execute(

--- a/go/vt/vtgate/resolver.go
+++ b/go/vt/vtgate/resolver.go
@@ -123,7 +123,7 @@ func (res *Resolver) Execute(
 		return nil, err
 	}
 	if logStats != nil {
-		logStats.ShardQueries = int32(len(shards))
+		logStats.ShardQueries = uint32(len(shards))
 	}
 	for {
 		qr, err := res.scatterConn.Execute(

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -97,8 +97,8 @@ func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 }
 
 // Execute performs a V3 level execution of the query. It does not take any routing directives.
-func (vc *vcursorImpl) Execute(query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
-	qr, err := vc.executor.Execute(vc.ctx, vc.session, query+vc.trailingComments, BindVars)
+func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+	qr, err := vc.executor.Execute(vc.ctx, method, vc.session, query+vc.trailingComments, BindVars)
 	if err == nil {
 		vc.hasPartialDML = true
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -134,6 +134,7 @@ func (vc *vcursorImpl) ExecuteStandalone(query string, BindVars map[string]*quer
 
 // StreamExeculteMulti is the streaming version of ExecuteMultiShard.
 func (vc *vcursorImpl) StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error {
+	vc.logStats.ShardQueries += len(shardVars)
 	return vc.executor.scatterConn.StreamExecuteMulti(vc.ctx, query+vc.trailingComments, keyspace, shardVars, vc.target.TabletType, vc.session.Options, callback)
 }
 

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -111,7 +111,7 @@ func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]
 
 // ExecuteMultiShard executes different queries on different shards and returns the combined result.
 func (vc *vcursorImpl) ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML bool) (*sqltypes.Result, error) {
-	atomic.AddInt32(&vc.logStats.ShardQueries, int32(len(shardQueries)))
+	atomic.AddUint32(&vc.logStats.ShardQueries, uint32(len(shardQueries)))
 	qr, err := vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, keyspace, commentedShardQueries(shardQueries, vc.trailingComments), vc.target.TabletType, NewSafeSession(vc.session), false, vc.session.Options)
 	if err == nil {
 		vc.hasPartialDML = true
@@ -136,7 +136,7 @@ func (vc *vcursorImpl) ExecuteStandalone(query string, BindVars map[string]*quer
 
 // StreamExeculteMulti is the streaming version of ExecuteMultiShard.
 func (vc *vcursorImpl) StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error {
-	atomic.AddInt32(&vc.logStats.ShardQueries, int32(len(shardVars)))
+	atomic.AddUint32(&vc.logStats.ShardQueries, uint32(len(shardVars)))
 	return vc.executor.scatterConn.StreamExecuteMulti(vc.ctx, query+vc.trailingComments, keyspace, shardVars, vc.target.TabletType, vc.session.Options, callback)
 }
 

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -51,7 +51,7 @@ func (lkp *lookupInternal) Lookup(vcursor VCursor, ids []sqltypes.Value) ([]*sql
 		bindVars := map[string]*querypb.BindVariable{
 			lkp.From: sqltypes.ValueBindVariable(id),
 		}
-		result, err := vcursor.Execute(lkp.sel, bindVars, false /* isDML */)
+		result, err := vcursor.Execute("VindexLookup", lkp.sel, bindVars, false /* isDML */)
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Map: %v", err)
 		}
@@ -68,7 +68,7 @@ func (lkp *lookupInternal) Verify(vcursor VCursor, ids, values []sqltypes.Value)
 			lkp.From: sqltypes.ValueBindVariable(id),
 			lkp.To:   sqltypes.ValueBindVariable(values[i]),
 		}
-		result, err := vcursor.Execute(lkp.ver, bindVars, true /* isDML */)
+		result, err := vcursor.Execute("VindexVerify", lkp.ver, bindVars, true /* isDML */)
 		if err != nil {
 			return nil, fmt.Errorf("lookup.Verify: %v", err)
 		}
@@ -96,7 +96,7 @@ func (lkp *lookupInternal) Create(vcursor VCursor, ids, values []sqltypes.Value,
 		bindVars[fromStr] = sqltypes.ValueBindVariable(id)
 		bindVars[toStr] = sqltypes.ValueBindVariable(values[i])
 	}
-	_, err := vcursor.Execute(insBuffer.String(), bindVars, true /* isDML */)
+	_, err := vcursor.Execute("VindexCreate", insBuffer.String(), bindVars, true /* isDML */)
 	if err != nil {
 		return fmt.Errorf("lookup.Create: %v", err)
 	}
@@ -110,7 +110,7 @@ func (lkp *lookupInternal) Delete(vcursor VCursor, ids []sqltypes.Value, value s
 			lkp.From: sqltypes.ValueBindVariable(id),
 			lkp.To:   sqltypes.ValueBindVariable(value),
 		}
-		if _, err := vcursor.Execute(lkp.del, bindVars, true /* isDML */); err != nil {
+		if _, err := vcursor.Execute("VindexDelete", lkp.del, bindVars, true /* isDML */); err != nil {
 			return fmt.Errorf("lookup.Delete: %v", err)
 		}
 	}

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -38,7 +38,7 @@ type vcursor struct {
 	queries  []*querypb.BoundQuery
 }
 
-func (vc *vcursor) Execute(query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+func (vc *vcursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
 	vc.queries = append(vc.queries, &querypb.BoundQuery{
 		Sql:           query,
 		BindVariables: bindvars,

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -30,7 +30,7 @@ import (
 // in the current context and session of a VTGate request. Vindexes
 // can use this interface to execute lookup queries.
 type VCursor interface {
-	Execute(query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
 }
 
 // Vindex defines the interface required to register a vindex.

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -202,6 +202,8 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server
 		}
 	})
 	vtgateOnce.Do(rpcVTGate.registerDebugHealthHandler)
+	initQueryLogger()
+
 	return rpcVTGate
 }
 
@@ -360,6 +362,7 @@ func (vtg *VTGate) ExecuteShards(ctx context.Context, sql string, bindVariables 
 		},
 		notInTransaction,
 		options,
+		nil,
 	)
 	if err == nil {
 		vtg.rowsReturned.Add(statsKey, int64(len(qr.Rows)))

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -202,7 +202,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server
 		}
 	})
 	vtgateOnce.Do(rpcVTGate.registerDebugHealthHandler)
-	initQueryLogger()
+	initQueryLogger(rpcVTGate)
 
 	return rpcVTGate
 }

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -311,6 +311,7 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 	} else {
 		err = vtg.executor.StreamExecute(
 			ctx,
+			"StreamExecute",
 			session,
 			sql,
 			bindVariables,

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -237,7 +237,7 @@ func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql s
 		goto handleError
 	}
 
-	qr, err = vtg.executor.Execute(ctx, session, sql, bindVariables)
+	qr, err = vtg.executor.Execute(ctx, "Execute", session, sql, bindVariables)
 	if err == nil {
 		vtg.rowsReturned.Add(statsKey, int64(len(qr.Rows)))
 		return session, qr, nil


### PR DESCRIPTION
## Overview

Add a logstats implementation to vtgate to add an infrastructure to expose per-query timings to either a log target or in the debug UIs, both aggregated and unaggregated.

Implements #2802

## Tasks 
~This is not currently complete but I wanted to put it up to start the review process while finishing off the implementation.~
This is ready for review

Current status / to do list:

- [x] The basic logstats structure, support in Execute, and unit tests for various cases
- [x] Support for StreamExecute
- [x] Include Row Count in the logstats structure
- [x] Support for non-execute cases (SHOW, DDL, etc)
- [x] Support Errors
- [x] /debug/querylog endpoint for tab-delimited query logs
- [x] /debug/querylogz endpoint for human-readable consumption
- [x] /debug/queryz endpoint for aggregate statistics
- [x] Link the various endpoints into the vtgate debug UI
- [x] Test in a real environment
- [x] Fix data race in vcursor by using atomics
- [x] Fix multiple registrations for querylog HTTP endpoints in vtcombo

## Notes

The logstats structure is currently:
```
type LogStats struct {
	Ctx           context.Context
	Method        string
	Target        *querypb.Target
	StmtType      string
	SQL           string
	BindVariables map[string]*querypb.BindVariable
	StartTime     time.Time
	EndTime       time.Time
	ShardQueries  uint32
	RowsAffected  uint64
	PlanTime      time.Duration
	ExecuteTime   time.Duration
	CommitTime    time.Duration
	Error         error
}
```

I also updated `engine.Plan` to include some basic metrics:

```
type Plan struct {
	// Original is the original query.
	Original string `json:",omitempty"`
	// Instructions contains the instructions needed to
	// fulfil the query.
	Instructions Primitive `json:",omitempty"`
	// Mutex to protect the stats
	mu sync.Mutex
	// Count of times this plan was executed
	ExecCount uint64
	// Total execution time
	ExecTime time.Duration
	// Total number of shard queries
	ShardQueries uint64
	// Total number of rows
	Rows uint64
	// Total number of errors
	Errors uint64
}
```


