### PR TITLE
v3: cosmetic prep work for autocommit

### DIFF
--- a/go/vt/vtexplain/vtexplain_vtgate.go
+++ b/go/vt/vtexplain/vtexplain_vtgate.go
@@ -114,7 +114,7 @@ func buildTopology(vschemaStr string, numShardsPerKeyspace int) error {
 }
 
 func vtgateExecute(sql string) ([]*engine.Plan, map[string]*TabletActions, error) {
-	_, err := vtgateExecutor.Execute(context.Background(), "VtexplainExecute", vtgateSession, sql, nil)
+	_, err := vtgateExecutor.Execute(context.Background(), "VtexplainExecute", vtgate.NewSafeSession(vtgateSession), sql, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("vtexplain execute error: %v in %s", err, sql)
 	}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -110,9 +110,9 @@ func NewExecutor(ctx context.Context, serv srvtopo.Server, cell, statsName strin
 }
 
 // Execute executes a non-streaming query.
-func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (result *sqltypes.Result, err error) {
+func (e *Executor) Execute(ctx context.Context, method string, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable) (result *sqltypes.Result, err error) {
 	logStats := NewLogStats(ctx, method, sql, bindVars)
-	result, err = e.execute(ctx, session, sql, bindVars, logStats)
+	result, err = e.execute(ctx, safeSession, sql, bindVars, logStats)
 	logStats.Error = err
 
 	// The mysql plugin runs an implicit rollback whenever a connection closes.
@@ -124,17 +124,17 @@ func (e *Executor) Execute(ctx context.Context, method string, session *vtgatepb
 	return result, err
 }
 
-func (e *Executor) execute(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) execute(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, logStats *LogStats) (*sqltypes.Result, error) {
 	// Start an implicit transaction if necessary.
 	// TODO(sougou): deprecate legacyMode after all users are migrated out.
-	if !e.legacyAutocommit && !session.Autocommit && !session.InTransaction {
-		if err := e.txConn.Begin(ctx, NewSafeSession(session)); err != nil {
+	if !e.legacyAutocommit && !safeSession.Autocommit && !safeSession.InTransaction() {
+		if err := e.txConn.Begin(ctx, safeSession); err != nil {
 			return nil, err
 		}
 	}
 
-	target := e.ParseTarget(session.TargetString)
-	if session.InTransaction && target.TabletType != topodatapb.TabletType_MASTER {
+	target := e.ParseTarget(safeSession.TargetString)
+	if safeSession.InTransaction() && target.TabletType != topodatapb.TabletType_MASTER {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "transactions are supported only for master tablet types, current type: %v", target.TabletType)
 	}
 	if bindVars == nil {
@@ -146,59 +146,60 @@ func (e *Executor) execute(ctx context.Context, session *vtgatepb.Session, sql s
 
 	switch stmtType {
 	case sqlparser.StmtSelect:
-		return e.handleExec(ctx, session, sql, bindVars, target, logStats)
+		return e.handleExec(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtInsert, sqlparser.StmtReplace, sqlparser.StmtUpdate, sqlparser.StmtDelete:
+		safeSession := safeSession
+
 		// In legacy mode, we ignore autocommit settings.
 		if e.legacyAutocommit {
-			return e.handleExec(ctx, session, sql, bindVars, target, logStats)
+			return e.handleExec(ctx, safeSession, sql, bindVars, target, logStats)
 		}
 
-		nsf := NewSafeSession(session)
-		autocommit := false
-		if session.Autocommit && !session.InTransaction {
-			autocommit = true
-			if err := e.txConn.Begin(ctx, nsf); err != nil {
+		mustCommit := false
+		if safeSession.Autocommit && !safeSession.InTransaction() {
+			mustCommit = true
+			if err := e.txConn.Begin(ctx, safeSession); err != nil {
 				return nil, err
 			}
 			// The defer acts as a failsafe. If commit was successful,
 			// the rollback will be a no-op.
-			defer e.txConn.Rollback(ctx, nsf)
+			defer e.txConn.Rollback(ctx, safeSession)
 		}
 
-		qr, err := e.handleExec(ctx, session, sql, bindVars, target, logStats)
+		qr, err := e.handleExec(ctx, safeSession, sql, bindVars, target, logStats)
 		if err != nil {
 			return nil, err
 		}
 
-		if autocommit {
+		if mustCommit {
 			commitStart := time.Now()
-			if err = e.txConn.Commit(ctx, nsf); err != nil {
+			if err = e.txConn.Commit(ctx, safeSession); err != nil {
 				return nil, err
 			}
 			logStats.CommitTime = time.Since(commitStart)
 		}
 		return qr, nil
 	case sqlparser.StmtDDL:
-		return e.handleDDL(ctx, session, sql, bindVars, target, logStats)
+		return e.handleDDL(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtBegin:
-		return e.handleBegin(ctx, session, sql, bindVars, target, logStats)
+		return e.handleBegin(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtCommit:
-		return e.handleCommit(ctx, session, sql, bindVars, target, logStats)
+		return e.handleCommit(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtRollback:
-		return e.handleRollback(ctx, session, sql, bindVars, target, logStats)
+		return e.handleRollback(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtSet:
-		return e.handleSet(ctx, session, sql, bindVars, logStats)
+		return e.handleSet(ctx, safeSession, sql, bindVars, logStats)
 	case sqlparser.StmtShow:
-		return e.handleShow(ctx, session, sql, bindVars, target, logStats)
+		return e.handleShow(ctx, safeSession, sql, bindVars, target, logStats)
 	case sqlparser.StmtUse:
-		return e.handleUse(ctx, session, sql, bindVars)
+		return e.handleUse(ctx, safeSession, sql, bindVars)
 	case sqlparser.StmtOther:
-		return e.handleOther(ctx, session, sql, bindVars, target, logStats)
+		return e.handleOther(ctx, safeSession, sql, bindVars, target, logStats)
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unrecognized statement: %s", sql)
 }
 
-func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleExec(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Shard != "" {
 		// V1 mode or V3 mode with a forced shard target
 		sql = sqlannotation.AnnotateIfDML(sql, nil)
@@ -220,7 +221,7 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 		execStart := time.Now()
 		logStats.PlanTime = execStart.Sub(logStats.StartTime)
 
-		result, err := e.shardExec(ctx, session, sql, bindVars, target, logStats)
+		result, err := e.shardExec(ctx, safeSession, sql, bindVars, target, logStats)
 		logStats.ExecuteTime = time.Now().Sub(execStart)
 
 		logStats.ShardQueries = 1
@@ -230,13 +231,13 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 
 	// V3 mode.
 	query, comments := sqlparser.SplitTrailingComments(sql)
-	vcursor := newVCursorImpl(ctx, session, target, comments, e, logStats)
+	vcursor := newVCursorImpl(ctx, safeSession, target, comments, e, logStats)
 	plan, err := e.getPlan(
 		vcursor,
 		query,
 		comments,
 		bindVars,
-		skipQueryPlanCache(session),
+		skipQueryPlanCache(safeSession),
 		logStats,
 	)
 	execStart := time.Now()
@@ -258,8 +259,8 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 	}
 
 	// Check if there was partial DML execution. If so, rollback the transaction.
-	if err != nil && session.InTransaction && vcursor.hasPartialDML {
-		_ = e.txConn.Rollback(ctx, NewSafeSession(session))
+	if err != nil && safeSession.InTransaction() && vcursor.hasPartialDML {
+		_ = e.txConn.Rollback(ctx, safeSession)
 		err = vterrors.Errorf(vtrpcpb.Code_ABORTED, "transaction rolled back due to partial DML execution: %v", err)
 	}
 
@@ -268,14 +269,14 @@ func (e *Executor) handleExec(ctx context.Context, session *vtgatepb.Session, sq
 	return qr, err
 }
 
-func (e *Executor) shardExec(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) shardExec(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	f := func(keyspace string) (string, []string, error) {
 		return keyspace, []string{target.Shard}, nil
 	}
-	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options, logStats)
+	return e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, safeSession.Session, f, false /* notInTransaction */, safeSession.Options, logStats)
 }
 
-func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleDDL(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Keyspace == "" {
 		return nil, errNoKeyspace
 	}
@@ -303,41 +304,41 @@ func (e *Executor) handleDDL(ctx context.Context, session *vtgatepb.Session, sql
 
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-	result, err := e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, session, f, false /* notInTransaction */, session.Options, logStats)
+	result, err := e.resolver.Execute(ctx, sql, bindVars, target.Keyspace, target.TabletType, safeSession.Session, f, false /* notInTransaction */, safeSession.Options, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
 }
 
-func (e *Executor) handleBegin(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleBegin(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.TabletType != topodatapb.TabletType_MASTER {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "transactions are supported only for master tablet types, current type: %v", target.TabletType)
 	}
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-	err := e.txConn.Begin(ctx, NewSafeSession(session))
+	err := e.txConn.Begin(ctx, safeSession)
 	logStats.ExecuteTime = time.Since(execStart)
 	return &sqltypes.Result{}, err
 }
 
-func (e *Executor) handleCommit(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleCommit(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-	logStats.ShardQueries = uint32(len(session.ShardSessions))
-	err := e.txConn.Commit(ctx, NewSafeSession(session))
+	logStats.ShardQueries = uint32(len(safeSession.ShardSessions))
+	err := e.txConn.Commit(ctx, safeSession)
 	logStats.CommitTime = time.Since(execStart)
 	return &sqltypes.Result{}, err
 }
 
-func (e *Executor) handleRollback(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleRollback(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
-	logStats.ShardQueries = uint32(len(session.ShardSessions))
-	err := e.txConn.Rollback(ctx, NewSafeSession(session))
+	logStats.ShardQueries = uint32(len(safeSession.ShardSessions))
+	err := e.txConn.Rollback(ctx, safeSession)
 	logStats.CommitTime = time.Since(execStart)
 	return &sqltypes.Result{}, err
 }
 
-func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleSet(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, logStats *LogStats) (*sqltypes.Result, error) {
 	vals, charset, err := sqlparser.ExtractSetValues(sql)
 	execStart := time.Now()
 	logStats.PlanTime = execStart.Sub(logStats.StartTime)
@@ -368,14 +369,14 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 			}
 			switch val {
 			case 0:
-				session.Autocommit = false
+				safeSession.Autocommit = false
 			case 1:
-				if session.InTransaction {
-					if err := e.txConn.Commit(ctx, NewSafeSession(session)); err != nil {
+				if safeSession.InTransaction() {
+					if err := e.txConn.Commit(ctx, safeSession); err != nil {
 						return nil, err
 					}
 				}
-				session.Autocommit = true
+				safeSession.Autocommit = true
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value for autocommit: %d", val)
 			}
@@ -384,14 +385,14 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 			if !ok {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value type for client_found_rows: %T", v)
 			}
-			if session.Options == nil {
-				session.Options = &querypb.ExecuteOptions{}
+			if safeSession.Options == nil {
+				safeSession.Options = &querypb.ExecuteOptions{}
 			}
 			switch val {
 			case 0:
-				session.Options.ClientFoundRows = false
+				safeSession.Options.ClientFoundRows = false
 			case 1:
-				session.Options.ClientFoundRows = true
+				safeSession.Options.ClientFoundRows = true
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value for client_found_rows: %d", val)
 			}
@@ -400,14 +401,14 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 			if !ok {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value type for skip_query_plan_cache: %T", v)
 			}
-			if session.Options == nil {
-				session.Options = &querypb.ExecuteOptions{}
+			if safeSession.Options == nil {
+				safeSession.Options = &querypb.ExecuteOptions{}
 			}
 			switch val {
 			case 0:
-				session.Options.SkipQueryPlanCache = false
+				safeSession.Options.SkipQueryPlanCache = false
 			case 1:
-				session.Options.SkipQueryPlanCache = true
+				safeSession.Options.SkipQueryPlanCache = true
 			default:
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value for skip_query_plan_cache: %d", val)
 			}
@@ -420,7 +421,7 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 			if !ok {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid transaction_mode: %s", val)
 			}
-			session.TransactionMode = vtgatepb.TransactionMode(out)
+			safeSession.TransactionMode = vtgatepb.TransactionMode(out)
 		case "workload":
 			val, ok := v.(string)
 			if !ok {
@@ -430,10 +431,10 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 			if !ok {
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid workload: %s", val)
 			}
-			if session.Options == nil {
-				session.Options = &querypb.ExecuteOptions{}
+			if safeSession.Options == nil {
+				safeSession.Options = &querypb.ExecuteOptions{}
 			}
-			session.Options.Workload = querypb.ExecuteOptions_Workload(out)
+			safeSession.Options.Workload = querypb.ExecuteOptions_Workload(out)
 		case "sql_select_limit":
 			var val int64
 
@@ -448,10 +449,10 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value type for sql_select_limit: %T", v)
 			}
 
-			if session.Options == nil {
-				session.Options = &querypb.ExecuteOptions{}
+			if safeSession.Options == nil {
+				safeSession.Options = &querypb.ExecuteOptions{}
 			}
-			session.Options.SqlSelectLimit = val
+			safeSession.Options.SqlSelectLimit = val
 		case "character_set_results":
 			// This is a statement that mysql-connector-j sends at the beginning. We return a canned response for it.
 			switch v {
@@ -469,7 +470,7 @@ func (e *Executor) handleSet(ctx context.Context, session *vtgatepb.Session, sql
 	return &sqltypes.Result{}, nil
 }
 
-func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	stmt, err := sqlparser.Parse(sql)
 	if err != nil {
 		return nil, err
@@ -657,10 +658,10 @@ func (e *Executor) handleShow(ctx context.Context, session *vtgatepb.Session, sq
 	}
 
 	// Any other show statement is passed through
-	return e.handleOther(ctx, session, sql, bindVars, target, logStats)
+	return e.handleOther(ctx, safeSession, sql, bindVars, target, logStats)
 }
 
-func (e *Executor) handleUse(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
+func (e *Executor) handleUse(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
 	stmt, err := sqlparser.Parse(sql)
 	if err != nil {
 		return nil, err
@@ -671,14 +672,14 @@ func (e *Executor) handleUse(ctx context.Context, session *vtgatepb.Session, sql
 		return nil, vterrors.Errorf(vtrpcpb.Code_INTERNAL, "unrecognized USE statement: %v", sql)
 	}
 	target := e.ParseTarget(use.DBName.String())
-	if session.InTransaction && target.TabletType != topodatapb.TabletType_MASTER {
+	if safeSession.InTransaction() && target.TabletType != topodatapb.TabletType_MASTER {
 		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "cannot change to a non-master type in the middle of a transaction: %v", target.TabletType)
 	}
-	session.TargetString = use.DBName.String()
+	safeSession.TargetString = use.DBName.String()
 	return &sqltypes.Result{}, nil
 }
 
-func (e *Executor) handleOther(ctx context.Context, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
 	if target.Keyspace == "" {
 		return nil, errNoKeyspace
 	}
@@ -690,13 +691,13 @@ func (e *Executor) handleOther(ctx context.Context, session *vtgatepb.Session, s
 		}
 	}
 	execStart := time.Now()
-	result, err := e.shardExec(ctx, session, sql, bindVars, target, logStats)
+	result, err := e.shardExec(ctx, safeSession, sql, bindVars, target, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
 }
 
 // StreamExecute executes a streaming query.
-func (e *Executor) StreamExecute(ctx context.Context, method string, session *vtgatepb.Session, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, callback func(*sqltypes.Result) error) (err error) {
+func (e *Executor) StreamExecute(ctx context.Context, method string, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, callback func(*sqltypes.Result) error) (err error) {
 	logStats := NewLogStats(ctx, method, sql, bindVars)
 	logStats.StmtType = sqlparser.StmtType(sqlparser.Preview(sql))
 	defer logStats.Send()
@@ -705,13 +706,13 @@ func (e *Executor) StreamExecute(ctx context.Context, method string, session *vt
 		bindVars = make(map[string]*querypb.BindVariable)
 	}
 	query, comments := sqlparser.SplitTrailingComments(sql)
-	vcursor := newVCursorImpl(ctx, session, target, comments, e, logStats)
+	vcursor := newVCursorImpl(ctx, safeSession, target, comments, e, logStats)
 	plan, err := e.getPlan(
 		vcursor,
 		query,
 		comments,
 		bindVars,
-		skipQueryPlanCache(session),
+		skipQueryPlanCache(safeSession),
 		logStats,
 	)
 	if err != nil {
@@ -778,7 +779,7 @@ func (e *Executor) MessageAck(ctx context.Context, keyspace, name string, ids []
 	// TODO(sougou): Change this to use Session.
 	vcursor := newVCursorImpl(
 		ctx,
-		&vtgatepb.Session{},
+		NewSafeSession(&vtgatepb.Session{}),
 		querypb.Target{
 			Keyspace:   table.Keyspace.Name,
 			TabletType: topodatapb.TabletType_MASTER,
@@ -1028,11 +1029,11 @@ func (e *Executor) getPlan(vcursor *vcursorImpl, sql string, comments string, bi
 }
 
 // skipQueryPlanCache extracts SkipQueryPlanCache from session
-func skipQueryPlanCache(session *vtgatepb.Session) bool {
-	if session == nil || session.Options == nil {
+func skipQueryPlanCache(safeSession *SafeSession) bool {
+	if safeSession == nil || safeSession.Options == nil {
 		return false
 	}
-	return session.Options.SkipQueryPlanCache
+	return safeSession.Options.SkipQueryPlanCache
 }
 
 // ServeHTTP shows the current plans in the query cache.

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -1195,7 +1195,7 @@ func TestInsertPartialFail1(t *testing.T) {
 	_, err := executor.Execute(
 		context.Background(),
 		"TestExecute",
-		&vtgatepb.Session{InTransaction: true},
+		NewSafeSession(&vtgatepb.Session{InTransaction: true}),
 		"insert into user(id, v, name) values (1, 2, 'myname')",
 		nil,
 	)
@@ -1217,7 +1217,7 @@ func TestInsertPartialFail2(t *testing.T) {
 	_, err := executor.Execute(
 		context.Background(),
 		"TestExecute",
-		&vtgatepb.Session{InTransaction: true},
+		NewSafeSession(&vtgatepb.Session{InTransaction: true}),
 		"insert into user(id, v, name) values (1, 2, 'myname')",
 		nil,
 	)

--- a/go/vt/vtgate/executor_framework_test.go
+++ b/go/vt/vtgate/executor_framework_test.go
@@ -273,7 +273,7 @@ func executorExec(executor *Executor, sql string, bv map[string]*querypb.BindVar
 	return executor.Execute(
 		context.Background(),
 		"TestExecute",
-		masterSession,
+		NewSafeSession(masterSession),
 		sql,
 		bv)
 }
@@ -283,7 +283,7 @@ func executorStream(executor *Executor, sql string) (qr *sqltypes.Result, err er
 	err = executor.StreamExecute(
 		context.Background(),
 		"TestExecuteStream",
-		masterSession,
+		NewSafeSession(masterSession),
 		sql,
 		nil,
 		querypb.Target{

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -60,7 +60,7 @@ func TestExecDBA(t *testing.T) {
 	_, err := executor.Execute(
 		context.Background(),
 		"TestExecDBA",
-		&vtgatepb.Session{TargetString: "TestExecutor"},
+		NewSafeSession(&vtgatepb.Session{TargetString: "TestExecutor"}),
 		query,
 		map[string]*querypb.BindVariable{},
 	)
@@ -230,7 +230,7 @@ func TestStreamBuffering(t *testing.T) {
 	err := executor.StreamExecute(
 		context.Background(),
 		"TestStreamBuffering",
-		masterSession,
+		NewSafeSession(masterSession),
 		"select id from music_user_map where id = 1",
 		nil,
 		querypb.Target{

--- a/go/vt/vtgate/safe_session.go
+++ b/go/vt/vtgate/safe_session.go
@@ -19,6 +19,7 @@ package vtgate
 import (
 	"sync"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/youtube/vitess/go/vt/vterrors"
 
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -39,6 +40,16 @@ type SafeSession struct {
 // NewSafeSession returns a new SafeSession based on the Session
 func NewSafeSession(sessn *vtgatepb.Session) *SafeSession {
 	return &SafeSession{Session: sessn}
+}
+
+// NewAutocommitSession returns a SafeSession based on the original
+// session, but with autocommit enabled.
+func NewAutocommitSession(sessn *vtgatepb.Session) *SafeSession {
+	newSession := proto.Clone(sessn).(*vtgatepb.Session)
+	newSession.InTransaction = false
+	newSession.ShardSessions = nil
+	newSession.Autocommit = true
+	return NewSafeSession(newSession)
 }
 
 // InTransaction returns true if we are in a transaction

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -57,7 +57,7 @@ func TestScatterConnExecuteMulti(t *testing.T) {
 			shardQueries[shard] = query
 		}
 
-		return sc.ExecuteMultiShard(context.Background(), "TestScatterConnExecuteMultiShard", shardQueries, topodatapb.TabletType_REPLICA, nil, false, nil)
+		return sc.ExecuteMultiShard(context.Background(), "TestScatterConnExecuteMultiShard", shardQueries, topodatapb.TabletType_REPLICA, nil, false)
 	})
 }
 
@@ -249,7 +249,7 @@ func TestMultiExecs(t *testing.T) {
 		shardQueries[shard] = query
 	}
 
-	_, _ = sc.ExecuteMultiShard(context.Background(), "TestMultiExecs", shardQueries, topodatapb.TabletType_REPLICA, nil, false, nil)
+	_, _ = sc.ExecuteMultiShard(context.Background(), "TestMultiExecs", shardQueries, topodatapb.TabletType_REPLICA, nil, false)
 	if len(sbc0.Queries) == 0 || len(sbc1.Queries) == 0 {
 		t.Fatalf("didn't get expected query")
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -29,7 +29,6 @@ import (
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
-	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
 	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
 )
 
@@ -37,7 +36,7 @@ import (
 // packages to call back into VTGate.
 type vcursorImpl struct {
 	ctx              context.Context
-	session          *vtgatepb.Session
+	safeSession      *SafeSession
 	target           querypb.Target
 	trailingComments string
 	executor         *Executor
@@ -52,10 +51,10 @@ type vcursorImpl struct {
 // the query and supply it here. Trailing comments are typically sent by the application for various reasons,
 // including as identifying markers. So, they have to be added back to all queries that are executed
 // on behalf of the original query.
-func newVCursorImpl(ctx context.Context, session *vtgatepb.Session, target querypb.Target, trailingComments string, executor *Executor, logStats *LogStats) *vcursorImpl {
+func newVCursorImpl(ctx context.Context, safeSession *SafeSession, target querypb.Target, trailingComments string, executor *Executor, logStats *LogStats) *vcursorImpl {
 	return &vcursorImpl{
 		ctx:              ctx,
-		session:          session,
+		safeSession:      safeSession,
 		target:           target,
 		trailingComments: trailingComments,
 		executor:         executor,
@@ -103,7 +102,7 @@ func (vc *vcursorImpl) DefaultKeyspace() (*vindexes.Keyspace, error) {
 
 // Execute performs a V3 level execution of the query. It does not take any routing directives.
 func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
-	qr, err := vc.executor.Execute(vc.ctx, method, vc.session, query+vc.trailingComments, BindVars)
+	qr, err := vc.executor.Execute(vc.ctx, method, vc.safeSession, query+vc.trailingComments, BindVars)
 	if err == nil {
 		vc.hasPartialDML = true
 	}
@@ -113,14 +112,14 @@ func (vc *vcursorImpl) Execute(method string, query string, BindVars map[string]
 // ExecuteMultiShard executes different queries on different shards and returns the combined result.
 func (vc *vcursorImpl) ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML bool) (*sqltypes.Result, error) {
 	atomic.AddUint32(&vc.logStats.ShardQueries, uint32(len(shardQueries)))
-	qr, err := vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, keyspace, commentedShardQueries(shardQueries, vc.trailingComments), vc.target.TabletType, NewSafeSession(vc.session), false, vc.session.Options)
+	qr, err := vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, keyspace, commentedShardQueries(shardQueries, vc.trailingComments), vc.target.TabletType, vc.safeSession, false)
 	if err == nil {
 		vc.hasPartialDML = true
 	}
 	return qr, err
 }
 
-// ExecuteStandalone executes the specified query on keyspace:shard, but outside of the current transaction, as an independent statement.
+// ExecuteStandalone executes the specified query on keyspace:shard using an independent session with autocommit enabled.
 func (vc *vcursorImpl) ExecuteStandalone(query string, BindVars map[string]*querypb.BindVariable, keyspace, shard string) (*sqltypes.Result, error) {
 	bq := map[string]*querypb.BoundQuery{
 		shard: {
@@ -128,17 +127,13 @@ func (vc *vcursorImpl) ExecuteStandalone(query string, BindVars map[string]*quer
 			BindVariables: BindVars,
 		},
 	}
-	qr, err := vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, keyspace, bq, vc.target.TabletType, NewSafeSession(nil), false, vc.session.Options)
-	if err == nil {
-		vc.hasPartialDML = true
-	}
-	return qr, err
+	return vc.executor.scatterConn.ExecuteMultiShard(vc.ctx, keyspace, bq, vc.target.TabletType, NewAutocommitSession(vc.safeSession.Session), false)
 }
 
 // StreamExeculteMulti is the streaming version of ExecuteMultiShard.
 func (vc *vcursorImpl) StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error {
 	atomic.AddUint32(&vc.logStats.ShardQueries, uint32(len(shardVars)))
-	return vc.executor.scatterConn.StreamExecuteMulti(vc.ctx, query+vc.trailingComments, keyspace, shardVars, vc.target.TabletType, vc.session.Options, callback)
+	return vc.executor.scatterConn.StreamExecuteMulti(vc.ctx, query+vc.trailingComments, keyspace, shardVars, vc.target.TabletType, vc.safeSession.Options, callback)
 }
 
 // GetKeyspaceShards returns the list of shards for a keyspace, and the mapped keyspace if an alias was used.

--- a/go/vt/vtgate/vtgate.go
+++ b/go/vt/vtgate/vtgate.go
@@ -243,7 +243,7 @@ func (vtg *VTGate) Execute(ctx context.Context, session *vtgatepb.Session, sql s
 		goto handleError
 	}
 
-	qr, err = vtg.executor.Execute(ctx, "Execute", session, sql, bindVariables)
+	qr, err = vtg.executor.Execute(ctx, "Execute", NewSafeSession(session), sql, bindVariables)
 	if err == nil {
 		vtg.rowsReturned.Add(statsKey, int64(len(qr.Rows)))
 		return session, qr, nil
@@ -316,7 +316,7 @@ func (vtg *VTGate) StreamExecute(ctx context.Context, session *vtgatepb.Session,
 		err = vtg.executor.StreamExecute(
 			ctx,
 			"StreamExecute",
-			session,
+			NewSafeSession(session),
 			sql,
 			bindVariables,
 			target,


### PR DESCRIPTION
This change is mostly cosmetic. Previously, vtgatepb.Session was
the variable that the Executor shared through its layers.
We now change it to share a SafeSession, which also encapsulates
vtgatepb.Session, but it can carry additional state that lower
layers can use to make instant-commit decisions.

This additional flag will be added in the next iteration.