### PR TITLE
make the resilient topo cache even more resilient and informative

### DIFF
--- a/go/vt/srvtopo/resilient_server.go
+++ b/go/vt/srvtopo/resilient_server.go
@@ -375,7 +375,7 @@ func (server *ResilientServer) GetSrvKeyspace(ctx context.Context, cell, keyspac
 				log.Errorf("%v", err)
 				server.counts.Add(errorCategory, 1)
 				entry.mutex.Lock()
-				if c.Err == topo.ErrNoNode {
+				if c.Err == topo.ErrNoNode || time.Since(entry.lastValueTime) > server.cacheTTL {
 					entry.value = nil
 				}
 				entry.watchRunning = false

--- a/go/vt/srvtopo/resilient_server_flaky_test.go
+++ b/go/vt/srvtopo/resilient_server_flaky_test.go
@@ -82,7 +82,14 @@ func TestGetSrvKeyspace(t *testing.T) {
 	}
 
 	// make sure the HTML template works
-	templ := template.New("").Funcs(status.StatusFuncs)
+	funcs := map[string]interface{}{}
+	for k, v := range status.StatusFuncs {
+		funcs[k] = v
+	}
+	for k, v := range statusFuncs {
+		funcs[k] = v
+	}
+	templ := template.New("").Funcs(funcs)
 	templ, err = templ.Parse(TopoTemplate)
 	if err != nil {
 		t.Fatalf("error parsing template: %v", err)

--- a/go/vt/topo/memorytopo/memorytopo.go
+++ b/go/vt/topo/memorytopo/memorytopo.go
@@ -98,6 +98,18 @@ func (f *Factory) SetError(err error) {
 	}
 }
 
+// Lock blocks all requests to the topo and is exposed to allow tests to
+// simulate an unresponsive topo server
+func (f *Factory) Lock() {
+	f.mu.Lock()
+}
+
+// Unlock unblocks all requests to the topo and is exposed to allow tests to
+// simulate an unresponsive topo server
+func (f *Factory) Unlock() {
+	f.mu.Unlock()
+}
+
 // Conn implements the topo.Conn interface. It remembers the cell, and
 // points at the Factory that has all the data.
 type Conn struct {

--- a/go/vt/vtgate/vschema_stats.go
+++ b/go/vt/vtgate/vschema_stats.go
@@ -77,14 +77,17 @@ const (
 </style>
 <table>
   <tr>
-    <th colspan="4">VSchema{{if not .Error}} <i><a href="/debug/vschema">in JSON</a></i>{{end}}</th>
+    <th colspan="4">VSchema Cache <i><a href="/debug/vschema">in JSON</a></i></th>
   </tr>
 {{if .Error}}
   <tr>
     <th>Error</th>
     <td colspan="3">{{$.Error}}</td>
   </tr>
-{{else}}
+  <tr>
+    <td>colspan="4"></td>
+  </tr>
+{{end}}
   <tr>
     <th>Keyspace</th>
     <th>Sharded</th>
@@ -97,7 +100,6 @@ const (
     <td>{{$ks.TableCount}}</td>
     <td>{{$ks.VindexCount}}</td>
   </tr>{{end}}
-{{end}}
 </table>
 `
 )


### PR DESCRIPTION
# Overview
Improve the status UI for the resilient topo cache, make GetSrvKeyspaceNames fetch asynchronously, and fix a logic bug in the watch-based caching for GetSrvKeyspace.

This incorporates the ideas first proposed by @yangxuanjia in #3640 while addressing my concerns about the refresh interval and properly managing locks and state.

# Details
This first came up because I wanted better indication in the status UI about the state of the cache. In particular, it used to either show the cached value _or_ show the most recent error, but would not indicate if the cache was valid or not.

To address this, I changed the status UI to display the current cached value (if any), the last error (if any), as well as information about the cache freshness / TTL.

Next, as discussed in slack and in #3640 I moved the topo in GetSrvKeyspaceNames into a separate goroutine, and kept tracking state in the entry to make sure only one topo request is outstanding. This makes sure that a cached value can always be returned immediately even if the topo service is unresponsive or slow.

However, unlike in the other proposal, if there is no cached value, all requests block waiting for the fetcher goroutine to complete. This seems like an acceptable tradeoff to me since it avoids errors on the initial query, and for the most part should insulate callers from topo service unavailability or slowness.

Finally, I noticed a logic bug in the earlier changes that I made to cache the watched SrvKeyspace object. Previously the lastValueTime was updated on every change, but that meant that if the watch failed after some time where no changes were detected, the cache did not properly keep the last value for the full TTL as designed. To address this, I changed it to update lastValueTime whenever an established watch returns, either due to error or the value being in the cache.

# Testing
I added a unit test for the last case and did a decent amount of manual testing both using zookeeper and consul. 

I'd like to add some tests for the logic in the status UI since that turned out to be surprisingly tricky to get right, as well as the case where the topo service is blocked.
