### PR TITLE
Improving topo.ListDir

### DIFF
--- a/go/vt/topo/cell_info.go
+++ b/go/vt/topo/cell_info.go
@@ -37,18 +37,14 @@ import (
 // available cells, if necessary. A CellInfo can only be removed if no
 // Shard record references the corresponding cell in its Cells list.
 
-const (
-	cellsPath = "cells"
-)
-
 func pathForCellInfo(cell string) string {
-	return path.Join(cellsPath, cell, CellInfoFile)
+	return path.Join(CellsPath, cell, CellInfoFile)
 }
 
 // GetCellInfoNames returns the names of the existing cells. They are
 // sorted by name.
 func (ts *Server) GetCellInfoNames(ctx context.Context) ([]string, error) {
-	entries, err := ts.globalCell.ListDir(ctx, cellsPath)
+	entries, err := ts.globalCell.ListDir(ctx, CellsPath, false /*full*/)
 	switch err {
 	case ErrNoNode:
 		return nil, nil
@@ -171,7 +167,7 @@ func (ts *Server) DeleteCellInfo(ctx context.Context, cell string) error {
 func (ts *Server) GetKnownCells(ctx context.Context) ([]string, error) {
 	// Note we use the global read-only cell here, as the result
 	// is not time sensitive.
-	entries, err := ts.globalReadOnlyCell.ListDir(ctx, cellsPath)
+	entries, err := ts.globalReadOnlyCell.ListDir(ctx, CellsPath, false /*full*/)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/topo/cell_info.go
+++ b/go/vt/topo/cell_info.go
@@ -53,7 +53,7 @@ func (ts *Server) GetCellInfoNames(ctx context.Context) ([]string, error) {
 	case ErrNoNode:
 		return nil, nil
 	case nil:
-		return entries, nil
+		return DirEntriesToStringArray(entries), nil
 	default:
 		return nil, err
 	}
@@ -171,5 +171,9 @@ func (ts *Server) DeleteCellInfo(ctx context.Context, cell string) error {
 func (ts *Server) GetKnownCells(ctx context.Context) ([]string, error) {
 	// Note we use the global read-only cell here, as the result
 	// is not time sensitive.
-	return ts.globalReadOnlyCell.ListDir(ctx, cellsPath)
+	entries, err := ts.globalReadOnlyCell.ListDir(ctx, cellsPath)
+	if err != nil {
+		return nil, err
+	}
+	return DirEntriesToStringArray(entries), nil
 }

--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -43,7 +43,11 @@ type Conn interface {
 	// list should be sorted by entry.Name.
 	// If there are no files under the provided path, returns ErrNoNode.
 	// dirPath is a path relative to the root directory of the cell.
-	ListDir(ctx context.Context, dirPath string) ([]DirEntry, error)
+	// If full is set, we want all the fields in DirEntry to be filled in.
+	// If full is not set, only Name will be used. This is intended for
+	// implementations where getting more than the names is more expensive,
+	// as in most cases only the names are needed.
+	ListDir(ctx context.Context, dirPath string, full bool) ([]DirEntry, error)
 
 	//
 	// File support
@@ -185,14 +189,17 @@ const (
 // DirEntry is an entry in a directory, as returned by ListDir.
 type DirEntry struct {
 	// Name is the name of the entry.
+	// Always filled in.
 	Name string
 
 	// Type is the DirEntryType of the entry.
+	// Only filled in if full is true.
 	Type DirEntryType
 
 	// Ephemeral is set if the directory / file only contains
 	// data that was not set by the file API, like lock files
 	// or master-election related files.
+	// Only filled in if full is true.
 	Ephemeral bool
 }
 

--- a/go/vt/topo/consultopo/directory.go
+++ b/go/vt/topo/consultopo/directory.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ListDir is part of the topo.Conn interface.
-func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) {
+func (s *Server) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
 	nodePath := path.Join(s.root, dirPath) + "/"
 	if nodePath == "//" {
 		// Special case where c.root is "/", dirPath is empty,
@@ -45,7 +45,7 @@ func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) 
 	}
 
 	prefixLen := len(nodePath)
-	var result []string
+	var result []topo.DirEntry
 	for _, p := range keys {
 		// Remove the prefix, base path.
 		if !strings.HasPrefix(p, nodePath) {
@@ -59,8 +59,10 @@ func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) 
 		}
 
 		// Remove duplicates, add to list.
-		if len(result) == 0 || result[len(result)-1] != p {
-			result = append(result, p)
+		if len(result) == 0 || result[len(result)-1].Name != p {
+			result = append(result, topo.DirEntry{
+				Name: p,
+			})
 		}
 	}
 

--- a/go/vt/topo/consultopo/lock.go
+++ b/go/vt/topo/consultopo/lock.go
@@ -36,7 +36,7 @@ type consulLockDescriptor struct {
 // Lock is part of the topo.Conn interface.
 func (s *Server) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
 	// We list the directory first to make sure it exists.
-	if _, err := s.ListDir(ctx, dirPath); err != nil {
+	if _, err := s.ListDir(ctx, dirPath, false /*full*/); err != nil {
 		// We need to return the right error codes, like
 		// topo.ErrNoNode and topo.ErrInterrupted, and the
 		// easiest way to do this is to return convertError(err).

--- a/go/vt/topo/etcd2topo/directory.go
+++ b/go/vt/topo/etcd2topo/directory.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ListDir is part of the topo.Conn interface.
-func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) {
+func (s *Server) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
 	nodePath := path.Join(s.root, dirPath) + "/"
 	if nodePath == "//" {
 		// Special case where s.root is "/", dirPath is empty,
@@ -48,7 +48,7 @@ func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) 
 	}
 
 	prefixLen := len(nodePath)
-	var result []string
+	var result []topo.DirEntry
 	for _, ev := range resp.Kvs {
 		p := string(ev.Key)
 
@@ -64,8 +64,10 @@ func (s *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) 
 		}
 
 		// Remove duplicates, add to list.
-		if len(result) == 0 || result[len(result)-1] != p {
-			result = append(result, p)
+		if len(result) == 0 || result[len(result)-1].Name != p {
+			result = append(result, topo.DirEntry{
+				Name: p,
+			})
 		}
 	}
 

--- a/go/vt/topo/etcd2topo/lock.go
+++ b/go/vt/topo/etcd2topo/lock.go
@@ -117,7 +117,7 @@ type etcdLockDescriptor struct {
 // Lock is part of the topo.Conn interface.
 func (s *Server) Lock(ctx context.Context, dirPath, contents string) (topo.LockDescriptor, error) {
 	// We list the directory first to make sure it exists.
-	if _, err := s.ListDir(ctx, dirPath); err != nil {
+	if _, err := s.ListDir(ctx, dirPath, false /*full*/); err != nil {
 		// We need to return the right error codes, like
 		// topo.ErrNoNode and topo.ErrInterrupted, and the
 		// easiest way to do this is to return convertError(err).

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -97,7 +97,7 @@ func (c *TeeConn) Close() {
 }
 
 // ListDir is part of the topo.Conn interface.
-func (c *TeeConn) ListDir(ctx context.Context, dirPath string) ([]string, error) {
+func (c *TeeConn) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
 	return c.primary.ListDir(ctx, dirPath)
 }
 

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -97,8 +97,8 @@ func (c *TeeConn) Close() {
 }
 
 // ListDir is part of the topo.Conn interface.
-func (c *TeeConn) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
-	return c.primary.ListDir(ctx, dirPath)
+func (c *TeeConn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
+	return c.primary.ListDir(ctx, dirPath, full)
 }
 
 // Create is part of the topo.Conn interface.

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -271,7 +271,7 @@ func (ts *Server) DeleteKeyspace(ctx context.Context, keyspace string) error {
 
 // GetKeyspaces returns the list of keyspaces in the topology.
 func (ts *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
-	children, err := ts.globalCell.ListDir(ctx, KeyspacesPath)
+	children, err := ts.globalCell.ListDir(ctx, KeyspacesPath, false /*full*/)
 	switch err {
 	case nil:
 		return DirEntriesToStringArray(children), nil
@@ -285,7 +285,7 @@ func (ts *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
 // GetShardNames returns the list of shards in a keyspace.
 func (ts *Server) GetShardNames(ctx context.Context, keyspace string) ([]string, error) {
 	shardsPath := path.Join(KeyspacesPath, keyspace, ShardsPath)
-	children, err := ts.globalCell.ListDir(ctx, shardsPath)
+	children, err := ts.globalCell.ListDir(ctx, shardsPath, false /*full*/)
 	if err == ErrNoNode {
 		// The directory doesn't exist, let's see if the keyspace
 		// is here or not.

--- a/go/vt/topo/keyspace.go
+++ b/go/vt/topo/keyspace.go
@@ -274,7 +274,7 @@ func (ts *Server) GetKeyspaces(ctx context.Context) ([]string, error) {
 	children, err := ts.globalCell.ListDir(ctx, KeyspacesPath)
 	switch err {
 	case nil:
-		return children, nil
+		return DirEntriesToStringArray(children), nil
 	case ErrNoNode:
 		return nil, nil
 	default:
@@ -296,5 +296,5 @@ func (ts *Server) GetShardNames(ctx context.Context, keyspace string) ([]string,
 		}
 		return nil, err
 	}
-	return children, err
+	return DirEntriesToStringArray(children), err
 }

--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -18,7 +18,6 @@ package memorytopo
 
 import (
 	"fmt"
-	"sort"
 
 	"golang.org/x/net/context"
 
@@ -26,7 +25,7 @@ import (
 )
 
 // ListDir is part of the topo.Conn interface.
-func (c *Conn) ListDir(ctx context.Context, dirPath string) ([]string, error) {
+func (c *Conn) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
 
@@ -41,10 +40,12 @@ func (c *Conn) ListDir(ctx context.Context, dirPath string) ([]string, error) {
 		return nil, fmt.Errorf("node %v in cell %v is not a directory", dirPath, c.cell)
 	}
 
-	var result []string
+	var result []topo.DirEntry
 	for n := range n.children {
-		result = append(result, n)
+		result = append(result, topo.DirEntry{
+			Name: n,
+		})
 	}
-	sort.Strings(result)
+	topo.DirEntriesSortByName(result)
 	return result, nil
 }

--- a/go/vt/topo/memorytopo/directory.go
+++ b/go/vt/topo/memorytopo/directory.go
@@ -25,9 +25,14 @@ import (
 )
 
 // ListDir is part of the topo.Conn interface.
-func (c *Conn) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
+func (c *Conn) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
 	c.factory.mu.Lock()
 	defer c.factory.mu.Unlock()
+
+	isRoot := false
+	if dirPath == "" || dirPath == "/" {
+		isRoot = true
+	}
 
 	// Get the node to list.
 	n := c.factory.nodeByPath(c.cell, dirPath)
@@ -40,11 +45,21 @@ func (c *Conn) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, er
 		return nil, fmt.Errorf("node %v in cell %v is not a directory", dirPath, c.cell)
 	}
 
-	var result []topo.DirEntry
-	for n := range n.children {
-		result = append(result, topo.DirEntry{
-			Name: n,
-		})
+	result := make([]topo.DirEntry, 0, len(n.children))
+	for name, child := range n.children {
+		e := topo.DirEntry{
+			Name: name,
+		}
+		if full {
+			e.Type = topo.TypeFile
+			if child.isDirectory() {
+				e.Type = topo.TypeDirectory
+			}
+			if isRoot && name == electionsPath {
+				e.Ephemeral = true
+			}
+		}
+		result = append(result, e)
 	}
 	topo.DirEntriesSortByName(result)
 	return result, nil

--- a/go/vt/topo/server.go
+++ b/go/vt/topo/server.go
@@ -78,6 +78,7 @@ const (
 
 // Path for all object types.
 const (
+	CellsPath     = "cells"
 	KeyspacesPath = "keyspaces"
 	ShardsPath    = "shards"
 	TabletsPath   = "tablets"

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -107,7 +107,7 @@ func (ts *Server) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]strin
 	children, err := conn.ListDir(ctx, KeyspacesPath)
 	switch err {
 	case nil:
-		return children, nil
+		return DirEntriesToStringArray(children), nil
 	case ErrNoNode:
 		return nil, nil
 	default:

--- a/go/vt/topo/srv_keyspace.go
+++ b/go/vt/topo/srv_keyspace.go
@@ -104,7 +104,7 @@ func (ts *Server) GetSrvKeyspaceNames(ctx context.Context, cell string) ([]strin
 		return nil, err
 	}
 
-	children, err := conn.ListDir(ctx, KeyspacesPath)
+	children, err := conn.ListDir(ctx, KeyspacesPath, false /*full*/)
 	switch err {
 	case nil:
 		return DirEntriesToStringArray(children), nil

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -463,7 +463,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cell string) ([]*topodat
 
 	result := make([]*topodatapb.TabletAlias, len(children))
 	for i, child := range children {
-		result[i], err = topoproto.ParseTabletAlias(child)
+		result[i], err = topoproto.ParseTabletAlias(child.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/go/vt/topo/tablet.go
+++ b/go/vt/topo/tablet.go
@@ -452,7 +452,7 @@ func (ts *Server) GetTabletsByCell(ctx context.Context, cell string) ([]*topodat
 	}
 
 	// List the directory, and parse the aliases
-	children, err := conn.ListDir(ctx, TabletsPath)
+	children, err := conn.ListDir(ctx, TabletsPath, false /*full*/)
 	if err != nil {
 		if err == ErrNoNode {
 			// directory doesn't exist, empty list, no error.

--- a/go/vt/topo/test/directory.go
+++ b/go/vt/topo/test/directory.go
@@ -48,20 +48,45 @@ func checkDirectory(t *testing.T, ts *topo.Server) {
 
 func checkListDir(ctx context.Context, t *testing.T, conn topo.Conn, dirPath string, expected []topo.DirEntry) {
 	t.Helper()
-	entries, err := conn.ListDir(ctx, dirPath)
+
+	// Build the shallow expected list, when full=false.
+	se := make([]topo.DirEntry, len(expected))
+	for i, e := range expected {
+		se[i].Name = e.Name
+	}
+
+	// Test with full=false.
+	entries, err := conn.ListDir(ctx, dirPath, false /*full*/)
+	switch err {
+	case topo.ErrNoNode:
+		if len(se) != 0 {
+			t.Errorf("ListDir(%v, false) returned ErrNoNode but was expecting %v", dirPath, se)
+		}
+	case nil:
+		if len(se) != 0 || len(entries) != 0 {
+			if !reflect.DeepEqual(entries, se) {
+				t.Errorf("ListDir(%v, false) returned %v but was expecting %v", dirPath, entries, se)
+			}
+		}
+	default:
+		t.Errorf("ListDir(%v, false) returned unexpected error: %v", dirPath, err)
+	}
+
+	// Test with full=true.
+	entries, err = conn.ListDir(ctx, dirPath, true /*full*/)
 	switch err {
 	case topo.ErrNoNode:
 		if len(expected) != 0 {
-			t.Errorf("ListDir(%v) returned ErrNoNode but was expecting %v", dirPath, expected)
+			t.Errorf("ListDir(%v, true) returned ErrNoNode but was expecting %v", dirPath, expected)
 		}
 	case nil:
 		if len(expected) != 0 || len(entries) != 0 {
 			if !reflect.DeepEqual(entries, expected) {
-				t.Errorf("ListDir(%v) returned %v but was expecting %v", dirPath, entries, expected)
+				t.Errorf("ListDir(%v, true) returned %v but was expecting %v", dirPath, entries, expected)
 			}
 		}
 	default:
-		t.Errorf("ListDir(%v) returned unexpected error: %v", dirPath, err)
+		t.Errorf("ListDir(%v, true) returned unexpected error: %v", dirPath, err)
 	}
 }
 
@@ -73,6 +98,7 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	if hasCells {
 		expected = append(expected, topo.DirEntry{
 			Name: "cells",
+			Type: topo.TypeDirectory,
 		})
 	}
 	checkListDir(ctx, t, conn, "/", expected)
@@ -87,6 +113,7 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	expected = append([]topo.DirEntry{
 		{
 			Name: "MyFile",
+			Type: topo.TypeFile,
 		},
 	}, expected...)
 	checkListDir(ctx, t, conn, "/", expected)
@@ -105,6 +132,7 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	}
 	expected = append(expected, topo.DirEntry{
 		Name: "types",
+		Type: topo.TypeDirectory,
 	})
 
 	// Check listing at all levels.
@@ -112,11 +140,13 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	checkListDir(ctx, t, conn, "/types/", []topo.DirEntry{
 		{
 			Name: "name",
+			Type: topo.TypeDirectory,
 		},
 	})
 	checkListDir(ctx, t, conn, "/types/name/", []topo.DirEntry{
 		{
 			Name: "MyFile",
+			Type: topo.TypeFile,
 		},
 	})
 
@@ -131,19 +161,23 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	checkListDir(ctx, t, conn, "/types/", []topo.DirEntry{
 		{
 			Name: "name",
+			Type: topo.TypeDirectory,
 		},
 		{
 			Name: "othername",
+			Type: topo.TypeDirectory,
 		},
 	})
 	checkListDir(ctx, t, conn, "/types/name/", []topo.DirEntry{
 		{
 			Name: "MyFile",
+			Type: topo.TypeFile,
 		},
 	})
 	checkListDir(ctx, t, conn, "/types/othername/", []topo.DirEntry{
 		{
 			Name: "MyFile",
+			Type: topo.TypeFile,
 		},
 	})
 
@@ -155,12 +189,14 @@ func checkDirectoryInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	checkListDir(ctx, t, conn, "/types/", []topo.DirEntry{
 		{
 			Name: "othername",
+			Type: topo.TypeDirectory,
 		},
 	})
 	checkListDir(ctx, t, conn, "/types/name/", nil)
 	checkListDir(ctx, t, conn, "/types/othername/", []topo.DirEntry{
 		{
 			Name: "MyFile",
+			Type: topo.TypeFile,
 		},
 	})
 

--- a/go/vt/topo/test/election.go
+++ b/go/vt/topo/test/election.go
@@ -70,6 +70,20 @@ func checkElection(t *testing.T, ts *topo.Server) {
 		t.Fatalf("mp1 cannot become master: %v", err)
 	}
 
+	// A lot of implementations use a toplevel directory for their elections.
+	// Make sure it is marked as 'Ephemeral'.
+	entries, err := conn.ListDir(context.Background(), "/", true /*full*/)
+	if err != nil {
+		t.Fatalf("ListDir(/) failed: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name != topo.CellsPath {
+			if !e.Ephemeral {
+				t.Errorf("toplevel directory that is not ephemeral: %v", e)
+			}
+		}
+	}
+
 	// get the current master name, better be id1
 	waitForMasterID(t, mp1, id1)
 

--- a/go/vt/topo/test/file.go
+++ b/go/vt/topo/test/file.go
@@ -54,6 +54,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	if hasCells {
 		expected = append(expected, topo.DirEntry{
 			Name: "cells",
+			Type: topo.TypeDirectory,
 		})
 	}
 	checkListDir(ctx, t, conn, "/", expected)
@@ -73,6 +74,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	// See it in the listing now.
 	expected = append(expected, topo.DirEntry{
 		Name: "myfile",
+		Type: topo.TypeFile,
 	})
 	checkListDir(ctx, t, conn, "/", expected)
 
@@ -186,6 +188,7 @@ func checkFileInCell(t *testing.T, conn topo.Conn, hasCells bool) {
 	// See it in the listing now.
 	expected = append(expected, topo.DirEntry{
 		Name: "myfile",
+		Type: topo.TypeFile,
 	})
 	checkListDir(ctx, t, conn, "/", expected)
 

--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -199,7 +199,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 			var children []DirEntry
 			var err error
 			parentPath := strings.Join(parts[:i], "/")
-			children, err = conn.ListDir(ctx, parentPath)
+			children, err = conn.ListDir(ctx, parentPath, false /*full*/)
 			if err != nil {
 				// we asked for something like
 				// /keyspaces/aaa/* and
@@ -274,7 +274,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 	}
 
 	// This is an expanded path, we need to check if it exists.
-	if _, err = conn.ListDir(ctx, p); err == nil {
+	if _, err = conn.ListDir(ctx, p, false /*full*/); err == nil {
 		// The path exists as a directory, return it.
 		return []string{p}, nil
 	}

--- a/go/vt/topo/wildcards.go
+++ b/go/vt/topo/wildcards.go
@@ -196,7 +196,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 
 	for i, part := range parts {
 		if fileutil.HasWildcard(part) {
-			var children []string
+			var children []DirEntry
 			var err error
 			parentPath := strings.Join(parts[:i], "/")
 			children, err = conn.ListDir(ctx, parentPath)
@@ -218,7 +218,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 			var firstError error
 
 			for j, child := range children {
-				matched, err := path.Match(part, child)
+				matched, err := path.Match(part, child.Name)
 				if err != nil {
 					return nil, err
 				}
@@ -227,7 +227,7 @@ func (ts *Server) resolveRecursive(ctx context.Context, cell string, parts []str
 					wg.Add(1)
 					newParts := make([]string, len(parts))
 					copy(newParts, parts)
-					newParts[i] = child
+					newParts[i] = child.Name
 					go func(j int) {
 						defer wg.Done()
 						subResult, err := ts.resolveRecursive(ctx, cell, newParts, false)

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -51,7 +51,7 @@ func (ts *Server) GetWorkflowNames(ctx context.Context) ([]string, error) {
 	case ErrNoNode:
 		return nil, nil
 	case nil:
-		return entries, nil
+		return DirEntriesToStringArray(entries), nil
 	default:
 		return nil, err
 	}

--- a/go/vt/topo/workflow.go
+++ b/go/vt/topo/workflow.go
@@ -46,7 +46,7 @@ type WorkflowInfo struct {
 // GetWorkflowNames returns the names of the existing
 // workflows. They are sorted by uuid.
 func (ts *Server) GetWorkflowNames(ctx context.Context) ([]string, error) {
-	entries, err := ts.globalCell.ListDir(ctx, workflowsPath)
+	entries, err := ts.globalCell.ListDir(ctx, workflowsPath, false /*full*/)
 	switch err {
 	case ErrNoNode:
 		return nil, nil

--- a/go/vt/topo/zk2topo/directory.go
+++ b/go/vt/topo/zk2topo/directory.go
@@ -19,14 +19,20 @@ package zk2topo
 import (
 	"path"
 	"sort"
+	"sync"
 
 	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
 )
 
 // ListDir is part of the topo.Conn interface.
-func (zs *Server) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
+func (zs *Server) ListDir(ctx context.Context, dirPath string, full bool) ([]topo.DirEntry, error) {
 	zkPath := path.Join(zs.root, dirPath)
+
+	isRoot := false
+	if dirPath == "" || dirPath == "/" {
+		isRoot = true
+	}
 
 	children, _, err := zs.conn.Children(ctx, zkPath)
 	if err != nil {
@@ -36,9 +42,40 @@ func (zs *Server) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry,
 
 	result := make([]topo.DirEntry, len(children))
 	for i, child := range children {
-		result[i] = topo.DirEntry{
-			Name: child,
-		}
+		result[i].Name = child
 	}
+
+	if full {
+		var wg sync.WaitGroup
+		for i := range result {
+			if isRoot && result[i].Name == electionsPath {
+				// Shortcut here: we know it's an ephemeral directory.
+				result[i].Type = topo.TypeDirectory
+				result[i].Ephemeral = true
+				continue
+			}
+
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				p := path.Join(zkPath, result[i].Name)
+				_, stat, err := zs.conn.Get(ctx, p)
+				if err != nil {
+					return
+				}
+				if stat.NumChildren == 0 {
+					result[i].Type = topo.TypeFile
+				} else {
+					result[i].Type = topo.TypeDirectory
+				}
+				if stat.EphemeralOwner != 0 {
+					// This is an ephemeral node, we use this for locks.
+					result[i].Ephemeral = true
+				}
+			}(i)
+		}
+		wg.Wait()
+	}
+
 	return result, nil
 }

--- a/go/vt/topo/zk2topo/directory.go
+++ b/go/vt/topo/zk2topo/directory.go
@@ -20,11 +20,12 @@ import (
 	"path"
 	"sort"
 
+	"github.com/youtube/vitess/go/vt/topo"
 	"golang.org/x/net/context"
 )
 
 // ListDir is part of the topo.Conn interface.
-func (zs *Server) ListDir(ctx context.Context, dirPath string) ([]string, error) {
+func (zs *Server) ListDir(ctx context.Context, dirPath string) ([]topo.DirEntry, error) {
 	zkPath := path.Join(zs.root, dirPath)
 
 	children, _, err := zs.conn.Children(ctx, zkPath)
@@ -32,5 +33,12 @@ func (zs *Server) ListDir(ctx context.Context, dirPath string) ([]string, error)
 		return nil, convertError(err)
 	}
 	sort.Strings(children)
-	return children, nil
+
+	result := make([]topo.DirEntry, len(children))
+	for i, child := range children {
+		result[i] = topo.DirEntry{
+			Name: child,
+		}
+	}
+	return result, nil
 }

--- a/go/vt/vtctld/explorer.go
+++ b/go/vt/vtctld/explorer.go
@@ -114,7 +114,7 @@ func (ex *backendExplorer) HandlePath(nodePath string, r *http.Request) *Result 
 
 	// It worked as a directory, clear any file error.
 	result.Error = ""
-	result.Children = children
+	result.Children = topo.DirEntriesToStringArray(children)
 	return result
 }
 

--- a/go/vt/vtctld/explorer.go
+++ b/go/vt/vtctld/explorer.go
@@ -105,7 +105,7 @@ func (ex *backendExplorer) HandlePath(nodePath string, r *http.Request) *Result 
 	}
 
 	// Get the children, if any.
-	children, err := conn.ListDir(ctx, relativePath)
+	children, err := conn.ListDir(ctx, relativePath, false /*full*/)
 	if err != nil {
 		// It failed as a directory, let's just return what it did
 		// as a file.


### PR DESCRIPTION
It now returns a list of DirEntry objects. Each has a Name, that is always filled in.

Additionally, if the new 'full' flag is sent, we also fill in the Type (TypeFile or TypeDirectory), and the Ephemeral flag (only set for lock and election related files).

Also adding unit tests for all new fields and flags.

Note we don't really use this yet. The next few applications for this:
- improving vtctld topology browser so it shows the extra flags.
- adding 'vtctl TopoZip' and 'vtctl TopoUnzip' commands, that allow saving / restoring the topology (and supersede the 'zk zip' and 'zk unzip' commands). Will skip Ephemeral entries.
- adding 'vtctl TopoLs' command that shows the entries in a topo directory (and supersede 'zk ls' command).
