### PR TITLE
Fix for refreshing schema after update

### DIFF
--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -333,7 +333,7 @@ func (server *ResilientServer) WatchSrvVSchema(ctx context.Context, cell string,
 			} else {
 				for c := range changes {
 					// Note we forward topo.ErrNoNode as is.
-					callback(nil, c.Err)
+					callback(c.Value, c.Err)
 					if c.Err != nil {
 						log.Warningf("Error while watching vschema for cell %s (will wait 5s before retrying): %v", cell, c.Err)
 						break

--- a/go/vt/srvtopo/resilient_server_test.go
+++ b/go/vt/srvtopo/resilient_server_test.go
@@ -236,7 +236,7 @@ func TestWatchSrvVSchema(t *testing.T) {
 	// Update value, wait for it.
 	updatedValue := &vschemapb.SrvVSchema{
 		Keyspaces: map[string]*vschemapb.Keyspace{
-			"ks1": {},
+			"ks2": {},
 		},
 	}
 	if err := ts.UpdateSrvVSchema(ctx, "test_cell", updatedValue); err != nil {


### PR DESCRIPTION
### Description

I think there was a bug introduced in [3539](https://github.com/youtube/vitess/pull/3539/files) where after updating a vschema, vtgate is not properly updating it's version of it.

### Steps to reproduce

1) Add a new table schema to a keyspace with:
  ```
  vtctlclient ApplyVSchema -vschema_file schema-file keyspace
  ```
2) Updated schema is not shown in `/debug/vschema` and vtgate can't issue queries to that table.


After some debugging, I noticed that the callback was always passing nil in the changes and the vschema doesn't get updated. 

This PR fixes this and seems to be working as expected. However, not sure if I'm missing something and `nil` here is needed.