### PR TITLE
Try to return a better error message when a transaction is not found

### DIFF
--- a/go/pools/numbered.go
+++ b/go/pools/numbered.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/youtube/vitess/go/cache"
 )
 
 // Numbered allows you to manage resources by tracking them with numbers.
 // There are no interface restrictions on what you can track.
 type Numbered struct {
-	mu        sync.Mutex
-	empty     *sync.Cond // Broadcast when pool becomes empty
-	resources map[int64]*numberedWrapper
+	mu                   sync.Mutex
+	empty                *sync.Cond // Broadcast when pool becomes empty
+	resources            map[int64]*numberedWrapper
+	recentlyUnregistered *cache.LRUCache
 }
 
 type numberedWrapper struct {
@@ -39,8 +42,20 @@ type numberedWrapper struct {
 	enforceTimeout bool
 }
 
+type unregistered struct {
+	reason           string
+	timeUnregistered time.Time
+}
+
+func (u *unregistered) Size() int {
+	return 1
+}
+
 func NewNumbered() *Numbered {
-	n := &Numbered{resources: make(map[int64]*numberedWrapper)}
+	n := &Numbered{
+		resources:            make(map[int64]*numberedWrapper),
+		recentlyUnregistered: cache.NewLRUCache(1000),
+	}
 	n.empty = sync.NewCond(&n.mu)
 	return n
 }
@@ -66,13 +81,14 @@ func (nu *Numbered) Register(id int64, val interface{}, enforceTimeout bool) err
 
 // Unregiester forgets the specified resource.
 // If the resource is not present, it's ignored.
-func (nu *Numbered) Unregister(id int64) {
+func (nu *Numbered) Unregister(id int64, reason string) {
 	nu.mu.Lock()
 	defer nu.mu.Unlock()
 	delete(nu.resources, id)
 	if len(nu.resources) == 0 {
 		nu.empty.Broadcast()
 	}
+	nu.recentlyUnregistered.Set(fmt.Sprintf("%v", id), &unregistered{reason: reason, timeUnregistered: time.Now()})
 }
 
 // Get locks the resource for use. It accepts a purpose as a string.
@@ -83,6 +99,10 @@ func (nu *Numbered) Get(id int64, purpose string) (val interface{}, err error) {
 	defer nu.mu.Unlock()
 	nw, ok := nu.resources[id]
 	if !ok {
+		if val, ok := nu.recentlyUnregistered.Get(fmt.Sprintf("%v", id)); ok {
+			unreg := val.(*unregistered)
+			return nil, fmt.Errorf("ended at %v (%v)", unreg.timeUnregistered.Format("2006-01-02 15:04:05.000 MST"), unreg.reason)
+		}
 		return nil, fmt.Errorf("not found")
 	}
 	if nw.inUse {
@@ -117,12 +137,12 @@ func (nu *Numbered) GetAll() (vals []interface{}) {
 
 // GetOutdated returns a list of resources that are older than age, and locks them.
 // It does not return any resources that are already locked.
-func (nu *Numbered) GetOutdated(age time.Duration, purpose string) (vals []interface{}) {
+func (nu *Numbered) GetOutdated(age time.Duration, strict bool, purpose string) (vals []interface{}) {
 	nu.mu.Lock()
 	defer nu.mu.Unlock()
 	now := time.Now()
 	for _, nw := range nu.resources {
-		if nw.inUse || !nw.enforceTimeout {
+		if !strict && (nw.inUse || !nw.enforceTimeout) {
 			continue
 		}
 		if nw.timeCreated.Add(age).Sub(now) <= 0 {

--- a/go/pools/numbered.go
+++ b/go/pools/numbered.go
@@ -137,12 +137,12 @@ func (nu *Numbered) GetAll() (vals []interface{}) {
 
 // GetOutdated returns a list of resources that are older than age, and locks them.
 // It does not return any resources that are already locked.
-func (nu *Numbered) GetOutdated(age time.Duration, strict bool, purpose string) (vals []interface{}) {
+func (nu *Numbered) GetOutdated(age time.Duration, purpose string) (vals []interface{}) {
 	nu.mu.Lock()
 	defer nu.mu.Unlock()
 	now := time.Now()
 	for _, nw := range nu.resources {
-		if !strict && (nw.inUse || !nw.enforceTimeout) {
+		if nw.inUse || !nw.enforceTimeout {
 			continue
 		}
 		if nw.timeCreated.Add(age).Sub(now) <= 0 {

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pools
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -46,9 +47,13 @@ func TestNumbered(t *testing.T) {
 	if v, err = p.Get(1, "test2"); err.Error() != "not found" {
 		t.Errorf("want 'not found', got '%v'", err)
 	}
-	p.Unregister(1) // Should not fail
-	p.Unregister(0)
+	p.Unregister(1, "test") // Should not fail
+	p.Unregister(0, "test")
 	// p is now empty
+
+	if v, err = p.Get(0, "test3"); !(strings.HasPrefix(err.Error(), "ended at") && strings.HasSuffix(err.Error(), ": test")) {
+		t.Errorf("want 'not found', got '%v'", err)
+	}
 
 	p.Register(id, id, true)
 	id++
@@ -60,10 +65,21 @@ func TestNumbered(t *testing.T) {
 	p.Register(id, id, true)
 	time.Sleep(100 * time.Millisecond)
 
-	// p has 0, 1, 2, 3 (0, 1, 2 are aged, but 2 is not enforced)
-	vals := p.GetOutdated(200*time.Millisecond, "by outdated")
-	if len(vals) != 2 {
-		t.Errorf("want 2, got %v", len(vals))
+	// p has 0, 1, 2, 3 (0, 1, 2 are aged, but 2 is not enforced unless strict)
+
+	// all aged should be returned because strict
+	vals := p.GetOutdated(200*time.Millisecond, true, "by outdated - strict")
+	if num := len(vals); num != 3 {
+		t.Errorf("want 3, got %v", num)
+	}
+	for _, v := range vals {
+		p.Put(v.(int64))
+	}
+
+	// just 0 and 1 should be returned now because not strict
+	vals = p.GetOutdated(200*time.Millisecond, false, "by outdated")
+	if num := len(vals); num != 2 {
+		t.Errorf("want 2, got %v", num)
 	}
 	if v, err = p.Get(vals[0].(int64), "test1"); err.Error() != "in use: by outdated" {
 		t.Errorf("want 'in use: by outdated', got '%v'", err)
@@ -85,16 +101,16 @@ func TestNumbered(t *testing.T) {
 	if vals[0].(int64) != 3 {
 		t.Errorf("want 3, got %v", vals[0])
 	}
-	p.Unregister(vals[0].(int64))
+	p.Unregister(vals[0].(int64), "test")
 
 	// p has 0, 1, and 2
 	if p.Size() != 3 {
 		t.Errorf("want 3, got %v", p.Size())
 	}
 	go func() {
-		p.Unregister(0)
-		p.Unregister(1)
-		p.Unregister(2)
+		p.Unregister(0, "test")
+		p.Unregister(1, "test")
+		p.Unregister(2, "test")
 	}()
 	p.WaitForEmpty()
 }

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -51,8 +51,8 @@ func TestNumbered(t *testing.T) {
 	p.Unregister(0, "test")
 	// p is now empty
 
-	if v, err = p.Get(0, "test3"); !(strings.HasPrefix(err.Error(), "ended at") && strings.HasSuffix(err.Error(), ": test")) {
-		t.Errorf("want 'not found', got '%v'", err)
+	if v, err = p.Get(0, "test3"); !(strings.HasPrefix(err.Error(), "ended at") && strings.HasSuffix(err.Error(), "(test)")) {
+		t.Errorf("want prefix 'ended at' and suffix '(test'), got '%v'", err)
 	}
 
 	p.Register(id, id, true)

--- a/go/pools/numbered_test.go
+++ b/go/pools/numbered_test.go
@@ -65,19 +65,8 @@ func TestNumbered(t *testing.T) {
 	p.Register(id, id, true)
 	time.Sleep(100 * time.Millisecond)
 
-	// p has 0, 1, 2, 3 (0, 1, 2 are aged, but 2 is not enforced unless strict)
-
-	// all aged should be returned because strict
-	vals := p.GetOutdated(200*time.Millisecond, true, "by outdated - strict")
-	if num := len(vals); num != 3 {
-		t.Errorf("want 3, got %v", num)
-	}
-	for _, v := range vals {
-		p.Put(v.(int64))
-	}
-
-	// just 0 and 1 should be returned now because not strict
-	vals = p.GetOutdated(200*time.Millisecond, false, "by outdated")
+	// p has 0, 1, 2, 3 (0, 1, 2 are aged, but 2 is not enforced)
+	vals := p.GetOutdated(200*time.Millisecond, "by outdated")
 	if num := len(vals); num != 2 {
 		t.Errorf("want 2, got %v", num)
 	}

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -470,14 +470,14 @@ func TestTxPoolGetConnRecentlyRemovedTransaction(t *testing.T) {
 		t.Fatalf("got error: %v", err)
 	}
 
-	assertErrorMatch(id, "commit requested")
+	assertErrorMatch(id, "transaction committed")
 
 	id, err = txPool.Begin(ctx, &querypb.ExecuteOptions{})
 	if err := txPool.Rollback(ctx, id); err != nil {
 		t.Fatalf("got error: %v", err)
 	}
 
-	assertErrorMatch(id, "rollback requested")
+	assertErrorMatch(id, "transaction rolled back")
 
 	txPool.Close()
 	txPool = newTxPool()

--- a/go/vt/vttablet/tabletserver/tx_pool_test.go
+++ b/go/vt/vttablet/tabletserver/tx_pool_test.go
@@ -585,6 +585,7 @@ func TestTxPoolExecFailDueToConnFail_Errno2013(t *testing.T) {
 }
 
 func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
+	startingStray := tabletenv.InternalErrors.Counts()["StrayTransactions"]
 	db := fakesqldb.New(t)
 	defer db.Close()
 	db.AddQuery("begin", &sqltypes.Result{})
@@ -600,7 +601,7 @@ func TestTxPoolCloseKillsStrayTransactions(t *testing.T) {
 
 	// Close kills stray transaction.
 	txPool.Close()
-	if got, want := tabletenv.InternalErrors.Counts()["StrayTransactions"], int64(1); got != want {
+	if got, want := tabletenv.InternalErrors.Counts()["StrayTransactions"]-startingStray, int64(1); got != want {
 		t.Fatalf("internal error count for stray transactions not increased: got = %v, want = %v", got, want)
 	}
 	if got, want := txPool.conns.Capacity(), int64(0); got != want {


### PR DESCRIPTION
### Why
Transactions are killed asynchronously by a background goroutine. So it's hard to return direct feedback to the user at the time of the transaction being killed. This results in a confusing error when a new query is submitted against the now-killed transaction:

`transaction 123342343452: not found`

Most of our users have no idea what this means, despite some documentation. So let's make the error message more usable by including details as to *why* it's not found.

### How
Since transactions are killed asynchronously I opted to keep an LRU cache of recently killed transactions. When a a pool Get is called, rather than just return `not found`, it checks the `recentlyUnregistered` cache and returns the reason and time instead.

A side benefit of this is that we can also handle the case where someone tries to access a transaction that was committed, rolled back, or whose connection was closed.

### Examples

```
transaction 1518194127682142274: ended at 2018-02-09 11:35:27.683 EST (transaction committed)
transaction 1518194127682142274: ended at 2018-02-09 11:35:27.683 EST (transaction rolled back)
transaction 1518194127682142274: ended at 2018-02-09 11:35:27.683 EST (pool closed)
transaction 1518194127682142274: ended at 2018-02-09 11:35:27.683 EST (exceeded timeout: 30s)
```

### Open questions
I arbitrarily chose 1000 for the LRU cache size. This seems like a reasonably safe limit from a memory footprint standpoint considering the size of the cache item. It also seems like it would reasonably catch most errors because these should be infrequent. In the case of a systemic issue resulting in many not found transactions, there is probably something more nefarious going on.  That said, I'm open to upping it. Even 10k would probably be fine.  Thoughts?

I also added a `strict` mode to the GetOutdated. I can revert this if there are objections. But it seemed like when the pool is closed it should force all transactions to be closed. That could be a wrong assumption though.