### PR TITLE
trim space from query before splitting off comments

### DIFF
--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -29,15 +29,16 @@ type matchtracker struct {
 
 // SplitTrailingComments splits the query trailing comments from the query.
 func SplitTrailingComments(sql string) (query, comments string) {
+	trimmed := strings.TrimSpace(sql)
 	tracker := matchtracker{
-		query: sql,
-		index: len(sql),
+		query: trimmed,
+		index: len(trimmed),
 	}
 	pos := tracker.matchComments()
 	if pos >= 0 {
 		return tracker.query[:pos], tracker.query[pos:]
 	}
-	return sql, ""
+	return trimmed, ""
 }
 
 // matchComments matches trailing comments. If no comment was found,

--- a/go/vt/sqlparser/comments.go
+++ b/go/vt/sqlparser/comments.go
@@ -29,7 +29,7 @@ type matchtracker struct {
 
 // SplitTrailingComments splits the query trailing comments from the query.
 func SplitTrailingComments(sql string) (query, comments string) {
-	trimmed := strings.TrimSpace(sql)
+	trimmed := strings.TrimRightFunc(sql, unicode.IsSpace)
 	tracker := matchtracker{
 		query: trimmed,
 		index: len(trimmed),

--- a/go/vt/sqlparser/comments_test.go
+++ b/go/vt/sqlparser/comments_test.go
@@ -82,6 +82,10 @@ func TestSplitTrailingComments(t *testing.T) {
 		outSQL:      "foo",
 		outComments: " /*** bar ***/",
 	}, {
+		input:       "foo /*** bar ***/ ",
+		outSQL:      "foo",
+		outComments: " /*** bar ***/",
+	}, {
 		input:       "*** bar ***/",
 		outSQL:      "*** bar ***/",
 		outComments: "",


### PR DESCRIPTION
previously, "select 1 from dual /* comment*/ " with a space at the end
would be considered to have an "internal comment" which we throw away forever, instead
of merrily piping along to mysql to be logged.