### PR TITLE
build: fix bootstrap and docker images

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -103,10 +103,10 @@ else
 fi
 ln -snf $consul_dist/consul $VTROOT/bin/consul
 
-# install gRPC C++ base, so we can install the python adapters.
-# this also installs protobufs
-grpc_dist=$VTROOT/dist/grpc
-grpc_ver=v1.7.1
+# Install gRPC proto compilers. There is no download for grpc_python_plugin.
+# So, we need to build it.
+export grpc_dist=$VTROOT/dist/grpc
+export grpc_ver="v1.7.0"
 if [ $SKIP_ROOT_INSTALLS == "True" ]; then
   echo "skipping grpc build, as root version was already installed."
 elif [[ -f $grpc_dist/.build_finished && "$(cat $grpc_dist/.build_finished)" == "$grpc_ver" ]]; then

--- a/docker/bootstrap/Dockerfile.common
+++ b/docker/bootstrap/Dockerfile.common
@@ -11,7 +11,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     g++ \
     git \
     libgconf-2-4 \
-    libssl-dev \
     libtool \
     make \
     openjdk-8-jdk \
@@ -27,23 +26,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     unzip \
     xvfb \
     zip \
-    # gRPC PHP requirements \
     libz-dev \
-    php-pear \
-    php7.0-cli \
-    php7.0-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install PHP modules for running tests
-RUN export MAKEFLAGS="-j$(nproc)" && \
-    mkdir -p /vt/bin && \
-    curl -sL --connect-timeout 10 --retry 3 \
-        https://phar.phpunit.de/phpunit-4.8.9.phar > /vt/bin/phpunit && \
-    chmod +x /vt/bin/phpunit && \
-    curl -sL --connect-timeout 10 --retry 3 \
-        https://getcomposer.org/installer | php -- --install-dir=/vt/bin --filename=composer && \
-    pecl install xdebug && \
-    echo "zend_extension=$(pecl config-get ext_dir default)/xdebug.so" > /etc/php/7.0/cli/conf.d/20-xdebug.ini
+# Not sure if this is needed, but it was part of php init, which we don't do any more.
+RUN mkdir -p /vt/bin
 
 # Install Maven 3.1+
 RUN mkdir -p /vt/dist && \
@@ -72,34 +59,17 @@ COPY config /vt/src/github.com/youtube/vitess/config
 COPY third_party /vt/src/github.com/youtube/vitess/third_party
 COPY tools /vt/src/github.com/youtube/vitess/tools
 COPY travis /vt/src/github.com/youtube/vitess/travis
-COPY composer.json composer.lock /vt/src/github.com/youtube/vitess/
 COPY vendor/vendor.json /vt/src/github.com/youtube/vitess/vendor/
+
+# grpcio runtime is needed for python tests.
+RUN grpcio_ver="1.7.0" && \
+    pip install --upgrade grpcio==$grpcio_ver
 
 # Download vendored Go dependencies
 RUN cd /vt/src/github.com/youtube/vitess && \
     go get -u github.com/kardianos/govendor && \
     govendor sync && \
     rm -rf /vt/.cache
-
-# Install gRPC as root
-RUN export MAKEFLAGS="-j$(nproc)" && \
-    $VTTOP/travis/install_grpc.sh && \
-    rm -rf /vt/dist/grpc
-
-# Install gRPC PHP dependencies
-RUN export MAKEFLAGS="-j$(nproc)" && \
-    pecl install grpc && \
-    cd /vt/src/github.com/youtube/vitess && \
-    composer install && \
-    echo 'extension=grpc.so' > /etc/php/7.0/cli/conf.d/20-grpc.ini && \
-    find php/vendor/grpc/grpc -mindepth 1 -maxdepth 1 ! -name src | xargs rm -rf && \
-    find php/vendor/grpc/grpc/src -mindepth 1 -maxdepth 1 ! -name php | xargs rm -rf
-
-# Install PHP protobuf compiler plugin
-RUN cd /vt/src/github.com/youtube/vitess/php/vendor/stanley-cheung/protobuf-php && \
-    gem install rake ronn && \
-    rake pear:package version=1.0 && \
-    pear install Protobuf-1.0.tgz
 
 # Create vitess user
 RUN groupadd -r vitess && useradd -r -g vitess vitess && \


### PR DESCRIPTION
The bootstrap scripts were broken because the grpc version was
not getting passed into the install script. This is fixed now.

Also, the docker build for grpc was even more broken. The linux
image on docker requires a newer version of libssl-dev (1.1.x).
Unfortunately, grpc can only build against the older 1.0.x.
I couldn't find an easy way to work around this. Fortunately,
the docker image is only meant for deployment. So, it doesn't
require the grpc compilers. So, I got rid of the full install
and for now, just installed the python runtime (grpcio).

Other than the usual flakyness, all tests are passing. So,
I've pushed the new docker images into hub.