### PR TITLE
add an option to enable grpc tracing

### DIFF
--- a/go/vt/grpcclient/client.go
+++ b/go/vt/grpcclient/client.go
@@ -43,6 +43,7 @@ func RegisterGRPCDialOptions(grpcDialOptionsFunc func(opts []grpc.DialOption) ([
 // failFast is a non-optional parameter because callers are required to specify
 // what that should be.
 func Dial(target string, failFast FailFast, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	grpccommon.EnableTracingOpt()
 	newopts := []grpc.DialOption{
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallRecvMsgSize(*grpccommon.MaxMessageSize),

--- a/go/vt/grpccommon/options.go
+++ b/go/vt/grpccommon/options.go
@@ -18,6 +18,9 @@ package grpccommon
 
 import (
 	"flag"
+	"sync"
+
+	"google.golang.org/grpc"
 )
 
 var (
@@ -27,4 +30,17 @@ var (
 	// Note: We're using 4 MiB as default value because that's the default in the
 	// gRPC 1.0.0 Go server.
 	MaxMessageSize = flag.Int("grpc_max_message_size", defaultMaxMessageSize, "Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'.")
+	// EnableTracing sets a flag to enable grpc client/server tracing.
+	EnableTracing = flag.Bool("grpc_enable_tracing", false, "Enable GRPC tracing")
 )
+
+var enableTracing sync.Once
+
+// EnableTracingOpt enables grpc tracing if requested.
+// It must be called before any grpc server or client is created but is safe
+// to be called multiple times.
+func EnableTracingOpt() {
+	enableTracing.Do(func() {
+		grpc.EnableTracing = *EnableTracing
+	})
+}

--- a/go/vt/servenv/grpc_server.go
+++ b/go/vt/servenv/grpc_server.go
@@ -99,6 +99,8 @@ func createGRPCServer() {
 		return
 	}
 
+	grpccommon.EnableTracingOpt()
+
 	var opts []grpc.ServerOption
 	if GRPCPort != nil && *GRPCCert != "" && *GRPCKey != "" {
 		config, err := vttls.ServerConfig(*GRPCCert, *GRPCKey, *GRPCCA)


### PR DESCRIPTION
GRPC has an option to enable tracing using the builtin golang net tracing package:
https://godoc.org/golang.org/x/net/trace

Add a flag to enable tracing the first time a grpc client or server is created.
