### PR TITLE
vtgate: Handle SET for `sql_auto_is_null`

### DIFF
--- a/go/vt/vtexplain/vtexplain_vttablet.go
+++ b/go/vt/vtexplain/vtexplain_vttablet.go
@@ -286,6 +286,15 @@ func initTabletEnvironment(ddls []*sqlparser.DDL, opts *Options) error {
 				{sqltypes.NewVarBinary("1")},
 			},
 		},
+		"select @@sql_auto_is_null": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("0")},
+			},
+		},
 		"show variables like 'binlog_format'": {
 			Fields: []*querypb.Field{{
 				Type: sqltypes.VarChar,

--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -471,6 +471,19 @@ func (e *Executor) handleSet(ctx context.Context, safeSession *SafeSession, sql 
 				safeSession.Options = &querypb.ExecuteOptions{}
 			}
 			safeSession.Options.SqlSelectLimit = val
+		case "sql_auto_is_null":
+			val, ok := v.(int64)
+			if !ok {
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value type for sql_auto_is_null: %T", v)
+			}
+			switch val {
+			case 0:
+				// This is the default setting for MySQL. Do nothing.
+			case 1:
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "sql_auto_is_null is not currently supported")
+			default:
+				return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "unexpected value for sql_auto_is_null: %d", val)
+			}
 		case "character_set_results":
 			// This is a statement that mysql-connector-j sends at the beginning. We return a canned response for it.
 			switch v {

--- a/go/vt/vtgate/executor_test.go
+++ b/go/vt/vtgate/executor_test.go
@@ -329,6 +329,12 @@ func TestExecutorSet(t *testing.T) {
 	}, {
 		in:  "set skip_query_plan_cache = 0",
 		out: &vtgatepb.Session{Autocommit: true, Options: &querypb.ExecuteOptions{}},
+	}, {
+		in:  "set sql_auto_is_null = 0",
+		out: &vtgatepb.Session{Autocommit: true}, // no effect
+	}, {
+		in:  "set sql_auto_is_null = 1",
+		err: "sql_auto_is_null is not currently supported",
 	}}
 	for _, tcase := range testcases {
 		session := NewSafeSession(&vtgatepb.Session{Autocommit: true})

--- a/go/vt/vttablet/tabletserver/query_executor_test.go
+++ b/go/vt/vttablet/tabletserver/query_executor_test.go
@@ -2107,6 +2107,15 @@ func getQueryExecutorSupportedQueries(testTableHasMultipleUniqueKeys bool) map[s
 				{sqltypes.NewVarBinary("1")},
 			},
 		},
+		"select @@sql_auto_is_null": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("0")},
+			},
+		},
 		"show variables like 'binlog_format'": {
 			Fields: []*querypb.Field{{
 				Type: sqltypes.VarChar,

--- a/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
+++ b/go/vt/vttablet/tabletserver/schema/schematest/schematest.go
@@ -57,6 +57,15 @@ func Queries() map[string]*sqltypes.Result {
 				{sqltypes.NewVarBinary("1")},
 			},
 		},
+		"select @@sql_auto_is_null": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("0")},
+			},
+		},
 		"show variables like 'binlog_format'": {
 			Fields: []*querypb.Field{{
 				Type: sqltypes.VarChar,

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2897,6 +2897,15 @@ func getSupportedQueries() map[string]*sqltypes.Result {
 				{sqltypes.NewVarBinary("1")},
 			},
 		},
+		"select @@sql_auto_is_null": {
+			Fields: []*querypb.Field{{
+				Type: sqltypes.Uint64,
+			}},
+			RowsAffected: 1,
+			Rows: [][]sqltypes.Value{
+				{sqltypes.NewVarBinary("0")},
+			},
+		},
 		"show variables like 'binlog_format'": {
 			Fields: []*querypb.Field{{
 				Type: sqltypes.VarChar,


### PR DESCRIPTION
Hi @sougou! Here's a small patch to improve compatibility with Ruby on Rails for the MySQL layer. I know you discussed this briefly with @arthurnn in chat.

I would also love it if there was a way for Vitess (probably the vttablets) to ensure that `sql_auto_is_null` has not been enabled manually by the user (i.e. in the MySQL configs), because the feature is insane and it's gonna break stuff. I haven't found the right place to add the check tho.

---

Many ORMs (most notably Rails' ActiveRecord and Django) start their
MySQL connections with a `SET sql_auto_is_null=0`.

This setting is superfluous in all MySQL engines that are supported by
Vitess, where `sql_auto_is_null` is always disabled by default.
Furthermore, it doesn't seem feasible to actually implement this feature
in Vitess because of sharded queries.

Because of this, we propose handling the case where the feature is set
to 0 (i.e. a no-op), and returning an explicit error when somebody tries
to actually enable the feature.

This improves the compatibility of Vitess' MySQL layer with these ORMs,
and improves the UX for users attempting to enable `sql_auto_is_null` in
a connection.