### PR TITLE
add a serving state column to show vitess_tablets

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -553,18 +553,23 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 		stats := e.scatterConn.healthCheck.CacheStatus()
 		for _, s := range stats {
 			for _, ts := range s.TabletsStats {
+				state := "SERVING"
+				if !ts.Serving {
+					state = "NOT_SERVING"
+				}
 				rows = append(rows, buildVarCharRow(
 					s.Cell,
 					s.Target.Keyspace,
 					s.Target.Shard,
 					ts.Tablet.Type.String(),
+					state,
 					topoproto.TabletAliasString(ts.Tablet.Alias),
 					ts.Tablet.Hostname,
 				))
 			}
 		}
 		return &sqltypes.Result{
-			Fields:       buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "Alias", "Hostname"),
+			Fields:       buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname"),
 			Rows:         rows,
 			RowsAffected: uint64(len(rows)),
 		}, nil

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -554,10 +554,10 @@ func TestExecutorShow(t *testing.T) {
 	// Just test for first & last.
 	qr.Rows = [][]sqltypes.Value{qr.Rows[0], qr.Rows[len(qr.Rows)-1]}
 	wantqr = &sqltypes.Result{
-		Fields: buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "Alias", "Hostname"),
+		Fields: buildVarCharFields("Cell", "Keyspace", "Shard", "TabletType", "State", "Alias", "Hostname"),
 		Rows: [][]sqltypes.Value{
-			buildVarCharRow("FakeCell", "TestExecutor", "-20", "MASTER", "aa-0000000000", "-20"),
-			buildVarCharRow("FakeCell", "TestUnsharded", "0", "MASTER", "aa-0000000000", "0"),
+			buildVarCharRow("FakeCell", "TestExecutor", "-20", "MASTER", "SERVING", "aa-0000000000", "-20"),
+			buildVarCharRow("FakeCell", "TestUnsharded", "0", "MASTER", "SERVING", "aa-0000000000", "0"),
 		},
 		RowsAffected: 9,
 	}


### PR DESCRIPTION
I noticed that a vtgate had some tablets in the cache that failed health checks but they still showed up in the `show vitess_tablets` list.

Add a column for SERVING / NOT_SERVING to the output of `show vitess_tablets` to help differentiate these.
