### PR TITLE
Greatly reducing flakiness of vtgate tests.

### DIFF
--- a/test/vtgate_gateway_flavor/discoverygateway.py
+++ b/test/vtgate_gateway_flavor/discoverygateway.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
 # Copyright 2017 Google Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,10 @@ class DiscoveryGateway(gateway.VTGateGateway):
 
   def flags(self, cell=None, tablets=None):
     """Return a list of args that tell a VTGate process to start with."""
-    return ['-cells_to_watch', cell]
+    return [
+        '-cells_to_watch', cell,
+        '-tablet_refresh_interval', '2s',
+    ]
 
   def connection_count_vars(self):
     """Return the vars name containing the number of serving connections."""


### PR DESCRIPTION
The tablet_refresh_interval parameter is how often vtgate will re-read
the topology to update its internal records. The default is 1 minute.
Changing that to 2s.

I am not sure how this ever worked as when we restart tablets, we clear
the topo record, and the next tablet re-populates it. vtgate can take up
to a minute to figure it out. Most tests were timing out after 20s.
Oops. With this, flakiness internally went from *63 out of 158* to
*3 out of 103*. Will investigate the remaining three, but this is
progress.