### PR TITLE
bug: SplitQuery name escaping

### DIFF
--- a/go/vt/vttablet/tabletserver/splitquery/equal_splits_algorithm.go
+++ b/go/vt/vttablet/tabletserver/splitquery/equal_splits_algorithm.go
@@ -194,9 +194,9 @@ func buildMinMaxQuery(splitParams *SplitParams) string {
 		panic(fmt.Sprintf("Can't get tableName from query %v", splitParams.sql))
 	}
 	return fmt.Sprintf("select min(%v), max(%v) from %v",
-		splitParams.splitColumns[0].Name,
-		splitParams.splitColumns[0].Name,
-		tableName)
+		sqlparser.String(splitParams.splitColumns[0].Name),
+		sqlparser.String(splitParams.splitColumns[0].Name),
+		sqlparser.String(tableName))
 }
 
 // bigRatToValue converts 'number' to an SQL value with SQL type: valueType.


### PR DESCRIPTION
SplitQuery was not escaping table or column names when it converted
the original query into min, max.