### PR TITLE
Fix for show vindexes, not picking the correct stat

### DIFF
--- a/go/vt/vtgate/executor.go
+++ b/go/vt/vtgate/executor.go
@@ -574,7 +574,7 @@ func (e *Executor) handleShow(ctx context.Context, safeSession *SafeSession, sql
 					s.Cell,
 					s.Target.Keyspace,
 					s.Target.Shard,
-					ts.Tablet.Type.String(),
+					ts.Target.TabletType.String(),
 					state,
 					topoproto.TabletAliasString(ts.Tablet.Alias),
 					ts.Tablet.Hostname,


### PR DESCRIPTION
###  Description

Fixes small bug where is `show vitess_tablets` is not fetching tablet type from the right source. 