### PR TITLE
Revert "re-enable the vtexplain tests"

### DIFF
--- a/go/vt/vtexplain/vtexplain_flaky_test.go
+++ b/go/vt/vtexplain/vtexplain_flaky_test.go
@@ -55,6 +55,11 @@ func initTest(opts *Options, t *testing.T) {
 }
 
 func testExplain(testcase string, opts *Options, t *testing.T) {
+	// TODO(sougou): remove this skip for manual testing.
+	// We need to find a better testing strategy.
+	// These tests are almost always failing on travis.
+	t.Skip()
+
 	initTest(opts, t)
 
 	sqlFile := testfiles.Locate(fmt.Sprintf("vtexplain/%s-queries.sql", testcase))


### PR DESCRIPTION
This reverts commit a6da2c52653d021c3ce40990a6d8cb4ca463461f.

The vtexplain tests are still flaky. Temporarily reverting till
fix.