### PR TITLE
helm: graceful MySQL termination + PodDisruptionBudgets

### DIFF
--- a/helm/vitess/templates/_vtgate.tpl
+++ b/helm/vitess/templates/_vtgate.tpl
@@ -122,6 +122,22 @@ spec:
         - name: creds
           emptyDir: {}
 
+---
+###################################
+# vtgate PodDisruptionBudget
+###################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: vtgate-{{ $cellClean }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: vitess
+      component: vtgate
+      cell: {{ $cellClean }}
+
 {{ if gt .maxReplicas .replicas }}
 ###################################
 # optional HPA for vtgate

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -110,6 +110,25 @@ spec:
       spec:
 {{ toYaml (.dataVolumeClaimSpec | default $defaultVttablet.dataVolumeClaimSpec) | indent 8 }}
 
+---
+###################################
+# vttablet PodDisruptionBudget
+###################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $setName | quote }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: vitess
+      component: vttablet
+      cell: {{ $cellClean | quote }}
+      keyspace: {{ $keyspaceClean | quote }}
+      shard: {{ $shardClean | quote }}
+      type: {{ $tablet.type | quote }}
+
 {{- end -}}
 {{- end -}}
 

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -83,6 +83,7 @@ spec:
         shard: {{ $shardClean | quote }}
         type: {{ $tablet.type | quote }}
     spec:
+      terminationGracePeriodSeconds: 600
 {{ include "pod-security" . | indent 6 }}
 {{ include "vttablet-affinity" (tuple $cellClean $keyspaceClean $shardClean $cell.region) | indent 6 }}
 


### PR DESCRIPTION
This PR sets `terminationGracePeriodSeconds` to 600 for `vttablet` to give MySQL more time than the default 30s to gracefully shut down.

It also adds Pod Disruption Budgets to `vtgate` and `vttablet` to only allow one pod per cell, keyspace, shard and tablet type to be unavailable at any point. This eliminates the possibility of voluntary actions taking down an entire shard. 

@enisoc 