### PR TITLE
v3: instant-commit for autocommit

### DIFF
--- a/data/test/vtexplain/multi-output/deletesharded-output.txt
+++ b/data/test/vtexplain/multi-output/deletesharded-output.txt
@@ -3,7 +3,7 @@ delete from music_extra where id=1
 
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: delete from music_extra where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
-2 ks_sharded/-40: commit
+1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 delete from music_extra where id=1 and extra='abc'
@@ -11,7 +11,7 @@ delete from music_extra where id=1 and extra='abc'
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: select id from music_extra where id = 1 and extra = 'abc' limit 10001 for update /* vtgate:: keyspace_id:166b40b44aba4bd6 */
 1 ks_sharded/-40: delete from music_extra where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
-2 ks_sharded/-40: commit
+1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 delete from user where id=1

--- a/data/test/vtexplain/multi-output/unsharded-output.txt
+++ b/data/test/vtexplain/multi-output/unsharded-output.txt
@@ -8,7 +8,7 @@ insert into t1 (id,intval,floatval) values (1,2,3.14)
 
 1 ks_unsharded/-: begin
 1 ks_unsharded/-: insert into t1(id, intval, floatval) values (1, 2, 3.14)
-2 ks_unsharded/-: commit
+1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------
 update t1 set intval = 10
@@ -16,7 +16,7 @@ update t1 set intval = 10
 1 ks_unsharded/-: begin
 1 ks_unsharded/-: select id from t1 limit 10001 for update
 1 ks_unsharded/-: update t1 set intval = 10 where id in (1)
-2 ks_unsharded/-: commit
+1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------
 update t1 set floatval = 9.99
@@ -24,20 +24,20 @@ update t1 set floatval = 9.99
 1 ks_unsharded/-: begin
 1 ks_unsharded/-: select id from t1 limit 10001 for update
 1 ks_unsharded/-: update t1 set floatval = 9.99 where id in (1)
-2 ks_unsharded/-: commit
+1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------
 delete from t1 where id = 100
 
 1 ks_unsharded/-: begin
 1 ks_unsharded/-: delete from t1 where id in (100)
-2 ks_unsharded/-: commit
+1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------
 insert into t1 (id,intval,floatval) values (1,2,3.14) on duplicate key update intval=3, floatval=3.14
 
 1 ks_unsharded/-: begin
 1 ks_unsharded/-: insert into t1(id, intval, floatval) values (1, 2, 3.14) on duplicate key update intval = 3, floatval = 3.14
-2 ks_unsharded/-: commit
+1 ks_unsharded/-: commit
 
 ----------------------------------------------------------------------

--- a/data/test/vtexplain/multi-output/updatesharded-output.txt
+++ b/data/test/vtexplain/multi-output/updatesharded-output.txt
@@ -3,7 +3,7 @@ update user set nickname='alice' where id=1
 
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: update user set nickname = 'alice' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
-2 ks_sharded/-40: commit
+1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 update user set nickname='alice' where name='alice'
@@ -21,7 +21,7 @@ update user set pet='fido' where id=1
 
 1 ks_sharded/-40: begin
 1 ks_sharded/-40: update user set pet = 'fido' where id in (1) /* vtgate:: keyspace_id:166b40b44aba4bd6 */
-2 ks_sharded/-40: commit
+1 ks_sharded/-40: commit
 
 ----------------------------------------------------------------------
 update user set name='alicia' where id=1

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vtgate
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/sqltypes"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	vtgatepb "github.com/youtube/vitess/go/vt/proto/vtgate"
+)
+
+// This file contains tests for all the autocommit code paths
+// to make sure that single round-trip commits are executed
+// correctly whenever possible.
+
+// TestAutocommitUpdateSharded: instant-commit.
+func TestAutocommitUpdateSharded(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "update user set a=2 where id = 1"); err != nil {
+		t.Fatal(err)
+	}
+	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
+		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	})
+	testAsTransactionCount(t, "sbc1", sbc1, 1)
+	testCommitCount(t, "sbc1", sbc1, 0)
+
+	testBatchQuery(t, "sbc2", sbc2, nil)
+	testAsTransactionCount(t, "sbc2", sbc2, 0)
+	testCommitCount(t, "sbc1", sbc1, 0)
+}
+
+// TestAutocommitUpdateLookup: transaction: select before update.
+func TestAutocommitUpdateLookup(t *testing.T) {
+	executor, sbc1, _, sbclookup := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "update music set a=2 where id = 2"); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql: "select user_id from music_user_map where music_id = :music_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"music_id": sqltypes.Int64BindVariable(2),
+		},
+	}})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
+	testCommitCount(t, "sbclookup", sbclookup, 1)
+
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql:           "update music set a = 2 where id = 2 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 1)
+}
+
+// TestAutocommitUpdateVindexChange: transaction: select & update before final update.
+func TestAutocommitUpdateVindexChange(t *testing.T) {
+	executor, sbc1, _, sbclookup := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "update user2 set name='myname', lastname='mylastname' where id = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql: "delete from name_lastname_keyspace_id_map where name = :name and lastname = :lastname and keyspace_id = :keyspace_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"lastname":    sqltypes.StringBindVariable("foo"),
+			"name":        sqltypes.Int32BindVariable(1),
+			"keyspace_id": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
+		},
+	}, {
+		Sql: "insert into name_lastname_keyspace_id_map(name, lastname, keyspace_id) values (:name0, :lastname0, :keyspace_id0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"name0":        sqltypes.BytesBindVariable([]byte("myname")),
+			"lastname0":    sqltypes.BytesBindVariable([]byte("mylastname")),
+			"keyspace_id0": sqltypes.BytesBindVariable([]byte("\026k@\264J\272K\326")),
+		},
+	}})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
+	testCommitCount(t, "sbclookup", sbclookup, 1)
+
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql:           "select name, lastname from user2 where id = 1 for update",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}, {
+		Sql: "update user2 set name = 'myname', lastname = 'mylastname' where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_name0":     sqltypes.BytesBindVariable([]byte("myname")),
+			"_lastname0": sqltypes.BytesBindVariable([]byte("mylastname")),
+		},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 1)
+}
+
+// TestAutocommitDeleteSharded: instant-commit.
+func TestAutocommitDeleteSharded(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "delete from user_extra where user_id = 1"); err != nil {
+		t.Fatal(err)
+	}
+	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
+		Sql:           "delete from user_extra where user_id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	})
+	testAsTransactionCount(t, "sbc1", sbc1, 1)
+	testCommitCount(t, "sbc1", sbc1, 0)
+
+	testBatchQuery(t, "sbc2", sbc2, nil)
+	testAsTransactionCount(t, "sbc2", sbc2, 0)
+	testCommitCount(t, "sbc1", sbc1, 0)
+}
+
+// TestAutocommitDeleteLookup: transaction: select before update.
+func TestAutocommitDeleteLookup(t *testing.T) {
+	executor, sbc1, _, sbclookup := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "delete from music where id = 1"); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql: "select user_id from music_user_map where music_id = :music_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"music_id": sqltypes.Int64BindVariable(1),
+		},
+	}, {
+		Sql: "delete from music_user_map where music_id = :music_id and user_id = :user_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"music_id": sqltypes.Int32BindVariable(1),
+			"user_id":  sqltypes.Uint64BindVariable(1),
+		},
+	}})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
+	testCommitCount(t, "sbclookup", sbclookup, 1)
+
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql:           "select id from music where id = 1 for update",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}, {
+		Sql:           "delete from music where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 1)
+}
+
+// TestAutocommitInsertSharded: instant-commit.
+func TestAutocommitInsertSharded(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "insert into user_extra(user_id, v) values (1, 2)"); err != nil {
+		t.Fatal(err)
+	}
+	testBatchQuery(t, "sbc1", sbc1, &querypb.BoundQuery{
+		Sql: "insert into user_extra(user_id, v) values (:_user_id0, 2) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+		},
+	})
+	testAsTransactionCount(t, "sbc1", sbc1, 1)
+	testCommitCount(t, "sbc1", sbc1, 0)
+
+	testBatchQuery(t, "sbc2", sbc2, nil)
+	testAsTransactionCount(t, "sbc2", sbc2, 0)
+	testCommitCount(t, "sbc1", sbc1, 0)
+}
+
+// TestAutocommitInsertLookup: transaction: select before update.
+func TestAutocommitInsertLookup(t *testing.T) {
+	executor, sbc1, _, sbclookup := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "insert into user(id, v, name) values (1, 2, 'myname')"); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql: "insert into name_user_map(name, user_id) values (:name0, :user_id0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"name0":    sqltypes.BytesBindVariable([]byte("myname")),
+			"user_id0": sqltypes.Uint64BindVariable(1),
+		},
+	}})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
+	testCommitCount(t, "sbclookup", sbclookup, 1)
+
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql: "insert into user(id, v, name) values (:_Id0, 2, :_name0) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_Id0":   sqltypes.Int64BindVariable(1),
+			"_name0": sqltypes.BytesBindVariable([]byte("myname")),
+			"__seq0": sqltypes.Int64BindVariable(1),
+		},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 1)
+}
+
+func TestAutocommitInsertMultishard(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "insert into user_extra(user_id, v) values (1, 2), (3, 4)"); err != nil {
+		t.Fatal(err)
+	}
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql: "insert into user_extra(user_id, v) values (:_user_id0, 2) /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+			"_user_id1": sqltypes.Int64BindVariable(3),
+		},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 1)
+
+	testQueries(t, "sbc2", sbc2, []*querypb.BoundQuery{{
+		Sql: "insert into user_extra(user_id, v) values (:_user_id1, 4) /* vtgate:: keyspace_id:4eb190c9a2fa169c */",
+		BindVariables: map[string]*querypb.BindVariable{
+			"_user_id0": sqltypes.Int64BindVariable(1),
+			"_user_id1": sqltypes.Int64BindVariable(3),
+		},
+	}})
+	testAsTransactionCount(t, "sbc2", sbc2, 0)
+	testCommitCount(t, "sbc2", sbc2, 1)
+}
+
+// TestAutocommitInsertAutoinc: instant-commit: sequence fetch is not transactional.
+func TestAutocommitInsertAutoinc(t *testing.T) {
+	executor, _, _, sbclookup := createExecutorEnv()
+
+	if _, err := autocommitExec(executor, "insert into main1(id, name) values (null, 'myname')"); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql:           "select next :n values from user_seq",
+		BindVariables: map[string]*querypb.BindVariable{"n": sqltypes.Int64BindVariable(1)},
+	}})
+	testBatchQuery(t, "sbclookup", sbclookup, &querypb.BoundQuery{
+		Sql: "insert into main1(id, name) values (:__seq0, 'myname')",
+		BindVariables: map[string]*querypb.BindVariable{
+			"__seq0": sqltypes.Int64BindVariable(1),
+		},
+	})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 1)
+	testCommitCount(t, "sbclookup", sbclookup, 0)
+}
+
+// TestAutocommitTransactionStarted: no instant-commit.
+func TestAutocommitTransactionStarted(t *testing.T) {
+	executor, sbc1, _, _ := createExecutorEnv()
+
+	session := &vtgatepb.Session{
+		TargetString:    "@master",
+		Autocommit:      true,
+		InTransaction:   true,
+		TransactionMode: vtgatepb.TransactionMode_MULTI,
+	}
+	sql := "update user set a=2 where id = 1"
+
+	if _, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{}); err != nil {
+		t.Fatal(err)
+	}
+
+	testQueries(t, "sbc1", sbc1, []*querypb.BoundQuery{{
+		Sql:           "update user set a = 2 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}})
+	testAsTransactionCount(t, "sbc1", sbc1, 0)
+	testCommitCount(t, "sbc1", sbc1, 0)
+}
+
+// TestAutocommitDirectTarget: no instant-commit.
+func TestAutocommitDirectTarget(t *testing.T) {
+	executor, _, _, sbclookup := createExecutorEnv()
+
+	session := &vtgatepb.Session{
+		TargetString:    "TestUnsharded/0@master",
+		Autocommit:      true,
+		TransactionMode: vtgatepb.TransactionMode_MULTI,
+	}
+	sql := "insert into simple(val) values ('val')"
+
+	if _, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{}); err != nil {
+		t.Error(err)
+	}
+	testQueries(t, "sbclookup", sbclookup, []*querypb.BoundQuery{{
+		Sql:           sql + "/* vtgate:: filtered_replication_unfriendly */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}})
+	testAsTransactionCount(t, "sbclookup", sbclookup, 0)
+	testCommitCount(t, "sbclookup", sbclookup, 1)
+}
+
+func autocommitExec(executor *Executor, sql string) (*sqltypes.Result, error) {
+	session := &vtgatepb.Session{
+		TargetString:    "@master",
+		Autocommit:      true,
+		TransactionMode: vtgatepb.TransactionMode_MULTI,
+	}
+
+	return executor.Execute(context.Background(), "TestExecute", NewSafeSession(session), sql, map[string]*querypb.BindVariable{})
+}

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -342,7 +342,7 @@ func (t *fakeVcursor) Execute(method string, query string, bindvars map[string]*
 	panic("unimplemented")
 }
 
-func (t *fakeVcursor) ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML bool) (*sqltypes.Result, error) {
+func (t *fakeVcursor) ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }
 

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -43,7 +43,7 @@ type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
-	ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML bool) (*sqltypes.Result, error)
+	ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error)
 	ExecuteStandalone(query string, bindvars map[string]*querypb.BindVariable, keyspace, shard string) (*sqltypes.Result, error)
 	StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error
 	GetKeyspaceShards(vkeyspace *vindexes.Keyspace) (string, []*topodatapb.ShardReference, error)

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -385,7 +385,9 @@ func TestExecutorAutocommit(t *testing.T) {
 		t.Errorf("Commit count: %d, want %d", got, want)
 	}
 
-	startCount = sbclookup.CommitCount.Get()
+	// In the following section, we look at AsTransaction count instead of CommitCount because
+	// the update results in a single round-trip ExecuteBatch call.
+	startCount = sbclookup.AsTransactionCount.Get()
 	_, err = executor.Execute(context.Background(), "TestExecute", session, "update main1 set id=1", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -394,7 +396,7 @@ func TestExecutorAutocommit(t *testing.T) {
 	if !proto.Equal(session.Session, wantSession) {
 		t.Errorf("autocommit=1: %v, want %v", session.Session, wantSession)
 	}
-	if got, want := sbclookup.CommitCount.Get(), startCount+1; got != want {
+	if got, want := sbclookup.AsTransactionCount.Get(), startCount+1; got != want {
 		t.Errorf("Commit count: %d, want %d", got, want)
 	}
 
@@ -407,6 +409,7 @@ func TestExecutorAutocommit(t *testing.T) {
 	}
 
 	// autocommit = 1, "begin"
+	session.Reset()
 	startCount = sbclookup.CommitCount.Get()
 	_, err = executor.Execute(context.Background(), "TestExecute", session, "begin", nil)
 	if err != nil {

--- a/go/vt/vtgate/scatter_conn.go
+++ b/go/vt/vtgate/scatter_conn.go
@@ -166,6 +166,7 @@ func (stc *ScatterConn) ExecuteMultiShard(
 	tabletType topodatapb.TabletType,
 	session *SafeSession,
 	notInTransaction bool,
+	canAutocommit bool,
 ) (*sqltypes.Result, error) {
 
 	// mu protects qr
@@ -176,6 +177,8 @@ func (stc *ScatterConn) ExecuteMultiShard(
 		shards = append(shards, shard)
 	}
 
+	canCommit := len(shards) == 1 && canAutocommit && session.AutocommitApproval()
+
 	err := stc.multiGoTransaction(
 		ctx,
 		"Execute",
@@ -185,23 +188,25 @@ func (stc *ScatterConn) ExecuteMultiShard(
 		session,
 		notInTransaction,
 		func(target *querypb.Target, shouldBegin bool, transactionID int64) (int64, error) {
-			var innerqr *sqltypes.Result
-			var opts *querypb.ExecuteOptions
+			var (
+				innerqr *sqltypes.Result
+				err     error
+				opts    *querypb.ExecuteOptions
+			)
 			if session != nil && session.Session != nil {
 				opts = session.Session.Options
 			}
-			if shouldBegin {
-				var err error
+
+			switch {
+			case canCommit:
+				innerqr, err = stc.executeAutocommit(ctx, target, shardQueries[target.Shard].Sql, shardQueries[target.Shard].BindVariables, opts)
+			case shouldBegin:
 				innerqr, transactionID, err = stc.gateway.BeginExecute(ctx, target, shardQueries[target.Shard].Sql, shardQueries[target.Shard].BindVariables, opts)
-				if err != nil {
-					return transactionID, err
-				}
-			} else {
-				var err error
+			default:
 				innerqr, err = stc.gateway.Execute(ctx, target, shardQueries[target.Shard].Sql, shardQueries[target.Shard].BindVariables, transactionID, opts)
-				if err != nil {
-					return transactionID, err
-				}
+			}
+			if err != nil {
+				return transactionID, err
 			}
 
 			mu.Lock()
@@ -210,6 +215,20 @@ func (stc *ScatterConn) ExecuteMultiShard(
 			return transactionID, nil
 		})
 	return qr, err
+}
+
+func (stc *ScatterConn) executeAutocommit(ctx context.Context, target *querypb.Target, sql string, bindVariables map[string]*querypb.BindVariable, options *querypb.ExecuteOptions) (*sqltypes.Result, error) {
+	queries := []*querypb.BoundQuery{{
+		Sql:           sql,
+		BindVariables: bindVariables,
+	}}
+	// ExecuteBatch is a stop-gap because it's the only function that can currently do
+	// single round-trip commit.
+	qrs, err := stc.gateway.ExecuteBatch(ctx, target, queries, true /* asTransaction */, 0, options)
+	if err != nil {
+		return nil, err
+	}
+	return &qrs[0], nil
 }
 
 // ExecuteEntityIds executes queries that are shard specific.

--- a/go/vt/vtgate/scatter_conn_test.go
+++ b/go/vt/vtgate/scatter_conn_test.go
@@ -57,7 +57,7 @@ func TestScatterConnExecuteMulti(t *testing.T) {
 			shardQueries[shard] = query
 		}
 
-		return sc.ExecuteMultiShard(context.Background(), "TestScatterConnExecuteMultiShard", shardQueries, topodatapb.TabletType_REPLICA, nil, false)
+		return sc.ExecuteMultiShard(context.Background(), "TestScatterConnExecuteMultiShard", shardQueries, topodatapb.TabletType_REPLICA, nil, false, false)
 	})
 }
 
@@ -249,7 +249,7 @@ func TestMultiExecs(t *testing.T) {
 		shardQueries[shard] = query
 	}
 
-	_, _ = sc.ExecuteMultiShard(context.Background(), "TestMultiExecs", shardQueries, topodatapb.TabletType_REPLICA, nil, false)
+	_, _ = sc.ExecuteMultiShard(context.Background(), "TestMultiExecs", shardQueries, topodatapb.TabletType_REPLICA, nil, false, false)
 	if len(sbc0.Queries) == 0 || len(sbc1.Queries) == 0 {
 		t.Fatalf("didn't get expected query")
 	}


### PR DESCRIPTION
If we are in autocommit mode and vtgate does not break a DML into smaller parts, then it has the opportunity to send that statement through to a vttablet as autocommit in a single round-trip.

Reviewer instructions:
@demmer: I'm not too sure about the vtexplain fixes, or if additional tests are required there. Extra scrutiny may be required there.

Implementation notes:
* SafeSession has a state machine for tracking autocommit state.
* The autocommit state is initialized by executor as needed.
* VCursor API has been changed for ExecMultiShard. It now accept an extra canCommit flag that should be set to true if the engine is executing its final DML. This, combined with the autocommit state will decide if an instant autocommit is possible.