### PR TITLE
bug: fix panic

### DIFF
--- a/go/vt/topotools/events/migrate_syslog.go
+++ b/go/vt/topotools/events/migrate_syslog.go
@@ -52,10 +52,16 @@ func (ev *MigrateServedTypes) Syslog() (syslog.Priority, string) {
 
 	sourceShards := make([]string, len(ev.SourceShards))
 	for i, shard := range ev.SourceShards {
+		if shard == nil {
+			continue
+		}
 		sourceShards[i] = shard.ShardName()
 	}
 	destShards := make([]string, len(ev.DestinationShards))
 	for i, shard := range ev.DestinationShards {
+		if shard == nil {
+			continue
+		}
 		destShards[i] = shard.ShardName()
 	}
 

--- a/go/vt/topotools/events/migrate_syslog_test.go
+++ b/go/vt/topotools/events/migrate_syslog_test.go
@@ -87,6 +87,31 @@ func TestMigrateServedTypesSyslogForward(t *testing.T) {
 	}
 }
 
+func TestMigrateServedTypesSyslogForwardWithNil(t *testing.T) {
+	wantSev, wantMsg := syslog.LOG_INFO, "keyspace-1 [migrate served-types {src1, } -> {, dst2}] status"
+	ev := &MigrateServedTypes{
+		KeyspaceName: "keyspace-1",
+		SourceShards: []*topo.ShardInfo{
+			topo.NewShardInfo("keyspace-1", "src1", nil, nil),
+			nil,
+		},
+		DestinationShards: []*topo.ShardInfo{
+			nil,
+			topo.NewShardInfo("keyspace-1", "dst2", nil, nil),
+		},
+		Reverse:       false,
+		StatusUpdater: base.StatusUpdater{Status: "status"},
+	}
+	gotSev, gotMsg := ev.Syslog()
+
+	if gotSev != wantSev {
+		t.Errorf("wrong severity: got %v, want %v", gotSev, wantSev)
+	}
+	if gotMsg != wantMsg {
+		t.Errorf("wrong message: got %v, want %v", gotMsg, wantMsg)
+	}
+}
+
 func TestMigrateServedTypesSyslogReverse(t *testing.T) {
 	wantSev, wantMsg := syslog.LOG_INFO, "keyspace-1 [migrate served-types {src1, src2} <- {dst1, dst2}] status"
 	ev := &MigrateServedTypes{


### PR DESCRIPTION
Issue #3444
If MigrateServedTypes encounters an error, it sometimes sets
the shard info as nil, which causes the syslogger to panic.