### PR TITLE
Deprecate LookupHash

### DIFF
--- a/doc/V3VindexDesign.md
+++ b/doc/V3VindexDesign.md
@@ -68,19 +68,19 @@ We introduce the new term ‘vindex’ so that we can differentiate from the tra
 
 The vindex type is basically an indexing scheme represented by code. It can be a lookup index, or a hash, or anything else. A vindex type has a name that’s indicative of what kind of algorithm it implements to map a value to a keyspace id. A vindex type is not associated to any particular keyspace id or table. The list of vindex types is a very static list. New types have to be compiled into vitess.
 
-For example, a “lookup\_hash\_unique\_autoinc” index is one that will use a lookup table to convert a value, and hash it to compute the keyspace\_id. Additionally, it ensures that the values are unique, and it’s also capable of generating new values if needed.
+For example, a “lookup\_unique\_autoinc” index is one that will use a lookup table to convert a value, and hash it to compute the keyspace\_id. Additionally, it ensures that the values are unique, and it’s also capable of generating new values if needed.
 
-There is a hint here that there may be a “lookup\_hash\_autoinc”. Indeed there is. Just like database indexes, there are practical justifications for non-unique vindexes. In the future, we can also explore composite vindexes.
+There is a hint here that there may be a “lookup\_autoinc”. Indeed there is. Just like database indexes, there are practical justifications for non-unique vindexes. In the future, we can also explore composite vindexes.
 
 This is the currently supported list of vindex types:
 
 * **numeric**: binpack a uint64 into a keyspace_id
 * **hash**: hashes a uint64 into a keyspace_id
 * **hash_autoinc**: Same as hash, but can generate autoincrement values
-* **lookup\_hash**: Uses a lookup table, and hashes the result to generate a keyspace\_id. It’s non-unique.
-* **lookup\_hash\_unique**: lookup\_hash, but unique
-* **lookup\_hash\_autoinc**
-* **lookup\_hash\_unique\_autoinc**
+* **lookup**: Uses a lookup table, and hashes the result to generate a keyspace\_id. It’s non-unique.
+* **lookup\_unique**: lookup, but unique
+* **lookup\_autoinc**
+* **lookup\_unique\_autoinc**
 
 In the future, if we decide to go with our alternate sharding scheme where we require the main id to be stored with each table instead of the keyspace_id, the above list covers those needs also.
 

--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -51,23 +51,12 @@ def exec_query(conn, title, query, response, keyspace=None, kr=None):  # pylint:
       cursor.begin()
       cursor.execute(query, {})
       cursor.commit()
-    # sanatize results (index columns are binary blobs)
-    sanatized_results = list(
-      map(
-        lambda row:
-        list(
-          map(
-            lambda column:
-            str(column).decode('unicode_escape').encode('ascii','replace'),
-            row)),
-        cursor.results)
-    )
     response[title] = {
         "title": title,
         "description": cursor.description,
         "rowcount": cursor.rowcount,
         "lastrowid": cursor.lastrowid,
-        "results": sanatized_results,
+        "results": cursor.results,
         }
     cursor.close()
   except Exception as e:  # pylint: disable=broad-except
@@ -154,13 +143,13 @@ def main():
         conn, "name_info1",
         "select * from name_info", response, keyspace="user", kr="80-")
 
-    # music_user_idx table
+    # music_keyspace_idx table
     exec_query(
-        conn, "music_user_idx0",
-        "select * from music_user_idx", response, keyspace="user", kr="-80")
+        conn, "music_keyspace_idx0",
+        "select music_id, hex(keyspace_id) from music_keyspace_idx", response, keyspace="user", kr="-80")
     exec_query(
-        conn, "music_user_idx1",
-        "select * from music_user_idx", response, keyspace="user", kr="80-")
+        conn, "music_keyspace_idx1",
+        "select music_id, hex(keyspace_id) from music_keyspace_idx", response, keyspace="user", kr="80-")
 
     # lookup tables
     exec_query(
@@ -170,7 +159,7 @@ def main():
         conn, "music_seq", "select * from music_seq", response,
         keyspace="lookup", kr="-")
     exec_query(
-        conn, "name_user_idx", "select * from name_user_idx", response,
+        conn, "name_keyspace_idx", "select name, hex(keyspace_id) from name_keyspace_idx", response,
         keyspace="lookup", kr="-")
 
     print json.dumps(response, default=decimal_default)

--- a/examples/demo/cgi-bin/data.py
+++ b/examples/demo/cgi-bin/data.py
@@ -51,12 +51,23 @@ def exec_query(conn, title, query, response, keyspace=None, kr=None):  # pylint:
       cursor.begin()
       cursor.execute(query, {})
       cursor.commit()
+    # sanatize results (index columns are binary blobs)
+    sanatized_results = list(
+      map(
+        lambda row:
+        list(
+          map(
+            lambda column:
+            str(column).decode('unicode_escape').encode('ascii','replace'),
+            row)),
+        cursor.results)
+    )
     response[title] = {
         "title": title,
         "description": cursor.description,
         "rowcount": cursor.rowcount,
         "lastrowid": cursor.lastrowid,
-        "results": cursor.results,
+        "results": sanatized_results,
         }
     cursor.close()
   except Exception as e:  # pylint: disable=broad-except

--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -57,7 +57,7 @@
           data-ng-include="'result.html'"></div>
         <div data-ng-repeat="curResult in [result.name_info0]"
           data-ng-include="'result.html'"></div>
-        <div data-ng-repeat="curResult in [result.music_user_idx0]"
+        <div data-ng-repeat="curResult in [result.music_keyspace_idx0]"
           data-ng-include="'result.html'"></div>
       </div>
       <div class="col-md-2">
@@ -73,7 +73,7 @@
           data-ng-include="'result.html'"></div>
         <div data-ng-repeat="curResult in [result.name_info1]"
           data-ng-include="'result.html'"></div>
-        <div data-ng-repeat="curResult in [result.music_user_idx1]"
+        <div data-ng-repeat="curResult in [result.music_keyspace_idx1]"
           data-ng-include="'result.html'"></div>
       </div>
       <div class="col-md-2">
@@ -81,7 +81,7 @@
           data-ng-include="'result.html'"></div>
         <div data-ng-repeat="curResult in [result.music_seq]"
           data-ng-include="'result.html'"></div>
-        <div data-ng-repeat="curResult in [result.name_user_idx]"
+        <div data-ng-repeat="curResult in [result.name_keyspace_idx]"
           data-ng-include="'result.html'"></div>
       </div>
     </div>

--- a/examples/demo/schema/lookup/lookup_schema.sql
+++ b/examples/demo/schema/lookup/lookup_schema.sql
@@ -2,4 +2,4 @@ create table user_seq(id int, next_id bigint, cache bigint, primary key(id)) com
 insert into user_seq(id, next_id, cache) values(0, 1, 3);
 create table music_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into music_seq(id, next_id, cache) values(0, 1, 2);
-create table name_user_idx(name varchar(128), user_id bigint, primary key(name, user_id));
+create table name_user_idx(name varchar(128), user_id binary(8), primary key(name, user_id));

--- a/examples/demo/schema/lookup/lookup_schema.sql
+++ b/examples/demo/schema/lookup/lookup_schema.sql
@@ -2,4 +2,4 @@ create table user_seq(id int, next_id bigint, cache bigint, primary key(id)) com
 insert into user_seq(id, next_id, cache) values(0, 1, 3);
 create table music_seq(id int, next_id bigint, cache bigint, primary key(id)) comment 'vitess_sequence';
 insert into music_seq(id, next_id, cache) values(0, 1, 2);
-create table name_user_idx(name varchar(128), user_id binary(8), primary key(name, user_id));
+create table name_keyspace_idx(name varchar(128), keyspace_id binary(8), primary key(name, keyspace_id));

--- a/examples/demo/schema/lookup/vschema.json
+++ b/examples/demo/schema/lookup/vschema.json
@@ -7,6 +7,6 @@
     "music_seq": {
       "type": "sequence"
     },
-    "name_user_idx": {}
+    "name_keyspace_idx": {}
   }
 }

--- a/examples/demo/schema/user/user_schema.sql
+++ b/examples/demo/schema/user/user_schema.sql
@@ -3,4 +3,4 @@ create table user_extra(user_id bigint, extra varchar(128), primary key(user_id)
 create table music(user_id bigint, music_id bigint, primary key(user_id, music_id));
 create table music_extra(music_id bigint, keyspace_id bigint unsigned, primary key(music_id));
 create table name_info(name varchar(128), info varchar(128), primary key(name));
-create table music_user_idx(music_id bigint not null auto_increment, user_id binary(8), primary key(music_id));
+create table music_keyspace_idx(music_id bigint not null auto_increment, keyspace_id binary(8), primary key(music_id));

--- a/examples/demo/schema/user/user_schema.sql
+++ b/examples/demo/schema/user/user_schema.sql
@@ -3,4 +3,4 @@ create table user_extra(user_id bigint, extra varchar(128), primary key(user_id)
 create table music(user_id bigint, music_id bigint, primary key(user_id, music_id));
 create table music_extra(music_id bigint, keyspace_id bigint unsigned, primary key(music_id));
 create table name_info(name varchar(128), info varchar(128), primary key(name));
-create table music_user_idx(music_id bigint not null auto_increment, user_id bigint, primary key(music_id));
+create table music_user_idx(music_id bigint not null auto_increment, user_id binary(8), primary key(music_id));

--- a/examples/demo/schema/user/vschema.json
+++ b/examples/demo/schema/user/vschema.json
@@ -8,7 +8,7 @@
       "type": "unicode_loose_md5"
     },
     "name_user_idx": {
-      "type": "lookup_hash",
+      "type": "lookup",
       "params": {
         "table": "name_user_idx",
         "from": "name",
@@ -17,7 +17,7 @@
       "owner": "user"
     },
     "music_user_idx": {
-      "type": "lookup_hash_unique",
+      "type": "lookup_unique",
       "params": {
         "table": "music_user_idx",
         "from": "music_id",

--- a/examples/demo/schema/user/vschema.json
+++ b/examples/demo/schema/user/vschema.json
@@ -7,21 +7,21 @@
     "unicode_loose_md5": {
       "type": "unicode_loose_md5"
     },
-    "name_user_idx": {
+    "name_keyspace_idx": {
       "type": "lookup",
       "params": {
-        "table": "name_user_idx",
+        "table": "name_keyspace_idx",
         "from": "name",
-        "to": "user_id"
+        "to": "keyspace_id"
       },
       "owner": "user"
     },
-    "music_user_idx": {
+    "music_keyspace_idx": {
       "type": "lookup_unique",
       "params": {
-        "table": "music_user_idx",
+        "table": "music_keyspace_idx",
         "from": "music_id",
-        "to": "user_id"
+        "to": "keyspace_id"
       },
       "owner": "music"
     },
@@ -38,7 +38,7 @@
         },
         {
           "column": "name",
-          "name": "name_user_idx"
+          "name": "name_keyspace_idx"
         }
       ],
       "auto_increment": {
@@ -62,7 +62,7 @@
         },
         {
           "column": "music_id",
-          "name": "music_user_idx"
+          "name": "music_keyspace_idx"
         }
       ],
       "auto_increment": {
@@ -74,7 +74,7 @@
       "column_vindexes": [
         {
           "column": "music_id",
-          "name": "music_user_idx"
+          "name": "music_keyspace_idx"
         },
         {
           "column": "keyspace_id",
@@ -90,7 +90,7 @@
         }
       ]
     },
-    "music_user_idx": {
+    "music_keyspace_idx": {
       "column_vindexes": [
         {
           "column": "music_id",

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -91,7 +91,7 @@ func (ln *LookupNonUnique) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []
 	return ln.lkp.Delete(vcursor, ids, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid))
 }
 
-// MarshalJSON returns a JSON representation of LookupHash.
+// MarshalJSON returns a JSON representation of Lookup
 func (ln *LookupNonUnique) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ln.lkp)
 }
@@ -114,7 +114,7 @@ type LookupUnique struct {
 	lkp  lookupInternal
 }
 
-// NewLookupUnique creates a LookupHashUnique vindex.
+// NewLookupUnique creates a LookupUnique vindex.
 func NewLookupUnique(name string, m map[string]string) (Vindex, error) {
 	lu := &LookupUnique{name: name}
 	lu.lkp.Init(m)
@@ -145,7 +145,7 @@ func (lu *LookupUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][]byte, er
 		case 1:
 			out = append(out, result.Rows[0][0].ToBytes())
 		default:
-			return nil, fmt.Errorf("LookupHash.Map: unexpected multiple results from vindex %s: %v", lu.lkp.Table, ids[i])
+			return nil, fmt.Errorf("Lookup.Map: unexpected multiple results from vindex %s: %v", lu.lkp.Table, ids[i])
 		}
 	}
 	return out, nil
@@ -166,7 +166,7 @@ func (lu *LookupUnique) Delete(vcursor VCursor, ids []sqltypes.Value, ksid []byt
 	return lu.lkp.Delete(vcursor, ids, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid))
 }
 
-// MarshalJSON returns a JSON representation of LookupHashUnique.
+// MarshalJSON returns a JSON representation of LookupUnique.
 func (lu *LookupUnique) MarshalJSON() ([]byte, error) {
 	return json.Marshal(lu.lkp)
 }

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
 )
 
@@ -36,7 +37,7 @@ func init() {
 }
 
 //====================================================================
-
+// Warning: This Vindex is being depcreated in favor of Lookup
 // LookupHash defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // NonUnique and a Lookup.
@@ -47,6 +48,7 @@ type LookupHash struct {
 
 // NewLookupHash creates a LookupHash vindex.
 func NewLookupHash(name string, m map[string]string) (Vindex, error) {
+	log.Warningf("LookupHash index (%q) it's being deprecated. Please use Lookup", name)
 	lh := &LookupHash{name: name}
 	lh.lkp.Init(m)
 	return lh, nil
@@ -132,6 +134,7 @@ func unhashList(ksids [][]byte) ([]sqltypes.Value, error) {
 
 //====================================================================
 
+// Warning: This Vindex is being depcreated in favor of LookupUnique
 // LookupHashUnique defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // Unique and a Lookup.
@@ -142,6 +145,7 @@ type LookupHashUnique struct {
 
 // NewLookupHashUnique creates a LookupHashUnique vindex.
 func NewLookupHashUnique(name string, m map[string]string) (Vindex, error) {
+	log.Warningf("LookupHashUnique index (%q) it's being deprecated. Please use LookupUnique", name)
 	lhu := &LookupHashUnique{name: name}
 	lhu.lkp.Init(m)
 	return lhu, nil

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -37,6 +37,7 @@ func init() {
 }
 
 //====================================================================
+
 // LookupHash defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // NonUnique and a Lookup.

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -37,10 +37,10 @@ func init() {
 }
 
 //====================================================================
-// Warning: This Vindex is being depcreated in favor of Lookup
 // LookupHash defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // NonUnique and a Lookup.
+// Warning: This Vindex is being depcreated in favor of Lookup
 type LookupHash struct {
 	name string
 	lkp  lookupInternal
@@ -134,10 +134,10 @@ func unhashList(ksids [][]byte) ([]sqltypes.Value, error) {
 
 //====================================================================
 
-// Warning: This Vindex is being depcreated in favor of LookupUnique
 // LookupHashUnique defines a vindex that uses a lookup table.
 // The table is expected to define the id column as unique. It's
 // Unique and a Lookup.
+// Warning: This Vindex is being depcreated in favor of LookupUnique
 type LookupHashUnique struct {
 	name string
 	lkp  lookupInternal

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -62,7 +62,7 @@ func TestLookupUniqueMap(t *testing.T) {
 
 	vc.numRows = 2
 	_, err = lookupUnique.(Unique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
-	wantErr := "LookupHash.Map: unexpected multiple results from vindex t: INT64(1)"
+	wantErr := "Lookup.Map: unexpected multiple results from vindex t: INT64(1)"
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("lookupUnique(query fail) err: %v, want %s", err, wantErr)
 	}


### PR DESCRIPTION
### Desc

Per discussion in Slack. LookupHash vindexes should be deprecated in favor of Lookup. 

