### PR TITLE
suppress errors for package vtgate tests

### DIFF
--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -55,7 +55,7 @@ var masterSession = &vtgatepb.Session{
 }
 
 func init() {
-	flag.CommandLine.Parse([]string{})   // prevents glog "ERROR: logging before flag.Parse"
+	flag.CommandLine.Parse([]string{}) // prevents glog "ERROR: logging before flag.Parse"
 
 	getSandbox(KsTestUnsharded).VSchema = `
 {

--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -18,6 +18,7 @@ package vtgate
 
 import (
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -54,6 +55,8 @@ var masterSession = &vtgatepb.Session{
 }
 
 func init() {
+	flag.CommandLine.Parse([]string{})   // prevents glog "ERROR: logging before flag.Parse"
+
 	getSandbox(KsTestUnsharded).VSchema = `
 {
 	"Sharded": false,


### PR DESCRIPTION
I noticed when running
```
go test 'github.com/youtube/vitess/go/vt/vtgate' -v
```

these errors from glog:

> ERROR: logging before flag.Parse: I0104 16:13:49.401758   22951 buffer.go:144] vtgate buffer not enabled.
> ERROR: logging before flag.Parse: I0104 16:13:49.401895   22951 discoverygateway.go:103] loading tablets for cells: 
> ERROR: logging before flag.Parse: I0104 16:13:49.401907   22951 gateway.go:84] Gateway waiting for serving tablets...
> ERROR: logging before flag.Parse: I0104 16:13:49.401925   22951 gateway.go:91] Waiting for tablets completed
> ERROR: logging before flag.Parse: I0104 16:13:49.401949   22951 vtgate.go:68] Transaction mode: 'MULTI'
> ERROR: logging before flag.Parse: I0104 16:13:49.402435   22951 streamlog.go:141] Streaming logs from VTGate at /debug/querylog.

This trick from https://github.com/kubernetes/kubernetes/issues/17162 can suppress them, if you want.