### PR TITLE
Tablet left in up state when being killed

### DIFF
--- a/go/vt/discovery/healthcheck.go
+++ b/go/vt/discovery/healthcheck.go
@@ -456,6 +456,7 @@ func (hcc *healthCheckConn) stream(ctx context.Context, hc *HealthCheckImpl, cal
 		hcc.conn.Close(ctx)
 		hcc.conn = nil
 		hcc.tabletStats.Serving = false
+		hcc.tabletStats.Up = false
 		hcc.tabletStats.LastError = err
 		ts := hcc.tabletStats
 		hcc.mu.Unlock()


### PR DESCRIPTION
### Description

Couple days ago, we noticed that during a hard crash of vttablet, vtgate does not removes the tablet from the healthy list. I was digging a little bit into this issue and found that it was due to the following:

1) Health checker changes the status of the tablet to `Serving` false, but `Up` remains true.
2) The logic in tablet_stats_cache doesn't remove it from the healthy list in this situation. 

I'm not familiarized with this part of the codebase, but at first glance we have two options:
1) Set `Up` to false.
2) Change the tablet_stats_cache to remove it from the healthy state when `Up`  but not `Serving`

I did a quick change using first approach that seems to solve the problem. But debating myself if number two is a better way. Looking forward to getting feedback on this :) 

One more question that I had while thinking on this problem:  Should this kind of error enter in the buffering requests state ? Right now it will not do that. 

### Test

The bug is reproducible by running `local/examples` and killing a tablet. Without this change, you can see that the gates keeps retrying to connect to the tablet without removing it from the healthy hosts. 

