### PR TITLE
vtgate: remove accidental vttablet dependency

### DIFF
--- a/go/vt/vtgate/querylogz.go
+++ b/go/vt/vtgate/querylogz.go
@@ -29,7 +29,6 @@ import (
 	"github.com/youtube/vitess/go/acl"
 	"github.com/youtube/vitess/go/vt/logz"
 	"github.com/youtube/vitess/go/vt/sqlparser"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 )
 
 var (
@@ -105,7 +104,7 @@ func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Reques
 			}
 			stats, ok := out.(*LogStats)
 			if !ok {
-				err := fmt.Errorf("Unexpected value in %s: %#v (expecting value of type %T)", tabletenv.TxLogger.Name(), out, &LogStats{})
+				err := fmt.Errorf("unexpected value in %s: %#v (expecting value of type %T)", QueryLogger.Name(), out, &LogStats{})
 				io.WriteString(w, `<tr class="error">`)
 				io.WriteString(w, err.Error())
 				io.WriteString(w, "</tr>")

--- a/go/vt/vtgate/queryz.go
+++ b/go/vt/vtgate/queryz.go
@@ -28,7 +28,6 @@ import (
 	"github.com/youtube/vitess/go/vt/logz"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vtgate/engine"
-	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/planbuilder"
 )
 
 var (
@@ -68,8 +67,6 @@ var (
 type queryzRow struct {
 	Query        string
 	Table        string
-	Plan         planbuilder.PlanType
-	Reason       planbuilder.ReasonType
 	Count        uint64
 	tm           time.Duration
 	ShardQueries uint64

--- a/go/vt/vttablet/tabletserver/querylogz.go
+++ b/go/vt/vttablet/tabletserver/querylogz.go
@@ -117,7 +117,7 @@ func querylogzHandler(ch chan interface{}, w http.ResponseWriter, r *http.Reques
 			}
 			stats, ok := out.(*tabletenv.LogStats)
 			if !ok {
-				err := fmt.Errorf("Unexpected value in %s: %#v (expecting value of type %T)", tabletenv.TxLogger.Name(), out, &tabletenv.LogStats{})
+				err := fmt.Errorf("unexpected value in %s: %#v (expecting value of type %T)", tabletenv.TxLogger.Name(), out, &tabletenv.LogStats{})
 				io.WriteString(w, `<tr class="error">`)
 				io.WriteString(w, err.Error())
 				io.WriteString(w, "</tr>")


### PR DESCRIPTION
Some copy-paste code introduced a dependency from vtgate to
tabletserver, and ended up exporting all of vttablet's flags
in vtgate. This PR fixes it.