### PR TITLE
v3: incorporate vschema column info into symtab

### DIFF
--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -66,7 +66,15 @@
           "auto_increment": {
             "column": "id",
             "sequence": "seq"
-          }
+          },
+          "columns": [
+            {
+              "name": "predef1"
+            },
+            {
+              "name": "predef2"
+            }
+          ]
         },
         "user_metadata": {
           "column_vindexes": [
@@ -163,7 +171,16 @@
     },
     "main": {
       "tables": {
-        "unsharded": {},
+        "unsharded": {
+          "columns": [
+            {
+              "name": "predef1"
+            },
+            {
+              "name": "predef3"
+            }
+          ]
+        },
         "unsharded_a": {},
         "unsharded_b": {},
         "unsharded_auto": {

--- a/data/test/vtgate/symtab_cases.txt
+++ b/data/test/vtgate/symtab_cases.txt
@@ -1,0 +1,42 @@
+# Tests in this file are for testing symtab functionality
+
+# Column names need not be qualified if they are predefined in vschema and unambiguous.
+"select predef2, predef3 from user join unsharded on predef2 = predef3"
+{
+  "Original": "select predef2, predef3 from user join unsharded on predef2 = predef3",
+  "Instructions": {
+    "Opcode": "Join",
+    "Left": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select predef2 from user",
+      "FieldQuery": "select predef2 from user where 1 != 1"
+    },
+    "Right": {
+      "Opcode": "SelectUnsharded",
+      "Keyspace": {
+        "Name": "main",
+        "Sharded": false
+      },
+      "Query": "select predef3 from unsharded where predef3 = :predef2",
+      "FieldQuery": "select predef3 from unsharded where 1 != 1",
+      "JoinVars": {
+        "predef2": {}
+      }
+    },
+    "Cols": [
+      -1,
+      1
+    ],
+    "Vars": {
+      "predef2": 0
+    }
+  }
+}
+
+# predef1 is in both user and unsharded. So, it's ambiguous.
+"select predef1, predef3 from user join unsharded on predef1 = predef3"
+"symbol predef1 not found"

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -113,14 +113,15 @@ func TestPlan(t *testing.T) {
 	// column names are case-preserved, but treated as
 	// case-insensitive even if they come from the vschema.
 	testFile(t, "aggr_cases.txt", vschema)
+	testFile(t, "dml_cases.txt", vschema)
 	testFile(t, "from_cases.txt", vschema)
 	testFile(t, "filter_cases.txt", vschema)
-	testFile(t, "select_cases.txt", vschema)
 	testFile(t, "postprocess_cases.txt", vschema)
-	testFile(t, "wireup_cases.txt", vschema)
-	testFile(t, "dml_cases.txt", vschema)
-	testFile(t, "vindex_func_cases.txt", vschema)
+	testFile(t, "select_cases.txt", vschema)
+	testFile(t, "symtab_cases.txt", vschema)
 	testFile(t, "unsupported_cases.txt", vschema)
+	testFile(t, "vindex_func_cases.txt", vschema)
+	testFile(t, "wireup_cases.txt", vschema)
 }
 
 func TestOne(t *testing.T) {

--- a/go/vt/vtgate/planbuilder/symtab_test.go
+++ b/go/vt/vtgate/planbuilder/symtab_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"testing"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vtgate/vindexes"
+)
+
+func TestSymtabAddVindexTable(t *testing.T) {
+	tname := sqlparser.TableName{Name: sqlparser.NewTableIdent("t")}
+	rb := &route{}
+
+	tcases := []struct {
+		in  *vindexes.Table
+		out []string
+	}{{
+		in: &vindexes.Table{
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			ColumnVindexes: []*vindexes.ColumnVindex{{
+				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("C1")},
+			}},
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			ColumnVindexes: []*vindexes.ColumnVindex{{
+				Columns: []sqlparser.ColIdent{
+					sqlparser.NewColIdent("C1"),
+					sqlparser.NewColIdent("C2"),
+				},
+			}},
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			AutoIncrement: &vindexes.AutoIncrement{
+				Column: sqlparser.NewColIdent("C1"),
+			},
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C1"),
+			}, {
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			ColumnVindexes: []*vindexes.ColumnVindex{{
+				Columns: []sqlparser.ColIdent{sqlparser.NewColIdent("C1")},
+			}},
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			ColumnVindexes: []*vindexes.ColumnVindex{{
+				Columns: []sqlparser.ColIdent{
+					sqlparser.NewColIdent("C1"),
+					sqlparser.NewColIdent("C2"),
+				},
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}, {
+		in: &vindexes.Table{
+			AutoIncrement: &vindexes.AutoIncrement{
+				Column: sqlparser.NewColIdent("C1"),
+			},
+			Columns: []vindexes.Column{{
+				Name: sqlparser.NewColIdent("C2"),
+				Type: sqltypes.VarChar,
+			}},
+		},
+		out: []string{"c1", "c2"},
+	}}
+
+	for _, tcase := range tcases {
+		st := newSymtab(nil)
+		err := st.AddVindexTable(tname, tcase.in, rb)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		tab := st.tables[tname]
+		for _, col := range tcase.out {
+			if tab.columns[col] == nil {
+				t.Errorf("st.AddVindexTable(%+v): column %s not found", tcase.in, col)
+			}
+		}
+	}
+}


### PR DESCRIPTION
symtab now pulls the new column info from the vschema. With this
change, if all columns are speicified for a table, the planbuilder
can auto-resolve those symbols to the correct table, which allows
you to use unqualified column names for join queries.

An example of this is provided in symtab_cases.txt.