### PR TITLE
add logging and a max wait time to vtgate shutdown drain

### DIFF
--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -244,21 +244,13 @@ func shutdownMysqlProtocolAndDrain() {
 		log.Infof("Waiting for all client connections to be idle (%d active)...", atomic.LoadInt32(&busyConnections))
 		start := time.Now()
 		reported := start
-		for time.Since(start) < 30*time.Second {
-			if atomic.LoadInt32(&busyConnections) == 0 {
-				break
-			}
-
+		for atomic.LoadInt32(&busyConnections) != 0 {
 			if time.Since(reported) > 2*time.Second {
 				log.Infof("Still waiting for client connections to be idle (%d active)...", atomic.LoadInt32(&busyConnections))
 				reported = time.Now()
 			}
 
 			time.Sleep(1 * time.Millisecond)
-		}
-
-		if atomic.LoadInt32(&busyConnections) > 0 {
-			log.Infof("Client connections still not idle, exiting anyway (%d active)...", atomic.LoadInt32(&busyConnections))
 		}
 	}
 }

--- a/go/vt/vtgate/plugin_mysql_server.go
+++ b/go/vt/vtgate/plugin_mysql_server.go
@@ -241,9 +241,24 @@ func shutdownMysqlProtocolAndDrain() {
 	}
 
 	if atomic.LoadInt32(&busyConnections) > 0 {
-		log.Infof("Waiting for all client connections to be idle...")
-		for atomic.LoadInt32(&busyConnections) > 0 {
+		log.Infof("Waiting for all client connections to be idle (%d active)...", atomic.LoadInt32(&busyConnections))
+		start := time.Now()
+		reported := start
+		for time.Since(start) < 30*time.Second {
+			if atomic.LoadInt32(&busyConnections) == 0 {
+				break
+			}
+
+			if time.Since(reported) > 2*time.Second {
+				log.Infof("Still waiting for client connections to be idle (%d active)...", atomic.LoadInt32(&busyConnections))
+				reported = time.Now()
+			}
+
 			time.Sleep(1 * time.Millisecond)
+		}
+
+		if atomic.LoadInt32(&busyConnections) > 0 {
+			log.Infof("Client connections still not idle, exiting anyway (%d active)...", atomic.LoadInt32(&busyConnections))
 		}
 	}
 }


### PR DESCRIPTION
Wait no more than 30 seconds for active vtgate mysql connections to
drain, and emit a log every 2 seconds while waiting with the count
of connections that we're waiting for.