### PR TITLE
vttablet: update by pk with limit -> DML_SUBQUERY

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -637,6 +637,17 @@
   "FullQuery": "replace into b select * from a"
 }
 
+# update limit with pk
+"update d set foo='foo' where name in ('a', 'b') limit 1"
+{
+  "PlanID": "DML_SUBQUERY",
+  "TableName": "d",
+  "FullQuery": "update d set foo = 'foo' where name in ('a', 'b') limit 1",
+  "OuterQuery": "update d set foo = 'foo' where :#pk",
+  "Subquery": "select name from d where name in ('a', 'b') limit 1 for update",
+  "WhereClause": " where name in ('a', 'b')"
+}
+
 # update cross-db
 "update b.a set name='foo' where eid=1 and id=1"
 {
@@ -841,6 +852,17 @@
   "OuterQuery": "update a set name = 'foo' where :#pk order by id desc",
   "Subquery": "select eid, id from a where eid = 1 order by id desc limit :#maxLimit for update",
   "WhereClause": " where eid = 1"
+}
+
+# delete limit with pk
+"delete from d where name in ('a', 'b') limit 1"
+{
+  "PlanID": "DML_SUBQUERY",
+  "TableName": "d",
+  "FullQuery": "delete from d where name in ('a', 'b') limit 1",
+  "OuterQuery": "delete from d where :#pk",
+  "Subquery": "select name from d where name in ('a', 'b') limit 1 for update",
+  "WhereClause": " where name in ('a', 'b')"
 }
 
 # delete cross-db

--- a/go/vt/vttablet/tabletserver/planbuilder/dml.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/dml.go
@@ -76,9 +76,12 @@ func analyzeUpdate(upd *sqlparser.Update, tables map[string]*schema.Table) (plan
 	plan.OuterQuery = GenerateUpdateOuterQuery(upd, nil)
 
 	if pkValues := analyzeWhere(upd.Where, table.Indexes[0]); pkValues != nil {
-		plan.PlanID = PlanDMLPK
-		plan.PKValues = pkValues
-		return plan, nil
+		// Also, there should be no limit clause.
+		if upd.Limit == nil {
+			plan.PlanID = PlanDMLPK
+			plan.PKValues = pkValues
+			return plan, nil
+		}
 	}
 
 	plan.PlanID = PlanDMLSubquery
@@ -125,9 +128,12 @@ func analyzeDelete(del *sqlparser.Delete, tables map[string]*schema.Table) (plan
 	plan.OuterQuery = GenerateDeleteOuterQuery(del)
 
 	if pkValues := analyzeWhere(del.Where, table.Indexes[0]); pkValues != nil {
-		plan.PlanID = PlanDMLPK
-		plan.PKValues = pkValues
-		return plan, nil
+		// Also, there should be no limit clause.
+		if del.Limit == nil {
+			plan.PlanID = PlanDMLPK
+			plan.PKValues = pkValues
+			return plan, nil
+		}
 	}
 
 	plan.PlanID = PlanDMLSubquery


### PR DESCRIPTION
BUG=70932988
An update by pk that also has a limit clause should fall back to
a subquery plan instead of DML_PK because we can't predict the
rows that will be affected.