### PR TITLE
For unsharded dml, fix inner subquery referencing outer symbol

### DIFF
--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -1255,8 +1255,7 @@
   }
 }
 
-
-# sharded subqueries in unsharded update
+# unsharded update where inner query references outer query
 "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)"
 {
   "Original": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)",
@@ -1267,5 +1266,19 @@
       "Sharded":false
     },
     "Query": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)"
+  }
+}
+
+# unsharded delete where inner query references outer query
+"delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)"
+{
+  "Original": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)",
+  "Instructions": {
+    "Opcode": "DeleteUnsharded",
+    "Keyspace": {
+      "Name": "main",
+      "Sharded": false
+    },
+    "Query": "delete from unsharded where col = (select id from unsharded_a where id = unsharded.col)"
   }
 }

--- a/data/test/vtgate/dml_cases.txt
+++ b/data/test/vtgate/dml_cases.txt
@@ -1254,3 +1254,18 @@
     "Table": "user_extra"
   }
 }
+
+
+# sharded subqueries in unsharded update
+"update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)"
+{
+  "Original": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)",
+  "Instructions": {
+    "Opcode": "UpdateUnsharded",
+    "Keyspace": {
+      "Name":"main",
+      "Sharded":false
+    },
+    "Query": "update unsharded set col = (select id from unsharded_a where id = unsharded.col) where col = (select id from unsharded_b)"
+  }
+}

--- a/go/vt/vtgate/planbuilder/dml.go
+++ b/go/vt/vtgate/planbuilder/dml.go
@@ -56,7 +56,7 @@ func buildUpdatePlan(upd *sqlparser.Update, vschema VSchema) (*engine.Route, err
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
 		// We only validate non-table subexpressions because the previous analysis has already validated them.
-		if !validateSubquerySamePlan(rb.ERoute, vschema, upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
+		if !validateSubquerySamePlan(rb.ERoute, rb, vschema, upd.Exprs, upd.Where, upd.OrderBy, upd.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		er.Opcode = engine.UpdateUnsharded
@@ -157,7 +157,7 @@ func buildDeletePlan(del *sqlparser.Delete, vschema VSchema) (*engine.Route, err
 	er.Keyspace = rb.ERoute.Keyspace
 	if !er.Keyspace.Sharded {
 		// We only validate non-table subexpressions because the previous analysis has already validated them.
-		if !validateSubquerySamePlan(rb.ERoute, vschema, del.Targets, del.Where, del.OrderBy, del.Limit) {
+		if !validateSubquerySamePlan(rb.ERoute, rb, vschema, del.Targets, del.Where, del.OrderBy, del.Limit) {
 			return nil, errors.New("unsupported: sharded subqueries in DML")
 		}
 		er.Opcode = engine.DeleteUnsharded

--- a/go/vt/vtgate/planbuilder/expr.go
+++ b/go/vt/vtgate/planbuilder/expr.go
@@ -151,7 +151,7 @@ func hasSubquery(node sqlparser.SQLNode) bool {
 	return has
 }
 
-func validateSubquerySamePlan(outer *engine.Route, vschema VSchema, nodes ...sqlparser.SQLNode) bool {
+func validateSubquerySamePlan(outerRoute *engine.Route, bldr builder, vschema VSchema, nodes ...sqlparser.SQLNode) bool {
 	samePlan := true
 
 	for _, node := range nodes {
@@ -165,7 +165,7 @@ func validateSubquerySamePlan(outer *engine.Route, vschema VSchema, nodes ...sql
 				if !inSubQuery {
 					return true, nil
 				}
-				bldr, err := processSelect(nodeType, vschema, nil)
+				bldr, err := processSelect(nodeType, vschema, bldr)
 				if err != nil {
 					samePlan = false
 					return false, err
@@ -175,7 +175,7 @@ func validateSubquerySamePlan(outer *engine.Route, vschema VSchema, nodes ...sql
 					samePlan = false
 					return false, errors.New("dummy")
 				}
-				if innerRoute.ERoute.Keyspace.Name != outer.Keyspace.Name {
+				if innerRoute.ERoute.Keyspace.Name != outerRoute.Keyspace.Name {
 					samePlan = false
 					return false, errors.New("dummy")
 				}
@@ -193,7 +193,7 @@ func validateSubquerySamePlan(outer *engine.Route, vschema VSchema, nodes ...sql
 					samePlan = false
 					return false, errors.New("dummy")
 				}
-				if innerRoute.ERoute.Keyspace.Name != outer.Keyspace.Name {
+				if innerRoute.ERoute.Keyspace.Name != outerRoute.Keyspace.Name {
 					samePlan = false
 					return false, errors.New("dummy")
 				}

--- a/go/vt/vtgate/planbuilder/insert.go
+++ b/go/vt/vtgate/planbuilder/insert.go
@@ -48,7 +48,7 @@ func buildInsertUnshardedPlan(ins *sqlparser.Insert, table *vindexes.Table, vsch
 		Table:    table,
 		Keyspace: table.Keyspace,
 	}
-	if !validateSubquerySamePlan(eRoute, vschema, ins) {
+	if !validateSubquerySamePlan(eRoute, nil, vschema, ins) {
 		return nil, errors.New("unsupported: sharded subquery in insert values")
 	}
 	var rows sqlparser.Values


### PR DESCRIPTION
We had a use case come by recently, and this should work as long as all tables are within the same keyspace. It was failing to find the symbol in the symtab, but I noticed `processSelect` can take an outer bldr. This fix applies to updates and deletes, but not inserts because there was no outer bldr to pass in. Also dont think it makes sense for inserts anyway.

@sougou @acharis 