### PR TITLE
Fixing proto imports.

### DIFF
--- a/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
+++ b/go/vt/throttler/grpcthrottlerclient/grpcthrottlerclient.go
@@ -21,13 +21,14 @@ import (
 	"flag"
 
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 
 	"github.com/youtube/vitess/go/vt/grpcclient"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
-	"github.com/youtube/vitess/go/vt/proto/throttlerservice"
 	"github.com/youtube/vitess/go/vt/throttler/throttlerclient"
 	"github.com/youtube/vitess/go/vt/vterrors"
-	"google.golang.org/grpc"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
+	throttlerservicepb "github.com/youtube/vitess/go/vt/proto/throttlerservice"
 )
 
 var (
@@ -39,7 +40,7 @@ var (
 
 type client struct {
 	conn       *grpc.ClientConn
-	gRPCClient throttlerservice.ThrottlerClient
+	gRPCClient throttlerservicepb.ThrottlerClient
 }
 
 func factory(addr string) (throttlerclient.Client, error) {
@@ -51,7 +52,7 @@ func factory(addr string) (throttlerclient.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	gRPCClient := throttlerservice.NewThrottlerClient(conn)
+	gRPCClient := throttlerservicepb.NewThrottlerClient(conn)
 
 	return &client{conn, gRPCClient}, nil
 }
@@ -59,7 +60,7 @@ func factory(addr string) (throttlerclient.Client, error) {
 // MaxRates is part of the throttlerclient.Client interface and returns the
 // current max rate for each throttler of the process.
 func (c *client) MaxRates(ctx context.Context) (map[string]int64, error) {
-	response, err := c.gRPCClient.MaxRates(ctx, &throttlerdata.MaxRatesRequest{})
+	response, err := c.gRPCClient.MaxRates(ctx, &throttlerdatapb.MaxRatesRequest{})
 	if err != nil {
 		return nil, vterrors.FromGRPC(err)
 	}
@@ -69,7 +70,7 @@ func (c *client) MaxRates(ctx context.Context) (map[string]int64, error) {
 // SetMaxRate is part of the throttlerclient.Client interface and sets the rate
 // on all throttlers of the server.
 func (c *client) SetMaxRate(ctx context.Context, rate int64) ([]string, error) {
-	request := &throttlerdata.SetMaxRateRequest{
+	request := &throttlerdatapb.SetMaxRateRequest{
 		Rate: rate,
 	}
 
@@ -81,8 +82,8 @@ func (c *client) SetMaxRate(ctx context.Context, rate int64) ([]string, error) {
 }
 
 // GetConfiguration is part of the throttlerclient.Client interface.
-func (c *client) GetConfiguration(ctx context.Context, throttlerName string) (map[string]*throttlerdata.Configuration, error) {
-	response, err := c.gRPCClient.GetConfiguration(ctx, &throttlerdata.GetConfigurationRequest{
+func (c *client) GetConfiguration(ctx context.Context, throttlerName string) (map[string]*throttlerdatapb.Configuration, error) {
+	response, err := c.gRPCClient.GetConfiguration(ctx, &throttlerdatapb.GetConfigurationRequest{
 		ThrottlerName: throttlerName,
 	})
 	if err != nil {
@@ -92,8 +93,8 @@ func (c *client) GetConfiguration(ctx context.Context, throttlerName string) (ma
 }
 
 // UpdateConfiguration is part of the throttlerclient.Client interface.
-func (c *client) UpdateConfiguration(ctx context.Context, throttlerName string, configuration *throttlerdata.Configuration, copyZeroValues bool) ([]string, error) {
-	response, err := c.gRPCClient.UpdateConfiguration(ctx, &throttlerdata.UpdateConfigurationRequest{
+func (c *client) UpdateConfiguration(ctx context.Context, throttlerName string, configuration *throttlerdatapb.Configuration, copyZeroValues bool) ([]string, error) {
+	response, err := c.gRPCClient.UpdateConfiguration(ctx, &throttlerdatapb.UpdateConfigurationRequest{
 		ThrottlerName:  throttlerName,
 		Configuration:  configuration,
 		CopyZeroValues: copyZeroValues,
@@ -106,7 +107,7 @@ func (c *client) UpdateConfiguration(ctx context.Context, throttlerName string, 
 
 // ResetConfiguration is part of the throttlerclient.Client interface.
 func (c *client) ResetConfiguration(ctx context.Context, throttlerName string) ([]string, error) {
-	response, err := c.gRPCClient.ResetConfiguration(ctx, &throttlerdata.ResetConfigurationRequest{
+	response, err := c.gRPCClient.ResetConfiguration(ctx, &throttlerdatapb.ResetConfigurationRequest{
 		ThrottlerName: throttlerName,
 	})
 	if err != nil {

--- a/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
+++ b/go/vt/throttler/grpcthrottlerserver/grpcthrottlerserver.go
@@ -25,8 +25,8 @@ import (
 	"github.com/youtube/vitess/go/vt/servenv"
 	"github.com/youtube/vitess/go/vt/throttler"
 
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
-	"github.com/youtube/vitess/go/vt/proto/throttlerservice"
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
+	throttlerservicepb "github.com/youtube/vitess/go/vt/proto/throttlerservice"
 )
 
 // Server is the gRPC server implementation of the Throttler service.
@@ -41,68 +41,68 @@ func NewServer(m throttler.Manager) *Server {
 
 // MaxRates implements the gRPC server interface. It returns the current max
 // rate for each throttler of the process.
-func (s *Server) MaxRates(_ context.Context, request *throttlerdata.MaxRatesRequest) (_ *throttlerdata.MaxRatesResponse, err error) {
+func (s *Server) MaxRates(_ context.Context, request *throttlerdatapb.MaxRatesRequest) (_ *throttlerdatapb.MaxRatesResponse, err error) {
 	defer servenv.HandlePanic("throttler", &err)
 
 	rates := s.manager.MaxRates()
-	return &throttlerdata.MaxRatesResponse{
+	return &throttlerdatapb.MaxRatesResponse{
 		Rates: rates,
 	}, nil
 }
 
 // SetMaxRate implements the gRPC server interface. It sets the rate on all
 // throttlers controlled by the manager.
-func (s *Server) SetMaxRate(_ context.Context, request *throttlerdata.SetMaxRateRequest) (_ *throttlerdata.SetMaxRateResponse, err error) {
+func (s *Server) SetMaxRate(_ context.Context, request *throttlerdatapb.SetMaxRateRequest) (_ *throttlerdatapb.SetMaxRateResponse, err error) {
 	defer servenv.HandlePanic("throttler", &err)
 
 	names := s.manager.SetMaxRate(request.Rate)
-	return &throttlerdata.SetMaxRateResponse{
+	return &throttlerdatapb.SetMaxRateResponse{
 		Names: names,
 	}, nil
 }
 
 // GetConfiguration implements the gRPC server interface.
-func (s *Server) GetConfiguration(_ context.Context, request *throttlerdata.GetConfigurationRequest) (_ *throttlerdata.GetConfigurationResponse, err error) {
+func (s *Server) GetConfiguration(_ context.Context, request *throttlerdatapb.GetConfigurationRequest) (_ *throttlerdatapb.GetConfigurationResponse, err error) {
 	defer servenv.HandlePanic("throttler", &err)
 
 	configurations, err := s.manager.GetConfiguration(request.ThrottlerName)
 	if err != nil {
 		return nil, err
 	}
-	return &throttlerdata.GetConfigurationResponse{
+	return &throttlerdatapb.GetConfigurationResponse{
 		Configurations: configurations,
 	}, nil
 }
 
 // UpdateConfiguration implements the gRPC server interface.
-func (s *Server) UpdateConfiguration(_ context.Context, request *throttlerdata.UpdateConfigurationRequest) (_ *throttlerdata.UpdateConfigurationResponse, err error) {
+func (s *Server) UpdateConfiguration(_ context.Context, request *throttlerdatapb.UpdateConfigurationRequest) (_ *throttlerdatapb.UpdateConfigurationResponse, err error) {
 	defer servenv.HandlePanic("throttler", &err)
 
 	names, err := s.manager.UpdateConfiguration(request.ThrottlerName, request.Configuration, request.CopyZeroValues)
 	if err != nil {
 		return nil, err
 	}
-	return &throttlerdata.UpdateConfigurationResponse{
+	return &throttlerdatapb.UpdateConfigurationResponse{
 		Names: names,
 	}, nil
 }
 
 // ResetConfiguration implements the gRPC server interface.
-func (s *Server) ResetConfiguration(_ context.Context, request *throttlerdata.ResetConfigurationRequest) (_ *throttlerdata.ResetConfigurationResponse, err error) {
+func (s *Server) ResetConfiguration(_ context.Context, request *throttlerdatapb.ResetConfigurationRequest) (_ *throttlerdatapb.ResetConfigurationResponse, err error) {
 	defer servenv.HandlePanic("throttler", &err)
 
 	names, err := s.manager.ResetConfiguration(request.ThrottlerName)
 	if err != nil {
 		return nil, err
 	}
-	return &throttlerdata.ResetConfigurationResponse{
+	return &throttlerdatapb.ResetConfigurationResponse{
 		Names: names,
 	}, nil
 }
 
 // RegisterServer registers a new throttler server instance with the gRPC server.
 func RegisterServer(s *grpc.Server, m throttler.Manager) {
-	throttlerservice.RegisterThrottlerServer(s, NewServer(m))
+	throttlerservicepb.RegisterThrottlerServer(s, NewServer(m))
 }
 
 func init() {

--- a/go/vt/throttler/manager.go
+++ b/go/vt/throttler/manager.go
@@ -22,7 +22,8 @@ import (
 	"sync"
 
 	log "github.com/golang/glog"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // GlobalManager is the per-process manager which manages all active throttlers.
@@ -40,7 +41,7 @@ type Manager interface {
 
 	// GetConfiguration returns the configuration of the MaxReplicationlag module
 	// for the given throttler or all throttlers if "throttlerName" is empty.
-	GetConfiguration(throttlerName string) (map[string]*throttlerdata.Configuration, error)
+	GetConfiguration(throttlerName string) (map[string]*throttlerdatapb.Configuration, error)
 
 	// UpdateConfiguration (partially) updates the configuration of the
 	// MaxReplicationlag module for the given throttler or all throttlers if
@@ -48,7 +49,7 @@ type Manager interface {
 	// If "copyZeroValues" is true, fields with zero values will be copied
 	// as well.
 	// The function returns the names of the updated throttlers.
-	UpdateConfiguration(throttlerName string, configuration *throttlerdata.Configuration, copyZeroValues bool) ([]string, error)
+	UpdateConfiguration(throttlerName string, configuration *throttlerdatapb.Configuration, copyZeroValues bool) ([]string, error)
 
 	// ResetConfiguration resets the configuration of the MaxReplicationlag module
 	// to the initial configuration for the given throttler or all throttlers if
@@ -118,11 +119,11 @@ func (m *managerImpl) SetMaxRate(rate int64) []string {
 }
 
 // GetConfiguration implements the "Manager" interface.
-func (m *managerImpl) GetConfiguration(throttlerName string) (map[string]*throttlerdata.Configuration, error) {
+func (m *managerImpl) GetConfiguration(throttlerName string) (map[string]*throttlerdatapb.Configuration, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	configurations := make(map[string]*throttlerdata.Configuration)
+	configurations := make(map[string]*throttlerdatapb.Configuration)
 
 	if throttlerName != "" {
 		t, ok := m.throttlers[throttlerName]
@@ -140,7 +141,7 @@ func (m *managerImpl) GetConfiguration(throttlerName string) (map[string]*thrott
 }
 
 // UpdateConfiguration implements the "Manager" interface.
-func (m *managerImpl) UpdateConfiguration(throttlerName string, configuration *throttlerdata.Configuration, copyZeroValues bool) ([]string, error) {
+func (m *managerImpl) UpdateConfiguration(throttlerName string, configuration *throttlerdatapb.Configuration, copyZeroValues bool) ([]string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/go/vt/throttler/manager_test.go
+++ b/go/vt/throttler/manager_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // We base our test data on these defaults.
@@ -103,7 +103,7 @@ func TestManager_GetConfiguration(t *testing.T) {
 	defer f.tearDown()
 
 	// Test GetConfiguration() when all throttlers are returned.
-	want := map[string]*throttlerdata.Configuration{
+	want := map[string]*throttlerdatapb.Configuration{
 		"t1": &defaultMaxReplicationLagModuleConfig.Configuration,
 		"t2": &defaultMaxReplicationLagModuleConfig.Configuration,
 	}
@@ -116,7 +116,7 @@ func TestManager_GetConfiguration(t *testing.T) {
 	}
 
 	// Test GetConfiguration() when a specific throttler is requested.
-	wantT2 := map[string]*throttlerdata.Configuration{
+	wantT2 := map[string]*throttlerdatapb.Configuration{
 		"t2": &defaultMaxReplicationLagModuleConfig.Configuration,
 	}
 	gotT2, err := f.m.GetConfiguration("t2")
@@ -128,7 +128,7 @@ func TestManager_GetConfiguration(t *testing.T) {
 	}
 
 	// Now change the config and then reset it back.
-	newConfig := &throttlerdata.Configuration{
+	newConfig := &throttlerdatapb.Configuration{
 		TargetReplicationLagSec: defaultTargetLag + 1,
 		IgnoreNSlowestReplicas:  defaultIgnoreNSlowestReplicas + 1,
 	}
@@ -172,7 +172,7 @@ func TestManager_UpdateConfiguration_Error(t *testing.T) {
 	defer f.tearDown()
 
 	// Check that errors from Verify() are correctly propagated.
-	invalidConfig := &throttlerdata.Configuration{
+	invalidConfig := &throttlerdatapb.Configuration{
 		// max < 2 is not allowed.
 		MaxReplicationLagSec: 1,
 	}
@@ -195,7 +195,7 @@ func TestManager_UpdateConfiguration_Partial(t *testing.T) {
 
 	// Verify that a partial update only updates that one field.
 	wantIgnoreNSlowestReplicas := defaultIgnoreNSlowestReplicas + 1
-	partialConfig := &throttlerdata.Configuration{
+	partialConfig := &throttlerdatapb.Configuration{
 		IgnoreNSlowestReplicas: wantIgnoreNSlowestReplicas,
 	}
 	names, err := f.m.UpdateConfiguration("t2", partialConfig, false /* copyZeroValues */)

--- a/go/vt/throttler/max_replication_lag_module.go
+++ b/go/vt/throttler/max_replication_lag_module.go
@@ -23,14 +23,13 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
-
 	"github.com/golang/protobuf/proto"
 
 	"github.com/youtube/vitess/go/sync2"
 	"github.com/youtube/vitess/go/vt/discovery"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
@@ -204,7 +203,7 @@ func (m *MaxReplicationLagModule) applyLatestConfig() {
 	}
 }
 
-func (m *MaxReplicationLagModule) getConfiguration() *throttlerdata.Configuration {
+func (m *MaxReplicationLagModule) getConfiguration() *throttlerdatapb.Configuration {
 	m.mutableConfigMu.Lock()
 	defer m.mutableConfigMu.Unlock()
 
@@ -212,14 +211,14 @@ func (m *MaxReplicationLagModule) getConfiguration() *throttlerdata.Configuratio
 	return &configCopy
 }
 
-func (m *MaxReplicationLagModule) updateConfiguration(configuration *throttlerdata.Configuration, copyZeroValues bool) error {
+func (m *MaxReplicationLagModule) updateConfiguration(configuration *throttlerdatapb.Configuration, copyZeroValues bool) error {
 	m.mutableConfigMu.Lock()
 	defer m.mutableConfigMu.Unlock()
 
 	newConfig := m.mutableConfig
 
 	if copyZeroValues {
-		newConfig.Configuration = *proto.Clone(configuration).(*throttlerdata.Configuration)
+		newConfig.Configuration = *proto.Clone(configuration).(*throttlerdatapb.Configuration)
 	} else {
 		proto.Merge(&newConfig.Configuration, configuration)
 	}

--- a/go/vt/throttler/max_replication_lag_module_config.go
+++ b/go/vt/throttler/max_replication_lag_module_config.go
@@ -20,14 +20,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // MaxReplicationLagModuleConfig stores all configuration parameters for
 // MaxReplicationLagModule. Internally, the parameters are represented by a
 // protobuf message. This message is also used to update the parameters.
 type MaxReplicationLagModuleConfig struct {
-	throttlerdata.Configuration
+	throttlerdatapb.Configuration
 }
 
 // Most of the values are based on the assumption that vttablet is started
@@ -35,7 +35,7 @@ type MaxReplicationLagModuleConfig struct {
 const healthCheckInterval = 20
 
 var defaultMaxReplicationLagModuleConfig = MaxReplicationLagModuleConfig{
-	throttlerdata.Configuration{
+	throttlerdatapb.Configuration{
 		TargetReplicationLagSec: 2,
 		MaxReplicationLagSec:    ReplicationLagModuleDisabled,
 

--- a/go/vt/throttler/throttler.go
+++ b/go/vt/throttler/throttler.go
@@ -34,8 +34,10 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+
 	"github.com/youtube/vitess/go/vt/discovery"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 const (
@@ -299,12 +301,12 @@ func (t *Throttler) RecordReplicationLag(time time.Time, ts *discovery.TabletSta
 }
 
 // GetConfiguration returns the configuration of the MaxReplicationLag module.
-func (t *Throttler) GetConfiguration() *throttlerdata.Configuration {
+func (t *Throttler) GetConfiguration() *throttlerdatapb.Configuration {
 	return t.maxReplicationLagModule.getConfiguration()
 }
 
 // UpdateConfiguration updates the configuration of the MaxReplicationLag module.
-func (t *Throttler) UpdateConfiguration(configuration *throttlerdata.Configuration, copyZeroValues bool) error {
+func (t *Throttler) UpdateConfiguration(configuration *throttlerdatapb.Configuration, copyZeroValues bool) error {
 	return t.maxReplicationLagModule.updateConfiguration(configuration, copyZeroValues)
 }
 

--- a/go/vt/throttler/throttlerclient/throttlerclient.go
+++ b/go/vt/throttler/throttlerclient/throttlerclient.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
-
 	"golang.org/x/net/context"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // protocol specifices which RPC client implementation should be used.
@@ -44,7 +44,7 @@ type Client interface {
 
 	// GetConfiguration returns the configuration of the MaxReplicationlag module
 	// for the given throttler or all throttlers if "throttlerName" is empty.
-	GetConfiguration(ctx context.Context, throttlerName string) (map[string]*throttlerdata.Configuration, error)
+	GetConfiguration(ctx context.Context, throttlerName string) (map[string]*throttlerdatapb.Configuration, error)
 
 	// UpdateConfiguration (partially) updates the configuration of the
 	// MaxReplicationlag module for the given throttler or all throttlers if
@@ -52,7 +52,7 @@ type Client interface {
 	// If "copyZeroValues" is true, fields with zero values will be copied
 	// as well.
 	// The function returns the names of the updated throttlers.
-	UpdateConfiguration(ctx context.Context, throttlerName string, configuration *throttlerdata.Configuration, copyZeroValues bool) ([]string, error)
+	UpdateConfiguration(ctx context.Context, throttlerName string, configuration *throttlerdatapb.Configuration, copyZeroValues bool) ([]string, error)
 
 	// ResetConfiguration resets the configuration of the MaxReplicationlag module
 	// to the initial configuration for the given throttler or all throttlers if

--- a/go/vt/throttler/throttlerclienttest/throttlerclient_testsuite.go
+++ b/go/vt/throttler/throttlerclienttest/throttlerclient_testsuite.go
@@ -30,12 +30,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
 	"github.com/youtube/vitess/go/vt/throttler"
 	"github.com/youtube/vitess/go/vt/throttler/throttlerclient"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // TestSuite runs the test suite on the given throttlerclient and throttlerserver.
@@ -128,7 +129,7 @@ func (tf *testFixture) configuration(t *testing.T, client throttlerclient.Client
 	}
 
 	// Test UpdateConfiguration.
-	config := &throttlerdata.Configuration{
+	config := &throttlerdatapb.Configuration{
 		TargetReplicationLagSec:        1,
 		MaxReplicationLagSec:           2,
 		InitialRate:                    3,
@@ -201,12 +202,12 @@ func (fm *FakeManager) SetMaxRate(int64) []string {
 }
 
 // GetConfiguration implements the throttler.Manager interface. It always panics.
-func (fm *FakeManager) GetConfiguration(throttlerName string) (map[string]*throttlerdata.Configuration, error) {
+func (fm *FakeManager) GetConfiguration(throttlerName string) (map[string]*throttlerdatapb.Configuration, error) {
 	panic(panicMsg)
 }
 
 // UpdateConfiguration implements the throttler.Manager interface. It always panics.
-func (fm *FakeManager) UpdateConfiguration(throttlerName string, configuration *throttlerdata.Configuration, copyZeroValues bool) ([]string, error) {
+func (fm *FakeManager) UpdateConfiguration(throttlerName string, configuration *throttlerdatapb.Configuration, copyZeroValues bool) ([]string, error) {
 	panic(panicMsg)
 }
 

--- a/go/vt/vtctl/throttler.go
+++ b/go/vt/vtctl/throttler.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/olekukonko/tablewriter"
+	"golang.org/x/net/context"
+
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/proto/throttlerdata"
 	"github.com/youtube/vitess/go/vt/throttler"
 	"github.com/youtube/vitess/go/vt/throttler/throttlerclient"
 	"github.com/youtube/vitess/go/vt/wrangler"
-	"golang.org/x/net/context"
+
+	throttlerdatapb "github.com/youtube/vitess/go/vt/proto/throttlerdata"
 )
 
 // This file contains the commands to control the throttler which is used during
@@ -220,7 +222,7 @@ func commandUpdateThrottlerConfiguration(ctx context.Context, wr *wrangler.Wrang
 	}
 
 	protoText := subFlags.Arg(0)
-	configuration := &throttlerdata.Configuration{}
+	configuration := &throttlerdatapb.Configuration{}
 	if err := proto.UnmarshalText(protoText, configuration); err != nil {
 		return fmt.Errorf("Failed to unmarshal the configuration protobuf text (%v) into a protobuf instance: %v", protoText, err)
 	}

--- a/go/vt/vtctld/tablet_stats_cache_test.go
+++ b/go/vt/vtctld/tablet_stats_cache_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/youtube/vitess/go/vt/discovery"
-	"github.com/youtube/vitess/go/vt/proto/topodata"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
 	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
@@ -146,7 +145,7 @@ func TestHeatmapData(t *testing.T) {
 				{float64(ts2.Stats.SecondsBehindMaster), float64(ts4.Stats.SecondsBehindMaster)},
 				{float64(ts1.Stats.SecondsBehindMaster), float64(-1)},
 			},
-			Aliases: [][]*topodata.TabletAlias{
+			Aliases: [][]*topodatapb.TabletAlias{
 				{nil, ts9.Tablet.Alias},
 				{ts6.Tablet.Alias, ts8.Tablet.Alias},
 				{ts5.Tablet.Alias, nil},
@@ -193,7 +192,7 @@ func TestHeatmapData(t *testing.T) {
 				{float64(ts3.Stats.SecondsBehindMaster), float64(-1)},
 				{float64(ts2.Stats.SecondsBehindMaster), float64(ts4.Stats.SecondsBehindMaster)},
 			},
-			Aliases: [][]*topodata.TabletAlias{
+			Aliases: [][]*topodatapb.TabletAlias{
 				{ts5.Tablet.Alias, nil},
 				{ts3.Tablet.Alias, nil},
 				{ts2.Tablet.Alias, ts4.Tablet.Alias},
@@ -233,7 +232,7 @@ func TestHeatmapData(t *testing.T) {
 				{float64(ts11.Stats.SecondsBehindMaster), float64(ts13.Stats.SecondsBehindMaster)},
 				{float64(ts10.Stats.SecondsBehindMaster), float64(-1)},
 			},
-			Aliases: [][]*topodata.TabletAlias{
+			Aliases: [][]*topodatapb.TabletAlias{
 				{ts12.Tablet.Alias, nil},
 				{ts11.Tablet.Alias, ts13.Tablet.Alias},
 				{ts10.Tablet.Alias, nil},
@@ -313,7 +312,7 @@ func TestHeatmapData(t *testing.T) {
 			Data: [][]float64{
 				{float64(-1), float64(ts7.Stats.SecondsBehindMaster)},
 			},
-			Aliases: [][]*topodata.TabletAlias{
+			Aliases: [][]*topodatapb.TabletAlias{
 				{nil, ts7.Tablet.Alias},
 			},
 			CellAndTypeLabels: []yLabel{

--- a/go/vt/vttablet/heartbeat/reader.go
+++ b/go/vt/vttablet/heartbeat/reader.go
@@ -30,7 +30,6 @@ import (
 	"github.com/youtube/vitess/go/timer"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
@@ -91,7 +90,7 @@ func (r *Reader) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
 
 // Init does last minute initialization of db settings, such as dbName
 // and keyspaceShard
-func (r *Reader) Init(target query.Target) {
+func (r *Reader) Init(target querypb.Target) {
 	if !r.enabled {
 		return
 	}

--- a/go/vt/vttablet/heartbeat/reader_test.go
+++ b/go/vt/vttablet/heartbeat/reader_test.go
@@ -27,8 +27,9 @@ import (
 	"github.com/youtube/vitess/go/sqlescape"
 	"github.com/youtube/vitess/go/sqltypes"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
-	"github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // TestReaderReadHeartbeat tests that reading a heartbeat sets the appropriate
@@ -40,7 +41,7 @@ func TestReaderReadHeartbeat(t *testing.T) {
 	defer tr.Close()
 
 	db.AddQuery(fmt.Sprintf("SELECT ts FROM %s.heartbeat WHERE keyspaceShard='%s'", tr.dbName, tr.keyspaceShard), &sqltypes.Result{
-		Fields: []*query.Field{
+		Fields: []*querypb.Field{
 			{Name: "ts", Type: sqltypes.Int64},
 		},
 		Rows: [][]sqltypes.Value{{

--- a/go/vt/vttablet/heartbeat/writer.go
+++ b/go/vt/vttablet/heartbeat/writer.go
@@ -33,13 +33,12 @@ import (
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dbconnpool"
 	"github.com/youtube/vitess/go/vt/logutil"
-	"github.com/youtube/vitess/go/vt/proto/query"
-	"github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/sqlparser"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 
 	querypb "github.com/youtube/vitess/go/vt/proto/query"
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 const (
@@ -61,7 +60,7 @@ type Writer struct {
 
 	enabled       bool
 	interval      time.Duration
-	tabletAlias   topodata.TabletAlias
+	tabletAlias   topodatapb.TabletAlias
 	keyspaceShard string
 	dbName        string
 	now           func() time.Time
@@ -74,7 +73,7 @@ type Writer struct {
 }
 
 // NewWriter creates a new Writer.
-func NewWriter(checker connpool.MySQLChecker, alias topodata.TabletAlias, config tabletenv.TabletConfig) *Writer {
+func NewWriter(checker connpool.MySQLChecker, alias topodatapb.TabletAlias, config tabletenv.TabletConfig) *Writer {
 	if !config.HeartbeatEnable {
 		return &Writer{}
 	}
@@ -96,7 +95,7 @@ func (w *Writer) InitDBConfig(dbcfgs dbconfigs.DBConfigs) {
 
 // Init runs at tablet startup and last minute initialization of db settings, and
 // creates the necessary tables for heartbeat.
-func (w *Writer) Init(target query.Target) error {
+func (w *Writer) Init(target querypb.Target) error {
 	if !w.enabled {
 		return nil
 	}

--- a/go/vt/vttablet/tabletserver/tabletserver_test.go
+++ b/go/vt/vttablet/tabletserver/tabletserver_test.go
@@ -2777,7 +2777,7 @@ func TestConfigChanges(t *testing.T) {
 
 	tsv.SetAutoCommit(true)
 	if val := tsv.qe.autoCommit.Get(); !val {
-		t.Errorf("tsv.qe.autoCommit.Get: %d, want true", val)
+		t.Errorf("tsv.qe.autoCommit.Get: %v, want true", val)
 	}
 
 	tsv.SetMaxResultSize(newSize)

--- a/go/vt/vttablet/tabletserver/tx_engine.go
+++ b/go/vt/vttablet/tabletserver/tx_engine.go
@@ -27,11 +27,12 @@ import (
 	"github.com/youtube/vitess/go/vt/concurrency"
 	"github.com/youtube/vitess/go/vt/dbconfigs"
 	"github.com/youtube/vitess/go/vt/dtids"
-	"github.com/youtube/vitess/go/vt/proto/query"
 	"github.com/youtube/vitess/go/vt/vtgate/vtgateconn"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/connpool"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
 	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/txlimiter"
+
+	querypb "github.com/youtube/vitess/go/vt/proto/query"
 )
 
 // TxEngine handles transactions.
@@ -223,7 +224,7 @@ outer:
 		if txid > maxid {
 			maxid = txid
 		}
-		conn, err := te.txPool.LocalBegin(ctx, false, query.ExecuteOptions_DEFAULT)
+		conn, err := te.txPool.LocalBegin(ctx, false, querypb.ExecuteOptions_DEFAULT)
 		if err != nil {
 			allErr.RecordError(err)
 			continue

--- a/go/vt/worker/tablet_provider.go
+++ b/go/vt/worker/tablet_provider.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/youtube/vitess/go/vt/discovery"
-	"github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/topo"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
 
@@ -36,7 +35,7 @@ type tabletProvider interface {
 
 	// returnTablet must be called after the tablet is no longer used and e.g.
 	// TabletTracker.Untrack() should get called for it.
-	returnTablet(*topodata.Tablet)
+	returnTablet(*topodatapb.Tablet)
 
 	// description returns a string which can be used in error messages e.g.
 	// the name of the keyspace and the shard.
@@ -65,7 +64,7 @@ func (p *singleTabletProvider) getTablet() (*topodatapb.Tablet, error) {
 	return tablet.Tablet, err
 }
 
-func (p *singleTabletProvider) returnTablet(*topodata.Tablet) {}
+func (p *singleTabletProvider) returnTablet(*topodatapb.Tablet) {}
 
 func (p *singleTabletProvider) description() string {
 	return topoproto.TabletAliasString(p.alias)

--- a/go/vt/worker/tablet_tracker.go
+++ b/go/vt/worker/tablet_tracker.go
@@ -23,8 +23,9 @@ import (
 	"sync"
 
 	"github.com/youtube/vitess/go/vt/discovery"
-	"github.com/youtube/vitess/go/vt/proto/topodata"
 	"github.com/youtube/vitess/go/vt/topo/topoproto"
+
+	topodatapb "github.com/youtube/vitess/go/vt/proto/topodata"
 )
 
 // TabletTracker tracks for each tablet alias how often it is currently in use
@@ -49,7 +50,7 @@ func NewTabletTracker() *TabletTracker {
 // Track will pick the least used tablet from "stats", increment its usage by 1
 // and return it.
 // "stats" must not be empty.
-func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.Tablet {
+func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodatapb.Tablet {
 	if len(stats) == 0 {
 		panic("stats must not be empty")
 	}
@@ -80,7 +81,7 @@ func (t *TabletTracker) Track(stats []discovery.TabletStats) *topodata.Tablet {
 }
 
 // Untrack decrements the usage of "alias" by 1.
-func (t *TabletTracker) Untrack(alias *topodata.TabletAlias) {
+func (t *TabletTracker) Untrack(alias *topodatapb.TabletAlias) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 


### PR DESCRIPTION
To always reflect our +pb rename on import.

(turns out our import scripts need this to be cleaned now, so that's the real incentive for this cleanup).