### PR TITLE
for dba workload, dont enforce transaction timeout

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -283,7 +283,7 @@ func (qre *QueryExecutor) execDmlAutoCommit() (reply *sqltypes.Result, err error
 }
 
 func (qre *QueryExecutor) execAsTransaction(f func(conn *TxConnection) (*sqltypes.Result, error)) (reply *sqltypes.Result, err error) {
-	conn, err := qre.tsv.te.txPool.LocalBegin(qre.ctx, qre.options.GetClientFoundRows(), qre.options.GetTransactionIsolation())
+	conn, err := qre.tsv.te.txPool.LocalBegin(qre.ctx, qre.options)
 	if err != nil {
 		return nil, err
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -681,7 +681,7 @@ func (tsv *TabletServer) Begin(ctx context.Context, target *querypb.Target, opti
 				// TODO(erez): I think this should be RESOURCE_EXHAUSTED.
 				return vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "Transaction throttled")
 			}
-			transactionID, err = tsv.te.txPool.Begin(ctx, options.GetClientFoundRows(), options.GetTransactionIsolation())
+			transactionID, err = tsv.te.txPool.Begin(ctx, options)
 			logStats.TransactionID = transactionID
 			return err
 		},

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -224,7 +224,7 @@ outer:
 		if txid > maxid {
 			maxid = txid
 		}
-		conn, err := te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+		conn, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 		if err != nil {
 			allErr.RecordError(err)
 			continue

--- a/go/vt/vttablet/tabletserver/tx_engine_test.go
+++ b/go/vt/vttablet/tabletserver/tx_engine_test.go
@@ -49,7 +49,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Normal close with timeout wait.
 	te.Open()
-	c, err := te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	c, err := te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close.
 	te.Open()
-	c, err = te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.Open()
-	c, err = te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestTxEngineClose(t *testing.T) {
 	// Normal close with short grace period, but pool gets empty early.
 	te.shutdownGracePeriod = 250 * time.Millisecond
 	te.Open()
-	c, err = te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestTxEngineClose(t *testing.T) {
 
 	// Immediate close, but connection is in use.
 	te.Open()
-	c, err = te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	c, err = te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/vt/vttablet/tabletserver/tx_executor.go
+++ b/go/vt/vttablet/tabletserver/tx_executor.go
@@ -68,7 +68,7 @@ func (txe *TxExecutor) Prepare(transactionID int64, dtid string) error {
 		return vterrors.Errorf(vtrpcpb.Code_RESOURCE_EXHAUSTED, "prepare failed for transaction %d: %v", transactionID, err)
 	}
 
-	localConn, err := txe.te.txPool.LocalBegin(txe.ctx, false, querypb.ExecuteOptions_DEFAULT)
+	localConn, err := txe.te.txPool.LocalBegin(txe.ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func (txe *TxExecutor) CommitPrepared(dtid string) error {
 func (txe *TxExecutor) markFailed(ctx context.Context, dtid string) {
 	tabletenv.InternalErrors.Add("TwopcCommit", 1)
 	txe.te.preparedPool.SetFailed(dtid)
-	conn, err := txe.te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	conn, err := txe.te.txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		log.Errorf("markFailed: Begin failed for dtid %s: %v", dtid, err)
 		return
@@ -170,7 +170,7 @@ func (txe *TxExecutor) RollbackPrepared(dtid string, originalID int64) error {
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("ROLLBACK_PREPARED", time.Now())
-	conn, err := txe.te.txPool.LocalBegin(txe.ctx, false, querypb.ExecuteOptions_DEFAULT)
+	conn, err := txe.te.txPool.LocalBegin(txe.ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		goto returnConn
 	}
@@ -200,7 +200,7 @@ func (txe *TxExecutor) CreateTransaction(dtid string, participants []*querypb.Ta
 		return vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "2pc is not enabled")
 	}
 	defer tabletenv.QueryStats.Record("CREATE_TRANSACTION", time.Now())
-	conn, err := txe.te.txPool.LocalBegin(txe.ctx, false, querypb.ExecuteOptions_DEFAULT)
+	conn, err := txe.te.txPool.LocalBegin(txe.ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func (txe *TxExecutor) SetRollback(dtid string, transactionID int64) error {
 		txe.te.txPool.Rollback(txe.ctx, transactionID)
 	}
 
-	conn, err := txe.te.txPool.LocalBegin(txe.ctx, false, querypb.ExecuteOptions_DEFAULT)
+	conn, err := txe.te.txPool.LocalBegin(txe.ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func (txe *TxExecutor) ConcludeTransaction(dtid string) error {
 	}
 	defer tabletenv.QueryStats.Record("RESOLVE", time.Now())
 
-	conn, err := txe.te.txPool.LocalBegin(txe.ctx, false, querypb.ExecuteOptions_DEFAULT)
+	conn, err := txe.te.txPool.LocalBegin(txe.ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		return err
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -49,7 +49,7 @@ func TestTxPoolExecuteRollback(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
 	ctx := context.Background()
-	transactionID, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	transactionID, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,11 +76,11 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
 	ctx := context.Background()
-	txid1, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	txid1, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	_, err = txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,12 +101,15 @@ func TestTxPoolRollbackNonBusy(t *testing.T) {
 	}
 }
 
-func TestTxPoolTransactionKiller(t *testing.T) {
-	sql := "alter table test_table add test_column int"
+func TestTxPoolTransactionKillerEnforceTimeoutEnabled(t *testing.T) {
+	sqlWithTimeout := "alter table test_table add test_column int"
+	sqlWithoutTimeout := "alter table test_table add test_column_no_timeout int"
 	db := fakesqldb.New(t)
 	defer db.Close()
-	db.AddQuery(sql, &sqltypes.Result{})
+	db.AddQuery(sqlWithTimeout, &sqltypes.Result{})
+	db.AddQuery(sqlWithoutTimeout, &sqltypes.Result{})
 	db.AddQuery("begin", &sqltypes.Result{})
+	db.AddQuery("rollback", &sqltypes.Result{})
 
 	txPool := newTxPool()
 	// make sure transaction killer will run frequent enough
@@ -115,22 +118,69 @@ func TestTxPoolTransactionKiller(t *testing.T) {
 	defer txPool.Close()
 	ctx := context.Background()
 	killCount := tabletenv.KillStats.Counts()["Transactions"]
-	transactionID, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+
+	txWithoutTimeout, err := addQuery(ctx, sqlWithoutTimeout, txPool, querypb.ExecuteOptions_DBA)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if _, err := addQuery(ctx, sqlWithTimeout, txPool, querypb.ExecuteOptions_UNSPECIFIED); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		killCountDiff int64
+		expectedKills = int64(1)
+		timeoutCh     = time.After(5 * time.Second)
+	)
+
+	// transaction killer should kill the query the second query
+	for {
+		killCountDiff = tabletenv.KillStats.Counts()["Transactions"] - killCount
+		if killCountDiff >= expectedKills {
+			break
+		}
+
+		select {
+		case <-timeoutCh:
+			t.Fatal("waited too long for timed transaction to be killed by transaction killer")
+		default:
+		}
+	}
+
+	if killCountDiff > expectedKills {
+		t.Fatalf("expected only %v query to be killed, but got %v killed", expectedKills, killCountDiff)
+	}
+
+	txPool.Rollback(ctx, txWithoutTimeout)
+	txPool.WaitForEmpty()
+
+	if got, expected := db.GetQueryCalledNum("begin"), 2; got != expected {
+		t.Fatalf("'begin' called: got=%v, expected=%v", got, expected)
+	}
+	if got, expected := db.GetQueryCalledNum(sqlWithoutTimeout), 1; got != expected {
+		t.Fatalf("'%v' called: got=%v, expected=%v", sqlWithoutTimeout, got, expected)
+	}
+	if got, expected := db.GetQueryCalledNum(sqlWithTimeout), 1; got != expected {
+		t.Fatalf("'%v' called: got=%v, expected=%v", sqlWithTimeout, got, expected)
+	}
+	if got, expected := db.GetQueryCalledNum("rollback"), 1; got != expected {
+		t.Fatalf("'rollback' called: got=%v, expected=%v", got, expected)
+	}
+
+}
+func addQuery(ctx context.Context, sql string, txPool *TxPool, workload querypb.ExecuteOptions_Workload) (int64, error) {
+	transactionID, err := txPool.Begin(ctx, &querypb.ExecuteOptions{Workload: workload})
+	if err != nil {
+		return 0, err
 	}
 	txConn, err := txPool.Get(transactionID, "for query")
 	if err != nil {
-		t.Fatal(err)
+		return 0, err
 	}
-	txConn.RecordQuery(sql)
+	txConn.Exec(ctx, sql, 1, false)
 	txConn.Recycle()
-	// transaction killer should kill the query
-	txPool.WaitForEmpty()
-	killCountDiff := tabletenv.KillStats.Counts()["Transactions"] - killCount
-	if killCountDiff != 1 {
-		t.Fatalf("query: %s should be killed by transaction killer", sql)
-	}
+	return transactionID, nil
 }
 
 func TestTxPoolClientRowsFound(t *testing.T) {
@@ -146,7 +196,7 @@ func TestTxPoolClientRowsFound(t *testing.T) {
 
 	// Start a 'normal' transaction. It should take a connection
 	// for the normal 'conns' pool.
-	id1, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	id1, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +209,7 @@ func TestTxPoolClientRowsFound(t *testing.T) {
 
 	// Start a 'foundRows' transaction. It should take a connection
 	// from the foundRows pool.
-	id2, err := txPool.Begin(ctx, true, querypb.ExecuteOptions_DEFAULT)
+	id2, err := txPool.Begin(ctx, &querypb.ExecuteOptions{ClientFoundRows: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,13 +250,13 @@ func TestTxPoolTransactionIsolation(t *testing.T) {
 	ctx := context.Background()
 
 	// Start a transaction with default. It should not change isolation.
-	_, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	_, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	db.AddQuery("set transaction isolation level READ COMMITTED", &sqltypes.Result{})
-	_, err = txPool.Begin(ctx, false, querypb.ExecuteOptions_READ_COMMITTED)
+	_, err = txPool.Begin(ctx, &querypb.ExecuteOptions{TransactionIsolation: querypb.ExecuteOptions_READ_COMMITTED})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +281,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2006_Transient(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	txConn, err := txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	txConn, err := txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatalf("Begin should have succeeded after the retry in DBConn.Exec(): %v", err)
 	}
@@ -262,7 +312,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2006_Permanent(t *testing.T) {
 	// After that, vttablet will automatically try to reconnect and this fail.
 	// DBConn.Exec() will return the reconnect error as final error and not the
 	// initial connection error.
-	_, err = txPool.LocalBegin(context.Background(), false, querypb.ExecuteOptions_DEFAULT)
+	_, err = txPool.LocalBegin(context.Background(), &querypb.ExecuteOptions{})
 	if err == nil || !strings.Contains(err.Error(), "(errno 2013)") {
 		t.Fatalf("Begin did not return the reconnect error: %v", err)
 	}
@@ -288,7 +338,7 @@ func TestTxPoolBeginWithPoolConnectionError_Errno2013(t *testing.T) {
 	db.EnableShouldClose()
 
 	// 2013 is not retryable. DBConn.Exec() fails after the first attempt.
-	_, err = txPool.Begin(context.Background(), false, querypb.ExecuteOptions_DEFAULT)
+	_, err = txPool.Begin(context.Background(), &querypb.ExecuteOptions{})
 	if err == nil || !strings.Contains(err.Error(), "(errno 2013)") {
 		t.Fatalf("Begin must return connection error with MySQL errno 2013: %v", err)
 	}
@@ -311,7 +361,7 @@ func primeTxPoolWithConnection(t *testing.T) (*fakesqldb.DB, *TxPool, error) {
 	db.AddQuery("begin", &sqltypes.Result{})
 	db.AddQuery("rollback", &sqltypes.Result{})
 	ctx := context.Background()
-	txConn, err := txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	txConn, err := txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -328,7 +378,7 @@ func TestTxPoolBeginWithError(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
 	ctx := context.Background()
-	_, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	_, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	want := "error: rejected"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Errorf("Begin: %v, want %s", err, want)
@@ -350,7 +400,7 @@ func TestTxPoolRollbackFail(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 	defer txPool.Close()
 	ctx := context.Background()
-	transactionID, err := txPool.Begin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	transactionID, err := txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -395,7 +445,7 @@ func TestTxPoolExecFailDueToConnFail_Errno2006(t *testing.T) {
 	ctx := context.Background()
 
 	// Start the transaction.
-	txConn, err := txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	txConn, err := txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +483,7 @@ func TestTxPoolExecFailDueToConnFail_Errno2013(t *testing.T) {
 	ctx := context.Background()
 
 	// Start the transaction.
-	txConn, err := txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
+	txConn, err := txPool.LocalBegin(ctx, &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +514,7 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 	txPool.Open(db.ConnParams(), db.ConnParams(), db.ConnParams())
 
 	// Start stray transaction.
-	_, err := txPool.Begin(context.Background(), false, querypb.ExecuteOptions_DEFAULT)
+	_, err := txPool.Begin(context.Background(), &querypb.ExecuteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
@sougou 

This treats the transaction timeout similarly to the existing request context for DBA workloads. Now that we're passing in yet another option into Begin, I changed it to take the full ExecuteOptions instead of the individual args.

Note: I left the idle connection calculation alone. This only applies to `GetOutdated`