### PR TITLE
Removing non-collaborators from pullapprove config.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -12,17 +12,12 @@ groups:
     required: 1
     users:
       - alainjobart
-      - alainjobart-bot
       - AndyDiamondstein
       - bbeaudreault
       - demmer
       - enisoc
-      - enisoc-bot
-      - harshit-gangal
       - mberlin-bot
       - michael-berlin
       - pivanof
-      - pivanof-bot
       - sougou
-      - sougou-bot
 


### PR DESCRIPTION
The non-2FA accounts were removed earlier.