### PR TITLE
Add Netlify rewrite rules for custom Go import path.

### DIFF
--- a/vitess.io/_config.yml
+++ b/vitess.io/_config.yml
@@ -41,4 +41,5 @@ owner:
 
 
 exclude: ["config.rb", ".sass-cache", "Capfile", "config", "log", "Rakefile", "Rakefile.rb", "tmp", "*.sublime-project", "*.sublime-workspace", "Gemfile", "Gemfile.lock", "README.md", "LICENSE", "node_modules", "Gruntfile.js", "package.json", "preview-site.sh", "publish-site.sh"]
-
+include:
+  - "_redirects"

--- a/vitess.io/_redirects
+++ b/vitess.io/_redirects
@@ -1,0 +1,1 @@
+/vitess/* go-get=1  /go-import/vitess.html  200

--- a/vitess.io/go-import/vitess.html
+++ b/vitess.io/go-import/vitess.html
@@ -1,0 +1,4 @@
+<html><head>
+<meta name="go-import" content="vitess.io/vitess git https://github.com/youtube/vitess">
+<meta name="go-source" content="vitess.io/vitess     https://github.com/youtube/vitess https://github.com/youtube/vitess/tree/master{/dir} https://github.com/youtube/vitess/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
This sets us up to rewrite our Go import path from `github.com/youtube/vitess` to `vitess.io/vitess`.

This leaves room for other repos under `github.com/vitessio/<repo>` to be imported as `vitess.io/<repo>`.