### PR TITLE
Adding a Check method to the topo locks.

### DIFF
--- a/go/vt/topo/conn.go
+++ b/go/vt/topo/conn.go
@@ -232,8 +232,14 @@ type Version interface {
 }
 
 // LockDescriptor is an interface that describes a lock.
-// It will be returned by Lock(). It contains the Unlock method.
+// It will be returned by Lock().
 type LockDescriptor interface {
+	// Check returns an error if the lock was lost.
+	// Some topology implementations use a keep-alive mechanism, and
+	// sometimes it fails. The users of the lock are responsible for
+	// checking on it when convenient.
+	Check(ctx context.Context) error
+
 	// Unlock releases the lock.
 	Unlock(ctx context.Context) error
 }

--- a/go/vt/topo/helpers/tee.go
+++ b/go/vt/topo/helpers/tee.go
@@ -200,6 +200,14 @@ func (c *TeeConn) Lock(ctx context.Context, dirPath, contents string) (topo.Lock
 	}, nil
 }
 
+// Check is part of the topo.LockDescriptor interface.
+func (ld *teeTopoLockDescriptor) Check(ctx context.Context) error {
+	if err := ld.firstLockDescriptor.Check(ctx); err != nil {
+		return err
+	}
+	return ld.secondLockDescriptor.Check(ctx)
+}
+
 // Unlock is part of the topo.LockDescriptor interface.
 func (ld *teeTopoLockDescriptor) Unlock(ctx context.Context) error {
 	// Unlock lockSecond, then lockFirst.

--- a/go/vt/topo/locks.go
+++ b/go/vt/topo/locks.go
@@ -336,16 +336,13 @@ func CheckShardLocked(ctx context.Context, keyspace, shard string) error {
 
 	// func the individual entry
 	mapKey := keyspace + "/" + shard
-	_, ok = i.info[mapKey]
+	li, ok := i.info[mapKey]
 	if !ok {
 		return fmt.Errorf("shard %v/%v is not locked (no lockInfo in map)", keyspace, shard)
 	}
 
-	// TODO(alainjobart): check the lock server implementation
-	// still holds the lock. Will need to look at the lockInfo struct.
-
-	// and we're good for now.
-	return nil
+	// Check the lock server implementation still holds the lock.
+	return li.lockDescriptor.Check(ctx)
 }
 
 // lockShard will lock the shard in the topology server.

--- a/go/vt/topo/memorytopo/lock.go
+++ b/go/vt/topo/memorytopo/lock.go
@@ -76,6 +76,12 @@ func (c *Conn) Lock(ctx context.Context, dirPath, contents string) (topo.LockDes
 	}
 }
 
+// Check is part of the topo.LockDescriptor interface.
+// We can never lose a lock in this implementation.
+func (ld *memoryTopoLockDescriptor) Check(ctx context.Context) error {
+	return nil
+}
+
 // Unlock is part of the topo.LockDescriptor interface.
 func (ld *memoryTopoLockDescriptor) Unlock(ctx context.Context) error {
 	return ld.c.unlock(ctx, ld.dirPath)

--- a/go/vt/topo/test/lock.go
+++ b/go/vt/topo/test/lock.go
@@ -108,6 +108,10 @@ func checkLockTimeout(ctx context.Context, t *testing.T, conn topo.Conn) {
 		t.Fatalf("Lock(interrupted): %v", err)
 	}
 
+	if err := lockDescriptor.Check(ctx); err != nil {
+		t.Errorf("Check(): %v", err)
+	}
+
 	if err := lockDescriptor.Unlock(ctx); err != nil {
 		t.Fatalf("Unlock(): %v", err)
 	}

--- a/go/vt/topo/zk2topo/lock.go
+++ b/go/vt/topo/zk2topo/lock.go
@@ -96,6 +96,13 @@ func (zs *Server) Lock(ctx context.Context, dirPath, contents string) (topo.Lock
 	}, nil
 }
 
+// Check is part of the topo.LockDescriptor interface.
+func (ld *zkLockDescriptor) Check(ctx context.Context) error {
+	// TODO(alainjobart): check the connection has not been interrupted.
+	// We'd lose the ephemeral node in case of a session loss.
+	return nil
+}
+
 // Unlock is part of the topo.LockDescriptor interface.
 func (ld *zkLockDescriptor) Unlock(ctx context.Context) error {
 	return ld.zs.Delete(ctx, ld.nodePath, nil)


### PR DESCRIPTION
Most implementations don't keep locks forever, and provide a way to
check the lock is still held. This is just wiring it up.
Using it in CheckShardLock. Adding more calls to CheckShardLock.

BUG=28966609