### PR TITLE
v3: migration support for lookup vindexes

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -200,6 +200,10 @@
   }
 }
 
+# update by primary keyspace id, changing same vindex twice
+"update user_metadata set email = 'a', email = 'b' where user_id = 1"
+"column has duplicate set values: 'email'"
+
 # update by primary keyspace id, changing multiple vindex columns
 "update user_metadata set email = 'juan@vitess.io', address = '155 5th street' where user_id = 1"
 {

--- a/data/test/vtgate/vindex_func_cases.txt
+++ b/data/test/vtgate/vindex_func_cases.txt
@@ -1,4 +1,39 @@
-# vindex func read
+# vindex func read all cols
+"select id, keyspace_id, range_start, range_end from user_index where id = :id"
+{
+  "Original": "select id, keyspace_id, range_start, range_end from user_index where id = :id",
+  "Instructions": {
+    "Opcode": "VindexMap",
+    "Fields": [
+      {
+        "name": "id",
+        "type": 10262
+      },
+      {
+        "name": "keyspace_id",
+        "type": 10262
+      },
+      {
+        "name": "range_start",
+        "type": 10262
+      },
+      {
+        "name": "range_end",
+        "type": 10262
+      }
+    ],
+    "Cols": [
+      0,
+      1,
+      2,
+      3
+    ],
+    "Vindex": "user_index",
+    "Value": ":id"
+  }
+}
+
+# vindex func read with id repeated
 "select id, keyspace_id, id from user_index where id = :id"
 {
   "Original": "select id, keyspace_id, id from user_index where id = :id",

--- a/go/vt/srvtopo/resolve.go
+++ b/go/vt/srvtopo/resolve.go
@@ -144,7 +144,7 @@ func MapKeyRangesToShards(ctx context.Context, topoServ Server, cell, keyspace s
 	}
 	uniqueShards := make(map[string]bool)
 	for _, kr := range krs {
-		ResolveKeyRangeToShards(allShards, uniqueShards, kr)
+		keyRangeToShardMap(allShards, uniqueShards, kr)
 	}
 	var res = make([]string, 0, len(uniqueShards))
 	for s := range uniqueShards {
@@ -153,8 +153,8 @@ func MapKeyRangesToShards(ctx context.Context, topoServ Server, cell, keyspace s
 	return keyspace, res, nil
 }
 
-// ResolveKeyRangeToShards maps a list of keyranges to shard names.
-func ResolveKeyRangeToShards(allShards []*topodatapb.ShardReference, matches map[string]bool, kr *topodatapb.KeyRange) {
+// keyRangeToShardMap adds shards to a map based on the input KeyRange.
+func keyRangeToShardMap(allShards []*topodatapb.ShardReference, matches map[string]bool, kr *topodatapb.KeyRange) {
 	if !key.KeyRangeIsPartial(kr) {
 		for _, shard := range allShards {
 			matches[shard.Name] = true
@@ -166,6 +166,18 @@ func ResolveKeyRangeToShards(allShards []*topodatapb.ShardReference, matches map
 			matches[shard.Name] = true
 		}
 	}
+}
+
+// GetShardsForKeyRange maps keyranges to shards.
+func GetShardsForKeyRange(allShards []*topodatapb.ShardReference, kr *topodatapb.KeyRange) []string {
+	isPartial := key.KeyRangeIsPartial(kr)
+	var shards []string
+	for _, shard := range allShards {
+		if !isPartial || key.KeyRangesIntersect(kr, shard.KeyRange) {
+			shards = append(shards, shard.Name)
+		}
+	}
+	return shards
 }
 
 // MapExactShards maps a keyrange to shards only if there's a complete

--- a/go/vt/vtgate/autocommit_test.go
+++ b/go/vt/vtgate/autocommit_test.go
@@ -105,11 +105,8 @@ func TestAutocommitUpdateVindexChange(t *testing.T) {
 		Sql:           "select name, lastname from user2 where id = 1 for update",
 		BindVariables: map[string]*querypb.BindVariable{},
 	}, {
-		Sql: "update user2 set name = 'myname', lastname = 'mylastname' where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-		BindVariables: map[string]*querypb.BindVariable{
-			"_name0":     sqltypes.BytesBindVariable([]byte("myname")),
-			"_lastname0": sqltypes.BytesBindVariable([]byte("mylastname")),
-		},
+		Sql:           "update user2 set name = 'myname', lastname = 'mylastname' where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
 	}})
 	testAsTransactionCount(t, "sbc1", sbc1, 0)
 	testCommitCount(t, "sbc1", sbc1, 1)

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -342,6 +342,10 @@ func (t *fakeVcursor) Execute(method string, query string, bindvars map[string]*
 	panic("unimplemented")
 }
 
+func (t *fakeVcursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+	panic("unimplemented")
+}
+
 func (t *fakeVcursor) ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error) {
 	panic("unimplemented")
 }

--- a/go/vt/vtgate/engine/merge_sort_test.go
+++ b/go/vt/vtgate/engine/merge_sort_test.go
@@ -374,6 +374,10 @@ func (t *fakeVcursor) GetKeyspaceShards(vkeyspace *vindexes.Keyspace) (string, [
 	panic("unimplemented")
 }
 
+func (t *fakeVcursor) GetShardsForKsids(allShards []*topodatapb.ShardReference, ksids vindexes.Ksids) ([]string, error) {
+	panic("unimplemented")
+}
+
 func (t *fakeVcursor) GetShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []byte) (string, error) {
 	panic("unimplemented")
 }

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -48,6 +48,7 @@ type VCursor interface {
 	StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error
 	GetKeyspaceShards(vkeyspace *vindexes.Keyspace) (string, []*topodatapb.ShardReference, error)
 	GetShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []byte) (string, error)
+	GetShardsForKsids(allShards []*topodatapb.ShardReference, ksids vindexes.Ksids) ([]string, error)
 }
 
 // Plan represents the execution strategy for a given query.

--- a/go/vt/vtgate/engine/primitive.go
+++ b/go/vt/vtgate/engine/primitive.go
@@ -42,10 +42,17 @@ const ListVarName = "__vals"
 type VCursor interface {
 	// Context returns the context of the current request.
 	Context() context.Context
+
+	// V3 functions.
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+
+	// Shard-level functions.
 	ExecuteMultiShard(keyspace string, shardQueries map[string]*querypb.BoundQuery, isDML, canAutocommit bool) (*sqltypes.Result, error)
 	ExecuteStandalone(query string, bindvars map[string]*querypb.BindVariable, keyspace, shard string) (*sqltypes.Result, error)
 	StreamExecuteMulti(query string, keyspace string, shardVars map[string]map[string]*querypb.BindVariable, callback func(reply *sqltypes.Result) error) error
+
+	// Topo functions.
 	GetKeyspaceShards(vkeyspace *vindexes.Keyspace) (string, []*topodatapb.ShardReference, error)
 	GetShardForKeyspaceID(allShards []*topodatapb.ShardReference, keyspaceID []byte) (string, error)
 	GetShardsForKsids(allShards []*topodatapb.ShardReference, ksids vindexes.Ksids) ([]string, error)

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -648,40 +648,34 @@ func (route *Route) resolveSingleShard(vcursor VCursor, bindVars map[string]*que
 }
 
 func (route *Route) updateChangedVindexes(subQueryResult *sqltypes.Result, vcursor VCursor, bindVars map[string]*querypb.BindVariable, ksid []byte) error {
-	if len(route.ChangedVindexValues) == 0 {
-		return nil
-	}
 	if len(subQueryResult.Rows) == 0 {
 		// NOOP, there are no actual rows changing due to this statement
 		return nil
 	}
-	for tIdx, colVindex := range route.Table.Owned {
-		if colValues, ok := route.ChangedVindexValues[colVindex.Name]; ok {
-			if len(subQueryResult.Rows) > 1 {
-				return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: update changes multiple columns in the vindex")
-			}
+	if len(subQueryResult.Rows) > 1 {
+		return vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "unsupported: update changes multiple columns in the vindex")
+	}
+	colnum := 0
+	for _, colVindex := range route.Table.Owned {
+		// Fetch the column values. colnum must keep incrementing.
+		fromIds := make([]sqltypes.Value, 0, len(colVindex.Columns))
+		for range colVindex.Columns {
+			fromIds = append(fromIds, subQueryResult.Rows[0][colnum])
+			colnum++
+		}
 
-			fromIds := make([][]sqltypes.Value, len(subQueryResult.Rows))
-			var vindexColumnKeys []sqltypes.Value
+		// Update columns only if they're being changed.
+		if colValues, ok := route.ChangedVindexValues[colVindex.Name]; ok {
+			vindexColumnKeys := make([]sqltypes.Value, 0, len(colValues))
 			for _, colValue := range colValues {
 				resolvedVal, err := colValue.ResolveValue(bindVars)
 				if err != nil {
 					return err
 				}
 				vindexColumnKeys = append(vindexColumnKeys, resolvedVal)
-
 			}
 
-			for rowIdx, row := range subQueryResult.Rows {
-				for colIdx := range colVindex.Columns {
-					fromIds[rowIdx] = append(fromIds[rowIdx], row[tIdx+colIdx])
-				}
-			}
-
-			if err := colVindex.Vindex.(vindexes.Lookup).Delete(vcursor, fromIds, ksid); err != nil {
-				return err
-			}
-			if err := route.processOwned(vcursor, [][]sqltypes.Value{vindexColumnKeys}, colVindex, bindVars, [][]byte{ksid}); err != nil {
+			if err := colVindex.Vindex.(vindexes.Lookup).Update(vcursor, fromIds, ksid, vindexColumnKeys); err != nil {
 				return err
 			}
 		}

--- a/go/vt/vtgate/engine/route.go
+++ b/go/vt/vtgate/engine/route.go
@@ -612,11 +612,11 @@ func (route *Route) resolveShards(vcursor VCursor, bindVars map[string]*querypb.
 			return "", nil, err
 		}
 		for i, ksids := range ksidss {
-			for _, ksid := range ksids {
-				shard, err := vcursor.GetShardForKeyspaceID(allShards, ksid)
-				if err != nil {
-					return "", nil, err
-				}
+			shards, err := vcursor.GetShardsForKsids(allShards, ksids)
+			if err != nil {
+				return "", nil, err
+			}
+			for _, shard := range shards {
 				routing.Add(shard, sqltypes.ValueToProto(vindexKeys[i]))
 			}
 		}

--- a/go/vt/vtgate/executor_dml_test.go
+++ b/go/vt/vtgate/executor_dml_test.go
@@ -106,11 +106,8 @@ func TestUpdateEqual(t *testing.T) {
 			BindVariables: map[string]*querypb.BindVariable{},
 		},
 		{
-			Sql: "update user2 set name = 'myname', lastname = 'mylastname' where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
-			BindVariables: map[string]*querypb.BindVariable{
-				"_name0":     sqltypes.BytesBindVariable([]byte("myname")),
-				"_lastname0": sqltypes.BytesBindVariable([]byte("mylastname")),
-			},
+			Sql:           "update user2 set name = 'myname', lastname = 'mylastname' where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+			BindVariables: map[string]*querypb.BindVariable{},
 		},
 	}
 	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
@@ -142,7 +139,127 @@ func TestUpdateEqual(t *testing.T) {
 	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
 		t.Errorf("sbclookup.Queries: %+v, want %+v\n", sbclookup.Queries, wantQueries)
 	}
+}
 
+func TestUpdateMultiOwned(t *testing.T) {
+	vschema := `
+{
+	"sharded": true,
+	"vindexes": {
+		"hash_index": {
+			"type": "hash"
+		},
+		"lookup1": {
+			"type": "lookup_hash_unique",
+			"owner": "user",
+			"params": {
+				"table": "music_user_map",
+				"from": "from1,from2",
+				"to": "user_id"
+			}
+		},
+		"lookup2": {
+			"type": "lookup_hash_unique",
+			"owner": "user",
+			"params": {
+				"table": "music_user_map",
+				"from": "from1,from2",
+				"to": "user_id"
+			}
+		},
+		"lookup3": {
+			"type": "lookup_hash_unique",
+			"owner": "user",
+			"params": {
+				"table": "music_user_map",
+				"from": "from1,from2",
+				"to": "user_id"
+			}
+		}
+	},
+	"tables": {
+		"user": {
+			"column_vindexes": [
+				{
+					"column": "id",
+					"name": "hash_index"
+				},
+				{
+					"columns": ["a", "b"],
+					"name": "lookup1"
+				},
+				{
+					"columns": ["c", "d"],
+					"name": "lookup2"
+				},
+				{
+					"columns": ["e", "f"],
+					"name": "lookup3"
+				}
+			]
+		}
+	}
+}
+`
+	executor, sbc1, sbc2, sbclookup := createCustomExecutor(vschema)
+
+	sbc1.SetResults([]*sqltypes.Result{
+		sqltypes.MakeTestResult(
+			sqltypes.MakeTestFields("a|b|c|d|e|f", "int64|int64|int64|int64|int64|int64"),
+			"10|20|30|40|50|60",
+		),
+	})
+	_, err := executorExec(executor, "update user set a=1, b=2, f=4, e=3 where id=1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantQueries := []*querypb.BoundQuery{{
+		Sql:           "select a, b, c, d, e, f from user where id = 1 for update",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}, {
+		Sql:           "update user set a = 1, b = 2, f = 4, e = 3 where id = 1 /* vtgate:: keyspace_id:166b40b44aba4bd6 */",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries:\n%+v, want\n%+v\n", sbc1.Queries, wantQueries)
+	}
+	if sbc2.Queries != nil {
+		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
+	}
+
+	wantQueries = []*querypb.BoundQuery{{
+		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"from1":   sqltypes.Int64BindVariable(10),
+			"from2":   sqltypes.Int64BindVariable(20),
+			"user_id": sqltypes.Uint64BindVariable(1),
+		},
+	}, {
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"from10":   sqltypes.Int64BindVariable(1),
+			"from20":   sqltypes.Int64BindVariable(2),
+			"user_id0": sqltypes.Uint64BindVariable(1),
+		},
+	}, {
+		Sql: "delete from music_user_map where from1 = :from1 and from2 = :from2 and user_id = :user_id",
+		BindVariables: map[string]*querypb.BindVariable{
+			"from1":   sqltypes.Int64BindVariable(50),
+			"from2":   sqltypes.Int64BindVariable(60),
+			"user_id": sqltypes.Uint64BindVariable(1),
+		},
+	}, {
+		Sql: "insert into music_user_map(from1, from2, user_id) values (:from10, :from20, :user_id0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"from10":   sqltypes.Int64BindVariable(3),
+			"from20":   sqltypes.Int64BindVariable(4),
+			"user_id0": sqltypes.Uint64BindVariable(1),
+		},
+	}}
+
+	if !reflect.DeepEqual(sbclookup.Queries, wantQueries) {
+		t.Errorf("sbclookup.Queries:\n%+v, want\n%+v\n", sbclookup.Queries, wantQueries)
+	}
 }
 
 func TestUpdateComments(t *testing.T) {

--- a/go/vt/vtgate/executor_select_test.go
+++ b/go/vt/vtgate/executor_select_test.go
@@ -583,6 +583,26 @@ func TestStreamSelectEqual(t *testing.T) {
 	}
 }
 
+func TestSelectKeyRange(t *testing.T) {
+	executor, sbc1, sbc2, _ := createExecutorEnv()
+
+	_, err := executorExec(executor, "select id, krcol from keyrange_table where krcol = 1", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	wantQueries := []*querypb.BoundQuery{{
+		Sql:           "select id, krcol from keyrange_table where krcol = 1",
+		BindVariables: map[string]*querypb.BindVariable{},
+	}}
+	if !reflect.DeepEqual(sbc1.Queries, wantQueries) {
+		t.Errorf("sbc1.Queries: %+v, want %+v\n", sbc1.Queries, wantQueries)
+	}
+	if sbc2.Queries != nil {
+		t.Errorf("sbc2.Queries: %+v, want nil\n", sbc2.Queries)
+	}
+	sbc1.Queries = nil
+}
+
 func TestSelectEqualFail(t *testing.T) {
 	executor, _, _, sbclookup := createExecutorEnv()
 	s := getSandbox("TestExecutor")

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -580,11 +580,12 @@ func TestExecutorShow(t *testing.T) {
 			buildVarCharRow("TestExecutor", "idx_noauto", "hash", "", "noauto_table"),
 			buildVarCharRow("TestExecutor", "insert_ignore_idx", "lookup_hash", "from=fromcol; table=ins_lookup; to=tocol", "insert_ignore_test"),
 			buildVarCharRow("TestExecutor", "keyspace_id", "numeric", "", ""),
+			buildVarCharRow("TestExecutor", "krcol_vdx", "keyrange_lookuper", "", ""),
 			buildVarCharRow("TestExecutor", "music_user_map", "lookup_hash_unique", "from=music_id; table=music_user_map; to=user_id", "music"),
 			buildVarCharRow("TestExecutor", "name_lastname_keyspace_id_map", "lookup", "from=name,lastname; table=name_lastname_keyspace_id_map; to=keyspace_id", "user2"),
 			buildVarCharRow("TestExecutor", "name_user_map", "lookup_hash", "from=name; table=name_user_map; to=user_id", "user"),
 		},
-		RowsAffected: 8,
+		RowsAffected: 9,
 	}
 	if !reflect.DeepEqual(qr, wantqr) {
 		t.Errorf("show vindexes:\n%+v, want\n%+v", qr, wantqr)

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -72,7 +72,7 @@ func (*multiIndex) Cost() int        { return 3 }
 func (*multiIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
 	return []bool{}, nil
 }
-func (*multiIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error)        { return nil, nil }
+func (*multiIndex) Map(vindexes.VCursor, []sqltypes.Value) ([]vindexes.Ksids, error)  { return nil, nil }
 func (*multiIndex) Create(vindexes.VCursor, [][]sqltypes.Value, [][]byte, bool) error { return nil }
 func (*multiIndex) Delete(vindexes.VCursor, [][]sqltypes.Value, []byte) error         { return nil }
 
@@ -88,7 +88,7 @@ func (*costlyIndex) Cost() int        { return 10 }
 func (*costlyIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool, error) {
 	return []bool{}, nil
 }
-func (*costlyIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][][]byte, error)        { return nil, nil }
+func (*costlyIndex) Map(vindexes.VCursor, []sqltypes.Value) ([]vindexes.Ksids, error)  { return nil, nil }
 func (*costlyIndex) Create(vindexes.VCursor, [][]sqltypes.Value, [][]byte, bool) error { return nil }
 func (*costlyIndex) Delete(vindexes.VCursor, [][]sqltypes.Value, []byte) error         { return nil }
 

--- a/go/vt/vtgate/planbuilder/plan_test.go
+++ b/go/vt/vtgate/planbuilder/plan_test.go
@@ -48,6 +48,8 @@ func newHashIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &hashIndex{name: name}, nil
 }
 
+var _ vindexes.Unique = (*hashIndex)(nil)
+
 // lookupIndex satisfies Lookup, Unique.
 type lookupIndex struct{ name string }
 
@@ -59,10 +61,16 @@ func (*lookupIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool
 func (*lookupIndex) Map(vindexes.VCursor, []sqltypes.Value) ([][]byte, error)          { return nil, nil }
 func (*lookupIndex) Create(vindexes.VCursor, [][]sqltypes.Value, [][]byte, bool) error { return nil }
 func (*lookupIndex) Delete(vindexes.VCursor, [][]sqltypes.Value, []byte) error         { return nil }
+func (*lookupIndex) Update(vindexes.VCursor, []sqltypes.Value, []byte, []sqltypes.Value) error {
+	return nil
+}
 
 func newLookupIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &lookupIndex{name: name}, nil
 }
+
+var _ vindexes.Unique = (*lookupIndex)(nil)
+var _ vindexes.Lookup = (*lookupIndex)(nil)
 
 // multiIndex satisfies Lookup, NonUnique.
 type multiIndex struct{ name string }
@@ -75,10 +83,16 @@ func (*multiIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool,
 func (*multiIndex) Map(vindexes.VCursor, []sqltypes.Value) ([]vindexes.Ksids, error)  { return nil, nil }
 func (*multiIndex) Create(vindexes.VCursor, [][]sqltypes.Value, [][]byte, bool) error { return nil }
 func (*multiIndex) Delete(vindexes.VCursor, [][]sqltypes.Value, []byte) error         { return nil }
+func (*multiIndex) Update(vindexes.VCursor, []sqltypes.Value, []byte, []sqltypes.Value) error {
+	return nil
+}
 
 func newMultiIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &multiIndex{name: name}, nil
 }
+
+var _ vindexes.NonUnique = (*multiIndex)(nil)
+var _ vindexes.Lookup = (*multiIndex)(nil)
 
 // costlyIndex satisfies Lookup, NonUnique.
 type costlyIndex struct{ name string }
@@ -91,10 +105,16 @@ func (*costlyIndex) Verify(vindexes.VCursor, []sqltypes.Value, [][]byte) ([]bool
 func (*costlyIndex) Map(vindexes.VCursor, []sqltypes.Value) ([]vindexes.Ksids, error)  { return nil, nil }
 func (*costlyIndex) Create(vindexes.VCursor, [][]sqltypes.Value, [][]byte, bool) error { return nil }
 func (*costlyIndex) Delete(vindexes.VCursor, [][]sqltypes.Value, []byte) error         { return nil }
+func (*costlyIndex) Update(vindexes.VCursor, []sqltypes.Value, []byte, []sqltypes.Value) error {
+	return nil
+}
 
 func newCostlyIndex(name string, _ map[string]string) (vindexes.Vindex, error) {
 	return &costlyIndex{name: name}, nil
 }
+
+var _ vindexes.NonUnique = (*costlyIndex)(nil)
+var _ vindexes.Lookup = (*costlyIndex)(nil)
 
 func init() {
 	vindexes.Register("hash_test", newHashIndex)

--- a/go/vt/vtgate/planbuilder/vindex_func.go
+++ b/go/vt/vtgate/planbuilder/vindex_func.go
@@ -172,6 +172,10 @@ func (vf *vindexFunc) PushSelect(expr *sqlparser.AliasedExpr, _ columnOriginator
 		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 0)
 	case col.Name.EqualString("keyspace_id"):
 		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 1)
+	case col.Name.EqualString("range_start"):
+		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 2)
+	case col.Name.EqualString("range_end"):
+		vf.eVindexFunc.Cols = append(vf.eVindexFunc.Cols, 3)
 	default:
 		return nil, 0, fmt.Errorf("unrecognized column %s for vindex: %s", col.Name, vf.eVindexFunc.Vindex)
 	}

--- a/go/vt/vtgate/vcursor_impl.go
+++ b/go/vt/vtgate/vcursor_impl.go
@@ -157,6 +157,21 @@ func (vc *vcursorImpl) GetShardForKeyspaceID(allShards []*topodatapb.ShardRefere
 	return srvtopo.GetShardForKeyspaceID(allShards, keyspaceID)
 }
 
+func (vc *vcursorImpl) GetShardsForKsids(allShards []*topodatapb.ShardReference, ksids vindexes.Ksids) ([]string, error) {
+	if ksids.Range != nil {
+		return srvtopo.GetShardsForKeyRange(allShards, ksids.Range), nil
+	}
+	var shards []string
+	for _, ksid := range ksids.IDs {
+		shard, err := srvtopo.GetShardForKeyspaceID(allShards, ksid)
+		if err != nil {
+			return nil, err
+		}
+		shards = append(shards, shard)
+	}
+	return shards, nil
+}
+
 func commentedShardQueries(shardQueries map[string]*querypb.BoundQuery, trailingComments string) map[string]*querypb.BoundQuery {
 	if trailingComments == "" {
 		return shardQueries

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -102,6 +102,11 @@ func (ln *LookupNonUnique) Delete(vcursor VCursor, rowsColValues [][]sqltypes.Va
 	return ln.lkp.Delete(vcursor, rowsColValues, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid))
 }
 
+// Update updates the entry in the vindex table.
+func (ln *LookupNonUnique) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error {
+	return ln.lkp.Update(vcursor, oldValues, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid), newValues)
+}
+
 // MarshalJSON returns a JSON representation of LookupHash.
 func (ln *LookupNonUnique) MarshalJSON() ([]byte, error) {
 	return json.Marshal(ln.lkp)
@@ -204,6 +209,11 @@ func (lu *LookupUnique) Verify(vcursor VCursor, ids []sqltypes.Value, ksids [][]
 // Create reserves the id by inserting it into the vindex table.
 func (lu *LookupUnique) Create(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte, ignoreMode bool) error {
 	return lu.lkp.Create(vcursor, rowsColValues, ksidsToValues(ksids), ignoreMode)
+}
+
+// Update updates the entry in the vindex table.
+func (lu *LookupUnique) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error {
+	return lu.lkp.Update(vcursor, oldValues, sqltypes.MakeTrusted(sqltypes.VarBinary, ksid), newValues)
 }
 
 // Delete deletes the entry from the vindex table.

--- a/go/vt/vtgate/vindexes/lookup.go
+++ b/go/vt/vtgate/vindexes/lookup.go
@@ -53,8 +53,8 @@ func (ln *LookupNonUnique) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (ln *LookupNonUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, error) {
-	out := make([][][]byte, 0, len(ids))
+func (ln *LookupNonUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([]Ksids, error) {
+	out := make([]Ksids, 0, len(ids))
 	results, err := ln.lkp.Lookup(vcursor, ids)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func (ln *LookupNonUnique) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byt
 		for _, row := range result.Rows {
 			ksids = append(ksids, row[0].ToBytes())
 		}
-		out = append(out, ksids)
+		out = append(out, Ksids{IDs: ksids})
 	}
 	return out, nil
 }

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -127,6 +127,15 @@ func (lh *LookupHash) Create(vcursor VCursor, rowsColValues [][]sqltypes.Value, 
 	return lh.lkp.Create(vcursor, rowsColValues, values, ignoreMode)
 }
 
+// Update updates the entry in the vindex table.
+func (lh *LookupHash) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error {
+	v, err := vunhash(ksid)
+	if err != nil {
+		return fmt.Errorf("lookup.Update.vunhash: %v", err)
+	}
+	return lh.lkp.Update(vcursor, oldValues, sqltypes.NewUint64(v), newValues)
+}
+
 // Delete deletes the entry from the vindex table.
 func (lh *LookupHash) Delete(vcursor VCursor, rowsColValues [][]sqltypes.Value, ksid []byte) error {
 	v, err := vunhash(ksid)
@@ -239,6 +248,15 @@ func (lhu *LookupHashUnique) Delete(vcursor VCursor, rowsColValues [][]sqltypes.
 		return fmt.Errorf("lookup.Delete.vunhash: %v", err)
 	}
 	return lhu.lkp.Delete(vcursor, rowsColValues, sqltypes.NewUint64(v))
+}
+
+// Update updates the entry in the vindex table.
+func (lhu *LookupHashUnique) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error {
+	v, err := vunhash(ksid)
+	if err != nil {
+		return fmt.Errorf("lookup.Update.vunhash: %v", err)
+	}
+	return lhu.lkp.Update(vcursor, oldValues, sqltypes.NewUint64(v), newValues)
 }
 
 // MarshalJSON returns a JSON representation of LookupHashUnique.

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -50,11 +50,21 @@ type LookupHash struct {
 }
 
 // NewLookupHash creates a LookupHash vindex.
+// The supplied map has the following required fields:
+//   table: name of the backing table. It can be qualified by the keyspace.
+//   from: list of columns in the table that have the 'from' values of the lookup vindex.
+//   to: The 'to' column name of the table.
+//
+// The following fields are optional:
+//   autocommit: setting this to "true" will cause inserts to upsert, deletes to be ignored, and updates to fail.
+//   scatter_if_absent: if an entry is missing, this flag will the query to be sent to all shards.
 func NewLookupHash(name string, m map[string]string) (Vindex, error) {
 	lh := &LookupHash{name: name}
-	lh.lkp.Init(m)
+	if err := lh.lkp.Init(m); err != nil {
+		return nil, err
+	}
 	var err error
-	lh.scatterIfAbsent, err = getScatterIfAbsent(m)
+	lh.scatterIfAbsent, err = boolFromMap(m, "scatter_if_absent")
 	if err != nil {
 		return nil, err
 	}
@@ -175,10 +185,19 @@ type LookupHashUnique struct {
 }
 
 // NewLookupHashUnique creates a LookupHashUnique vindex.
+// The supplied map has the following required fields:
+//   table: name of the backing table. It can be qualified by the keyspace.
+//   from: list of columns in the table that have the 'from' values of the lookup vindex.
+//   to: The 'to' column name of the table.
+//
+// The following fields are optional:
+//   autocommit: setting this to "true" will cause inserts to upsert, deletes to be ignored, and updates to fail.
 func NewLookupHashUnique(name string, m map[string]string) (Vindex, error) {
 	lhu := &LookupHashUnique{name: name}
-	lhu.lkp.Init(m)
-	scatter, err := getScatterIfAbsent(m)
+	if err := lhu.lkp.Init(m); err != nil {
+		return nil, err
+	}
+	scatter, err := boolFromMap(m, "scatter_if_absent")
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash.go
+++ b/go/vt/vtgate/vindexes/lookup_hash.go
@@ -64,8 +64,8 @@ func (lh *LookupHash) Cost() int {
 }
 
 // Map returns the corresponding KeyspaceId values for the given ids.
-func (lh *LookupHash) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, error) {
-	out := make([][][]byte, 0, len(ids))
+func (lh *LookupHash) Map(vcursor VCursor, ids []sqltypes.Value) ([]Ksids, error) {
+	out := make([]Ksids, 0, len(ids))
 	results, err := lh.lkp.Lookup(vcursor, ids)
 	if err != nil {
 		return nil, err
@@ -81,7 +81,7 @@ func (lh *LookupHash) Map(vcursor VCursor, ids []sqltypes.Value) ([][][]byte, er
 			}
 			ksids = append(ksids, vhash(num))
 		}
-		out = append(out, ksids)
+		out = append(out, Ksids{IDs: ksids})
 	}
 	return out, nil
 }

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -64,12 +64,16 @@ func TestLookupHashMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want := [][][]byte{{
-		[]byte("\x16k@\xb4J\xbaK\xd6"),
-		[]byte("\x06\xe7\xea\"Βp\x8f"),
+	want := []Ksids{{
+		IDs: [][]byte{
+			[]byte("\x16k@\xb4J\xbaK\xd6"),
+			[]byte("\x06\xe7\xea\"Βp\x8f"),
+		},
 	}, {
-		[]byte("\x16k@\xb4J\xbaK\xd6"),
-		[]byte("\x06\xe7\xea\"Βp\x8f"),
+		IDs: [][]byte{
+			[]byte("\x16k@\xb4J\xbaK\xd6"),
+			[]byte("\x06\xe7\xea\"Βp\x8f"),
+		},
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
@@ -84,7 +88,7 @@ func TestLookupHashMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want = [][][]byte{{}}
+	want = []Ksids{{IDs: [][]byte{}}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %#v, want %#v", got, want)
 	}
@@ -133,7 +137,7 @@ func TestLookupHashVerify(t *testing.T) {
 
 func TestLookupHashCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lookuphash.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
+	err := lookuphash.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
 	if err != nil {
 		t.Error(err)
 	}
@@ -141,7 +145,7 @@ func TestLookupHashCreate(t *testing.T) {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
 
-	err = lookuphash.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, [][]byte{[]byte("bogus")}, false /* ignoreMode */)
+	err = lookuphash.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("bogus")}, false /* ignoreMode */)
 	want := "lookup.Create.vunhash: invalid keyspace id: 626f677573"
 	if err == nil || err.Error() != want {
 		t.Errorf("lookuphash.Create(bogus) err: %v, want %s", err, want)
@@ -150,7 +154,7 @@ func TestLookupHashCreate(t *testing.T) {
 
 func TestLookupHashDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lookuphash.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err := lookuphash.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -158,7 +162,7 @@ func TestLookupHashDelete(t *testing.T) {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
 
-	err = lookuphash.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, []byte("bogus"))
+	err = lookuphash.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("bogus"))
 	want := "lookup.Delete.vunhash: invalid keyspace id: 626f677573"
 	if err == nil || err.Error() != want {
 		t.Errorf("lookuphash.Delete(bogus) err: %v, want %s", err, want)

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -22,25 +22,36 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/sqltypes"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
-var lookuphash Vindex
-var lookuphashunique Vindex
+func TestLookupHashNew(t *testing.T) {
+	l := createLookup(t, "lookup_hash", false)
+	if want, got := l.(*LookupHash).scatterIfAbsent, false; got != want {
+		t.Errorf("Create(lookup, false): %v, want %v", got, want)
+	}
 
-func init() {
-	lh, err := CreateVindex("lookup_hash", "lookup_hash", map[string]string{"table": "t", "from": "fromc", "to": "toc"})
-	if err != nil {
-		panic(err)
+	l = createLookup(t, "lookup_hash", true)
+	if want, got := l.(*LookupHash).scatterIfAbsent, true; got != want {
+		t.Errorf("Create(lookup, false): %v, want %v", got, want)
 	}
-	lu, err := CreateVindex("lookup_hash_unique", "lookup_hash_unique", map[string]string{"table": "t", "from": "fromc", "to": "toc"})
-	if err != nil {
-		panic(err)
+
+	l, err := CreateVindex("lookup_hash", "lookup_hash", map[string]string{
+		"table":             "t",
+		"from":              "fromc",
+		"to":                "toc",
+		"scatter_if_absent": "invalid",
+	})
+	want := "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	if err == nil || err.Error() != want {
+		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
-	lookuphash = lh
-	lookuphashunique = lu
 }
 
 func TestLookupHashCost(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
+	lookuphashunique := createLookup(t, "lookup_hash_unique", false)
+
 	if lookuphash.Cost() != 20 {
 		t.Errorf("Cost(): %d, want 20", lookuphash.Cost())
 	}
@@ -50,6 +61,9 @@ func TestLookupHashCost(t *testing.T) {
 }
 
 func TestLookupHashString(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
+	lookuphashunique := createLookup(t, "lookup_hash_unique", false)
+
 	if strings.Compare("lookup_hash", lookuphash.String()) != 0 {
 		t.Errorf("String(): %s, want lookup_hash", lookuphash.String())
 	}
@@ -59,7 +73,9 @@ func TestLookupHashString(t *testing.T) {
 }
 
 func TestLookupHashMap(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
 	vc := &vcursor{numRows: 2}
+
 	got, err := lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	if err != nil {
 		t.Error(err)
@@ -103,8 +119,39 @@ func TestLookupHashMap(t *testing.T) {
 	vc.mustFail = false
 }
 
+func TestLookupHashMapAbsent(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
+	vc := &vcursor{numRows: 0}
+
+	got, err := lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+	want := []Ksids{{}, {}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map(): %#v, want %+v", got, want)
+	}
+
+	// scatterIfAbsent true should return full keyranges.
+	lookuphash = createLookup(t, "lookup_hash", true)
+	got, err = lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+	want = []Ksids{{
+		Range: &topodatapb.KeyRange{},
+	}, {
+		Range: &topodatapb.KeyRange{},
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Map(): %#v, want %+v", got, want)
+	}
+}
+
 func TestLookupHashVerify(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
 	vc := &vcursor{numRows: 1}
+
 	// The check doesn't actually happen. But we give correct values
 	// to avoid confusion.
 	got, err := lookuphash.Verify(vc,
@@ -133,10 +180,28 @@ func TestLookupHashVerify(t *testing.T) {
 	if err == nil || err.Error() != wantErr {
 		t.Errorf("lookuphash.Verify(bogus) err: %v, want %s", err, wantErr)
 	}
+
+	// scatterIfAbsent true should always yield true.
+	lookuphash = createLookup(t, "lookup_hash", true)
+	vc.queries = nil
+
+	got, err = lookuphash.Verify(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)}, [][]byte{[]byte(""), []byte("")})
+	if err != nil {
+		t.Error(err)
+	}
+	if vc.queries != nil {
+		t.Errorf("lookuphash.Verify(scatter), queries: %v, want nil", vc.queries)
+	}
+	wantBools := []bool{true, true}
+	if !reflect.DeepEqual(got, wantBools) {
+		t.Errorf("lookuphash.Verify(scatter): %v, want %v", got, wantBools)
+	}
 }
 
 func TestLookupHashCreate(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
 	vc := &vcursor{}
+
 	err := lookuphash.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
 	if err != nil {
 		t.Error(err)
@@ -153,7 +218,9 @@ func TestLookupHashCreate(t *testing.T) {
 }
 
 func TestLookupHashDelete(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
 	vc := &vcursor{}
+
 	err := lookuphash.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -27,22 +27,22 @@ import (
 
 func TestLookupHashNew(t *testing.T) {
 	l := createLookup(t, "lookup_hash", false)
-	if want, got := l.(*LookupHash).scatterIfAbsent, false; got != want {
+	if want, got := l.(*LookupHash).writeOnly, false; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
 	}
 
 	l = createLookup(t, "lookup_hash", true)
-	if want, got := l.(*LookupHash).scatterIfAbsent, true; got != want {
+	if want, got := l.(*LookupHash).writeOnly, true; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
 	}
 
 	l, err := CreateVindex("lookup_hash", "lookup_hash", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "invalid",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "invalid",
 	})
-	want := "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	want := "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
@@ -132,7 +132,7 @@ func TestLookupHashMapAbsent(t *testing.T) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 
-	// scatterIfAbsent true should return full keyranges.
+	// writeOnly true should return full keyranges.
 	lookuphash = createLookup(t, "lookup_hash", true)
 	got, err = lookuphash.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	if err != nil {
@@ -181,7 +181,7 @@ func TestLookupHashVerify(t *testing.T) {
 		t.Errorf("lookuphash.Verify(bogus) err: %v, want %s", err, wantErr)
 	}
 
-	// scatterIfAbsent true should always yield true.
+	// writeOnly true should always yield true.
 	lookuphash = createLookup(t, "lookup_hash", true)
 	vc.queries = nil
 

--- a/go/vt/vtgate/vindexes/lookup_hash_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_test.go
@@ -235,3 +235,16 @@ func TestLookupHashDelete(t *testing.T) {
 		t.Errorf("lookuphash.Delete(bogus) err: %v, want %s", err, want)
 	}
 }
+
+func TestLookupHashUpdate(t *testing.T) {
+	lookuphash := createLookup(t, "lookup_hash", false)
+	vc := &vcursor{}
+
+	err := lookuphash.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("\x16k@\xb4J\xbaK\xd6"), []sqltypes.Value{sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := len(vc.queries), 2; got != want {
+		t.Errorf("vc.queries length: %v, want %v", got, want)
+	}
+}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -184,3 +184,16 @@ func TestLookupHashUniqueDelete(t *testing.T) {
 		t.Errorf("lhu.Delete(bogus) err: %v, want %s", err, want)
 	}
 }
+
+func TestLookupHashUniqueUpdate(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
+	vc := &vcursor{}
+
+	err := lhu.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("\x16k@\xb4J\xbaK\xd6"), []sqltypes.Value{sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := len(vc.queries), 2; got != want {
+		t.Errorf("vc.queries length: %v, want %v", got, want)
+	}
+}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -27,23 +27,23 @@ func TestLookupHashUniqueNew(t *testing.T) {
 	_ = createLookup(t, "lookup_hash_unique", false)
 
 	_, err := CreateVindex("lookup_hash_unique", "lookup_hash_unique", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "true",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "true",
 	})
-	want := "scatter_if_absent cannot be true for a unique lookup vindex"
+	want := "write_only cannot be true for a unique lookup vindex"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
 
 	_, err = CreateVindex("lookup_hash_unique", "lookup_hash_unique", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "invalid",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "invalid",
 	})
-	want = "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	want = "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_hash_unique_test.go
@@ -23,24 +23,43 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 )
 
-var lhu Vindex
+func TestLookupHashUniqueNew(t *testing.T) {
+	_ = createLookup(t, "lookup_hash_unique", false)
 
-func init() {
-	h, err := CreateVindex("lookup_hash_unique", "nn", map[string]string{"table": "t", "from": "fromc", "to": "toc"})
-	if err != nil {
-		panic(err)
+	_, err := CreateVindex("lookup_hash_unique", "lookup_hash_unique", map[string]string{
+		"table":             "t",
+		"from":              "fromc",
+		"to":                "toc",
+		"scatter_if_absent": "true",
+	})
+	want := "scatter_if_absent cannot be true for a unique lookup vindex"
+	if err == nil || err.Error() != want {
+		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
-	lhu = h
+
+	_, err = CreateVindex("lookup_hash_unique", "lookup_hash_unique", map[string]string{
+		"table":             "t",
+		"from":              "fromc",
+		"to":                "toc",
+		"scatter_if_absent": "invalid",
+	})
+	want = "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	if err == nil || err.Error() != want {
+		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
+	}
 }
 
 func TestLookupHashUniqueCost(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
 	if lhu.Cost() != 10 {
 		t.Errorf("Cost(): %d, want 10", lhu.Cost())
 	}
 }
 
 func TestLookupHashUniqueMap(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
 	vc := &vcursor{numRows: 1}
+
 	got, err := lhu.(Unique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	if err != nil {
 		t.Error(err)
@@ -95,7 +114,9 @@ func TestLookupHashUniqueMap(t *testing.T) {
 }
 
 func TestLookupHashUniqueVerify(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
 	vc := &vcursor{numRows: 1}
+
 	// The check doesn't actually happen. But we give correct values
 	// to avoid confusion.
 	got, err := lhu.Verify(vc,
@@ -127,8 +148,10 @@ func TestLookupHashUniqueVerify(t *testing.T) {
 }
 
 func TestLookupHashUniqueCreate(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
 	vc := &vcursor{}
-	err := lhu.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
+
+	err := lhu.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
 	if err != nil {
 		t.Error(err)
 	}
@@ -136,7 +159,7 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
 
-	err = lhu.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, [][]byte{[]byte("bogus")}, false /* ignoreMode */)
+	err = lhu.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("bogus")}, false /* ignoreMode */)
 	want := "lookup.Create.vunhash: invalid keyspace id: 626f677573"
 	if err == nil || err.Error() != want {
 		t.Errorf("lhu.Create(bogus) err: %v, want %s", err, want)
@@ -144,8 +167,10 @@ func TestLookupHashUniqueCreate(t *testing.T) {
 }
 
 func TestLookupHashUniqueDelete(t *testing.T) {
+	lhu := createLookup(t, "lookup_hash_unique", false)
 	vc := &vcursor{}
-	err := lhu.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
+
+	err := lhu.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -153,7 +178,7 @@ func TestLookupHashUniqueDelete(t *testing.T) {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
 
-	err = lhu.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, []byte("bogus"))
+	err = lhu.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("bogus"))
 	want := "lookup.Delete.vunhash: invalid keyspace id: 626f677573"
 	if err == nil || err.Error() != want {
 		t.Errorf("lhu.Delete(bogus) err: %v, want %s", err, want)

--- a/go/vt/vtgate/vindexes/lookup_internal.go
+++ b/go/vt/vtgate/vindexes/lookup_internal.go
@@ -160,6 +160,14 @@ func (lkp *lookupInternal) Delete(vcursor VCursor, rowsColValues [][]sqltypes.Va
 	return nil
 }
 
+// Update implements the update functionality.
+func (lkp *lookupInternal) Update(vcursor VCursor, oldValues []sqltypes.Value, ksid sqltypes.Value, newValues []sqltypes.Value) error {
+	if err := lkp.Delete(vcursor, [][]sqltypes.Value{oldValues}, ksid); err != nil {
+		return err
+	}
+	return lkp.Create(vcursor, [][]sqltypes.Value{newValues}, []sqltypes.Value{ksid}, false /* ignoreMode */)
+}
+
 func (lkp *lookupInternal) initDelStm() string {
 	var delBuffer bytes.Buffer
 	fmt.Fprintf(&delBuffer, "delete from %s where ", lkp.Table)

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -33,13 +33,23 @@ import (
 // They also test lookupInternal functionality.
 
 type vcursor struct {
-	mustFail bool
-	numRows  int
-	result   *sqltypes.Result
-	queries  []*querypb.BoundQuery
+	mustFail    bool
+	numRows     int
+	result      *sqltypes.Result
+	queries     []*querypb.BoundQuery
+	autocommits int
 }
 
 func (vc *vcursor) Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+	return vc.execute(method, query, bindvars, isDML)
+}
+
+func (vc *vcursor) ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
+	vc.autocommits++
+	return vc.execute(method, query, bindvars, isDML)
+}
+
+func (vc *vcursor) execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error) {
 	vc.queries = append(vc.queries, &querypb.BoundQuery{
 		Sql:           query,
 		BindVariables: bindvars,
@@ -280,6 +290,51 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 	vc.mustFail = false
 }
 
+func TestLookupNonUniqueCreateAutocommit(t *testing.T) {
+	lookupNonUnique, err := CreateVindex("lookup", "lookup", map[string]string{
+		"table":      "t",
+		"from":       "from1,from2",
+		"to":         "toc",
+		"autocommit": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vc := &vcursor{}
+
+	err = lookupNonUnique.(Lookup).Create(
+		vc,
+		[][]sqltypes.Value{{
+			sqltypes.NewInt64(1), sqltypes.NewInt64(2),
+		}, {
+			sqltypes.NewInt64(3), sqltypes.NewInt64(4),
+		}},
+		[][]byte{[]byte("test1"), []byte("test2")},
+		false /* ignoreMode */)
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantqueries := []*querypb.BoundQuery{{
+		Sql: "insert into t(from1, from2, toc) values(:from10, :from20, :toc0), (:from11, :from21, :toc1) on duplicate key update from1=values(from1), from2=values(from2), toc=values(toc)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"from10": sqltypes.Int64BindVariable(1),
+			"from20": sqltypes.Int64BindVariable(2),
+			"toc0":   sqltypes.BytesBindVariable([]byte("test1")),
+			"from11": sqltypes.Int64BindVariable(3),
+			"from21": sqltypes.Int64BindVariable(4),
+			"toc1":   sqltypes.BytesBindVariable([]byte("test2")),
+		},
+	}}
+	if !reflect.DeepEqual(vc.queries, wantqueries) {
+		t.Errorf("lookup.Create queries:\n%v, want\n%v", vc.queries, wantqueries)
+	}
+
+	if got, want := vc.autocommits, 1; got != want {
+		t.Errorf("Create(autocommit) count: %d, want %d", got, want)
+	}
+}
+
 func TestLookupNonUniqueDelete(t *testing.T) {
 	lookupNonUnique := createLookup(t, "lookup", false)
 	vc := &vcursor{}
@@ -314,6 +369,33 @@ func TestLookupNonUniqueDelete(t *testing.T) {
 		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
 	}
 	vc.mustFail = false
+}
+
+func TestLookupNonUniqueUpdate(t *testing.T) {
+	lookupNonUnique := createLookup(t, "lookup", false)
+	vc := &vcursor{}
+
+	err := lookupNonUnique.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("test"), []sqltypes.Value{sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+
+	wantqueries := []*querypb.BoundQuery{{
+		Sql: "delete from t where fromc = :fromc and toc = :toc",
+		BindVariables: map[string]*querypb.BindVariable{
+			"fromc": sqltypes.Int64BindVariable(1),
+			"toc":   sqltypes.BytesBindVariable([]byte("test")),
+		},
+	}, {
+		Sql: "insert into t(fromc, toc) values(:fromc0, :toc0)",
+		BindVariables: map[string]*querypb.BindVariable{
+			"fromc0": sqltypes.Int64BindVariable(2),
+			"toc0":   sqltypes.BytesBindVariable([]byte("test")),
+		},
+	}}
+	if !reflect.DeepEqual(vc.queries, wantqueries) {
+		t.Errorf("lookup.Update queries:\n%v, want\n%v", vc.queries, wantqueries)
+	}
 }
 
 func createLookup(t *testing.T, name string, scatterIfAbsent bool) Vindex {

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -82,22 +82,22 @@ func (vc *vcursor) execute(method string, query string, bindvars map[string]*que
 
 func TestLookupNonUniqueNew(t *testing.T) {
 	l := createLookup(t, "lookup", false)
-	if want, got := l.(*LookupNonUnique).scatterIfAbsent, false; got != want {
+	if want, got := l.(*LookupNonUnique).writeOnly, false; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
 	}
 
 	l = createLookup(t, "lookup", true)
-	if want, got := l.(*LookupNonUnique).scatterIfAbsent, true; got != want {
+	if want, got := l.(*LookupNonUnique).writeOnly, true; got != want {
 		t.Errorf("Create(lookup, false): %v, want %v", got, want)
 	}
 
 	l, err := CreateVindex("lookup", "lookup", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "invalid",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "invalid",
 	})
-	want := "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	want := "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
@@ -178,7 +178,7 @@ func TestLookupNonUniqueMapAbsent(t *testing.T) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
 	}
 
-	// scatterIfAbsent true should return full keyranges.
+	// writeOnly true should return full keyranges.
 	lookupNonUnique = createLookup(t, "lookup", true)
 	got, err = lookupNonUnique.(NonUnique).Map(vc, []sqltypes.Value{sqltypes.NewInt64(1), sqltypes.NewInt64(2)})
 	if err != nil {
@@ -229,7 +229,7 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 	}
 	vc.mustFail = false
 
-	// scatterIfAbsent true should always yield true.
+	// writeOnly true should always yield true.
 	lookupNonUnique = createLookup(t, "lookup", true)
 	vc.queries = nil
 
@@ -238,11 +238,11 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 		t.Error(err)
 	}
 	if vc.queries != nil {
-		t.Errorf("lookup.Verify(scatter), queries: %v, want nil", vc.queries)
+		t.Errorf("lookup.Verify(writeOnly), queries: %v, want nil", vc.queries)
 	}
 	wantBools := []bool{true, true}
 	if !reflect.DeepEqual(got, wantBools) {
-		t.Errorf("lookup.Verify(scatter): %v, want %v", got, wantBools)
+		t.Errorf("lookup.Verify(writeOnly): %v, want %v", got, wantBools)
 	}
 }
 
@@ -398,17 +398,17 @@ func TestLookupNonUniqueUpdate(t *testing.T) {
 	}
 }
 
-func createLookup(t *testing.T, name string, scatterIfAbsent bool) Vindex {
+func createLookup(t *testing.T, name string, writeOnly bool) Vindex {
 	t.Helper()
-	scatter := "false"
-	if scatterIfAbsent {
-		scatter = "true"
+	write := "false"
+	if writeOnly {
+		write = "true"
 	}
 	l, err := CreateVindex(name, name, map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": scatter,
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": write,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/go/vt/vtgate/vindexes/lookup_test.go
+++ b/go/vt/vtgate/vindexes/lookup_test.go
@@ -104,12 +104,16 @@ func TestLookupNonUniqueMap(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want := [][][]byte{{
-		[]byte("1"),
-		[]byte("2"),
+	want := []Ksids{{
+		IDs: [][]byte{
+			[]byte("1"),
+			[]byte("2"),
+		},
 	}, {
-		[]byte("1"),
-		[]byte("2"),
+		IDs: [][]byte{
+			[]byte("1"),
+			[]byte("2"),
+		},
 	}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Map(): %#v, want %+v", got, want)
@@ -176,7 +180,7 @@ func TestLookupNonUniqueVerify(t *testing.T) {
 
 func TestLookupNonUniqueCreate(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}, []sqltypes.Value{sqltypes.NewInt64(2)}}, [][]byte{[]byte("test1"), []byte("test2")}, false /* ignoreMode */)
+	err := lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, [][]byte{[]byte("test1"), []byte("test2")}, false /* ignoreMode */)
 	if err != nil {
 		t.Error(err)
 	}
@@ -196,7 +200,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 
 	// With ignore.
 	vc.queries = nil
-	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}, []sqltypes.Value{sqltypes.NewInt64(2)}}, [][]byte{[]byte("test1"), []byte("test2")}, true /* ignoreMode */)
+	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, [][]byte{[]byte("test1"), []byte("test2")}, true /* ignoreMode */)
 	if err != nil {
 		t.Error(err)
 	}
@@ -208,7 +212,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 
 	// Test query fail.
 	vc.mustFail = true
-	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
+	err = lookupNonUnique.(Lookup).Create(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, [][]byte{[]byte("\x16k@\xb4J\xbaK\xd6")}, false /* ignoreMode */)
 	want := "lookup.Create: execute failed"
 	if err == nil || err.Error() != want {
 		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)
@@ -218,7 +222,7 @@ func TestLookupNonUniqueCreate(t *testing.T) {
 
 func TestLookupNonUniqueDelete(t *testing.T) {
 	vc := &vcursor{}
-	err := lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}, []sqltypes.Value{sqltypes.NewInt64(2)}}, []byte("test"))
+	err := lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}, {sqltypes.NewInt64(2)}}, []byte("test"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -242,7 +246,7 @@ func TestLookupNonUniqueDelete(t *testing.T) {
 
 	// Test query fail.
 	vc.mustFail = true
-	err = lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{[]sqltypes.Value{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
+	err = lookupNonUnique.(Lookup).Delete(vc, [][]sqltypes.Value{{sqltypes.NewInt64(1)}}, []byte("\x16k@\xb4J\xbaK\xd6"))
 	want := "lookup.Delete: execute failed"
 	if err == nil || err.Error() != want {
 		t.Errorf("lookupNonUnique(query fail) err: %v, want %s", err, want)

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -28,23 +28,23 @@ func TestLookupUniqueNew(t *testing.T) {
 	_ = createLookup(t, "lookup_unique", false)
 
 	_, err := CreateVindex("lookup_unique", "lookup_unique", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "true",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "true",
 	})
-	want := "scatter_if_absent cannot be true for a unique lookup vindex"
+	want := "write_only cannot be true for a unique lookup vindex"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}
 
 	_, err = CreateVindex("lookup_unique", "lookup_unique", map[string]string{
-		"table":             "t",
-		"from":              "fromc",
-		"to":                "toc",
-		"scatter_if_absent": "invalid",
+		"table":      "t",
+		"from":       "fromc",
+		"to":         "toc",
+		"write_only": "invalid",
 	})
-	want = "scatter_if_absent value must be 'true' or 'false': 'invalid'"
+	want = "write_only value must be 'true' or 'false': 'invalid'"
 	if err == nil || err.Error() != want {
 		t.Errorf("Create(bad_scatter): %v, want %s", err, want)
 	}

--- a/go/vt/vtgate/vindexes/lookup_unique_test.go
+++ b/go/vt/vtgate/vindexes/lookup_unique_test.go
@@ -145,3 +145,16 @@ func TestLookupUniqueDelete(t *testing.T) {
 		t.Errorf("vc.queries length: %v, want %v", got, want)
 	}
 }
+
+func TestLookupUniqueUpdate(t *testing.T) {
+	lookupUnique := createLookup(t, "lookup_unique", false)
+	vc := &vcursor{}
+
+	err := lookupUnique.(Lookup).Update(vc, []sqltypes.Value{sqltypes.NewInt64(1)}, []byte("test"), []sqltypes.Value{sqltypes.NewInt64(2)})
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := len(vc.queries), 2; got != want {
+		t.Errorf("vc.queries length: %v, want %v", got, want)
+	}
+}

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -32,6 +32,7 @@ import (
 // can use this interface to execute lookup queries.
 type VCursor interface {
 	Execute(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
+	ExecuteAutocommit(method string, query string, bindvars map[string]*querypb.BindVariable, isDML bool) (*sqltypes.Result, error)
 }
 
 // Vindex defines the interface required to register a vindex.

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -111,7 +111,11 @@ type Lookup interface {
 	// Create creates an association between ids and ksids. If ignoreMode
 	// is true, then the Create should ignore dup key errors.
 	Create(vc VCursor, rowsColValues [][]sqltypes.Value, ksids [][]byte, ignoreMode bool) error
-	Delete(VCursor, [][]sqltypes.Value, []byte) error
+
+	Delete(vc VCursor, rowsColValues [][]sqltypes.Value, ksid []byte) error
+
+	// Update replaces the mapping of old values with new values for a keyspace id.
+	Update(vc VCursor, oldValues []sqltypes.Value, ksid []byte, newValues []sqltypes.Value) error
 }
 
 // A NewVindexFunc is a function that creates a Vindex based on the

--- a/go/vt/vtgate/vindexes/vindex.go
+++ b/go/vt/vtgate/vindexes/vindex.go
@@ -22,6 +22,7 @@ import (
 	"github.com/youtube/vitess/go/sqltypes"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 // This file defines interfaces and registration for vindexes.
@@ -62,10 +63,17 @@ type Unique interface {
 	Map(cursor VCursor, ids []sqltypes.Value) ([][]byte, error)
 }
 
+// Ksids represents keyspace ids. It's either a list of keyspace ids
+// or a keyrange.
+type Ksids struct {
+	Range *topodatapb.KeyRange
+	IDs   [][]byte
+}
+
 // NonUnique defines the interface for a non-unique vindex.
 // This means that an id can map to multiple keyspace ids.
 type NonUnique interface {
-	Map(cursor VCursor, ids []sqltypes.Value) ([][][]byte, error)
+	Map(cursor VCursor, ids []sqltypes.Value) ([]Ksids, error)
 }
 
 // IsUnique returns true if the Vindex is Unique.

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -47,6 +47,8 @@ func NewSTFU(name string, params map[string]string) (Vindex, error) {
 	return &stFU{name: name, Params: params}, nil
 }
 
+var _ Unique = (*stFU)(nil)
+
 // stF satisfies Functional, but no Map. Invalid vindex.
 type stF struct {
 	name   string
@@ -67,16 +69,20 @@ type stLN struct {
 	Params map[string]string
 }
 
-func (v *stLN) String() string                                           { return v.name }
-func (*stLN) Cost() int                                                  { return 0 }
-func (*stLN) Verify(VCursor, []sqltypes.Value, [][]byte) ([]bool, error) { return []bool{}, nil }
-func (*stLN) Map(VCursor, []sqltypes.Value) ([]Ksids, error)             { return nil, nil }
-func (*stLN) Create(VCursor, [][]sqltypes.Value, [][]byte, bool) error   { return nil }
-func (*stLN) Delete(VCursor, [][]sqltypes.Value, []byte) error           { return nil }
+func (v *stLN) String() string                                                 { return v.name }
+func (*stLN) Cost() int                                                        { return 0 }
+func (*stLN) Verify(VCursor, []sqltypes.Value, [][]byte) ([]bool, error)       { return []bool{}, nil }
+func (*stLN) Map(VCursor, []sqltypes.Value) ([]Ksids, error)                   { return nil, nil }
+func (*stLN) Create(VCursor, [][]sqltypes.Value, [][]byte, bool) error         { return nil }
+func (*stLN) Delete(VCursor, [][]sqltypes.Value, []byte) error                 { return nil }
+func (*stLN) Update(VCursor, []sqltypes.Value, []byte, []sqltypes.Value) error { return nil }
 
 func NewSTLN(name string, params map[string]string) (Vindex, error) {
 	return &stLN{name: name, Params: params}, nil
 }
+
+var _ NonUnique = (*stLN)(nil)
+var _ Lookup = (*stLN)(nil)
 
 // stLU satisfies Lookup, Unique.
 type stLU struct {
@@ -84,16 +90,20 @@ type stLU struct {
 	Params map[string]string
 }
 
-func (v *stLU) String() string                                           { return v.name }
-func (*stLU) Cost() int                                                  { return 2 }
-func (*stLU) Verify(VCursor, []sqltypes.Value, [][]byte) ([]bool, error) { return []bool{}, nil }
-func (*stLU) Map(VCursor, []sqltypes.Value) ([][]byte, error)            { return nil, nil }
-func (*stLU) Create(VCursor, [][]sqltypes.Value, [][]byte, bool) error   { return nil }
-func (*stLU) Delete(VCursor, [][]sqltypes.Value, []byte) error           { return nil }
+func (v *stLU) String() string                                                 { return v.name }
+func (*stLU) Cost() int                                                        { return 2 }
+func (*stLU) Verify(VCursor, []sqltypes.Value, [][]byte) ([]bool, error)       { return []bool{}, nil }
+func (*stLU) Map(VCursor, []sqltypes.Value) ([][]byte, error)                  { return nil, nil }
+func (*stLU) Create(VCursor, [][]sqltypes.Value, [][]byte, bool) error         { return nil }
+func (*stLU) Delete(VCursor, [][]sqltypes.Value, []byte) error                 { return nil }
+func (*stLU) Update(VCursor, []sqltypes.Value, []byte, []sqltypes.Value) error { return nil }
 
 func NewSTLU(name string, params map[string]string) (Vindex, error) {
 	return &stLU{name: name, Params: params}, nil
 }
+
+var _ Unique = (*stLU)(nil)
+var _ Lookup = (*stLU)(nil)
 
 func init() {
 	Register("stfu", NewSTFU)

--- a/go/vt/vtgate/vindexes/vschema_test.go
+++ b/go/vt/vtgate/vindexes/vschema_test.go
@@ -70,7 +70,7 @@ type stLN struct {
 func (v *stLN) String() string                                           { return v.name }
 func (*stLN) Cost() int                                                  { return 0 }
 func (*stLN) Verify(VCursor, []sqltypes.Value, [][]byte) ([]bool, error) { return []bool{}, nil }
-func (*stLN) Map(VCursor, []sqltypes.Value) ([][][]byte, error)          { return nil, nil }
+func (*stLN) Map(VCursor, []sqltypes.Value) ([]Ksids, error)             { return nil, nil }
 func (*stLN) Create(VCursor, [][]sqltypes.Value, [][]byte, bool) error   { return nil }
 func (*stLN) Delete(VCursor, [][]sqltypes.Value, []byte) error           { return nil }
 


### PR DESCRIPTION
Commits:
* change the vindex protocol allowing a non-unique vindex to return either a keyrange or keyspace ids.
* change lookup vindexes to support a new flag: "scatter_if_absent" that will cause it to return the full keyrange if an entry is not found. This behavior is changed in a newer commit.
* change the vindex protocol and requires Lookup vindexes to supply the Update function. This allow them to be more efficient, and some vindexes can choose to return an error if they cannot support it.
* add "autocommit" flag for lookup vindexes. Please see the commit comments for the associated behavior changes.
* change "scatter_if_absent" to "write_only".