### PR TITLE
zksrv.sh: remove unneeded start variable

### DIFF
--- a/go/vt/zkctl/zksrv.sh
+++ b/go/vt/zkctl/zksrv.sh
@@ -55,7 +55,6 @@ fi
 
 cmd="$java -DZOO_LOG_DIR=$logdir -cp $classpath org.apache.zookeeper.server.quorum.QuorumPeerMain $config"
 
-start=`/bin/date +%s`
 log "INFO starting $cmd"
 $cmd < /dev/null &> /dev/null &
 pid=$!


### PR DESCRIPTION
Cleaning up something which probably shouldn't be there. The variable `start` is assigned to but then never used or exported so is probably not needed.