### PR TITLE
Use defer replace goto statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,10 @@ _test/
 /web/vtctld2/bower.json~
 /web/vtctld2/public/bower_components/
 
+bin/
+config/config
+data/data
+dist/
+lib/
+py-vtdb
+vthook/

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -235,6 +235,7 @@ func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql s
 	defer vtg.timings.Record(statsKey, time.Now())
 
 	defer func() {
+		newSession = session
 		if err != nil {
 			query := map[string]interface{}{
 				"Sql":           sql,


### PR DESCRIPTION
I make a small change on vtgate Execute. golang prefer to use defer than goto statement, I make this change for guys to have a look which is better.