### PR TITLE
Add handler to support a callback before the OK packet is sent

### DIFF
--- a/go/mysql/fakesqldb/server.go
+++ b/go/mysql/fakesqldb/server.go
@@ -314,6 +314,10 @@ func (db *DB) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Resu
 	return db.Handler.HandleQuery(c, query, callback)
 }
 
+func (db *DB) ConnectionNegotiated(c *mysql.Conn) error {
+	return nil
+}
+
 // HandleQuery is the default implementation of the QueryHandler interface
 func (db *DB) HandleQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	if db.AllowAll {

--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -69,6 +69,12 @@ type Handler interface {
 	// ConnectionClosed is called when a connection is closed.
 	ConnectionClosed(c *Conn)
 
+	// Called when authorization is completed, but before the OK packet is sent
+	// This can be used to verify that the connection and all resources are valid
+	// before accepting the connection.  If error is returned, the connection is
+	// closed.
+	ConnectionNegotiated(c *Conn) error
+
 	// ComQuery is called when a connection receives a query.
 	// Note the contents of the query slice may change after
 	// the first call to callback. So the Handler should not
@@ -276,6 +282,12 @@ func (l *Listener) handle(conn net.Conn, connectionID uint32, acceptTime time.Ti
 		}
 		c.User = user
 		c.UserData = userData
+	}
+
+	// Verify with the handler that this connection is valid
+	if err = l.handler.ConnectionNegotiated(c); err != nil {
+		c.writeErrorPacket(CRServerHandshakeErr, SSUnknownSQLState, "%v", err)
+		return
 	}
 
 	// Negotiation worked, send OK packet.

--- a/go/mysql/server_test.go
+++ b/go/mysql/server_test.go
@@ -69,6 +69,10 @@ func (th *testHandler) NewConnection(c *Conn) {
 	th.lastConn = c
 }
 
+func (vh *testHandler) ConnectionNegotiated(c *Conn) error {
+	return nil
+}
+
 func (th *testHandler) ConnectionClosed(c *Conn) {
 }
 

--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -56,6 +56,7 @@ func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.Clie
 			log.Fatalf("There was an error initializing client grpc.DialOption: %v", err)
 		}
 	}
+	grpc.EnableTracing = true
 	return grpc.Dial(target, newopts...)
 }
 

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -75,6 +75,10 @@ func (vh *vtgateHandler) ConnectionClosed(c *mysql.Conn) {
 	}
 }
 
+func (vh *vtgateHandler) ConnectionNegotiated(c *mysql.Conn) error {
+	return nil
+}
+
 func (vh *vtgateHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
 	// FIXME(alainjobart): Add some kind of timeout to the context.
 	ctx := context.Background()


### PR DESCRIPTION
This is useful for verifying that the backend of the mysql
service can support this session before the OK packet is sent.
This is useful if you want to fail the mysql connection phase,
before the client can issue queries.