### PR TITLE
codeclimate disable annoying checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,8 @@ engines:
     enabled: true
   shellcheck:
     enabled: true
+  duplication:
+    enabled: false
 
 ratings:
   paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,6 +15,28 @@ ratings:
     - "**.go"
     - "**.sh"
 
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+
 # Ignore generated code.
 exclude_paths:
 - "go/vt/proto/"


### PR DESCRIPTION
Attempt to disable the duplication engine and all the "maintainability" checks from codeclimate.

I had pushed some commits to this branch which triggered errors, then once I made these .codeclimate.yml changes, codeclimate reported >6000 "fixed" errors, so I _think_ this should disable these annoying checks.
