### PR TITLE
Handle auth method empty string

### DIFF
--- a/go/mysql/server.go
+++ b/go/mysql/server.go
@@ -608,6 +608,11 @@ func (l *Listener) parseClientHandshakePacket(c *Conn, firstTime bool, data []by
 		}
 	}
 
+	// The JDBC driver sometimes sends an empty string as the auth method when it wants to use mysql_native_password
+	if authMethod == "" {
+		authMethod = MysqlNativePassword
+	}
+
 	// FIXME(alainjobart) Add CLIENT_CONNECT_ATTRS parsing if we need it.
 
 	return username, authMethod, authResponse, nil


### PR DESCRIPTION
The JDBC driver sends the empty string as the requested auth method
when you don't specify a database name in the connection string. We
should default to mysql_native_password in this case just like mysqld.