### PR TITLE
vttablet: get_lock and release_lock

### DIFF
--- a/data/test/tabletserver/exec_cases.txt
+++ b/data/test/tabletserver/exec_cases.txt
@@ -1900,6 +1900,87 @@ options:PassthroughDMLs
 "select next value from id"
 "table id not found in schema"
 
+# get_lock (no values)
+"select get_lock()"
+{
+  "PlanID": "GET_LOCK",
+  "TableName": "dual",
+  "Permissions": [
+    {
+      "TableName": "dual",
+      "Role": 0
+    }
+  ],
+  "FieldQuery": "select get_lock() from dual where 1 != 1",
+  "FullQuery": "select get_lock() from dual limit :#maxLimit"
+}
+
+# get_lock all values
+"select get_lock('name', 10)"
+{
+  "PlanID": "GET_LOCK",
+  "TableName": "dual",
+  "Permissions": [
+    {
+      "TableName": "dual",
+      "Role": 0
+    }
+  ],
+  "FieldQuery": "select get_lock('name', 10) from dual where 1 != 1",
+  "FullQuery": "select get_lock('name', 10) from dual limit :#maxLimit",
+  "PKValues": [
+    "name",
+    10
+  ]
+}
+
+# get_lock non-dual
+"select get_lock() from a"
+"GET_LOCK can only be used in a simple SELECT"
+
+# get_lock multiple selects
+"select a, get_lock()"
+"GET_LOCK can only be used in a simple SELECT"
+
+# get_lock in select *
+"select * from dual where get_lock()=1"
+"GET_LOCK can only be used in a simple SELECT"
+
+# get_lock in select non-func
+"select a from dual where get_lock()=1"
+"GET_LOCK can only be used in a simple SELECT"
+
+# get_lock in a function call.
+"select f(get_lock())"
+"GET_LOCK can only be used in a simple SELECT"
+
+# get_lock star expr inside
+"select get_lock(*)"
+"invalid syntax for GET_LOCK or RELEASE_LOCK"
+
+# get_lock complex expr
+"select get_lock(a+1)"
+"GET_LOCK or RELEASE_LOCK require simple value params"
+
+# release_lock
+"select release_lock() from dual"
+{
+  "PlanID": "RELEASE_LOCK",
+  "TableName": "dual",
+  "Permissions": [
+    {
+      "TableName": "dual",
+      "Role": 0
+    }
+  ],
+  "FieldQuery": "select release_lock() from dual where 1 != 1",
+  "FullQuery": "select release_lock() from dual limit :#maxLimit"
+}
+
+# release_lock non-dual
+"select release_lock() from a"
+"RELEASE_LOCK can only be used in a simple SELECT"
+
 # int
 "set  a=1"
 {

--- a/go/vt/vttablet/tabletserver/locker/locker.go
+++ b/go/vt/vttablet/tabletserver/locker/locker.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package locker provides vitess level support for GET_LOCK
+// and RELEASE_LOCK functionality.
+package locker
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/youtube/vitess/go/vt/vterrors"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+// Locker is the service for locking funcionality.
+type Locker struct {
+	mu      sync.Mutex
+	isOpen  bool
+	timeout time.Duration
+	locks   map[string]*lock
+}
+
+type lock struct {
+	ctx      context.Context
+	cancel   context.CancelFunc
+	released chan struct{}
+}
+
+// NewLocker creates a new Locker.
+func NewLocker(config tabletenv.TabletConfig) *Locker {
+	return &Locker{
+		timeout: time.Duration(config.TransactionTimeout * 1e9),
+	}
+}
+
+// Open opens the Locker service.
+func (lk *Locker) Open() {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	lk.locks = make(map[string]*lock)
+	lk.isOpen = true
+}
+
+// Close closes the Locker service.
+func (lk *Locker) Close() {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	lk.isOpen = false
+	lk.locks = nil
+}
+
+// Lock obtains a lock of the specified name. The wait time is the minimum
+// of the timeout or the timeout in the context (if any). On success the function
+// returns true, and false otherwise.
+func (lk *Locker) Lock(ctx context.Context, name string, timeout time.Duration) (bool, error) {
+	if err := lk.verifyOpen(); err != nil {
+		return false, err
+	}
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	for {
+		l, ok := lk.newLock(name)
+		if ok {
+			return true, nil
+		}
+		select {
+		case <-l.released:
+			// retry
+		case <-ctx.Done():
+			return false, nil
+		}
+	}
+}
+
+func (lk *Locker) newLock(name string) (*lock, bool) {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+
+	// There exists a prior lock.
+	if l, ok := lk.locks[name]; ok {
+		return l, false
+	}
+
+	// No prior lock. Create one.
+	ctx, cancel := context.WithTimeout(context.Background(), lk.timeout)
+	l := &lock{
+		ctx:      ctx,
+		cancel:   cancel,
+		released: make(chan struct{}),
+	}
+	lk.locks[name] = l
+
+	go func() {
+		<-l.ctx.Done()
+
+		lk.mu.Lock()
+		delete(lk.locks, name)
+		lk.mu.Unlock()
+
+		close(l.released)
+	}()
+	return nil, true
+}
+
+// Release releases the named lock. If no lock is held, the function is a no-op.
+func (lk *Locker) Release(name string) error {
+	if err := lk.verifyOpen(); err != nil {
+		return err
+	}
+
+	lk.mu.Lock()
+	l, ok := lk.locks[name]
+	lk.mu.Unlock()
+	if !ok {
+		return nil
+	}
+
+	// Cancel the context, wait for release and return
+	l.cancel()
+	<-l.released
+	return nil
+}
+
+func (lk *Locker) verifyOpen() error {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	if !lk.isOpen {
+		return vterrors.Errorf(vtrpcpb.Code_UNAVAILABLE, "cannot perform locking function, probably because this is not a master any more")
+	}
+	return nil
+}

--- a/go/vt/vttablet/tabletserver/locker/locker_test.go
+++ b/go/vt/vttablet/tabletserver/locker/locker_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package locker
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/tabletenv"
+	"golang.org/x/net/context"
+)
+
+func TestOpenClose(t *testing.T) {
+	l := newTestLocker()
+	l.Close()
+
+	_, err := l.Lock(context.Background(), "", 0)
+	want := "cannot perform locking function, probably because this is not a master any more"
+	verifyError(t, "Lock", err, want)
+
+	err = l.Release("")
+	verifyError(t, "Lock", err, want)
+}
+
+func TestLock(t *testing.T) {
+	l := newTestLocker()
+
+	// First lock.
+	start := time.Now()
+	result, err := l.Lock(context.Background(), "", 0)
+	checkError(t, err)
+	if want, got := result, true; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, want <10ms", diff)
+	}
+
+	// Second lock: specify long timeout.
+	start = time.Now()
+	result, err = l.Lock(context.Background(), "", 20*time.Millisecond)
+	checkError(t, err)
+	if want, got := result, true; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff < 5*time.Millisecond || diff > 15*time.Millisecond {
+		t.Errorf("Lock time: %v, 1ms< want <10ms", diff)
+	}
+}
+
+func TestLockTimeout(t *testing.T) {
+	l := newTestLocker()
+
+	// First lock.
+	start := time.Now()
+	result, err := l.Lock(context.Background(), "", 0)
+	checkError(t, err)
+	if want, got := result, true; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, want <10ms", diff)
+	}
+
+	// Second lock: specify a short timeout.
+	start = time.Now()
+	result, err = l.Lock(context.Background(), "", 1*time.Millisecond)
+	checkError(t, err)
+	if want, got := result, false; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff < 1*time.Millisecond || diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, 1ms< want <10ms", diff)
+	}
+
+	// Third lock: see if context timeout gets overridden.
+	start = time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	result, err = l.Lock(ctx, "", 1*time.Millisecond)
+	checkError(t, err)
+	if want, got := result, false; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff < 1*time.Millisecond || diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, 1ms< want <10ms", diff)
+	}
+
+	// Fourth lock: see if context timeout overrides longer timeout
+	start = time.Now()
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	result, err = l.Lock(ctx, "", 5*time.Millisecond)
+	checkError(t, err)
+	if want, got := result, false; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff < 1*time.Millisecond || diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, 1ms< want <10ms", diff)
+	}
+
+	// Fifth lock: set a large timeout and see it succeed
+	start = time.Now()
+	ctx, cancel = context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	result, err = l.Lock(ctx, "", 5*time.Millisecond)
+	checkError(t, err)
+	if want, got := result, false; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff < 1*time.Millisecond || diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, 1ms< want <10ms", diff)
+	}
+}
+
+func TestRelease(t *testing.T) {
+	l := newTestLocker()
+
+	start := time.Now()
+	result, err := l.Lock(context.Background(), "", 0)
+	checkError(t, err)
+	if want, got := result, true; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, want <10ms", diff)
+	}
+
+	// Release
+	err = l.Release("")
+	checkError(t, err)
+
+	// Re-release
+	err = l.Release("")
+	checkError(t, err)
+
+	// New lock. Should be immediate
+	start = time.Now()
+	result, err = l.Lock(context.Background(), "", 0)
+	checkError(t, err)
+	if want, got := result, true; got != want {
+		t.Errorf("Lock: %v, want %v", got, want)
+	}
+	if diff := time.Now().Sub(start); diff > 10*time.Millisecond {
+		t.Errorf("Lock time: %v, want <10ms", diff)
+	}
+}
+
+func newTestLocker() *Locker {
+	l := NewLocker(tabletenv.TabletConfig{
+		TransactionTimeout: 0.01,
+	})
+	l.Open()
+	return l
+}
+
+func verifyError(t *testing.T, prefix string, err error, want string) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("%s error: %v, must contina %s", prefix, err, want)
+	}
+}
+
+func checkError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/go/vt/vttablet/tabletserver/planbuilder/plan.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/plan.go
@@ -83,6 +83,10 @@ const (
 	PlanOtherAdmin
 	// PlanMessageStream is used for streaming messages.
 	PlanMessageStream
+	// PlanGetLock is used for GET_LOCK.
+	PlanGetLock
+	// PlanReleaseLock is used for RELEASE_LOCK.
+	PlanReleaseLock
 	// NumPlans stores the total number of plans
 	NumPlans
 )
@@ -105,6 +109,8 @@ var planName = [NumPlans]string{
 	"OTHER_READ",
 	"OTHER_ADMIN",
 	"MESSAGE_STREAM",
+	"GET_LOCK",
+	"RELEASE_LOCK",
 }
 
 func (pt PlanType) String() string {
@@ -156,6 +162,8 @@ var tableACLRoles = map[PlanType]tableacl.Role{
 	PlanUpsertPK:       tableacl.WRITER,
 	PlanNextval:        tableacl.WRITER,
 	PlanMessageStream:  tableacl.WRITER,
+	PlanGetLock:        tableacl.READER,
+	PlanReleaseLock:    tableacl.READER,
 }
 
 //_______________________________________________

--- a/go/vt/vttablet/tabletserver/planbuilder/select.go
+++ b/go/vt/vttablet/tabletserver/planbuilder/select.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package planbuilder
+
+import (
+	"github.com/youtube/vitess/go/sqltypes"
+	"github.com/youtube/vitess/go/vt/sqlparser"
+	"github.com/youtube/vitess/go/vt/vterrors"
+	"github.com/youtube/vitess/go/vt/vttablet/tabletserver/schema"
+
+	vtrpcpb "github.com/youtube/vitess/go/vt/proto/vtrpc"
+)
+
+func analyzeSelect(sel *sqlparser.Select, tables map[string]*schema.Table) (plan *Plan, err error) {
+	plan = &Plan{
+		PlanID:     PlanPassSelect,
+		FieldQuery: GenerateFieldQuery(sel),
+		FullQuery:  GenerateLimitQuery(sel),
+	}
+	if sel.Lock != "" {
+		plan.PlanID = PlanSelectLock
+	}
+
+	tableName := analyzeFrom(sel.From)
+	if tableName.IsEmpty() {
+		if err := verifyNoGetLock(sel); err != nil {
+			return nil, err
+		}
+		return plan, nil
+	}
+	if _, err := plan.setTable(tableName, tables); err != nil {
+		return nil, err
+	}
+
+	if altPlan, err := analyzeNextValue(sel, plan); altPlan != nil || err != nil {
+		return altPlan, err
+	}
+	if altPlan, err := analyzeGetLock(sel, plan); altPlan != nil || err != nil {
+		return altPlan, err
+	}
+	return plan, nil
+}
+
+func analyzeNextValue(sel *sqlparser.Select, plan *Plan) (*Plan, error) {
+	nextVal, ok := sel.SelectExprs[0].(sqlparser.Nextval)
+	if !ok {
+		return nil, nil
+	}
+
+	if plan.Table.Type != schema.Sequence {
+		return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%v is not a sequence", plan.Table.Name)
+	}
+	plan.PlanID = PlanNextval
+	v, err := sqlparser.NewPlanValue(nextVal.Expr)
+	if err != nil {
+		return nil, err
+	}
+	plan.PKValues = []sqltypes.PlanValue{v}
+	plan.FieldQuery = nil
+	plan.FullQuery = nil
+	return plan, nil
+}
+
+func analyzeGetLock(sel *sqlparser.Select, plan *Plan) (*Plan, error) {
+	if plan.Table.Name.String() != "dual" {
+		return nil, verifyNoGetLock(sel)
+	}
+	if len(sel.SelectExprs) != 1 {
+		return nil, verifyNoGetLock(sel)
+	}
+	aliased, ok := sel.SelectExprs[0].(*sqlparser.AliasedExpr)
+	if !ok {
+		return nil, verifyNoGetLock(sel)
+	}
+	fun, ok := aliased.Expr.(*sqlparser.FuncExpr)
+	if !ok {
+		return nil, verifyNoGetLock(sel)
+	}
+	if fun.Name.EqualString("get_lock") {
+		plan.PlanID = PlanGetLock
+	}
+	if fun.Name.EqualString("release_lock") {
+		plan.PlanID = PlanReleaseLock
+	}
+	var err error
+	if plan.PlanID == PlanGetLock || plan.PlanID == PlanReleaseLock {
+		plan.PKValues, err = extractFuncValues(fun)
+		if err != nil {
+			return nil, err
+		}
+		return plan, nil
+	}
+
+	return nil, verifyNoGetLock(sel)
+}
+
+func verifyNoGetLock(sel *sqlparser.Select) error {
+	return sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		switch node := node.(type) {
+		case *sqlparser.FuncExpr:
+			if node.Name.EqualString("get_lock") {
+				return false, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "GET_LOCK can only be used in a simple SELECT")
+			}
+			if node.Name.EqualString("release_lock") {
+				return false, vterrors.Errorf(vtrpcpb.Code_UNIMPLEMENTED, "RELEASE_LOCK can only be used in a simple SELECT")
+			}
+		}
+		return true, nil
+	}, sel)
+}
+
+func extractFuncValues(fun *sqlparser.FuncExpr) ([]sqltypes.PlanValue, error) {
+	var pvs []sqltypes.PlanValue
+	for _, selExpr := range fun.Exprs {
+		aliased, ok := selExpr.(*sqlparser.AliasedExpr)
+		if !ok {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "invalid syntax for GET_LOCK or RELEASE_LOCK")
+		}
+		if !sqlparser.IsValue(aliased.Expr) {
+			return nil, vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "GET_LOCK or RELEASE_LOCK require simple value params")
+		}
+		pv, err := sqlparser.NewPlanValue(aliased.Expr)
+		if err != nil {
+			return nil, err
+		}
+		pvs = append(pvs, pv)
+	}
+	return pvs, nil
+}


### PR DESCRIPTION
Issue #3631
get_lock and release_lock cannot be passed through to MySQL because
their behavior is connection dependent, which doesn't work well
for distributed systems, and for pooled connections.

So, we implement our own version of these functions that are more
distributed system friendly, with timeouts as well as session
independent behaviors. More details on the issue.