### PR TITLE
v3: support for aggregation and sorting of TEXT

### DIFF
--- a/data/test/vtgate/aggr_cases.txt
+++ b/data/test/vtgate/aggr_cases.txt
@@ -93,6 +93,49 @@
   }
 }
 
+# scatter group by a text column
+"select count(*), a, textcol1, b from user group by a, textcol1, b"
+{
+  "Original": "select count(*), a, textcol1, b from user group by a, textcol1, b",
+  "Instructions": {
+    "Aggregates": [
+      {
+        "Opcode": "count",
+        "Col": 0
+      }
+    ],
+    "Keys": [
+      1,
+      4,
+      3
+    ],
+    "TruncateColumnCount": 4,
+    "Input": {
+      "Opcode": "SelectScatter",
+      "Keyspace": {
+        "Name": "user",
+        "Sharded": true
+      },
+      "Query": "select count(*), a, textcol1, b, weight_string(textcol1) from user group by a, textcol1, b order by a asc, textcol1 asc, b asc",
+      "FieldQuery": "select count(*), a, textcol1, b, weight_string(textcol1) from user where 1 != 1 group by a, textcol1, b",
+      "OrderBy": [
+        {
+          "Col": 1,
+          "Desc": false
+        },
+        {
+          "Col": 4,
+          "Desc": false
+        },
+        {
+          "Col": 3,
+          "Desc": false
+        }
+      ]
+    }
+  }
+}
+
 # count aggregate
 "select count(*) from user"
 {

--- a/data/test/vtgate/postprocess_cases.txt
+++ b/data/test/vtgate/postprocess_cases.txt
@@ -135,6 +135,100 @@
   }
 }
 
+# ORDER BY on scatter with text column
+"select a, textcol1, b from user order by a, textcol1, b"
+{
+  "Original": "select a, textcol1, b from user order by a, textcol1, b",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select a, textcol1, b, weight_string(textcol1) from user order by a asc, textcol1 asc, b asc",
+    "FieldQuery": "select a, textcol1, b, weight_string(textcol1) from user where 1 != 1",
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "TruncateColumnCount": 3
+  }
+}
+
+# ORDER BY on scatter with text column, qualified name
+"select a, user.textcol1, b from user order by a, textcol1, b"
+{
+  "Original": "select a, user.textcol1, b from user order by a, textcol1, b",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select a, user.textcol1, b, weight_string(user.textcol1) from user order by a asc, textcol1 asc, b asc",
+    "FieldQuery": "select a, user.textcol1, b, weight_string(user.textcol1) from user where 1 != 1",
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 3,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      }
+    ],
+    "TruncateColumnCount": 3
+  }
+}
+
+# ORDER BY on scatter with multiple text columns
+"select a, textcol1, b, textcol2 from user order by a, textcol1, b, textcol2"
+{
+  "Original": "select a, textcol1, b, textcol2 from user order by a, textcol1, b, textcol2",
+  "Instructions": {
+    "Opcode": "SelectScatter",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "select a, textcol1, b, textcol2, weight_string(textcol1), weight_string(textcol2) from user order by a asc, textcol1 asc, b asc, textcol2 asc",
+    "FieldQuery": "select a, textcol1, b, textcol2, weight_string(textcol1), weight_string(textcol2) from user where 1 != 1",
+    "OrderBy": [
+      {
+        "Col": 0,
+        "Desc": false
+      },
+      {
+        "Col": 4,
+        "Desc": false
+      },
+      {
+        "Col": 2,
+        "Desc": false
+      },
+      {
+        "Col": 5,
+        "Desc": false
+      }
+    ],
+    "TruncateColumnCount": 4
+  }
+}
+
 # ORDER BY invalid col number on scatter
 "select col from user order by 2"
 "column number out of range: 2"

--- a/data/test/vtgate/schema_test.json
+++ b/data/test/vtgate/schema_test.json
@@ -73,6 +73,14 @@
             },
             {
               "name": "predef2"
+            },
+            {
+              "name": "textcol1",
+              "type": "VARCHAR"
+            },
+            {
+              "name": "textcol2",
+              "type": "VARCHAR"
             }
           ]
         },

--- a/go/sqltypes/result.go
+++ b/go/sqltypes/result.go
@@ -98,6 +98,41 @@ func CopyRow(r []Value) []Value {
 	return out
 }
 
+// Truncate returns a new Result with all the rows truncated
+// to the specified number of columns.
+func (result *Result) Truncate(l int) *Result {
+	if l == 0 {
+		return result
+	}
+
+	out := &Result{
+		InsertID:     result.InsertID,
+		RowsAffected: result.RowsAffected,
+	}
+	if result.Fields != nil {
+		out.Fields = result.Fields[:l]
+	}
+	if result.Rows != nil {
+		out.Rows = make([][]Value, 0, len(result.Rows))
+		for _, r := range result.Rows {
+			out.Rows = append(out.Rows, r[:l])
+		}
+	}
+	if result.Extras != nil {
+		out.Extras = &querypb.ResultExtras{
+			Fresher: result.Extras.Fresher,
+		}
+		if result.Extras.EventToken != nil {
+			out.Extras.EventToken = &querypb.EventToken{
+				Timestamp: result.Extras.EventToken.Timestamp,
+				Shard:     result.Extras.EventToken.Shard,
+				Position:  result.Extras.EventToken.Position,
+			}
+		}
+	}
+	return out
+}
+
 // FieldsEqual compares two arrays of fields.
 // reflect.DeepEqual shouldn't be used because of the protos.
 func FieldsEqual(f1, f2 []*querypb.Field) bool {

--- a/go/sqltypes/result_test.go
+++ b/go/sqltypes/result_test.go
@@ -76,6 +76,61 @@ func TestCopy(t *testing.T) {
 	}
 }
 
+func TestTruncate(t *testing.T) {
+	in := &Result{
+		Fields: []*querypb.Field{{
+			Type: Int64,
+		}, {
+			Type: VarChar,
+		}},
+		InsertID:     1,
+		RowsAffected: 2,
+		Rows: [][]Value{
+			{TestValue(Int64, "1"), MakeTrusted(Null, nil)},
+			{TestValue(Int64, "2"), MakeTrusted(VarChar, nil)},
+			{TestValue(Int64, "3"), TestValue(VarChar, "")},
+		},
+		Extras: &querypb.ResultExtras{
+			EventToken: &querypb.EventToken{
+				Timestamp: 123,
+				Shard:     "sh",
+				Position:  "po",
+			},
+			Fresher: true,
+		},
+	}
+
+	out := in.Truncate(0)
+	if !reflect.DeepEqual(out, in) {
+		t.Errorf("Truncate(0):\n%v, want\n%v", out, in)
+	}
+
+	out = in.Truncate(1)
+	want := &Result{
+		Fields: []*querypb.Field{{
+			Type: Int64,
+		}},
+		InsertID:     1,
+		RowsAffected: 2,
+		Rows: [][]Value{
+			{TestValue(Int64, "1")},
+			{TestValue(Int64, "2")},
+			{TestValue(Int64, "3")},
+		},
+		Extras: &querypb.ResultExtras{
+			EventToken: &querypb.EventToken{
+				Timestamp: 123,
+				Shard:     "sh",
+				Position:  "po",
+			},
+			Fresher: true,
+		},
+	}
+	if !reflect.DeepEqual(out, want) {
+		t.Errorf("Truncate(1):\n%v, want\n%v", out, want)
+	}
+}
+
 func TestStripMetaData(t *testing.T) {
 	testcases := []struct {
 		name           string

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -101,7 +101,13 @@ var executorVSchema = `
 			"auto_increment": {
 				"column": "id",
 				"sequence": "user_seq"
-			}
+			},
+			"columns": [
+				{
+					"name": "textcol",
+					"type": "VARCHAR"
+				}
+			]
 		},
 		"user2": {
 			"column_vindexes": [

--- a/go/vt/vtgate/sandbox_test.go
+++ b/go/vt/vtgate/sandbox_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package vtgate
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"sync"
 
+	"github.com/youtube/vitess/go/json2"
 	"github.com/youtube/vitess/go/vt/grpcclient"
 	"github.com/youtube/vitess/go/vt/key"
 	"github.com/youtube/vitess/go/vt/topo"
@@ -78,7 +78,9 @@ func getSandboxSrvVSchema() *vschemapb.SrvVSchema {
 	defer sandboxMu.Unlock()
 	for keyspace, sandbox := range ksToSandbox {
 		var vs vschemapb.Keyspace
-		_ = json.Unmarshal([]byte(sandbox.VSchema), &vs)
+		if err := json2.Unmarshal([]byte(sandbox.VSchema), &vs); err != nil {
+			panic(err)
+		}
 		result.Keyspaces[keyspace] = &vs
 	}
 	return result

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/golang/glog"
 	"github.com/youtube/vitess/go/sqltypes"
 )
 
@@ -49,7 +48,6 @@ type LookupHash struct {
 
 // NewLookupHash creates a LookupHash vindex.
 func NewLookupHash(name string, m map[string]string) (Vindex, error) {
-	log.Warningf("LookupHash index (%q) it's being deprecated. Please use Lookup", name)
 	lh := &LookupHash{name: name}
 	lh.lkp.Init(m)
 	return lh, nil
@@ -146,7 +144,6 @@ type LookupHashUnique struct {
 
 // NewLookupHashUnique creates a LookupHashUnique vindex.
 func NewLookupHashUnique(name string, m map[string]string) (Vindex, error) {
-	log.Warningf("LookupHashUnique index (%q) it's being deprecated. Please use LookupUnique", name)
 	lhu := &LookupHashUnique{name: name}
 	lhu.lkp.Init(m)
 	return lhu, nil

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -56,8 +56,8 @@ var masterSession = &vtgatepb.Session{
 func init() {
 	getSandbox(KsTestUnsharded).VSchema = `
 {
-	"Sharded": false,
-	"Tables": {
+	"sharded": false,
+	"tables": {
 		"t1": {}
 	}
 }

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 
+from decimal import Decimal
 import itertools
 import logging
 import unittest
@@ -67,6 +68,12 @@ cola varchar(64),
 colb varchar(64),
 colc varchar(64),
 primary key (kid)
+) Engine=InnoDB'''
+
+create_vt_aggr = '''create table vt_aggr (
+id bigint,
+name varchar(64),
+primary key (id)
 ) Engine=InnoDB'''
 
 create_vt_music = '''create table vt_music (
@@ -334,6 +341,36 @@ vschema = {
             }
           ]
         },
+        "vt_multicolvin": {
+          "column_vindexes": [
+            {
+              "column": "kid",
+              "name": "hash_index"
+            },
+            {
+              "column": "cola",
+              "name": "cola_map"
+            },
+            {
+              "columns": ["colb", "colc"],
+              "name": "colb_colc_map"
+            }
+          ]
+        },
+        "vt_aggr": {
+          "column_vindexes": [
+            {
+              "column": "id",
+              "name": "hash_index"
+            }
+          ],
+          "columns": [
+            {
+              "name": "name",
+              "type": "VARCHAR"
+            }
+          ]
+        },
         "vt_music": {
           "column_vindexes": [
             {
@@ -359,22 +396,6 @@ vschema = {
             {
               "column": "user_id",
               "name": "hash_index"
-            }
-          ]
-        },
-        "vt_multicolvin": {
-          "column_vindexes": [
-            {
-              "column": "kid",
-              "name": "hash_index"
-            },
-            {
-              "column": "cola",
-              "name": "cola_map"
-            },
-            {
-              "columns": ["colb", "colc"],
-              "name": "colb_colc_map"
             }
           ]
         },
@@ -480,6 +501,7 @@ def setUpModule():
             create_vt_user_extra,
             create_vt_user_extra2,
             create_vt_multicolvin,
+            create_vt_aggr,
             create_vt_music,
             create_vt_music_extra,
             create_upsert,
@@ -552,6 +574,7 @@ def get_connection(timeout=10.0):
 
 class TestVTGateFunctions(unittest.TestCase):
 
+  decimal_type = 18
   int_type = 265
   string_type = 6165
   varbinary_type = 10262
@@ -1148,6 +1171,39 @@ class TestVTGateFunctions(unittest.TestCase):
         })
     self.assertEqual(result, ([], 2L, 0L, []))
     vtgate_conn.commit()
+
+  def test_aggr(self):
+    # test_aggr tests text column aggregation
+    vtgate_conn = get_connection()
+    vtgate_conn.begin()
+    # insert upper and lower-case mixed rows in jumbled order
+    result = self.execute_on_master(
+        vtgate_conn,
+        'insert into vt_aggr (id, name) values '
+        '(10, \'A\'), '
+        '(9, \'a\'), '
+        '(8, \'b\'), '
+        '(7, \'B\'), '
+        '(6, \'d\'), '
+        '(5, \'c\'), '
+        '(4, \'C\'), '
+        '(3, \'d\'), '
+        '(2, \'e\'), '
+        '(1, \'E\')',
+        {})
+    vtgate_conn.commit()
+
+    result = self.execute_on_master(
+        vtgate_conn, 'select sum(id), name from vt_aggr group by name', {})
+    values = [v1 for v1, v2 in result[0]]
+    print values
+    self.assertEqual(
+        [v1 for v1, v2 in result[0]],
+        [(Decimal('19')),
+          (Decimal('15')),
+          (Decimal('9')),
+          (Decimal('9')),
+          (Decimal('3'))])
 
   def test_music(self):
     # music is for testing owned lookup index


### PR DESCRIPTION
This change adds support for aggregating and sorting of columns
that may need to follow collation rules.

The feature depends on mysql's weight_string function
that returns a lexically comparable value of any text column.
If a group by or order by uses a text column like varchar, then
v3 will additionally request the weight_string versions of such
columns and perform ordering and aggregation using those values
instead.

The identification of a text column is currently based on a new
"columns" field in the vschema that allows you to specify the
type of each column. This part was implemented in a previous PR.

Two approaches were possible:
1. Request additional weight_string values at the time of push-down.
2. Rewire the primitives to request and use the additional weight_string
   values during the Wireup phase.
I went with option 2 because it minimizes overall impact of the
code, which will allow us to yank this behavior out when we
implement collation aware sorting in vtgate. Also, since all
the weight_string columns get added at the end, we only have
to truncate the rows before returning what's needed.

The following changes were made:
* sqltypes: result truncate functionality.
* engine: Add TruncateColumnCount field that can be used to truncate
  a result if needed.
* planbuilder: Change Wireup to check and request weight_strings.
  If weight_string was requested, set the row truncation to make
  sure that the weight_string values don't get passed on.