### PR TITLE
Moving SlaveConnection from mysqlctl to binlog.

### DIFF
--- a/go/vt/binlog/binlog_streamer_rbr_test.go
+++ b/go/vt/binlog/binlog_streamer_rbr_test.go
@@ -254,7 +254,7 @@ func TestStreamerParseRBREvents(t *testing.T) {
 		})
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, se, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, se, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -494,7 +494,7 @@ func TestStreamerParseRBRNameEscapes(t *testing.T) {
 		})
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, se, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, se, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)

--- a/go/vt/binlog/binlog_streamer_test.go
+++ b/go/vt/binlog/binlog_streamer_test.go
@@ -113,7 +113,7 @@ func TestStreamerParseEventsXID(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -167,7 +167,7 @@ func TestStreamerParseEventsCommit(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -186,7 +186,7 @@ func TestStreamerStop(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	// Start parseEvents(), but don't send it anything, so it just waits.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -231,7 +231,7 @@ func TestStreamerParseEventsClientEOF(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return io.EOF
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -249,7 +249,7 @@ func TestStreamerParseEventsServerEOF(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	_, err := bls.parseEvents(context.Background(), events)
 	if err != want {
@@ -279,7 +279,7 @@ func TestStreamerParseEventsSendErrorXID(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return fmt.Errorf("foobar")
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 
@@ -317,7 +317,7 @@ func TestStreamerParseEventsSendErrorCommit(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return fmt.Errorf("foobar")
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -350,7 +350,7 @@ func TestStreamerParseEventsInvalid(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -385,7 +385,7 @@ func TestStreamerParseEventsInvalidFormat(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -420,7 +420,7 @@ func TestStreamerParseEventsNoFormat(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -453,7 +453,7 @@ func TestStreamerParseEventsInvalidQuery(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -530,7 +530,7 @@ func TestStreamerParseEventsRollback(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -591,7 +591,7 @@ func TestStreamerParseEventsDMLWithoutBegin(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -655,7 +655,7 @@ func TestStreamerParseEventsBeginWithoutCommit(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -708,7 +708,7 @@ func TestStreamerParseEventsSetInsertID(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -743,7 +743,7 @@ func TestStreamerParseEventsInvalidIntVar(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 
 	go sendTestEvents(events, input)
 	_, err := bls.parseEvents(context.Background(), events)
@@ -798,7 +798,7 @@ func TestStreamerParseEventsOtherDB(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -852,7 +852,7 @@ func TestStreamerParseEventsOtherDBBegin(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -887,7 +887,7 @@ func TestStreamerParseEventsBeginAgain(t *testing.T) {
 	sendTransaction := func(eventToken *querypb.EventToken, statements []FullBinlogStatement) error {
 		return nil
 	}
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, sendTransaction)
 	before := binlogStreamerErrors.Counts()["ParseEvents"]
 
 	go sendTestEvents(events, input)
@@ -948,7 +948,7 @@ func TestStreamerParseEventsMariadbBeginGTID(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {
@@ -999,7 +999,7 @@ func TestStreamerParseEventsMariadbStandaloneGTID(t *testing.T) {
 		},
 	}
 	var got binlogStatements
-	bls := NewStreamer("vt_test_keyspace", nil, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
+	bls := NewStreamer(&mysql.ConnParams{DbName: "vt_test_keyspace"}, nil, nil, mysql.Position{}, 0, (&got).sendTransaction)
 
 	go sendTestEvents(events, input)
 	if _, err := bls.parseEvents(context.Background(), events); err != ErrServerEOF {

--- a/go/vt/binlog/event_streamer.go
+++ b/go/vt/binlog/event_streamer.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/sqltypes"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 
@@ -52,11 +51,11 @@ type EventStreamer struct {
 }
 
 // NewEventStreamer returns a new EventStreamer on top of a Streamer
-func NewEventStreamer(dbname string, mysqld mysqlctl.MysqlDaemon, se *schema.Engine, startPos mysql.Position, timestamp int64, sendEvent sendEventFunc) *EventStreamer {
+func NewEventStreamer(cp *mysql.ConnParams, se *schema.Engine, startPos mysql.Position, timestamp int64, sendEvent sendEventFunc) *EventStreamer {
 	evs := &EventStreamer{
 		sendEvent: sendEvent,
 	}
-	evs.bls = NewStreamer(dbname, mysqld, se, nil, startPos, timestamp, evs.transactionToEvent)
+	evs.bls = NewStreamer(cp, se, nil, startPos, timestamp, evs.transactionToEvent)
 	evs.bls.extractPK = true
 	return evs
 }

--- a/go/vt/binlog/slave_connection.go
+++ b/go/vt/binlog/slave_connection.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mysqlctl
+package binlog
 
 import (
 	"fmt"
@@ -53,18 +53,7 @@ type SlaveConnection struct {
 // 1) No other processes are making fake slave connections to our mysqld.
 // 2) No real slave servers will have IDs in the range 1-N where N is the peak
 //    number of concurrent fake slave connections we will ever make.
-func (mysqld *Mysqld) NewSlaveConnection() (*SlaveConnection, error) {
-	// TODO(demmer) Move this entire file to go/vt/binlog.
-	// Pass in 'cp *mysql.ConnParams' in the NewSlaveConnection above.
-	// Then in tabletserver, we already have the DBA config,
-	// just wire that in, by replacing the current dbname/mysqld parameters
-	// NewStreamer(dbname string, mysqld mysqlctl.MysqlDaemon, ...
-	// with just a *mysql.ConnParams. Then the caller:
-	// streamer := binlog.NewStreamer(dbconfigs.App.DbName, mysqld, ...
-	// becomes:
-	// streamer := binlog.NewStreamer(dbconfigs.App, ...
-	// Then NewSlaveConnection can be removed from mysqlctl.MysqlDaemon.
-	cp := &mysqld.dbcfgs.Dba
+func NewSlaveConnection(cp *mysql.ConnParams) (*SlaveConnection, error) {
 	conn, err := connectForReplication(cp)
 	if err != nil {
 		return nil, err

--- a/go/vt/binlog/updatestreamctl.go
+++ b/go/vt/binlog/updatestreamctl.go
@@ -27,7 +27,6 @@ import (
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/tb"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 
@@ -109,8 +108,7 @@ type UpdateStreamImpl struct {
 	ts       *topo.Server
 	keyspace string
 	cell     string
-	mysqld   mysqlctl.MysqlDaemon
-	dbname   string
+	cp       *mysql.ConnParams
 	se       *schema.Engine
 
 	// actionLock protects the following variables
@@ -171,14 +169,13 @@ type RegisterUpdateStreamServiceFunc func(UpdateStream)
 var RegisterUpdateStreamServices []RegisterUpdateStreamServiceFunc
 
 // NewUpdateStream returns a new UpdateStreamImpl object
-func NewUpdateStream(ts *topo.Server, keyspace string, cell string, mysqld mysqlctl.MysqlDaemon, se *schema.Engine, dbname string) *UpdateStreamImpl {
+func NewUpdateStream(ts *topo.Server, keyspace string, cell string, cp *mysql.ConnParams, se *schema.Engine) *UpdateStreamImpl {
 	return &UpdateStreamImpl{
 		ts:       ts,
 		keyspace: keyspace,
 		cell:     cell,
-		mysqld:   mysqld,
+		cp:       cp,
 		se:       se,
-		dbname:   dbname,
 	}
 }
 
@@ -213,7 +210,7 @@ func (updateStream *UpdateStreamImpl) Enable() {
 
 	updateStream.state.Set(usEnabled)
 	updateStream.streams.Init()
-	log.Infof("Enabling update stream, dbname: %s", updateStream.dbname)
+	log.Infof("Enabling update stream, dbname: %s", updateStream.cp.DbName)
 }
 
 // Disable will disallow any connection to the service
@@ -263,7 +260,7 @@ func (updateStream *UpdateStreamImpl) StreamKeyRange(ctx context.Context, positi
 		keyrangeTransactions.Add(1)
 		return callback(trans)
 	})
-	bls := NewStreamer(updateStream.dbname, updateStream.mysqld, updateStream.se, charset, pos, 0, f)
+	bls := NewStreamer(updateStream.cp, updateStream.se, charset, pos, 0, f)
 	bls.resolverFactory, err = newKeyspaceIDResolverFactory(ctx, updateStream.ts, updateStream.keyspace, updateStream.cell)
 	if err != nil {
 		return fmt.Errorf("newKeyspaceIDResolverFactory failed: %v", err)
@@ -303,7 +300,7 @@ func (updateStream *UpdateStreamImpl) StreamTables(ctx context.Context, position
 		tablesTransactions.Add(1)
 		return callback(trans)
 	})
-	bls := NewStreamer(updateStream.dbname, updateStream.mysqld, updateStream.se, charset, pos, 0, f)
+	bls := NewStreamer(updateStream.cp, updateStream.se, charset, pos, 0, f)
 
 	streamCtx, cancel := context.WithCancel(ctx)
 	i := updateStream.streams.Add(cancel)

--- a/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
+++ b/go/vt/mysqlctl/fakemysqldaemon/fakemysqldaemon.go
@@ -342,11 +342,6 @@ func (fmd *FakeMysqlDaemon) FetchSuperQuery(ctx context.Context, query string) (
 	return qr, nil
 }
 
-// NewSlaveConnection is part of the MysqlDaemon interface
-func (fmd *FakeMysqlDaemon) NewSlaveConnection() (*mysqlctl.SlaveConnection, error) {
-	panic(fmt.Errorf("not implemented on FakeMysqlDaemon"))
-}
-
 // EnableBinlogPlayback is part of the MysqlDaemon interface
 func (fmd *FakeMysqlDaemon) EnableBinlogPlayback() error {
 	if fmd.BinlogPlayerEnabled {

--- a/go/vt/mysqlctl/mycnf_gen.go
+++ b/go/vt/mysqlctl/mycnf_gen.go
@@ -156,8 +156,8 @@ func (cnf *Mycnf) fillMycnfTemplate(tmplSrc string) (string, error) {
 // The value assigned to ServerID will be in the range [100, 2^31):
 // - It avoids 0 because that's reserved for mysqlbinlog dumps.
 // - It also avoids 1-99 because low numbers are used for fake slave
-// connections.  See NewSlaveConnection() in slave_connection.go for
-// more on that.
+// connections.  See NewSlaveConnection() in binlog/slave_connection.go
+// for more on that.
 // - It avoids the 2^31 - 2^32-1 range, as there seems to be some
 // confusion there. The main MySQL documentation at:
 // http://dev.mysql.com/doc/refman/5.7/en/replication-options.html

--- a/go/vt/mysqlctl/mysql_daemon.go
+++ b/go/vt/mysqlctl/mysql_daemon.go
@@ -89,9 +89,6 @@ type MysqlDaemon interface {
 	// FetchSuperQuery executes one query, returns the result
 	FetchSuperQuery(ctx context.Context, query string) (*sqltypes.Result, error)
 
-	// NewSlaveConnection returns a SlaveConnection to the database.
-	NewSlaveConnection() (*SlaveConnection, error)
-
 	// EnableBinlogPlayback enables playback of binlog events
 	EnableBinlogPlayback() error
 

--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -93,18 +93,13 @@ func newTablet(t *topodatapb.Tablet) *explainTablet {
 	}
 	cnf := mysqlctl.NewMycnf(22222, 6802)
 	cnf.ServerID = 33333
-	mysqld := mysqlctl.NewMysqld(
-		cnf,
-		&dbcfgs,
-		dbconfigs.AppConfig, // These tests only use the app pool.
-	)
 
 	target := querypb.Target{
 		Keyspace:   t.Keyspace,
 		Shard:      t.Shard,
 		TabletType: topodatapb.TabletType_MASTER,
 	}
-	tsv.StartService(target, dbcfgs, mysqld)
+	tsv.StartService(target, dbcfgs)
 
 	// clear all the schema initialization queries out of the tablet
 	// to avoid clutttering the output

--- a/go/vt/vttablet/endtoend/framework/server.go
+++ b/go/vt/vttablet/endtoend/framework/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vtgate/fakerpcvtgateconn"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver"
@@ -66,12 +65,6 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
 		SidecarDBName: "_vt",
 	}
 
-	mysqld := mysqlctl.NewMysqld(
-		&mysqlctl.Mycnf{},
-		&dbcfgs,
-		dbconfigs.AppConfig,
-	)
-
 	config := tabletenv.DefaultQsConfig
 	config.EnableAutoCommit = true
 	config.StrictTableACL = true
@@ -88,7 +81,7 @@ func StartServer(connParams, connAppDebugParams mysql.ConnParams) error {
 
 	Server = tabletserver.NewTabletServerWithNilTopoServer(config)
 	Server.Register()
-	err := Server.StartService(Target, dbcfgs, mysqld)
+	err := Server.StartService(Target, dbcfgs)
 	if err != nil {
 		return fmt.Errorf("could not start service: %v", err)
 	}

--- a/go/vt/vttablet/tabletmanager/action_agent.go
+++ b/go/vt/vttablet/tabletmanager/action_agent.go
@@ -595,7 +595,7 @@ func (agent *ActionAgent) Start(ctx context.Context, mysqlHost string, mysqlPort
 	// (it needs the dbname, so it has to be delayed up to here,
 	// but it has to be before updateState below that may use it)
 	if initUpdateStream {
-		us := binlog.NewUpdateStream(agent.TopoServer, agent.initialTablet.Keyspace, agent.TabletAlias.Cell, agent.MysqlDaemon, agent.QueryServiceControl.SchemaEngine(), agent.DBConfigs.App.DbName)
+		us := binlog.NewUpdateStream(agent.TopoServer, agent.initialTablet.Keyspace, agent.TabletAlias.Cell, &agent.DBConfigs.App, agent.QueryServiceControl.SchemaEngine())
 		agent.UpdateStream = us
 		servenv.OnRun(func() {
 			us.RegisterService()
@@ -615,7 +615,7 @@ func (agent *ActionAgent) Start(ctx context.Context, mysqlHost string, mysqlPort
 		Keyspace:   agent.initialTablet.Keyspace,
 		Shard:      agent.initialTablet.Shard,
 		TabletType: agent.initialTablet.Type,
-	}, agent.DBConfigs, agent.MysqlDaemon); err != nil {
+	}, agent.DBConfigs); err != nil {
 		return fmt.Errorf("failed to InitDBConfig: %v", err)
 	}
 

--- a/go/vt/vttablet/tabletserver/bench_test.go
+++ b/go/vt/vttablet/tabletserver/bench_test.go
@@ -70,7 +70,7 @@ func BenchmarkExecuteVarBinary(b *testing.B) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbconfigs); err != nil {
 		panic(err)
 	}
 	defer tsv.StopService()
@@ -102,7 +102,7 @@ func BenchmarkExecuteExpression(b *testing.B) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs)); err != nil {
+	if err := tsv.StartService(target, dbconfigs); err != nil {
 		panic(err)
 	}
 	defer tsv.StopService()

--- a/go/vt/vttablet/tabletserver/controller.go
+++ b/go/vt/vttablet/tabletserver/controller.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/rules"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -39,7 +38,7 @@ type Controller interface {
 	AddStatusPart()
 
 	// InitDBConfig sets up the db config vars.
-	InitDBConfig(querypb.Target, dbconfigs.DBConfigs, mysqlctl.MysqlDaemon) error
+	InitDBConfig(querypb.Target, dbconfigs.DBConfigs) error
 
 	// SetServingType transitions the query service to the required serving type.
 	// Returns true if the state of QueryService or the tablet type changed.

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -1887,7 +1887,7 @@ func newTestTabletServer(ctx context.Context, flags executorFlags, db *fakesqldb
 	testUtils := newTestUtils()
 	dbconfigs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	tsv.StartService(target, dbconfigs, testUtils.newMysqld(&dbconfigs))
+	tsv.StartService(target, dbconfigs)
 	return tsv
 }
 

--- a/go/vt/vttablet/tabletserver/replication_watcher.go
+++ b/go/vt/vttablet/tabletserver/replication_watcher.go
@@ -28,7 +28,6 @@ import (
 	"github.com/youtube/vitess/go/vt/binlog"
 	"github.com/youtube/vitess/go/vt/binlog/eventtoken"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
@@ -41,7 +40,6 @@ import (
 // and it will trigger schema reloads if a DDL is encountered.
 type ReplicationWatcher struct {
 	dbconfigs dbconfigs.DBConfigs
-	mysqld    mysqlctl.MysqlDaemon
 
 	// Life cycle management vars
 	isOpen bool
@@ -81,9 +79,8 @@ func NewReplicationWatcher(se *schema.Engine, config tabletenv.TabletConfig) *Re
 }
 
 // InitDBConfig must be called before Open.
-func (rpw *ReplicationWatcher) InitDBConfig(dbcfgs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) {
+func (rpw *ReplicationWatcher) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
 	rpw.dbconfigs = dbcfgs
-	rpw.mysqld = mysqld
 }
 
 // Open starts the ReplicationWatcher service.
@@ -94,7 +91,7 @@ func (rpw *ReplicationWatcher) Open() {
 	ctx, cancel := context.WithCancel(tabletenv.LocalContext())
 	rpw.cancel = cancel
 	rpw.wg.Add(1)
-	go rpw.Process(ctx, rpw.dbconfigs, rpw.mysqld)
+	go rpw.Process(ctx, rpw.dbconfigs)
 	rpw.isOpen = true
 }
 
@@ -109,14 +106,14 @@ func (rpw *ReplicationWatcher) Close() {
 }
 
 // Process processes the replication stream.
-func (rpw *ReplicationWatcher) Process(ctx context.Context, dbconfigs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) {
+func (rpw *ReplicationWatcher) Process(ctx context.Context, dbconfigs dbconfigs.DBConfigs) {
 	defer func() {
 		tabletenv.LogError()
 		rpw.wg.Done()
 	}()
 	for {
 		log.Infof("Starting a binlog Streamer from current replication position to monitor binlogs")
-		streamer := binlog.NewStreamer(dbconfigs.App.DbName, mysqld, rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
+		streamer := binlog.NewStreamer(&dbconfigs.App, rpw.se, nil /*clientCharset*/, mysql.Position{}, 0 /*timestamp*/, func(eventToken *querypb.EventToken, statements []binlog.FullBinlogStatement) error {
 			// Save the event token.
 			rpw.mu.Lock()
 			rpw.eventToken = eventToken

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -85,7 +85,7 @@ func TestTabletServerAllowQueriesFailBadConn(t *testing.T) {
 	checkTabletServerState(t, tsv, StateNotConnected)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err == nil {
 		t.Fatalf("TabletServer.StartService should fail")
 	}
@@ -102,14 +102,14 @@ func TestTabletServerAllowQueries(t *testing.T) {
 	dbcfgs := testUtils.newDBConfigs(db)
 	tsv.setState(StateServing)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	tsv.StopService()
 	want := "InitDBConfig failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("TabletServer.StartService: %v, must contain %s", err, want)
 	}
 	tsv.setState(StateShuttingDown)
-	err = tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err = tsv.StartService(target, dbcfgs)
 	if err == nil {
 		t.Fatalf("TabletServer.StartService should fail")
 	}
@@ -125,13 +125,13 @@ func TestTabletServerInitDBConfig(t *testing.T) {
 	tsv.setState(StateServing)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	dbcfgs := testUtils.newDBConfigs(db)
-	err := tsv.InitDBConfig(target, dbcfgs, nil)
+	err := tsv.InitDBConfig(target, dbcfgs)
 	want := "InitDBConfig failed"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("InitDBConfig: %v, must contain %s", err, want)
 	}
 	tsv.setState(StateNotConnected)
-	err = tsv.InitDBConfig(target, dbcfgs, nil)
+	err = tsv.InitDBConfig(target, dbcfgs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -145,7 +145,7 @@ func TestDecideAction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	dbcfgs := testUtils.newDBConfigs(db)
-	err := tsv.InitDBConfig(target, dbcfgs, nil)
+	err := tsv.InitDBConfig(target, dbcfgs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -252,7 +252,7 @@ func TestSetServingType(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.InitDBConfig(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.InitDBConfig(target, dbcfgs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -335,7 +335,7 @@ func TestTabletServerSingleSchemaFailure(t *testing.T) {
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
 	originalSchemaErrorCount := tabletenv.InternalErrors.Counts()["Schema"]
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatalf("TabletServer should successfully start even if a table's schema is unloadable, but got error: %v", err)
@@ -366,7 +366,7 @@ func TestTabletServerAllSchemaFailure(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	defer tsv.StopService()
 	// tabletsever shouldn't start if it can't access schema for any tables
 	wantErr := "could not get schema for any tables"
@@ -383,7 +383,7 @@ func TestTabletServerCheckMysql(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatal(err)
@@ -412,7 +412,7 @@ func TestTabletServerCheckMysqlFailInvalidConn(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	defer tsv.StopService()
 	if err != nil {
 		t.Fatalf("TabletServer.StartService should succeed, but got error: %v", err)
@@ -459,7 +459,7 @@ func TestTabletServerReconnect(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	defer tsv.StopService()
 
 	if tsv.GetState() != "SERVING" {
@@ -489,7 +489,7 @@ func TestTabletServerReconnect(t *testing.T) {
 	db.AddQuery(query, want)
 	db.AddQuery("select addr from test_table where 1 != 1", &sqltypes.Result{})
 	dbcfgs = testUtils.newDBConfigs(db)
-	err = tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err = tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Error(err)
 	}
@@ -511,7 +511,7 @@ func TestTabletServerTarget(t *testing.T) {
 		Shard:      "test_shard",
 		TabletType: topodatapb.TabletType_MASTER,
 	}
-	err := tsv.StartService(target1, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target1, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -967,7 +967,7 @@ func TestTabletServerBeginFail(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1002,7 +1002,7 @@ func TestTabletServerCommitTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1028,7 +1028,7 @@ func TestTabletServerCommiRollbacktFail(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1065,7 +1065,7 @@ func TestTabletServerRollback(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1169,7 +1169,7 @@ func TestTabletServerStreamExecute(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1196,7 +1196,7 @@ func TestTabletServerExecuteBatch(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1220,7 +1220,7 @@ func TestTabletServerExecuteBatchFailEmptyQueryList(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1241,7 +1241,7 @@ func TestTabletServerExecuteBatchFailAsTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1269,7 +1269,7 @@ func TestTabletServerExecuteBatchBeginFail(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1295,7 +1295,7 @@ func TestTabletServerExecuteBatchCommitFail(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1334,7 +1334,7 @@ func TestTabletServerExecuteBatchSqlExecFailInTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1377,7 +1377,7 @@ func TestTabletServerExecuteBatchSqlSucceedInTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1401,7 +1401,7 @@ func TestTabletServerExecuteBatchCallCommitWithoutABegin(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1431,7 +1431,7 @@ func TestExecuteBatchNestedTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -1483,7 +1483,7 @@ func TestSerializeTransactionsSameRow(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1610,7 +1610,7 @@ func TestSerializeTransactionsSameRow_ExecuteBatchAsTransaction(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1728,7 +1728,7 @@ func TestSerializeTransactionsSameRow_ConcurrentTransactions(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1869,7 +1869,7 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -1958,7 +1958,7 @@ func TestSerializeTransactionsSameRow_TooManyPendingRequests_ExecuteBatchAsTrans
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -2050,7 +2050,7 @@ func TestSerializeTransactionsSameRow_RequestCanceled(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	if err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs)); err != nil {
+	if err := tsv.StartService(target, dbcfgs); err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
 	defer tsv.StopService()
@@ -2344,7 +2344,7 @@ func TestTabletServerSplitQuery(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2375,7 +2375,7 @@ func TestTabletServerSplitQueryInvalidQuery(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2405,7 +2405,7 @@ func TestTabletServerSplitQueryInvalidParams(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2434,7 +2434,7 @@ func TestTabletServerSplitQueryEqualSplitsOnStringColumn(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_RDONLY}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}
@@ -2682,7 +2682,7 @@ func TestConfigChanges(t *testing.T) {
 	tsv := NewTabletServerWithNilTopoServer(config)
 	dbcfgs := testUtils.newDBConfigs(db)
 	target := querypb.Target{TabletType: topodatapb.TabletType_MASTER}
-	err := tsv.StartService(target, dbcfgs, testUtils.newMysqld(&dbcfgs))
+	err := tsv.StartService(target, dbcfgs)
 	if err != nil {
 		t.Fatalf("StartService failed: %v", err)
 	}

--- a/go/vt/vttablet/tabletserver/testutils_test.go
+++ b/go/vt/vttablet/tabletserver/testutils_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/youtube/vitess/go/mysql/fakesqldb"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -48,18 +47,6 @@ func (util *testUtils) checkEqual(t *testing.T, expected interface{}, result int
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("expect to get: %v, but got: %v", expected, result)
 	}
-}
-
-func (util *testUtils) newMysqld(dbcfgs *dbconfigs.DBConfigs) mysqlctl.MysqlDaemon {
-	cnf := mysqlctl.NewMycnf(11111, 6802)
-	// Assigning ServerID to be different from tablet UID to make sure that there are no
-	// assumptions in the code that those IDs are the same.
-	cnf.ServerID = 22222
-	return mysqlctl.NewMysqld(
-		cnf,
-		dbcfgs,
-		dbconfigs.AppConfig, // These tests only use the app pool.
-	)
 }
 
 func (util *testUtils) newDBConfigs(db *fakesqldb.DB) dbconfigs.DBConfigs {

--- a/go/vt/vttablet/tabletservermock/controller.go
+++ b/go/vt/vttablet/tabletservermock/controller.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/mysqlctl"
 	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/rules"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
@@ -102,7 +101,7 @@ func (tqsc *Controller) AddStatusPart() {
 }
 
 // InitDBConfig is part of the tabletserver.Controller interface
-func (tqsc *Controller) InitDBConfig(target querypb.Target, dbcfgs dbconfigs.DBConfigs, mysqld mysqlctl.MysqlDaemon) error {
+func (tqsc *Controller) InitDBConfig(target querypb.Target, dbcfgs dbconfigs.DBConfigs) error {
 	tqsc.mu.Lock()
 	defer tqsc.mu.Unlock()
 


### PR DESCRIPTION
This is a more natural place for it. Also, it can be initialized with
just a ConnParams instead of mysqlctl.MysqlDaemon, and that reduces
dependencies greatly. tabletserver lost his dependency on mysqlctl, that
is good.