### PR TITLE
query logger json format and file output

### DIFF
--- a/go/cmd/vttablet/plugin_filelogger.go
+++ b/go/cmd/vttablet/plugin_filelogger.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Imports and register the file-based query logger
+
+import (
+	_ "github.com/youtube/vitess/go/vt/vttablet/filelogger"
+)

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -18,6 +18,7 @@ limitations under the License.
 package streamlog
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,6 +34,12 @@ import (
 )
 
 var (
+	// RedactDebugUIQueries controls whether full queries and bind variables are suppressed from debug UIs.
+	RedactDebugUIQueries = flag.Bool("redact-debug-ui-queries", false, "redact full queries and bind variables from debug UI")
+
+	// QueryLogFormat controls the format of the query log (either text or json)
+	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
+
 	sendCount         = stats.NewCounters("StreamlogSend")
 	deliveredCount    = stats.NewMultiCounters("StreamlogDelivered", []string{"Log", "Subscriber"})
 	deliveryDropCount = stats.NewMultiCounters("StreamlogDeliveryDroppedMessages", []string{"Log", "Subscriber"})

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -22,7 +22,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/acl"
@@ -121,6 +124,36 @@ func (logger *StreamLogger) ServeLogs(url string, messageFmt func(url.Values, in
 		}
 	})
 	log.Infof("Streaming logs from %s at %v.", logger.Name(), url)
+}
+
+// LogToFile starts logging to the specified file path and will reopen the
+// file in response to SIGUSR1
+func (logger *StreamLogger) LogToFile(path string, messageFmt func(url.Values, interface{}) string) error {
+	rotateChan := make(chan os.Signal, 1)
+	signal.Notify(rotateChan, syscall.SIGUSR1)
+
+	logChan := logger.Subscribe("FileLog")
+	formatParams := map[string][]string{"full": {}}
+
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case record, _ := <-logChan:
+				formatted := messageFmt(formatParams, record)
+				f.WriteString(formatted)
+			case _, _ = <-rotateChan:
+				f.Close()
+				f, _ = os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+			}
+		}
+	}()
+
+	return nil
 }
 
 // Formatter is a simple interface for objects that expose a Format function

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -18,6 +18,7 @@ limitations under the License.
 package streamlog
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -120,4 +121,22 @@ func (logger *StreamLogger) ServeLogs(url string, messageFmt func(url.Values, in
 		}
 	})
 	log.Infof("Streaming logs from %s at %v.", logger.Name(), url)
+}
+
+// Formatter is a simple interface for objects that expose a Format function
+// as needed for streamlog.
+type Formatter interface {
+	Format(url.Values) string
+}
+
+// GetFormatter returns a formatter function for objects conforming to the
+// Formatter interface
+func GetFormatter(logger *StreamLogger) func(url.Values, interface{}) string {
+	return func(params url.Values, val interface{}) string {
+		fmter, ok := val.(Formatter)
+		if !ok {
+			return fmt.Sprintf("Error: unexpected value of type %T in %s!", val, logger.Name())
+		}
+		return fmter.Format(params)
+	}
 }

--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -127,13 +127,13 @@ func (logger *StreamLogger) ServeLogs(url string, messageFmt func(url.Values, in
 }
 
 // LogToFile starts logging to the specified file path and will reopen the
-// file in response to SIGUSR1.
+// file in response to SIGUSR2.
 //
 // Returns the channel used for the subscription which can be used to close
 // it.
 func (logger *StreamLogger) LogToFile(path string, messageFmt func(url.Values, interface{}) string) (chan interface{}, error) {
 	rotateChan := make(chan os.Signal, 1)
-	signal.Notify(rotateChan, syscall.SIGUSR1)
+	signal.Notify(rotateChan, syscall.SIGUSR2)
 
 	logChan := logger.Subscribe("FileLog")
 	formatParams := map[string][]string{"full": {}}

--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -194,7 +194,8 @@ func TestFile(t *testing.T) {
 	}
 
 	logPath := path.Join(dir, "test.log")
-	err = logger.LogToFile(logPath, func(params url.Values, x interface{}) string { return x.(*logMessage).Format(params) })
+	logChan, err := logger.LogToFile(logPath, func(params url.Values, x interface{}) string { return x.(*logMessage).Format(params) })
+	defer logger.Unsubscribe(logChan)
 	if err != nil {
 		t.Errorf("error enabling file logger: %v", err)
 	}

--- a/go/streamlog/streamlog_flaky_test.go
+++ b/go/streamlog/streamlog_flaky_test.go
@@ -229,7 +229,7 @@ func TestFile(t *testing.T) {
 
 	// Send the rotate signal which should reopen the original file path
 	// for new logs to go to
-	syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	syscall.Kill(syscall.Getpid(), syscall.SIGUSR2)
 	time.Sleep(10 * time.Millisecond)
 
 	logger.Send(&logMessage{"test 4"})

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -58,12 +58,6 @@ var (
 	onTermTimeout  = flag.Duration("onterm_timeout", 10*time.Second, "wait no more than this for OnTermSync handlers before stopping")
 	memProfileRate = flag.Int("mem-profile-rate", 512*1024, "profile every n bytes allocated")
 
-	// RedactDebugUIQueries controls whether full queries and bind variables are suppressed from debug UIs.
-	RedactDebugUIQueries = flag.Bool("redact-debug-ui-queries", false, "redact full queries and bind variables from debug UI")
-
-	// QueryLogFormat controls the format of the query log (either text or json)
-	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
-
 	// mutex used to protect the Init function
 	mu sync.Mutex
 
@@ -90,13 +84,6 @@ func Init() {
 	// non-privileged user starting the program correctly.
 	if uid := os.Getuid(); uid == 0 {
 		log.Exitf("servenv.Init: running this as root makes no sense")
-	}
-
-	switch *QueryLogFormat {
-	case "text":
-	case "json":
-	default:
-		log.Exitf("servenv.Init: Invalid querylog-format value %v: must be either text or json")
 	}
 
 	runtime.MemProfileRate = *memProfileRate

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -61,6 +61,9 @@ var (
 	// RedactDebugUIQueries controls whether full queries and bind variables are suppressed from debug UIs.
 	RedactDebugUIQueries = flag.Bool("redact-debug-ui-queries", false, "redact full queries and bind variables from debug UI")
 
+	// QueryLogFormat controls the format of the query log (either text or json)
+	QueryLogFormat = flag.String("querylog-format", "text", "format for query logs (\"text\" or \"json\")")
+
 	// mutex used to protect the Init function
 	mu sync.Mutex
 
@@ -87,6 +90,13 @@ func Init() {
 	// non-privileged user starting the program correctly.
 	if uid := os.Getuid(); uid == 0 {
 		log.Exitf("servenv.Init: running this as root makes no sense")
+	}
+
+	switch *QueryLogFormat {
+	case "text":
+	case "json":
+	default:
+		log.Exitf("servenv.Init: Invalid querylog-format value %v: must be either text or json")
 	}
 
 	runtime.MemProfileRate = *memProfileRate

--- a/go/vt/servenv/servenv.go
+++ b/go/vt/servenv/servenv.go
@@ -58,6 +58,9 @@ var (
 	onTermTimeout  = flag.Duration("onterm_timeout", 10*time.Second, "wait no more than this for OnTermSync handlers before stopping")
 	memProfileRate = flag.Int("mem-profile-rate", 512*1024, "profile every n bytes allocated")
 
+	// RedactDebugUIQueries controls whether full queries and bind variables are suppressed from debug UIs.
+	RedactDebugUIQueries = flag.Bool("redact-debug-ui-queries", false, "redact full queries and bind variables from debug UI")
+
 	// mutex used to protect the Init function
 	mu sync.Mutex
 

--- a/go/vt/vttablet/filelogger/filelogger.go
+++ b/go/vt/vttablet/filelogger/filelogger.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package filelogger implements an optional plugin that logs all queries to syslog.
+package filelogger
+
+import (
+	"flag"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/streamlog"
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+// logQueriesToFile is the vttablet startup flag that must be set for this plugin to be active.
+var logQueriesToFile = flag.String("log_queries_to_file", "", "Enable query logging to the specified file")
+
+func init() {
+	servenv.OnRun(func() {
+		if *logQueriesToFile != "" {
+			Init(*logQueriesToFile)
+		}
+	})
+}
+
+// FileLogger is an opaque interface used to control the file logging
+type FileLogger interface {
+	// Stop logging to the given file
+	Stop()
+}
+
+type fileLogger struct {
+	logChan chan interface{}
+}
+
+func (l *fileLogger) Stop() {
+	tabletenv.StatsLogger.Unsubscribe(l.logChan)
+}
+
+// Init starts logging to the given file path.
+func Init(path string) (FileLogger, error) {
+	log.Info("Logging queries to file %s", path)
+	logChan, err := tabletenv.StatsLogger.LogToFile(path, streamlog.GetFormatter(tabletenv.StatsLogger))
+	if err != nil {
+		return nil, err
+	}
+	return &fileLogger{
+		logChan: logChan,
+	}, nil
+}

--- a/go/vt/vttablet/filelogger/filelogger_test.go
+++ b/go/vt/vttablet/filelogger/filelogger_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -72,9 +72,9 @@ func TestFileLog(t *testing.T) {
 
 // TestFileLog sends a stream of five query records to the plugin, and verifies that they are logged.
 func TestFileLogRedacted(t *testing.T) {
-	*servenv.RedactDebugUIQueries = true
+	*streamlog.RedactDebugUIQueries = true
 	defer func() {
-		*servenv.RedactDebugUIQueries = false
+		*streamlog.RedactDebugUIQueries = false
 	}()
 
 	dir, err := ioutil.TempDir("", "filelogger_test")

--- a/go/vt/vttablet/filelogger/filelogger_test.go
+++ b/go/vt/vttablet/filelogger/filelogger_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filelogger
+
+import (
+	"context"
+	"io/ioutil"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+// TestFileLog sends a stream of five query records to the plugin, and verifies that they are logged.
+func TestFileLog(t *testing.T) {
+	dir, err := ioutil.TempDir("", "filelogger_test")
+	if err != nil {
+		t.Fatalf("error getting tempdir: %v", err)
+	}
+
+	logPath := path.Join(dir, "test.log")
+	logger, err := Init(logPath)
+	defer logger.Stop()
+	if err != nil {
+		t.Fatalf("error setting up file logger: %v", err)
+	}
+
+	ctx := context.Background()
+
+	log1 := &tabletenv.LogStats{
+		Ctx:         ctx,
+		OriginalSQL: "test 1",
+	}
+	log1.AddRewrittenSQL("test 1 PII", time.Time{})
+	log1.MysqlResponseTime = 0
+	tabletenv.StatsLogger.Send(log1)
+
+	log2 := &tabletenv.LogStats{
+		Ctx:         ctx,
+		OriginalSQL: "test 2",
+	}
+	log2.AddRewrittenSQL("test 2 PII", time.Time{})
+	log2.MysqlResponseTime = 0
+	tabletenv.StatsLogger.Send(log2)
+
+	// Allow time for propagation
+	time.Sleep(10 * time.Millisecond)
+
+	want := "\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 1\"\tmap[]\t1\t\"test 1 PII\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 2\"\tmap[]\t1\t\"test 2 PII\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n"
+	contents, _ := ioutil.ReadFile(logPath)
+	got := string(contents)
+	if want != string(got) {
+		t.Errorf("streamlog file: want %q got %q", want, got)
+	}
+}
+
+// TestFileLog sends a stream of five query records to the plugin, and verifies that they are logged.
+func TestFileLogRedacted(t *testing.T) {
+	*servenv.RedactDebugUIQueries = true
+	defer func() {
+		*servenv.RedactDebugUIQueries = false
+	}()
+
+	dir, err := ioutil.TempDir("", "filelogger_test")
+	if err != nil {
+		t.Fatalf("error getting tempdir: %v", err)
+	}
+
+	logPath := path.Join(dir, "test.log")
+	logger, err := Init(logPath)
+	defer logger.Stop()
+	if err != nil {
+		t.Fatalf("error setting up file logger: %v", err)
+	}
+
+	ctx := context.Background()
+
+	log1 := &tabletenv.LogStats{
+		Ctx:         ctx,
+		OriginalSQL: "test 1",
+	}
+	log1.AddRewrittenSQL("test 1 PII", time.Time{})
+	log1.MysqlResponseTime = 0
+	tabletenv.StatsLogger.Send(log1)
+
+	log2 := &tabletenv.LogStats{
+		Ctx:         ctx,
+		OriginalSQL: "test 2",
+	}
+	log2.AddRewrittenSQL("test 2 PII", time.Time{})
+	log2.MysqlResponseTime = 0
+	tabletenv.StatsLogger.Send(log2)
+
+	// Allow time for propagation
+	time.Sleep(10 * time.Millisecond)
+
+	want := "\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 1\"\t[REDACTED]\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 2\"\t[REDACTED]\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n"
+	contents, _ := ioutil.ReadFile(logPath)
+	got := string(contents)
+	if want != string(got) {
+		t.Errorf("streamlog file: want %q got %q", want, got)
+	}
+}

--- a/go/vt/vttablet/sysloglogger/sysloglogger_test.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger_test.go
@@ -27,7 +27,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -141,9 +141,9 @@ func TestSyslog(t *testing.T) {
 // when redaction is enabled.
 func TestSyslogRedacted(t *testing.T) {
 	// Overwrite the usual syslog writer and StatsLogger subscription channel with mocks
-	*servenv.RedactDebugUIQueries = true
+	*streamlog.RedactDebugUIQueries = true
 	defer func() {
-		*servenv.RedactDebugUIQueries = false
+		*streamlog.RedactDebugUIQueries = false
 	}()
 	mock := newFakeWriter()
 	writer = mock

--- a/go/vt/vttablet/sysloglogger/sysloglogger_test.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger_test.go
@@ -27,6 +27,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -140,9 +141,9 @@ func TestSyslog(t *testing.T) {
 // when redaction is enabled.
 func TestSyslogRedacted(t *testing.T) {
 	// Overwrite the usual syslog writer and StatsLogger subscription channel with mocks
-	*tabletenv.RedactDebugUIQueries = true
+	*servenv.RedactDebugUIQueries = true
 	defer func() {
-		*tabletenv.RedactDebugUIQueries = false
+		*servenv.RedactDebugUIQueries = false
 	}()
 	mock := newFakeWriter()
 	writer = mock

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -31,12 +31,12 @@ import (
 	"github.com/youtube/vitess/go/cache"
 	"github.com/youtube/vitess/go/mysql"
 	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/trace"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	tacl "github.com/youtube/vitess/go/vt/tableacl/acl"
@@ -557,7 +557,7 @@ func (qe *QueryEngine) handleHTTPQueryRules(response http.ResponseWriter, reques
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, request *http.Request) {
-	if *servenv.RedactDebugUIQueries {
+	if *streamlog.RedactDebugUIQueries {
 		response.Write([]byte(`
 	<!DOCTYPE html>
 	<html>

--- a/go/vt/vttablet/tabletserver/query_engine.go
+++ b/go/vt/vttablet/tabletserver/query_engine.go
@@ -36,6 +36,7 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/tableacl"
 	tacl "github.com/youtube/vitess/go/vt/tableacl/acl"
@@ -556,7 +557,7 @@ func (qe *QueryEngine) handleHTTPQueryRules(response http.ResponseWriter, reques
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (qe *QueryEngine) handleHTTPConsolidations(response http.ResponseWriter, request *http.Request) {
-	if *tabletenv.RedactDebugUIQueries {
+	if *servenv.RedactDebugUIQueries {
 		response.Write([]byte(`
 	<!DOCTYPE html>
 	<html>

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -33,9 +33,6 @@ var (
 	queryLogHandler = flag.String("query-log-stream-handler", "/debug/querylog", "URL handler for streaming queries log")
 	txLogHandler    = flag.String("transaction-log-stream-handler", "/debug/txlog", "URL handler for streaming transactions log")
 
-	// RedactDebugUIQueries controls whether full queries and bind variables are suppressed from debug UIs.
-	RedactDebugUIQueries = flag.Bool("redact-debug-ui-queries", false, "redact full queries and bind variables from debug UI")
-
 	// TxLogger can be used to enable logging of transactions.
 	// Call TxLogger.ServeLogs in your main program to enable logging.
 	// The log format can be inferred by looking at TxConnection.Format.

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -94,11 +93,11 @@ func init() {
 // Init must be called after flag.Parse, and before doing any other operations.
 func Init() {
 	if *queryLogHandler != "" {
-		StatsLogger.ServeLogs(*queryLogHandler, buildFmter(StatsLogger))
+		StatsLogger.ServeLogs(*queryLogHandler, streamlog.GetFormatter(StatsLogger))
 	}
 
 	if *txLogHandler != "" {
-		TxLogger.ServeLogs(*txLogHandler, buildFmter(TxLogger))
+		TxLogger.ServeLogs(*txLogHandler, streamlog.GetFormatter(TxLogger))
 	}
 }
 
@@ -238,18 +237,4 @@ func VerifyConfig() error {
 		return fmt.Errorf("-hot_row_protection_concurrent_transactions must be > 0 (specified value: %v)", v)
 	}
 	return nil
-}
-
-func buildFmter(logger *streamlog.StreamLogger) func(url.Values, interface{}) string {
-	type formatter interface {
-		Format(url.Values) string
-	}
-
-	return func(params url.Values, val interface{}) string {
-		fmter, ok := val.(formatter)
-		if !ok {
-			return fmt.Sprintf("Error: unexpected value of type %T in %s!", val, logger.Name())
-		}
-		return fmter.Format(params)
-	}
 }

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/golang/glog"
+
 	"github.com/golang/protobuf/proto"
 
 	"github.com/youtube/vitess/go/flagutil"
@@ -89,6 +91,13 @@ func init() {
 
 // Init must be called after flag.Parse, and before doing any other operations.
 func Init() {
+	switch *streamlog.QueryLogFormat {
+	case "text":
+	case "json":
+	default:
+		log.Exitf("Invalid querylog-format value %v: must be either text or json")
+	}
+
 	if *queryLogHandler != "" {
 		StatsLogger.ServeLogs(*queryLogHandler, streamlog.GetFormatter(StatsLogger))
 	}

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -211,8 +211,18 @@ func (stats *LogStats) Format(params url.Values) string {
 
 	// TODO: remove username here we fully enforce immediate caller id
 	remoteAddr, username := stats.RemoteAddrUsername()
+
+	// Valid options for the QueryLogFormat are text or json
+	var fmtString string
+	switch *servenv.QueryLogFormat {
+	case "text":
+		fmtString = "%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%v\t%q\t%v\t%v\t%q\t%v\t%.6f\t%.6f\t%v\t%v\t%q\t\n"
+	case "json":
+		fmtString = "{\"Method\": %q, \"RemoteAddr\": %q, \"Username\": %q, \"ImmediateCaller\": %q, \"Effective Caller\": %q, \"Start\": \"%v\", \"End\": \"%v\", \"TotalTime\": %.6f, \"PlanType\": %q, \"OriginalSQL\": %q, \"BindVars\": \"%v\", \"Queries\": %v, \"RewrittenSQL\": %q, \"QuerySources\": %q, \"MysqlTime\": %.6f, \"ConnWaitTime\": %.6f, \"RowsAffected\": %v, \"ResponseSize\": %v, \"Error\": %q}\n"
+	}
+
 	return fmt.Sprintf(
-		"%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%v\t%q\t%v\t%v\t%q\t%v\t%.6f\t%.6f\t%v\t%v\t%q\t\n",
+		fmtString,
 		stats.Method,
 		remoteAddr,
 		username,

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -26,9 +26,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/callinfo"
-	"github.com/youtube/vitess/go/vt/servenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -203,7 +203,7 @@ func (stats *LogStats) Format(params url.Values) string {
 	rewrittenSQL := "[REDACTED]"
 	formattedBindVars := "[REDACTED]"
 
-	if !*servenv.RedactDebugUIQueries {
+	if !*streamlog.RedactDebugUIQueries {
 		_, fullBindParams := params["full"]
 		rewrittenSQL = stats.RewrittenSQL()
 		formattedBindVars = stats.FmtBindVariables(fullBindParams)
@@ -214,7 +214,7 @@ func (stats *LogStats) Format(params url.Values) string {
 
 	// Valid options for the QueryLogFormat are text or json
 	var fmtString string
-	switch *servenv.QueryLogFormat {
+	switch *streamlog.QueryLogFormat {
 	case "text":
 		fmtString = "%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%v\t%q\t%v\t%v\t%q\t%v\t%.6f\t%.6f\t%v\t%v\t%q\t\n"
 	case "json":

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -28,6 +28,7 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/callinfo"
+	"github.com/youtube/vitess/go/vt/servenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
@@ -202,7 +203,7 @@ func (stats *LogStats) Format(params url.Values) string {
 	rewrittenSQL := "[REDACTED]"
 	formattedBindVars := "[REDACTED]"
 
-	if !*RedactDebugUIQueries {
+	if !*servenv.RedactDebugUIQueries {
 		_, fullBindParams := params["full"]
 		rewrittenSQL = stats.RewrittenSQL()
 		formattedBindVars = stats.FmtBindVariables(fullBindParams)

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -26,10 +26,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/callinfo"
 	"github.com/youtube/vitess/go/vt/callinfo/fakecallinfo"
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
-	"github.com/youtube/vitess/go/vt/servenv"
 )
 
 func TestLogStats(t *testing.T) {
@@ -71,14 +71,14 @@ func TestLogStatsFormat(t *testing.T) {
 		t.Errorf("logstats text format: got:\n%q\nwant:\n%q\n", got, want)
 	}
 
-	*servenv.QueryLogFormat = "json"
+	*streamlog.QueryLogFormat = "json"
 	got = logStats.Format(url.Values(params))
 	want = "{\"Method\": \"test\", \"RemoteAddr\": \"\", \"Username\": \"\", \"ImmediateCaller\": \"\", \"Effective Caller\": \"\", \"Start\": \"Jan  1 01:02:03.000000\", \"End\": \"Jan  1 01:02:04.000000\", \"TotalTime\": 1.000000, \"PlanType\": \"\", \"OriginalSQL\": \"sql1\", \"BindVars\": \"map[]\", \"Queries\": 1, \"RewrittenSQL\": \"sql1\", \"QuerySources\": \"mysql\", \"MysqlTime\": 0.000000, \"ConnWaitTime\": 0.000000, \"RowsAffected\": 0, \"ResponseSize\": 1, \"Error\": \"\"}\n"
 	if got != want {
 		t.Errorf("logstats text format: got:\n%v\nwant:\n%v\n", got, want)
 	}
 
-	*servenv.QueryLogFormat = "text"
+	*streamlog.QueryLogFormat = "text"
 }
 
 func TestLogStatsFormatBindVariables(t *testing.T) {

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -60,6 +60,7 @@ func TestLogStatsFormat(t *testing.T) {
 	logStats.EndTime = time.Date(2017, time.January, 1, 1, 2, 4, 0, time.UTC)
 	logStats.OriginalSQL = "sql1"
 	logStats.AddRewrittenSQL("sql1", time.Now())
+	logStats.MysqlResponseTime = 0
 
 	logStats.Rows = [][]sqltypes.Value{{sqltypes.NewVarBinary("a")}}
 

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -27,6 +27,7 @@ import (
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/logz"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -85,7 +86,7 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if *tabletenv.RedactDebugUIQueries {
+	if *servenv.RedactDebugUIQueries {
 		io.WriteString(w, `
 <!DOCTYPE html>
 <html>

--- a/go/vt/vttablet/tabletserver/txlogz.go
+++ b/go/vt/vttablet/tabletserver/txlogz.go
@@ -25,9 +25,9 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/acl"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/callerid"
 	"github.com/youtube/vitess/go/vt/logz"
-	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
@@ -86,7 +86,7 @@ func txlogzHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if *servenv.RedactDebugUIQueries {
+	if *streamlog.RedactDebugUIQueries {
 		io.WriteString(w, `
 <!DOCTYPE html>
 <html>

--- a/go/vt/vttablet/tabletserver/txlogz_test.go
+++ b/go/vt/vttablet/tabletserver/txlogz_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/callerid"
-	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -72,10 +72,10 @@ func testHandler(req *http.Request, t *testing.T) {
 	tabletenv.TxLogger.Send(txConn)
 	txlogzHandler(response, req)
 	testNotRedacted(t, response)
-	*servenv.RedactDebugUIQueries = true
+	*streamlog.RedactDebugUIQueries = true
 	txlogzHandler(response, req)
 	testRedacted(t, response)
-	*servenv.RedactDebugUIQueries = false
+	*streamlog.RedactDebugUIQueries = false
 
 }
 

--- a/go/vt/vttablet/tabletserver/txlogz_test.go
+++ b/go/vt/vttablet/tabletserver/txlogz_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/callerid"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
@@ -71,10 +72,10 @@ func testHandler(req *http.Request, t *testing.T) {
 	tabletenv.TxLogger.Send(txConn)
 	txlogzHandler(response, req)
 	testNotRedacted(t, response)
-	*tabletenv.RedactDebugUIQueries = true
+	*servenv.RedactDebugUIQueries = true
 	txlogzHandler(response, req)
 	testRedacted(t, response)
-	*tabletenv.RedactDebugUIQueries = false
+	*servenv.RedactDebugUIQueries = false
 
 }
 

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/stats"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vterrors"
 
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
@@ -282,7 +282,7 @@ func (t *TxSerializer) Pending(key string) int {
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (t *TxSerializer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	if *servenv.RedactDebugUIQueries {
+	if *streamlog.RedactDebugUIQueries {
 		response.Write([]byte(`
 	<!DOCTYPE html>
 	<html>

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer.go
@@ -30,8 +30,8 @@ import (
 	"github.com/youtube/vitess/go/stats"
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/logutil"
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vterrors"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
@@ -282,7 +282,7 @@ func (t *TxSerializer) Pending(key string) int {
 
 // ServeHTTP lists the most recent, cached queries and their count.
 func (t *TxSerializer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
-	if *tabletenv.RedactDebugUIQueries {
+	if *servenv.RedactDebugUIQueries {
 		response.Write([]byte(`
 	<!DOCTYPE html>
 	<html>

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -27,8 +27,8 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/vterrors"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
@@ -67,9 +67,9 @@ func TestTxSerializer_NoHotRow(t *testing.T) {
 
 func TestTxSerializerRedactDebugUI(t *testing.T) {
 	resetVariables()
-	*tabletenv.RedactDebugUIQueries = true
+	*servenv.RedactDebugUIQueries = true
 	defer func() {
-		*tabletenv.RedactDebugUIQueries = false
+		*servenv.RedactDebugUIQueries = false
 	}()
 
 	txs := New(false, 1, 1, 5)

--- a/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
+++ b/go/vt/vttablet/tabletserver/txserializer/tx_serializer_test.go
@@ -27,7 +27,7 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/streamlog"
 	"github.com/youtube/vitess/go/vt/vterrors"
 
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
@@ -67,9 +67,9 @@ func TestTxSerializer_NoHotRow(t *testing.T) {
 
 func TestTxSerializerRedactDebugUI(t *testing.T) {
 	resetVariables()
-	*servenv.RedactDebugUIQueries = true
+	*streamlog.RedactDebugUIQueries = true
 	defer func() {
-		*servenv.RedactDebugUIQueries = false
+		*streamlog.RedactDebugUIQueries = false
 	}()
 
 	txs := New(false, 1, 1, 5)


### PR DESCRIPTION
Add a couple of new features and a bit of refactoring to the query logging infrastructure:

Initial refactoring includes a couple commits that were cherry-picked from #3430:
(a) move the generic record formatting logic into the streamlog package and
(b) move the `-redact-debug-ui-queries` flag into servenv so (in the future) it can be shared with vtgate

Also added support for an option `-querylog-format` which can be either "text" or "json" and added support to the logstats formatter to render as newline-separated json records.

Also added optional support to streamlog to log the records to a file and plumbed a vttablet option to use this feature. It also includes a signal handler so that it closes and reopens the file in response to SIGUSR2.

Once #3430 merges I plan to add similar support to vtgate to log to a file.
