### PR TITLE
helm: add Orchestrator 3.0 using raft

### DIFF
--- a/docker/k8s/Dockerfile
+++ b/docker/k8s/Dockerfile
@@ -21,6 +21,7 @@ COPY --from=base /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificat
 COPY --from=base /vt/bin/mysqlctld /vt/bin/
 COPY --from=base /vt/bin/vtctld /vt/bin/
 COPY --from=base /vt/bin/vtctl /vt/bin/
+COPY --from=base /vt/bin/vtctlclient /vt/bin/
 COPY --from=base /vt/bin/vtgate /vt/bin/
 COPY --from=base /vt/bin/vttablet /vt/bin/
 COPY --from=base /vt/bin/vtworker /vt/bin/

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -1,0 +1,20 @@
+FROM vitess/k8s AS k8s
+
+FROM debian:stretch-slim
+
+# Copy certs to allow https calls
+COPY --from=k8s /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# Copy vtctlclient to be used to notify 
+COPY --from=k8s /vt/bin/vtctlclient /usr/bin/
+
+RUN apt-get update && \
+    apt-get upgrade -qq && \
+    apt-get install wget -qq --no-install-recommends && \
+    wget https://github.com/github/orchestrator/releases/download/v3.0.6/orchestrator_3.0.6_amd64.deb && \
+    dpkg -i orchestrator_3.0.6_amd64.deb && \
+    rm orchestrator_3.0.6_amd64.deb && \
+    apt-get purge wget -qq && \
+    apt-get autoremove -qq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/docker/k8s/orchestrator/Dockerfile
+++ b/docker/k8s/orchestrator/Dockerfile
@@ -18,3 +18,6 @@ RUN apt-get update && \
     apt-get autoremove -qq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/orchestrator
+CMD ["./orchestrator", "--config=/conf/orchestrator.conf.json", "http"]

--- a/helm/vitess/README.md
+++ b/helm/vitess/README.md
@@ -250,3 +250,15 @@ pmm:
     env:
       metricsMemory: "3000000"
 ```
+
+### Enable Orchestrator
+#### NOTE: This requires at least Kubernetes 1.9
+
+```
+topology:
+  cells:
+    ...
+
+orchestrator:
+  enabled: true
+```

--- a/helm/vitess/templates/NOTES.txt
+++ b/helm/vitess/templates/NOTES.txt
@@ -8,6 +8,7 @@ To access administrative web pages, start a proxy with:
 
 Then use the following URLs:
 
-vtctld: {{$proxyURL}}/services/vtctld:web/app/
-vtgate: {{$proxyURL}}/services/vtgate-{{$cell}}:web/
-{{ if $.Values.pmm.enabled }}   pmm: {{$proxyURL}}/services/pmm:web/{{ end }}
+      vtctld: {{$proxyURL}}/services/vtctld:web/app/
+      vtgate: {{$proxyURL}}/services/vtgate-{{$cell}}:web/
+{{ if $.Values.orchestrator.enabled }}orchestrator: {{$proxyURL}}/services/orchestrator:web/{{ end }}
+{{ if $.Values.pmm.enabled }}         pmm: {{$proxyURL}}/services/pmm:web/{{ end }}

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -117,7 +117,7 @@ data:
     "ReduceReplicationAnalysisCount": true,
     "RejectHostnameResolvePattern": "",
     "RemoveTextFromHostnameDisplay": ".mydomain.com:3306",
-    "ReplicationLagQuery": "select round(absolute_lag) from meta.heartbeat_view",
+    "ReplicationLagQuery": "SELECT unix_timestamp() - floor(ts/1000000000) FROM `_vt`.heartbeat WHERE keyspaceShard='KEYSPACE:SHARD';",
     "ServeAgentsHttp": false,
     "SkipBinlogEventsContaining": [
     ],

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -1,0 +1,163 @@
+###################################
+# Orchestrator Config
+###################################
+{{- define "orchestrator-config" -}}
+# set tuple values to more recognizable variables
+{{- $orc := index . 0 -}}
+{{- $namespace := index . 1 -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: orchestrator-cm
+data: 
+  orchestrator.conf.json: |-
+    {
+    "AccessTokenExpiryMinutes": 1440,
+    "AccessTokenUseExpirySeconds": 60,
+    "ActiveNodeExpireSeconds": 5,
+    "AgentPollMinutes": 60,
+    "AgentsServerPort": ":3001",
+    "AgentSSLCAFile": "",
+    "AgentSSLCertFile": "",
+    "AgentSSLPrivateKeyFile": "",
+    "AgentSSLSkipVerify": false,
+    "AgentSSLValidOUs": [
+    ],
+    "AgentsUseMutualTLS": false,
+    "AgentsUseSSL": false,
+    "ApplyMySQLPromotionAfterMasterFailover": true,
+    "AuditLogFile": "/tmp/orchestrator-audit.log",
+    "AuditToSyslog": false,
+    "AuthenticationMethod": "",
+    "AuthUserHeader": "",
+    "AutoPseudoGTID": false,
+    "BackendDB": "sqlite",
+    "BinlogEventsChunkSize": 10000,
+    "CandidateInstanceExpireMinutes": 60,
+    "ClusterNameToAlias": {
+        "127.0.0.1": "test suite"
+    },
+    "CoMasterRecoveryMustPromoteOtherCoMaster": true,
+    "DataCenterPattern": "[.]([^.]+)[.][^.]+[.]mydomain[.]com",
+    "Debug": true,
+    "DefaultInstancePort": 3306,
+    "DefaultRaftPort": 10008,
+    "DetachLostSlavesAfterMasterFailover": true,
+    "DetectClusterAliasQuery": "SELECT value FROM _vt.local_metadata WHERE name='ClusterAlias'",
+    "DetectClusterDomainQuery": "",
+    "DetectInstanceAliasQuery": "SELECT value FROM _vt.local_metadata WHERE name='Alias'",
+    "DetectPromotionRuleQuery": "SELECT value FROM _vt.local_metadata WHERE name='PromotionRule'",
+    "DetectPseudoGTIDQuery": "",
+    "DetectSemiSyncEnforcedQuery": "SELECT @@global.rpl_semi_sync_master_wait_no_slave AND @@global.rpl_semi_sync_master_timeout > 1000000",
+    "DiscoverByShowSlaveHosts": true,
+    "EnableSyslog": false,
+    "ExpiryHostnameResolvesMinutes": 60,
+    "FailureDetectionPeriodBlockMinutes": 60,
+    "GraphiteAddr": "",
+    "GraphiteConvertHostnameDotsToUnderscores": true,
+    "GraphitePath": "",
+    "HostnameResolveMethod": "none",
+    "HTTPAuthPassword": "",
+    "HTTPAuthUser": "",
+    "InstanceBulkOperationsWaitTimeoutSeconds": 10,
+    "InstancePollSeconds": 12,
+    "ListenAddress": ":3000",
+    "MasterFailoverLostInstancesDowntimeMinutes": 0,
+    "MySQLConnectTimeoutSeconds": 1,
+    "MySQLHostnameResolveMethod": "none",
+    "MySQLTopologyCredentialsConfigFile": "",
+    "MySQLTopologyMaxPoolConnections": 3,
+    "MySQLTopologyPassword": "orc_client_user_password",
+    "MySQLTopologyReadTimeoutSeconds": 3,
+    "MySQLTopologySSLCAFile": "",
+    "MySQLTopologySSLCertFile": "",
+    "MySQLTopologySSLPrivateKeyFile": "",
+    "MySQLTopologySSLSkipVerify": true,
+    "MySQLTopologyUseMutualTLS": false,
+    "MySQLTopologyUser": "orc_client_user",
+    "OnFailureDetectionProcesses": [
+        "echo 'Detected {failureType} on {failureCluster}. Affected replicas: {countSlaves}' >> /tmp/recovery.log"
+    ],
+    "OSCIgnoreHostnameFilters": [
+    ],
+    "PhysicalEnvironmentPattern": "[.]([^.]+[.][^.]+)[.]mydomain[.]com",
+    "PostFailoverProcesses": [
+        "echo '(for all types) Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Successor: {successorHost}:{successorPort}' >> /tmp/recovery.log"
+    ],
+    "PostIntermediateMasterFailoverProcesses": [
+        "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Successor: {successorHost}:{successorPort}' >> /tmp/recovery.log"
+    ],
+    "PostMasterFailoverProcesses": [
+        "echo 'Recovered from {failureType} on {failureCluster}. Failed: {failedHost}:{failedPort}; Promoted: {successorHost}:{successorPort}' >> /tmp/recovery.log",
+        "vtctlclient -server vtctld.{{ $namespace }}:15999 TabletExternallyReparented {successorAlias}"
+    ],
+    "PostponeSlaveRecoveryOnLagMinutes": 0,
+    "PostUnsuccessfulFailoverProcesses": [
+    ],
+    "PowerAuthUsers": [
+        "*"
+    ],
+    "PreFailoverProcesses": [
+        "echo 'Will recover from {failureType} on {failureCluster}' >> /tmp/recovery.log"
+    ],
+    "ProblemIgnoreHostnameFilters": [
+    ],
+    "PromotionIgnoreHostnameFilters": [
+    ],
+    "PseudoGTIDMonotonicHint": "asc:",
+    "PseudoGTIDPattern": "drop view if exists .*?`_pseudo_gtid_hint__",
+    "RaftAdvertise": "POD_NAME.{{ $namespace }}",
+    "RaftBind": "POD_NAME",
+    "RaftDataDir": "/var/lib/orchestrator",
+    "RaftEnabled": true,
+    "RaftNodes": [
+    {{ range $i := until (int $orc.replicas) }}
+        "orchestrator-{{ $i }}.{{ $namespace }}"{{ if lt $i (sub (int64 $orc.replicas) 1) }},{{ end }}
+    {{ end }}
+    ],
+    "ReadLongRunningQueries": false,
+    "ReadOnly": false,
+    "ReasonableMaintenanceReplicationLagSeconds": 20,
+    "ReasonableReplicationLagSeconds": 10,
+    "RecoverIntermediateMasterClusterFilters": [
+        "_intermediate_master_pattern_"
+    ],
+    "RecoverMasterClusterFilters": [
+        ".*"
+    ],
+    "RecoveryIgnoreHostnameFilters": [
+    ],
+    "RecoveryPeriodBlockMinutes": 1,
+    "RecoveryPeriodBlockSeconds": 60,
+    "ReduceReplicationAnalysisCount": true,
+    "RejectHostnameResolvePattern": "",
+    "RemoveTextFromHostnameDisplay": ".mydomain.com:3306",
+    "ReplicationLagQuery": "select round(absolute_lag) from meta.heartbeat_view",
+    "SeedAcceptableBytesDiff": 8192,
+    "ServeAgentsHttp": false,
+    "SkipBinlogEventsContaining": [
+    ],
+    "SkipBinlogServerUnresolveCheck": true,
+    "SkipMaxScaleCheck": true,
+    "SkipOrchestratorDatabaseUpdate": false,
+    "SlaveLagQuery": "",
+    "SlaveStartPostWaitMilliseconds": 1000,
+    "SnapshotTopologiesIntervalHours": 0,
+    "SQLite3DataFile": ":memory:",
+    "SSLCAFile": "",
+    "SSLCertFile": "",
+    "SSLPrivateKeyFile": "",
+    "SSLSkipVerify": false,
+    "SSLValidOUs": [
+    ],
+    "StaleSeedFailMinutes": 60,
+    "StatusEndpoint": "/api/status",
+    "StatusOUVerify": false,
+    "UnseenAgentForgetHours": 6,
+    "UnseenInstanceForgetHours": 240,
+    "UseMutualTLS": false,
+    "UseSSL": false,
+    "VerifyReplicationFilters": false
+    }
+{{ end }}

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -117,7 +117,7 @@ data:
     "ReduceReplicationAnalysisCount": true,
     "RejectHostnameResolvePattern": "",
     "RemoveTextFromHostnameDisplay": ".mydomain.com:3306",
-    "ReplicationLagQuery": "SELECT unix_timestamp() - floor(ts/1000000000) FROM `_vt`.heartbeat WHERE keyspaceShard='KEYSPACE:SHARD';",
+    "ReplicationLagQuery": "SELECT unix_timestamp() - floor(ts/1000000000) FROM `_vt`.heartbeat ORDER BY ts DESC LIMIT 1;",
     "ServeAgentsHttp": false,
     "SkipBinlogEventsContaining": [
     ],

--- a/helm/vitess/templates/_orchestrator-conf.tpl
+++ b/helm/vitess/templates/_orchestrator-conf.tpl
@@ -13,19 +13,7 @@ metadata:
 data: 
   orchestrator.conf.json: |-
     {
-    "AccessTokenExpiryMinutes": 1440,
-    "AccessTokenUseExpirySeconds": 60,
     "ActiveNodeExpireSeconds": 5,
-    "AgentPollMinutes": 60,
-    "AgentsServerPort": ":3001",
-    "AgentSSLCAFile": "",
-    "AgentSSLCertFile": "",
-    "AgentSSLPrivateKeyFile": "",
-    "AgentSSLSkipVerify": false,
-    "AgentSSLValidOUs": [
-    ],
-    "AgentsUseMutualTLS": false,
-    "AgentsUseSSL": false,
     "ApplyMySQLPromotionAfterMasterFailover": true,
     "AuditLogFile": "/tmp/orchestrator-audit.log",
     "AuditToSyslog": false,
@@ -35,9 +23,6 @@ data:
     "BackendDB": "sqlite",
     "BinlogEventsChunkSize": 10000,
     "CandidateInstanceExpireMinutes": 60,
-    "ClusterNameToAlias": {
-        "127.0.0.1": "test suite"
-    },
     "CoMasterRecoveryMustPromoteOtherCoMaster": true,
     "DataCenterPattern": "[.]([^.]+)[.][^.]+[.]mydomain[.]com",
     "Debug": true,
@@ -61,7 +46,7 @@ data:
     "HTTPAuthPassword": "",
     "HTTPAuthUser": "",
     "InstanceBulkOperationsWaitTimeoutSeconds": 10,
-    "InstancePollSeconds": 12,
+    "InstancePollSeconds": 5,
     "ListenAddress": ":3000",
     "MasterFailoverLostInstancesDowntimeMinutes": 0,
     "MySQLConnectTimeoutSeconds": 1,
@@ -121,27 +106,24 @@ data:
     "ReasonableMaintenanceReplicationLagSeconds": 20,
     "ReasonableReplicationLagSeconds": 10,
     "RecoverIntermediateMasterClusterFilters": [
-        "_intermediate_master_pattern_"
+        "*"
     ],
     "RecoverMasterClusterFilters": [
         ".*"
     ],
     "RecoveryIgnoreHostnameFilters": [
     ],
-    "RecoveryPeriodBlockMinutes": 1,
     "RecoveryPeriodBlockSeconds": 60,
     "ReduceReplicationAnalysisCount": true,
     "RejectHostnameResolvePattern": "",
     "RemoveTextFromHostnameDisplay": ".mydomain.com:3306",
     "ReplicationLagQuery": "select round(absolute_lag) from meta.heartbeat_view",
-    "SeedAcceptableBytesDiff": 8192,
     "ServeAgentsHttp": false,
     "SkipBinlogEventsContaining": [
     ],
     "SkipBinlogServerUnresolveCheck": true,
     "SkipMaxScaleCheck": true,
     "SkipOrchestratorDatabaseUpdate": false,
-    "SlaveLagQuery": "",
     "SlaveStartPostWaitMilliseconds": 1000,
     "SnapshotTopologiesIntervalHours": 0,
     "SQLite3DataFile": ":memory:",

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -1,0 +1,170 @@
+###################################
+# Master Orchestrator Service
+###################################
+{{- define "orchestrator" -}}
+# set tuple values to more recognizable variables
+{{- $orc := index . 0 -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator
+  labels:
+    app: vitess
+    component: orchestrator
+spec:
+  ports:
+    - name: web
+      port: 80
+      targetPort: 3000
+  selector:
+    app: vitess
+    component: orchestrator
+  type: ClusterIP
+
+---
+
+###################################
+# Headless Orchestrator Service
+###################################
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator-headless
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  labels:
+    app: vitess
+    component: orchestrator
+spec:
+  clusterIP: None
+  ports:
+    - name: web
+      port: 80
+      targetPort: 3000
+    - name: raft
+      port: 10008
+      targetPort: 10008
+  selector:
+    component: orchestrator
+    app: vitess
+
+---
+
+###################################
+# Orchestrator StatefulSet
+###################################
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: orchestrator
+spec:
+  serviceName: orchestrator-headless
+  replicas: {{ $orc.replicas }}
+  podManagementPolicy: Parallel
+  updateStrategy: 
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: vitess
+      component: orchestrator
+  template:
+    metadata:
+      labels:
+        app: vitess
+        component: orchestrator
+    spec:
+      containers:
+        - name: orchestrator
+          image: {{ $orc.image }}
+          ports:
+            - containerPort: 3000
+              name: web
+              protocol: TCP
+            - containerPort: 10008
+              name: raft
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 300
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "/api/leader-check"
+              port: 3000
+            timeoutSeconds: 10
+          volumeMounts:
+            - name: config-volume
+              mountPath: /conf/
+          resources:
+{{ toYaml ($orc.resources ) | indent 12 }}
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VTCTLD_SERVER_PORT
+              value: "15999"
+          
+          command: ["bash"]
+          args:
+            - "-c"
+            - |
+              set -ex
+
+              # set the local config to advertise/bind its own service IP
+              sed -i -e "s/POD_NAME/$MY_POD_NAME/g" /conf/orchestrator.conf.json
+
+              cd /usr/local/orchestrator && ./orchestrator --config=/conf/orchestrator.conf.json http
+
+        - name: recovery-log
+          image: busybox
+          command: ["/bin/sh"]
+          args: ["-c", "tail -n+1 -F /tmp/recovery.log"]
+
+        - name: audit-log
+          image: busybox
+          command: ["/bin/sh"]
+          args: ["-c", "tail -n+1 -F /tmp/orchestrator-audit.log"]
+
+      volumes:
+        - name: config-volume
+          configMap:
+            name: orchestrator-cm
+{{- end -}}
+
+###################################
+# Per StatefulSet Orchestrator Service
+###################################
+{{- define "orchestrator-statefulset-services" -}}
+# set tuple values to more recognizable variables
+{{- $orc := index . 0 -}}
+{{- $i := index . 1 -}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: orchestrator-{{ $i }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  labels:
+    app: vitess
+    component: orchestrator
+spec:
+  ports:
+    - name: web
+      port: 80
+      targetPort: 3000
+    - name: raft
+      port: 10008
+      targetPort: 10008
+  selector:
+    component: orchestrator
+    app: vitess
+    # this should be auto-filled by kubernetes
+    statefulset.kubernetes.io/pod-name: "orchestrator-{{ $i }}"
+
+{{- end -}}

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -75,12 +75,25 @@ spec:
         app: vitess
         component: orchestrator
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          # strongly prefer to stay away from other orchestrators
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app: "vitess"
+                  component: "orchestrator"
+
       initContainers:
 {{ include "init-orchestrator" $orc | indent 8 }}
 
       containers:
         - name: orchestrator
           image: {{ $orc.image | quote }}
+          imagePullPolicy: Always
           ports:
             - containerPort: 3000
               name: web

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -87,7 +87,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /api/lb-check
               port: 3000
             initialDelaySeconds: 300
             timeoutSeconds: 10
@@ -139,7 +139,7 @@ spec:
 ###################################
 # Per StatefulSet Orchestrator Service
 ###################################
-{{- define "orchestrator-statefulset-services" -}}
+{{- define "orchestrator-statefulset-service" -}}
 # set tuple values to more recognizable variables
 {{- $orc := index . 0 -}}
 {{- $i := index . 1 -}}

--- a/helm/vitess/templates/_orchestrator.tpl
+++ b/helm/vitess/templates/_orchestrator.tpl
@@ -106,6 +106,8 @@ spec:
           volumeMounts:
             - name: config-shared
               mountPath: /conf/
+            - name: tmplogs
+              mountPath: /tmp
 
           env:
             - name: VTCTLD_SERVER_PORT
@@ -115,17 +117,25 @@ spec:
           image: busybox
           command: ["/bin/sh"]
           args: ["-c", "tail -n+1 -F /tmp/recovery.log"]
+          volumeMounts:
+            - name: tmplogs
+              mountPath: /tmp
 
         - name: audit-log
           image: busybox
           command: ["/bin/sh"]
           args: ["-c", "tail -n+1 -F /tmp/orchestrator-audit.log"]
+          volumeMounts:
+            - name: tmplogs
+              mountPath: /tmp
 
       volumes:
         - name: config-map
           configMap:
             name: orchestrator-cm
         - name: config-shared
+          emptyDir: {}
+        - name: tmplogs
           emptyDir: {}
 
 {{- end -}}

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -324,6 +324,7 @@ spec:
         -enable_semi_sync
         -enable_replication_reporter
 {{ if $orc.enabled }}
+        -heartbeat_enable
         -orc_api_url "http://orchestrator.{{ $namespace }}/api"
         -orc_discover_interval "5m"
 {{ end }}

--- a/helm/vitess/templates/_vttablet.tpl
+++ b/helm/vitess/templates/_vttablet.tpl
@@ -46,6 +46,7 @@ spec:
 {{- $namespace := index . 6 -}}
 {{- $config := index . 7 -}}
 {{- $pmm := index . 8 -}}
+{{- $orc := index . 9 -}}
 
 # sanitize inputs to create tablet name
 {{- $cellClean := include "clean-label" $cell.name -}}
@@ -102,7 +103,7 @@ spec:
 
       containers:
 {{ include "cont-mysql" (tuple $topology $cell $keyspace $shard $tablet $defaultVttablet $uid) | indent 8 }}
-{{ include "cont-vttablet" (tuple $topology $cell $keyspace $shard $tablet $defaultVttablet $vitessTag $uid $namespace $config) | indent 8 }}
+{{ include "cont-vttablet" (tuple $topology $cell $keyspace $shard $tablet $defaultVttablet $vitessTag $uid $namespace $config $orc) | indent 8 }}
 {{ include "cont-mysql-errorlog" . | indent 8 }}
 {{ include "cont-mysql-slowlog" . | indent 8 }}
 {{ if $pmm.enabled }}{{ include "cont-pmm-client" (tuple $pmm $namespace) | indent 8 }}{{ end }}
@@ -242,6 +243,7 @@ spec:
 {{- $uid := index . 7 -}}
 {{- $namespace := index . 8 -}}
 {{- $config := index . 9 -}}
+{{- $orc := index . 10 -}}
 
 {{- $cellClean := include "clean-label" $cell.name -}}
 {{- with $tablet.vttablet -}}
@@ -321,6 +323,10 @@ spec:
         -db-config-filtered-charset "utf8"
         -enable_semi_sync
         -enable_replication_reporter
+{{ if $orc.enabled }}
+        -orc_api_url "http://orchestrator.{{ $namespace }}/api"
+        -orc_discover_interval "5m"
+{{ end }}
 {{ include "backup-flags" $config.backup | indent 8 }}
       END_OF_COMMAND
       )

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -9,6 +9,22 @@
 ---
 {{ end }}
 
+{{ if $.Values.orchestrator.enabled }}
+
+# create orchestrator global services and StatefulSet
+{{ include "orchestrator" (tuple $.Values.orchestrator) }}
+---
+# create orchestrator config map
+{{ include "orchestrator-config" (tuple $.Values.orchestrator $.Release.Namespace) }}
+---
+# create a Service per StatefulSet replica
+{{ range $i := until (int $.Values.orchestrator.replicas) }}
+{{ include "orchestrator-statefulset-services" (tuple $.Values.orchestrator $i) }}
+---
+{{ end }}
+
+{{ end }}
+
 # create an etcd cluster for the global topology
 {{- $replicas := $.Values.topology.globalCell.replicas | default $.Values.etcd.replicas -}}
 {{- $version := $.Values.topology.globalCell.version | default $.Values.etcd.version -}}
@@ -39,7 +55,7 @@
     {{ range $shard := $keyspace.shards }}
       {{ range $tablet := $shard.tablets }}
 ---
-{{ include "vttablet" (tuple $.Values.topology $cell $keyspace $shard $tablet $.Values.vttablet $.Release.Namespace $.Values.config $.Values.pmm) }}
+{{ include "vttablet" (tuple $.Values.topology $cell $keyspace $shard $tablet $.Values.vttablet $.Release.Namespace $.Values.config $.Values.pmm $.Values.orchestrator) }}
       {{ end }} # range $tablet
     {{ end }} # range $shard
   {{ end }} # range $keyspace

--- a/helm/vitess/templates/vitess.yaml
+++ b/helm/vitess/templates/vitess.yaml
@@ -19,7 +19,7 @@
 ---
 # create a Service per StatefulSet replica
 {{ range $i := until (int $.Values.orchestrator.replicas) }}
-{{ include "orchestrator-statefulset-services" (tuple $.Values.orchestrator $i) }}
+{{ include "orchestrator-statefulset-service" (tuple $.Values.orchestrator $i) }}
 ---
 {{ end }}
 

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -207,3 +207,13 @@ pmm:
       # The limit affects only memory reserved for data chunks. Actual RAM usage by Prometheus is higher. 
       # It is recommended to set this limit to roughly 2/3 of the total memory that you are planning to allow for Prometheus.
       metricsMemory: "600000"
+
+# Default values for orchestrator resources defined in 'topology'.
+orchestrator:
+  enabled: true
+  image: "vitess/orchestrator:3.0.6"
+  replicas: 3
+  resources:
+    limits:
+      memory: "512Mi"
+      cpu: "100m"

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -214,6 +214,6 @@ orchestrator:
   image: "vitess/orchestrator:3.0.6"
   replicas: 3
   resources:
-    limits:
-      memory: "512Mi"
+    requests:
       cpu: "100m"
+      memory: "64Mi"

--- a/helm/vitess/values.yaml
+++ b/helm/vitess/values.yaml
@@ -208,9 +208,10 @@ pmm:
       # It is recommended to set this limit to roughly 2/3 of the total memory that you are planning to allow for Prometheus.
       metricsMemory: "600000"
 
-# Default values for orchestrator resources defined in 'topology'.
+# Orchestrator requires at least Kubernetes 1.9 to work
+# Default values for orchestrator resources
 orchestrator:
-  enabled: true
+  enabled: false
   image: "vitess/orchestrator:3.0.6"
   replicas: 3
   resources:


### PR DESCRIPTION
Since this is my first time using Orchestrator, I'm going to document my workflow here to try and make a review easier.

After running a diff from the original helm config for orchestrator against the valid config entries, here are items that are no longer configurable.

```
"ActiveNodeExpireSeconds": 12
"AgentAutoDiscover": false
"AuditPageSize": 20
"AuditPurgeDays": 365
"BufferBinlogEvents": true
"DatabaselessMode__experimental": false
"DiscoveryPollSeconds": 5
"HttpTimeoutSeconds": 60
"MaintenanceExpireMinutes": 10
"MaintenanceOwner": "orchestrator"
"MaintenancePurgeDays": 365
"MySQLTopologyMaxPoolConnections": 3
"ReadLongRunningQueries": true
"RecoveryPollSeconds": 10
"SlaveStartPostWaitMilliseconds": 1000
"StatusSimpleHealth": true
```