### PR TITLE
Do not stard servenv when running in CLI mode

### DIFF
--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -93,15 +93,13 @@ func main() {
 			exit.Return(1)
 		}
 		// Run the subsequent, blocking wait asynchronously.
-		go func() {
-			if err := wi.WaitForCommand(worker, done); err != nil {
-				log.Error(err)
-				logutil.Flush()
-				// We cannot use exit.Return() here because we are in a different go routine now.
-				os.Exit(1)
-			}
+		if err := wi.WaitForCommand(worker, done); err != nil {
+			log.Error(err)
 			logutil.Flush()
-			os.Exit(0)
-		}()
+			// We cannot use exit.Return() here because we are in a different go routine now.
+			exit.Return(1)
+		}
+		logutil.Flush()
+		exit.Return(0)
 	}
 }

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -76,7 +76,6 @@ func main() {
 
 	if len(args) == 0 {
 		// In interactive mode, initialize the web UI to choose a command.
-		wi.InitInteractiveMode()
 		servenv.Init()
 		defer servenv.Close()
 
@@ -84,6 +83,7 @@ func main() {
 			servenv.AppVersion.Print()
 			os.Exit(0)
 		}
+		wi.InitInteractiveMode()
 		servenv.RunDefault()
 	} else {
 		// In single command mode, just run it.

--- a/go/cmd/vtworker/vtworker.go
+++ b/go/cmd/vtworker/vtworker.go
@@ -67,14 +67,6 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
-	servenv.Init()
-	defer servenv.Close()
-
-	if *servenv.Version {
-		servenv.AppVersion.Print()
-		os.Exit(0)
-	}
-
 	ts := topo.Open()
 	defer ts.Close()
 
@@ -85,6 +77,14 @@ func main() {
 	if len(args) == 0 {
 		// In interactive mode, initialize the web UI to choose a command.
 		wi.InitInteractiveMode()
+		servenv.Init()
+		defer servenv.Close()
+
+		if *servenv.Version {
+			servenv.AppVersion.Print()
+			os.Exit(0)
+		}
+		servenv.RunDefault()
 	} else {
 		// In single command mode, just run it.
 		worker, done, err := wi.RunCommand(context.Background(), args, nil /*custom wrangler*/, true /*runFromCli*/)
@@ -104,6 +104,4 @@ func main() {
 			os.Exit(0)
 		}()
 	}
-
-	servenv.RunDefault()
 }


### PR DESCRIPTION
### Description

When running in CLI mode there is no need to start the server (I think). This is creating problem for us as we need to pass some credentials to `vtworker` and it runs with a sudo user. `servenv`  is rightfully not happy when running as root:

```
F0213 09:28:05.837039   10597 servenv.go:87] servenv.Init: running this as root makes no sense
```

The following changes `vtworker` logic to not start a server if running from `CLI`.

###  Test

I tested this in our environment and seems to be working 👌 