### PR TITLE
grpc: use FailFast as needed

### DIFF
--- a/go/cmd/automation_client/automation_client.go
+++ b/go/cmd/automation_client/automation_client.go
@@ -79,7 +79,7 @@ func main() {
 
 	fmt.Println("Connecting to Automation Server:", *automationServer)
 
-	conn, err := grpcclient.Dial(*automationServer, grpc.WithInsecure())
+	conn, err := grpcclient.Dial(*automationServer, grpcclient.FailFast(false), grpc.WithInsecure())
 	if err != nil {
 		fmt.Println("Cannot create connection:", err)
 		os.Exit(3)

--- a/go/cmd/l2vtgate/main.go
+++ b/go/cmd/l2vtgate/main.go
@@ -37,12 +37,11 @@ import (
 )
 
 var (
-	cell                   = flag.String("cell", "test_nj", "cell to use")
-	retryCount             = flag.Int("retry-count", 2, "retry count")
-	healthCheckConnTimeout = flag.Duration("healthcheck_conn_timeout", 3*time.Second, "healthcheck connection timeout")
-	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
-	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
-	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
+	cell                  = flag.String("cell", "test_nj", "cell to use")
+	retryCount            = flag.Int("retry-count", 2, "retry count")
+	healthCheckRetryDelay = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
+	healthCheckTimeout    = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
+	tabletTypesToWait     = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -69,7 +68,7 @@ func main() {
 
 	resilientSrvTopoServer = vtgate.NewResilientSrvTopoServer(ts, "ResilientSrvTopoServer")
 
-	healthCheck = discovery.NewHealthCheck(*healthCheckConnTimeout, *healthCheckRetryDelay, *healthCheckTimeout)
+	healthCheck = discovery.NewHealthCheck(*healthCheckRetryDelay, *healthCheckTimeout)
 	healthCheck.RegisterStats()
 
 	tabletTypes := make([]topodatapb.TabletType, 0, 1)

--- a/go/cmd/vtcombo/main.go
+++ b/go/cmd/vtcombo/main.go
@@ -127,7 +127,7 @@ func main() {
 
 	// vtgate configuration and init
 	resilientSrvTopoServer := vtgate.NewResilientSrvTopoServer(ts, "ResilientSrvTopoServer")
-	healthCheck := discovery.NewHealthCheck(30*time.Second /*connTimeoutTotal*/, 1*time.Millisecond /*retryDelay*/, 1*time.Hour /*healthCheckTimeout*/)
+	healthCheck := discovery.NewHealthCheck(1*time.Millisecond /*retryDelay*/, 1*time.Hour /*healthCheckTimeout*/)
 	tabletTypesToWait := []topodatapb.TabletType{
 		topodatapb.TabletType_MASTER,
 		topodatapb.TabletType_REPLICA,

--- a/go/cmd/vtcombo/tablet_map.go
+++ b/go/cmd/vtcombo/tablet_map.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/hook"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -265,7 +266,7 @@ func initTabletMap(ts *topo.Server, tpb *vttestpb.VTTestTopology, mysqld mysqlct
 //
 
 // dialer is our tabletconn.Dialer
-func dialer(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+func dialer(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 	t, ok := tabletMap[tablet.Alias.Uid]
 	if !ok {
 		return nil, vterrors.New(vtrpcpb.Code_UNAVAILABLE, "connection refused")

--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -38,12 +38,11 @@ import (
 )
 
 var (
-	cell                   = flag.String("cell", "test_nj", "cell to use")
-	retryCount             = flag.Int("retry-count", 2, "retry count")
-	healthCheckConnTimeout = flag.Duration("healthcheck_conn_timeout", 3*time.Second, "healthcheck connection timeout")
-	healthCheckRetryDelay  = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
-	healthCheckTimeout     = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
-	tabletTypesToWait      = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
+	cell                  = flag.String("cell", "test_nj", "cell to use")
+	retryCount            = flag.Int("retry-count", 2, "retry count")
+	healthCheckRetryDelay = flag.Duration("healthcheck_retry_delay", 2*time.Millisecond, "health check retry delay")
+	healthCheckTimeout    = flag.Duration("healthcheck_timeout", time.Minute, "the health check timeout period")
+	tabletTypesToWait     = flag.String("tablet_types_to_wait", "", "wait till connected for specified tablet types during Gateway initialization")
 )
 
 var resilientSrvTopoServer *vtgate.ResilientSrvTopoServer
@@ -75,7 +74,7 @@ func main() {
 
 	resilientSrvTopoServer = vtgate.NewResilientSrvTopoServer(ts, "ResilientSrvTopoServer")
 
-	healthCheck = discovery.NewHealthCheck(*healthCheckConnTimeout, *healthCheckRetryDelay, *healthCheckTimeout)
+	healthCheck = discovery.NewHealthCheck(*healthCheckRetryDelay, *healthCheckTimeout)
 	healthCheck.RegisterStats()
 
 	tabletTypes := make([]topodatapb.TabletType, 0, 1)

--- a/go/cmd/vtgateclienttest/goclienttest/main.go
+++ b/go/cmd/vtgateclienttest/goclienttest/main.go
@@ -18,7 +18,6 @@ package goclienttest
 
 import (
 	"testing"
-	"time"
 
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 	"golang.org/x/net/context"
@@ -38,7 +37,7 @@ const connectionKeyspace = "conn_ks"
 func TestGoClient(t *testing.T, protocol, addr string) {
 	// Create a client connecting to the server
 	ctx := context.Background()
-	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr, 30*time.Second)
+	conn, err := vtgateconn.DialProtocol(ctx, protocol, addr)
 	session := conn.Session(connectionKeyspace, nil)
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)

--- a/go/vt/binlog/binlogplayer/binlog_player.go
+++ b/go/vt/binlog/binlogplayer/binlog_player.go
@@ -21,7 +21,6 @@ package binlogplayer
 
 import (
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"sync"
 	"time"
@@ -41,10 +40,6 @@ import (
 )
 
 var (
-	// BinlogPlayerConnTimeout is the flag for binlog player connection
-	// timeout. It is public so the discovery module can also use it.
-	BinlogPlayerConnTimeout = flag.Duration("binlog_player_conn_timeout", 5*time.Second, "binlog player connection timeout")
-
 	// SlowQueryThreshold will cause we logging anything that's higher than it.
 	SlowQueryThreshold = time.Duration(100 * time.Millisecond)
 
@@ -362,7 +357,7 @@ func (blp *BinlogPlayer) ApplyBinlogEvents(ctx context.Context) error {
 		return fmt.Errorf("no binlog player client factory named %v", *binlogPlayerProtocol)
 	}
 	blplClient := clientFactory()
-	err = blplClient.Dial(blp.tablet, *BinlogPlayerConnTimeout)
+	err = blplClient.Dial(blp.tablet)
 	if err != nil {
 		err := fmt.Errorf("error dialing binlog server: %v", err)
 		log.Error(err)

--- a/go/vt/binlog/binlogplayer/client.go
+++ b/go/vt/binlog/binlogplayer/client.go
@@ -18,11 +18,9 @@ package binlogplayer
 
 import (
 	"flag"
-	"time"
-
-	"golang.org/x/net/context"
 
 	log "github.com/golang/glog"
+	"golang.org/x/net/context"
 
 	binlogdatapb "github.com/youtube/vitess/go/vt/proto/binlogdata"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -45,7 +43,7 @@ type BinlogTransactionStream interface {
 // Client is the interface all clients must satisfy
 type Client interface {
 	// Dial a server
-	Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error
+	Dial(tablet *topodatapb.Tablet) error
 
 	// Close the connection
 	Close()

--- a/go/vt/binlog/binlogplayertest/player.go
+++ b/go/vt/binlog/binlogplayertest/player.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
@@ -224,7 +223,7 @@ func (fake *FakeBinlogStreamer) HandlePanic(err *error) {
 
 // Run runs the test suite
 func Run(t *testing.T, bpc binlogplayer.Client, tablet *topodatapb.Tablet, fake *FakeBinlogStreamer) {
-	if err := bpc.Dial(tablet, 30*time.Second); err != nil {
+	if err := bpc.Dial(tablet); err != nil {
 		t.Fatalf("Dial failed: %v", err)
 	}
 

--- a/go/vt/binlog/grpcbinlogplayer/player.go
+++ b/go/vt/binlog/grpcbinlogplayer/player.go
@@ -17,8 +17,6 @@ limitations under the License.
 package grpcbinlogplayer
 
 import (
-	"time"
-
 	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
@@ -38,10 +36,10 @@ type client struct {
 	c  binlogservicepb.UpdateStreamClient
 }
 
-func (client *client) Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error {
+func (client *client) Dial(tablet *topodatapb.Tablet) error {
 	addr := netutil.JoinHostPort(tablet.Hostname, tablet.PortMap["grpc"])
 	var err error
-	client.cc, err = grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(connTimeout))
+	client.cc, err = grpcclient.Dial(addr, grpcclient.FailFast(false), grpc.WithInsecure())
 	if err != nil {
 		return err
 	}

--- a/go/vt/discovery/healthcheck_test.go
+++ b/go/vt/discovery/healthcheck_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/status"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
@@ -56,7 +57,7 @@ func TestHealthCheck(t *testing.T) {
 	createFakeConn(tablet, input)
 	t.Logf(`createFakeConn({Host: "a", PortMap: {"vt": 1}}, c)`)
 	l := newListener()
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, time.Hour).(*HealthCheckImpl)
+	hc := NewHealthCheck(1*time.Millisecond, time.Hour).(*HealthCheckImpl)
 	hc.SetListener(l, true)
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
@@ -237,7 +238,7 @@ func TestHealthCheckStreamError(t *testing.T) {
 	fc.errCh = make(chan error)
 	t.Logf(`createFakeConn({Host: "a", PortMap: {"vt": 1}}, c)`)
 	l := newListener()
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, time.Hour).(*HealthCheckImpl)
+	hc := NewHealthCheck(1*time.Millisecond, time.Hour).(*HealthCheckImpl)
 	hc.SetListener(l, true)
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
@@ -309,7 +310,7 @@ func TestHealthCheckVerifiesTabletAlias(t *testing.T) {
 	t.Logf(`createFakeConn({Host: "a", PortMap: {"vt": 1}}, c)`)
 
 	l := newListener()
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, time.Hour).(*HealthCheckImpl)
+	hc := NewHealthCheck(1*time.Millisecond, time.Hour).(*HealthCheckImpl)
 	hc.SetListener(l, false)
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
@@ -375,7 +376,7 @@ func TestHealthCheckCloseWaitsForGoRoutines(t *testing.T) {
 	t.Logf(`createFakeConn({Host: "a", PortMap: {"vt": 1}}, c)`)
 
 	l := newListener()
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, time.Hour).(*HealthCheckImpl)
+	hc := NewHealthCheck(1*time.Millisecond, time.Hour).(*HealthCheckImpl)
 	hc.SetListener(l, false)
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
@@ -470,7 +471,7 @@ func TestHealthCheckTimeout(t *testing.T) {
 	fc := createFakeConn(tablet, input)
 	t.Logf(`createFakeConn({Host: "a", PortMap: {"vt": 1}}, c)`)
 	l := newListener()
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, timeout).(*HealthCheckImpl)
+	hc := NewHealthCheck(1*time.Millisecond, timeout).(*HealthCheckImpl)
 	hc.SetListener(l, false)
 	hc.AddTablet(tablet, "")
 	t.Logf(`hc = HealthCheck(); hc.AddTablet({Host: "a", PortMap: {"vt": 1}}, "")`)
@@ -596,7 +597,7 @@ func createFakeConn(tablet *topodatapb.Tablet, c chan *querypb.StreamHealthRespo
 	return conn
 }
 
-func discoveryDialer(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+func discoveryDialer(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 	key := TabletToMapKey(tablet)
 	return connMap[key], nil
 }

--- a/go/vt/discovery/tablet_stats_cache_wait_test.go
+++ b/go/vt/discovery/tablet_stats_cache_wait_test.go
@@ -130,7 +130,7 @@ func TestWaitForTablets(t *testing.T) {
 	input := make(chan *querypb.StreamHealthResponse)
 	createFakeConn(tablet, input)
 
-	hc := NewHealthCheck(1*time.Millisecond, 1*time.Millisecond, 1*time.Hour)
+	hc := NewHealthCheck(1*time.Millisecond, 1*time.Hour)
 	tsc := NewTabletStatsCache(hc, "cell")
 	hc.AddTablet(tablet, "")
 

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -24,12 +24,18 @@ import (
 	"github.com/youtube/vitess/go/vt/vttls"
 )
 
+// FailFast is a self-documenting type for the grpc.FailFast.
+type FailFast bool
+
 // Dial creates a grpc connection to the given target.
-func Dial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+// failFast is a non-optional parameter because callers are required to specify
+// what that should be.
+func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	newopts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),
 			grpc.MaxCallSendMsgSize(*grpccommon.MaxMessageSize),
+			grpc.FailFast(bool(failFast)),
 		),
 	}
 	newopts = append(newopts, opts...)

--- a/go/vt/mysqlctl/grpcmysqlctlclient/client.go
+++ b/go/vt/mysqlctl/grpcmysqlctlclient/client.go
@@ -39,9 +39,9 @@ type client struct {
 	c  mysqlctlpb.MysqlCtlClient
 }
 
-func factory(network, addr string, dialTimeout time.Duration) (mysqlctlclient.MysqlctlClient, error) {
+func factory(network, addr string) (mysqlctlclient.MysqlctlClient, error) {
 	// create the RPC client
-	cc, err := grpcclient.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(dialTimeout), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), grpc.WithInsecure(), grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout(network, addr, timeout)
 	}))
 	if err != nil {

--- a/go/vt/mysqlctl/mysqlctlclient/interface.go
+++ b/go/vt/mysqlctl/mysqlctlclient/interface.go
@@ -21,14 +21,12 @@ package mysqlctlclient
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	log "github.com/golang/glog"
 	"golang.org/x/net/context"
 )
 
 var protocol = flag.String("mysqlctl_client_protocol", "grpc", "the protocol to use to talk to the mysqlctl server")
-var connectionTimeout = flag.Duration("mysqlctl_client_connection_timeout", 30*time.Second, "the connection timeout to use to talk to the mysqlctl server")
 
 // MysqlctlClient defines the interface used to send remote mysqlctl commands
 type MysqlctlClient interface {
@@ -49,7 +47,7 @@ type MysqlctlClient interface {
 }
 
 // Factory functions are registered by client implementations.
-type Factory func(network, addr string, dialTimeout time.Duration) (MysqlctlClient, error)
+type Factory func(network, addr string) (MysqlctlClient, error)
 
 var factories = make(map[string]Factory)
 
@@ -67,5 +65,5 @@ func New(network, addr string) (MysqlctlClient, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown mysqlctl client protocol: %v", *protocol)
 	}
-	return factory(network, addr, *connectionTimeout)
+	return factory(network, addr)
 }

--- a/go/vt/schemamanager/schemaswap/schema_swap.go
+++ b/go/vt/schemamanager/schemaswap/schema_swap.go
@@ -682,8 +682,7 @@ func (shardSwap *shardSchemaSwap) writeFinishedSwap() error {
 func (shardSwap *shardSchemaSwap) startHealthWatchers() error {
 	shardSwap.allTablets = make(map[string]*discovery.TabletStats)
 
-	shardSwap.tabletHealthCheck = discovery.NewHealthCheck(
-		*vtctl.HealthCheckTopologyRefresh, *vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout)
+	shardSwap.tabletHealthCheck = discovery.NewHealthCheck(*vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout)
 	shardSwap.tabletHealthCheck.SetListener(shardSwap, true /* sendDownEvents */)
 
 	topoServer := shardSwap.parent.topoServer

--- a/go/vt/throttler/demo/throttler_demo.go
+++ b/go/vt/throttler/demo/throttler_demo.go
@@ -226,7 +226,7 @@ func newClient(master *master, replica *replica) *client {
 		log.Fatal(err)
 	}
 
-	healthCheck := discovery.NewHealthCheck(1*time.Minute, 5*time.Second, 1*time.Minute)
+	healthCheck := discovery.NewHealthCheck(5*time.Second, 1*time.Minute)
 	c := &client{
 		master:      master,
 		healthCheck: healthCheck,

--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
@@ -47,7 +47,7 @@ func factory(addr string) (throttlerclient.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	conn, err := grpcclient.Dial(addr, opt)
+	conn, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vitessdriver/driver.go
+++ b/go/vt/vitessdriver/driver.go
@@ -167,9 +167,9 @@ type conn struct {
 func (c *conn) dial() error {
 	var err error
 	if c.Protocol == "" {
-		c.conn, err = vtgateconn.Dial(context.Background(), c.Address, c.Timeout)
+		c.conn, err = vtgateconn.Dial(context.Background(), c.Address)
 	} else {
-		c.conn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address, c.Timeout)
+		c.conn, err = vtgateconn.DialProtocol(context.Background(), c.Protocol, c.Address)
 	}
 	if err != nil {
 		return err

--- a/go/vt/vitessdriver/time.go
+++ b/go/vt/vitessdriver/time.go
@@ -74,15 +74,6 @@ func parseISOTime(tstr string, loc *time.Location, minLen, maxLen int) (t time.T
 	return time.ParseInLocation(isoTimeFormat[:tlen], tstr, loc)
 }
 
-func checkTimeFormat(t string) (err error) {
-	// Valid format string offsets for any ISO time from MySQL:
-	//  |DATETIME |10      |19+
-	//  |---------|--------|
-	// "2006-01-02 15:04:05.999999"
-	_, err = parseISOTime(t, time.UTC, 10, isoTimeLength)
-	return
-}
-
 // DatetimeToNative converts a Datetime Value into a time.Time
 func DatetimeToNative(v sqltypes.Value, loc *time.Location) (time.Time, error) {
 	// Valid format string offsets for a DATETIME

--- a/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
+++ b/go/vt/vtctl/fakevtctlclient/fakevtctlclient.go
@@ -38,7 +38,7 @@ func NewFakeVtctlClient() *FakeVtctlClient {
 }
 
 // FakeVtctlClientFactory always returns the current instance.
-func (f *FakeVtctlClient) FakeVtctlClientFactory(addr string, dialTimeout time.Duration) (vtctlclient.VtctlClient, error) {
+func (f *FakeVtctlClient) FakeVtctlClientFactory(addr string) (vtctlclient.VtctlClient, error) {
 	return f, nil
 }
 

--- a/go/vt/vtctl/grpcvtctlclient/client.go
+++ b/go/vt/vtctl/grpcvtctlclient/client.go
@@ -44,13 +44,13 @@ type gRPCVtctlClient struct {
 	c  vtctlservicepb.VtctlClient
 }
 
-func gRPCVtctlClientFactory(addr string, dialTimeout time.Duration) (vtctlclient.VtctlClient, error) {
+func gRPCVtctlClientFactory(addr string) (vtctlclient.VtctlClient, error) {
 	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
 	// create the RPC client
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtctl/grpcvtctlclient/client_test.go
+++ b/go/vt/vtctl/grpcvtctlclient/client_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/youtube/vitess/go/vt/vtctl/grpcvtctlserver"
 	"github.com/youtube/vitess/go/vt/vtctl/vtctlclienttest"
@@ -47,7 +46,7 @@ func TestVtctlServer(t *testing.T) {
 	go server.Serve(listener)
 
 	// Create a VtctlClient gRPC client to talk to the fake server
-	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port), 30*time.Second)
+	client, err := gRPCVtctlClientFactory(fmt.Sprintf("localhost:%v", port))
 	if err != nil {
 		t.Fatalf("Cannot create client: %v", err)
 	}

--- a/go/vt/vtctl/vtctlclient/interface.go
+++ b/go/vt/vtctl/vtctlclient/interface.go
@@ -42,7 +42,7 @@ type VtctlClient interface {
 }
 
 // Factory functions are registered by client implementations
-type Factory func(addr string, connectTimeout time.Duration) (VtctlClient, error)
+type Factory func(addr string) (VtctlClient, error)
 
 var factories = make(map[string]Factory)
 
@@ -66,10 +66,10 @@ func UnregisterFactoryForTest(name string) {
 }
 
 // New allows a user of the client library to get its implementation.
-func New(addr string, connectTimeout time.Duration) (VtctlClient, error) {
+func New(addr string) (VtctlClient, error) {
 	factory, ok := factories[*vtctlClientProtocol]
 	if !ok {
 		return nil, fmt.Errorf("unknown vtctl client protocol: %v", *vtctlClientProtocol)
 	}
-	return factory(addr, connectTimeout)
+	return factory(addr)
 }

--- a/go/vt/vtctl/vtctlclient/wrapper.go
+++ b/go/vt/vtctl/vtctlclient/wrapper.go
@@ -35,7 +35,7 @@ func RunCommandAndWait(ctx context.Context, server string, args []string, action
 		return errors.New("No function closure for Event stream specified")
 	}
 	// create the client
-	client, err := New(server, 30*time.Second /* dialTimeout */)
+	client, err := New(server)
 	if err != nil {
 		return fmt.Errorf("Cannot dial to server %v: %v", server, err)
 	}

--- a/go/vt/vtctld/realtime_status.go
+++ b/go/vt/vtctld/realtime_status.go
@@ -34,7 +34,7 @@ type realtimeStats struct {
 }
 
 func newRealtimeStats(ts *topo.Server) (*realtimeStats, error) {
-	hc := discovery.NewHealthCheck(*vtctl.HealthCheckTimeout, *vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout)
+	hc := discovery.NewHealthCheck(*vtctl.HealthcheckRetryDelay, *vtctl.HealthCheckTimeout)
 	tabletStatsCache := newTabletStatsCache()
 	// sendDownEvents is set to true here, as we want to receive
 	// Up=False events for a tablet.

--- a/go/vt/vtctld/tablet_data.go
+++ b/go/vt/vtctld/tablet_data.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/golang/glog"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletconn"
@@ -101,7 +102,7 @@ func (th *tabletHealth) stream(ctx context.Context, ts *topo.Server, tabletAlias
 		return err
 	}
 
-	conn, err := tabletconn.GetDialer()(ti.Tablet, 30*time.Second)
+	conn, err := tabletconn.GetDialer()(ti.Tablet, grpcclient.FailFast(true))
 	if err != nil {
 		return err
 	}

--- a/go/vt/vtgate/fakerpcvtgateconn/conn.go
+++ b/go/vt/vtgate/fakerpcvtgateconn/conn.go
@@ -27,7 +27,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
@@ -95,7 +94,7 @@ func RegisterFakeVTGateConnDialer() (*FakeVTGateConn, string) {
 		execMap:       make(map[string]*queryResponse),
 		splitQueryMap: make(map[string]*splitQueryResponse),
 	}
-	vtgateconn.RegisterDialer(protocol, func(ctx context.Context, address string, timeout time.Duration) (vtgateconn.Impl, error) {
+	vtgateconn.RegisterDialer(protocol, func(ctx context.Context, address string) (vtgateconn.Impl, error) {
 		return impl, nil
 	})
 	return impl, protocol

--- a/go/vt/vtgate/gateway/l2vtgategateway.go
+++ b/go/vt/vtgate/gateway/l2vtgategateway.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/youtube/vitess/go/flagutil"
 	"github.com/youtube/vitess/go/vt/discovery"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
@@ -128,7 +129,7 @@ func (lg *l2VTGateGateway) addL2VTGateConn(addr, keyspace, shard string) error {
 		// Dial in the background, as specified by timeout=0.
 		conn, err = tabletconn.GetDialer()(&topodatapb.Tablet{
 			Hostname: addr,
-		}, 0)
+		}, grpcclient.FailFast(true))
 		if err != nil {
 			return err
 		}

--- a/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
+++ b/go/vt/vtgate/gatewaytest/grpc_discovery_test.go
@@ -65,7 +65,7 @@ func TestGRPCDiscovery(t *testing.T) {
 
 	// VTGate: create the discovery healthcheck, and the gateway.
 	// Wait for the right tablets to be present.
-	hc := discovery.NewHealthCheck(30*time.Second, 10*time.Second, 2*time.Minute)
+	hc := discovery.NewHealthCheck(10*time.Second, 2*time.Minute)
 	dg := gateway.GetCreator()(hc, ts, ts, cell, 2)
 	hc.AddTablet(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{
@@ -116,7 +116,7 @@ func TestL2VTGateDiscovery(t *testing.T) {
 
 	// L2VTGate: Create the discovery healthcheck, and the gateway.
 	// Wait for the right tablets to be present.
-	hc := discovery.NewHealthCheck(30*time.Second, 10*time.Second, 2*time.Minute)
+	hc := discovery.NewHealthCheck(10*time.Second, 2*time.Minute)
 	l2vtgate := l2vtgate.Init(hc, ts, ts, "", cell, 2, nil)
 	hc.AddTablet(&topodatapb.Tablet{
 		Alias: &topodatapb.TabletAlias{

--- a/go/vt/vtgate/gatewaytest/suite.go
+++ b/go/vt/vtgate/gatewaytest/suite.go
@@ -26,10 +26,10 @@ package gatewaytest
 
 import (
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/memorytopo"
 	"github.com/youtube/vitess/go/vt/vtgate/gateway"
@@ -96,7 +96,7 @@ func TestSuite(t *testing.T, name string, g gateway.Gateway, f *tabletconntest.F
 
 	protocolName := "gateway-test-" + name
 
-	tabletconn.RegisterDialer(protocolName, func(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+	tabletconn.RegisterDialer(protocolName, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		return &gatewayAdapter{Gateway: g}, nil
 	})
 

--- a/go/vt/vtgate/grpcvtgateconn/conn.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn.go
@@ -20,7 +20,6 @@ package grpcvtgateconn
 import (
 	"flag"
 	"io"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -53,12 +52,12 @@ type vtgateConn struct {
 	c  vtgateservicepb.VitessClient
 }
 
-func dial(ctx context.Context, addr string, timeout time.Duration) (vtgateconn.Impl, error) {
+func dial(ctx context.Context, addr string) (vtgateconn.Impl, error) {
 	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(timeout))
+	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
+++ b/go/vt/vtgate/grpcvtgateconn/conn_rpc_test.go
@@ -19,7 +19,6 @@ package grpcvtgateconn
 import (
 	"net"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -46,7 +45,7 @@ func TestGRPCVTGateConn(t *testing.T) {
 
 	// Create a Go RPC client connecting to the server
 	ctx := context.Background()
-	client, err := dial(ctx, listener.Addr().String(), 30*time.Second)
+	client, err := dial(ctx, listener.Addr().String())
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}

--- a/go/vt/vtgate/vtgateconn/vtgateconn.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn.go
@@ -19,7 +19,6 @@ package vtgateconn
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -385,7 +384,7 @@ type Impl interface {
 
 // DialerFunc represents a function that will return an Impl
 // object that can communicate with a VTGate.
-type DialerFunc func(ctx context.Context, address string, timeout time.Duration) (Impl, error)
+type DialerFunc func(ctx context.Context, address string) (Impl, error)
 
 var dialers = make(map[string]DialerFunc)
 
@@ -399,12 +398,12 @@ func RegisterDialer(name string, dialer DialerFunc) {
 }
 
 // DialProtocol dials a specific protocol, and returns the *VTGateConn
-func DialProtocol(ctx context.Context, protocol string, address string, timeout time.Duration) (*VTGateConn, error) {
+func DialProtocol(ctx context.Context, protocol string, address string) (*VTGateConn, error) {
 	dialer, ok := dialers[protocol]
 	if !ok {
 		return nil, fmt.Errorf("no dialer registered for VTGate protocol %s", protocol)
 	}
-	impl, err := dialer(ctx, address, timeout)
+	impl, err := dialer(ctx, address)
 	if err != nil {
 		return nil, err
 	}
@@ -415,6 +414,6 @@ func DialProtocol(ctx context.Context, protocol string, address string, timeout 
 
 // Dial dials using the command-line specified protocol, and returns
 // the *VTGateConn.
-func Dial(ctx context.Context, address string, timeout time.Duration) (*VTGateConn, error) {
-	return DialProtocol(ctx, *VtgateProtocol, address, timeout)
+func Dial(ctx context.Context, address string) (*VTGateConn, error) {
+	return DialProtocol(ctx, *VtgateProtocol, address)
 }

--- a/go/vt/vtgate/vtgateconn/vtgateconn_test.go
+++ b/go/vt/vtgate/vtgateconn/vtgateconn_test.go
@@ -18,13 +18,12 @@ package vtgateconn
 
 import (
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 )
 
 func TestRegisterDialer(t *testing.T) {
-	dialerFunc := func(context.Context, string, time.Duration) (Impl, error) {
+	dialerFunc := func(context.Context, string) (Impl, error) {
 		return nil, nil
 	}
 	RegisterDialer("test1", dialerFunc)
@@ -33,14 +32,14 @@ func TestRegisterDialer(t *testing.T) {
 
 func TestGetDialerWithProtocol(t *testing.T) {
 	protocol := "test2"
-	c, err := DialProtocol(context.Background(), protocol, "", 0)
+	c, err := DialProtocol(context.Background(), protocol, "")
 	if err == nil || err.Error() != "no dialer registered for VTGate protocol "+protocol {
 		t.Fatalf("protocol: %s is not registered, should return error: %v", protocol, err)
 	}
-	RegisterDialer(protocol, func(context.Context, string, time.Duration) (Impl, error) {
+	RegisterDialer(protocol, func(context.Context, string) (Impl, error) {
 		return nil, nil
 	})
-	c, err = DialProtocol(context.Background(), protocol, "", 0)
+	c, err = DialProtocol(context.Background(), protocol, "")
 	if err != nil || c == nil {
 		t.Fatalf("dialerFunc has been registered, should not get nil: %v %v", err, c)
 	}

--- a/go/vt/vtgate/vtgateconntest/client.go
+++ b/go/vt/vtgate/vtgateconntest/client.go
@@ -25,7 +25,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
@@ -971,7 +970,7 @@ func CreateFakeServer(t *testing.T) vtgateservice.VTGateService {
 
 // RegisterTestDialProtocol registers a vtgateconn implementation under the "test" protocol
 func RegisterTestDialProtocol(impl vtgateconn.Impl) {
-	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string, timeout time.Duration) (vtgateconn.Impl, error) {
+	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string) (vtgateconn.Impl, error) {
 		return impl, nil
 	})
 }
@@ -987,10 +986,10 @@ func (f *fakeVTGateService) HandlePanic(err *error) {
 
 // TestSuite runs all the tests
 func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGateService) {
-	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string, timeout time.Duration) (vtgateconn.Impl, error) {
+	vtgateconn.RegisterDialer("test", func(ctx context.Context, address string) (vtgateconn.Impl, error) {
 		return impl, nil
 	})
-	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0)
+	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "")
 	if err != nil {
 		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
 	}
@@ -1050,7 +1049,7 @@ func TestSuite(t *testing.T, impl vtgateconn.Impl, fakeServer vtgateservice.VTGa
 
 // TestErrorSuite runs all the tests that expect errors
 func TestErrorSuite(t *testing.T, fakeServer vtgateservice.VTGateService) {
-	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "", 0)
+	conn, err := vtgateconn.DialProtocol(context.Background(), "test", "")
 	if err != nil {
 		t.Fatalf("Got err: %v from vtgateconn.DialProtocol", err)
 	}

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -54,7 +54,7 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
 	// Setup a fake vtgate server.
 	protocol := "resolveTest"
 	*vtgateconn.VtgateProtocol = protocol
-	vtgateconn.RegisterDialer(protocol, func(context.Context, string, time.Duration) (vtgateconn.Impl, error) {
+	vtgateconn.RegisterDialer(protocol, func(context.Context, string) (vtgateconn.Impl, error) {
 		return &txResolver{
 			FakeVTGateConn: fakerpcvtgateconn.FakeVTGateConn{},
 		}, nil

--- a/go/vt/vttablet/grpctabletconn/conn.go
+++ b/go/vt/vttablet/grpctabletconn/conn.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"io"
 	"sync"
-	"time"
 
 	"github.com/youtube/vitess/go/netutil"
 	"github.com/youtube/vitess/go/sqltypes"
@@ -61,7 +60,7 @@ type gRPCQueryClient struct {
 }
 
 // DialTablet creates and initializes gRPCQueryClient.
-func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+func DialTablet(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 	// create the RPC client
 	addr := ""
 	if grpcPort, ok := tablet.PortMap["grpc"]; ok {
@@ -73,11 +72,7 @@ func DialTablet(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.
 	if err != nil {
 		return nil, err
 	}
-	opts := []grpc.DialOption{opt}
-	if timeout > 0 {
-		opts = append(opts, grpc.WithTimeout(timeout))
-	}
-	cc, err := grpcclient.Dial(addr, opts...)
+	cc, err := grpcclient.Dial(addr, failFast, opt)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/grpctmclient/client.go
+++ b/go/vt/vttablet/grpctmclient/client.go
@@ -83,7 +83,7 @@ func (client *Client) dial(tablet *topodatapb.Tablet) (*grpc.ClientConn, tabletm
 	if err != nil {
 		return nil, nil, err
 	}
-	cc, err := grpcclient.Dial(addr, opt)
+	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -108,7 +108,7 @@ func (client *Client) dialPool(tablet *topodatapb.Tablet) (tabletmanagerservicep
 		client.mu.Unlock()
 
 		for i := 0; i < cap(c); i++ {
-			cc, err := grpcclient.Dial(addr, opt)
+			cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 			if err != nil {
 				return nil, err
 			}

--- a/go/vt/vttablet/tabletconn/tablet_conn.go
+++ b/go/vt/vttablet/tabletconn/tablet_conn.go
@@ -18,10 +18,10 @@ package tabletconn
 
 import (
 	"flag"
-	"time"
 
 	log "github.com/golang/glog"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 
@@ -51,7 +51,7 @@ var (
 // timeout represents the connection timeout. If set to 0, this
 // connection should be established in the background and the
 // TabletDialer should return right away.
-type TabletDialer func(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error)
+type TabletDialer func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error)
 
 var dialers = make(map[string]TabletDialer)
 

--- a/go/vt/vttablet/tabletconntest/tabletconntest.go
+++ b/go/vt/vttablet/tabletconntest/tabletconntest.go
@@ -22,13 +22,13 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/callerid"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/vterrors"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletconn"
@@ -1008,7 +1008,7 @@ func TestSuite(t *testing.T, protocol string, tablet *topodatapb.Tablet, fake *F
 	*tabletconn.TabletProtocol = protocol
 
 	// create a connection
-	conn, err := tabletconn.GetDialer()(tablet, 30*time.Second)
+	conn, err := tabletconn.GetDialer()(tablet, grpcclient.FailFast(false))
 	if err != nil {
 		t.Fatalf("dial failed: %v", err)
 	}

--- a/go/vt/vttablet/tabletmanager/binlog_players.go
+++ b/go/vt/vttablet/tabletmanager/binlog_players.go
@@ -117,7 +117,7 @@ type BinlogPlayerController struct {
 // Once stopped, you should call Close() to stop and free resources e.g. the
 // healthcheck instance.
 func newBinlogPlayerController(ts *topo.Server, vtClientFactory func() binlogplayer.VtClient, mysqld mysqlctl.MysqlDaemon, cell string, keyRange *topodatapb.KeyRange, sourceShard *topodatapb.Shard_SourceShard, dbName string) *BinlogPlayerController {
-	healthCheck := discovery.NewHealthCheck(*binlogplayer.BinlogPlayerConnTimeout, *healthcheckRetryDelay, *healthCheckTimeout)
+	healthCheck := discovery.NewHealthCheck(*healthcheckRetryDelay, *healthCheckTimeout)
 	return &BinlogPlayerController{
 		ts:                ts,
 		vtClientFactory:   vtClientFactory,

--- a/go/vt/vttablet/tabletmanager/binlog_players_test.go
+++ b/go/vt/vttablet/tabletmanager/binlog_players_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/binlog/binlogplayer"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/mysqlctl/tmutils"
@@ -82,7 +83,7 @@ func newFakeBinlogClient(t *testing.T, expectedDialUID uint32) *fakeBinlogClient
 }
 
 // Dial is part of the binlogplayer.Client interface
-func (fbc *fakeBinlogClient) Dial(tablet *topodatapb.Tablet, connTimeout time.Duration) error {
+func (fbc *fakeBinlogClient) Dial(tablet *topodatapb.Tablet) error {
 	if fbc.expectedDialUID != tablet.Alias.Uid {
 		fbc.t.Errorf("fakeBinlogClient.Dial expected uid %v got %v", fbc.expectedDialUID, tablet.Alias.Uid)
 	}
@@ -174,7 +175,7 @@ func createSourceTablet(t *testing.T, name string, ts *topo.Server, keyspace, sh
 
 	// register a tablet conn dialer that will return the instance
 	// we want
-	tabletconn.RegisterDialer(name, func(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+	tabletconn.RegisterDialer(name, func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		return &fakeTabletConn{
 			QueryService: fakes.ErrorQueryService,
 			tablet:       tablet,

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -291,7 +291,7 @@ func (te *TxEngine) startWatchdog() {
 			return
 		}
 
-		coordConn, err := vtgateconn.Dial(ctx, te.coordinatorAddress, te.abandonAge/4)
+		coordConn, err := vtgateconn.Dial(ctx, te.coordinatorAddress)
 		if err != nil {
 			tabletenv.InternalErrors.Add("WatchdogFail", 1)
 			log.Errorf("Error connecting to coordinator '%v': %v", te.coordinatorAddress, err)

--- a/go/vt/vttablet/tabletserver/tx_executor_test.go
+++ b/go/vt/vttablet/tabletserver/tx_executor_test.go
@@ -484,7 +484,7 @@ func TestExecutorResolveTransaction(t *testing.T) {
 	save, *vtgateconn.VtgateProtocol = *vtgateconn.VtgateProtocol, protocol
 	defer func() { *vtgateconn.VtgateProtocol = save }()
 
-	vtgateconn.RegisterDialer(protocol, func(context.Context, string, time.Duration) (vtgateconn.Impl, error) {
+	vtgateconn.RegisterDialer(protocol, func(context.Context, string) (vtgateconn.Impl, error) {
 		return &FakeVTGateConn{
 			FakeVTGateConn: fakerpcvtgateconn.FakeVTGateConn{},
 		}, nil

--- a/go/vt/vttest/local_cluster_old_test.go
+++ b/go/vt/vttest/local_cluster_old_test.go
@@ -94,7 +94,7 @@ func TestVitess(t *testing.T) {
 	}
 
 	proto := hdl.db.Env.DefaultProtocol()
-	conn, err := vtgateconn.DialProtocol(ctx, proto, vtgateAddr, 5*time.Second)
+	conn, err := vtgateconn.DialProtocol(ctx, proto, vtgateAddr)
 	if err != nil {
 		t.Error(err)
 		return

--- a/go/vt/worker/diff_utils.go
+++ b/go/vt/worker/diff_utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -64,7 +65,7 @@ func NewQueryResultReaderForTablet(ctx context.Context, ts *topo.Server, tabletA
 		return nil, err
 	}
 
-	conn, err := tabletconn.GetDialer()(tablet.Tablet, *remoteActionsTimeout)
+	conn, err := tabletconn.GetDialer()(tablet.Tablet, grpcclient.FailFast(false))
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
+++ b/go/vt/worker/fakevtworkerclient/fakevtworkerclient.go
@@ -18,8 +18,6 @@ limitations under the License.
 package fakevtworkerclient
 
 import (
-	"time"
-
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -41,7 +39,7 @@ func NewFakeVtworkerClient() *FakeVtworkerClient {
 
 // FakeVtworkerClientFactory returns the current instance and stores the
 // dialed server address in an outer struct.
-func (f *FakeVtworkerClient) FakeVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.Client, error) {
+func (f *FakeVtworkerClient) FakeVtworkerClientFactory(addr string) (vtworkerclient.Client, error) {
 	return &perAddrFakeVtworkerClient{f, addr}, nil
 }
 

--- a/go/vt/worker/grpcvtworkerclient/client.go
+++ b/go/vt/worker/grpcvtworkerclient/client.go
@@ -19,7 +19,6 @@ package grpcvtworkerclient
 
 import (
 	"flag"
-	"time"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -47,13 +46,13 @@ type gRPCVtworkerClient struct {
 	c  vtworkerservicepb.VtworkerClient
 }
 
-func gRPCVtworkerClientFactory(addr string, dialTimeout time.Duration) (vtworkerclient.Client, error) {
+func gRPCVtworkerClientFactory(addr string) (vtworkerclient.Client, error) {
 	// create the RPC client
 	opt, err := grpcclient.SecureDialOption(*cert, *key, *ca, *name)
 	if err != nil {
 		return nil, err
 	}
-	cc, err := grpcclient.Dial(addr, opt, grpc.WithTimeout(dialTimeout))
+	cc, err := grpcclient.Dial(addr, grpcclient.FailFast(false), opt)
 	if err != nil {
 		return nil, vterrors.Errorf(vtrpcpb.Code_DEADLINE_EXCEEDED, "grpcclient.Dial() err: %v", err)
 	}

--- a/go/vt/worker/grpcvtworkerclient/client_test.go
+++ b/go/vt/worker/grpcvtworkerclient/client_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/youtube/vitess/go/vt/worker/grpcvtworkerserver"
 	"github.com/youtube/vitess/go/vt/worker/vtworkerclienttest"
@@ -46,7 +45,7 @@ func TestVtworkerServer(t *testing.T) {
 	go server.Serve(listener)
 
 	// Create a VtworkerClient gRPC client to talk to the vtworker.
-	client, err := gRPCVtworkerClientFactory(fmt.Sprintf("localhost:%v", port), 30*time.Second)
+	client, err := gRPCVtworkerClientFactory(fmt.Sprintf("localhost:%v", port))
 	if err != nil {
 		t.Fatalf("Cannot create client: %v", err)
 	}

--- a/go/vt/worker/legacy_split_clone.go
+++ b/go/vt/worker/legacy_split_clone.go
@@ -373,7 +373,7 @@ func (scw *LegacySplitCloneWorker) findTargets(ctx context.Context) error {
 	}
 
 	// Initialize healthcheck and add destination shards to it.
-	scw.healthCheck = discovery.NewHealthCheck(*remoteActionsTimeout, *healthcheckRetryDelay, *healthCheckTimeout)
+	scw.healthCheck = discovery.NewHealthCheck(*healthcheckRetryDelay, *healthCheckTimeout)
 	scw.tsc = discovery.NewTabletStatsCache(scw.healthCheck, scw.cell)
 	for _, si := range scw.destinationShards {
 		watcher := discovery.NewShardReplicationWatcher(scw.wr.TopoServer(), scw.healthCheck,

--- a/go/vt/worker/restartable_result_reader.go
+++ b/go/vt/worker/restartable_result_reader.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
@@ -111,7 +112,7 @@ func (r *RestartableResultReader) getTablet() (bool, error) {
 	}
 
 	// Connect (dial) to the tablet.
-	conn, err := tabletconn.GetDialer()(tablet, *remoteActionsTimeout)
+	conn, err := tabletconn.GetDialer()(tablet, grpcclient.FailFast(false))
 	if err != nil {
 		return false /* retryable */, fmt.Errorf("failed to get dialer for tablet: %v", err)
 	}

--- a/go/vt/worker/restartable_result_reader_test.go
+++ b/go/vt/worker/restartable_result_reader_test.go
@@ -22,11 +22,11 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/logutil"
 	"github.com/youtube/vitess/go/vt/topo/memorytopo"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
@@ -184,7 +184,7 @@ func TestGenerateQuery(t *testing.T) {
 func TestNewRestartableResultReader(t *testing.T) {
 	wantErr := errors.New("restartable_result_reader_test.go: context canceled")
 
-	tabletconn.RegisterDialer("fake_dialer", func(tablet *topodatapb.Tablet, timeout time.Duration) (queryservice.QueryService, error) {
+	tabletconn.RegisterDialer("fake_dialer", func(tablet *topodatapb.Tablet, failFast grpcclient.FailFast) (queryservice.QueryService, error) {
 		return nil, wantErr
 	})
 	protocol := flag.CommandLine.Lookup("tablet_protocol").Value.String()

--- a/go/vt/worker/split_clone.go
+++ b/go/vt/worker/split_clone.go
@@ -554,7 +554,7 @@ func (scw *SplitCloneWorker) init(ctx context.Context) error {
 	}
 
 	// Initialize healthcheck and add destination shards to it.
-	scw.healthCheck = discovery.NewHealthCheck(*remoteActionsTimeout, *healthcheckRetryDelay, *healthCheckTimeout)
+	scw.healthCheck = discovery.NewHealthCheck(*healthcheckRetryDelay, *healthCheckTimeout)
 	scw.tsc = discovery.NewTabletStatsCacheDoNotSetListener(scw.cell)
 	// We set sendDownEvents=true because it's required by TabletStatsCache.
 	scw.healthCheck.SetListener(scw, true /* sendDownEvents */)

--- a/go/vt/worker/topo_utils.go
+++ b/go/vt/worker/topo_utils.go
@@ -49,7 +49,7 @@ var (
 func FindHealthyRdonlyTablet(ctx context.Context, wr *wrangler.Wrangler, tsc *discovery.TabletStatsCache, cell, keyspace, shard string, minHealthyRdonlyTablets int) (*topodatapb.TabletAlias, error) {
 	if tsc == nil {
 		// No healthcheck instance provided. Create one.
-		healthCheck := discovery.NewHealthCheck(*remoteActionsTimeout, *healthcheckRetryDelay, *healthCheckTimeout)
+		healthCheck := discovery.NewHealthCheck(*healthcheckRetryDelay, *healthCheckTimeout)
 		tsc = discovery.NewTabletStatsCache(healthCheck, cell)
 		watcher := discovery.NewShardReplicationWatcher(wr.TopoServer(), healthCheck, cell, keyspace, shard, *healthCheckTopologyRefresh, discovery.DefaultTopoReadConcurrency)
 		defer watcher.Stop()

--- a/go/vt/worker/vtworkerclient/interface.go
+++ b/go/vt/worker/vtworkerclient/interface.go
@@ -20,7 +20,6 @@ package vtworkerclient
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/vt/logutil"
@@ -41,7 +40,7 @@ type Client interface {
 }
 
 // Factory functions are registered by client implementations.
-type Factory func(addr string, connectTimeout time.Duration) (Client, error)
+type Factory func(addr string) (Client, error)
 
 var factories = make(map[string]Factory)
 
@@ -65,10 +64,10 @@ func UnregisterFactoryForTest(name string) {
 }
 
 // New allows a user of the client library to get its implementation.
-func New(addr string, connectTimeout time.Duration) (Client, error) {
+func New(addr string) (Client, error) {
 	factory, ok := factories[*protocol]
 	if !ok {
 		return nil, fmt.Errorf("unknown vtworker client protocol: %v", *protocol)
 	}
-	return factory(addr, connectTimeout)
+	return factory(addr)
 }

--- a/go/vt/worker/vtworkerclient/wrapper.go
+++ b/go/vt/worker/vtworkerclient/wrapper.go
@@ -18,7 +18,6 @@ package vtworkerclient
 
 import (
 	"io"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -35,7 +34,7 @@ func RunCommandAndWait(ctx context.Context, server string, args []string, recv f
 		panic("no function closure for Event stream specified")
 	}
 	// create the client
-	client, err := New(server, 30*time.Second /* dialTimeout */)
+	client, err := New(server)
 	if err != nil {
 		return vterrors.Wrapf(err, "cannot dial to server %v", server)
 	}

--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -505,7 +505,7 @@ func (wr *Wrangler) waitForDrainInCell(ctx context.Context, cell, keyspace, shar
 	retryDelay, healthCheckTopologyRefresh, healthcheckRetryDelay, healthCheckTimeout, initialWait time.Duration) error {
 
 	// Create the healthheck module, with a cache.
-	hc := discovery.NewHealthCheck(healthCheckTimeout /* connectTimeout */, healthcheckRetryDelay, healthCheckTimeout)
+	hc := discovery.NewHealthCheck(healthcheckRetryDelay, healthCheckTimeout)
 	defer hc.Close()
 	tsc := discovery.NewTabletStatsCache(hc, cell)
 
@@ -708,11 +708,7 @@ func (wr *Wrangler) replicaMigrateServedFrom(ctx context.Context, ki *topo.Keysp
 	// Now refresh the source servers so they reload their
 	// blacklisted table list
 	event.DispatchUpdate(ev, "refreshing sources tablets state so they update their blacklisted tables")
-	if err := wr.RefreshTabletsByShard(ctx, sourceShard, []topodatapb.TabletType{servedType}, cells); err != nil {
-		return err
-	}
-
-	return nil
+	return wr.RefreshTabletsByShard(ctx, sourceShard, []topodatapb.TabletType{servedType}, cells)
 }
 
 // masterMigrateServedFrom handles the master migration. The ordering is
@@ -789,11 +785,7 @@ func (wr *Wrangler) masterMigrateServedFrom(ctx context.Context, ki *topo.Keyspa
 	// Invoking a remote action will also make the tablet stop filtered
 	// replication.
 	event.DispatchUpdate(ev, "setting destination shard masters read-write")
-	if err := wr.refreshMasters(ctx, []*topo.ShardInfo{destinationShard}); err != nil {
-		return err
-	}
-
-	return nil
+	return wr.refreshMasters(ctx, []*topo.ShardInfo{destinationShard})
 }
 
 // SetKeyspaceServedFrom locks a keyspace and changes its ServerFromMap

--- a/go/vt/wrangler/split.go
+++ b/go/vt/wrangler/split.go
@@ -23,6 +23,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletconn"
@@ -101,7 +102,7 @@ func (wr *Wrangler) WaitForFilteredReplication(ctx context.Context, keyspace, sh
 		return fmt.Errorf("failed to run explicit healthcheck on tablet: %v err: %v", tabletInfo, err)
 	}
 
-	conn, err := tabletconn.GetDialer()(tabletInfo.Tablet, 30*time.Second)
+	conn, err := tabletconn.GetDialer()(tabletInfo.Tablet, grpcclient.FailFast(false))
 	if err != nil {
 		return fmt.Errorf("cannot connect to tablet %v: %v", alias, err)
 	}

--- a/go/vt/wrangler/testlib/vtctl_pipe.go
+++ b/go/vt/wrangler/testlib/vtctl_pipe.go
@@ -74,7 +74,7 @@ func NewVtctlPipe(t *testing.T, ts *topo.Server) *VtctlPipe {
 	go server.Serve(listener)
 
 	// Create a VtctlClient gRPC client to talk to the fake server
-	client, err := vtctlclient.New(listener.Addr().String(), 30*time.Second)
+	client, err := vtctlclient.New(listener.Addr().String())
 	if err != nil {
 		t.Fatalf("Cannot create client: %v", err)
 	}

--- a/test/utils.py
+++ b/test/utils.py
@@ -554,7 +554,6 @@ class VtGate(object):
 
   def start(self, cell='test_nj', retry_count=2,
             topo_impl=None, cache_ttl='1s',
-            healthcheck_conn_timeout='2s',
             extra_args=None, tablets=None,
             tablet_types_to_wait='MASTER,REPLICA',
             l2vtgates=None):
@@ -577,7 +576,6 @@ class VtGate(object):
       ])
     else:
       args.extend([
-          '-healthcheck_conn_timeout', healthcheck_conn_timeout,
           '-gateway_implementation', vtgate_gateway_flavor().flavor(),
       ])
       args.extend(vtgate_gateway_flavor().flags(cell=cell, tablets=tablets))
@@ -798,7 +796,6 @@ class L2VtGate(object):
 
   def start(self, cell='test_nj', retry_count=2,
             topo_impl=None, cache_ttl='1s',
-            healthcheck_conn_timeout='2s',
             extra_args=None, tablets=None,
             tablet_types_to_wait='MASTER,REPLICA',
             tablet_filters=None):
@@ -810,7 +807,6 @@ class L2VtGate(object):
         '-retry-count', str(retry_count),
         '-log_dir', environment.vtlogroot,
         '-srv_topo_cache_ttl', cache_ttl,
-        '-healthcheck_conn_timeout', healthcheck_conn_timeout,
         '-tablet_protocol', protocols_flavor().tabletconn_protocol(),
         '-gateway_implementation', vtgate_gateway_flavor().flavor(),
     ]


### PR DESCRIPTION
Issues #3401, #3412
Now that we always dial asynchronously, we have to make sure that
requests don't fail fast. Otherwise, we sometimes see errors if
request is made immediately after dialing; Because the connection
is not ready yet.

Consequently, dial timeouts are obsolete. So, I've removed all
usage of it.