### PR TITLE
Sharded delete

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -1194,3 +1194,63 @@
     "Subquery": "select column_a, column_b, column_c from multicolvin where kid = 1 for update"
   }
 }
+
+# delete from with no where clause
+"delete from user_extra"
+{
+  "Original": "delete from user_extra",
+  "Instructions": {
+    "Opcode": "DeleteSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "delete from user_extra",
+    "Table": "user_extra"
+  }
+}
+
+# delete with non-comparison expr
+"delete from user_extra where user_id between 1 and 2"
+{
+  "Original": "delete from user_extra where user_id between 1 and 2",
+  "Instructions": {
+    "Opcode": "DeleteSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "delete from user_extra where user_id between 1 and 2",
+    "Table": "user_extra"
+  }
+}
+
+# delete from with no index match
+"delete from user_extra where name = 'jose'"
+{
+  "Original": "delete from user_extra where name = 'jose'",
+  "Instructions": {
+    "Opcode": "DeleteSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "delete from user_extra where name = 'jose'",
+    "Table": "user_extra"
+  }
+}
+
+# delete from with primary id in through IN clause
+"delete from user_extra where user_id in (1, 2)"
+{
+  "Original": "delete from user_extra where user_id in (1, 2)",
+  "Instructions": {
+    "Opcode": "DeleteSharded",
+    "Keyspace": {
+      "Name": "user",
+      "Sharded": true
+    },
+    "Query": "delete from user_extra where user_id in (1, 2)",
+    "Table": "user_extra"
+  }
+}

--- a/data/test/vtgate/unsupported_cases.txt
+++ b/data/test/vtgate/unsupported_cases.txt
@@ -251,48 +251,24 @@
 "update user set val = 1"
 "unsupported: multi-shard where clause in DML"
 
-# delete from with no where clause
-"delete from user"
-"unsupported: multi-shard where clause in DML"
-
 # update with non-comparison expr
 "update user set val = 1 where id between 1 and 2"
-"unsupported: multi-shard where clause in DML"
-
-# delete with non-comparison expr
-"delete from user where id between 1 and 2"
 "unsupported: multi-shard where clause in DML"
 
 # update with primary id through IN clause
 "update user set val = 1 where id in (1, 2)"
 "unsupported: multi-shard where clause in DML"
 
-# delete from with primary id through IN clause
-"delete from user where id in (1, 2)"
-"unsupported: multi-shard where clause in DML"
-
 # update with non-unique key
 "update user set val = 1 where name = 'foo'"
-"unsupported: multi-shard where clause in DML"
-
-# delete from with primary id through IN clause
-"delete from user where name = 'foo'"
 "unsupported: multi-shard where clause in DML"
 
 # update with no index match
 "update user set val = 1 where user_id = 1"
 "unsupported: multi-shard where clause in DML"
 
-# delete from with no index match
-"delete from user where user_id = 1"
-"unsupported: multi-shard where clause in DML"
-
 # update by lookup with IN clause
 "update music set val = 1 where id in (1, 2)"
-"unsupported: multi-shard where clause in DML"
-
-# delete from by lookup with IN clause
-"delete from music where id in (1, 2)"
 "unsupported: multi-shard where clause in DML"
 
 # delete with multi-table targets
@@ -302,6 +278,10 @@
 # multi delete multi table
 "delete user from user join user_extra on user.id = user_extra.id where user.name = 'foo'"
 "unsupported: multi-table delete statement in sharded keyspace"
+
+# delete from table with no where clause and owned lookup vindex
+"delete from user"
+"unsupported: multi shard delete on a table with owned lookup vindexes"
 
 # update changes primary vindex column
 "update user set id = 1 where id = 1"

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -374,6 +374,25 @@ func TestDeleteEqual(t *testing.T) {
 	}
 }
 
+func TestDeleteSharded(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+	_, err := executorExec(executor, "delete from user_extra", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	// Queries get annotatted.
+	wantQueries := []*querypb.BoundQuery{{
+		Sql:           "delete from user_extra/* vtgate:: filtered_replication_unfriendly */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
+	}
+	if !reflect.DeepEqual(sbc2.Queries, wantQueries) {
+		t.Errorf("sbc.Queries:\n%+v, want\n%+v\n", sbc2.Queries, wantQueries)
+	}
+}
+
 func TestDeleteComments(t *testing.T) {
 	executor, sbc, _, sbclookup := createExecutorEnv()
 

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -894,6 +894,20 @@ class TestVTGateFunctions(unittest.TestCase):
         {'id': 3})
     vtgate_conn.commit()
 
+    # Test multi shard delete
+    vtgate_conn.begin()
+    result = self.execute_on_master(
+        vtgate_conn,
+        'insert into vt_user (id, name) values (:id0, :name0),(:id1, :name1)',
+        {'id0': 22, 'name0': 'name2', 'id1': 33, 'name1': 'name2'})
+    self.assertEqual(result, ([], 2L, 0L, []))
+    result = self.execute_on_master(
+        vtgate_conn,
+        'delete from vt_user where id > :id',
+        {'id': 20})
+    self.assertEqual(result, ([], 2L, 0L, []))
+    vtgate_conn.commit()
+
   def test_user_truncate(self):
     vtgate_conn = get_connection()
     vtgate_conn.begin()


### PR DESCRIPTION
### Description

The following adds support to multi-shard delete statements. It only allows it when the table does not have any owned lookup vindex defined.

This could be the groundwork to support scattered updates as well. Also, in the future, when it's safe we could also push the scattered delete to the lookup vindexes.

### Tests 

* Locally and unit.