### PR TITLE
Fix nil pointer exception when using appDebug feature

### DIFF
--- a/go/vt/vttablet/tabletserver/connpool/dbconn.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn.go
@@ -293,8 +293,9 @@ func (dbc *DBConn) Recycle() {
 func (dbc *DBConn) Kill(reason string, elapsed time.Duration) error {
 	tabletenv.KillStats.Add("Queries", 1)
 	log.Infof("Due to %s, elapsed time: %v, killing query %s", reason, elapsed, dbc.Current())
-	// Hack: when using appDebug feature, there is no connection pool, so
-	// connections needs to be killed in a different way.
+	// Hack: Most of the times DBConn is created with a pool. There is a snowflake case
+	// (NewDBConnNoPool) used for AppDebug user where there is no pool set.
+	// In those cases dbaPool will be available in the context directly.
 	var dbaPool *dbconnpool.ConnectionPool
 	if dbc.pool == nil {
 		dbaPool = dbc.dbaPool

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -120,8 +120,11 @@ func TestDBConnKill(t *testing.T) {
 
 func TestDBNoPoolConnKill(t *testing.T) {
 	db := fakesqldb.New(t)
+	connPool := newPool()
+	connPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
+	defer connPool.Close()
 	defer db.Close()
-	dbConn, err := NewDBConnNoPool(db.ConnParams())
+	dbConn, err := NewDBConnNoPool(db.ConnParams(), connPool.dbaPool)
 	defer dbConn.Close()
 	query := fmt.Sprintf("kill %d", dbConn.ID())
 	db.AddQuery(query, &sqltypes.Result{})

--- a/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
+++ b/go/vt/vttablet/tabletserver/connpool/dbconn_test.go
@@ -118,6 +118,42 @@ func TestDBConnKill(t *testing.T) {
 	}
 }
 
+func TestDBNoPoolConnKill(t *testing.T) {
+	db := fakesqldb.New(t)
+	defer db.Close()
+	dbConn, err := NewDBConnNoPool(db.ConnParams())
+	defer dbConn.Close()
+	query := fmt.Sprintf("kill %d", dbConn.ID())
+	db.AddQuery(query, &sqltypes.Result{})
+	// Kill failed because we are not able to connect to the database
+	db.EnableConnFail()
+	err = dbConn.Kill("test kill", 0)
+	want := "errno 2013"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Exec: %v, want %s", err, want)
+	}
+	db.DisableConnFail()
+
+	// Kill succeed
+	err = dbConn.Kill("test kill", 0)
+	if err != nil {
+		t.Fatalf("kill should succeed, but got error: %v", err)
+	}
+
+	err = dbConn.reconnect()
+	if err != nil {
+		t.Fatalf("reconnect should succeed, but got error: %v", err)
+	}
+	newKillQuery := fmt.Sprintf("kill %d", dbConn.ID())
+	// Kill failed because "kill query_id" failed
+	db.AddRejectedQuery(newKillQuery, errors.New("rejected"))
+	err = dbConn.Kill("test kill", 0)
+	want = "rejected"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("Exec: %v, want %s", err, want)
+	}
+}
+
 func TestDBConnStream(t *testing.T) {
 	db := fakesqldb.New(t)
 	defer db.Close()

--- a/go/vt/vttablet/tabletserver/connpool/pool.go
+++ b/go/vt/vttablet/tabletserver/connpool/pool.go
@@ -135,7 +135,7 @@ func (cp *Pool) Close() {
 // You must call Recycle on DBConn once done.
 func (cp *Pool) Get(ctx context.Context) (*DBConn, error) {
 	if cp.isCallerIDAppDebug(ctx) {
-		return NewDBConnNoPool(cp.appDebugParams)
+		return NewDBConnNoPool(cp.appDebugParams, cp.dbaPool)
 	}
 	p := cp.pool()
 	if p == nil {


### PR DESCRIPTION
### Description

There was a bug in [appDebug](https://github.com/youtube/vitess/pull/3078) implementation. When queries timeout and vttablet attempts to kill it, when there is no pool, the tablet will crash. 

### Tests

Added unit test to catch this.


