### PR TITLE
vtgate: autocommit like MySQL

### DIFF
--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -64,7 +64,7 @@ func initVtgateExecutor(vSchemaStr string, opts *Options) error {
 
 	streamSize := 10
 	queryPlanCacheSize := int64(10)
-	vtgateExecutor = vtgate.NewExecutor(context.Background(), explainTopo, vtexplainCell, "", resolver, opts.Normalize, streamSize, queryPlanCacheSize)
+	vtgateExecutor = vtgate.NewExecutor(context.Background(), explainTopo, vtexplainCell, "", resolver, opts.Normalize, streamSize, queryPlanCacheSize, false /* legacyAutocommit */)
 
 	return nil
 }

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1000,8 +1000,8 @@ func TestInsertFail(t *testing.T) {
 	sbclookup.SetResults([]*sqltypes.Result{{}})
 	_, err = executorExec(executor, "insert into music_extra_reversed(music_id, user_id) values (1, 1)", nil)
 	want = "execInsertSharded: getInsertShardedRoute: could not map INT64(1) to a keyspace id"
-	if err == nil || err.Error() != want {
-		t.Errorf("paramsSelectEqual: executorExec: %v, want %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("paramsSelectEqual: executorExec: %v, must contain %v", err, want)
 	}
 
 	getSandbox("TestExecutor").SrvKeyspaceMustFail = 1
@@ -1014,8 +1014,8 @@ func TestInsertFail(t *testing.T) {
 	getSandbox("TestExecutor").ShardSpec = "80-"
 	_, err = executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
 	want = "execInsertSharded: getInsertShardedRoute: KeyspaceId 166b40b44aba4bd6 didn't match any shards"
-	if err == nil || !strings.HasPrefix(err.Error(), want) {
-		t.Errorf("executorExec: %v, want prefix %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("executorExec: %v, must contain %v", err, want)
 	}
 	getSandbox("TestExecutor").ShardSpec = DefaultShardSpec
 
@@ -1041,21 +1041,21 @@ func TestInsertFail(t *testing.T) {
 
 	_, err = executorExec(executor, "insert into music_extra_reversed(music_id, user_id) values (1, 'aa')", nil)
 	want = `execInsertSharded: getInsertShardedRoute: hash.Verify: could not parse value: aa`
-	if err == nil || err.Error() != want {
-		t.Errorf("executorExec: %v, want %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("executorExec: %v, must contain %v", err, want)
 	}
 
 	_, err = executorExec(executor, "insert into music_extra_reversed(music_id, user_id) values (1, 3)", nil)
 	want = "execInsertSharded: getInsertShardedRoute: values [INT64(3)] for column user_id does not map to keyspaceids"
-	if err == nil || err.Error() != want {
-		t.Errorf("executorExec: %v, want %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("executorExec: %v, must contain %v", err, want)
 	}
 
 	sbc.MustFailCodes[vtrpcpb.Code_INVALID_ARGUMENT] = 1
 	_, err = executorExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')", nil)
 	want = "execInsertSharded: target: TestExecutor.-20.master"
-	if err == nil || !strings.HasPrefix(err.Error(), want) {
-		t.Errorf("executorExec: %v, want prefix %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("executorExec: %v, must contain %v", err, want)
 	}
 
 	_, err = executorExec(executor, "insert into noauto_table(id) values (null)", nil)

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -231,7 +231,7 @@ func createExecutorEnv() (executor *Executor, sbc1, sbc2, sbclookup *sandboxconn
 
 	getSandbox(KsTestUnsharded).VSchema = unshardedVSchema
 
-	executor = NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor = NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 	return executor, sbc1, sbc2, sbclookup
 }
 

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -613,8 +613,8 @@ func TestSelectEqualFail(t *testing.T) {
 	s.ShardSpec = "80-"
 	_, err = executorExec(executor, "select id from user where name = 'foo'", nil)
 	want = "paramsSelectEqual: KeyspaceId 166b40b44aba4bd6 didn't match any shards"
-	if err == nil || !strings.HasPrefix(err.Error(), want) {
-		t.Errorf("executorExec: %v, want prefix %v", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("executorExec: %v, must contain %v", err, want)
 	}
 	s.ShardSpec = DefaultShardSpec
 }
@@ -820,7 +820,7 @@ func TestSelectScatter(t *testing.T) {
 		sbc := hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_MASTER, true, 1, nil)
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	_, err := executorExec(executor, "select id from user", nil)
 	if err != nil {
@@ -852,7 +852,7 @@ func TestStreamSelectScatter(t *testing.T) {
 		sbc := hc.AddTestTablet(cell, shard, 1, "TestExecutor", shard, topodatapb.TabletType_MASTER, true, 1, nil)
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	sql := "select id from user"
 	result, err := executorStream(executor, sql)
@@ -893,7 +893,7 @@ func TestSelectScatterFail(t *testing.T) {
 	}
 	serv := new(sandboxTopo)
 	resolver := newTestResolver(hc, serv, cell)
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	_, err := executorExec(executor, "select id from user", nil)
 	want := "paramsAllShards: keyspace TestExecutor fetch error: topo error GetSrvKeyspace"
@@ -933,7 +933,7 @@ func TestSelectScatterOrderBy(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select col1, col2 from user order by col2 desc"
 	gotResult, err := executorExec(executor, query, nil)
@@ -1001,7 +1001,7 @@ func TestStreamSelectScatterOrderBy(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select id, col from user order by col desc"
 	gotResult, err := executorStream(executor, query)
@@ -1064,12 +1064,12 @@ func TestSelectScatterOrderByFail(t *testing.T) {
 			}},
 		}})
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	_, err := executorExec(executor, "select id, col from user order by col asc", nil)
 	want := "types are not comparable: VARCHAR vs VARCHAR"
-	if err == nil || err.Error() != want {
-		t.Errorf("scatter order by error: %v, want %s", err, want)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("scatter order by error: %v, must contain %s", err, want)
 	}
 }
 
@@ -1101,7 +1101,7 @@ func TestSelectScatterAggregate(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select col, sum(foo) from user group by col"
 	gotResult, err := executorExec(executor, query, nil)
@@ -1166,7 +1166,7 @@ func TestStreamSelectScatterAggregate(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select col, sum(foo) from user group by col"
 	gotResult, err := executorStream(executor, query)
@@ -1231,7 +1231,7 @@ func TestSelectScatterLimit(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select col1, col2 from user order by col2 desc limit 3"
 	gotResult, err := executorExec(executor, query, nil)
@@ -1305,7 +1305,7 @@ func TestStreamSelectScatterLimit(t *testing.T) {
 		}})
 		conns = append(conns, sbc)
 	}
-	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize)
+	executor := NewExecutor(context.Background(), serv, cell, "", resolver, false, testBufferSize, testCacheSize, false)
 
 	query := "select col1, col2 from user order by col2 desc limit 3"
 	gotResult, err := executorStream(executor, query)

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -190,10 +190,10 @@ func TestExecutorSet(t *testing.T) {
 		err: "unexpected value for autocommit: 2",
 	}, {
 		in:  "set client_found_rows=1",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{ClientFoundRows: true}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{ClientFoundRows: true}},
 	}, {
 		in:  "set client_found_rows=0",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{}},
 	}, {
 		in:  "set client_found_rows='aa'",
 		err: "unexpected value type for client_found_rows: string",
@@ -202,16 +202,16 @@ func TestExecutorSet(t *testing.T) {
 		err: "unexpected value for client_found_rows: 2",
 	}, {
 		in:  "set transaction_mode = 'unspecified'",
-		out: &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_UNSPECIFIED},
+		out: &vtgatepb.Session{Autocommit: true, TransactionMode: vtgatepb.TransactionMode_UNSPECIFIED},
 	}, {
 		in:  "set transaction_mode = 'single'",
-		out: &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_SINGLE},
+		out: &vtgatepb.Session{Autocommit: true, TransactionMode: vtgatepb.TransactionMode_SINGLE},
 	}, {
 		in:  "set transaction_mode = 'multi'",
-		out: &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_MULTI},
+		out: &vtgatepb.Session{Autocommit: true, TransactionMode: vtgatepb.TransactionMode_MULTI},
 	}, {
 		in:  "set transaction_mode = 'twopc'",
-		out: &vtgatepb.Session{TransactionMode: vtgatepb.TransactionMode_TWOPC},
+		out: &vtgatepb.Session{Autocommit: true, TransactionMode: vtgatepb.TransactionMode_TWOPC},
 	}, {
 		in:  "set transaction_mode = 'aa'",
 		err: "invalid transaction_mode: aa",
@@ -220,16 +220,16 @@ func TestExecutorSet(t *testing.T) {
 		err: "unexpected value type for transaction_mode: int64",
 	}, {
 		in:  "set workload = 'unspecified'",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_UNSPECIFIED}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_UNSPECIFIED}},
 	}, {
 		in:  "set workload = 'oltp'",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_OLTP}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_OLTP}},
 	}, {
 		in:  "set workload = 'olap'",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_OLAP}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_OLAP}},
 	}, {
 		in:  "set workload = 'dba'",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_DBA}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{Workload: querypb.ExecuteOptions_DBA}},
 	}, {
 		in:  "set workload = 'aa'",
 		err: "invalid workload: aa",
@@ -241,10 +241,10 @@ func TestExecutorSet(t *testing.T) {
 		out: &vtgatepb.Session{Autocommit: true, TransactionMode: vtgatepb.TransactionMode_TWOPC},
 	}, {
 		in:  "set sql_select_limit = 5",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{SqlSelectLimit: 5}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{SqlSelectLimit: 5}},
 	}, {
 		in:  "set sql_select_limit = DEFAULT",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{SqlSelectLimit: 0}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{SqlSelectLimit: 0}},
 	}, {
 		in:  "set sql_select_limit = 'asdfasfd'",
 		err: "unexpected string value for sql_select_limit: asdfasfd",
@@ -253,7 +253,7 @@ func TestExecutorSet(t *testing.T) {
 		err: "invalid syntax: 1 + 1",
 	}, {
 		in:  "set character_set_results=null",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set character_set_results='abcd'",
 		err: "disallowed value for character_set_results: abcd",
@@ -262,34 +262,34 @@ func TestExecutorSet(t *testing.T) {
 		err: "unsupported construct: set foo=1",
 	}, {
 		in:  "set names utf8",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set names ascii",
 		err: "unexpected value for charset: ascii",
 	}, {
 		in:  "set charset utf8",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set character set default",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set character set ascii",
 		err: "unexpected value for charset: ascii",
 	}, {
 		in:  "set net_write_timeout = 600",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set net_read_timeout = 600",
-		out: &vtgatepb.Session{},
+		out: &vtgatepb.Session{Autocommit: true},
 	}, {
 		in:  "set skip_query_plan_cache = 1",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{SkipQueryPlanCache: true}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{SkipQueryPlanCache: true}},
 	}, {
 		in:  "set skip_query_plan_cache = 0",
-		out: &vtgatepb.Session{Options: &querypb.ExecuteOptions{}},
+		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{}},
 	}}
 	for _, tcase := range testcases {
-		session := &vtgatepb.Session{}
+		session := &vtgatepb.Session{Autocommit: true}
 		_, err := executor.Execute(context.Background(), session, tcase.in, nil)
 		if err != nil {
 			if err.Error() != tcase.err {
@@ -308,13 +308,16 @@ func TestExecutorAutocommit(t *testing.T) {
 	session := &vtgatepb.Session{TargetString: "@master"}
 
 	// autocommit = 0
+	startCount := sbclookup.CommitCount.Get()
 	_, err := executor.Execute(context.Background(), session, "select id from main1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantSession := &vtgatepb.Session{TargetString: "@master"}
-	if !proto.Equal(session, wantSession) {
-		t.Errorf("autocommit=0: %v, want %v", session, wantSession)
+	wantSession := &vtgatepb.Session{TargetString: "@master", InTransaction: true}
+	testSession := *session
+	testSession.ShardSessions = nil
+	if !proto.Equal(&testSession, wantSession) {
+		t.Errorf("autocommit=0: %v, want %v", testSession, wantSession)
 	}
 
 	// autocommit = 1
@@ -322,6 +325,12 @@ func TestExecutorAutocommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Setting autocommit=1 commits existing transaction.
+	if got, want := sbclookup.CommitCount.Get(), startCount+1; got != want {
+		t.Errorf("Commit count: %d, want %d", got, want)
+	}
+
+	startCount = sbclookup.CommitCount.Get()
 	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -330,12 +339,12 @@ func TestExecutorAutocommit(t *testing.T) {
 	if !proto.Equal(session, wantSession) {
 		t.Errorf("autocommit=1: %v, want %v", session, wantSession)
 	}
-	if commitCount := sbclookup.CommitCount.Get(); commitCount != 1 {
-		t.Errorf("want 1, got %d", commitCount)
+	if got, want := sbclookup.CommitCount.Get(), startCount+1; got != want {
+		t.Errorf("Commit count: %d, want %d", got, want)
 	}
 
 	// autocommit = 1, "begin"
-	startCount := sbclookup.CommitCount.Get()
+	startCount = sbclookup.CommitCount.Get()
 	_, err = executor.Execute(context.Background(), session, "begin", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -345,7 +354,7 @@ func TestExecutorAutocommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantSession = &vtgatepb.Session{InTransaction: true, Autocommit: true, TargetString: "@master"}
-	testSession := *session
+	testSession = *session
 	testSession.ShardSessions = nil
 	if !proto.Equal(&testSession, wantSession) {
 		t.Errorf("autocommit=1: %v, want %v", &testSession, wantSession)
@@ -389,6 +398,32 @@ func TestExecutorAutocommit(t *testing.T) {
 	}
 	if got, want := sbclookup.CommitCount.Get(), startCount+1; got != want {
 		t.Errorf("Commit count: %d, want %d", got, want)
+	}
+}
+
+func TestExecutorLegacyAutocommit(t *testing.T) {
+	executor, _, _, sbclookup := createExecutorEnv()
+	session := &vtgatepb.Session{TargetString: "@master", Autocommit: false}
+
+	// If legacy is on, there should be no implicit transaction.
+	executor.legacyAutocommit = true
+	startCount := sbclookup.BeginCount.Get()
+	_, err := executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := sbclookup.BeginCount.Get(), startCount; got != want {
+		t.Errorf("Begin count: %d, want %d", got, want)
+	}
+
+	// If legacy is off, there should be an implicit begin.
+	executor.legacyAutocommit = false
+	_, err = executor.Execute(context.Background(), session, "update main1 set id=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := sbclookup.BeginCount.Get(), startCount+1; got != want {
+		t.Errorf("Begin count: %d, want %d", got, want)
 	}
 }
 
@@ -499,7 +534,7 @@ func TestExecutorShow(t *testing.T) {
 
 func TestExecutorUse(t *testing.T) {
 	executor, _, _, _ := createExecutorEnv()
-	session := &vtgatepb.Session{TargetString: "@master"}
+	session := &vtgatepb.Session{Autocommit: true, TargetString: "@master"}
 
 	stmts := []string{
 		"use db",
@@ -514,7 +549,7 @@ func TestExecutorUse(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		wantSession := &vtgatepb.Session{TargetString: want[i]}
+		wantSession := &vtgatepb.Session{Autocommit: true, TargetString: want[i]}
 		if !proto.Equal(session, wantSession) {
 			t.Errorf("%s: %v, want %v", stmt, session, wantSession)
 		}

--- a/go/vt/vtgate/grpcvtgateservice/server.go
+++ b/go/vt/vtgate/grpcvtgateservice/server.go
@@ -105,7 +105,7 @@ func (vtg *VTGate) Execute(ctx context.Context, request *vtgatepb.ExecuteRequest
 	// Handle backward compatibility.
 	session := request.Session
 	if session == nil {
-		session = &vtgatepb.Session{}
+		session = &vtgatepb.Session{Autocommit: true}
 	}
 	if session.TargetString == "" && request.TabletType != topodatapb.TabletType_UNKNOWN {
 		session.TargetString = request.KeyspaceShard + "@" + topoproto.TabletTypeLString(request.TabletType)
@@ -135,7 +135,7 @@ func (vtg *VTGate) ExecuteBatch(ctx context.Context, request *vtgatepb.ExecuteBa
 	// Handle backward compatibility.
 	session := request.Session
 	if session == nil {
-		session = &vtgatepb.Session{}
+		session = &vtgatepb.Session{Autocommit: true}
 	}
 	if session.TargetString == "" {
 		session.TargetString = request.KeyspaceShard + "@" + topoproto.TabletTypeLString(request.TabletType)
@@ -159,7 +159,7 @@ func (vtg *VTGate) StreamExecute(request *vtgatepb.StreamExecuteRequest, stream 
 	// Handle backward compatibility.
 	session := request.Session
 	if session == nil {
-		session = &vtgatepb.Session{}
+		session = &vtgatepb.Session{Autocommit: true}
 	}
 	if session.TargetString == "" {
 		session.TargetString = request.KeyspaceShard + "@" + topoproto.TabletTypeLString(request.TabletType)

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -56,6 +56,7 @@ var (
 	normalizeQueries   = flag.Bool("normalize_queries", true, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
 	streamBufferSize   = flag.Int("stream_buffer_size", 32*1024, "the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size.")
 	queryPlanCacheSize = flag.Int64("gate_query_cache_size", 10000, "gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache.")
+	legacyAutocommit   = flag.Bool("legacy_autocommit", false, "DEPRECATED: set this flag to true to get the legacy behavior: all transactions will need an explicit begin, and DMLs outside transactions will return an error.")
 )
 
 func getTxMode() vtgatepb.TransactionMode {
@@ -161,7 +162,7 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server
 	resolver := NewResolver(serv, cell, sc)
 
 	rpcVTGate = &VTGate{
-		executor:     NewExecutor(ctx, serv, cell, "VTGateExecutor", resolver, *normalizeQueries, *streamBufferSize, *queryPlanCacheSize),
+		executor:     NewExecutor(ctx, serv, cell, "VTGateExecutor", resolver, *normalizeQueries, *streamBufferSize, *queryPlanCacheSize, *legacyAutocommit),
 		resolver:     resolver,
 		txConn:       tc,
 		timings:      stats.NewMultiTimings("VtgateApi", []string{"Operation", "Keyspace", "DbType"}),

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -222,6 +222,7 @@ func TestVTGateExecute(t *testing.T) {
 	_, qr, err := rpcVTGate.Execute(
 		context.Background(),
 		&vtgatepb.Session{
+			Autocommit:   true,
 			TargetString: "@master",
 			Options:      executeOptions,
 		},
@@ -689,9 +690,18 @@ func TestVTGateExecuteEntityIds(t *testing.T) {
 }
 
 func TestVTGateExecuteBatch(t *testing.T) {
+	// TODO(sougou): using masterSession as global has some bugs
+	// which requires us to reset it here. This needs to be fixed.
+	masterSession = &vtgatepb.Session{
+		TargetString: "@master",
+	}
+
 	createSandbox(KsTestUnsharded)
 	hcVTGateTest.Reset()
 	sbc := hcVTGateTest.AddTestTablet("aa", "1.1.1.1", 1001, KsTestUnsharded, "0", topodatapb.TabletType_MASTER, true, 1, nil)
+
+	startCommit := sbc.CommitCount.Get()
+	startRollback := sbc.RollbackCount.Get()
 
 	sqlList := []string{
 		"begin",
@@ -722,11 +732,11 @@ func TestVTGateExecuteBatch(t *testing.T) {
 	if len(session.ShardSessions) != 1 {
 		t.Errorf("want 1, got %d", len(session.ShardSessions))
 	}
-	if commitCount := sbc.CommitCount.Get(); commitCount != 2 {
-		t.Errorf("want 2, got %d", commitCount)
+	if got, want := sbc.CommitCount.Get(), startCommit+3; got != want {
+		t.Errorf("got %d, want %d", got, want)
 	}
-	if rollbackCount := sbc.RollbackCount.Get(); rollbackCount != 1 {
-		t.Errorf("want 1, got %d", rollbackCount)
+	if got, want := sbc.RollbackCount.Get(), startRollback+2; got != want {
+		t.Errorf("got %d, want %d", got, want)
 	}
 }
 

--- a/java/client/src/test/java/io/vitess/client/RpcClientTest.java
+++ b/java/client/src/test/java/io/vitess/client/RpcClientTest.java
@@ -144,7 +144,7 @@ public abstract class RpcClientTest {
 
   private static final String SESSION_ECHO = "in_transaction:true ";
 
-  private static final String NONTX_V3_SESSION_ECHO = "target_string:\"test_keyspace@replica\" options:<included_fields:ALL > ";
+  private static final String NONTX_V3_SESSION_ECHO = "autocommit:true target_string:\"test_keyspace@replica\" options:<included_fields:ALL > ";
 
   private static final String V3_SESSION_ECHO = "in_transaction:true target_string:\"test_keyspace@replica\" options:<included_fields:ALL > ";
 

--- a/py/vtdb/vtgate_client_testsuite.py
+++ b/py/vtdb/vtgate_client_testsuite.py
@@ -493,7 +493,8 @@ class TestEcho(TestPythonClientBase):
   options_echo = ('include_event_token:true compare_event_token:'
                   '<timestamp:123 shard:"-80" position:"test_pos" > ')
 
-  session_echo = ('target_string:"@replica" options:<include_event_token:'
+  session_echo = ('autocommit:true target_string:"@replica" '
+                  'options:<include_event_token:'
                   'true compare_event_token:<timestamp:123 shard:'
                   '"-80" position:"test_pos" > > ')
 


### PR DESCRIPTION
Issue #3041
This changes vtgate autocommit behavior to be very similar to
MySQL: if autocommit is off, a new transaction is always started
implicitly.

This breaks backward compatibility with old behavior: if a DML
was issued with autocommit=false, then it would have resulted in
an error. A new legacy_autocommit flag has been introduced for
those who still rely on the old behavior.