### PR TITLE
Ignore comments in query consolidation

### DIFF
--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -304,7 +304,7 @@ func TestConsolidation(t *testing.T) {
 	framework.Server.SetPoolSize(1)
 
 	for sleep := 0.1; sleep < 10.0; sleep *= 2 {
-		query := fmt.Sprintf("select sleep(%v) from dual", sleep)
+		query := fmt.Sprintf("select sleep(%v) from dual /* query: %v */", sleep, sleep)
 
 		vstart := framework.DebugVars()
 		var wg sync.WaitGroup

--- a/go/vt/vttablet/endtoend/misc_test.go
+++ b/go/vt/vttablet/endtoend/misc_test.go
@@ -304,16 +304,16 @@ func TestConsolidation(t *testing.T) {
 	framework.Server.SetPoolSize(1)
 
 	for sleep := 0.1; sleep < 10.0; sleep *= 2 {
-		query := fmt.Sprintf("select sleep(%v) from dual /* query: %v */", sleep, sleep)
-
 		vstart := framework.DebugVars()
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
+			query := fmt.Sprintf("select sleep(%v) from dual /* query: 1 */", sleep)
 			framework.NewClient().Execute(query, nil)
 			wg.Done()
 		}()
 		go func() {
+			query := fmt.Sprintf("select sleep(%v) from dual /* query: 2 */", sleep)
 			framework.NewClient().Execute(query, nil)
 			wg.Done()
 		}()

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -377,7 +377,7 @@ func (qre *QueryExecutor) execDDL() (*sqltypes.Result, error) {
 	sql := qre.query
 	var err error
 	if qre.plan.FullQuery != nil {
-		sql, err = qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars, nil, nil)
+		sql, _, err = qre.generateFinalSQL(qre.plan.FullQuery, qre.bindVars, nil, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -767,11 +767,11 @@ func (qre *QueryExecutor) getConn(pool *connpool.Pool) (*connpool.DBConn, error)
 }
 
 func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable) (*sqltypes.Result, error) {
-	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, nil)
+	sql, sqlWithoutComments, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, nil)
 	if err != nil {
 		return nil, err
 	}
-	q, ok := qre.tsv.qe.consolidator.Create(string(sql))
+	q, ok := qre.tsv.qe.consolidator.Create(string(sqlWithoutComments))
 	if ok {
 		defer q.Broadcast()
 		waitingForConnectionStart := time.Now()
@@ -797,7 +797,7 @@ func (qre *QueryExecutor) qFetch(logStats *tabletenv.LogStats, parsedQuery *sqlp
 
 // txFetch fetches from a TxConnection.
 func (qre *QueryExecutor) txFetch(conn *TxConnection, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, extras map[string]sqlparser.Encodable, buildStreamComment []byte, wantfields, record bool) (*sqltypes.Result, error) {
-	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, extras, buildStreamComment)
+	sql, _, err := qre.generateFinalSQL(parsedQuery, bindVars, extras, buildStreamComment)
 	if err != nil {
 		return nil, err
 	}
@@ -814,7 +814,7 @@ func (qre *QueryExecutor) txFetch(conn *TxConnection, parsedQuery *sqlparser.Par
 
 // dbConnFetch fetches from a connpool.DBConn.
 func (qre *QueryExecutor) dbConnFetch(conn *connpool.DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, buildStreamComment []byte, wantfields bool) (*sqltypes.Result, error) {
-	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, buildStreamComment)
+	sql, _, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, buildStreamComment)
 	if err != nil {
 		return nil, err
 	}
@@ -823,24 +823,24 @@ func (qre *QueryExecutor) dbConnFetch(conn *connpool.DBConn, parsedQuery *sqlpar
 
 // streamFetch performs a streaming fetch.
 func (qre *QueryExecutor) streamFetch(conn *connpool.DBConn, parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, buildStreamComment []byte, callback func(*sqltypes.Result) error) error {
-	sql, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, buildStreamComment)
+	sql, _, err := qre.generateFinalSQL(parsedQuery, bindVars, nil, buildStreamComment)
 	if err != nil {
 		return err
 	}
 	return qre.execStreamSQL(conn, sql, callback)
 }
 
-func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, extras map[string]sqlparser.Encodable, buildStreamComment []byte) (string, error) {
+func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, bindVars map[string]*querypb.BindVariable, extras map[string]sqlparser.Encodable, buildStreamComment []byte) (string, string, error) {
 	bindVars["#maxLimit"] = sqltypes.Int64BindVariable(qre.getLimit(parsedQuery))
 	sql, err := parsedQuery.GenerateQuery(bindVars, extras)
 	if err != nil {
-		return "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%s", err)
+		return "", "", vterrors.Errorf(vtrpcpb.Code_INVALID_ARGUMENT, "%s", err)
 	}
 	if buildStreamComment != nil {
 		sql = append(sql, buildStreamComment...)
 	}
-	sql = append(sql, qre.trailingComments...)
-	return hack.String(sql), nil
+	fullSql := append(sql, qre.trailingComments...)
+	return hack.String(fullSql), hack.String(sql), nil
 }
 
 func (qre *QueryExecutor) getLimit(query *sqlparser.ParsedQuery) int64 {

--- a/go/vt/vttablet/tabletserver/query_executor.go
+++ b/go/vt/vttablet/tabletserver/query_executor.go
@@ -839,8 +839,8 @@ func (qre *QueryExecutor) generateFinalSQL(parsedQuery *sqlparser.ParsedQuery, b
 	if buildStreamComment != nil {
 		sql = append(sql, buildStreamComment...)
 	}
-	fullSql := append(sql, qre.trailingComments...)
-	return hack.String(fullSql), hack.String(sql), nil
+	fullSQL := append(sql, qre.trailingComments...)
+	return hack.String(fullSQL), hack.String(sql), nil
 }
 
 func (qre *QueryExecutor) getLimit(query *sqlparser.ParsedQuery) int64 {


### PR DESCRIPTION
Background:

We annotate all our SQL queries with a trailing comment that includes the HTTP request id. This meant that the consolidator didn't work with any online queries from our application.

Changes:
• Use the formatted SQL statement before comments are added back as the consolidation key