### PR TITLE
Create and use minimal docker images in Kubernetes

### DIFF
--- a/docker/k8s/mysqlctld/Dockerfile
+++ b/docker/k8s/mysqlctld/Dockerfile
@@ -1,0 +1,20 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vtdataroot
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin && \
+   mkdir -p /vt/config
+
+# Copy binaries
+COPY --from=k8s /vt/bin/mysqlctld /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# copy vitess config
+COPY --from=k8s /vt/config /vt/config

--- a/docker/k8s/vtctl/Dockerfile
+++ b/docker/k8s/vtctl/Dockerfile
@@ -1,0 +1,15 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtctl /vt/bin/

--- a/docker/k8s/vtctld/Dockerfile
+++ b/docker/k8s/vtctld/Dockerfile
@@ -1,0 +1,19 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin && \
+   mkdir -p /vt/web
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtctld /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# copy web admin files
+COPY --from=k8s /vt/web /vt/web

--- a/docker/k8s/vtgate/Dockerfile
+++ b/docker/k8s/vtgate/Dockerfile
@@ -1,0 +1,15 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vtgate /vt/bin/

--- a/docker/k8s/vttablet/Dockerfile
+++ b/docker/k8s/vttablet/Dockerfile
@@ -1,0 +1,24 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Set up Vitess environment (just enough to run pre-built Go binaries)
+ENV VTROOT /vt
+ENV VTDATAROOT /vtdataroot
+
+# Prepare directory structure.
+RUN mkdir -p /vt/bin
+
+# Copy binaries
+COPY --from=k8s /vt/bin/vttablet /vt/bin/
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# TODO: remove when https://github.com/youtube/vitess/issues/3553 is fixed
+RUN apt-get update && \
+   apt-get upgrade -qq && \
+   apt-get install mysql-client -qq --no-install-recommends && \
+   apt-get autoremove && \
+   apt-get clean && \
+   rm -rf /var/lib/apt/lists/*

--- a/helm/vitess/templates/_vtctld.tpl
+++ b/helm/vitess/templates/_vtctld.tpl
@@ -59,7 +59,7 @@ spec:
 {{ include "vtctld-affinity" (tuple $cellClean $cell.region) | indent 6 }}
       containers:
         - name: vtctld
-          image: vitess/k8s:{{$vitessTag}}
+          image: vitess/vtctld:{{$vitessTag}}
           livenessProbe:
             httpGet:
               path: /debug/vars

--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -72,7 +72,7 @@ spec:
 
       containers:
         - name: vtgate
-          image: vitess/k8s:{{$vitessTag}}
+          image: vitess/vtgate:{{$vitessTag}}
           livenessProbe:
             httpGet:
               path: /debug/vars
@@ -192,7 +192,7 @@ affinity:
 {{- with $cell.mysqlProtocol -}}
 
 - name: init-mysql-creds
-  image: "vitess/k8s:{{$vitessTag}}"
+  image: "vitess/vtgate:{{$vitessTag}}"
   volumeMounts:
     - name: creds
       mountPath: "/mysqlcreds"


### PR DESCRIPTION
For performance reasons, have containers specific to each component with only the binary and whatever supporting files are required.