### PR TITLE
docker: Add vtctlclient image.

### DIFF
--- a/docker/k8s/vtctlclient/Dockerfile
+++ b/docker/k8s/vtctlclient/Dockerfile
@@ -1,0 +1,4 @@
+FROM vitess/base AS base
+FROM debian:stretch-slim
+COPY --from=base /vt/bin/vtctlclient /usr/bin/
+CMD ["/usr/bin/vtctlclient"]


### PR DESCRIPTION
This one is simpler than the others because the client doesn't need any environment setup. We just need the binary.

@derekperkins 