### PR TITLE
ignore mysql-specific comment statements

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -45,6 +45,7 @@ const (
 	StmtUse
 	StmtOther
 	StmtUnknown
+	StmtComment
 )
 
 // Preview analyzes the beginning of the query using a simpler and faster
@@ -90,6 +91,9 @@ func Preview(sql string) int {
 		return StmtUse
 	case "analyze", "describe", "desc", "explain", "repair", "optimize", "truncate":
 		return StmtOther
+	}
+	if strings.Index(trimmed, "/*!") == 0 {
+		return StmtComment
 	}
 	return StmtUnknown
 }

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -66,6 +66,8 @@ func TestPreview(t *testing.T) {
 
 		{"/* leading comment */ select ...", StmtSelect},
 		{"/* leading comment */ /* leading comment 2 */ select ...", StmtSelect},
+		{"/*! MySQL-specific comment */", StmtComment},
+		{"/*!50708 MySQL-version comment */", StmtComment},
 		{"-- leading single line comment \n select ...", StmtSelect},
 		{"-- leading single line comment \n -- leading single line comment 2\n select ...", StmtSelect},
 

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -145,13 +145,14 @@ func hasCommentPrefix(sql string) bool {
 	return len(sql) > 1 && ((sql[0] == '/' && sql[1] == '*') || (sql[0] == '-' && sql[1] == '-'))
 }
 
-func ExtractMysqlComment(sql string) (version string, inner_sql string) {
-	// assuming sql is already trimmed, trim off "/*!" and "*/"
+// ExtractMysqlComment extracts the version and SQL from a comment-only query
+// such as /*!50708 sql here */
+func ExtractMysqlComment(sql string) (version string, innerSQL string) {
 	sql = sql[3 : len(sql)-2]
 
-	end_of_version_index := strings.IndexFunc(sql, func(c rune) bool { return !unicode.IsDigit(c) })
-	version = sql[0:end_of_version_index]
-	inner_sql = strings.TrimFunc(sql[end_of_version_index:], unicode.IsSpace)
+	endOfVersionIndex := strings.IndexFunc(sql, func(c rune) bool { return !unicode.IsDigit(c) })
+	version = sql[0:endOfVersionIndex]
+	innerSQL = strings.TrimFunc(sql[endOfVersionIndex:], unicode.IsSpace)
 
-	return version, inner_sql
+	return version, innerSQL
 }

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -129,6 +129,12 @@ func TestStripLeadingComments(t *testing.T) {
 		input:  "/**/",
 		outSQL: "",
 	}, {
+		input:  "/*!*/",
+		outSQL: "/*!*/",
+	}, {
+		input:  "/*!a*/",
+		outSQL: "/*!a*/",
+	}, {
 		input:  "/*b*/ /*a*/",
 		outSQL: "",
 	}, {
@@ -162,6 +168,34 @@ a`,
 	for _, testCase := range testCases {
 		gotSQL := StripLeadingComments(testCase.input)
 
+		if gotSQL != testCase.outSQL {
+			t.Errorf("test input: '%s', got SQL\n%+v, want\n%+v", testCase.input, gotSQL, testCase.outSQL)
+		}
+	}
+}
+
+func TestExtractMysqlComment(t *testing.T) {
+	var testCases = []struct {
+		input, outSQL, outVersion string
+	}{{
+		input:      "/*!50708SET max_execution_time=5000 */",
+		outSQL:     "SET max_execution_time=5000",
+		outVersion: "50708",
+	}, {
+		input:      "/*!50708 SET max_execution_time=5000*/",
+		outSQL:     "SET max_execution_time=5000",
+		outVersion: "50708",
+	}, {
+		input:      "/*! SET max_execution_time=5000*/",
+		outSQL:     "SET max_execution_time=5000",
+		outVersion: "",
+	}}
+	for _, testCase := range testCases {
+		gotVersion, gotSQL := ExtractMysqlComment(testCase.input)
+
+		if gotVersion != testCase.outVersion {
+			t.Errorf("test input: '%s', got version\n%+v, want\n%+v", testCase.input, gotVersion, testCase.outVersion)
+		}
 		if gotSQL != testCase.outSQL {
 			t.Errorf("test input: '%s', got SQL\n%+v, want\n%+v", testCase.input, gotSQL, testCase.outSQL)
 		}

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -195,6 +195,8 @@ func (e *Executor) execute(ctx context.Context, safeSession *SafeSession, sql st
 		return e.handleUse(ctx, safeSession, sql, bindVars)
 	case sqlparser.StmtOther:
 		return e.handleOther(ctx, safeSession, sql, bindVars, target, logStats)
+	case sqlparser.StmtComment:
+		return e.handleComment(ctx, safeSession, sql, bindVars, target, logStats)
 	}
 	return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unrecognized statement: %s", sql)
 }
@@ -703,6 +705,13 @@ func (e *Executor) handleOther(ctx context.Context, safeSession *SafeSession, sq
 	result, err := e.shardExec(ctx, safeSession, sql, bindVars, target, logStats)
 	logStats.ExecuteTime = time.Since(execStart)
 	return result, err
+}
+
+func (e *Executor) handleComment(ctx context.Context, safeSession *SafeSession, sql string, bindVars map[string]*querypb.BindVariable, target querypb.Target, logStats *LogStats) (*sqltypes.Result, error) {
+	_, sql = sqlparser.ExtractMysqlComment(sql)
+
+	// Not sure if this is a good idea.
+	return &sqltypes.Result{}, nil
 }
 
 // StreamExecute executes a streaming query.

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -734,6 +734,26 @@ func TestExecutorUse(t *testing.T) {
 	}
 }
 
+func TestExecutorComment(t *testing.T) {
+	executor, _, _, _ := createExecutorEnv()
+
+	stmts := []string{
+		"/*! SET max_execution_time=5000*/",
+		"/*!50708 SET max_execution_time=5000*/",
+	}
+	wantResult := &sqltypes.Result{}
+
+	for _, stmt := range stmts {
+		gotResult, err := executor.Execute(context.Background(), "TestExecute", NewSafeSession(&vtgatepb.Session{TargetString: KsTestUnsharded}), stmt, nil)
+		if err != nil {
+			t.Error(err)
+		}
+		if !reflect.DeepEqual(gotResult, wantResult) {
+			t.Errorf("Exec %s: %v, want %v", stmt, gotResult, wantResult)
+		}
+	}
+}
+
 func TestExecutorOther(t *testing.T) {
 	executor, sbc1, sbc2, sbclookup := createExecutorEnv()
 


### PR DESCRIPTION
This is related to https://github.com/youtube/vitess/issues/3520

Ignore ```/*! mysql-specific */``` and ```/*!50708 mysql-version-specific */``` comments.

I'm not sure if it's a good idea. Instead of stripping leading comments,
in case it's ```/*! ... */``` we don't strip it, and consider it a new StmtComment statement type.
(Not sure if that should be added to ast.go . I didn't.)
I assumed this kind of comment was the only thing in the query,
so if there's something like ```"/*! ... */ select ..."``` it wouldn't work.
The handleComment in executor.go basically does nothing, returning ```&sqltypes.Result{}```