### PR TITLE
docker compose

### DIFF
--- a/examples/compose/.env
+++ b/examples/compose/.env
@@ -1,0 +1,7 @@
+TOPOLOGY_FLAGS=-topo_implementation consul -topo_global_server_address consul1:8500 -topo_global_root vitess/global
+GRPC_PORT=15999
+WEB_PORT=8080
+MYSQL_PORT=15306
+
+CELL=test
+KEYSPACE=test_keyspace

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -1,0 +1,45 @@
+# Local Vitess cluster using docker-compose 
+
+This directory have a docker-compose sample application.
+To understand it better, you can run it.
+
+First you will need to [install docker-compose](https://docs.docker.com/compose/install/).
+
+### Start the cluster
+To start Consul(which saves the topology config), vtctld, vtgate and a few vttablets with MySQL running on them.
+```
+vitess/examples/compose$ docker-compose up -d
+```
+
+### Load the schema
+We need to create a few tables into our new cluster. To do that, we can run the `ApplySchema` command.
+```
+vitess/examples/compose$ ./lvtctl.sh ApplySchema -sql "$(cat create_test_table.sql)" test_keyspace
+```
+
+### Run the client to insert and read some data
+This will build and run the `client.go` file. It will insert and read data from the master and from the replica.
+```
+vitess/examples/compose$ ./client.sh
+```
+
+### Connect to vgate and run queries
+vtgate responds to the MySQL protocol, so we can connect to it using the default MySQL client command line.
+```
+$ mysql --port=15306 --host=127.0.0.1
+```
+
+
+### Play around with vtctl commands
+
+```
+vitess/examples/compose$ ./lvtctl.sh Help
+```
+
+
+## Troubleshooting
+If the cluster gets in a bad state, you most likely will have to stop and kill the containers. Note: you will lose all the data.
+```
+vitess/examples/compose$ docker-compose kill
+vitess/examples/compose$ docker-compose rm
+```

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -36,6 +36,19 @@ $ mysql --port=15306 --host=127.0.0.1
 vitess/examples/compose$ ./lvtctl.sh Help
 ```
 
+## Exploring
+
+- vtctld web ui:
+  http://localhost:15000
+
+- vttablets web ui:
+  http://localhost:15001/debug/status
+  http://localhost:15002/debug/status
+  http://localhost:15003/debug/status
+
+- vtgate web ui:
+  http://localhost:15099/debug/status
+  
 
 ## Troubleshooting
 If the cluster gets in a bad state, you most likely will have to stop and kill the containers. Note: you will lose all the data.

--- a/examples/compose/client.go
+++ b/examples/compose/client.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// client.go is a sample for using the Vitess Go SQL driver.
+//
+// Before running this, start up a local example cluster as described in the
+// README.md file.
+//
+// Then run:
+// vitess$ . dev.env
+// vitess$ cd examples/local
+// vitess/examples/local$ go run client.go -server=localhost:15991
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/vitessdriver"
+)
+
+var (
+	server = flag.String("server", "", "vtgate server to connect to")
+)
+
+func main() {
+	flag.Parse()
+	rand.Seed(time.Now().UnixNano())
+
+	// Connect to vtgate.
+	db, err := vitessdriver.Open(*server, "@master")
+	if err != nil {
+		fmt.Printf("client error: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	// Insert some messages on random pages.
+	fmt.Println("Inserting into master...")
+	for i := 0; i < 3; i++ {
+		tx, err := db.Begin()
+		if err != nil {
+			fmt.Printf("begin failed: %v\n", err)
+			os.Exit(1)
+		}
+		page := rand.Intn(100) + 1
+		timeCreated := time.Now().UnixNano()
+		if _, err := tx.Exec("INSERT INTO messages (page,time_created_ns,message) VALUES (?,?,?)",
+			page, timeCreated, "V is for speed"); err != nil {
+			fmt.Printf("exec failed: %v\n", err)
+			os.Exit(1)
+		}
+		if err := tx.Commit(); err != nil {
+			fmt.Printf("commit failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Read it back from the master.
+	fmt.Println("Reading from master...")
+	rows, err := db.Query("SELECT page, time_created_ns, message FROM messages")
+	if err != nil {
+		fmt.Printf("query failed: %v\n", err)
+		os.Exit(1)
+	}
+	for rows.Next() {
+		var page, timeCreated uint64
+		var msg string
+		if err := rows.Scan(&page, &timeCreated, &msg); err != nil {
+			fmt.Printf("scan failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("(%v, %v, %q)\n", page, timeCreated, msg)
+	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("row iteration failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Read from a replica.
+	// Note that this may be behind master due to replication lag.
+	fmt.Println("Reading from replica...")
+
+	dbr, err := vitessdriver.Open(*server, "@replica")
+	if err != nil {
+		fmt.Printf("client error: %v\n", err)
+		os.Exit(1)
+	}
+	defer dbr.Close()
+
+	rows, err = dbr.Query("SELECT page, time_created_ns, message FROM messages")
+	if err != nil {
+		fmt.Printf("query failed: %v\n", err)
+		os.Exit(1)
+	}
+	for rows.Next() {
+		var page, timeCreated uint64
+		var msg string
+		if err := rows.Scan(&page, &timeCreated, &msg); err != nil {
+			fmt.Printf("scan failed: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("(%v, %v, %q)\n", page, timeCreated, msg)
+	}
+	if err := rows.Err(); err != nil {
+		fmt.Printf("row iteration failed: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/examples/compose/client.sh
+++ b/examples/compose/client.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright 2017 GitHub Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+
+exec docker-compose run -v$(pwd):/vt/client vtgate go run /vt/client/client.go -server=vtgate:15999

--- a/examples/compose/create_test_table.sql
+++ b/examples/compose/create_test_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE messages (
+  page BIGINT(20) UNSIGNED,
+  time_created_ns BIGINT(20) UNSIGNED,
+  message VARCHAR(10000),
+  PRIMARY KEY (page, time_created_ns)
+) ENGINE=InnoDB
+

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -111,3 +111,20 @@ services:
     command: ["sh", "-c", "/script/vttablet-up.sh 2"]
     depends_on:
       - vtctld
+  vttablet3:
+    image: vitess/base
+    ports:
+      - "15003:$WEB_PORT"
+      - "$GRPC_PORT"
+      - "3306"
+    volumes:
+      - ".:/script"
+    environment:
+      - TOPOLOGY_FLAGS
+      - WEB_PORT
+      - GRPC_PORT
+      - CELL
+      - KEYSPACE
+    command: ["sh", "-c", "/script/vttablet-up.sh 3"]
+    depends_on:
+      - vtctld

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -1,0 +1,112 @@
+version: "3"
+services:
+  consul1:
+    image: consul:latest
+    hostname: "consul1"
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+    command: "agent -server -bootstrap-expect 3 -ui -disable-host-node-id -client 0.0.0.0"
+  consul2:
+    image: consul:latest
+    hostname: "consul2"
+    expose:
+      - "8400"
+      - "8500"
+      - "8600"
+    command: "agent -server -retry-join consul1 -disable-host-node-id"
+    depends_on:
+      - consul1
+  consul3:
+    image: consul:latest
+    hostname: "consul3"
+    expose:
+      - "8400"
+      - "8500"
+      - "8600"
+    command: "agent -server -retry-join consul1 -disable-host-node-id"
+    depends_on:
+      - consul1
+
+  vtctld:
+    image: vitess/base
+    ports:
+      - "15000:$WEB_PORT"
+      - "$GRPC_PORT"
+    command: ["sh", "-c", " $$VTROOT/bin/vtctld \
+        $TOPOLOGY_FLAGS \
+        -cell $CELL \
+        -web_dir $$VTTOP/web/vtctld \
+        -web_dir2 $$VTTOP/web/vtctld2/app \
+        -workflow_manager_init \
+        -workflow_manager_use_election \
+        -service_map 'grpc-vtctl' \
+        -backup_storage_implementation file \
+        -file_backup_storage_root $$VTDATAROOT/backups \
+        -logtostderr=true \
+        -port $WEB_PORT \
+        -grpc_port $GRPC_PORT \
+        -pid_file $$VTDATAROOT/tmp/vtctld.pid
+        "]
+    depends_on:
+      - consul1
+      - consul2
+      - consul3
+
+  vtgate:
+    image: vitess/base
+    ports:
+      - "15306:$MYSQL_PORT"
+      - "$GRPC_PORT"
+    command: ["sh", "-c", "$$VTROOT/bin/vtgate \
+        $TOPOLOGY_FLAGS \
+        -logtostderr=true \
+        -port $WEB_PORT \
+        -grpc_port $GRPC_PORT \
+        -mysql_server_port $MYSQL_PORT \
+        -mysql_auth_server_impl none \
+        -cell $CELL \
+        -cells_to_watch $CELL \
+        -tablet_types_to_wait MASTER,REPLICA \
+        -gateway_implementation discoverygateway \
+        -service_map 'grpc-vtgateservice' \
+        -pid_file $$VTDATAROOT/tmp/vtgate.pid \
+        "]
+    depends_on:
+      - vtctld
+
+  vttablet1:
+    image: vitess/base
+    ports:
+      - "15001:$WEB_PORT"
+      - "$GRPC_PORT"
+      - "3306"
+    volumes:
+      - ".:/script"
+    environment:
+      - TOPOLOGY_FLAGS
+      - WEB_PORT
+      - GRPC_PORT
+      - CELL
+      - KEYSPACE
+    command: ["sh", "-c", "/script/vttablet-up.sh 1"]
+    depends_on:
+      - vtctld
+  vttablet2:
+    image: vitess/base
+    ports:
+      - "15002:$WEB_PORT"
+      - "$GRPC_PORT"
+      - "3306"
+    volumes:
+      - ".:/script"
+    environment:
+      - TOPOLOGY_FLAGS
+      - WEB_PORT
+      - GRPC_PORT
+      - CELL
+      - KEYSPACE
+    command: ["sh", "-c", "/script/vttablet-up.sh 2"]
+    depends_on:
+      - vtctld

--- a/examples/compose/docker-compose.yml
+++ b/examples/compose/docker-compose.yml
@@ -57,8 +57,9 @@ services:
   vtgate:
     image: vitess/base
     ports:
-      - "15306:$MYSQL_PORT"
+      - "15099:$WEB_PORT"
       - "$GRPC_PORT"
+      - "15306:$MYSQL_PORT"
     command: ["sh", "-c", "$$VTROOT/bin/vtgate \
         $TOPOLOGY_FLAGS \
         -logtostderr=true \

--- a/examples/compose/lvtctl.sh
+++ b/examples/compose/lvtctl.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright 2017 GitHub Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a convenience script to run vtctlclient against the local example.
+exec docker-compose run vttablet1 vtctlclient -server vtctld:15999 "$@"

--- a/examples/compose/vttablet-up.sh
+++ b/examples/compose/vttablet-up.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+set -u
+
+keyspace=${KEYSPACE:-'test_keyspace'}
+shard=${SHARD:-'0'}
+uid=$1
+
+printf -v alias '%s-%010d' $CELL $uid
+printf -v tablet_dir 'vt_%010d' $uid
+
+tablet_role='replica'
+if [ "$uid" = "1" ]; then
+    tablet_role='master'
+fi
+
+dbconfig_dba_flags="\
+    -db-config-dba-uname root \
+    -db-config-dba-charset utf8"
+
+dbconfig_flags="$dbconfig_dba_flags \
+    -db-config-app-uname root \
+    -db-config-app-charset utf8 \
+    -db-config-appdebug-uname root \
+    -db-config-appdebug-charset utf8 \
+    -db-config-allprivs-uname root \
+    -db-config-allprivs-charset utf8 \
+    -db-config-repl-uname root \
+    -db-config-repl-charset utf8 \
+    -db-config-filtered-uname root \
+    -db-config-filtered-charset utf8"
+
+init_db_sql_file="$VTROOT/init_db.sql"
+echo "GRANT ALL ON *.* TO 'root'@'%';" > $init_db_sql_file
+
+if [ "$tablet_role" = "master" ]; then
+    echo "CREATE DATABASE vt_$keyspace;" >> $init_db_sql_file
+fi
+
+export EXTRA_MY_CNF=$VTROOT/config/mycnf/master_mysql56.cnf
+
+mkdir -p $VTDATAROOT/backups
+
+echo "Starting MySQL for tablet..."
+action="init -init_db_sql_file $init_db_sql_file"
+if [ -d $VTDATAROOT/$tablet_dir ]; then
+  echo "Resuming from existing vttablet dir:"
+  echo "    $VTDATAROOT/$tablet_dir"
+  action='start'
+fi
+
+$VTROOT/bin/mysqlctl \
+  -log_dir $VTDATAROOT/tmp \
+  -tablet_uid $uid \
+  $dbconfig_dba_flags \
+  -mysql_port 3306 \
+  $action &
+
+wait
+
+$VTROOT/bin/vtctl $TOPOLOGY_FLAGS AddCellInfo -root vitess/$CELL -server_address consul1:8500 $CELL
+
+$VTROOT/bin/vtctl $TOPOLOGY_FLAGS CreateKeyspace $keyspace
+$VTROOT/bin/vtctl $TOPOLOGY_FLAGS CreateShard $keyspace/$shard
+
+$VTROOT/bin/vtctl $TOPOLOGY_FLAGS InitTablet -shard $shard -keyspace $keyspace -allow_master_override $alias $tablet_role
+
+echo "Starting vttablet..."
+exec $VTROOT/bin/vttablet \
+  $TOPOLOGY_FLAGS \
+  -logtostderr=true \
+  -tablet-path $alias \
+  -tablet_hostname "" \
+  -health_check_interval 5s \
+  -enable_semi_sync \
+  -enable_replication_reporter \
+  -port $WEB_PORT \
+  -grpc_port $GRPC_PORT \
+  -service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
+  -pid_file $VTDATAROOT/$tablet_dir/vttablet.pid \
+  -vtctld_addr http://vtctld:$WEB_PORT/ \
+  $dbconfig_flags


### PR DESCRIPTION
Add docker-compose configuration.
With that, we can start a cluster with one command:
```
docker-compose up
```

With that in place, we can load schema, and run queries.

The setup exposes the web ports and the vtgate MySQL port to the host. So we can connect to them to query and poke around.

[fixes #3384]
cc @vmg as we worked on this initial version while ago.
WDYT @sougou?