### PR TITLE
prune unused functions

### DIFF
--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -58,22 +58,6 @@ type QueryExecutor struct {
 	tsv              *TabletServer
 }
 
-// NewQueryExecutor creates a new QueryExecutor with the given contents. It is
-// used by vtexplain to create the struct ouside the package and assign the private
-// members.
-func NewQueryExecutor(ctx context.Context, query string, bindVars map[string]*querypb.BindVariable, transactionID int64, options *querypb.ExecuteOptions, plan *TabletPlan, logStats *tabletenv.LogStats, tsv *TabletServer) *QueryExecutor {
-	return &QueryExecutor{
-		query:         query,
-		bindVars:      bindVars,
-		transactionID: transactionID,
-		options:       options,
-		plan:          plan,
-		ctx:           ctx,
-		logStats:      logStats,
-		tsv:           tsv,
-	}
-}
-
 var sequenceFields = []*querypb.Field{
 	{
 		Name: "nextval",

--- a/go/vt/vttablet/tabletserver/tabletserver.go
+++ b/go/vt/vttablet/tabletserver/tabletserver.go
@@ -1834,11 +1834,6 @@ func (tsv *TabletServer) endRequest(isTx bool) {
 	}
 }
 
-// GetPlan is only used from vtexplain
-func (tsv *TabletServer) GetPlan(ctx context.Context, logStats *tabletenv.LogStats, sql string) (*TabletPlan, error) {
-	return tsv.qe.GetPlan(ctx, logStats, sql, false /* skipQueryPlanCache */)
-}
-
 func (tsv *TabletServer) registerDebugHealthHandler() {
 	http.HandleFunc("/debug/health", func(w http.ResponseWriter, r *http.Request) {
 		if err := acl.CheckAccessHTTP(r, acl.MONITORING); err != nil {


### PR DESCRIPTION
Remove NewQueryExecutor() and TabletServer.GetPlan(), both of which are no longer used.