### PR TITLE
vtgate: fix vtgate_test

### DIFF
--- a/go/vt/vtgate/vtgate_test.go
+++ b/go/vt/vtgate/vtgate_test.go
@@ -18,7 +18,6 @@ package vtgate
 
 import (
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -55,8 +54,6 @@ var masterSession = &vtgatepb.Session{
 }
 
 func init() {
-	flag.CommandLine.Parse([]string{}) // prevents glog "ERROR: logging before flag.Parse"
-
 	getSandbox(KsTestUnsharded).VSchema = `
 {
 	"sharded": false,


### PR DESCRIPTION
The parsing of flags in vtgate_test caused it to eat all flags
including the ones used by the test package. This caused tests
here to ignore things like -run, etc.

I tried changing the init to TestMain. That didn't help. So,
I'm removing the parsing call for now until we figure out a
different way to fix this.