### PR TITLE
Not refreshing tablets that are not running.

### DIFF
--- a/go/vt/wrangler/keyspace.go
+++ b/go/vt/wrangler/keyspace.go
@@ -829,6 +829,12 @@ func (wr *Wrangler) RefreshTabletsByShard(ctx context.Context, si *topo.ShardInf
 		if tabletTypes != nil && !topoproto.IsTypeInList(ti.Type, tabletTypes) {
 			continue
 		}
+		if ti.Hostname == "" {
+			// The tablet is not running, we don't have the host
+			// name to connect to, so we just skip this tablet.
+			wr.Logger().Infof("Tablet %v has no hostname, skipping its RefreshState", ti.AliasString())
+			continue
+		}
 
 		wg.Add(1)
 		go func(ti *topo.TabletInfo) {


### PR DESCRIPTION
When a tablet shuts down, it now clears its Hostname in the topo. Do not
call RefreshState at all on such tablets. This avoids a possible 60s
timeout on these.

BUG=31857640