### PR TITLE
add a flag to enable query logging to a file for vtgate

### DIFF
--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -202,7 +202,10 @@ func Init(ctx context.Context, hc discovery.HealthCheck, topoServer *topo.Server
 		}
 	})
 	vtgateOnce.Do(rpcVTGate.registerDebugHealthHandler)
-	initQueryLogger(rpcVTGate)
+	err := initQueryLogger(rpcVTGate)
+	if err != nil {
+		log.Fatalf("error initializing query logger: %v", err)
+	}
 
 	return rpcVTGate
 }


### PR DESCRIPTION
I had intended originally this to be part of #3430 but forgot to add it then.

This simply adds a command line flag to vtgate to enable query logging to a file, similar to the functionality that vttablet has.

In this case I opted to go the simpler route of just making the flag part of the vtgate package rather than the more complicated route making this a plugin. If this ends up being a problem, I can always move the flag registration to be an optional plugin but this overall seemed simpler.
