### PR TITLE
add option to disable the querylog and txlog debug UIs

### DIFF
--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -93,8 +93,13 @@ func init() {
 
 // Init must be called after flag.Parse, and before doing any other operations.
 func Init() {
-	StatsLogger.ServeLogs(*queryLogHandler, buildFmter(StatsLogger))
-	TxLogger.ServeLogs(*txLogHandler, buildFmter(TxLogger))
+	if *queryLogHandler != "" {
+		StatsLogger.ServeLogs(*queryLogHandler, buildFmter(StatsLogger))
+	}
+
+	if *txLogHandler != "" {
+		TxLogger.ServeLogs(*txLogHandler, buildFmter(TxLogger))
+	}
 }
 
 // TabletConfig contains all the configuration for query service


### PR DESCRIPTION
Upon inspection I noticed that the streaming /debug/txlog handler didn't properly redact the queries like the other debug UIs do.

Since there's really no point in keeping that handler without the underlying queries (unlike /debug/querylog) I added a check to the init sequence so that it skips registering the handler if the path is set to "".

For completeness I did the same for /debug/querylog.
