### PR TITLE
resource pool idle closer and more stats

### DIFF
--- a/go/pools/resource_pool.go
+++ b/go/pools/resource_pool.go
@@ -93,7 +93,7 @@ func NewResourcePool(factory Factory, capacity, maxCap int, idleTimeout time.Dur
 
 	if idleTimeout != 0 {
 		rp.idleTimer = timer.NewTimer(idleTimeout / 10)
-		rp.idleTimer.Start(func() { rp.closeIdleResources() })
+		rp.idleTimer.Start(rp.closeIdleResources)
 	}
 	return rp
 }

--- a/go/pools/resource_pool_test.go
+++ b/go/pools/resource_pool_test.go
@@ -408,6 +408,9 @@ func TestIdleTimeout(t *testing.T) {
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
 	}
+	if p.IdleClosed() != 0 {
+		t.Errorf("Expecting 0, received %d", p.IdleClosed())
+	}
 	p.Put(r)
 	if lastID.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
@@ -415,10 +418,16 @@ func TestIdleTimeout(t *testing.T) {
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
 	}
+	if p.IdleClosed() != 0 {
+		t.Errorf("Expecting 0, received %d", p.IdleClosed())
+	}
 	time.Sleep(20 * time.Millisecond)
 
 	if count.Get() != 0 {
 		t.Errorf("Expecting 0, received %d", count.Get())
+	}
+	if p.IdleClosed() != 1 {
+		t.Errorf("Expecting 1, received %d", p.IdleClosed())
 	}
 	r, err = p.Get(ctx)
 	if err != nil {
@@ -429,6 +438,9 @@ func TestIdleTimeout(t *testing.T) {
 	}
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
+	}
+	if p.IdleClosed() != 1 {
+		t.Errorf("Expecting 1, received %d", p.IdleClosed())
 	}
 
 	// sleep to let the idle closer run while all resources are in use
@@ -440,7 +452,9 @@ func TestIdleTimeout(t *testing.T) {
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
 	}
-
+	if p.IdleClosed() != 1 {
+		t.Errorf("Expecting 1, received %d", p.IdleClosed())
+	}
 	p.Put(r)
 	r, err = p.Get(ctx)
 	if err != nil {
@@ -451,6 +465,9 @@ func TestIdleTimeout(t *testing.T) {
 	}
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
+	}
+	if p.IdleClosed() != 1 {
+		t.Errorf("Expecting 1, received %d", p.IdleClosed())
 	}
 
 	// the idle close thread wakes up every 1/100 of the idle time, so ensure
@@ -465,6 +482,9 @@ func TestIdleTimeout(t *testing.T) {
 	if count.Get() != 1 {
 		t.Errorf("Expecting 1, received %d", count.Get())
 	}
+	if p.IdleClosed() != 1 {
+		t.Errorf("Expecting 1, received %d", p.IdleClosed())
+	}
 
 	p.SetIdleTimeout(10 * time.Millisecond)
 	time.Sleep(20 * time.Millisecond)
@@ -474,7 +494,9 @@ func TestIdleTimeout(t *testing.T) {
 	if count.Get() != 0 {
 		t.Errorf("Expecting 1, received %d", count.Get())
 	}
-
+	if p.IdleClosed() != 2 {
+		t.Errorf("Expecting 2, received %d", p.IdleClosed())
+	}
 }
 
 func TestCreateFail(t *testing.T) {

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -67,6 +67,8 @@ func NewConnectionPool(name string, capacity int, idleTimeout time.Duration) *Co
 	usedNames[name] = true
 	stats.Publish(name+"Capacity", stats.IntFunc(cp.Capacity))
 	stats.Publish(name+"Available", stats.IntFunc(cp.Available))
+	stats.Publish(name+"Active", stats.IntFunc(cp.Active))
+	stats.Publish(name+"InUse", stats.IntFunc(cp.InUse))
 	stats.Publish(name+"MaxCap", stats.IntFunc(cp.MaxCap))
 	stats.Publish(name+"WaitCount", stats.IntFunc(cp.WaitCount))
 	stats.Publish(name+"WaitTime", stats.DurationFunc(cp.WaitTime))
@@ -205,6 +207,24 @@ func (cp *ConnectionPool) Available() int64 {
 		return 0
 	}
 	return p.Available()
+}
+
+// Active returns the number of active connections in the pool
+func (cp *ConnectionPool) Active() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.Active()
+}
+
+// InUse returns the number of in-use connections in the pool
+func (cp *ConnectionPool) InUse() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.InUse()
 }
 
 // MaxCap returns the maximum size of the pool

--- a/go/vt/dbconnpool/connection_pool.go
+++ b/go/vt/dbconnpool/connection_pool.go
@@ -71,6 +71,7 @@ func NewConnectionPool(name string, capacity int, idleTimeout time.Duration) *Co
 	stats.Publish(name+"WaitCount", stats.IntFunc(cp.WaitCount))
 	stats.Publish(name+"WaitTime", stats.DurationFunc(cp.WaitTime))
 	stats.Publish(name+"IdleTimeout", stats.DurationFunc(cp.IdleTimeout))
+	stats.Publish(name+"IdleClosed", stats.IntFunc(cp.IdleClosed))
 	return cp
 }
 
@@ -240,4 +241,13 @@ func (cp *ConnectionPool) IdleTimeout() time.Duration {
 		return 0
 	}
 	return p.IdleTimeout()
+}
+
+// IdleClosed returns the number of closed connections for the pool.
+func (cp *ConnectionPool) IdleClosed() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.IdleClosed()
 }

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -84,10 +84,13 @@ func New(
 	usedNames[name] = true
 	stats.Publish(name+"Capacity", stats.IntFunc(cp.Capacity))
 	stats.Publish(name+"Available", stats.IntFunc(cp.Available))
+	stats.Publish(name+"Active", stats.IntFunc(cp.Active))
+	stats.Publish(name+"InUse", stats.IntFunc(cp.InUse))
 	stats.Publish(name+"MaxCap", stats.IntFunc(cp.MaxCap))
 	stats.Publish(name+"WaitCount", stats.IntFunc(cp.WaitCount))
 	stats.Publish(name+"WaitTime", stats.DurationFunc(cp.WaitTime))
 	stats.Publish(name+"IdleTimeout", stats.DurationFunc(cp.IdleTimeout))
+	stats.Publish(name+"IdleClosed", stats.IntFunc(cp.IdleClosed))
 	return cp
 }
 
@@ -210,6 +213,24 @@ func (cp *Pool) Available() int64 {
 	return p.Available()
 }
 
+// Active returns the number of active connections in the pool
+func (cp *Pool) Active() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.Active()
+}
+
+// InUse returns the number of in-use connections in the pool
+func (cp *Pool) InUse() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.InUse()
+}
+
 // MaxCap returns the maximum size of the pool
 func (cp *Pool) MaxCap() int64 {
 	p := cp.pool()
@@ -244,6 +265,15 @@ func (cp *Pool) IdleTimeout() time.Duration {
 		return 0
 	}
 	return p.IdleTimeout()
+}
+
+// IdleClosed returns the number of closed connections for the pool.
+func (cp *Pool) IdleClosed() int64 {
+	p := cp.pool()
+	if p == nil {
+		return 0
+	}
+	return p.IdleClosed()
 }
 
 func (cp *Pool) isCallerIDAppDebug(ctx context.Context) bool {

--- a/go/vt/vttablet/tabletserver/connpool/pool_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool_test.go
@@ -191,13 +191,32 @@ func TestConnPoolStateWhilePoolIsOpen(t *testing.T) {
 	if connPool.Available() != 100 {
 		t.Fatalf("pool available connections should be 100")
 	}
+	if connPool.Active() != 0 {
+		t.Fatalf("pool active connections should be 0")
+	}
+	if connPool.InUse() != 0 {
+		t.Fatalf("pool inUse connections should be 0")
+	}
 	dbConn, _ := connPool.Get(context.Background())
 	if connPool.Available() != 99 {
 		t.Fatalf("pool available connections should be 99")
 	}
+	if connPool.Active() != 1 {
+		t.Fatalf("pool active connections should be 1")
+	}
+	if connPool.InUse() != 1 {
+		t.Fatalf("pool inUse connections should be 1")
+	}
+
 	dbConn.Recycle()
 	if connPool.Available() != 100 {
 		t.Fatalf("pool available connections should be 100")
+	}
+	if connPool.Active() != 1 {
+		t.Fatalf("pool active connections should be 1")
+	}
+	if connPool.InUse() != 0 {
+		t.Fatalf("pool inUse connections should be 0")
 	}
 }
 


### PR DESCRIPTION
Rework the resource pool to fix the idleTimeout implementation and to expose more stats.

### Idle Timeout Rework

First, the previous implementation of the idleTimeout didn't actually work when there are truly idle connections because it waited until a resource was obtained from the pool before checking the idle time. As such, when used in conjunction with mysql's network timeouts, we observed that connections were actually being closed by mysql due to network timeouts and not by the connection pool idle timer.

The new implementation spins up a separate goroutine to implement the idle timeout checks. It wakes up every 1/100th of the configured idle timeout and scans all the entries that are currently in the pool, closing them if they end up hitting the idle timeout.

### New Stats Counters

I also implemented three new stats counters:
* `Active` counts the number of underlying resources that are open, including both those which are in-use by the application and non-nil resources in the pool.
* `InUse` counts the number of resources used by the application. This is in most circumstances the same as Capacity - Available, except during resizing events. Also FWIW tracking the in-use connections is a more useful stat in a metrics system than having to do the derived calculation.
* `IdleClosed` counts the number of connections closed due to the idle timeout.

All these stats are also exposed in the tabletserver connection pool classes and via the JSON output.

### Miscellanea

Along the way, I removed the resource pool `Stats()` function rather than include the new stats in the list of returned counters since there are equivalent wrappers for the individual stats and this just seemed unnecessary.

I also reworked the implementation of the `Available` metric to use an explicit counter instead of relying on the length of the channel.  This is mostly irrelevant for the actual code, but it makes the tests more reliable since the idleCloser thread grabs resources from the pool for a short interval which can race with the tests.

### Open Issue

Finally, there is one open issue that I don't understand... during one test run I got a panic where the `idleCloser` was sending on a closed channel. The only explanation I can come up with is that this is a race during shutdown.