### PR TITLE
helm: remove hyphens from readme

### DIFF
--- a/helm/vitess/README.md
+++ b/helm/vitess/README.md
@@ -61,7 +61,7 @@ topology:
       mysqlProtocol:
         enabled: false
       keyspaces:
-        - name: "unsharded-dbname"
+        - name: "unsharded_dbname"
           shards:
             - name: "0"
               tablets:
@@ -78,14 +78,14 @@ topology:
     - name: "zone1"
       ...
       keyspaces:
-        - name: "unsharded-dbname"
+        - name: "unsharded_dbname"
           shards:
             - name: "0"
               tablets:
                 - type: "replica"
                   vttablet:
                     replicas: 2
-        - name: "sharded-db"
+        - name: "sharded_db"
           shards:
             - name: "-80"
               tablets:
@@ -107,7 +107,7 @@ topology:
     - name: "zone1"
       ...
       keyspaces:
-        - name: "unsharded-dbname"
+        - name: "unsharded_dbname"
           shards:
             - name: "0"
               tablets:


### PR DESCRIPTION
Currently this breaks the backup script, and could possibly cause issues elsewhere