### PR TITLE
Fix truncate sharded keyspace 

### DIFF
--- a/go/vt/sqlparser/analyzer.go
+++ b/go/vt/sqlparser/analyzer.go
@@ -81,7 +81,7 @@ func Preview(sql string) int {
 		return StmtRollback
 	}
 	switch loweredFirstWord {
-	case "create", "alter", "rename", "drop":
+	case "create", "alter", "rename", "drop", "truncate":
 		return StmtDDL
 	case "set":
 		return StmtSet
@@ -89,7 +89,7 @@ func Preview(sql string) int {
 		return StmtShow
 	case "use":
 		return StmtUse
-	case "analyze", "describe", "desc", "explain", "repair", "optimize", "truncate":
+	case "analyze", "describe", "desc", "explain", "repair", "optimize":
 		return StmtOther
 	}
 	if strings.Index(trimmed, "/*!") == 0 {

--- a/go/vt/sqlparser/analyzer_test.go
+++ b/go/vt/sqlparser/analyzer_test.go
@@ -61,7 +61,7 @@ func TestPreview(t *testing.T) {
 		{"explain", StmtOther},
 		{"repair", StmtOther},
 		{"optimize", StmtOther},
-		{"truncate", StmtOther},
+		{"truncate", StmtDDL},
 		{"unknown", StmtUnknown},
 
 		{"/* leading comment */ select ...", StmtSelect},

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -767,7 +767,6 @@ func TestExecutorOther(t *testing.T) {
 		"explain",
 		"repair",
 		"optimize",
-		"truncate",
 	}
 	wantCount := []int64{0, 0, 0}
 	for _, stmt := range stmts {
@@ -818,6 +817,7 @@ func TestExecutorDDL(t *testing.T) {
 		"alter",
 		"rename",
 		"drop",
+		"truncate",
 	}
 	wantCount := []int64{0, 0, 0}
 	for _, stmt := range stmts {

--- a/test/vtgatev3_test.py
+++ b/test/vtgatev3_test.py
@@ -921,7 +921,6 @@ class TestVTGateFunctions(unittest.TestCase):
         'vt_lookup', 'select name, user2_id from name_user2_map')
     self.assertEqual(result, (('name1', 1L), ('name1', 7L), ('name2', 2L),
                               ('name2', 3L)))
-    vtgate_conn.commit()
     vtgate_conn.begin()
     result = vtgate_conn._execute(
         'truncate vt_user2',


### PR DESCRIPTION
### Description

There was a bug in `TRUNCATE` statements for sharded keyspaces. `Preview`  method also needed to be updated, otherwise statement was being parsed as `StmtOther`. 
