### PR TITLE
Streamlog json fixup

### DIFF
--- a/go/streamlog/streamlog.go
+++ b/go/streamlog/streamlog.go
@@ -45,6 +45,14 @@ var (
 	deliveryDropCount = stats.NewMultiCounters("StreamlogDeliveryDroppedMessages", []string{"Log", "Subscriber"})
 )
 
+const (
+	// QueryLogFormatText is the format specifier for text querylog output
+	QueryLogFormatText = "text"
+
+	// QueryLogFormatJSON is the format specifier for json querylog output
+	QueryLogFormatJSON = "json"
+)
+
 // StreamLogger is a non-blocking broadcaster of messages.
 // Subscribers can use channels or HTTP.
 type StreamLogger struct {

--- a/go/vt/vttablet/filelogger/filelogger_test.go
+++ b/go/vt/vttablet/filelogger/filelogger_test.go
@@ -110,7 +110,7 @@ func TestFileLogRedacted(t *testing.T) {
 	// Allow time for propagation
 	time.Sleep(10 * time.Millisecond)
 
-	want := "\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 1\"\t[REDACTED]\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 2\"\t[REDACTED]\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n"
+	want := "\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 1\"\t\"[REDACTED]\"\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\t\t\"test 2\"\t\"[REDACTED]\"\t1\t\"[REDACTED]\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"\t\n"
 	contents, _ := ioutil.ReadFile(logPath)
 	got := string(contents)
 	if want != string(got) {

--- a/go/vt/vttablet/sysloglogger/sysloglogger_test.go
+++ b/go/vt/vttablet/sysloglogger/sysloglogger_test.go
@@ -93,7 +93,7 @@ func expectedLogStatsText(originalSQL string) string {
 // when redaction is enabled.
 func expectedRedactedLogStatsText(originalSQL string) string {
 	return fmt.Sprintf("Execute\t\t\t''\t''\tJan  1 00:00:00.000000\tJan  1 00:00:00.000000\t0.000000\tPASS_SELECT\t"+
-		"\"%s\"\t%s\t1\t\"%s\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"", originalSQL, "[REDACTED]", "[REDACTED]")
+		"\"%s\"\t%q\t1\t\"%s\"\tmysql\t0.000000\t0.000000\t0\t0\t\"\"", originalSQL, "[REDACTED]", "[REDACTED]")
 }
 
 // TestSyslog sends a stream of five query records to the plugin, and verifies that they are logged.

--- a/go/vt/vttablet/tabletserver/tabletenv/config.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/config.go
@@ -92,8 +92,8 @@ func init() {
 // Init must be called after flag.Parse, and before doing any other operations.
 func Init() {
 	switch *streamlog.QueryLogFormat {
-	case "text":
-	case "json":
+	case streamlog.QueryLogFormatText:
+	case streamlog.QueryLogFormatJSON:
 	default:
 		log.Exitf("Invalid querylog-format value %v: must be either text or json")
 	}

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tabletenv
 
 import (
+	"bytes"
 	"fmt"
 	"html/template"
 	"net/url"
@@ -132,10 +133,17 @@ func (stats *LogStats) SizeOfResponse() int {
 	return size
 }
 
-// FmtBindVariables returns the map of bind variables as JSON. For
-// values that are strings or byte slices it only reports their type
-// and length.
+// FmtBindVariables returns the map of bind variables as a string or a json
+// string depending on the streamlog.QueryLogFormat value. If RedactDebugUIQueries
+// is true then this returns the string "[REDACTED]"
+//
+// For values that are strings or byte slices it only reports their type
+// and length unless full is true.
 func (stats *LogStats) FmtBindVariables(full bool) string {
+	if *streamlog.RedactDebugUIQueries {
+		return "\"[REDACTED]\""
+	}
+
 	var out map[string]*querypb.BindVariable
 	if full {
 		out = stats.BindVariables
@@ -151,6 +159,27 @@ func (stats *LogStats) FmtBindVariables(full bool) string {
 			}
 		}
 	}
+
+	if *streamlog.QueryLogFormat == streamlog.QueryLogFormatJSON {
+		var buf bytes.Buffer
+		buf.WriteString("{")
+		first := true
+		for k, v := range out {
+			if !first {
+				buf.WriteString(", ")
+			} else {
+				first = false
+			}
+			if sqltypes.IsIntegral(v.Type) || sqltypes.IsFloat(v.Type) {
+				fmt.Fprintf(&buf, "%q: {\"type\": %q, \"value\": %v}", k, v.Type, string(v.Value))
+			} else {
+				fmt.Fprintf(&buf, "%q: {\"type\": %q, \"value\": %q}", k, v.Type, string(v.Value))
+			}
+		}
+		buf.WriteString("}")
+		return buf.String()
+	}
+
 	return fmt.Sprintf("%v", out)
 }
 
@@ -201,13 +230,12 @@ func (stats *LogStats) RemoteAddrUsername() (string, string) {
 // Format returns a tab separated list of logged fields.
 func (stats *LogStats) Format(params url.Values) string {
 	rewrittenSQL := "[REDACTED]"
-	formattedBindVars := "[REDACTED]"
-
 	if !*streamlog.RedactDebugUIQueries {
-		_, fullBindParams := params["full"]
 		rewrittenSQL = stats.RewrittenSQL()
-		formattedBindVars = stats.FmtBindVariables(fullBindParams)
 	}
+
+	_, fullBindParams := params["full"]
+	formattedBindVars := stats.FmtBindVariables(fullBindParams)
 
 	// TODO: remove username here we fully enforce immediate caller id
 	remoteAddr, username := stats.RemoteAddrUsername()
@@ -215,10 +243,10 @@ func (stats *LogStats) Format(params url.Values) string {
 	// Valid options for the QueryLogFormat are text or json
 	var fmtString string
 	switch *streamlog.QueryLogFormat {
-	case "text":
+	case streamlog.QueryLogFormatText:
 		fmtString = "%v\t%v\t%v\t'%v'\t'%v'\t%v\t%v\t%.6f\t%v\t%q\t%v\t%v\t%q\t%v\t%.6f\t%.6f\t%v\t%v\t%q\t\n"
-	case "json":
-		fmtString = "{\"Method\": %q, \"RemoteAddr\": %q, \"Username\": %q, \"ImmediateCaller\": %q, \"Effective Caller\": %q, \"Start\": \"%v\", \"End\": \"%v\", \"TotalTime\": %.6f, \"PlanType\": %q, \"OriginalSQL\": %q, \"BindVars\": \"%v\", \"Queries\": %v, \"RewrittenSQL\": %q, \"QuerySources\": %q, \"MysqlTime\": %.6f, \"ConnWaitTime\": %.6f, \"RowsAffected\": %v, \"ResponseSize\": %v, \"Error\": %q}\n"
+	case streamlog.QueryLogFormatJSON:
+		fmtString = "{\"Method\": %q, \"RemoteAddr\": %q, \"Username\": %q, \"ImmediateCaller\": %q, \"Effective Caller\": %q, \"Start\": \"%v\", \"End\": \"%v\", \"TotalTime\": %.6f, \"PlanType\": %q, \"OriginalSQL\": %q, \"BindVars\": %v, \"Queries\": %v, \"RewrittenSQL\": %q, \"QuerySources\": %q, \"MysqlTime\": %.6f, \"ConnWaitTime\": %.6f, \"RowsAffected\": %v, \"ResponseSize\": %v, \"Error\": %q}\n"
 	}
 
 	return fmt.Sprintf(

--- a/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
+++ b/go/vt/vttablet/tabletserver/tabletenv/logstats_test.go
@@ -60,7 +60,7 @@ func TestLogStatsFormat(t *testing.T) {
 	logStats.StartTime = time.Date(2017, time.January, 1, 1, 2, 3, 0, time.UTC)
 	logStats.EndTime = time.Date(2017, time.January, 1, 1, 2, 4, 0, time.UTC)
 	logStats.OriginalSQL = "sql"
-	logStats.BindVariables = map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1), "strVal": sqltypes.StringBindVariable("abc")}
+	logStats.BindVariables = map[string]*querypb.BindVariable{"intVal": sqltypes.Int64BindVariable(1)}
 	logStats.AddRewrittenSQL("sql with pii", time.Now())
 	logStats.MysqlResponseTime = 0
 	logStats.Rows = [][]sqltypes.Value{{sqltypes.NewVarBinary("a")}}
@@ -69,7 +69,7 @@ func TestLogStatsFormat(t *testing.T) {
 	*streamlog.RedactDebugUIQueries = false
 	*streamlog.QueryLogFormat = "text"
 	got := logStats.Format(url.Values(params))
-	want := "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t\t\"sql\"\tmap[intVal:type:INT64 value:\"1\"  strVal:type:VARCHAR value:\"abc\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
+	want := "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t\t\"sql\"\tmap[intVal:type:INT64 value:\"1\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
 	if got != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
 	}
@@ -94,7 +94,7 @@ func TestLogStatsFormat(t *testing.T) {
 	if err != nil {
 		t.Errorf("logstats format: error marshaling json: %v -- got:\n%v", err, got)
 	}
-	want = "{\n    \"BindVars\": {\n        \"intVal\": {\n            \"type\": \"INT64\",\n            \"value\": 1\n        },\n        \"strVal\": {\n            \"type\": \"VARCHAR\",\n            \"value\": \"abc\"\n        }\n    },\n    \"ConnWaitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"MysqlTime\": 0,\n    \"OriginalSQL\": \"sql\",\n    \"PlanType\": \"\",\n    \"Queries\": 1,\n    \"QuerySources\": \"mysql\",\n    \"RemoteAddr\": \"\",\n    \"ResponseSize\": 1,\n    \"RewrittenSQL\": \"sql with pii\",\n    \"RowsAffected\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
+	want = "{\n    \"BindVars\": {\n        \"intVal\": {\n            \"type\": \"INT64\",\n            \"value\": 1\n        }\n    },\n    \"ConnWaitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"MysqlTime\": 0,\n    \"OriginalSQL\": \"sql\",\n    \"PlanType\": \"\",\n    \"Queries\": 1,\n    \"QuerySources\": \"mysql\",\n    \"RemoteAddr\": \"\",\n    \"ResponseSize\": 1,\n    \"RewrittenSQL\": \"sql with pii\",\n    \"RowsAffected\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
 	if string(formatted) != want {
 		t.Errorf("logstats format: got:\n%q\nwant:\n%v\n", string(formatted), want)
 	}
@@ -116,6 +116,33 @@ func TestLogStatsFormat(t *testing.T) {
 	}
 
 	*streamlog.RedactDebugUIQueries = false
+
+	// Make sure formatting works for string bind vars. We can't do this as part of a single
+	// map because the output ordering is undefined.
+	logStats.BindVariables = map[string]*querypb.BindVariable{"strVal": sqltypes.StringBindVariable("abc")}
+
+	*streamlog.QueryLogFormat = "text"
+	got = logStats.Format(url.Values(params))
+	want = "test\t\t\t''\t''\tJan  1 01:02:03.000000\tJan  1 01:02:04.000000\t1.000000\t\t\"sql\"\tmap[strVal:type:VARCHAR value:\"abc\" ]\t1\t\"sql with pii\"\tmysql\t0.000000\t0.000000\t0\t1\t\"\"\t\n"
+	if got != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%q\n", got, want)
+	}
+
+	*streamlog.QueryLogFormat = "json"
+	got = logStats.Format(url.Values(params))
+	err = json.Unmarshal([]byte(got), &parsed)
+	if err != nil {
+		t.Errorf("logstats format: error unmarshaling json: %v -- got:\n%v", err, got)
+	}
+	formatted, err = json.MarshalIndent(parsed, "", "    ")
+	if err != nil {
+		t.Errorf("logstats format: error marshaling json: %v -- got:\n%v", err, got)
+	}
+	want = "{\n    \"BindVars\": {\n        \"strVal\": {\n            \"type\": \"VARCHAR\",\n            \"value\": \"abc\"\n        }\n    },\n    \"ConnWaitTime\": 0,\n    \"Effective Caller\": \"\",\n    \"End\": \"Jan  1 01:02:04.000000\",\n    \"Error\": \"\",\n    \"ImmediateCaller\": \"\",\n    \"Method\": \"test\",\n    \"MysqlTime\": 0,\n    \"OriginalSQL\": \"sql\",\n    \"PlanType\": \"\",\n    \"Queries\": 1,\n    \"QuerySources\": \"mysql\",\n    \"RemoteAddr\": \"\",\n    \"ResponseSize\": 1,\n    \"RewrittenSQL\": \"sql with pii\",\n    \"RowsAffected\": 0,\n    \"Start\": \"Jan  1 01:02:03.000000\",\n    \"TotalTime\": 1,\n    \"Username\": \"\"\n}"
+	if string(formatted) != want {
+		t.Errorf("logstats format: got:\n%q\nwant:\n%v\n", string(formatted), want)
+	}
+
 	*streamlog.QueryLogFormat = "text"
 }
 


### PR DESCRIPTION
Fix an oversight in #3485 related to bind variables and json formatting.

The current version only works when bind variables are redacted but
outputs invalid json when not. Fix this to always output either a
json map with the bind variables or the string "[REDACTED]".

Also add completeness tests for the various modes of formatting and
ensure that the json format is valid json by parsing it in the test.