### PR TITLE
Fix Node.js can not query problem

### DIFF
--- a/go/mysql/query.go
+++ b/go/mysql/query.go
@@ -507,7 +507,7 @@ func (c *Conn) writeColumnDefinition(field *querypb.Field) error {
 	pos = writeByte(data, pos, byte(typ))
 	pos = writeUint16(data, pos, uint16(flags))
 	pos = writeByte(data, pos, byte(field.Decimals))
-	pos += 2
+	pos = writeUint16(data, pos, uint16(0x0000))
 
 	if pos != len(data) {
 		return fmt.Errorf("internal error: packing of column definition used %v bytes instead of %v", pos, len(data))


### PR DESCRIPTION
 Node.js mysql driver can not query from vitess, becase COM_QUERY response's filler Fields value not 0x00. 
Nodejs driver has a check on the filler field.
`if (filler[0] !== 0x0 || filler[1] !== 0x0) {
      var err  = new TypeError('Received invalid filler');
      err.code = 'PARSER_INVALID_FILLER';
      throw err;
  }`
[https://github.com/mysqljs/mysql/blob/3f371ca18a46150fc1fe1b8bb31a099b9f62f2fb/lib/protocol/packets/FieldPacket.js#L43](url)

https://dev.mysql.com/doc/internals/en/com-query-response.html

