### PR TITLE
vtqueryserver

### DIFF
--- a/go/cmd/vtqueryserver/index.go
+++ b/go/cmd/vtqueryserver/index.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+)
+
+// This is a separate file so it can be selectively included/excluded from
+// builds to opt in/out of the redirect.
+
+func init() {
+	// Anything unrecognized gets redirected to the status page.
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/debug/status", http.StatusFound)
+	})
+}

--- a/go/cmd/vtqueryserver/plugin_auth_static.go
+++ b/go/cmd/vtqueryserver/plugin_auth_static.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This plugin imports staticauthserver to register the flat-file implementation of AuthServer.
+
+import (
+	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/vt/vtqueryserver"
+)
+
+func init() {
+	vtqueryserver.RegisterPluginInitializer(func() { mysql.InitAuthServerStatic() })
+}

--- a/go/cmd/vtqueryserver/plugin_grpcqueryservice.go
+++ b/go/cmd/vtqueryserver/plugin_grpcqueryservice.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttablet/grpcqueryservice"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver"
+)
+
+// Imports and register the gRPC queryservice server
+
+func init() {
+	tabletserver.RegisterFunctions = append(tabletserver.RegisterFunctions, func(qsc tabletserver.Controller) {
+		if servenv.GRPCCheckServiceMap("queryservice") {
+			grpcqueryservice.Register(servenv.GRPCServer, qsc.QueryService())
+		}
+	})
+
+}

--- a/go/cmd/vtqueryserver/vtqueryserver.go
+++ b/go/cmd/vtqueryserver/vtqueryserver.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	log "github.com/golang/glog"
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vtqueryserver"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+)
+
+var (
+	mysqlSocketFile = flag.String("mysql-socket-file", "", "path to unix socket file to connect to mysql")
+)
+
+func init() {
+	servenv.RegisterDefaultFlags()
+}
+
+func main() {
+	dbconfigFlags := dbconfigs.AppConfig | dbconfigs.AppDebugConfig
+	dbconfigs.RegisterFlags(dbconfigFlags)
+	flag.Parse()
+
+	if *servenv.Version {
+		servenv.AppVersion.Print()
+		os.Exit(0)
+	}
+
+	if len(flag.Args()) > 0 {
+		flag.Usage()
+		log.Exit("vtqueryserver doesn't take any positional arguments")
+	}
+	if err := tabletenv.VerifyConfig(); err != nil {
+		log.Exitf("invalid config: %v", err)
+	}
+
+	tabletenv.Init()
+
+	servenv.Init()
+
+	dbcfgs, err := dbconfigs.Init(*mysqlSocketFile, dbconfigFlags)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = vtqueryserver.Init(dbcfgs)
+	if err != nil {
+		log.Exitf("error initializing proxy: %v", err)
+	}
+
+	servenv.RunDefault()
+}

--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mysqlproxy is a basic module that proxies a mysql server
+// session to appropriate calls in a queryservice back end, with optional
+// query normalization.
+package mysqlproxy
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vttablet/queryservice"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+// ProxySession holds session state for the proxy
+type ProxySession struct {
+	TransactionID int64
+	TargetString  string
+	Options       *querypb.ExecuteOptions
+	Autocommit    bool
+}
+
+// Proxy wraps the standalone query service
+type Proxy struct {
+	target    *querypb.Target
+	qs        queryservice.QueryService
+	normalize bool
+}
+
+// NewProxy creates a new proxy
+func NewProxy(target *querypb.Target, qs queryservice.QueryService, normalize bool) *Proxy {
+	return &Proxy{
+		target:    target,
+		qs:        qs,
+		normalize: normalize,
+	}
+}
+
+// Execute runs the given sql query in the specified session
+func (mp *Proxy) Execute(ctx context.Context, session *ProxySession, sql string, bindVariables map[string]*querypb.BindVariable) (*ProxySession, *sqltypes.Result, error) {
+	var err error
+	result := &sqltypes.Result{}
+
+	switch sqlparser.Preview(sql) {
+	case sqlparser.StmtBegin:
+		err = mp.doBegin(ctx, session)
+	case sqlparser.StmtCommit:
+		err = mp.doCommit(ctx, session)
+	case sqlparser.StmtRollback:
+		err = mp.doRollback(ctx, session)
+	case sqlparser.StmtSet:
+		result, err = mp.doSet(ctx, session, sql, bindVariables)
+	default:
+		result, err = mp.doExecute(ctx, session, sql, bindVariables)
+	}
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return session, result, nil
+}
+
+// Rollback rolls back the session
+func (mp *Proxy) Rollback(ctx context.Context, session *ProxySession) error {
+	return mp.doRollback(ctx, session)
+}
+
+func (mp *Proxy) doBegin(ctx context.Context, session *ProxySession) error {
+	txID, err := mp.qs.Begin(ctx, mp.target, session.Options)
+	if err != nil {
+		return err
+	}
+	session.TransactionID = txID
+	return nil
+}
+
+func (mp *Proxy) doCommit(ctx context.Context, session *ProxySession) error {
+	if session.TransactionID == 0 {
+		return fmt.Errorf("commit: no open transaction")
+
+	}
+	err := mp.qs.Commit(ctx, mp.target, session.TransactionID)
+	session.TransactionID = 0
+	return err
+}
+
+// Rollback rolls back the session
+func (mp *Proxy) doRollback(ctx context.Context, session *ProxySession) error {
+	if session.TransactionID != 0 {
+		err := mp.qs.Rollback(ctx, mp.target, session.TransactionID)
+		session.TransactionID = 0
+		return err
+	}
+	return nil
+}
+
+// Set is currently ignored
+func (mp *Proxy) doSet(ctx context.Context, session *ProxySession, sql string, bindVariables map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	vals, charset, err := sqlparser.ExtractSetValues(sql)
+	if err != nil {
+		return nil, err
+	}
+	if len(vals) > 0 && charset != "" {
+		return nil, err
+	}
+
+	switch charset {
+	case "", "utf8", "utf8mb4", "latin1", "default":
+		break
+	default:
+		return nil, fmt.Errorf("unexpected value for charset: %v", charset)
+	}
+
+	for k, v := range vals {
+		log.Warningf("Ignored inapplicable SET %v = %v", k, v)
+	}
+
+	return &sqltypes.Result{}, nil
+}
+
+// doExecute runs the given query
+func (mp *Proxy) doExecute(ctx context.Context, session *ProxySession, sql string, bindVariables map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+	if mp.normalize {
+		query, comments := sqlparser.SplitTrailingComments(sql)
+		stmt, err := sqlparser.Parse(query)
+		if err != nil {
+			return nil, err
+		}
+		sqlparser.Normalize(stmt, bindVariables, "vtp")
+		normalized := sqlparser.String(stmt)
+		sql = normalized + comments
+	}
+
+	return mp.qs.Execute(ctx, mp.target, sql, bindVariables, session.TransactionID, session.Options)
+}

--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -170,7 +170,6 @@ func (mp *Proxy) executeSelect(ctx context.Context, session *ProxySession, sql s
 		query, comments := sqlparser.SplitTrailingComments(sql)
 		stmt, err := sqlparser.Parse(query)
 		if err != nil {
-			fmt.Printf("YYY parse error  %s\n", query)
 			return nil, err
 		}
 		sqlparser.Normalize(stmt, bindVariables, "vtp")

--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -91,6 +91,13 @@ func (mp *Proxy) Rollback(ctx context.Context, session *ProxySession) error {
 }
 
 func (mp *Proxy) doBegin(ctx context.Context, session *ProxySession) error {
+	if session.TransactionID != 0 {
+		err := mp.doCommit(ctx, session)
+		if err != nil {
+			return err
+		}
+	}
+
 	txID, err := mp.qs.Begin(ctx, mp.target, session.Options)
 	if err != nil {
 		return err

--- a/go/vt/mysqlproxy/mysqlproxy.go
+++ b/go/vt/mysqlproxy/mysqlproxy.go
@@ -117,7 +117,7 @@ func (mp *Proxy) doRollback(ctx context.Context, session *ProxySession) error {
 
 // Set is currently ignored
 func (mp *Proxy) doSet(ctx context.Context, session *ProxySession, sql string, bindVariables map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	vals, charset, err := sqlparser.ExtractSetValues(sql)
+	vals, charset, _, err := sqlparser.ExtractSetValues(sql)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtqueryserver/endtoend_test.go
+++ b/go/vt/vtqueryserver/endtoend_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package vtqueryserver
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"github.com/youtube/vitess/go/vt/vttest"
+
+	vttestpb "github.com/youtube/vitess/go/vt/proto/vttest"
+)
+
+var (
+	mysqlConnParams mysql.ConnParams
+	proxyConnParams mysql.ConnParams
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse() // Do not remove this comment, import into google3 depends on it
+	tabletenv.Init()
+
+	exitCode := func() int {
+		// Launch MySQL.
+		// We need a Keyspace in the topology, so the DbName is set.
+		// We need a Shard too, so the database 'vttest' is created.
+		cfg := vttest.Config{
+			Topology: &vttestpb.VTTestTopology{
+				Keyspaces: []*vttestpb.Keyspace{
+					{
+						Name: "vttest",
+						Shards: []*vttestpb.Shard{
+							{
+								Name:           "0",
+								DbNameOverride: "vttest",
+							},
+						},
+					},
+				},
+			},
+			OnlyMySQL: true,
+		}
+		if err := cfg.InitSchemas("vttest", testSchema, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "InitSchemas failed: %v\n", err)
+			return 1
+		}
+		defer os.RemoveAll(cfg.SchemaDir)
+		cluster := vttest.LocalCluster{
+			Config: cfg,
+		}
+		if err := cluster.Setup(); err != nil {
+			fmt.Fprintf(os.Stderr, "could not launch mysql: %v\n", err)
+			return 1
+		}
+		defer cluster.TearDown()
+
+		mysqlConnParams = cluster.MySQLConnParams()
+
+		proxySock := path.Join(cluster.Env.Directory(), "mysqlproxy.sock")
+
+		proxyConnParams.UnixSocket = proxySock
+		proxyConnParams.Uname = "proxy"
+		proxyConnParams.Pass = "letmein"
+
+		*mysqlServerSocketPath = proxyConnParams.UnixSocket
+		*mysqlAuthServerImpl = "none"
+
+		dbcfgs := dbconfigs.DBConfigs{
+			App: mysqlConnParams,
+		}
+		qs, err := initProxy(&dbcfgs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not start proxy: %v\n", err)
+			return 1
+		}
+		defer qs.StopService()
+
+		initMySQLProtocol()
+		defer shutdownMySQLProtocol()
+
+		return m.Run()
+	}()
+	os.Exit(exitCode)
+}
+
+var testSchema = `
+create table test(id int, val varchar(256), primary key(id));
+create table valtest(intval int default 0, floatval float default null, charval varchar(256) default null, binval varbinary(256) default null, primary key(intval));
+`
+
+func testFetch(t *testing.T, conn *mysql.Conn, sql string, expectedRows int) {
+	t.Helper()
+
+	result, err := conn.ExecuteFetch(sql, 1000, true)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if len(result.Rows) != expectedRows {
+		t.Fatalf("expected %d rows but got %d", expectedRows, len(result.Rows))
+	}
+}
+
+func testDML(t *testing.T, conn *mysql.Conn, sql string, expectedRows int) {
+	t.Helper()
+
+	result, err := conn.ExecuteFetch(sql, 1000, true)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if int(result.RowsAffected) != expectedRows {
+		t.Fatalf("expected %d rows affected but got %d", expectedRows, result.RowsAffected)
+	}
+}
+
+func TestQueries(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &proxyConnParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try a simple query case.
+	testFetch(t, conn, "select * from test", 0)
+
+	// Try a simple error case.
+	_, err = conn.ExecuteFetch("select * from aa", 1000, true)
+	if err == nil || !strings.Contains(err.Error(), "table aa not found in schema") {
+		t.Fatalf("expected error but got: %v", err)
+	}
+}
+
+func TestAutocommitDMLs(t *testing.T) {
+	ctx := context.Background()
+
+	conn, err := mysql.Connect(ctx, &proxyConnParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn2, err := mysql.Connect(ctx, &proxyConnParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testDML(t, conn, "insert into test (id, val) values(1, 'hello')", 1)
+
+	testFetch(t, conn, "select * from test", 1)
+	testFetch(t, conn2, "select * from test", 1)
+
+	testDML(t, conn, "delete from test", 1)
+
+	testFetch(t, conn, "select * from test", 0)
+	testFetch(t, conn2, "select * from test", 0)
+}
+
+func TestTransactions(t *testing.T) {
+	ctx := context.Background()
+	conn, err := mysql.Connect(ctx, &proxyConnParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn2, err := mysql.Connect(ctx, &proxyConnParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testDML(t, conn, "begin", 0)
+	testDML(t, conn, "insert into test (id, val) values(1, 'hello')", 1)
+	testFetch(t, conn, "select * from test", 1)
+	testFetch(t, conn2, "select * from test", 0)
+	testDML(t, conn, "commit", 0)
+	testFetch(t, conn, "select * from test", 1)
+	testFetch(t, conn2, "select * from test", 1)
+
+	testDML(t, conn, "begin", 0)
+	testDML(t, conn, "delete from test", 1)
+	testFetch(t, conn, "select * from test", 0)
+	testFetch(t, conn2, "select * from test", 1)
+	testDML(t, conn, "rollback", 0)
+
+	testFetch(t, conn, "select * from test", 1)
+	testFetch(t, conn2, "select * from test", 1)
+
+	testDML(t, conn2, "begin", 0)
+	testDML(t, conn2, "delete from test", 1)
+	testDML(t, conn2, "commit", 0)
+
+	testFetch(t, conn, "select * from test", 0)
+	testFetch(t, conn2, "select * from test", 0)
+}

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtqueryserver
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+
+	log "github.com/golang/glog"
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/callerid"
+	"github.com/youtube/vitess/go/vt/mysqlproxy"
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttls"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+)
+
+var (
+	mysqlServerPort               = flag.Int("mysqlproxy_server_port", -1, "If set, also listen for MySQL binary protocol connections on this port.")
+	mysqlServerBindAddress        = flag.String("mysqlproxy_server_bind_address", "", "Binds on this address when listening to MySQL binary protocol. Useful to restrict listening to 'localhost' only for instance.")
+	mysqlServerSocketPath         = flag.String("mysqlproxy_server_socket_path", "", "This option specifies the Unix socket file to use when listening for local connections. By default it will be empty and it won't listen to a unix socket")
+	mysqlAuthServerImpl           = flag.String("mysql_auth_server_impl", "static", "Which auth server implementation to use.")
+	mysqlAllowClearTextWithoutTLS = flag.Bool("mysql_allow_clear_text_without_tls", false, "If set, the server will allow the use of a clear text password over non-SSL connections.")
+
+	mysqlSslCert = flag.String("mysqlproxy_server_ssl_cert", "", "Path to the ssl cert for mysql server plugin SSL")
+	mysqlSslKey  = flag.String("mysqlproxy_server_ssl_key", "", "Path to ssl key for mysql server plugin SSL")
+	mysqlSslCa   = flag.String("mysqlproxy_server_ssl_ca", "", "Path to ssl CA for mysql server plugin SSL. If specified, server will require and validate client certs.")
+
+	mysqlSlowConnectWarnThreshold = flag.Duration("mysqlproxy_slow_connect_warn_threshold", 0, "Warn if it takes more than the given threshold for a mysql connection to establish")
+)
+
+// proxyHandler implements the Listener interface.
+// It stores the Session in the ClientData of a Connection, if a transaction
+// is in progress.
+type proxyHandler struct {
+	mp *mysqlproxy.Proxy
+}
+
+func newProxyHandler(mp *mysqlproxy.Proxy) *proxyHandler {
+	return &proxyHandler{
+		mp: mp,
+	}
+}
+
+func (mh *proxyHandler) NewConnection(c *mysql.Conn) {
+}
+
+func (mh *proxyHandler) ConnectionClosed(c *mysql.Conn) {
+	// Rollback if there is an ongoing transaction. Ignore error.
+	ctx := context.Background()
+	session, _ := c.ClientData.(*mysqlproxy.ProxySession)
+	if session != nil && session.TransactionID != 0 {
+		_ = mh.mp.Rollback(ctx, session)
+	}
+}
+
+func (mh *proxyHandler) ComQuery(c *mysql.Conn, query string, callback func(*sqltypes.Result) error) error {
+	// FIXME(alainjobart): Add some kind of timeout to the context.
+	ctx := context.Background()
+
+	// Fill in the ImmediateCallerID with the UserData returned by
+	// the AuthServer plugin for that user. If nothing was
+	// returned, use the User. This lets the plugin map a MySQL
+	// user used for authentication to a Vitess User used for
+	// Table ACLs and Vitess authentication in general.
+	im := c.UserData.Get()
+	ef := callerid.NewEffectiveCallerID(
+		c.User,                  /* principal: who */
+		c.RemoteAddr().String(), /* component: running client process */
+		"mysqlproxy MySQL Connector" /* subcomponent: part of the client */)
+	ctx = callerid.NewContext(ctx, ef, im)
+
+	session, _ := c.ClientData.(*mysqlproxy.ProxySession)
+	if session == nil {
+		session = &mysqlproxy.ProxySession{
+			Options: &querypb.ExecuteOptions{
+				IncludedFields: querypb.ExecuteOptions_ALL,
+			},
+			Autocommit: true,
+		}
+		if c.Capabilities&mysql.CapabilityClientFoundRows != 0 {
+			session.Options.ClientFoundRows = true
+		}
+	}
+	if c.SchemaName != "" {
+		session.TargetString = c.SchemaName
+	}
+	session, result, err := mh.mp.Execute(ctx, session, query, make(map[string]*querypb.BindVariable))
+	c.ClientData = session
+	err = mysql.NewSQLErrorFromError(err)
+	if err != nil {
+		return err
+	}
+
+	return callback(result)
+}
+
+var mysqlListener *mysql.Listener
+var mysqlUnixListener *mysql.Listener
+
+// initiMySQLProtocol starts the mysql protocol.
+// It should be called only once in a process.
+func initMySQLProtocol() {
+	log.Infof("initializing mysql protocol")
+
+	// Flag is not set, just return.
+	if *mysqlServerPort < 0 && *mysqlServerSocketPath == "" {
+		return
+	}
+
+	// If no mysqlproxy was created, just return.
+	if mysqlProxy == nil {
+		log.Fatalf("mysqlProxy not initialized")
+		return
+	}
+
+	// Initialize registered AuthServer implementations (or other plugins)
+	for _, initFn := range pluginInitializers {
+		initFn()
+	}
+	authServer := mysql.GetAuthServer(*mysqlAuthServerImpl)
+
+	// Create a Listener.
+	var err error
+	mh := newProxyHandler(mysqlProxy)
+	if *mysqlServerPort >= 0 {
+		mysqlListener, err = mysql.NewListener("tcp", net.JoinHostPort(*mysqlServerBindAddress, fmt.Sprintf("%v", *mysqlServerPort)), authServer, mh)
+		if err != nil {
+			log.Exitf("mysql.NewListener failed: %v", err)
+		}
+		if *mysqlSslCert != "" && *mysqlSslKey != "" {
+			mysqlListener.TLSConfig, err = vttls.ServerConfig(*mysqlSslCert, *mysqlSslKey, *mysqlSslCa)
+			if err != nil {
+				log.Exitf("grpcutils.TLSServerConfig failed: %v", err)
+				return
+			}
+		}
+		mysqlListener.AllowClearTextWithoutTLS = *mysqlAllowClearTextWithoutTLS
+
+		// Check for the connection threshold
+		if *mysqlSlowConnectWarnThreshold != 0 {
+			log.Infof("setting mysql slow connection threshold to %v", mysqlSlowConnectWarnThreshold)
+			mysqlListener.SlowConnectWarnThreshold = *mysqlSlowConnectWarnThreshold
+		}
+		// Start listening for tcp
+		go mysqlListener.Accept()
+	}
+
+	if *mysqlServerSocketPath != "" {
+		// Let's create this unix socket with permissions to all users. In this way,
+		// clients can connect to mysqlproxy mysql server without being mysqlproxy user
+		oldMask := syscall.Umask(000)
+		mysqlUnixListener, err = newMysqlUnixSocket(*mysqlServerSocketPath, authServer, mh)
+		_ = syscall.Umask(oldMask)
+		if err != nil {
+			log.Exitf("mysql.NewListener failed: %v", err)
+			return
+		}
+		// Listen for unix socket
+		go mysqlUnixListener.Accept()
+	}
+}
+
+// newMysqlUnixSocket creates a new unix socket mysql listener. If a socket file already exists, attempts
+// to clean it up.
+func newMysqlUnixSocket(address string, authServer mysql.AuthServer, handler mysql.Handler) (*mysql.Listener, error) {
+	listener, err := mysql.NewListener("unix", address, authServer, handler)
+	switch err := err.(type) {
+	case nil:
+		return listener, nil
+	case *net.OpError:
+		log.Warningf("Found existent socket when trying to create new unix mysql listener: %s, attempting to clean up", address)
+		// err.Op should never be different from listen, just being extra careful
+		// in case in the future other errors are returned here
+		if err.Op != "listen" {
+			return nil, err
+		}
+		_, dialErr := net.Dial("unix", address)
+		if dialErr == nil {
+			log.Errorf("Existent socket '%s' is still accepting connections, aborting", address)
+			return nil, err
+		}
+		removeFileErr := os.Remove(address)
+		if removeFileErr != nil {
+			log.Errorf("Couldn't remove existent socket file: %s", address)
+			return nil, err
+		}
+		listener, listenerErr := mysql.NewListener("unix", address, authServer, handler)
+		return listener, listenerErr
+	default:
+		return nil, err
+	}
+}
+
+func init() {
+	servenv.OnRun(initMySQLProtocol)
+
+	servenv.OnTerm(func() {
+		if mysqlListener != nil {
+			mysqlListener.Close()
+			mysqlListener = nil
+		}
+		if mysqlUnixListener != nil {
+			mysqlUnixListener.Close()
+			mysqlUnixListener = nil
+		}
+	})
+}
+
+var pluginInitializers []func()
+
+// RegisterPluginInitializer lets plugins register themselves to be init'ed at servenv.OnRun-time
+func RegisterPluginInitializer(initializer func()) {
+	pluginInitializers = append(pluginInitializers, initializer)
+}

--- a/go/vt/vtqueryserver/plugin_mysql_server.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server.go
@@ -165,6 +165,7 @@ func initMySQLProtocol() {
 		}
 		// Start listening for tcp
 		go mysqlListener.Accept()
+		log.Infof("listening on %s:%d", *mysqlServerBindAddress, *mysqlServerPort)
 	}
 
 	if *mysqlServerSocketPath != "" {
@@ -213,19 +214,22 @@ func newMysqlUnixSocket(address string, authServer mysql.AuthServer, handler mys
 	}
 }
 
+func shutdownMySQLProtocol() {
+	log.Infof("shutting down mysql protocol")
+	if mysqlListener != nil {
+		mysqlListener.Close()
+		mysqlListener = nil
+	}
+
+	if mysqlUnixListener != nil {
+		mysqlUnixListener.Close()
+		mysqlUnixListener = nil
+	}
+}
+
 func init() {
 	servenv.OnRun(initMySQLProtocol)
-
-	servenv.OnTerm(func() {
-		if mysqlListener != nil {
-			mysqlListener.Close()
-			mysqlListener = nil
-		}
-		if mysqlUnixListener != nil {
-			mysqlUnixListener.Close()
-			mysqlUnixListener = nil
-		}
-	})
+	servenv.OnTerm(shutdownMySQLProtocol)
 }
 
 var pluginInitializers []func()

--- a/go/vt/vtqueryserver/plugin_mysql_server_test.go
+++ b/go/vt/vtqueryserver/plugin_mysql_server_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtqueryserver
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/mysql"
+	"github.com/youtube/vitess/go/sqltypes"
+)
+
+type testHandler struct {
+	lastConn *mysql.Conn
+}
+
+func (th *testHandler) NewConnection(c *mysql.Conn) {
+	th.lastConn = c
+}
+
+func (th *testHandler) ConnectionClosed(c *mysql.Conn) {
+}
+
+func (th *testHandler) ComQuery(c *mysql.Conn, q string, callback func(*sqltypes.Result) error) error {
+	return nil
+}
+
+func TestConnectionUnixSocket(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := mysql.NewAuthServerStatic()
+
+	authServer.Entries["user1"] = []*mysql.AuthServerStaticEntry{
+		{
+			Password:   "password1",
+			UserData:   "userData1",
+			SourceHost: "localhost",
+		},
+	}
+
+	// Use tmp file to reserve a path, remove it immediately, we only care about
+	// name in this context
+	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	if err != nil {
+		t.Fatalf("Failed to create temp file")
+	}
+	os.Remove(unixSocket.Name())
+
+	l, err := newMysqlUnixSocket(unixSocket.Name(), authServer, th)
+	if err != nil {
+		t.Fatalf("NewUnixSocket failed: %v", err)
+	}
+	defer l.Close()
+	go l.Accept()
+
+	params := &mysql.ConnParams{
+		UnixSocket: unixSocket.Name(),
+		Uname:      "user1",
+		Pass:       "password1",
+	}
+
+	c, err := mysql.Connect(context.Background(), params)
+	if err != nil {
+		t.Errorf("Should be able to connect to server but found error: %v", err)
+	}
+	c.Close()
+}
+
+func TestConnectionStaleUnixSocket(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := mysql.NewAuthServerStatic()
+
+	authServer.Entries["user1"] = []*mysql.AuthServerStaticEntry{
+		{
+			Password:   "password1",
+			UserData:   "userData1",
+			SourceHost: "localhost",
+		},
+	}
+
+	// First let's create a file. In this way, we simulate
+	// having a stale socket on disk that needs to be cleaned up.
+	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	if err != nil {
+		t.Fatalf("Failed to create temp file")
+	}
+
+	l, err := newMysqlUnixSocket(unixSocket.Name(), authServer, th)
+	if err != nil {
+		t.Fatalf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	go l.Accept()
+
+	params := &mysql.ConnParams{
+		UnixSocket: unixSocket.Name(),
+		Uname:      "user1",
+		Pass:       "password1",
+	}
+
+	c, err := mysql.Connect(context.Background(), params)
+	if err != nil {
+		t.Errorf("Should be able to connect to server but found error: %v", err)
+	}
+	c.Close()
+}
+
+func TestConnectionRespectsExistingUnixSocket(t *testing.T) {
+	th := &testHandler{}
+
+	authServer := mysql.NewAuthServerStatic()
+
+	authServer.Entries["user1"] = []*mysql.AuthServerStaticEntry{
+		{
+			Password:   "password1",
+			UserData:   "userData1",
+			SourceHost: "localhost",
+		},
+	}
+
+	unixSocket, err := ioutil.TempFile("", "mysql_vitess_test.sock")
+	if err != nil {
+		t.Fatalf("Failed to create temp file")
+	}
+	os.Remove(unixSocket.Name())
+
+	l, err := newMysqlUnixSocket(unixSocket.Name(), authServer, th)
+	if err != nil {
+		t.Errorf("NewListener failed: %v", err)
+	}
+	defer l.Close()
+	go l.Accept()
+	_, err = newMysqlUnixSocket(unixSocket.Name(), authServer, th)
+	want := "listen unix"
+	if err == nil || !strings.HasPrefix(err.Error(), want) {
+		t.Errorf("Error: %v, want prefix %s", err, want)
+	}
+}

--- a/go/vt/vtqueryserver/status.go
+++ b/go/vt/vtqueryserver/status.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreedto in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtqueryserver
+
+import (
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver"
+)
+
+var (
+	// proxyTemplate contains the style sheet and the tablet itself.
+	proxyTemplate = `
+<style>
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  td, th {
+    border: 1px solid #999;
+    padding: 0.5rem;
+  }
+  .time {
+    width: 15%;
+  }
+  .healthy {
+    background-color: LightGreen;
+  }
+  .unhealthy {
+    background-color: Salmon;
+  }
+  .unhappy {
+    background-color: Khaki;
+  }
+</style>
+<table width="100%" border="" frame="">
+  <tr border="">
+    <td width="25%" border="">
+      Target Keyspace: {{.Target.Keyspace}}<br>
+    </td>
+    <td width="25%" border="">
+      <a href="/schemaz">Schema</a></br>
+      <a href="/debug/tablet_plans">Schema&nbsp;Query&nbsp;Plans</a></br>
+      <a href="/debug/query_stats">Schema&nbsp;Query&nbsp;Stats</a></br>
+      <a href="/debug/table_stats">Schema&nbsp;Table&nbsp;Stats</a></br>
+    </td>
+    <td width="25%" border="">
+      <a href="/queryz">Query&nbsp;Stats</a></br>
+      <a href="/streamqueryz">Streaming&nbsp;Query&nbsp;Stats</a></br>
+      <a href="/debug/consolidations">Consolidations</a></br>
+      <a href="/querylogz">Current&nbsp;Query&nbsp;Log</a></br>
+      <a href="/txlogz">Current&nbsp;Transaction&nbsp;Log</a></br>
+      <a href="/twopcz">In-flight&nbsp;2PC&nbsp;Transactions</a></br>
+    </td>
+    <td width="25%" border="">
+      <a href="/debug/health">Query Service Health Check</a></br>
+      <a href="/streamqueryz">Current Stream Queries</a></br>
+    </td>
+  </tr>
+</table>
+`
+)
+
+// For use by plugins which wish to avoid racing when registering status page parts.
+var onStatusRegistered func()
+
+func addStatusParts(qsc tabletserver.Controller) {
+	servenv.AddStatusPart("Target", proxyTemplate, func() interface{} {
+		return map[string]interface{}{
+			"Target": target,
+		}
+	})
+	qsc.AddStatusPart()
+	if onStatusRegistered != nil {
+		onStatusRegistered()
+	}
+}

--- a/go/vt/vtqueryserver/vtqueryserver.go
+++ b/go/vt/vtqueryserver/vtqueryserver.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package vtqueryserver is a standalone version of the tablet server that
+// only implements the queryservice interface without any of the topology,
+// replication management, or other features of the full vttablet.
+package vtqueryserver
+
+import (
+	"flag"
+
+	log "github.com/golang/glog"
+
+	"github.com/youtube/vitess/go/vt/dbconfigs"
+	"github.com/youtube/vitess/go/vt/mysqlproxy"
+	"github.com/youtube/vitess/go/vt/servenv"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
+)
+
+var (
+	mysqlProxy *mysqlproxy.Proxy
+	target     = querypb.Target{
+		TabletType: topodatapb.TabletType_MASTER,
+		Keyspace:   "",
+	}
+
+	targetKeyspace   = flag.String("target", "", "Target database name")
+	normalizeQueries = flag.Bool("normalize_queries", true, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
+)
+
+// Init initializes the proxy
+func Init(dbcfgs *dbconfigs.DBConfigs) error {
+	target.Keyspace = *targetKeyspace
+	log.Infof("initalizing vtqueryserver.Proxy for target %s", target.Keyspace)
+
+	// force autocommit to be enabled
+	tabletenv.Config.EnableAutoCommit = true
+
+	// creates and registers the query service
+	qs := tabletserver.NewTabletServerWithNilTopoServer(tabletenv.Config)
+
+	mysqlProxy = mysqlproxy.NewProxy(&target, qs, *normalizeQueries)
+
+	servenv.OnRun(func() {
+		qs.Register()
+		addStatusParts(qs)
+	})
+
+	servenv.OnClose(func() {
+		// We now leave the queryservice running during lameduck,
+		// so stop it in OnClose(), after lameduck is over.
+		qs.StopService()
+	})
+
+	err := qs.StartService(target, *dbcfgs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go/vt/vtqueryserver/vtqueryserver.go
+++ b/go/vt/vtqueryserver/vtqueryserver.go
@@ -49,9 +49,6 @@ func initProxy(dbcfgs *dbconfigs.DBConfigs) (*tabletserver.TabletServer, error) 
 	target.Keyspace = *targetKeyspace
 	log.Infof("initalizing vtqueryserver.Proxy for target %s", target.Keyspace)
 
-	// force autocommit to be enabled
-	tabletenv.Config.EnableAutoCommit = true
-
 	// creates and registers the query service
 	qs := tabletserver.NewTabletServerWithNilTopoServer(tabletenv.Config)
 	mysqlProxy = mysqlproxy.NewProxy(&target, qs, *normalizeQueries)

--- a/go/vt/vtqueryserver/vtqueryserver.go
+++ b/go/vt/vtqueryserver/vtqueryserver.go
@@ -43,6 +43,7 @@ var (
 
 	targetKeyspace   = flag.String("target", "", "Target database name")
 	normalizeQueries = flag.Bool("normalize_queries", true, "Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars.")
+	allowUnsafeDMLs  = flag.Bool("allow_unsafe_dmls", false, "Allow passthrough DML statements when running with statement-based replication")
 )
 
 func initProxy(dbcfgs *dbconfigs.DBConfigs) (*tabletserver.TabletServer, error) {
@@ -51,6 +52,7 @@ func initProxy(dbcfgs *dbconfigs.DBConfigs) (*tabletserver.TabletServer, error) 
 
 	// creates and registers the query service
 	qs := tabletserver.NewTabletServerWithNilTopoServer(tabletenv.Config)
+	qs.SetAllowUnsafeDMLs(*allowUnsafeDMLs)
 	mysqlProxy = mysqlproxy.NewProxy(&target, qs, *normalizeQueries)
 
 	err := qs.StartService(target, *dbcfgs)

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -440,6 +440,7 @@ func (tsv *TabletServer) decideAction(tabletType topodatapb.TabletType, serving 
 func (tsv *TabletServer) fullStart() (err error) {
 	c, err := dbconnpool.NewDBConnection(&tsv.dbconfigs.App, tabletenv.MySQLStats)
 	if err != nil {
+		log.Errorf("error creating db app connection: %v", err)
 		return err
 	}
 	c.Close()

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1976,6 +1976,19 @@ func (tsv *TabletServer) MaxDMLRows() int {
 	return int(tsv.qe.maxDMLRows.Get())
 }
 
+// SetPassthroughDMLs changes the setting to pass through all DMLs
+// It should only be used for testing
+func (tsv *TabletServer) SetPassthroughDMLs(val bool) {
+	planbuilder.PassthroughDMLs = true
+	tsv.qe.passthroughDMLs.Set(val)
+}
+
+// SetAllowUnsafeDMLs changes the setting to allow unsafe DML statements
+// in SBR mode. It should be used only on initialization or for testing.
+func (tsv *TabletServer) SetAllowUnsafeDMLs(val bool) {
+	tsv.qe.allowUnsafeDMLs = val
+}
+
 // queryAsString prints a readable version of query+bind variables,
 // and also truncates data if it's too long
 func queryAsString(sql string, bindVariables map[string]*querypb.BindVariable) string {


### PR DESCRIPTION
# What 

Add a new binary called `vtqueryserver` which couples a standalone tabletserver with a grpc interface and a simple mysql server implementation. This can be deployed alongside any mysql server to provide connection pooling, query consolidation, logging, and other features of vttablet, without any query rewriting, topology management, replication control, or the need for a vtgate tier for query routing.

# Why
Although our intent is to migrate everything to a new vitess cluster, our existing mysql workload would benefit from a less-intrusive deployment in which we can still get some of the performance benefits of the tablet on our existing systems.

By skipping the query rewriting and routing elements of vitess, adding this proxy to an existing system is a lower risk change yet still provides some of the performance benefits. Also since the `vtqueryserver` supports both the mysql protocol and a GRPC interface (similar to vtgate) it can also enable long-lived connections and splitting of queries from bind variables.

