### PR TITLE
add a vtgate check that verifies there are no positional arguments

### DIFF
--- a/go/cmd/vtgate/vtgate.go
+++ b/go/cmd/vtgate/vtgate.go
@@ -67,6 +67,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if len(flag.Args()) > 0 {
+		flag.Usage()
+		log.Exit("vtgate doesn't take any positional arguments")
+	}
+
 	if initFakeZK != nil {
 		initFakeZK()
 	}


### PR DESCRIPTION
Ignore all positional arguments in the vtgate command binary rather than silently ignoring them.
