### PR TITLE
Fix for make proto

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -18,3 +18,4 @@ exclude_paths:
 - "go/vt/proto/"
 - "go/vt/sqlparser/sql.go"
 - "py/util/grpc_with_metadata.py"
+- "travis/install_grpc.sh"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -106,7 +106,7 @@ ln -snf $consul_dist/consul $VTROOT/bin/consul
 # install gRPC C++ base, so we can install the python adapters.
 # this also installs protobufs
 grpc_dist=$VTROOT/dist/grpc
-grpc_ver=v1.7.0
+grpc_ver=v1.7.1
 if [ $SKIP_ROOT_INSTALLS == "True" ]; then
   echo "skipping grpc build, as root version was already installed."
 elif [[ -f $grpc_dist/.build_finished && "$(cat $grpc_dist/.build_finished)" == "$grpc_ver" ]]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -48,24 +48,6 @@ mkdir -p $VTROOT/vthook
 echo "Updating git submodules..."
 git submodule update --init
 
-# Install "protoc" protobuf compiler binary.
-protoc_version=3.4.0
-protoc_dist=$VTROOT/dist/protoc
-protoc_version_file=$protoc_dist/version
-if [[ -f $protoc_version_file && "$(cat $protoc_version_file)" == "$protoc_version" ]]; then
-  echo "skipping protoc install. remove $protoc_version_file to force re-install."
-else
-  rm -rf $protoc_dist
-  mkdir -p $protoc_dist
-  download_url=https://github.com/google/protobuf/releases/download/v${protoc_version}/protoc-${protoc_version}-linux-x86_64.zip
-  (cd $protoc_dist && \
-    wget $download_url && \
-    unzip protoc-${protoc_version}-linux-x86_64.zip)
-  [ $? -eq 0 ] || fail "protoc download failed"
-  echo "$protoc_version" > $protoc_version_file
-fi
-ln -snf $protoc_dist/bin/protoc $VTROOT/bin/protoc
-
 # install zookeeper
 # TODO(sougou): when version changes, see if we can drop the 'zip -d' hack to get the fatjars working.
 zk_ver=3.4.10

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -66,7 +66,7 @@ fi
 # clone the repository, setup the submodules
 git clone https://github.com/grpc/grpc.git
 cd grpc
-git checkout v1.7.0
+git checkout $grpc_ver
 git submodule update --init
 
 # OSX specific setting + dependencies

--- a/travis/install_grpc.sh
+++ b/travis/install_grpc.sh
@@ -19,6 +19,14 @@
 # as root in the image.
 set -ex
 
+# Import prepend_path function.
+dir="$(dirname "${BASH_SOURCE[0]}")"
+source "${dir}/../tools/shell_functions.inc"
+if [ $? -ne 0 ]; then
+      echo "failed to load ../tools/shell_functions.inc"
+      return 1
+fi
+
 # grpc_dist can be empty, in which case we just install to the default paths
 grpc_dist="$1"
 if [ -n "$grpc_dist" ]; then
@@ -47,6 +55,52 @@ if [ -n "$grpc_dist" ]; then
   PIP=$grpc_dist/usr/local/bin/pip
   $PIP install --upgrade pip
   $PIP install --upgrade --ignore-installed virtualenv
+else
+  PIP=pip
+  $PIP install --upgrade pip
+  # System wide installations require an explicit upgrade of
+  # certain gRPC Python dependencies e.g. "six" on Debian Jessie.
+  $PIP install --upgrade --ignore-installed six
+fi
+
+# clone the repository, setup the submodules
+git clone https://github.com/grpc/grpc.git
+cd grpc
+git checkout v1.7.0
+git submodule update --init
+
+# OSX specific setting + dependencies
+if [ `uname -s` == "Darwin" ]; then
+     export GRPC_PYTHON_BUILD_WITH_CYTHON=1
+     $PIP install Cython
+
+     # Work-around macOS Sierra blocker, see: https://github.com/youtube/vitess/issues/2115
+     # TODO(mberlin): Remove this when the underlying issue is fixed and available
+     #                in the gRPC version used by Vitess.
+     #                See: https://github.com/google/protobuf/issues/2182
+     export CPPFLAGS="-Wno-deprecated-declarations"
+fi
+
+# build everything
+make
+
+cd third_party/protobuf
+# install protobuf side (it was already built by the 'make' earlier)
+if [ -n "$grpc_dist" ]; then
+    make install prefix=$grpc_dist/usr/local
+else
+    make install
+fi
+
+cd ../..
+# now install grpc itself
+if [ -n "$grpc_dist" ]; then
+  make install prefix=$grpc_dist/usr/local
+  # Add bin directory to the path such that gRPC python won't complain that
+  # it cannot find "grpc_python_plugin".
+  export PATH=$(prepend_path $PATH $grpc_dist/usr/local/bin)
+else
+  make install
 fi
 
 # Install gRPC python libraries from PyPI.


### PR DESCRIPTION
### Desc

This PR goes back to compiling grpc. It reverts the changes from https://github.com/youtube/vitess/commit/f109d14287af7250ae95544928ad01e2de89eba8#diff-3af436e6760a0c5f1e3d16a3384853a8. Even though compiling manually is not ideal, it fixes a problem where we can't make modifications to proto definitions due to not having  `grpc_python_plugin` installed:

```
/vagrant/bin//grpc_python_plugin: program not found or is not executable
--grpc_out: protoc-gen-grpc: Plugin failed with status code 1.
Makefile:151: recipe for target 'py/vtproto/topodata_pb2.py' failed
```

We tried different approaches to not have to compile grpc, but they were not successful. In the short term I think we should revert to the old approach while we find a way to fix this problem. 

### Tests

Tested locally. 
